### PR TITLE
Add an INTERNAL_FLAGS option to link to hpx_internal_flags

### DIFF
--- a/cmake/HPX_AddComponent.cmake
+++ b/cmake/HPX_AddComponent.cmake
@@ -7,7 +7,8 @@
 
 function(add_hpx_component name)
   # retrieve arguments
-  set(options EXCLUDE_FROM_ALL INSTALL_HEADERS NOEXPORT AUTOGLOB STATIC PLUGIN PREPEND_SOURCE_ROOT PREPEND_HEADER_ROOT)
+  set(options EXCLUDE_FROM_ALL INSTALL_HEADERS INTERNAL_FLAGS NOEXPORT AUTOGLOB
+    STATIC PLUGIN PREPEND_SOURCE_ROOT PREPEND_HEADER_ROOT)
   set(one_value_args INI FOLDER SOURCE_ROOT HEADER_ROOT SOURCE_GLOB HEADER_GLOB OUTPUT_SUFFIX INSTALL_SUFFIX LANGUAGE)
   set(multi_value_args SOURCES HEADERS AUXILIARY DEPENDENCIES COMPONENT_DEPENDENCIES COMPILE_FLAGS LINK_FLAGS)
   cmake_parse_arguments(${name} "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
@@ -137,6 +138,10 @@ function(add_hpx_component name)
         ARCHIVE DESTINATION ${archive_install_destination}
         RUNTIME DESTINATION ${runtime_install_destination}
     )
+  endif()
+
+  if(${name}_INTERNAL_FLAGS)
+    set(_target_flags ${_target_flags} INTERNAL_FLAGS)
   endif()
 
   if(${name}_PLUGIN)

--- a/cmake/HPX_AddExecutable.cmake
+++ b/cmake/HPX_AddExecutable.cmake
@@ -7,7 +7,8 @@
 
 function(add_hpx_executable name)
   # retrieve arguments
