### PR TITLE
Fixing gcc warning on 32bit platforms (integer truncation)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1171,6 +1171,20 @@ if(HPX_WITH_CXX14_RETURN_TYPE_DEDUCTION)
 endif()
 
 ################################################################################
+# Set configuration option to use Boost.Context or not. This depends on the
+# platform.
+set(__use_generic_coroutine_context OFF)
+if(APPLE)
+  set(__use_generic_coroutine_context ON)
+endif()
+if("${HPX_PLATFORM_UC}" STREQUAL "BLUEGENEQ")
+  set(__use_generic_coroutine_context ON)
+endif()
+hpx_option(HPX_WITH_GENERIC_CONTEXT_COROUTINES BOOL
+  "Use Boost.Context as the underlying coroutines context switch implementation."
+  ${__use_generic_coroutine_context} ADVANCED)
+
+################################################################################
 # check for miscellaneous things
 ################################################################################
 
@@ -1561,20 +1575,6 @@ endif()
 
 # store target architecture for later use
 set(HPX_WITH_TARGET_ARCHITECTURE ${__target_arch} CACHE INTERNAL "" FORCE)
-
-################################################################################
-# Set configuration option to use Boost.Context or not. This depends on the
-# platform.
-set(__use_generic_coroutine_context OFF)
-if(APPLE)
-  set(__use_generic_coroutine_context ON)
-endif()
-if(HPX_PLATFORM_UC STREQUAL "BLUEGENEQ")
-  set(__use_generic_coroutine_context ON)
-endif()
-hpx_option(HPX_WITH_GENERIC_CONTEXT_COROUTINES BOOL
-  "Use Boost.Context as the underlying coroutines context switch implementation."
-  ${__use_generic_coroutine_context} ADVANCED)
 
 # Compatibility with using Boost.ProgramOptions, introduced in V1.4.0
 hpx_option(HPX_PROGRAM_OPTIONS_WITH_BOOST_PROGRAM_OPTIONS_COMPATIBILITY

--- a/libs/coroutines/include/hpx/coroutines/detail/context_impl.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/context_impl.hpp
@@ -116,7 +116,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
 }}}}    // namespace hpx::threads::coroutines::detail
 
 #elif (defined(__linux) || defined(linux) || defined(__linux__)) &&            \
-    !defined(__bgq__) && !defined(__powerpc__) && !defined(__s390x_)
+    !defined(__bgq__) && !defined(__powerpc__) && !defined(__s390x__)
 
 #include <hpx/coroutines/detail/context_linux_x86.hpp>
 namespace hpx { namespace threads { namespace coroutines { namespace detail {
@@ -125,7 +125,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
 }}}}    // namespace hpx::threads::coroutines::detail
 
 #elif defined(_POSIX_VERSION) || defined(__bgq__) || defined(__powerpc__) ||   \
-    defined(__s390x_)
+    defined(__s390x__)
 
 #include <hpx/coroutines/detail/context_posix.hpp>
 namespace hpx { namespace threads { namespace coroutines { namespace detail {

--- a/libs/hashing/include/hpx/hashing/fibhash.hpp
+++ b/libs/hashing/include/hpx/hashing/fibhash.hpp
@@ -12,14 +12,14 @@
 
 #include <hpx/config.hpp>
 
-#include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 
 namespace hpx { namespace util {
 
     namespace detail {
 
-        template <std::size_t N>
+        template <std::uint64_t N>
         struct hash_helper;
 
         template <>
@@ -28,7 +28,7 @@ namespace hpx { namespace util {
             HPX_STATIC_CONSTEXPR int log2 = -1;
         };
 
-        template <std::size_t N>
+        template <std::uint64_t N>
         struct hash_helper
         {
             HPX_STATIC_CONSTEXPR std::uint64_t log2 =
@@ -36,13 +36,14 @@ namespace hpx { namespace util {
             HPX_STATIC_CONSTEXPR std::uint64_t shift_amount = 64 - log2;
         };
 
-        HPX_STATIC_CONSTEXPR std::uint64_t golden_ratio = 11400714819323198485llu;
+        HPX_STATIC_CONSTEXPR std::uint64_t golden_ratio =
+            11400714819323198485llu;
     }    // namespace detail
 
     // This function calculates the hash based on a multiplicative Fibonacci
     // scheme
-    template <std::size_t N>
-    HPX_CONSTEXPR std::size_t fibhash(std::uint64_t i)
+    template <std::uint64_t N>
+    HPX_CONSTEXPR std::uint64_t fibhash(std::uint64_t i)
     {
         using helper = detail::hash_helper<N>;
         static_assert(N != 0, "This algorithm only works with N != 0");

--- a/libs/hashing/include/hpx/hashing/fibhash.hpp
+++ b/libs/hashing/include/hpx/hashing/fibhash.hpp
@@ -16,7 +16,9 @@
 #include <cstdlib>
 
 namespace hpx { namespace util {
+
     namespace detail {
+
         template <std::size_t N>
         struct hash_helper;
 
@@ -29,18 +31,18 @@ namespace hpx { namespace util {
         template <std::size_t N>
         struct hash_helper
         {
-            HPX_STATIC_CONSTEXPR std::size_t log2 =
+            HPX_STATIC_CONSTEXPR std::uint64_t log2 =
                 hash_helper<(N >> 1)>::log2 + 1;
-            HPX_STATIC_CONSTEXPR std::size_t shift_amount = 64 - log2;
+            HPX_STATIC_CONSTEXPR std::uint64_t shift_amount = 64 - log2;
         };
 
-        HPX_STATIC_CONSTEXPR std::size_t golden_ratio = 11400714819323198485llu;
+        HPX_STATIC_CONSTEXPR std::uint64_t golden_ratio = 11400714819323198485llu;
     }    // namespace detail
 
     // This function calculates the hash based on a multiplicative Fibonacci
     // scheme
     template <std::size_t N>
-    HPX_CONSTEXPR std::size_t fibhash(std::size_t i)
+    HPX_CONSTEXPR std::size_t fibhash(std::uint64_t i)
     {
         using helper = detail::hash_helper<N>;
         static_assert(N != 0, "This algorithm only works with N != 0");


### PR DESCRIPTION
- flyby: move hpx_option to before first usage of the option value
- also fixes a misspelled pp constant

Fixes 32bit rpm builds, @msimberg I think this should be part of the V1.4 release

Fixes #4215
