### PR TITLE
Add scheduling hints to hello_world_distributed

### DIFF
--- a/docs/sphinx/examples/hello_world.rst
+++ b/docs/sphinx/examples/hello_world.rst
@@ -75,7 +75,9 @@ Now that you have compiled and run the code, let's look at how the code works,
 beginning with ``main()``:
 
 .. literalinclude:: ../../examples/quickstart/hello_world_distributed.cpp
-   :lines: 130-156
+   :language: c++
+   :start-after: //[hello_world_hpx_main
+   :end-before: //]
 
 In this excerpt of the code we again see the use of futures. This time the
 futures are stored in a vector so that they can easily be accessed.
@@ -96,7 +98,9 @@ As in :ref:`examples_fibonacci` our futures are set using
 here:
 
 .. literalinclude:: ../../examples/quickstart/hello_world_distributed.cpp
-   :lines: 123-125
+   :language: c++
+   :start-after: //[hello_world_action_wrapper
+   :end-before: //]
 
 Another way of thinking about this wrapping technique is as follows: functions
 (the work to be done) are wrapped in actions, and actions can be executed
@@ -106,7 +110,9 @@ Now it is time to look at the ``hello_world_foreman()`` function which was
 wrapped in the action above:
 
 .. literalinclude:: ../../examples/quickstart/hello_world_distributed.cpp
-   :lines: 66-119
+   :language: c++
+   :start-after: //[hello_world_foreman
+   :end-before: //]
 
 Now, before we discuss ``hello_world_foreman()``, let's talk about the
 :cpp:func:`hpx::wait_each()` function.
@@ -122,7 +128,9 @@ executing on the correct OS-thread, it returns a value of -1, which causes
 ``hello_world_foreman()`` to leave the OS-thread id in ``attendance``.
 
 .. literalinclude:: ../../examples/quickstart/hello_world_distributed.cpp
-   :lines: 37-61
+   :language: c++
+   :start-after: //[hello_world_worker
+   :end-before: //]
 
 Because |hpx| features work stealing task schedulers, there is no way to
 guarantee that an action will be scheduled on a particular OS-thread. This is


### PR DESCRIPTION
This both makes sure tasks are scheduled sooner on the correct worker threads and avoids certain infinite loops in which the foreman thread always gets scheduled on an odd-numbered thread and the last worker task always gets scheduled on an even-numbered thread, or vice versa, because of round-robin scheduling. With an even number of worker threads this can lead to the worker thread never being scheduled on the correct thread. This commit adds scheduling hints to the worker tasks to ensure this will not happen. To make this happen `hello_world_worker` is no longer an action, but this is appropriate as it's only called locally.