-  set(options EXCLUDE_FROM_ALL EXCLUDE_FROM_DEFAULT_BUILD AUTOGLOB NOLIBS NOHPX_INIT)
+  set(options EXCLUDE_FROM_ALL EXCLUDE_FROM_DEFAULT_BUILD AUTOGLOB
+    INTERNAL_FLAGS NOLIBS NOHPX_INIT)
   set(one_value_args INI FOLDER SOURCE_ROOT HEADER_ROOT SOURCE_GLOB HEADER_GLOB OUTPUT_SUFFIX INSTALL_SUFFIX LANGUAGE HPX_PREFIX)
   set(multi_value_args SOURCES HEADERS AUXILIARY DEPENDENCIES COMPONENT_DEPENDENCIES COMPILE_FLAGS LINK_FLAGS)
   cmake_parse_arguments(${name} "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
@@ -162,6 +163,10 @@ function(add_hpx_executable name)
 
   if(${${name}_NOHPX_INIT})
     set(_target_flags ${_target_flags} NOHPX_INIT)
+  endif()
+
+  if(${name}_INTERNAL_FLAGS)
+    set(_target_flags ${_target_flags} INTERNAL_FLAGS)
   endif()
 
   hpx_setup_target(

--- a/cmake/HPX_AddLibrary.cmake
+++ b/cmake/HPX_AddLibrary.cmake
@@ -7,7 +7,7 @@
 
 function(add_hpx_library name)
   # retrieve arguments
-  set(options EXCLUDE_FROM_ALL NOLIBS NOEXPORT AUTOGLOB STATIC PLUGIN NONAMEPREFIX)
+  set(options EXCLUDE_FROM_ALL INTERNAL_FLAGS NOLIBS NOEXPORT AUTOGLOB STATIC PLUGIN NONAMEPREFIX)
   set(one_value_args FOLDER SOURCE_ROOT HEADER_ROOT SOURCE_GLOB HEADER_GLOB OUTPUT_SUFFIX INSTALL_SUFFIX)
   set(multi_value_args SOURCES HEADERS AUXILIARY DEPENDENCIES COMPONENT_DEPENDENCIES COMPILER_FLAGS LINK_FLAGS)
   cmake_parse_arguments(${name} "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
@@ -191,6 +191,10 @@ function(add_hpx_library name)
 
   if(NOT ${${name}_NOEXPORT})
     set(_target_flags ${_target_flags} EXPORT)
+  endif()
+
+  if(${name}_INTERNAL_FLAGS)
+    set(_target_flags ${_target_flags} INTERNAL_FLAGS)
   endif()
 
   hpx_setup_target(

--- a/cmake/HPX_SetupTarget.cmake
+++ b/cmake/HPX_SetupTarget.cmake
@@ -13,7 +13,8 @@ hpx_set_cmake_policy(CMP0060 NEW)
 
 function(hpx_setup_target target)
   # retrieve arguments
-  set(options EXPORT NOHPX_INIT INSTALL INSTALL_HEADERS NOLIBS PLUGIN NONAMEPREFIX NOTLLKEYWORD)
+  set(options EXPORT NOHPX_INIT INSTALL INSTALL_HEADERS INTERNAL_FLAGS NOLIBS PLUGIN
+    NONAMEPREFIX NOTLLKEYWORD)
   set(one_value_args TYPE FOLDER NAME SOVERSION VERSION HPX_PREFIX HEADER_ROOT)
   set(multi_value_args DEPENDENCIES COMPONENT_DEPENDENCIES COMPILE_FLAGS LINK_FLAGS INSTALL_FLAGS)
   cmake_parse_arguments(target "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
@@ -227,7 +228,7 @@ function(hpx_setup_target target)
 
   target_link_libraries(${target} ${__tll_public} ${hpx_libs} ${target_DEPENDENCIES})
 
-  if(TARGET hpx_internal_flags)
+  if(target_INTERNAL_FLAGS AND TARGET hpx_internal_flags)
     target_link_libraries(${target} ${__tll_private} hpx_internal_flags)
   endif()
 

--- a/components/component_storage/CMakeLists.txt
+++ b/components/component_storage/CMakeLists.txt
@@ -26,6 +26,7 @@ set(component_storage_sources
 )
 
 add_hpx_component(component_storage
+  INTERNAL_FLAGS
   FOLDER "Core/Components/IO"
   INSTALL_HEADERS
   PREPEND_HEADER_ROOT

--- a/components/containers/partitioned_vector/CMakeLists.txt
+++ b/components/containers/partitioned_vector/CMakeLists.txt
@@ -39,6 +39,7 @@ set(partitioned_vector_sources
 )
 
 add_hpx_component(partitioned_vector
+  INTERNAL_FLAGS
   FOLDER "Core/Components/Containers"
   INSTALL_HEADERS
   PREPEND_HEADER_ROOT

--- a/components/containers/partitioned_vector/tests/regressions/CMakeLists.txt
+++ b/components/containers/partitioned_vector/tests/regressions/CMakeLists.txt
@@ -18,11 +18,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Regressions/Components/Containers")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/Components/Containers")
 
   add_hpx_regression_test("components.partitioned_vector" ${test} ${${test}_PARAMETERS})
 endforeach()

--- a/components/containers/partitioned_vector/tests/unit/CMakeLists.txt
+++ b/components/containers/partitioned_vector/tests/unit/CMakeLists.txt
@@ -42,11 +42,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER ${folder_name})
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER ${folder_name})
 
   add_hpx_unit_test("components.partitioned_vector" ${test} ${${test}_PARAMETERS})
 endforeach()

--- a/components/containers/unordered/CMakeLists.txt
+++ b/components/containers/unordered/CMakeLists.txt
@@ -16,6 +16,7 @@ set(unordered_sources
 )
 
 add_hpx_component(unordered
+  INTERNAL_FLAGS
   FOLDER "Core/Components/Containers"
   INSTALL_HEADERS
   PREPEND_HEADER_ROOT

--- a/components/containers/unordered/tests/unit/CMakeLists.txt
+++ b/components/containers/unordered/tests/unit/CMakeLists.txt
@@ -26,11 +26,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER ${folder_name})
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER ${folder_name})
 
   add_hpx_unit_test("components.unordered" ${test} ${${test}_PARAMETERS})
 endforeach()

--- a/components/create_component_skeleton.py
+++ b/components/create_component_skeleton.py
@@ -40,6 +40,7 @@ set({component_name}_headers)
 set({component_name}_sources)
 
 add_hpx_component({component_name}
+  INTERNAL_FLAGS
   FOLDER "Core/Components"
   INSTALL_HEADERS
   HEADER_ROOT "${{CMAKE_CURRENT_SOURCE_DIR}}/include"

--- a/components/iostreams/CMakeLists.txt
+++ b/components/iostreams/CMakeLists.txt
@@ -29,6 +29,7 @@ set(iostreams_sources
 )
 
 add_hpx_component(iostreams
+  INTERNAL_FLAGS
   FOLDER "Core/Components/IO"
   INSTALL_HEADERS
   PREPEND_HEADER_ROOT

--- a/components/iostreams/tests/regressions/CMakeLists.txt
+++ b/components/iostreams/tests/regressions/CMakeLists.txt
@@ -23,11 +23,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Regressions/Components/IO")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/Components/IO")
 
   add_hpx_regression_test("components.iostreams" ${test} ${${test}_PARAMETERS})
 endforeach()

--- a/components/performance_counters/io/CMakeLists.txt
+++ b/components/performance_counters/io/CMakeLists.txt
@@ -18,6 +18,7 @@ if(HPX_WITH_IO_COUNTERS)
   )
 
   add_hpx_component(io_counters
+    INTERNAL_FLAGS
     FOLDER "Core/Components/Counters"
     INSTALL_HEADERS
     PLUGIN

--- a/components/performance_counters/memory/CMakeLists.txt
+++ b/components/performance_counters/memory/CMakeLists.txt
@@ -20,6 +20,7 @@ set(memory_sources
 )
 
 add_hpx_component(memory
+  INTERNAL_FLAGS
   FOLDER "Core/Components/Counters"
   INSTALL_HEADERS
   PLUGIN

--- a/components/performance_counters/papi/CMakeLists.txt
+++ b/components/performance_counters/papi/CMakeLists.txt
@@ -22,6 +22,7 @@ if(HPX_WITH_PAPI)
   )
 
   add_hpx_component(papi_counters
+    INTERNAL_FLAGS
     FOLDER "Core/Components/Counters"
     INSTALL_HEADERS
     PLUGIN

--- a/components/performance_counters/papi/tests/regressions/CMakeLists.txt
+++ b/components/performance_counters/papi/tests/regressions/CMakeLists.txt
@@ -17,12 +17,13 @@ foreach(test ${tests})
   source_group("Source Files" FILES ${sources})
 
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     COMPONENT_DEPENDENCIES papi_counters
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Regressions/Components")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    COMPONENT_DEPENDENCIES papi_counters
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/Components")
 
   add_hpx_regression_test("components.papi_counters" ${test} ${${test}_PARAMETERS})
 endforeach()

--- a/components/process/CMakeLists.txt
+++ b/components/process/CMakeLists.txt
@@ -105,6 +105,7 @@ set(process_sources
 )
 
 add_hpx_component(process
+  INTERNAL_FLAGS
   FOLDER "Core/Components/Process"
   INSTALL_HEADERS
   PREPEND_HEADER_ROOT

--- a/libs/algorithms/tests/performance/CMakeLists.txt
+++ b/libs/algorithms/tests/performance/CMakeLists.txt
@@ -29,10 +29,11 @@ foreach(benchmark ${benchmarks})
 
   # add example executable
   add_hpx_executable(${benchmark}_test
-                     SOURCES ${sources}
-                     EXCLUDE_FROM_ALL
-                     ${${benchmark}_FLAGS}
-                     FOLDER "Benchmarks/Modules/Algorithms")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    EXCLUDE_FROM_ALL
+    ${${benchmark}_FLAGS}
+    FOLDER "Benchmarks/Modules/Algorithms")
 
   add_hpx_performance_test("modules.algorithms" ${benchmark} ${${benchmark}_PARAMETERS})
 endforeach()

--- a/libs/algorithms/tests/regressions/CMakeLists.txt
+++ b/libs/algorithms/tests/regressions/CMakeLists.txt
@@ -29,10 +29,11 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     EXCLUDE_FROM_ALL
-                     ${${test}_FLAGS}
-                     FOLDER "Tests/Regressions/Modules/Algorithms/")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    EXCLUDE_FROM_ALL
+    ${${test}_FLAGS}
+    FOLDER "Tests/Regressions/Modules/Algorithms/")
 
   add_hpx_regression_test("modules.algorithms" ${test} ${${test}_PARAMETERS})
 

--- a/libs/algorithms/tests/unit/algorithms/CMakeLists.txt
+++ b/libs/algorithms/tests/unit/algorithms/CMakeLists.txt
@@ -145,11 +145,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER ${folder_name})
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER ${folder_name})
 
   add_hpx_unit_test("modules.algorithms" ${test} ${${test}_PARAMETERS})
 endforeach()

--- a/libs/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -59,11 +59,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/Modules/Algorithms/Container")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Modules/Algorithms/Container")
 
   add_hpx_unit_test("modules.algorithms" ${test} ${${test}_PARAMETERS})
 endforeach()

