### PR TITLE
Small const fix to basic_execution module

### DIFF
--- a/libs/basic_execution/include/hpx/basic_execution/agent_ref.hpp
+++ b/libs/basic_execution/include/hpx/basic_execution/agent_ref.hpp
@@ -38,7 +38,7 @@ namespace hpx { namespace basic_execution {
         HPX_CXX14_CONSTEXPR agent_ref& operator=(
             agent_ref&&) noexcept = default;
 
-        constexpr explicit operator bool() noexcept
+        constexpr explicit operator bool() const noexcept
         {
             return impl_ != nullptr;
         }


### PR DESCRIPTION
Building with C++11 gives the warning about constexpr not being implicitly const in newer standards. This adds the explicit const.