### PR TITLE
Only use quick_exit if available

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -624,6 +624,13 @@ function(hpx_check_for_cxx11_override)
 endfunction()
 
 ###############################################################################
+function(hpx_check_for_cxx11_std_quick_exit)
+  add_hpx_config_test(HPX_WITH_CXX11_STD_QUICK_EXIT
+    SOURCE cmake/tests/cxx11_std_quick_exit.cpp
+    FILE ${ARGN})
+endfunction()
+
+###############################################################################
 function(hpx_check_for_cxx14_constexpr)
   add_hpx_config_test(HPX_WITH_CXX14_CONSTEXPR
     SOURCE cmake/tests/cxx14_constexpr.cpp

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -124,6 +124,9 @@ function(hpx_perform_cxx_feature_tests)
   hpx_check_for_cxx11_std_lock_guard(
     REQUIRED "HPX needs support for C++11 std::lock_guard")
 
+  hpx_check_for_cxx11_std_quick_exit(
+    DEFINITIONS HPX_HAVE_CXX11_STD_QUICK_EXIT)
+
   hpx_check_for_cxx11_std_random(
     DEFINITIONS HPX_HAVE_CXX11_STD_RANDOM)
 

--- a/cmake/tests/cxx11_std_quick_exit.cpp
+++ b/cmake/tests/cxx11_std_quick_exit.cpp
@@ -1,0 +1,17 @@
+////////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2019 Mikael Simberg
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+////////////////////////////////////////////////////////////////////////////////
+
+#include <cstdlib>
+
+void on_exit() {}
+
+int main()
+{
+    std::at_quick_exit(on_exit);
+    std::quick_exit(0);
+}

--- a/hpx/hpx_init_impl.hpp
+++ b/hpx/hpx_init_impl.hpp
@@ -76,8 +76,10 @@ namespace hpx
 #endif
         // set a handler for std::abort
         std::signal(SIGABRT, detail::on_abort);
-        std::at_quick_exit(detail::on_exit);
         std::atexit(detail::on_exit);
+#if defined(HPX_HAVE_CXX11_STD_QUICK_EXIT)
+        std::at_quick_exit(detail::on_exit);
+#endif
 
         return detail::run_or_start(f, desc_cmdline, argc, argv,
             hpx_startup::user_main_config(cfg),

--- a/hpx/hpx_start_impl.hpp
+++ b/hpx/hpx_start_impl.hpp
@@ -77,8 +77,10 @@ namespace hpx
 #endif
         // set a handler for std::abort, std::at_quick_exit, and std::atexit
         std::signal(SIGABRT, detail::on_abort);
-        std::at_quick_exit(detail::on_exit);
         std::atexit(detail::on_exit);
+#if defined(HPX_HAVE_CXX11_STD_QUICK_EXIT)
+        std::at_quick_exit(detail::on_exit);
+#endif
 
         return 0 == detail::run_or_start(f, desc_cmdline, argc, argv,
             hpx_startup::user_main_config(cfg),


### PR DESCRIPTION
`quick_exit` is not always available on macOS.