--- a/libs/algorithms/tests/unit/datapar_algorithms/CMakeLists.txt
+++ b/libs/algorithms/tests/unit/datapar_algorithms/CMakeLists.txt
@@ -32,11 +32,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/Modules/Algorithms/Datapar")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Modules/Algorithms/Datapar")
 
   add_hpx_unit_test("modules.algorithms" ${test} ${${test}_PARAMETERS})
 endforeach()

--- a/libs/assertion/tests/unit/CMakeLists.txt
+++ b/libs/assertion/tests/unit/CMakeLists.txt
@@ -15,11 +15,12 @@ foreach(test ${tests})
   source_group("Source Files" FILES ${sources})
 
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     NOLIBS
-                     DEPENDENCIES hpx_assertion
-                     EXCLUDE_FROM_ALL
-                     FOLDER "Tests/Unit/Modules/Assertion/")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    NOLIBS
+    DEPENDENCIES hpx_assertion
+    EXCLUDE_FROM_ALL
+    FOLDER "Tests/Unit/Modules/Assertion/")
 
   add_hpx_unit_test("modules.assertion" ${test} ${${test}_PARAMETERS})
 

--- a/libs/cache/tests/unit/CMakeLists.txt
+++ b/libs/cache/tests/unit/CMakeLists.txt
@@ -18,11 +18,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/Modules/Cache")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Modules/Cache")
 
   add_hpx_unit_test("modules.cache" ${test} ${${test}_PARAMETERS})
 

--- a/libs/collectives/tests/performance/lcos/CMakeLists.txt
+++ b/libs/collectives/tests/performance/lcos/CMakeLists.txt
@@ -16,10 +16,11 @@ foreach(benchmark ${benchmarks})
 
   # add example executable
   add_hpx_executable(${benchmark}_test
-                     SOURCES ${sources}
-                     ${${benchmark}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     FOLDER "Benchmarks/Modules/Collectives/LCOs")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${benchmark}_FLAGS}
+    EXCLUDE_FROM_ALL
+    FOLDER "Benchmarks/Modules/Collectives/LCOs")
 
   add_hpx_performance_test("modules.collectives"
     ${benchmark} ${${benchmark}_PARAMETERS})

--- a/libs/collectives/tests/performance/osu/CMakeLists.txt
+++ b/libs/collectives/tests/performance/osu/CMakeLists.txt
@@ -21,10 +21,11 @@ foreach(benchmark ${benchmarks})
 
   # add example executable
   add_hpx_executable(${benchmark}_test
-                     SOURCES ${sources}
-                     ${${benchmark}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     FOLDER "Benchmarks/Modules/Collectives/OSU")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${benchmark}_FLAGS}
+    EXCLUDE_FROM_ALL
+    FOLDER "Benchmarks/Modules/Collectives/OSU")
 
   add_hpx_performance_test("modules.collectives"
     ${benchmark} ${${benchmark}_PARAMETERS})
@@ -44,10 +45,11 @@ foreach(benchmark ${coll_benchmarks})
 
   # add example executable
   add_hpx_executable(${benchmark}_test
-                     SOURCES ${sources}
-                     ${${benchmark}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     FOLDER "Benchmarks/Modules/Collectives/OSU")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${benchmark}_FLAGS}
+    EXCLUDE_FROM_ALL
+    FOLDER "Benchmarks/Modules/Collectives/OSU")
 
   add_hpx_performance_test("modules.collectives"
     ${benchmark} ${${benchmark}_PARAMETERS})

--- a/libs/collectives/tests/regressions/CMakeLists.txt
+++ b/libs/collectives/tests/regressions/CMakeLists.txt
@@ -26,11 +26,12 @@ if(HPX_WITH_NETWORKING)
 
     # add example executable
     add_hpx_executable(${test}_test
-                       SOURCES ${sources}
-                       ${${test}_FLAGS}
-                       EXCLUDE_FROM_ALL
-                       HPX_PREFIX ${HPX_BUILD_PREFIX}
-                       FOLDER "Tests/Regressions/Modules/Collectives")
+      INTERNAL_FLAGS
+      SOURCES ${sources}
+      ${${test}_FLAGS}
+      EXCLUDE_FROM_ALL
+      HPX_PREFIX ${HPX_BUILD_PREFIX}
+      FOLDER "Tests/Regressions/Modules/Collectives")
 
     add_hpx_regression_test("modules.collectives" ${test} ${${test}_PARAMETERS})
   endforeach()

--- a/libs/collectives/tests/unit/CMakeLists.txt
+++ b/libs/collectives/tests/unit/CMakeLists.txt
@@ -34,11 +34,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/Modules/Collectives")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Modules/Collectives")
 
   add_hpx_unit_test("modules.collectives" ${test} ${${test}_PARAMETERS})
 endforeach()

--- a/libs/compute/tests/regressions/CMakeLists.txt
+++ b/libs/compute/tests/regressions/CMakeLists.txt
@@ -19,11 +19,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Regressions/Compute")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/Compute")
 
   target_include_directories(${test}_test SYSTEM PRIVATE ${CUDA_INCLUDE_DIRS})
   add_hpx_regression_test("modules.compute" ${test} ${${test}_PARAMETERS})

