### PR TITLE
Fix CUDA 10 build

### DIFF
--- a/libs/algorithms/include/hpx/parallel/util/detail/handle_local_exceptions.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/detail/handle_local_exceptions.hpp
@@ -10,6 +10,7 @@
 #define HPX_PARALLEL_UTIL_DETAIL_HANDLE_LOCAL_EXCEPTIONS_OCT_03_2014_0142PM
 
 #include <hpx/config.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/async.hpp>
 #include <hpx/errors.hpp>
 #include <hpx/hpx_finalize.hpp>
@@ -30,6 +31,9 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         // std::bad_alloc has to be handled separately
         HPX_NORETURN static void call(std::exception_ptr const& e)
         {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_ASSERT(false);
+#else
             try
             {
                 std::rethrow_exception(e);
@@ -42,11 +46,15 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             {
                 throw exception_list(e);
             }
+#endif
         }
 
         static void call(
             std::exception_ptr const& e, std::list<std::exception_ptr>& errors)
         {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_ASSERT(false);
+#else
             try
             {
                 std::rethrow_exception(e);
@@ -59,12 +67,16 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             {
                 errors.push_back(e);
             }
+#endif
         }
 
         template <typename T>
         static void call(std::vector<hpx::future<T>> const& workitems,
             std::list<std::exception_ptr>& errors, bool throw_errors = true)
         {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_ASSERT(false);
+#else
             for (hpx::future<T> const& f : workitems)
             {
                 if (f.has_exception())
@@ -73,6 +85,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
             if (throw_errors && !errors.empty())
                 throw exception_list(std::move(errors));
+#endif
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -80,6 +93,9 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         static void call(std::vector<hpx::shared_future<T>> const& workitems,
             std::list<std::exception_ptr>& errors, bool throw_errors = true)
         {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_ASSERT(false);
+#else
             for (hpx::shared_future<T> const& f : workitems)
             {
                 if (f.has_exception())
@@ -88,6 +104,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
             if (throw_errors && !errors.empty())
                 throw exception_list(std::move(errors));
+#endif
         }
 
         template <typename T, typename Cleanup>
@@ -95,6 +112,9 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             std::list<std::exception_ptr>& errors, Cleanup&& cleanup,
             bool throw_errors = true)
         {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_ASSERT(false);
+#else
             bool has_exception = false;
             std::exception_ptr bad_alloc_exception;
             for (hpx::future<T>& f : workitems)
@@ -135,6 +155,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
             if (throw_errors && !errors.empty())
                 throw exception_list(std::move(errors));
+#endif
         }
     };
 
@@ -144,46 +165,66 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         ///////////////////////////////////////////////////////////////////////
         HPX_NORETURN static void call(std::exception_ptr const&)
         {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_ASSERT(false);
+#else
             hpx::terminate();
+#endif
         }
 
         HPX_NORETURN static void call(
             std::exception_ptr const&, std::list<std::exception_ptr>&)
         {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_ASSERT(false);
+#else
             hpx::terminate();
+#endif
         }
 
         template <typename T>
         static void call(std::vector<hpx::future<T>> const& workitems,
             std::list<std::exception_ptr>&, bool = true)
         {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_ASSERT(false);
+#else
             for (hpx::future<T> const& f : workitems)
             {
                 if (f.has_exception())
                     hpx::terminate();
             }
+#endif
         }
 
         template <typename T>
         static void call(std::vector<hpx::shared_future<T>> const& workitems,
             std::list<std::exception_ptr>&, bool = true)
         {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_ASSERT(false);
+#else
             for (hpx::shared_future<T> const& f : workitems)
             {
                 if (f.has_exception())
                     hpx::terminate();
             }
+#endif
         }
 
         template <typename T, typename Cleanup>
         static void call(std::vector<hpx::future<T>> const& workitems,
             std::list<std::exception_ptr>&, Cleanup&&, bool = true)
         {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_ASSERT(false);
+#else
             for (hpx::future<T> const& f : workitems)
             {
                 if (f.has_exception())
                     hpx::terminate();
             }
+#endif
         }
     };
 }}}}    // namespace hpx::parallel::util::detail

--- a/libs/assertion/include/hpx/assertion.hpp
+++ b/libs/assertion/include/hpx/assertion.hpp
@@ -7,6 +7,7 @@
 //  Make HPX inspect tool happy:
 //                               hpxinspect:noinclude:HPX_ASSERT
 //                               hpxinspect:noinclude:HPX_ASSERT_MSG
+//                               hpxinspect:noassert_macro
 
 //  Note: There are no include guards. This is intentional.
 
@@ -16,6 +17,9 @@
 #include <hpx/assertion/source_location.hpp>
 #include <hpx/preprocessor/stringize.hpp>
 
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+#include <assert.h>
+#endif
 #include <string>
 #include <type_traits>
 
@@ -61,8 +65,13 @@ namespace hpx { namespace assertion {
     /**/
 
 #if defined(HPX_DEBUG)
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+#define HPX_ASSERT(expr) assert(expr)
+#define HPX_ASSERT_MSG(expr, msg) HPX_ASSERT(expr)
+#else
 #define HPX_ASSERT(expr) HPX_ASSERT_(expr, std::string())
 #define HPX_ASSERT_MSG(expr, msg) HPX_ASSERT_(expr, msg)
+#endif
 #define HPX_NOEXCEPT_WITH_ASSERT
 #else
 #define HPX_ASSERT(expr)

--- a/src/util/interval_timer.cpp
+++ b/src/util/interval_timer.cpp
@@ -250,7 +250,7 @@ namespace hpx { namespace util { namespace detail
             // lock here would be the right thing but leads to crashes and hangs
             // at shutdown.
             //util::unlock_guard<std::unique_lock<mutex_type> > ul(l);
-            id = hpx::applier::register_thread_plain(
+            id = hpx::threads::register_thread_plain(
                 util::bind_front(&interval_timer::evaluate,
                     this->shared_from_this()),
                 description_.c_str(), threads::suspended, true,

--- a/src/util/one_size_heap_list.cpp
+++ b/src/util/one_size_heap_list.cpp
@@ -157,7 +157,7 @@ namespace hpx { namespace util
     {
         if (nullptr == threads::get_self_ptr())
         {
-            hpx::applier::register_work_nullary(
+            hpx::threads::register_work_nullary(
                 util::bind_front(&one_size_heap_list::free, this, p, count),
                 "one_size_heap_list::free");
             return true;


### PR DESCRIPTION
Disables `handle_local_exception` code from being compiled in device mode. Flybys:
- Use CUDA's `assert` for handling assertions on device (no custom message, but prints file and location)
- Change a couple of `register_*` calls from the `hpx::applier` namespace to `hpx::threads`
