### PR TITLE
Fix APEX build

### DIFF
--- a/libs/collectives/CMakeLists.txt
+++ b/libs/collectives/CMakeLists.txt
@@ -87,6 +87,4 @@ add_hpx_module(collectives
 # module that link to apex, and we'd be able to remove this.
 if (TARGET hpx::apex)
   target_link_libraries(hpx_collectives PRIVATE hpx::apex)
-  get_target_property(_apex_inc_dir hpx::apex INTERFACE_INCLUDE_DIRECTORIES)
-  target_include_directories(hpx_collectives INTERFACE "${_apex_inc_dir}")
 endif()

--- a/libs/compute/CMakeLists.txt
+++ b/libs/compute/CMakeLists.txt
@@ -66,6 +66,4 @@ add_hpx_module(compute
 # module that link to apex, and we'd be able to remove this.
 if (TARGET hpx::apex)
   target_link_libraries(hpx_compute PRIVATE hpx::apex)
-  get_target_property(_apex_inc_dir hpx::apex INTERFACE_INCLUDE_DIRECTORIES)
-  target_include_directories(hpx_compute INTERFACE "${_apex_inc_dir}")
 endif()

--- a/libs/compute_cuda/CMakeLists.txt
+++ b/libs/compute_cuda/CMakeLists.txt
@@ -62,3 +62,7 @@ add_hpx_module(compute_cuda
     hpx_serialization
   CMAKE_SUBDIRS examples tests
 )
+
+if (TARGET hpx::apex)
+  target_link_libraries(hpx_compute_cuda PRIVATE hpx::apex)
+endif()

--- a/libs/resource_partitioner/CMakeLists.txt
+++ b/libs/resource_partitioner/CMakeLists.txt
@@ -56,6 +56,4 @@ add_hpx_module(resource_partitioner
 
 if (TARGET hpx::apex)
   target_link_libraries(hpx_resource_partitioner PRIVATE hpx::apex)
-  get_target_property(_apex_inc_dir hpx::apex INTERFACE_INCLUDE_DIRECTORIES)
-  target_include_directories(hpx_compute INTERFACE "${_apex_inc_dir}")
 endif()

--- a/libs/threadmanager/CMakeLists.txt
+++ b/libs/threadmanager/CMakeLists.txt
@@ -45,3 +45,7 @@ add_hpx_module(threadmanager
     hpx_topology
   CMAKE_SUBDIRS examples tests
 )
+
+if (TARGET hpx::apex)
+  target_link_libraries(hpx_threadmanager PRIVATE hpx::apex)
+endif()


### PR DESCRIPTION
Adds APEX temporarily as a dependency to the `threadmanager` module.