--- a/libs/compute/tests/unit/CMakeLists.txt
+++ b/libs/compute/tests/unit/CMakeLists.txt
@@ -16,11 +16,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/Compute/Host")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Compute/Host")
 
   target_include_directories(${test}_test SYSTEM PRIVATE ${CUDA_INCLUDE_DIRS})
   add_hpx_unit_test("modules.compute" ${test} ${${test}_PARAMETERS})

--- a/libs/compute_cuda/examples/CMakeLists.txt
+++ b/libs/compute_cuda/examples/CMakeLists.txt
@@ -75,9 +75,10 @@ foreach(example_program ${example_programs})
 
   # add example executable
   add_hpx_executable(${example_program}
-                     SOURCES ${sources}
-                     ${${example_program}_FLAGS}
-                     FOLDER "Examples/Compute/CUDA")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${example_program}_FLAGS}
+    FOLDER "Examples/Compute/CUDA")
 
   add_hpx_example_target_dependencies("modules.compute_cuda" ${example_program})
 

--- a/libs/compute_cuda/tests/performance/CMakeLists.txt
+++ b/libs/compute_cuda/tests/performance/CMakeLists.txt
@@ -24,11 +24,12 @@ foreach(benchmark ${benchmarks})
 
   # add example executable
   add_hpx_executable(${benchmark}_test
-                     SOURCES ${sources}
-                     ${${benchmark}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Benchmarks/Modules/ComputeCuda")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${benchmark}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Benchmarks/Modules/ComputeCuda")
 
   add_hpx_performance_test("modules.compute_cuda" ${benchmark} ${${benchmark}_PARAMETERS})
 endforeach()

--- a/libs/compute_cuda/tests/unit/CMakeLists.txt
+++ b/libs/compute_cuda/tests/unit/CMakeLists.txt
@@ -33,11 +33,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/Compute/CUDA")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Compute/CUDA")
 
   add_hpx_unit_test("modules.compute_cuda" ${test} ${${test}_PARAMETERS})
 endforeach()

--- a/libs/datastructures/tests/regressions/CMakeLists.txt
+++ b/libs/datastructures/tests/regressions/CMakeLists.txt
@@ -19,10 +19,11 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     FOLDER ${folder_name})
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    FOLDER ${folder_name})
 
   add_hpx_regression_test("modules.datastructures" ${test} ${${test}_PARAMETERS})
 endforeach()

--- a/libs/datastructures/tests/unit/CMakeLists.txt
+++ b/libs/datastructures/tests/unit/CMakeLists.txt
@@ -22,10 +22,11 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     FOLDER ${folder_name})
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    FOLDER ${folder_name})
 
   add_hpx_unit_test("modules.datastructures" ${test} ${${test}_PARAMETERS})
 endforeach()

--- a/libs/errors/tests/unit/CMakeLists.txt
+++ b/libs/errors/tests/unit/CMakeLists.txt
@@ -21,11 +21,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     ${${test}_LIBS}
-                     EXCLUDE_FROM_ALL
-                     FOLDER ${folder_name})
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    ${${test}_LIBS}
+    EXCLUDE_FROM_ALL
+    FOLDER ${folder_name})
 
   add_hpx_unit_test("modules.errors" ${test} ${${test}_PARAMETERS})
 endforeach()

--- a/libs/execution/tests/regressions/CMakeLists.txt
+++ b/libs/execution/tests/regressions/CMakeLists.txt
@@ -31,11 +31,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Regressions/Modules/Execution")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/Modules/Execution")
 
   add_hpx_regression_test("modules.execution" ${test} ${${test}_PARAMETERS})
 

--- a/libs/execution/tests/unit/CMakeLists.txt
+++ b/libs/execution/tests/unit/CMakeLists.txt
@@ -42,11 +42,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER ${folder_name})
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER ${folder_name})
 
   add_hpx_unit_test("modules.execution" ${test} ${${test}_PARAMETERS})
 

--- a/libs/functional/tests/unit/CMakeLists.txt
+++ b/libs/functional/tests/unit/CMakeLists.txt
@@ -28,11 +28,12 @@ foreach(test ${function_tests})
   source_group("Source Files" FILES ${sources})
 
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     NOLIBS
-                     DEPENDENCIES hpx_functional hpx_testing
-                     EXCLUDE_FROM_ALL
-                     FOLDER "Tests/Unit/Modules/Functional/Function")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    NOLIBS
+    DEPENDENCIES hpx_functional hpx_testing
+    EXCLUDE_FROM_ALL
+    FOLDER "Tests/Unit/Modules/Functional/Function")
 
   add_hpx_unit_test("modules.functional.function" ${test})
 

--- a/libs/iterator_support/tests/unit/CMakeLists.txt
+++ b/libs/iterator_support/tests/unit/CMakeLists.txt
@@ -31,12 +31,13 @@ foreach(test ${tests})
   source_group("Source Files" FILES ${sources})
 
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     ${${test}_LIBS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/Modules/IteratorSupport")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    ${${test}_LIBS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Modules/IteratorSupport")
 
   add_hpx_unit_test("modules.iterator_support" ${test} ${${test}_PARAMETERS})
 

--- a/libs/memory/tests/unit/CMakeLists.txt
+++ b/libs/memory/tests/unit/CMakeLists.txt
@@ -22,12 +22,13 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     NOLIBS
-                     DEPENDENCIES hpx_memory hpx_testing
-                     FOLDER "Tests/Unit/Modules/Memory")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    NOLIBS
+    DEPENDENCIES hpx_memory hpx_testing
+    FOLDER "Tests/Unit/Modules/Memory")
 
   add_hpx_unit_test("modules.memory" ${test} ${${test}_PARAMETERS})
   target_compile_definitions(${test}_test PRIVATE -DHPX_MODULE_STATIC_LINKING)

