### PR TITLE
Adding APEX dependency to MPI parcelport

### DIFF
--- a/plugins/parcelport/mpi/CMakeLists.txt
+++ b/plugins/parcelport/mpi/CMakeLists.txt
@@ -7,6 +7,10 @@
 
 include(HPX_AddLibrary)
 
+if (TARGET hpx::apex)
+  set(EXTRA_DEPENDENCIES hpx::apex)
+endif()
+
 ################################################################################
 # Decide whether to use the MPI based parcelport
 ################################################################################
@@ -45,6 +49,7 @@ if(HPX_WITH_PARCELPORT_MPI)
       hpx_util
       hpx::boost
       hpx::mpi
+      ${EXTRA_DEPENDENCIES}
     INCLUDE_DIRS
       ${PROJECT_SOURCE_DIR}
     FOLDER


### PR DESCRIPTION
I tried to do it like the TCP parcel port, but that didn't work.  This works.  Fixes #4169

Fixes #

## Proposed Changes

  -
  -
  -

## Any background context you want to provide?
