### PR TITLE
Fix execution_agent.cpp compilation with GCC 5

### DIFF
--- a/src/runtime/threads/execution_agent.cpp
+++ b/src/runtime/threads/execution_agent.cpp
@@ -142,7 +142,8 @@ namespace hpx { namespace threads {
 #endif
             HPX_ASSERT(get_thread_id_data(id)->get_state().state() == active);
             HPX_ASSERT(state != active);
-            statex = self_.yield(threads::thread_result_type(state, nullptr));
+            statex = self_.yield(threads::thread_result_type(state,
+                threads::thread_id_type{nullptr}));
             HPX_ASSERT(get_thread_id_data(id)->get_state().state() == active);
         }
 


### PR DESCRIPTION
Fixes
```
/buildbot/rostam/slave_rostam/hpx_gcc_5_boost_1_62_centos_x86_64_release/src/src/runtime/threads/execution_agent.cpp:145:76: error: no matching function for call to ‘std::pair<hpx::threads::thread_state_enum, hpx::threads::thread_id>::pair(hpx::threads::thread_state_enum&, std::nullptr_t)’
             statex = self_.yield(threads::thread_result_type(state, nullptr));
```
caused by the implicit conversion required from `nullptr_t` to `thread_id`. GCC 6 onwards accepts the code as it is.