--- a/libs/program_options/examples/CMakeLists.txt
+++ b/libs/program_options/examples/CMakeLists.txt
@@ -39,10 +39,11 @@ if (HPX_WITH_EXAMPLES)
 
     # add example executable
     add_hpx_executable(${example}
-                        SOURCES ${sources}
-                        ${${example}_FLAGS}
-                        DEPENDENCIES ${${example}_LIBS}
-                        FOLDER ${folder_name})
+      INTERNAL_FLAGS
+      SOURCES ${sources}
+      ${${example}_FLAGS}
+      DEPENDENCIES ${${example}_LIBS}
+      FOLDER ${folder_name})
 
     add_hpx_example_target_dependencies(
       "modules.program_options" ${example} ${${example}_PARAMETERS})

--- a/libs/program_options/tests/regressions/CMakeLists.txt
+++ b/libs/program_options/tests/regressions/CMakeLists.txt
@@ -22,10 +22,11 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     FOLDER ${folder_name})
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    FOLDER ${folder_name})
 
   add_hpx_regression_test("modules.program_options" ${test} ${${test}_PARAMETERS})
 endforeach()

--- a/libs/program_options/tests/unit/CMakeLists.txt
+++ b/libs/program_options/tests/unit/CMakeLists.txt
@@ -33,10 +33,11 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     FOLDER ${folder_name})
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    FOLDER ${folder_name})
 
   add_hpx_unit_test("modules.program_options" ${test} ${${test}_PARAMETERS})
 endforeach()

--- a/libs/resiliency/examples/CMakeLists.txt
+++ b/libs/resiliency/examples/CMakeLists.txt
@@ -31,9 +31,10 @@ if (HPX_WITH_EXAMPLES)
 
     # add example executable
     add_hpx_executable(${example_program}
-                       SOURCES ${sources}
-                       ${${example_program}_FLAGS}
-                       FOLDER "Examples/Modules/Resiliency")
+      INTERNAL_FLAGS
+      SOURCES ${sources}
+      ${${example_program}_FLAGS}
+      FOLDER "Examples/Modules/Resiliency")
 
     add_hpx_example_target_dependencies("modules.resiliency" ${example_program})
 

--- a/libs/resiliency/tests/performance/replay/CMakeLists.txt
+++ b/libs/resiliency/tests/performance/replay/CMakeLists.txt
@@ -25,8 +25,8 @@ foreach(benchmark ${benchmarks})
   source_group("Source Files" FILES ${sources})
 
   # add benchmark executable
-  add_hpx_executable(
-    ${benchmark}_test
+  add_hpx_executable(${benchmark}_test
+    INTERNAL_FLAGS
     SOURCES ${sources}
     EXCLUDE_FROM_ALL
     ${${benchmark}_FLAGS}

--- a/libs/resiliency/tests/performance/replicate/CMakeLists.txt
+++ b/libs/resiliency/tests/performance/replicate/CMakeLists.txt
@@ -23,8 +23,8 @@ foreach(benchmark ${benchmarks})
   source_group("Source Files" FILES ${sources})
 
   # add benchmark executable
-  add_hpx_executable(
-    ${benchmark}_test
+  add_hpx_executable(${benchmark}_test
+    INTERNAL_FLAGS
     SOURCES ${sources}
     EXCLUDE_FROM_ALL
     ${${benchmark}_FLAGS}

--- a/libs/segmented_algorithms/tests/performance/CMakeLists.txt
+++ b/libs/segmented_algorithms/tests/performance/CMakeLists.txt
@@ -15,12 +15,13 @@ foreach(benchmark ${benchmarks})
 
   # add example executable
   add_hpx_executable(${benchmark}_test
-                     SOURCES ${sources}
-                     ${${benchmark}_FLAGS}
-                     DEPENDENCIES iostreams_component partitioned_vector_component
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Benchmarks/Modules/SegmentedAlgorithms")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${benchmark}_FLAGS}
+    DEPENDENCIES iostreams_component partitioned_vector_component
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Benchmarks/Modules/SegmentedAlgorithms")
 
   add_hpx_performance_test("modules.segmented_algorithms" ${benchmark} ${${benchmark}_PARAMETERS})
 endforeach()

--- a/libs/segmented_algorithms/tests/unit/CMakeLists.txt
+++ b/libs/segmented_algorithms/tests/unit/CMakeLists.txt
@@ -61,11 +61,13 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER ${folder_name})
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER ${folder_name})
+
   if(HPX_WITH_CUDA)
     target_include_directories(${test}_test SYSTEM PRIVATE ${CUDA_INCLUDE_DIRS})
     target_link_libraries(${test}_test PRIVATE ${${${test}}_LIBRARIES})

--- a/libs/serialization/tests/performance/CMakeLists.txt
+++ b/libs/serialization/tests/performance/CMakeLists.txt
@@ -25,10 +25,11 @@ foreach(benchmark ${benchmarks})
 
   # add example executable
   add_hpx_executable(${benchmark}_test
-                     SOURCES ${sources}
-                     ${${benchmark}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     FOLDER ${folder_name})
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${benchmark}_FLAGS}
+    EXCLUDE_FROM_ALL
+    FOLDER ${folder_name})
 
   add_hpx_performance_test("modules.serialization"
     ${benchmark} ${${benchmark}_PARAMETERS})

--- a/libs/serialization/tests/regressions/CMakeLists.txt
+++ b/libs/serialization/tests/regressions/CMakeLists.txt
@@ -18,10 +18,11 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     FOLDER ${folder_name})
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    FOLDER ${folder_name})
 
   add_hpx_regression_test("modules.serialization" ${test} ${${test}_PARAMETERS})
 endforeach()

--- a/libs/serialization/tests/unit/CMakeLists.txt
+++ b/libs/serialization/tests/unit/CMakeLists.txt
@@ -52,12 +52,13 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     NOLIBS
-                     DEPENDENCIES hpx_serialization hpx_testing
-                     FOLDER ${folder_name})
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    NOLIBS
+    DEPENDENCIES hpx_serialization hpx_testing
+    FOLDER ${folder_name})
 
   add_hpx_unit_test("modules.serialization" ${test} ${${test}_PARAMETERS})
   target_compile_definitions(${test}_test PRIVATE -DHPX_MODULE_STATIC_LINKING)
@@ -75,10 +76,11 @@ foreach(test ${full_tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     FOLDER ${folder_name})
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    FOLDER ${folder_name})
 
   add_hpx_unit_test("modules.serialization" ${test} ${${test}_PARAMETERS})
 

