### PR TITLE
Wait for runtime to be running before returning from hpx::start

### DIFF
--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -460,7 +460,18 @@ namespace hpx
 
         // block if required
         if (blocking)
+        {
             return wait();     // wait for the shutdown_action to be executed
+        }
+        else
+        {
+            // wait for at least state_running
+            util::yield_while(
+                [this]()
+                {
+                    return get_state() < state_running;
+                }, "runtime_impl::start");
+        }
 
         // Register this thread with the runtime system to allow calling certain
         // HPX functionality from the main thread.

--- a/tests/performance/local/resume_suspend.cpp
+++ b/tests/performance/local/resume_suspend.cpp
@@ -38,11 +38,6 @@ int main(int argc, char ** argv)
     std::uint64_t repetitions = vm["repetitions"].as<std::uint64_t>();
 
     hpx::start(nullptr, desc_commandline, argc, argv);
-    hpx::runtime* rt = hpx::get_runtime_ptr();
-    hpx::util::yield_while([rt]()
-        {
-            return rt->get_state() < hpx::state_running;
-        });
     hpx::suspend();
 
     std::uint64_t threads = hpx::resource::get_num_threads("default");

--- a/tests/unit/resource/suspend_runtime.cpp
+++ b/tests/unit/resource/suspend_runtime.cpp
@@ -34,12 +34,6 @@ void test_scheduler(int argc, char* argv[],
     rp.create_thread_pool("default", scheduler);
 
     hpx::start(nullptr, argc, argv);
-
-    // Wait for runtime to start
-    hpx::runtime* rt = hpx::get_runtime_ptr();
-    hpx::util::yield_while([rt]()
-        { return rt->get_state() < hpx::state_running; });
-
     hpx::suspend();
 
     hpx::util::high_resolution_timer t;


### PR DESCRIPTION
Makes `hpx::start` return slightly later, but means that users don't have to worry about waiting for `state_running` manually before calling `hpx::suspend`.