--- a/libs/serialization/tests/unit/polymorphic/CMakeLists.txt
+++ b/libs/serialization/tests/unit/polymorphic/CMakeLists.txt
@@ -23,12 +23,13 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     NOLIBS
-                     DEPENDENCIES hpx_serialization hpx_testing
-                     FOLDER "Tests/Unit/Modules/Serialization/Polymorphic")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    NOLIBS
+    DEPENDENCIES hpx_serialization hpx_testing
+    FOLDER "Tests/Unit/Modules/Serialization/Polymorphic")
 
   add_hpx_unit_test("modules.serialization" ${test} ${${test}_PARAMETERS})
   target_compile_definitions(${test}_test PRIVATE -DHPX_MODULE_STATIC_LINKING)

--- a/plugins/binary_filter/bzip2/CMakeLists.txt
+++ b/plugins/binary_filter/bzip2/CMakeLists.txt
@@ -20,6 +20,7 @@ if(HPX_WITH_COMPRESSION_BZIP2)
   hpx_debug("add_bzip2_module" "BZIP2_FOUND: ${BZIP2_FOUND}")
 
   add_hpx_library(compress_bzip2
+    INTERNAL_FLAGS
     PLUGIN
     SOURCES
       "${PROJECT_SOURCE_DIR}/plugins/binary_filter/bzip2/bzip2_serialization_filter.cpp"

--- a/plugins/binary_filter/snappy/CMakeLists.txt
+++ b/plugins/binary_filter/snappy/CMakeLists.txt
@@ -14,6 +14,7 @@ if(HPX_WITH_COMPRESSION_SNAPPY)
 
   hpx_debug("add_snappy_module" "SNAPPY_FOUND: ${SNAPPY_FOUND}")
   add_hpx_library(compress_snappy
+    INTERNAL_FLAGS
     PLUGIN
     SOURCES
       "${PROJECT_SOURCE_DIR}/plugins/binary_filter/snappy/snappy_serialization_filter.cpp"

--- a/plugins/binary_filter/zlib/CMakeLists.txt
+++ b/plugins/binary_filter/zlib/CMakeLists.txt
@@ -24,6 +24,7 @@ if(HPX_WITH_COMPRESSION_ZLIB)
 
   include(HPX_AddLibrary)
   add_hpx_library(compress_zlib
+    INTERNAL_FLAGS
     PLUGIN
     SOURCES
       "${PROJECT_SOURCE_DIR}/plugins/binary_filter/zlib/zlib_serialization_filter.cpp"

--- a/plugins/parcel/coalescing/CMakeLists.txt
+++ b/plugins/parcel/coalescing/CMakeLists.txt
@@ -9,17 +9,18 @@ include(HPX_AddLibrary)
 if(HPX_WITH_PARCEL_COALESCING)
   hpx_debug("add_coalescing_module")
   add_hpx_library(parcel_coalescing
-      PLUGIN
-      SOURCES
-          "${PROJECT_SOURCE_DIR}/plugins/parcel/coalescing/coalescing_message_handler.cpp"
-          "${PROJECT_SOURCE_DIR}/plugins/parcel/coalescing/coalescing_counter_registry.cpp"
-          "${PROJECT_SOURCE_DIR}/plugins/parcel/coalescing/performance_counters.cpp"
-      HEADERS
-            "${PROJECT_SOURCE_DIR}/hpx/plugins/parcel/coalescing_message_handler_registration.hpp"
-            "${PROJECT_SOURCE_DIR}/hpx/plugins/parcel/coalescing_message_handler.hpp"
-            "${PROJECT_SOURCE_DIR}/hpx/plugins/parcel/coalescing_counter_registry.hpp"
-            "${PROJECT_SOURCE_DIR}/hpx/plugins/parcel/message_buffer.hpp"
-      FOLDER "Core/Plugins/MessageHandler"
+    INTERNAL_FLAGS
+    PLUGIN
+    SOURCES
+      "${PROJECT_SOURCE_DIR}/plugins/parcel/coalescing/coalescing_message_handler.cpp"
+      "${PROJECT_SOURCE_DIR}/plugins/parcel/coalescing/coalescing_counter_registry.cpp"
+      "${PROJECT_SOURCE_DIR}/plugins/parcel/coalescing/performance_counters.cpp"
+    HEADERS
+      "${PROJECT_SOURCE_DIR}/hpx/plugins/parcel/coalescing_message_handler_registration.hpp"
+      "${PROJECT_SOURCE_DIR}/hpx/plugins/parcel/coalescing_message_handler.hpp"
+      "${PROJECT_SOURCE_DIR}/hpx/plugins/parcel/coalescing_counter_registry.hpp"
+      "${PROJECT_SOURCE_DIR}/hpx/plugins/parcel/message_buffer.hpp"
+    FOLDER "Core/Plugins/MessageHandler"
       )
 
   if (TARGET hpx::apex)

--- a/tests/performance/local/CMakeLists.txt
+++ b/tests/performance/local/CMakeLists.txt
@@ -193,11 +193,12 @@ foreach(benchmark ${benchmarks})
 
   # add example executable
   add_hpx_executable(${benchmark}_test
-                     SOURCES ${sources}
-                     ${${benchmark}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Benchmarks/Local")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${benchmark}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Benchmarks/Local")
 
   target_include_directories(${benchmark}_test SYSTEM PRIVATE ${${benchmark}_INCLUDE_DIRECTORIES})
   target_link_libraries(${benchmark}_test PRIVATE ${${benchmark}_LIBRARIES})

--- a/tests/performance/local/htts_v2/CMakeLists.txt
+++ b/tests/performance/local/htts_v2/CMakeLists.txt
@@ -68,11 +68,12 @@ foreach(benchmark ${benchmarks})
 
   # add example executable
   add_hpx_executable(${benchmark}
-                     SOURCES ${sources}
-                     ${${benchmark}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Benchmarks/HTTS v2/${benchmark}")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${benchmark}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Benchmarks/HTTS v2/${benchmark}")
 
   target_compile_definitions(${benchmark} PRIVATE HPX_MODULE_STATIC_LINKING)
   target_include_directories(${benchmark} SYSTEM PRIVATE ${${benchmark}_INCLUDE_DIRECTORIES})

--- a/tests/performance/network/CMakeLists.txt
+++ b/tests/performance/network/CMakeLists.txt
@@ -26,12 +26,13 @@ foreach(benchmark ${benchmarks})
 
   # add example executable
   add_hpx_executable(${benchmark}
-                     SOURCES ${sources}
-                     ${${benchmark}_FLAGS}
-                     COMPONENT_DEPENDENCIES iostreams
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Benchmarks/Network/${benchmark}")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${benchmark}_FLAGS}
+    COMPONENT_DEPENDENCIES iostreams
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Benchmarks/Network/${benchmark}")
 
   # add a custom target for this example
   add_hpx_pseudo_target(tests.performance.network.${benchmark})

--- a/tests/performance/network/network_storage/CMakeLists.txt
+++ b/tests/performance/network/network_storage/CMakeLists.txt
@@ -7,6 +7,7 @@
 ###############################################################################
 
 add_hpx_executable(network_storage
+  INTERNAL_FLAGS
   AUTOGLOB
   EXCLUDE_FROM_ALL
   HPX_PREFIX ${HPX_BUILD_PREFIX}

--- a/tests/regressions/CMakeLists.txt
+++ b/tests/regressions/CMakeLists.txt
@@ -45,11 +45,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Regressions/")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/")
 
   add_hpx_regression_test("" ${test} ${${test}_PARAMETERS})
 

--- a/tests/regressions/actions/CMakeLists.txt
+++ b/tests/regressions/actions/CMakeLists.txt
@@ -44,11 +44,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Regressions/Actions")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/Actions")
 
   add_hpx_regression_test("actions" ${test} ${${test}_PARAMETERS})
 

--- a/tests/regressions/agas/CMakeLists.txt
+++ b/tests/regressions/agas/CMakeLists.txt
@@ -26,11 +26,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Regressions/AGAS")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/AGAS")
 
   add_hpx_regression_test("agas" ${test} ${${test}_PARAMETERS})
 

--- a/tests/regressions/block_matrix/CMakeLists.txt
+++ b/tests/regressions/block_matrix/CMakeLists.txt
@@ -14,11 +14,12 @@ if(HPX_WITH_CXX11_DEFAULTED_FUNCTIONS)
   source_group("Source Files" FILES ${sources})
 
   add_hpx_executable(block_matrix_test
-                     SOURCES ${sources}
-                     ${block_matrix_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Regressions/Block-Matrix")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${block_matrix_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/Block-Matrix")
 
   add_hpx_regression_test("block_matrix" block_matrix ${block_matrix_PARAMETERS})
 

--- a/tests/regressions/component/CMakeLists.txt
+++ b/tests/regressions/component/CMakeLists.txt
@@ -30,11 +30,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Regressions/Components")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/Components")
 
   add_hpx_regression_test("components" ${test} ${${test}_PARAMETERS})
 

--- a/tests/regressions/lcos/CMakeLists.txt
+++ b/tests/regressions/lcos/CMakeLists.txt
@@ -90,11 +90,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Regressions/LCOs")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/LCOs")
 
   target_link_libraries(${test}_test PRIVATE ${${test}_LIBRARIES})
   add_hpx_regression_test("lcos" ${test} ${${test}_PARAMETERS})

--- a/tests/regressions/performance_counters/CMakeLists.txt
+++ b/tests/regressions/performance_counters/CMakeLists.txt
@@ -19,19 +19,21 @@ foreach(test ${tests})
   # add example executable
   if(${test} MATCHES "^papi_.*")
     add_hpx_executable(${test}_test
-                       SOURCES ${sources}
-                       COMPONENT_DEPENDENCIES "papi_counters"
-                       ${${test}_FLAGS}
-                       EXCLUDE_FROM_ALL
-                       HPX_PREFIX ${HPX_BUILD_PREFIX}
-                       FOLDER "Tests/Regressions/PerformanceCounters")
+      INTERNAL_FLAGS
+      SOURCES ${sources}
+      COMPONENT_DEPENDENCIES "papi_counters"
+      ${${test}_FLAGS}
+      EXCLUDE_FROM_ALL
+      HPX_PREFIX ${HPX_BUILD_PREFIX}
+      FOLDER "Tests/Regressions/PerformanceCounters")
   else()
     add_hpx_executable(${test}_test
-                       SOURCES ${sources}
-                       ${${test}_FLAGS}
-                       EXCLUDE_FROM_ALL
-                       HPX_PREFIX ${HPX_BUILD_PREFIX}
-                       FOLDER "Tests/Regressions/PerformanceCounters")
+      INTERNAL_FLAGS
+      SOURCES ${sources}
+      ${${test}_FLAGS}
+      EXCLUDE_FROM_ALL
+      HPX_PREFIX ${HPX_BUILD_PREFIX}
+      FOLDER "Tests/Regressions/PerformanceCounters")
   endif()
 
   add_hpx_regression_test("performance_counters" ${test} ${${test}_PARAMETERS})

--- a/tests/regressions/threads/CMakeLists.txt
+++ b/tests/regressions/threads/CMakeLists.txt
@@ -39,11 +39,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Regressions/Threads")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/Threads")
 
   add_hpx_regression_test("threads" ${test} ${${test}_PARAMETERS})
 

--- a/tests/regressions/traits/CMakeLists.txt
+++ b/tests/regressions/traits/CMakeLists.txt
@@ -17,11 +17,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Regressions/Traits")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/Traits")
 
   add_hpx_regression_test("traits" ${test} ${${test}_PARAMETERS})
 

--- a/tests/regressions/util/CMakeLists.txt
+++ b/tests/regressions/util/CMakeLists.txt
@@ -49,11 +49,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Regressions/Util")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/Util")
 
   add_hpx_regression_test("util" ${test} ${${test}_PARAMETERS})
 

--- a/tests/unit/actions/CMakeLists.txt
+++ b/tests/unit/actions/CMakeLists.txt
@@ -17,11 +17,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/Actions")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Actions")
 
   add_hpx_unit_test("actions" ${test} ${${test}_PARAMETERS})
 

--- a/tests/unit/agas/CMakeLists.txt
+++ b/tests/unit/agas/CMakeLists.txt
@@ -114,11 +114,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/AGAS")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/AGAS")
 
   add_hpx_unit_test("agas" ${test} ${${test}_PARAMETERS})
 

--- a/tests/unit/apex/CMakeLists.txt
+++ b/tests/unit/apex/CMakeLists.txt
@@ -17,11 +17,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/Apex")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Apex")
 
   add_hpx_unit_test("apex" ${test} ${${test}_PARAMETERS})
 

--- a/tests/unit/component/CMakeLists.txt
+++ b/tests/unit/component/CMakeLists.txt
@@ -35,6 +35,7 @@ if(HPX_WITH_NETWORKING)
 
     # add executable needed for launch_process_test
     add_hpx_executable(launched_process_test
+      INTERNAL_FLAGS
       SOURCES launched_process.cpp
       EXCLUDE_FROM_ALL
       HPX_PREFIX ${HPX_BUILD_PREFIX}
@@ -110,11 +111,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER ${folder_name})
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER ${folder_name})
 
   add_hpx_unit_test("component" ${test} ${${test}_PARAMETERS})
 

--- a/tests/unit/diagnostics/CMakeLists.txt
+++ b/tests/unit/diagnostics/CMakeLists.txt
@@ -27,11 +27,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/Diagnostics")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Diagnostics")
 
   add_hpx_unit_test("diagnostics" ${test} ${${test}_PARAMETERS})
 

--- a/tests/unit/lcos/CMakeLists.txt
+++ b/tests/unit/lcos/CMakeLists.txt
@@ -127,11 +127,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER ${folder_name})
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER ${folder_name})
 
   add_hpx_unit_test("lcos" ${test} ${${test}_PARAMETERS})
 

--- a/tests/unit/lcos/shared_mutex/CMakeLists.txt
+++ b/tests/unit/lcos/shared_mutex/CMakeLists.txt
@@ -22,11 +22,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/LCOs/SharedMutex")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/LCOs/SharedMutex")
 
   add_hpx_unit_test("lcos.shared_mutex" ${test} ${${test}_PARAMETERS})
 

--- a/tests/unit/parallel_block/CMakeLists.txt
+++ b/tests/unit/parallel_block/CMakeLists.txt
@@ -26,11 +26,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/ParallelBlock")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/ParallelBlock")
 
   add_hpx_unit_test("parallel_block" ${test} ${${test}_PARAMETERS})
 

--- a/tests/unit/parcelset/CMakeLists.txt
+++ b/tests/unit/parcelset/CMakeLists.txt
@@ -35,11 +35,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/Parcelset")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Parcelset")
 
   add_hpx_unit_test("parcelset" ${test} ${${test}_PARAMETERS})
 

--- a/tests/unit/performance_counter/CMakeLists.txt
+++ b/tests/unit/performance_counter/CMakeLists.txt
@@ -18,11 +18,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/PerformanceCounters/")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/PerformanceCounters/")
 
   add_hpx_unit_test("performance_counter" ${test} ${${test}_PARAMETERS})
 

--- a/tests/unit/resource/CMakeLists.txt
+++ b/tests/unit/resource/CMakeLists.txt
@@ -38,11 +38,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/ResourcePartitioner/")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/ResourcePartitioner/")
 
   add_hpx_unit_test("resource" ${test} ${${test}_PARAMETERS})
 

--- a/tests/unit/threads/CMakeLists.txt
+++ b/tests/unit/threads/CMakeLists.txt
@@ -72,12 +72,13 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     ${${test}_LIBRARIES}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/Threads")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    ${${test}_LIBRARIES}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Threads")
 
   add_hpx_unit_test("threads" ${test} ${${test}_PARAMETERS})
 

--- a/tests/unit/topology/CMakeLists.txt
+++ b/tests/unit/topology/CMakeLists.txt
@@ -28,11 +28,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/Topology/")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Topology/")
 
   add_hpx_unit_test("topology" ${test} ${${test}_PARAMETERS})
 

--- a/tests/unit/traits/CMakeLists.txt
+++ b/tests/unit/traits/CMakeLists.txt
@@ -16,11 +16,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/Traits/")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Traits/")
 
   add_hpx_unit_test("traits" ${test} ${${test}_PARAMETERS})
 

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -41,11 +41,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/Util/")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Util/")
 
   add_hpx_unit_test("util" ${test} ${${test}_PARAMETERS})
 

--- a/tests/unit/util/bind/CMakeLists.txt
+++ b/tests/unit/util/bind/CMakeLists.txt
@@ -26,11 +26,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/Util/Bind")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Util/Bind")
 
   add_hpx_unit_test("util.bind" ${test} ${${test}_PARAMETERS})
 

--- a/tests/unit/util/function/CMakeLists.txt
+++ b/tests/unit/util/function/CMakeLists.txt
@@ -16,11 +16,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/Util/Function")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Util/Function")
 
   add_hpx_unit_test("util.function" ${test} ${${test}_PARAMETERS})
 

--- a/tests/unit/util/iterator/CMakeLists.txt
+++ b/tests/unit/util/iterator/CMakeLists.txt
@@ -19,11 +19,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/Util/Iterator")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Util/Iterator")
 
   add_hpx_unit_test("util.iterator" ${test} ${${test}_PARAMETERS})
 

--- a/tests/unit/util/mem_fn/CMakeLists.txt
+++ b/tests/unit/util/mem_fn/CMakeLists.txt
@@ -22,11 +22,12 @@ foreach(test ${tests})
 
   # add example executable
   add_hpx_executable(${test}_test
-                     SOURCES ${sources}
-                     ${${test}_FLAGS}
-                     EXCLUDE_FROM_ALL
-                     HPX_PREFIX ${HPX_BUILD_PREFIX}
-                     FOLDER "Tests/Unit/Util/Mem_Fn")
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Util/Mem_Fn")
 
   add_hpx_unit_test("util.mem_fn" ${test} ${${test}_PARAMETERS})
 


### PR DESCRIPTION
This prevents external projects from inheriting hpx internal compile flags when using `hpx_setup_target`, `add_hpx_component`, `add_hpx_library` or `add_hpx_executable`.