### PR TITLE
Assorted small changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -550,8 +550,8 @@ if(HPX_WITH_STACKTRACES OR HPX_WITH_THREAD_BACKTRACE_ON_SUSPENSION)
   endif()
 
   hpx_option(HPX_WITH_THREAD_BACKTRACE_DEPTH STRING
-    "Thread stack back trace depth being captured (default: 5)"
-    "5"
+    "Thread stack back trace depth being captured (default: 20)"
+    "20"
     CATEGORY "Thread Manager" ADVANCED)
   hpx_add_config_define(HPX_HAVE_THREAD_BACKTRACE_DEPTH
     ${HPX_WITH_THREAD_BACKTRACE_DEPTH})

--- a/components/containers/unordered/tests/unit/unordered_map.cpp
+++ b/components/containers/unordered/tests/unit/unordered_map.cpp
@@ -73,7 +73,7 @@ void fill_unordered_map(hpx::unordered_map<Key, Value, Hash, KeyEqual>& m,
         std::string idx = std::to_string(i);
         m[idx] = val;
     }
-    HPX_TEST(m.size() == count);
+    HPX_TEST_EQ(m.size(), count);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/components/iostreams/tests/regressions/lost_output_2236.cpp
+++ b/components/iostreams/tests/regressions/lost_output_2236.cpp
@@ -299,12 +299,12 @@ namespace gc { namespace server {
         state();
         if (w < weight)
         {
-            HPX_TEST(strong_count > 0);
+            HPX_TEST_LT(std::size_t(0), strong_count);
             strong_count--;
         }
         else
         {
-            HPX_TEST(weak_count > 0);
+            HPX_TEST_LT(std::size_t(0), weak_count);
             weak_count--;
         }
         cd->phantom_count++;
@@ -367,12 +367,12 @@ namespace gc { namespace server {
     void collectable::recover_done()
     {
         cd->wc--;
-        HPX_TEST(cd->wc > 0);
+        HPX_TEST_LT(std::size_t(0), cd->wc);
         check_recover_done();
     }
     void collectable::done(hpx::id_type child)
     {
-        HPX_TEST(cd->wc > 0);
+        HPX_TEST_LT(std::size_t(0), cd->wc);
         cd->wc--;
         if (cd->wc == 0 && cd->cid == this->get_id())
         {
@@ -422,7 +422,7 @@ namespace gc { namespace server {
         }
         else
         {
-            HPX_TEST(weak_count > 0);
+            HPX_TEST_LT(std::size_t(0), weak_count);
             weak_count--;
             if (weak_count == 0 && strong_count == 0)
             {

--- a/components/performance_counters/papi/tests/regressions/papi_counters_segfault_1890.cpp
+++ b/components/performance_counters/papi/tests/regressions/papi_counters_segfault_1890.cpp
@@ -30,8 +30,8 @@ int hpx_main(int argc, char ** argv)
     std::int64_t val1 = total_cycles.get_value<std::int64_t>(hpx::launch::sync);
     std::int64_t val2 = cycles.get_value<std::int64_t>(hpx::launch::sync);
 
-    HPX_TEST(val1 != 0);
-    HPX_TEST(val2 != 0);
+    HPX_TEST_NEQ(val1, 0);
+    HPX_TEST_NEQ(val2, 0);
 #endif
 
     return hpx::finalize();

--- a/libs/affinity/tests/unit/parse_affinity_options.cpp
+++ b/libs/affinity/tests/unit/parse_affinity_options.cpp
@@ -1127,6 +1127,6 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=4"};
 
     // Initialize and run HPX
-    HPX_TEST(0 == hpx::init(argc, argv, cfg));
+    HPX_TEST_EQ(0, hpx::init(argc, argv, cfg));
     return hpx::util::report_errors();
 }

--- a/libs/algorithms/tests/regressions/for_loop_2281.cpp
+++ b/libs/algorithms/tests/regressions/for_loop_2281.cpp
@@ -26,7 +26,7 @@ int hpx_main()
         thread_ids.insert(hpx::this_thread::get_id());
     });
 
-    HPX_TEST(thread_ids.size() > std::size_t(1));
+    HPX_TEST_LT(std::size_t(1), thread_ids.size());
 
     thread_ids.clear();
 
@@ -36,7 +36,7 @@ int hpx_main()
             thread_ids.insert(hpx::this_thread::get_id());
         });
 
-    HPX_TEST(thread_ids.size() > std::size_t(1));
+    HPX_TEST_LT(std::size_t(1), thread_ids.size());
 
     return hpx::finalize();
 }

--- a/libs/algorithms/tests/unit/algorithms/exclusive_scan_validate.cpp
+++ b/libs/algorithms/tests/unit/algorithms/exclusive_scan_validate.cpp
@@ -81,7 +81,7 @@ void test_exclusive_scan_validate(
         // counting from zero,
         int value = b[i];    //-V108
         int expected_value = INITIAL_VAL + check_n_triangle(i - 1);
-        if (!HPX_TEST(value == expected_value))
+        if (!HPX_TEST_EQ(value, expected_value))
             break;
     }
 
@@ -115,7 +115,7 @@ void test_exclusive_scan_validate(
         // counting from 1, use i+1
         int value = b[i];    //-V108
         int expected_value = INITIAL_VAL + check_n_triangle(i);
-        if (!HPX_TEST(value == expected_value))
+        if (!HPX_TEST_EQ(value, expected_value))
             break;
     }
 
@@ -149,7 +149,7 @@ void test_exclusive_scan_validate(
         // counting from zero,
         int value = b[i];    //-V108
         int expected_value = INITIAL_VAL + check_n_const(i, FILL_VALUE);
-        if (!HPX_TEST(value == expected_value))
+        if (!HPX_TEST_EQ(value, expected_value))
             break;
     }
 }

--- a/libs/algorithms/tests/unit/algorithms/includes.cpp
+++ b/libs/algorithms/tests/unit/algorithms/includes.cpp
@@ -42,7 +42,7 @@ void test_includes1(ExPolicy policy, IteratorTag)
     std::size_t first_value = gen();    //-V101
     std::iota(std::begin(c1), std::end(c1), first_value);
 
-    HPX_TEST(start <= end);
+    HPX_TEST_LTE(start, end);
 
     base_iterator start_it = boost::next(std::begin(c1), start);
     base_iterator end_it = boost::next(std::begin(c1), end);
@@ -94,7 +94,7 @@ void test_includes1_async(ExPolicy p, IteratorTag)
     std::uniform_int_distribution<> dist(0, c1.size() - start - 1);
     std::size_t end = start + dist(gen);
 
-    HPX_TEST(start <= end);
+    HPX_TEST_LTE(start, end);
 
     base_iterator start_it = boost::next(std::begin(c1), start);
     base_iterator end_it = boost::next(std::begin(c1), end);
@@ -173,7 +173,7 @@ void test_includes2(ExPolicy policy, IteratorTag)
     std::uniform_int_distribution<> dist(0, c1.size() - start - 1);
     std::size_t end = start + dist(gen);
 
-    HPX_TEST(start <= end);
+    HPX_TEST_LTE(start, end);
 
     base_iterator start_it = boost::next(std::begin(c1), start);
     base_iterator end_it = boost::next(std::begin(c1), end);
@@ -226,7 +226,7 @@ void test_includes2_async(ExPolicy p, IteratorTag)
     std::uniform_int_distribution<> dist(0, c1.size() - start - 1);
     std::size_t end = start + dist(gen);
 
-    HPX_TEST(start <= end);
+    HPX_TEST_LTE(start, end);
 
     base_iterator start_it = boost::next(std::begin(c1), start);
     base_iterator end_it = boost::next(std::begin(c1), end);
@@ -306,12 +306,12 @@ void test_includes_exception(ExPolicy policy, IteratorTag)
     std::uniform_int_distribution<> dist(0, c1.size() - start - 1);
     std::size_t end = start + dist(gen);
 
-    HPX_TEST(start <= end);
+    HPX_TEST_LTE(start, end);
 
     if (start == end)
         ++end;
 
-    HPX_TEST(end <= c1.size());
+    HPX_TEST_LTE(end, c1.size());
 
     base_iterator start_it = boost::next(std::begin(c1), start);
     base_iterator end_it = boost::next(std::begin(c1), end);
@@ -355,12 +355,12 @@ void test_includes_exception_async(ExPolicy p, IteratorTag)
     std::uniform_int_distribution<> dist(0, c1.size() - start - 1);
     std::size_t end = start + dist(gen);
 
-    HPX_TEST(start <= end);
+    HPX_TEST_LTE(start, end);
 
     if (start == end)
         ++end;
 
-    HPX_TEST(end <= c1.size());
+    HPX_TEST_LTE(end, c1.size());
 
     base_iterator start_it = boost::next(std::begin(c1), start);
     base_iterator end_it = boost::next(std::begin(c1), end);
@@ -436,12 +436,12 @@ void test_includes_bad_alloc(ExPolicy policy, IteratorTag)
     std::uniform_int_distribution<> dist(0, c1.size() - start - 1);
     std::size_t end = start + dist(gen);
 
-    HPX_TEST(start <= end);
+    HPX_TEST_LTE(start, end);
 
     if (start == end)
         ++end;
 
-    HPX_TEST(end <= c1.size());
+    HPX_TEST_LTE(end, c1.size());
 
     base_iterator start_it = boost::next(std::begin(c1), start);
     base_iterator end_it = boost::next(std::begin(c1), end);
@@ -484,12 +484,12 @@ void test_includes_bad_alloc_async(ExPolicy p, IteratorTag)
     std::uniform_int_distribution<> dist(0, c1.size() - start - 1);
     std::size_t end = start + dist(gen);
 
-    HPX_TEST(start <= end);
+    HPX_TEST_LTE(start, end);
 
     if (start == end)
         ++end;
 
-    HPX_TEST(end <= c1.size());
+    HPX_TEST_LTE(end, c1.size());
 
     base_iterator start_it = boost::next(std::begin(c1), start);
     base_iterator end_it = boost::next(std::begin(c1), end);

--- a/libs/algorithms/tests/unit/algorithms/inclusive_scan_tests.hpp
+++ b/libs/algorithms/tests/unit/algorithms/inclusive_scan_tests.hpp
@@ -397,7 +397,7 @@ void test_inclusive_scan_validate(
         // counting from zero,
         int value = b[i];    //-V108
         int expected_value = check_n_triangle(i);
-        if (!HPX_TEST(value == expected_value))
+        if (!HPX_TEST_EQ(value, expected_value))
             break;
     }
 
@@ -415,7 +415,7 @@ void test_inclusive_scan_validate(
         // counting from 1, use i+1
         int value = b[i];    //-V108
         int expected_value = check_n_triangle(i + 1);
-        HPX_TEST(value == expected_value);
+        HPX_TEST_EQ(value, expected_value);
         if (value != expected_value)
             break;
     }
@@ -432,7 +432,7 @@ void test_inclusive_scan_validate(
     {
         int value = b[i];    //-V108
         int expected_value = check_n_const(i + 1, FILL_VALUE);
-        HPX_TEST(value == expected_value);
+        HPX_TEST_EQ(value, expected_value);
         if (value != expected_value)
             break;
     }

--- a/libs/algorithms/tests/unit/algorithms/is_heap_tests.hpp
+++ b/libs/algorithms/tests/unit/algorithms/is_heap_tests.hpp
@@ -99,7 +99,7 @@ void test_is_heap(
             policy, iterator(std::begin(c)), iterator(std::end(c)));
         bool solution = std::is_heap(std::begin(c), std::end(c));
 
-        HPX_TEST(result == solution);
+        HPX_TEST_EQ(result, solution);
     }
     else
     {
@@ -135,7 +135,7 @@ void test_is_heap_with_pred(ExPolicy policy, IteratorTag, DataType, Pred pred,
             policy, iterator(std::begin(c)), iterator(std::end(c)), pred);
         bool solution = std::is_heap(std::begin(c), std::end(c), pred);
 
-        HPX_TEST(result == solution);
+        HPX_TEST_EQ(result, solution);
     }
     else
     {
@@ -171,7 +171,7 @@ void test_is_heap_async(
         bool result = f.get();
         bool solution = std::is_heap(std::begin(c), std::end(c));
 
-        HPX_TEST(result == solution);
+        HPX_TEST_EQ(result, solution);
     }
     else
     {

--- a/libs/algorithms/tests/unit/container_algorithms/is_heap_range.cpp
+++ b/libs/algorithms/tests/unit/container_algorithms/is_heap_range.cpp
@@ -71,7 +71,7 @@ void test_is_heap(ExPolicy policy, DataType)
     bool result = hpx::parallel::is_heap(policy, c);
     bool solution = std::is_heap(std::begin(c), std::end(c));
 
-    HPX_TEST(result == solution);
+    HPX_TEST_EQ(result, solution);
 }
 
 template <typename ExPolicy, typename DataType>
@@ -94,7 +94,7 @@ void test_is_heap_async(ExPolicy policy, DataType)
     bool result = f.get();
     bool solution = std::is_heap(std::begin(c), std::end(c));
 
-    HPX_TEST(result == solution);
+    HPX_TEST_EQ(result, solution);
 }
 
 template <typename DataType>

--- a/libs/algorithms/tests/unit/datapar_algorithms/foreach_datapar_zipiter.cpp
+++ b/libs/algorithms/tests/unit/datapar_algorithms/foreach_datapar_zipiter.cpp
@@ -55,7 +55,7 @@ void for_each_zipiter_test(ExPolicy&& policy, IteratorTag)
     auto result = hpx::parallel::for_each(
         std::forward<ExPolicy>(policy), begin, end, set_42());
 
-    HPX_TEST(result == end);
+    HPX_TEST_EQ(result, end);
 
     // verify values
     std::size_t count = 0;

--- a/libs/algorithms/tests/unit/datapar_algorithms/foreach_tests.hpp
+++ b/libs/algorithms/tests/unit/datapar_algorithms/foreach_tests.hpp
@@ -68,7 +68,7 @@ void test_for_each(ExPolicy&& policy, IteratorTag)
     iterator result = hpx::parallel::for_each(std::forward<ExPolicy>(policy),
         iterator(std::begin(c)), iterator(std::end(c)), set_42());
 
-    HPX_TEST(result == iterator(std::end(c)));
+    HPX_TEST_EQ(result, iterator(std::end(c)));
 
     // verify values
     std::size_t count = 0;
@@ -92,7 +92,7 @@ void test_for_each_async(ExPolicy&& p, IteratorTag)
         iterator(std::begin(c)), iterator(std::end(c)), set_42());
     f.wait();
 
-    HPX_TEST(f.get() == iterator(std::end(c)));
+    HPX_TEST_EQ(f.get(), iterator(std::end(c)));
 
     // verify values
     std::size_t count = 0;
@@ -256,7 +256,7 @@ void test_for_each_n(ExPolicy policy, IteratorTag)
     iterator result = hpx::parallel::for_each_n(
         policy, iterator(std::begin(c)), c.size(), set_42());
     iterator end = iterator(std::end(c));
-    HPX_TEST(result == end);
+    HPX_TEST_EQ(result, end);
 
     // verify values
     std::size_t count = 0;
@@ -278,7 +278,7 @@ void test_for_each_n_async(ExPolicy p, IteratorTag)
 
     hpx::future<iterator> f = hpx::parallel::for_each_n(
         p, iterator(std::begin(c)), c.size(), set_42());
-    HPX_TEST(f.get() == iterator(std::end(c)));
+    HPX_TEST_EQ(f.get(), iterator(std::end(c)));
 
     // verify values
     std::size_t count = 0;

--- a/libs/basic_execution/tests/unit/execution_context.cpp
+++ b/libs/basic_execution/tests/unit/execution_context.cpp
@@ -165,11 +165,11 @@ void test_sleep()
     auto now = std::chrono::steady_clock::now();
     auto sleep_duration = std::chrono::milliseconds(100);
     hpx::basic_execution::this_thread::sleep_for(sleep_duration);
-    HPX_TEST(std::chrono::steady_clock::now() >= now + sleep_duration);
+    HPX_TEST(now + sleep_duration <= std::chrono::steady_clock::now());
 
     auto sleep_time = sleep_duration * 2 + std::chrono::steady_clock::now();
     hpx::basic_execution::this_thread::sleep_until(sleep_time);
-    HPX_TEST(std::chrono::steady_clock::now() >= now + sleep_duration * 2);
+    HPX_TEST(now + sleep_duration * 2 <= std::chrono::steady_clock::now());
 }
 
 int main()

--- a/libs/cache/tests/unit/local_lru_cache.cpp
+++ b/libs/cache/tests/unit/local_lru_cache.cpp
@@ -38,17 +38,17 @@ void test_lru_insert()
 
     cache_type c(3);
 
-    HPX_TEST(3 == c.capacity());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.capacity());
 
     // insert all items into the cache
     for (data* d = &cache_entries[0]; d->key != nullptr; ++d)
     {
         HPX_TEST(c.insert(d->key, d->value));
-        HPX_TEST(3 >= c.size());
+        HPX_TEST_LTE(c.size(), static_cast<cache_type::size_type>(3));
     }
 
     // there should be 3 items in the cache
-    HPX_TEST(3 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.size());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -59,7 +59,7 @@ void test_lru_insert_with_touch()
 
     cache_type c(3);
 
-    HPX_TEST(3 == c.capacity());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.capacity());
 
     // insert 3 items into the cache
     int i = 0;
@@ -68,25 +68,25 @@ void test_lru_insert_with_touch()
     for (/**/; i < 3 && d->key != nullptr; ++d, ++i)
     {
         HPX_TEST(c.insert(d->key, d->value));
-        HPX_TEST(3 >= c.size());
+        HPX_TEST_LTE(c.size(), static_cast<cache_type::size_type>(3));
     }
 
-    HPX_TEST(3 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.size());
 
     // now touch the first item
     std::string white;
     HPX_TEST(c.get_entry("white", white));
-    HPX_TEST(white == "255,255,255");
+    HPX_TEST_EQ(white, "255,255,255");
 
     // add two more items
     for (i = 0; i < 2 && d->key != nullptr; ++d, ++i)
     {
         HPX_TEST(c.insert(d->key, d->value));
-        HPX_TEST(3 == c.size());
+        HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.size());
     }
 
     // there should be 3 items in the cache, and white should be there as well
-    HPX_TEST(3 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.size());
     HPX_TEST(c.holds_key("white"));
 }
 
@@ -98,19 +98,19 @@ void test_lru_clear()
 
     cache_type c(3);
 
-    HPX_TEST(3 == c.capacity());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.capacity());
 
     // insert all items into the cache
     for (data* d = &cache_entries[0]; d->key != nullptr; ++d)
     {
         HPX_TEST(c.insert(d->key, d->value));
-        HPX_TEST(3 >= c.size());
+        HPX_TEST_LTE(c.size(), static_cast<cache_type::size_type>(3));
     }
 
     c.clear();
 
     // there should be no items in the cache
-    HPX_TEST(0 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(0), c.size());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -137,13 +137,13 @@ void test_lru_erase_one()
 
     cache_type c(3);
 
-    HPX_TEST(3 == c.capacity());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.capacity());
 
     // insert all items into the cache
     for (data* d = &cache_entries[0]; d->key != nullptr; ++d)
     {
         HPX_TEST(c.insert(d->key, d->value));
-        HPX_TEST(3 >= c.size());
+        HPX_TEST_LTE(c.size(), static_cast<cache_type::size_type>(3));
     }
 
     entry_type blue;
@@ -153,7 +153,7 @@ void test_lru_erase_one()
 
     // there should be 2 items in the cache
     HPX_TEST(!c.get_entry("blue", blue));
-    HPX_TEST(2 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(2), c.size());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -164,7 +164,7 @@ void test_lru_update()
 
     cache_type c(4);    // this time we can hold 4 items
 
-    HPX_TEST(4 == c.capacity());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(4), c.capacity());
 
     // insert 3 items into the cache
     int i = 0;
@@ -173,22 +173,22 @@ void test_lru_update()
     for (/**/; i < 3 && d->key != nullptr; ++d, ++i)
     {
         HPX_TEST(c.insert(d->key, d->value));
-        HPX_TEST(3 >= c.size());
+        HPX_TEST_LTE(c.size(), static_cast<cache_type::size_type>(3));
     }
 
     // there should be 3 items in the cache
-    HPX_TEST(3 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.size());
 
     // now update some items
     HPX_TEST(c.update("black", "255,0,0"));    // isn't in the cache
-    HPX_TEST(4 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(4), c.size());
 
     HPX_TEST(c.update("yellow", "255,0,0"));
-    HPX_TEST(4 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(4), c.size());
 
     std::string yellow;
     HPX_TEST(c.get_entry("yellow", yellow));
-    HPX_TEST(yellow == "255,0,0");
+    HPX_TEST_EQ(yellow, "255,0,0");
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/cache/tests/unit/local_mru_cache.cpp
+++ b/libs/cache/tests/unit/local_mru_cache.cpp
@@ -42,17 +42,17 @@ void test_mru_insert()
 
     cache_type c(3);
 
-    HPX_TEST(3 == c.capacity());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.capacity());
 
     // insert all items into the cache
     for (data* d = &cache_entries[0]; d->key != nullptr; ++d)
     {
         HPX_TEST(c.insert(d->key, d->value));
-        HPX_TEST(3 >= c.size());
+        HPX_TEST_LTE(c.size(), static_cast<cache_type::size_type>(3));
     }
 
     // there should be 3 items in the cache
-    HPX_TEST(3 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.size());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -65,7 +65,7 @@ void test_mru_insert_with_touch()
 
     cache_type c(3);
 
-    HPX_TEST(3 == c.capacity());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.capacity());
 
     // insert 3 items into the cache
     int i = 0;
@@ -74,30 +74,30 @@ void test_mru_insert_with_touch()
     for (/**/; i < 3 && d->key != nullptr; ++d, ++i)
     {
         HPX_TEST(c.insert(d->key, d->value));
-        HPX_TEST(3 >= c.size());
+        HPX_TEST_LTE(c.size(), static_cast<cache_type::size_type>(3));
     }
 
-    HPX_TEST(3 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.size());
 
     // now touch the first two items (will now be ejected first, even if they
     // are the oldest)
     std::string white;
     HPX_TEST(c.get_entry("white", white));
-    HPX_TEST(white == "255,255,255");
+    HPX_TEST_EQ(white, "255,255,255");
 
     std::string yellow;
     HPX_TEST(c.get_entry("yellow", yellow));
-    HPX_TEST(yellow == "255,255,0");
+    HPX_TEST_EQ(yellow, "255,255,0");
 
     // add two more items
     for (i = 0; i < 2 && d->key != nullptr; ++d, ++i)
     {
         HPX_TEST(c.insert(d->key, d->value));
-        HPX_TEST(3 == c.size());
+        HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.size());
     }
 
     // there should be 3 items in the cache, and green should be there as well
-    HPX_TEST(3 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.size());
     HPX_TEST(c.holds_key("green"));
     HPX_TEST(c.holds_key("green"));
     HPX_TEST(c.holds_key("green"));
@@ -113,19 +113,19 @@ void test_mru_clear()
 
     cache_type c(3);
 
-    HPX_TEST(3 == c.capacity());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.capacity());
 
     // insert all items into the cache
     for (data* d = &cache_entries[0]; d->key != nullptr; ++d)
     {
         HPX_TEST(c.insert(d->key, d->value));
-        HPX_TEST(3 >= c.size());
+        HPX_TEST_LTE(c.size(), static_cast<cache_type::size_type>(3));
     }
 
     c.clear();
 
     // there should be no items in the cache
-    HPX_TEST(0 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(0), c.size());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -154,13 +154,13 @@ void test_mru_erase_one()
 
     cache_type c(3);
 
-    HPX_TEST(3 == c.capacity());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.capacity());
 
     // insert all items into the cache
     for (data* d = &cache_entries[0]; d->key != nullptr; ++d)
     {
         HPX_TEST(c.insert(d->key, d->value));
-        HPX_TEST(3 >= c.size());
+        HPX_TEST_LTE(c.size(), static_cast<cache_type::size_type>(3));
     }
 
     entry_type black;
@@ -170,7 +170,7 @@ void test_mru_erase_one()
 
     // there should be 2 items in the cache
     HPX_TEST(!c.get_entry("black", black));
-    HPX_TEST(2 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(2), c.size());
 
     entry_type white, yellow;
     HPX_TEST(c.get_entry("white", white));
@@ -187,7 +187,7 @@ void test_mru_update()
 
     cache_type c(4);    // this time we can hold 4 items
 
-    HPX_TEST(4 == c.capacity());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(4), c.capacity());
 
     // insert 3 items into the cache
     int i = 0;
@@ -196,22 +196,22 @@ void test_mru_update()
     for (/**/; i < 3 && d->key != nullptr; ++d, ++i)
     {
         HPX_TEST(c.insert(d->key, d->value));
-        HPX_TEST(3 >= c.size());
+        HPX_TEST_LTE(c.size(), static_cast<cache_type::size_type>(3));
     }
 
     // there should be 3 items in the cache
-    HPX_TEST(3 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.size());
 
     // now update some items
     HPX_TEST(c.update("black", "255,0,0"));    // isn't in the cache
-    HPX_TEST(4 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(4), c.size());
 
     HPX_TEST(c.update("yellow", "255,0,0"));
-    HPX_TEST(4 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(4), c.size());
 
     std::string yellow;
     HPX_TEST(c.get_entry("yellow", yellow));
-    HPX_TEST(yellow == "255,0,0");
+    HPX_TEST_EQ(yellow, "255,0,0");
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/cache/tests/unit/local_statistics.cpp
+++ b/libs/cache/tests/unit/local_statistics.cpp
@@ -10,6 +10,7 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/testing.hpp>
 
+#include <cstddef>
 #include <functional>
 #include <map>
 #include <string>
@@ -45,24 +46,24 @@ void test_statistics_insert()
 
     cache_type c(3);
 
-    HPX_TEST(3 == c.capacity());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.capacity());
 
     // insert all items into the cache
     for (data* d = &cache_entries[0]; d->key != nullptr; ++d)
     {
         HPX_TEST(c.insert(d->key, d->value));
-        HPX_TEST(3 >= c.size());
+        HPX_TEST_LTE(c.size(), static_cast<cache_type::size_type>(3));
     }
 
     // there should be 3 items in the cache
-    HPX_TEST(3 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.size());
 
     // retrieve statistics
     statistics::local_statistics const& stats = c.get_statistics();
-    HPX_TEST(0 == stats.hits());
-    HPX_TEST(0 == stats.misses());
-    HPX_TEST(6 == stats.insertions());
-    HPX_TEST(3 == stats.evictions());
+    HPX_TEST_EQ(static_cast<std::size_t>(0), stats.hits());
+    HPX_TEST_EQ(static_cast<std::size_t>(0), stats.misses());
+    HPX_TEST_EQ(static_cast<std::size_t>(6), stats.insertions());
+    HPX_TEST_EQ(static_cast<std::size_t>(3), stats.evictions());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -78,7 +79,7 @@ void test_statistics_insert_with_touch()
 
     cache_type c(3);
 
-    HPX_TEST(3 == c.capacity());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.capacity());
 
     // insert 3 items into the cache
     int i = 0;
@@ -87,21 +88,21 @@ void test_statistics_insert_with_touch()
     for (/**/; i < 3 && d->key != nullptr; ++d, ++i)
     {
         HPX_TEST(c.insert(d->key, d->value));
-        HPX_TEST(3 >= c.size());
+        HPX_TEST_LTE(c.size(), static_cast<cache_type::size_type>(3));
     }
 
-    HPX_TEST(3 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.size());
 
     // now touch the first item
     std::string white;
     HPX_TEST(c.get_entry("white", white));
-    HPX_TEST(white == "255,255,255");
+    HPX_TEST_EQ(white, "255,255,255");
 
     // add two more items
     for (i = 0; i < 2 && d->key != nullptr; ++d, ++i)
     {
         HPX_TEST(c.insert(d->key, d->value));
-        HPX_TEST(3 == c.size());
+        HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.size());
     }
 
     // provoke a miss
@@ -109,15 +110,15 @@ void test_statistics_insert_with_touch()
     HPX_TEST(!c.get_entry("yellow", yellow));
 
     // there should be 3 items in the cache, and white should be there as well
-    HPX_TEST(3 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.size());
     HPX_TEST(c.holds_key("white"));    // does not call the entry's touch()
 
     // retrieve statistics
     statistics::local_statistics const& stats = c.get_statistics();
-    HPX_TEST(1 == stats.hits());
-    HPX_TEST(1 == stats.misses());
-    HPX_TEST(5 == stats.insertions());
-    HPX_TEST(2 == stats.evictions());
+    HPX_TEST_EQ(static_cast<std::size_t>(1), stats.hits());
+    HPX_TEST_EQ(static_cast<std::size_t>(1), stats.misses());
+    HPX_TEST_EQ(static_cast<std::size_t>(5), stats.insertions());
+    HPX_TEST_EQ(static_cast<std::size_t>(2), stats.evictions());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -133,7 +134,7 @@ void test_statistics_update()
 
     cache_type c(4);    // this time we can hold 4 items
 
-    HPX_TEST(4 == c.capacity());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(4), c.capacity());
 
     // insert 3 items into the cache
     int i = 0;
@@ -142,29 +143,29 @@ void test_statistics_update()
     for (/**/; i < 3 && d->key != nullptr; ++d, ++i)
     {
         HPX_TEST(c.insert(d->key, d->value));
-        HPX_TEST(3 >= c.size());
+        HPX_TEST_LTE(c.size(), static_cast<cache_type::size_type>(3));
     }
 
     // there should be 3 items in the cache
-    HPX_TEST(3 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.size());
 
     // now update some items
     HPX_TEST(c.update("black", "255,0,0"));    // isn't in the cache
-    HPX_TEST(4 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(4), c.size());
 
     HPX_TEST(c.update("yellow", "255,0,0"));
-    HPX_TEST(4 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(4), c.size());
 
     std::string yellow;
     HPX_TEST(c.get_entry("yellow", yellow));
-    HPX_TEST(yellow == "255,0,0");
+    HPX_TEST_EQ(yellow, "255,0,0");
 
     // retrieve statistics
     statistics::local_statistics const& stats = c.get_statistics();
-    HPX_TEST(2 == stats.hits());
-    HPX_TEST(1 == stats.misses());
-    HPX_TEST(4 == stats.insertions());
-    HPX_TEST(0 == stats.evictions());
+    HPX_TEST_EQ(static_cast<std::size_t>(2), stats.hits());
+    HPX_TEST_EQ(static_cast<std::size_t>(1), stats.misses());
+    HPX_TEST_EQ(static_cast<std::size_t>(4), stats.insertions());
+    HPX_TEST_EQ(static_cast<std::size_t>(0), stats.evictions());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -196,13 +197,13 @@ void test_statistics_erase_one()
 
     cache_type c(3);
 
-    HPX_TEST(3 == c.capacity());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(3), c.capacity());
 
     // insert all items into the cache
     for (data* d = &cache_entries[0]; d->key != nullptr; ++d)
     {
         HPX_TEST(c.insert(d->key, d->value));
-        HPX_TEST(3 >= c.size());
+        HPX_TEST_LTE(c.size(), static_cast<cache_type::size_type>(3));
     }
 
     entry_type blue;
@@ -212,14 +213,14 @@ void test_statistics_erase_one()
 
     // there should be 2 items in the cache
     HPX_TEST(!c.get_entry("blue", blue));
-    HPX_TEST(2 == c.size());
+    HPX_TEST_EQ(static_cast<cache_type::size_type>(2), c.size());
 
     // retrieve statistics
     statistics::local_statistics const& stats = c.get_statistics();
-    HPX_TEST(1 == stats.hits());
-    HPX_TEST(1 == stats.misses());
-    HPX_TEST(6 == stats.insertions());
-    HPX_TEST(4 == stats.evictions());
+    HPX_TEST_EQ(static_cast<std::size_t>(1), stats.hits());
+    HPX_TEST_EQ(static_cast<std::size_t>(1), stats.misses());
+    HPX_TEST_EQ(static_cast<std::size_t>(6), stats.insertions());
+    HPX_TEST_EQ(static_cast<std::size_t>(4), stats.evictions());
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/checkpoint/tests/unit/checkpoint.cpp
+++ b/libs/checkpoint/tests/unit/checkpoint.cpp
@@ -165,9 +165,9 @@ int main()
     int a8_2, b8_2, c8_2;
     restore_checkpoint(archive8, a8_2, b8_2, c8_2);
 
-    HPX_TEST(a8 == a8_2);
-    HPX_TEST(b8 == b8_2);
-    HPX_TEST(c8 == c8_2);
+    HPX_TEST_EQ(a8, a8_2);
+    HPX_TEST_EQ(b8, b8_2);
+    HPX_TEST_EQ(c8, c8_2);
 
     // Cleanup
     std::remove("checkpoint_test_file.txt");
@@ -188,9 +188,9 @@ int main()
     restore_checkpoint(archive9, a9_1, b9_1, c9_1);
     //]
 
-    HPX_TEST(a9 == a9_1);
-    HPX_TEST(b9 == b9_1);
-    HPX_TEST(c9 == c9_1);
+    HPX_TEST_EQ(a9, a9_1);
+    HPX_TEST_EQ(b9, b9_1);
+    HPX_TEST_EQ(c9, c9_1);
 
     // Cleanup
     std::remove("test_file_9.txt");

--- a/libs/collectives/tests/performance/osu/osu_bw.cpp
+++ b/libs/collectives/tests/performance/osu/osu_bw.cpp
@@ -68,7 +68,7 @@ double ireceive(hpx::naming::id_type dest, std::size_t loop, std::size_t size,
     // align used buffers on page boundaries
     unsigned long align_size = getpagesize();
     (void) align_size;
-    HPX_TEST(align_size <= MAX_ALIGNMENT);
+    HPX_TEST_LTE(align_size, static_cast<unsigned long>(MAX_ALIGNMENT));
 
     std::unique_ptr<char[]> send_buffer(new char[size]);
     std::memset(send_buffer.get(), 'a', size);

--- a/libs/collectives/tests/performance/osu/osu_multi_lat.cpp
+++ b/libs/collectives/tests/performance/osu/osu_multi_lat.cpp
@@ -77,7 +77,7 @@ double ireceive(
 
     // align used buffers on page boundaries
     unsigned long align_size = getpagesize();
-    HPX_TEST(align_size <= MAX_ALIGNMENT);
+    HPX_TEST_LTE(align_size, static_cast<unsigned long>(MAX_ALIGNMENT));
 
     char* aligned_send_buffer = align_buffer(send_buffer, align_size);
     std::memset(aligned_send_buffer, 'a', size);

--- a/libs/config/cmake/templates/config_version.hpp.in
+++ b/libs/config/cmake/templates/config_version.hpp.in
@@ -18,11 +18,11 @@
 #include <boost/version.hpp>
 
 /// Evaluates to the major version of HPX
-#define HPX_VERSION_MAJOR        @HPX_VERSION_MAJOR@u
+#define HPX_VERSION_MAJOR        @HPX_VERSION_MAJOR@
 /// Evaluates to the minor version of HPX
-#define HPX_VERSION_MINOR        @HPX_VERSION_MINOR@u
+#define HPX_VERSION_MINOR        @HPX_VERSION_MINOR@
 /// Evaluates to the subminor version of HPX
-#define HPX_VERSION_SUBMINOR     @HPX_VERSION_SUBMINOR@u
+#define HPX_VERSION_SUBMINOR     @HPX_VERSION_SUBMINOR@
 
 /// Evaluates to the HPX version:
 /// ``HPX_VERSION_FULL & 0xFF0000 == HPX_VERSION_MAJOR``

--- a/libs/config/include/hpx/config.hpp
+++ b/libs/config/include/hpx/config.hpp
@@ -263,7 +263,7 @@
 
 /// By default we capture only 5 levels of stack back trace on suspension
 #if !defined(HPX_HAVE_THREAD_BACKTRACE_DEPTH)
-#  define HPX_HAVE_THREAD_BACKTRACE_DEPTH 5
+#  define HPX_HAVE_THREAD_BACKTRACE_DEPTH 20
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/datastructures/tests/unit/any.cpp
+++ b/libs/datastructures/tests/unit/any.cpp
@@ -30,7 +30,7 @@ int main()
 
         buffer << any1;
 
-        HPX_TEST_EQ(buffer.str(), "3040");
+        HPX_TEST(buffer.str() == "3040");
     }
 
     // non serializable version
@@ -40,11 +40,11 @@ int main()
             any_nonser any1_nonser(7), any2_nonser(7), any3_nonser(10),
                 any4_nonser(std::string("seven"));
 
-            HPX_TEST(any_cast<int>(any1_nonser) == 7);
-            HPX_TEST(any_cast<int>(any1_nonser) != 10);
-            HPX_TEST(any_cast<int>(any1_nonser) != 10.0f);
-            HPX_TEST(any_cast<int>(any1_nonser) == any_cast<int>(any1_nonser));
-            HPX_TEST(any_cast<int>(any1_nonser) == any_cast<int>(any2_nonser));
+            HPX_TEST_EQ(any_cast<int>(any1_nonser), 7);
+            HPX_TEST_NEQ(any_cast<int>(any1_nonser), 10);
+            HPX_TEST_NEQ(any_cast<int>(any1_nonser), 10.0f);
+            HPX_TEST_EQ(any_cast<int>(any1_nonser), any_cast<int>(any1_nonser));
+            HPX_TEST_EQ(any_cast<int>(any1_nonser), any_cast<int>(any2_nonser));
             HPX_TEST(any1_nonser.type() == any3_nonser.type());
             HPX_TEST(any1_nonser.type() != any4_nonser.type());
 
@@ -56,8 +56,8 @@ int main()
             any3_nonser = other_str;
             any4_nonser = 10.0f;
 
-            HPX_TEST(any_cast<std::string>(any1_nonser) == long_str);
-            HPX_TEST(any_cast<std::string>(any1_nonser) != other_str);
+            HPX_TEST_EQ(any_cast<std::string>(any1_nonser), long_str);
+            HPX_TEST_NEQ(any_cast<std::string>(any1_nonser), other_str);
             HPX_TEST(any1_nonser.type() == typeid(std::string));
             HPX_TEST(any_cast<std::string>(any1_nonser) ==
                 any_cast<std::string>(any1_nonser));

--- a/libs/datastructures/tests/unit/tuple.cpp
+++ b/libs/datastructures/tests/unit/tuple.cpp
@@ -33,6 +33,7 @@
 // clang-format on
 
 #include <array>
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <string>
@@ -145,32 +146,32 @@ hpx::util::tuple<char (&)[10]> v2(cs);    // ok
 void construction_test()
 {
     hpx::util::tuple<int> t1;
-    HPX_TEST(hpx::util::get<0>(t1) == int());
+    HPX_TEST_EQ(hpx::util::get<0>(t1), int());
 
     hpx::util::tuple<float> t2(5.5f);
-    HPX_TEST(hpx::util::get<0>(t2) > 5.4f && hpx::util::get<0>(t2) < 5.6f);
+    HPX_TEST_RANGE(hpx::util::get<0>(t2), 5.4f, 5.6f);
 
     hpx::util::tuple<foo> t3(foo(12));
     HPX_TEST(hpx::util::get<0>(t3) == foo(12));
 
     hpx::util::tuple<double> t4(t2);
-    HPX_TEST(hpx::util::get<0>(t4) > 5.4 && hpx::util::get<0>(t4) < 5.6);
+    HPX_TEST_RANGE(hpx::util::get<0>(t4), 5.4f, 5.6f);
 
     hpx::util::tuple<int, float> t5;
-    HPX_TEST(hpx::util::get<0>(t5) == int());
-    HPX_TEST(hpx::util::get<1>(t5) == float());
+    HPX_TEST_EQ(hpx::util::get<0>(t5), int());
+    HPX_TEST_EQ(hpx::util::get<1>(t5), float());
 
     hpx::util::tuple<int, float> t6(12, 5.5f);
-    HPX_TEST(hpx::util::get<0>(t6) == 12);
-    HPX_TEST(hpx::util::get<1>(t6) > 5.4f && hpx::util::get<1>(t6) < 5.6f);
+    HPX_TEST_EQ(hpx::util::get<0>(t6), 12);
+    HPX_TEST_RANGE(hpx::util::get<1>(t6), 5.4f, 5.6f);
 
     hpx::util::tuple<int, float> t7(t6);
-    HPX_TEST(hpx::util::get<0>(t7) == 12);
-    HPX_TEST(hpx::util::get<1>(t7) > 5.4f && hpx::util::get<1>(t7) < 5.6f);
+    HPX_TEST_EQ(hpx::util::get<0>(t7), 12);
+    HPX_TEST_RANGE(hpx::util::get<1>(t7), 5.4f, 5.6f);
 
     hpx::util::tuple<long, double> t8(t6);
-    HPX_TEST(hpx::util::get<0>(t8) == 12);
-    HPX_TEST(hpx::util::get<1>(t8) > 5.4 && hpx::util::get<1>(t8) < 5.6);
+    HPX_TEST_EQ(hpx::util::get<0>(t8), 12);
+    HPX_TEST_RANGE(hpx::util::get<1>(t8), 5.4f, 5.6f);
 
     dummy(hpx::util::tuple<no_def_constructor, no_def_constructor,
         no_def_constructor>(std::string("Jaba"),    // ok, since the default
@@ -210,23 +211,23 @@ void element_access_test()
     HPX_TEST(i == 1 && i2 == 2);
 
     int j = hpx::util::get<0>(ct);
-    HPX_TEST(j == 1);
+    HPX_TEST_EQ(j, 1);
 
     HPX_TEST(hpx::util::get<0>(t) = 5);
 
     //hpx::util::get<0>(ct) = 5; // can't assign to const
 
     double e = hpx::util::get<1>(t);
-    HPX_TEST(e > 2.69 && e < 2.71);
+    HPX_TEST_RANGE(e, 2.69, 2.71);
 
     hpx::util::get<1>(t) = 3.14 + i;
-    HPX_TEST(hpx::util::get<1>(t) > 4.13 && hpx::util::get<1>(t) < 4.15);
+    HPX_TEST_RANGE(hpx::util::get<1>(t), 4.13, 4.15);
 
     //hpx::util::get<2>(t) = A(); // can't assign to const
     //dummy(hpx::util::get<4>(ct)); // illegal index
 
     ++hpx::util::get<0>(t);
-    HPX_TEST(hpx::util::get<0>(t) == 6);
+    HPX_TEST_EQ(hpx::util::get<0>(t), 6);
 
     HPX_TEST((std::is_const<hpx::util::tuple_element<0,
                   hpx::util::tuple<int, float>>::type>::value != true));
@@ -257,13 +258,13 @@ void copy_test()
     hpx::util::tuple<int, char> t1(4, 'a');
     hpx::util::tuple<int, char> t2(5, 'b');
     t2 = t1;
-    HPX_TEST(hpx::util::get<0>(t1) == hpx::util::get<0>(t2));
-    HPX_TEST(hpx::util::get<1>(t1) == hpx::util::get<1>(t2));
+    HPX_TEST_EQ(hpx::util::get<0>(t1), hpx::util::get<0>(t2));
+    HPX_TEST_EQ(hpx::util::get<1>(t1), hpx::util::get<1>(t2));
 
     hpx::util::tuple<long, std::string> t3(2, "a");
     t3 = t1;
-    HPX_TEST((double) hpx::util::get<0>(t1) == hpx::util::get<0>(t3));
-    HPX_TEST(hpx::util::get<1>(t1) == hpx::util::get<1>(t3)[0]);
+    HPX_TEST_EQ((double) hpx::util::get<0>(t1), hpx::util::get<0>(t3));
+    HPX_TEST_EQ(hpx::util::get<1>(t1), hpx::util::get<1>(t3)[0]);
 
     // testing copy and assignment with implicit conversions between elements
     // testing tie
@@ -277,9 +278,9 @@ void copy_test()
     double d;
     hpx::util::tie(i, c, d) = hpx::util::make_tuple(1, 'a', 5.5);
 
-    HPX_TEST(i == 1);
-    HPX_TEST(c == 'a');
-    HPX_TEST(d > 5.4 && d < 5.6);
+    HPX_TEST_EQ(i, 1);
+    HPX_TEST_EQ(c, 'a');
+    HPX_TEST_RANGE(d, 5.4, 5.6);
 }
 
 void mutate_test()
@@ -290,9 +291,9 @@ void mutate_test()
     hpx::util::get<2>(t1) = false;
     hpx::util::get<3>(t1) = foo(5);
 
-    HPX_TEST(hpx::util::get<0>(t1) == 6);
-    HPX_TEST(hpx::util::get<1>(t1) > 2.1f && hpx::util::get<1>(t1) < 2.3f);
-    HPX_TEST(hpx::util::get<2>(t1) == false);
+    HPX_TEST_EQ(hpx::util::get<0>(t1), 6);
+    HPX_TEST_RANGE(hpx::util::get<1>(t1), 2.1f, 2.3f);
+    HPX_TEST_EQ(hpx::util::get<2>(t1), false);
     HPX_TEST(hpx::util::get<3>(t1) == foo(5));
 }
 
@@ -303,13 +304,13 @@ void mutate_test()
 void make_tuple_test()
 {
     hpx::util::tuple<int, char> t1 = hpx::util::make_tuple(5, 'a');
-    HPX_TEST(hpx::util::get<0>(t1) == 5);
-    HPX_TEST(hpx::util::get<1>(t1) == 'a');
+    HPX_TEST_EQ(hpx::util::get<0>(t1), 5);
+    HPX_TEST_EQ(hpx::util::get<1>(t1), 'a');
 
     hpx::util::tuple<int, std::string> t2;
     t2 = hpx::util::make_tuple((short int) 2, std::string("Hi"));
-    HPX_TEST(hpx::util::get<0>(t2) == 2);
-    HPX_TEST(hpx::util::get<1>(t2) == "Hi");
+    HPX_TEST_EQ(hpx::util::get<0>(t2), 2);
+    HPX_TEST_EQ(hpx::util::get<1>(t2), "Hi");
 
     A a = A();
     B b;
@@ -352,14 +353,14 @@ void tie_test()
     foo c(5);
 
     hpx::util::tie(a, b, c) = hpx::util::make_tuple(2, 'a', foo(3));
-    HPX_TEST(a == 2);
-    HPX_TEST(b == 'a');
+    HPX_TEST_EQ(a, 2);
+    HPX_TEST_EQ(b, 'a');
     HPX_TEST(c == foo(3));
 
     hpx::util::tie(a, hpx::util::ignore, c) =
         hpx::util::make_tuple((short int) 5, false, foo(5));
-    HPX_TEST(a == 5);
-    HPX_TEST(b == 'a');
+    HPX_TEST_EQ(a, 5);
+    HPX_TEST_EQ(b, 'a');
     HPX_TEST(c == foo(5));
 
     // testing assignment from std::pair
@@ -387,7 +388,7 @@ void tuple_cat_test()
 
         auto expected = hpx::util::make_tuple(1, 2.f, 1, 2.f);
 
-        HPX_TEST((res == expected));
+        HPX_TEST(res == expected);
     }
 
     // Cat multiple tuples
@@ -397,7 +398,7 @@ void tuple_cat_test()
 
         auto expected = hpx::util::make_tuple(1, 2.f, 1, 2.f, 1, 2.f);
 
-        HPX_TEST((res == expected));
+        HPX_TEST(res == expected);
     }
 
     // Cat move only types
@@ -491,8 +492,8 @@ void ordering_test()
 void const_tuple_test()
 {
     const hpx::util::tuple<int, float> t1(5, 3.3f);
-    HPX_TEST(hpx::util::get<0>(t1) == 5);
-    HPX_TEST(hpx::util::get<1>(t1) == 3.3f);
+    HPX_TEST_EQ(hpx::util::get<0>(t1), 5);
+    HPX_TEST_EQ(hpx::util::get<1>(t1), 3.3f);
 }
 
 // ----------------------------------------------------------------------------
@@ -503,12 +504,12 @@ void tuple_length_test()
     typedef hpx::util::tuple<int, float, double> t1;
     typedef hpx::util::tuple<> t2;
 
-    HPX_TEST(hpx::util::tuple_size<t1>::value == 3);
-    HPX_TEST(hpx::util::tuple_size<t2>::value == 0);
+    HPX_TEST_EQ(hpx::util::tuple_size<t1>::value, std::size_t(3));
+    HPX_TEST_EQ(hpx::util::tuple_size<t2>::value, std::size_t(0));
 
     {
         using t3 = std::array<int, 4>;
-        HPX_TEST(hpx::util::tuple_size<t3>::value == 4);
+        HPX_TEST_EQ(hpx::util::tuple_size<t3>::value, std::size_t(4));
     }
 }
 
@@ -519,21 +520,21 @@ void tuple_swap_test()
 {
     hpx::util::tuple<int, float, double> t1(1, 2.0f, 3.0), t2(4, 5.0f, 6.0);
     boost::swap(t1, t2);
-    HPX_TEST(hpx::util::get<0>(t1) == 4);
-    HPX_TEST(hpx::util::get<1>(t1) == 5.0f);
-    HPX_TEST(hpx::util::get<2>(t1) == 6.0);
-    HPX_TEST(hpx::util::get<0>(t2) == 1);
-    HPX_TEST(hpx::util::get<1>(t2) == 2.0f);
-    HPX_TEST(hpx::util::get<2>(t2) == 3.0);
+    HPX_TEST_EQ(hpx::util::get<0>(t1), 4);
+    HPX_TEST_EQ(hpx::util::get<1>(t1), 5.0f);
+    HPX_TEST_EQ(hpx::util::get<2>(t1), 6.0);
+    HPX_TEST_EQ(hpx::util::get<0>(t2), 1);
+    HPX_TEST_EQ(hpx::util::get<1>(t2), 2.0f);
+    HPX_TEST_EQ(hpx::util::get<2>(t2), 3.0);
 
     int i = 1, j = 2;
 
     hpx::util::tuple<int&> t3(i), t4(j);
     boost::swap(t3, t4);
-    HPX_TEST(hpx::util::get<0>(t3) == 2);
-    HPX_TEST(hpx::util::get<0>(t4) == 1);
-    HPX_TEST(i == 2);
-    HPX_TEST(j == 1);
+    HPX_TEST_EQ(hpx::util::get<0>(t3), 2);
+    HPX_TEST_EQ(hpx::util::get<0>(t4), 1);
+    HPX_TEST_EQ(i, 2);
+    HPX_TEST_EQ(j, 1);
 }
 
 void tuple_std_test()
@@ -542,29 +543,29 @@ void tuple_std_test()
     hpx::util::tuple<int, float, double> t1(1, 2.0f, 3.0);
     std::tuple<int, float, double> t2 = t1;
     hpx::util::tuple<int, float, double> t3 = t2;
-    HPX_TEST(std::get<0>(t1) == 1);
-    HPX_TEST(std::get<0>(t2) == 1);
-    HPX_TEST(std::get<0>(t3) == 1);
+    HPX_TEST_EQ(std::get<0>(t1), 1);
+    HPX_TEST_EQ(std::get<0>(t2), 1);
+    HPX_TEST_EQ(std::get<0>(t3), 1);
 
-    HPX_TEST(hpx::util::get<0>(t1) == 1);
-    HPX_TEST(hpx::util::get<0>(t2) == 1);
-    HPX_TEST(hpx::util::get<0>(t3) == 1);
+    HPX_TEST_EQ(hpx::util::get<0>(t1), 1);
+    HPX_TEST_EQ(hpx::util::get<0>(t2), 1);
+    HPX_TEST_EQ(hpx::util::get<0>(t3), 1);
 
-    HPX_TEST(std::get<1>(t1) == 2.0f);
-    HPX_TEST(std::get<1>(t2) == 2.0f);
-    HPX_TEST(std::get<1>(t3) == 2.0f);
+    HPX_TEST_EQ(std::get<1>(t1), 2.0f);
+    HPX_TEST_EQ(std::get<1>(t2), 2.0f);
+    HPX_TEST_EQ(std::get<1>(t3), 2.0f);
 
-    HPX_TEST(hpx::util::get<1>(t1) == 2.0f);
-    HPX_TEST(hpx::util::get<1>(t2) == 2.0f);
-    HPX_TEST(hpx::util::get<1>(t3) == 2.0f);
+    HPX_TEST_EQ(hpx::util::get<1>(t1), 2.0f);
+    HPX_TEST_EQ(hpx::util::get<1>(t2), 2.0f);
+    HPX_TEST_EQ(hpx::util::get<1>(t3), 2.0f);
 
-    HPX_TEST(std::get<2>(t1) == 3.0);
-    HPX_TEST(std::get<2>(t2) == 3.0);
-    HPX_TEST(std::get<2>(t3) == 3.0);
+    HPX_TEST_EQ(std::get<2>(t1), 3.0);
+    HPX_TEST_EQ(std::get<2>(t2), 3.0);
+    HPX_TEST_EQ(std::get<2>(t3), 3.0);
 
-    HPX_TEST(hpx::util::get<2>(t1) == 3.0);
-    HPX_TEST(hpx::util::get<2>(t2) == 3.0);
-    HPX_TEST(hpx::util::get<2>(t3) == 3.0);
+    HPX_TEST_EQ(hpx::util::get<2>(t1), 3.0);
+    HPX_TEST_EQ(hpx::util::get<2>(t2), 3.0);
+    HPX_TEST_EQ(hpx::util::get<2>(t3), 3.0);
 #endif
 }
 

--- a/libs/datastructures/tests/unit/unique_any.cpp
+++ b/libs/datastructures/tests/unit/unique_any.cpp
@@ -40,11 +40,11 @@ int main()
             unique_any_nonser any1_nonser(7), any2_nonser(7), any3_nonser(10),
                 any4_nonser(std::string("seven"));
 
-            HPX_TEST(any_cast<int>(any1_nonser) == 7);
-            HPX_TEST(any_cast<int>(any1_nonser) != 10);
-            HPX_TEST(any_cast<int>(any1_nonser) != 10.0f);
-            HPX_TEST(any_cast<int>(any1_nonser) == any_cast<int>(any1_nonser));
-            HPX_TEST(any_cast<int>(any1_nonser) == any_cast<int>(any2_nonser));
+            HPX_TEST_EQ(any_cast<int>(any1_nonser), 7);
+            HPX_TEST_NEQ(any_cast<int>(any1_nonser), 10);
+            HPX_TEST_NEQ(any_cast<int>(any1_nonser), 10.0f);
+            HPX_TEST_EQ(any_cast<int>(any1_nonser), any_cast<int>(any1_nonser));
+            HPX_TEST_EQ(any_cast<int>(any1_nonser), any_cast<int>(any2_nonser));
             HPX_TEST(any1_nonser.type() == any3_nonser.type());
             HPX_TEST(any1_nonser.type() != any4_nonser.type());
 
@@ -56,8 +56,8 @@ int main()
             any3_nonser = other_str;
             any4_nonser = 10.0f;
 
-            HPX_TEST(any_cast<std::string>(any2_nonser) == long_str);
-            HPX_TEST(any_cast<std::string>(any2_nonser) != other_str);
+            HPX_TEST_EQ(any_cast<std::string>(any2_nonser), long_str);
+            HPX_TEST_NEQ(any_cast<std::string>(any2_nonser), other_str);
             HPX_TEST(any2_nonser.type() == typeid(std::string));
             HPX_TEST(any_cast<std::string>(any2_nonser) ==
                 any_cast<std::string>(any2_nonser));

--- a/libs/execution/tests/regressions/chunk_size_4118.cpp
+++ b/libs/execution/tests/regressions/chunk_size_4118.cpp
@@ -18,7 +18,7 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=2"};
 
     // Initialize and run HPX
-    HPX_TEST(hpx::init(argc, argv, cfg) == 0);
+    HPX_TEST_EQ(hpx::init(argc, argv, cfg), 0);
 
     return hpx::util::report_errors();
 }

--- a/libs/execution/tests/unit/bulk_async.cpp
+++ b/libs/execution/tests/unit/bulk_async.cpp
@@ -21,7 +21,7 @@
 int bulk_test(
     hpx::thread::id tid, int value, bool is_par, int passed_through)    //-V813
 {
-    HPX_TEST(is_par == (tid != hpx::this_thread::get_id()));
+    HPX_TEST_EQ(is_par, (tid != hpx::this_thread::get_id()));
     HPX_TEST_EQ(passed_through, 42);
     return value;
 }

--- a/libs/execution/tests/unit/created_executor.cpp
+++ b/libs/execution/tests/unit/created_executor.cpp
@@ -69,7 +69,7 @@ namespace hpx { namespace parallel { namespace execution {
 
 void bulk_test(int value, hpx::thread::id tid, int passed_through)    //-V813
 {
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 
@@ -200,8 +200,8 @@ void sum_test()
     hpx::future<int> f_void_par = hpx::parallel::execution::async_execute(
         exec, &void_parallel_sum, std::begin(vec), std::end(vec), num_parts);
 
-    HPX_TEST(f_par.get() == sum);
-    HPX_TEST(f_void_par.get() == sum);
+    HPX_TEST_EQ(f_par.get(), sum);
+    HPX_TEST_EQ(f_void_par.get(), sum);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libs/execution/tests/unit/foreach_tests.hpp
+++ b/libs/execution/tests/unit/foreach_tests.hpp
@@ -278,7 +278,7 @@ void test_for_each_n_async(ExPolicy p, IteratorTag)
 
     hpx::future<iterator> f = hpx::parallel::for_each_n(
         p, iterator(std::begin(c)), c.size(), set_42());
-    HPX_TEST(f.get() == iterator(std::end(c)));
+    HPX_TEST_EQ(f.get(), iterator(std::end(c)));
 
     // verify values
     std::size_t count = 0;

--- a/libs/execution/tests/unit/minimal_async_executor.cpp
+++ b/libs/execution/tests/unit/minimal_async_executor.cpp
@@ -40,7 +40,7 @@ void apply_test(
 void async_bulk_test(
     int value, hpx::thread::id tid, int passed_through)    //-V813
 {
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 
@@ -55,7 +55,7 @@ void test_apply(Executor& exec)
         exec, &apply_test, std::ref(l), std::ref(id), 42);
     l.count_down_and_wait();
 
-    HPX_TEST(id != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(id, hpx::this_thread::get_id());
 }
 
 template <typename Executor>

--- a/libs/execution/tests/unit/minimal_sync_executor.cpp
+++ b/libs/execution/tests/unit/minimal_sync_executor.cpp
@@ -44,7 +44,7 @@ hpx::thread::id sync_bulk_test(int value, hpx::thread::id tid,
 void sync_bulk_test_void(
     int value, hpx::thread::id tid, int passed_through)    //-V813
 {
-    HPX_TEST(tid == hpx::this_thread::get_id());
+    HPX_TEST_EQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 
@@ -74,7 +74,7 @@ hpx::thread::id then_bulk_test(int value, hpx::shared_future<void> f,
 
     f.get();    // propagate exceptions
 
-    HPX_TEST(tid == hpx::this_thread::get_id());
+    HPX_TEST_EQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 
     return hpx::this_thread::get_id();
@@ -87,7 +87,7 @@ void then_bulk_test_void(int value, hpx::shared_future<void> f,
 
     f.get();    // propagate exceptions
 
-    HPX_TEST(tid == hpx::this_thread::get_id());
+    HPX_TEST_EQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 
@@ -138,14 +138,14 @@ void test_bulk_sync(Executor& exec)
             exec, hpx::util::bind(&sync_bulk_test, _1, tid, _2), v, 42);
     for (auto const& id : ids)
     {
-        HPX_TEST(id == hpx::this_thread::get_id());
+        HPX_TEST_EQ(id, hpx::this_thread::get_id());
     }
 
     ids = hpx::parallel::execution::bulk_sync_execute(
         exec, &sync_bulk_test, v, tid, 42);
     for (auto const& id : ids)
     {
-        HPX_TEST(id == hpx::this_thread::get_id());
+        HPX_TEST_EQ(id, hpx::this_thread::get_id());
     }
 
     hpx::parallel::execution::bulk_sync_execute(
@@ -199,7 +199,7 @@ void test_bulk_then(Executor& exec)
 
     for (auto const& tid : tids)
     {
-        HPX_TEST(tid == hpx::this_thread::get_id());
+        HPX_TEST_EQ(tid, hpx::this_thread::get_id());
     }
 
     hpx::parallel::execution::bulk_then_execute(

--- a/libs/execution/tests/unit/minimal_timed_async_executor.cpp
+++ b/libs/execution/tests/unit/minimal_timed_async_executor.cpp
@@ -55,7 +55,7 @@ void test_timed_apply(Executor& exec)
 
         l.count_down_and_wait();
 
-        HPX_TEST(id != hpx::this_thread::get_id());
+        HPX_TEST_NEQ(id, hpx::this_thread::get_id());
     }
 
     {
@@ -70,7 +70,7 @@ void test_timed_apply(Executor& exec)
 
         l.count_down_and_wait();
 
-        HPX_TEST(id != hpx::this_thread::get_id());
+        HPX_TEST_NEQ(id, hpx::this_thread::get_id());
     }
 }
 

--- a/libs/execution/tests/unit/minimal_timed_sync_executor.cpp
+++ b/libs/execution/tests/unit/minimal_timed_sync_executor.cpp
@@ -55,7 +55,7 @@ void test_timed_apply(Executor& exec)
 
         l.count_down_and_wait();
 
-        HPX_TEST(id == hpx::this_thread::get_id());
+        HPX_TEST_EQ(id, hpx::this_thread::get_id());
     }
 
     {
@@ -70,7 +70,7 @@ void test_timed_apply(Executor& exec)
 
         l.count_down_and_wait();
 
-        HPX_TEST(id == hpx::this_thread::get_id());
+        HPX_TEST_EQ(id, hpx::this_thread::get_id());
     }
 }
 

--- a/libs/execution/tests/unit/parallel_executor.cpp
+++ b/libs/execution/tests/unit/parallel_executor.cpp
@@ -67,7 +67,7 @@ void test_then()
 ///////////////////////////////////////////////////////////////////////////////
 void bulk_test(int value, hpx::thread::id tid, int passed_through)    //-V813
 {
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 
@@ -119,7 +119,7 @@ void bulk_test_f(int value, hpx::shared_future<void> f, hpx::thread::id tid,
 
     f.get();    // propagate exceptions
 
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 

--- a/libs/execution/tests/unit/parallel_fork_executor.cpp
+++ b/libs/execution/tests/unit/parallel_fork_executor.cpp
@@ -67,7 +67,7 @@ void test_then()
 ///////////////////////////////////////////////////////////////////////////////
 void bulk_test(int value, hpx::thread::id tid, int passed_through)    //-V813
 {
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 
@@ -118,7 +118,7 @@ void bulk_test_f(int value, hpx::shared_future<void> f, hpx::thread::id tid,
 
     f.get();    // propagate exceptions
 
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 

--- a/libs/execution/tests/unit/parallel_policy_executor.cpp
+++ b/libs/execution/tests/unit/parallel_policy_executor.cpp
@@ -32,7 +32,7 @@ void test_sync(bool sync)
     bool result = hpx::parallel::execution::sync_execute(exec, &test, 42) ==
         hpx::this_thread::get_id();
 
-    HPX_TEST(sync == result);
+    HPX_TEST_EQ(sync, result);
 }
 
 template <typename Policy>
@@ -45,7 +45,7 @@ void test_async(bool sync)
         hpx::parallel::execution::async_execute(exec, &test, 42).get() ==
         hpx::this_thread::get_id();
 
-    HPX_TEST(sync == result);
+    HPX_TEST_EQ(sync, result);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -71,19 +71,19 @@ void test_then(bool sync)
         hpx::parallel::execution::then_execute(exec, &test_f, f, 42).get() ==
         hpx::this_thread::get_id();
 
-    HPX_TEST(sync == result);
+    HPX_TEST_EQ(sync, result);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 void bulk_test_s(int value, hpx::thread::id tid, int passed_through)    //-V813
 {
-    HPX_TEST(tid == hpx::this_thread::get_id());
+    HPX_TEST_EQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 
 void bulk_test_a(int value, hpx::thread::id tid, int passed_through)    //-V813
 {
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 
@@ -141,7 +141,7 @@ void bulk_test_f_s(int value, hpx::shared_future<void> f, hpx::thread::id tid,
 
     f.get();    // propagate exceptions
 
-    HPX_TEST(tid == hpx::this_thread::get_id());
+    HPX_TEST_EQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 
@@ -152,7 +152,7 @@ void bulk_test_f_a(int value, hpx::shared_future<void> f, hpx::thread::id tid,
 
     f.get();    // propagate exceptions
 
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 

--- a/libs/execution/tests/unit/service_executors.cpp
+++ b/libs/execution/tests/unit/service_executors.cpp
@@ -61,7 +61,7 @@ void test_then(Executor& exec)
 ///////////////////////////////////////////////////////////////////////////////
 void bulk_test(int value, std::thread::id tid, int passed_through)
 {
-    HPX_TEST(tid != std::this_thread::get_id());
+    HPX_TEST_NEQ(tid, std::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 
@@ -108,7 +108,7 @@ void bulk_test_f(int value, hpx::shared_future<void> f, hpx::thread::id tid,
 
     f.get();    // propagate exceptions
 
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 

--- a/libs/execution/tests/unit/shared_parallel_executor.cpp
+++ b/libs/execution/tests/unit/shared_parallel_executor.cpp
@@ -61,13 +61,13 @@ void test_async()
     hpx::shared_future<hpx::thread::id> fut =
         hpx::parallel::execution::async_execute(exec, &test, 42);
 
-    HPX_TEST(fut.get() != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(fut.get(), hpx::this_thread::get_id());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 void bulk_test(int value, hpx::thread::id tid, int passed_through)    //-V813
 {
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 

--- a/libs/execution/tests/unit/standalone_thread_pool_executor.cpp
+++ b/libs/execution/tests/unit/standalone_thread_pool_executor.cpp
@@ -75,7 +75,7 @@ void test_then(Executor& exec)
 ///////////////////////////////////////////////////////////////////////////////
 void bulk_test(int value, hpx::thread::id tid, int passed_through)    //-V813
 {
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 
@@ -122,7 +122,7 @@ void bulk_test_f(int value, hpx::shared_future<void> f, hpx::thread::id tid,
 
     f.get();    // propagate exceptions
 
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 

--- a/libs/execution/tests/unit/standalone_thread_pool_os_executors.cpp
+++ b/libs/execution/tests/unit/standalone_thread_pool_os_executors.cpp
@@ -71,7 +71,7 @@ void test_then(Executor& exec)
 ///////////////////////////////////////////////////////////////////////////////
 void bulk_test(int value, hpx::thread::id tid, int passed_through)    //-V813
 {
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 
@@ -118,7 +118,7 @@ void bulk_test_f(int value, hpx::shared_future<void> f, hpx::thread::id tid,
 
     f.get();    // propagate exceptions
 
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 

--- a/libs/execution/tests/unit/this_thread_executors.cpp
+++ b/libs/execution/tests/unit/this_thread_executors.cpp
@@ -61,7 +61,7 @@ void test_then(Executor& exec)
 ///////////////////////////////////////////////////////////////////////////////
 void bulk_test(int value, hpx::thread::id tid, int passed_through)    //-V813
 {
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 
@@ -108,7 +108,7 @@ void bulk_test_f(int value, hpx::shared_future<void> f, hpx::thread::id tid,
 
     f.get();    // propagate exceptions
 
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 

--- a/libs/execution/tests/unit/thread_pool_attached_executors.cpp
+++ b/libs/execution/tests/unit/thread_pool_attached_executors.cpp
@@ -62,7 +62,7 @@ void test_then(Executor& exec)
 ///////////////////////////////////////////////////////////////////////////////
 void bulk_test(int value, hpx::thread::id tid, int passed_through)    //-V813
 {
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 
@@ -109,7 +109,7 @@ void bulk_test_f(int value, hpx::shared_future<void> f, hpx::thread::id tid,
 
     f.get();    // propagate exceptions
 
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 

--- a/libs/execution/tests/unit/thread_pool_executors.cpp
+++ b/libs/execution/tests/unit/thread_pool_executors.cpp
@@ -62,7 +62,7 @@ void test_then(Executor& exec)
 ///////////////////////////////////////////////////////////////////////////////
 void bulk_test(int value, hpx::thread::id tid, int passed_through)    //-V813
 {
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 
@@ -109,7 +109,7 @@ void bulk_test_f(int value, hpx::shared_future<void> f, hpx::thread::id tid,
 
     f.get();    // propagate exceptions
 
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 

--- a/libs/execution/tests/unit/thread_pool_os_executors.cpp
+++ b/libs/execution/tests/unit/thread_pool_os_executors.cpp
@@ -62,7 +62,7 @@ void test_then(Executor& exec)
 ///////////////////////////////////////////////////////////////////////////////
 void bulk_test(int value, hpx::thread::id tid, int passed_through)    //-V813
 {
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 
@@ -109,7 +109,7 @@ void bulk_test_f(int value, hpx::shared_future<void> f, hpx::thread::id tid,
 
     f.get();    // propagate exceptions
 
-    HPX_TEST(tid != hpx::this_thread::get_id());
+    HPX_TEST_NEQ(tid, hpx::this_thread::get_id());
     HPX_TEST_EQ(passed_through, 42);
 }
 

--- a/libs/functional/tests/unit/function/contains_test.cpp
+++ b/libs/functional/tests/unit/function/contains_test.cpp
@@ -59,7 +59,7 @@ static void target_test()
     hpx::util::function_nonser<int()> f;
 
     f = &forty_two;
-    HPX_TEST(*f.target<int (*)()>() == &forty_two);
+    HPX_TEST_EQ(*f.target<int (*)()>(), &forty_two);
     HPX_TEST(!f.target<Seventeen>());
 
     f = Seventeen();

--- a/libs/functional/tests/unit/function/function_args.cpp
+++ b/libs/functional/tests/unit/function/function_args.cpp
@@ -72,9 +72,9 @@ void test_by_value()
     f(c);
     f(std::move(c));
 
-    HPX_TEST(counter::default_constructions == 1);
-    HPX_TEST(counter::copy_constructions <= 1);
-    HPX_TEST(counter::move_constructions <= 3);
+    HPX_TEST_EQ(counter::default_constructions, 1);
+    HPX_TEST_LTE(counter::copy_constructions, 1);
+    HPX_TEST_LTE(counter::move_constructions, 3);
 
     counter::print();
 }
@@ -91,9 +91,9 @@ void test_by_lvalue_ref()
     f(c);
     //f(std::move(c)); // cannot bind rvalue to lvalue-ref (except MSVC)
 
-    HPX_TEST(counter::default_constructions == 1);
-    HPX_TEST(counter::copy_constructions == 0);
-    HPX_TEST(counter::move_constructions == 0);
+    HPX_TEST_EQ(counter::default_constructions, 1);
+    HPX_TEST_EQ(counter::copy_constructions, 0);
+    HPX_TEST_EQ(counter::move_constructions, 0);
 
     counter::print();
 }
@@ -110,9 +110,9 @@ void test_by_const_lvalue_ref()
     f(c);
     f(std::move(c));
 
-    HPX_TEST(counter::default_constructions == 1);
-    HPX_TEST(counter::copy_constructions == 0);
-    HPX_TEST(counter::move_constructions == 0);
+    HPX_TEST_EQ(counter::default_constructions, 1);
+    HPX_TEST_EQ(counter::copy_constructions, 0);
+    HPX_TEST_EQ(counter::move_constructions, 0);
 
     counter::print();
 }
@@ -129,9 +129,9 @@ void test_by_rvalue_ref()
     //f(c); // cannot bind lvalue to rvalue-ref
     f(std::move(c));
 
-    HPX_TEST(counter::default_constructions == 1);
-    HPX_TEST(counter::copy_constructions == 0);
-    HPX_TEST(counter::move_constructions == 0);
+    HPX_TEST_EQ(counter::default_constructions, 1);
+    HPX_TEST_EQ(counter::copy_constructions, 0);
+    HPX_TEST_EQ(counter::move_constructions, 0);
 
     counter::print();
 }

--- a/libs/functional/tests/unit/function/function_ref.cpp
+++ b/libs/functional/tests/unit/function/function_ref.cpp
@@ -119,7 +119,7 @@ static void test_zero_args()
     func_void_type v1 = five;
     global_int = 0;
     v1();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation and self-assignment
     v1 = three;
@@ -135,7 +135,7 @@ static void test_zero_args()
 #endif
 
     v1();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Assignment to a function
     v1 = five;
@@ -153,97 +153,97 @@ static void test_zero_args()
 #endif
 
     v1();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation
     v1 = write_five;
     global_int = 0;
     v1();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation
     v1 = write_three;
     global_int = 0;
     v1();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Invocation
     v1 = five;
     global_int = 0;
     v1();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation
     v1 = &write_three;
     global_int = 0;
     v1();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Invocation
     func_void_type v2(v1);
     v2 = three;
     global_int = 0;
     v2();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Invocation
     v2 = (five);
     global_int = 0;
     v2();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation
     v2 = (write_five);
     global_int = 0;
     v2();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation
     v2 = write_three;
     global_int = 0;
     v2();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Swapping
     v1 = five;
     std::swap(v1, v2);
     v2();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
     v1();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
     std::swap(v1, v2);
 
     // Invocation
     v2 = five;
     global_int = 0;
     v2();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation
     v2 = &write_three;
     global_int = 0;
     v2();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Invocation
     v1 = three;
     v2 = v1;
     global_int = 0;
     v1();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
     global_int = 0;
     v2();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Assign to a function from a function with a function
     v2 = write_five;
     v1 = v2;
     global_int = 0;
     v1();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
     global_int = 0;
     v2();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Construct a function given another function containing a function
     func_void_type v3(v1);
@@ -251,37 +251,37 @@ static void test_zero_args()
     // Invocation of a function
     global_int = 0;
     v3();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation
     v3 = three;
     global_int = 0;
     v3();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Invocation
     v3 = five;
     global_int = 0;
     v3();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation
     v3 = &write_five;
     global_int = 0;
     v3();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation
     v3 = &write_three;
     global_int = 0;
     v3();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Invocation
     v3 = five;
     global_int = 0;
     v3();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Construction of a function from a function containing a functor
     func_void_type v4(v3);
@@ -289,13 +289,13 @@ static void test_zero_args()
     // Invocation of a function
     global_int = 0;
     v4();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation
     v4 = three;
     global_int = 0;
     v4();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Assignment to a function
     v4 = five;
@@ -303,25 +303,25 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v4();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation
     v4 = &write_five;
     global_int = 0;
     v4();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation
     v4 = &write_three;
     global_int = 0;
     v4();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Invocation
     v4 = five;
     global_int = 0;
     v4();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Construction of a function from a functor
     func_void_type v5(five);
@@ -329,13 +329,13 @@ static void test_zero_args()
     // Invocation of a function
     global_int = 0;
     v5();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation
     v5 = three;
     global_int = 0;
     v5();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Assignment to a function
     v5 = five;
@@ -343,25 +343,25 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v5();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation
     v5 = &write_five;
     global_int = 0;
     v5();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation
     v5 = &write_three;
     global_int = 0;
     v5();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Invocation
     v5 = five;
     global_int = 0;
     v5();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Construction of a function from a function
     func_void_type v6(&write_five);
@@ -369,13 +369,13 @@ static void test_zero_args()
     // Invocation of a function
     global_int = 0;
     v6();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation
     v6 = three;
     global_int = 0;
     v6();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Assignment to a function
     v6 = five;
@@ -383,25 +383,25 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v6();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation
     v6 = &write_five;
     global_int = 0;
     v6();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation
     v6 = &write_three;
     global_int = 0;
     v6();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Invocation
     v6 = five;
     global_int = 0;
     v6();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Const vs. non-const
     write_const_1_nonconst_2 one_or_two;
@@ -410,11 +410,11 @@ static void test_zero_args()
 
     global_int = 0;
     v7();
-    HPX_TEST(global_int == 2);
+    HPX_TEST_EQ(global_int, 2);
 
     global_int = 0;
     v8();
-    HPX_TEST(global_int == 2);
+    HPX_TEST_EQ(global_int, 2);
 
     // Test return values
     typedef hpx::util::function_ref<int()> func_int_type;
@@ -423,25 +423,25 @@ static void test_zero_args()
 
     func_int_type i0(gen_five);
 
-    HPX_TEST(i0() == 5);
+    HPX_TEST_EQ(i0(), 5);
     i0 = gen_three;
-    HPX_TEST(i0() == 3);
+    HPX_TEST_EQ(i0(), 3);
     i0 = &generate_five;
-    HPX_TEST(i0() == 5);
+    HPX_TEST_EQ(i0(), 5);
     i0 = &generate_three;
-    HPX_TEST(i0() == 3);
+    HPX_TEST_EQ(i0(), 3);
 
     // Test return values with compatible types
     typedef hpx::util::function_ref<long()> func_long_type;
     func_long_type i1(gen_five);
 
-    HPX_TEST(i1() == 5);
+    HPX_TEST_EQ(i1(), 5);
     i1 = gen_three;
-    HPX_TEST(i1() == 3);
+    HPX_TEST_EQ(i1(), 3);
     i1 = &generate_five;
-    HPX_TEST(i1() == 5);
+    HPX_TEST_EQ(i1(), 5);
     i1 = &generate_three;
-    HPX_TEST(i1() == 3);
+    HPX_TEST_EQ(i1(), 3);
 }
 
 static void test_one_arg()
@@ -449,30 +449,30 @@ static void test_one_arg()
     std::negate<int> neg;
 
     hpx::util::function_ref<int(int)> f1(neg);
-    HPX_TEST(f1(5) == -5);
+    HPX_TEST_EQ(f1(5), -5);
 
     hpx::util::function_ref<string(string)> id(&identity_str);
-    HPX_TEST(id("str") == "str");
+    HPX_TEST_EQ(id("str"), "str");
 
     hpx::util::function_ref<string(const char*)> id2(&identity_str);
-    HPX_TEST(id2("foo") == "foo");
+    HPX_TEST_EQ(id2("foo"), "foo");
 
     add_to_obj add_to(5);
     hpx::util::function_ref<int(int)> f2(add_to);
-    HPX_TEST(f2(3) == 8);
+    HPX_TEST_EQ(f2(3), 8);
 
     const hpx::util::function_ref<int(int)> cf2(add_to);
-    HPX_TEST(cf2(3) == 8);
+    HPX_TEST_EQ(cf2(3), 8);
 }
 
 static void test_two_args()
 {
     hpx::util::function_ref<string(const string&, const string&)> cat(
         &string_cat);
-    HPX_TEST(cat("str", "ing") == "string");
+    HPX_TEST_EQ(cat("str", "ing"), "string");
 
     hpx::util::function_ref<int(short, short)> sum(&sum_ints);
-    HPX_TEST(sum(2, 3) == 5);
+    HPX_TEST_EQ(sum(2, 3), 5);
 }
 
 struct add_with_throw_on_copy
@@ -501,7 +501,7 @@ static void test_ref()
     try
     {
         hpx::util::function_ref<int(int, int)> f(std::ref(atc));
-        HPX_TEST(f(1, 3) == 4);
+        HPX_TEST_EQ(f(1, 3), 4);
     }
     catch (std::runtime_error const& /*e*/)
     {
@@ -520,7 +520,7 @@ static void test_ptr_ref()
     global_int = 0;
     void_ptr = &write_three;
     v1();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation and assignment
     void_ptr = &write_five;
@@ -528,19 +528,19 @@ static void test_ptr_ref()
     global_int = 0;
     void_ptr = &write_three;
     v1();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Invocation of a function
     int (*int_ptr)() = &generate_five;
     func_int_type v2 = int_ptr;
     int_ptr = &generate_three;
-    HPX_TEST(v2() == 5);
+    HPX_TEST_EQ(v2(), 5);
 
     // Invocation and assignment
     int_ptr = &generate_five;
     v2 = int_ptr;
     int_ptr = &generate_three;
-    HPX_TEST(v2() == 5);
+    HPX_TEST_EQ(v2(), 5);
 }
 
 struct big_aggregating_structure
@@ -582,26 +582,26 @@ static void test_copy_semantics()
     f1_type f1 = obj;
     global_int = 0;
     f1();
-    HPX_TEST(global_int == 1);
+    HPX_TEST_EQ(global_int, 1);
 
     // Testing rvalue constructors
     f1_type f2(static_cast<f1_type&&>(f1));
-    HPX_TEST(global_int == 1);
+    HPX_TEST_EQ(global_int, 1);
     f2();
-    HPX_TEST(global_int == 2);
+    HPX_TEST_EQ(global_int, 2);
 
     f1_type f3(static_cast<f1_type&&>(f2));
-    HPX_TEST(global_int == 2);
+    HPX_TEST_EQ(global_int, 2);
     f3();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Testing, that no copies are made
     f1_type f4 = obj;
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
     f1_type f5 = obj;
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
     f4 = static_cast<f1_type&&>(f5);
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 }
 
 int main(int, char*[])

--- a/libs/functional/tests/unit/function/function_test.cpp
+++ b/libs/functional/tests/unit/function/function_test.cpp
@@ -141,7 +141,7 @@ static void test_zero_args()
     // Invocation of a function
     global_int = 0;
     v1();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // reset() method
     v1.reset();
@@ -164,7 +164,7 @@ static void test_zero_args()
 #endif
 
     v1();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Assignment to a non-empty function
     v1 = five;
@@ -182,7 +182,7 @@ static void test_zero_args()
 #endif
 
     v1();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // clear
     void (*fpv1)() = 0;    // NOLINT
@@ -200,7 +200,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v1();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Assignment to a non-empty function from a free function
     v1 = write_three;
@@ -209,7 +209,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v1();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Assignment
     v1 = five;
@@ -218,7 +218,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v1();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Assignment to a non-empty function from a free function
     v1 = &write_three;
@@ -227,7 +227,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v1();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Construction from another function (that is empty)
     v1.reset();
@@ -241,7 +241,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v2();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Assignment to a non-empty function
     v2 = (five);
@@ -249,7 +249,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v2();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     v2.reset();
     HPX_TEST(v2.empty());
@@ -261,7 +261,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v2();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Assignment to a non-empty function from a free function
     v2 = write_three;
@@ -270,15 +270,15 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v2();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Swapping
     v1 = five;
     std::swap(v1, v2);
     v2();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
     v1();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
     std::swap(v1, v2);
     v1.reset();
 
@@ -289,7 +289,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v2();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Assignment to a non-empty function from a free function
     v2 = &write_three;
@@ -298,7 +298,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v2();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Assignment to a function from an empty function
     v2 = v1;
@@ -313,10 +313,10 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v1();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
     global_int = 0;
     v2();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Assign to a function from a function with a function
     v2 = write_five;
@@ -325,10 +325,10 @@ static void test_zero_args()
     HPX_TEST(!v2.empty());
     global_int = 0;
     v1();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
     global_int = 0;
     v2();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Construct a function given another function containing a function
     func_void_type v3(v1);
@@ -336,7 +336,7 @@ static void test_zero_args()
     // Invocation of a function
     global_int = 0;
     v3();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // reset() method
     v3.reset();
@@ -349,7 +349,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v3();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Assignment to a non-empty function
     v3 = five;
@@ -357,7 +357,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v3();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // reset()
     v3.reset();
@@ -370,7 +370,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v3();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Assignment to a non-empty function from a free function
     v3 = &write_three;
@@ -379,7 +379,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v3();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Assignment
     v3 = five;
@@ -388,7 +388,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v3();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Construction of a function from a function containing a functor
     func_void_type v4(v3);
@@ -396,7 +396,7 @@ static void test_zero_args()
     // Invocation of a function
     global_int = 0;
     v4();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // reset() method
     v4.reset();
@@ -409,7 +409,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v4();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Assignment to a non-empty function
     v4 = five;
@@ -417,7 +417,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v4();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // reset()
     v4.reset();
@@ -430,7 +430,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v4();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Assignment to a non-empty function from a free function
     v4 = &write_three;
@@ -439,7 +439,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v4();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Assignment
     v4 = five;
@@ -448,7 +448,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v4();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Construction of a function from a functor
     func_void_type v5(five);
@@ -456,7 +456,7 @@ static void test_zero_args()
     // Invocation of a function
     global_int = 0;
     v5();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // reset() method
     v5.reset();
@@ -469,7 +469,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v5();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Assignment to a non-empty function
     v5 = five;
@@ -477,7 +477,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v5();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // reset()
     v5.reset();
@@ -490,7 +490,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v5();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Assignment to a non-empty function from a free function
     v5 = &write_three;
@@ -499,7 +499,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v5();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Assignment
     v5 = five;
@@ -508,7 +508,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v5();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Construction of a function from a function
     func_void_type v6(&write_five);
@@ -516,7 +516,7 @@ static void test_zero_args()
     // Invocation of a function
     global_int = 0;
     v6();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // reset() method
     v6.reset();
@@ -529,7 +529,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v6();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Assignment to a non-empty function
     v6 = five;
@@ -537,7 +537,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v6();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // reset()
     v6.reset();
@@ -550,7 +550,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v6();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Assignment to a non-empty function from a free function
     v6 = &write_three;
@@ -559,7 +559,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v6();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Assignment
     v6 = five;
@@ -568,7 +568,7 @@ static void test_zero_args()
     // Invocation
     global_int = 0;
     v6();
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
 
     // Const vs. non-const
     write_const_1_nonconst_2 one_or_two;
@@ -577,11 +577,11 @@ static void test_zero_args()
 
     global_int = 0;
     v7();
-    HPX_TEST(global_int == 2);
+    HPX_TEST_EQ(global_int, 2);
 
     global_int = 0;
     v8();
-    HPX_TEST(global_int == 2);
+    HPX_TEST_EQ(global_int, 2);
 
     // Test construction from 0
     void (*fpv9)() = 0;    // NOLINT
@@ -599,13 +599,13 @@ static void test_zero_args()
 
     func_int_type i0(gen_five);
 
-    HPX_TEST(i0() == 5);
+    HPX_TEST_EQ(i0(), 5);
     i0 = gen_three;
-    HPX_TEST(i0() == 3);
+    HPX_TEST_EQ(i0(), 3);
     i0 = &generate_five;
-    HPX_TEST(i0() == 5);
+    HPX_TEST_EQ(i0(), 5);
     i0 = &generate_three;
-    HPX_TEST(i0() == 3);
+    HPX_TEST_EQ(i0(), 3);
     HPX_TEST(!i0.empty());
     i0.reset();
     HPX_TEST(!i0);
@@ -614,13 +614,13 @@ static void test_zero_args()
     typedef hpx::util::function_nonser<long()> func_long_type;
     func_long_type i1(gen_five);
 
-    HPX_TEST(i1() == 5);
+    HPX_TEST_EQ(i1(), 5);
     i1 = gen_three;
-    HPX_TEST(i1() == 3);
+    HPX_TEST_EQ(i1(), 3);
     i1 = &generate_five;
-    HPX_TEST(i1() == 5);
+    HPX_TEST_EQ(i1(), 5);
     i1 = &generate_three;
-    HPX_TEST(i1() == 3);
+    HPX_TEST_EQ(i1(), 3);
     HPX_TEST(!i1.empty());
     i1.reset();
     HPX_TEST(!i1);
@@ -631,30 +631,30 @@ static void test_one_arg()
     std::negate<int> neg;
 
     hpx::util::function_nonser<int(int)> f1(neg);
-    HPX_TEST(f1(5) == -5);
+    HPX_TEST_EQ(f1(5), -5);
 
     hpx::util::function_nonser<string(string)> id(&identity_str);
-    HPX_TEST(id("str") == "str");
+    HPX_TEST_EQ(id("str"), "str");
 
     hpx::util::function_nonser<string(const char*)> id2(&identity_str);
-    HPX_TEST(id2("foo") == "foo");
+    HPX_TEST_EQ(id2("foo"), "foo");
 
     add_to_obj add_to(5);
     hpx::util::function_nonser<int(int)> f2(add_to);
-    HPX_TEST(f2(3) == 8);
+    HPX_TEST_EQ(f2(3), 8);
 
     const hpx::util::function_nonser<int(int)> cf2(add_to);
-    HPX_TEST(cf2(3) == 8);
+    HPX_TEST_EQ(cf2(3), 8);
 }
 
 static void test_two_args()
 {
     hpx::util::function_nonser<string(const string&, const string&)> cat(
         &string_cat);
-    HPX_TEST(cat("str", "ing") == "string");
+    HPX_TEST_EQ(cat("str", "ing"), "string");
 
     hpx::util::function_nonser<int(short, short)> sum(&sum_ints);
-    HPX_TEST(sum(2, 3) == 5);
+    HPX_TEST_EQ(sum(2, 3), 5);
 }
 
 static void test_emptiness()
@@ -697,18 +697,18 @@ static void test_member_functions()
     X one(1);
     X five(5);
 
-    HPX_TEST(f1(&one) == 2);
-    HPX_TEST(f1(&five) == 10);
+    HPX_TEST_EQ(f1(&one), 2);
+    HPX_TEST_EQ(f1(&five), 10);
 
     hpx::util::function_nonser<int(X*)> f1_2;
     f1_2 = &X::twice;
 
-    HPX_TEST(f1_2(&one) == 2);
-    HPX_TEST(f1_2(&five) == 10);
+    HPX_TEST_EQ(f1_2(&one), 2);
+    HPX_TEST_EQ(f1_2(&five), 10);
 
     hpx::util::function_nonser<int(X&, int)> f2(&X::plus);
-    HPX_TEST(f2(one, 3) == 4);
-    HPX_TEST(f2(five, 4) == 9);
+    HPX_TEST_EQ(f2(one, 3), 4);
+    HPX_TEST_EQ(f2(five, 4), 9);
 }
 
 struct add_with_throw_on_copy
@@ -737,7 +737,7 @@ static void test_ref()
     try
     {
         hpx::util::function_nonser<int(int, int)> f(std::ref(atc));
-        HPX_TEST(f(1, 3) == 4);
+        HPX_TEST_EQ(f(1, 3), 4);
     }
     catch (std::runtime_error const& /*e*/)
     {
@@ -855,23 +855,23 @@ static void test_move_semantics()
     f1();
 
     HPX_TEST(!f1.empty());
-    HPX_TEST(global_int == 1);
+    HPX_TEST_EQ(global_int, 1);
 
     // Testing rvalue constructors
     f1_type f2(static_cast<f1_type&&>(f1));
     HPX_TEST(f1.empty());
     HPX_TEST(!f2.empty());
-    HPX_TEST(global_int == 1);
+    HPX_TEST_EQ(global_int, 1);
     f2();
-    HPX_TEST(global_int == 2);
+    HPX_TEST_EQ(global_int, 2);
 
     f1_type f3(static_cast<f1_type&&>(f2));
     HPX_TEST(f1.empty());
     HPX_TEST(f2.empty());
     HPX_TEST(!f3.empty());
-    HPX_TEST(global_int == 2);
+    HPX_TEST_EQ(global_int, 2);
     f3();
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
 
     // Testing move assignment
     f1_type f4;
@@ -881,23 +881,23 @@ static void test_move_semantics()
     HPX_TEST(f2.empty());
     HPX_TEST(f3.empty());
     HPX_TEST(!f4.empty());
-    HPX_TEST(global_int == 3);
+    HPX_TEST_EQ(global_int, 3);
     f4();
-    HPX_TEST(global_int == 4);
+    HPX_TEST_EQ(global_int, 4);
 
     // Testing self move assignment
     f4 = static_cast<f1_type&&>(f4);
     HPX_TEST(!f4.empty());
-    HPX_TEST(global_int == 4);
+    HPX_TEST_EQ(global_int, 4);
 
     // Testing, that no memory leaked when assigning to nonempty function
     f4 = obj;
     HPX_TEST(!f4.empty());
-    HPX_TEST(global_int == 4);
+    HPX_TEST_EQ(global_int, 4);
     f1_type f5 = obj;
-    HPX_TEST(global_int == 5);
+    HPX_TEST_EQ(global_int, 5);
     f4 = static_cast<f1_type&&>(f5);
-    HPX_TEST(global_int == 4);
+    HPX_TEST_EQ(global_int, 4);
 }
 
 int main(int, char*[])

--- a/libs/functional/tests/unit/function/nothrow_swap.cpp
+++ b/libs/functional/tests/unit/function/nothrow_swap.cpp
@@ -66,13 +66,13 @@ int main(int, char*[])
     MaybeThrowOnCopy::throwOnCopy = false;
     f = MaybeThrowOnCopy(1);
     g = MaybeThrowOnCopy(2);
-    HPX_TEST(f() == 1);
-    HPX_TEST(g() == 2);
+    HPX_TEST_EQ(f(), 1);
+    HPX_TEST_EQ(g(), 2);
 
     MaybeThrowOnCopy::throwOnCopy = true;
     f.swap(g);
-    HPX_TEST(f() == 2);
-    HPX_TEST(g() == 1);
+    HPX_TEST_EQ(f(), 2);
+    HPX_TEST_EQ(g(), 1);
 
     return hpx::util::report_errors();
 }

--- a/libs/iterator_support/tests/unit/iterator_adaptor.cpp
+++ b/libs/iterator_support/tests/unit/iterator_adaptor.cpp
@@ -270,7 +270,7 @@ int main()
         int zero = 0;
         if (zero)    // don't do this, just make sure it compiles
         {
-            HPX_TEST((*i).x_ == i->foo());
+            HPX_TEST_EQ((*i).x_, i->foo());
         }
     }
 
@@ -282,7 +282,7 @@ int main()
         int zero = 0;
         if (zero)    // don't do this, just make sure it compiles
         {
-            HPX_TEST((*i).x_ == i->foo());
+            HPX_TEST_EQ((*i).x_, i->foo());
         }
     }
 

--- a/libs/iterator_support/tests/unit/iterator_facade.cpp
+++ b/libs/iterator_support/tests/unit/iterator_facade.cpp
@@ -171,14 +171,14 @@ int main()
     {
         int x = 0;
         iterator_with_proxy_reference i(x);
-        HPX_TEST(x == 0);
-        HPX_TEST(i.m_x == 0);
+        HPX_TEST_EQ(x, 0);
+        HPX_TEST_EQ(i.m_x, 0);
         ++(*i).m_x;
-        HPX_TEST(x == 1);
-        HPX_TEST(i.m_x == 1);
+        HPX_TEST_EQ(x, 1);
+        HPX_TEST_EQ(i.m_x, 1);
         ++i->m_x;
-        HPX_TEST(x == 2);
-        HPX_TEST(i.m_x == 2);
+        HPX_TEST_EQ(x, 2);
+        HPX_TEST_EQ(i.m_x, 2);
     }
 
     return hpx::util::report_errors();

--- a/libs/iterator_support/tests/unit/iterator_tests.hpp
+++ b/libs/iterator_support/tests/unit/iterator_tests.hpp
@@ -317,8 +317,8 @@ namespace tests {
             HPX_TEST(*i == *(j + c));
             HPX_TEST(*i == *(c + j));
             ++i;
-            HPX_TEST(i > j);
-            HPX_TEST(i >= j);
+            HPX_TEST(j < i);
+            HPX_TEST(j <= i);
             HPX_TEST(j <= i);
             HPX_TEST(j < i);
         }
@@ -331,8 +331,8 @@ namespace tests {
             HPX_TEST(*i == detail::implicit_cast<value_type>(j[N - 1 - c]));
             Iterator q = k - c;
             HPX_TEST(*i == *q);
-            HPX_TEST(i > j);
-            HPX_TEST(i >= j);
+            HPX_TEST(j < i);
+            HPX_TEST(j <= i);
             HPX_TEST(j <= i);
             HPX_TEST(j < i);
             --i;
@@ -357,8 +357,8 @@ namespace tests {
             HPX_TEST(*i == *(j + c));
             HPX_TEST(*i == *(c + j));
             ++i;
-            HPX_TEST(i > j);
-            HPX_TEST(i >= j);
+            HPX_TEST(j < i);
+            HPX_TEST(j <= i);
             HPX_TEST(j <= i);
             HPX_TEST(j < i);
         }
@@ -373,8 +373,8 @@ namespace tests {
             HPX_TEST(*i == x);
             Iterator q = k - c;
             HPX_TEST(*i == *q);
-            HPX_TEST(i > j);
-            HPX_TEST(i >= j);
+            HPX_TEST(j < i);
+            HPX_TEST(j <= i);
             HPX_TEST(j <= i);
             HPX_TEST(j < i);
             --i;
@@ -389,7 +389,7 @@ namespace tests {
         typedef typename std::iterator_traits<Iterator>::reference reference;
         HPX_TEST((std::is_same<const value_type&, reference>::value));
         const T& v2 = *i2;
-        HPX_TEST(v1 == v2);
+        HPX_TEST_EQ(v1, v2);
         //HPX_TEST(is_lvalue_iterator<Iterator>::value);
         //HPX_TEST(!is_non_const_lvalue_iterator<Iterator>::value);
     }
@@ -402,14 +402,14 @@ namespace tests {
         typedef typename std::iterator_traits<Iterator>::reference reference;
         HPX_TEST((std::is_same<value_type&, reference>::value));
         T& v3 = *i2;
-        HPX_TEST(v1 == v3);
+        HPX_TEST_EQ(v1, v3);
 
         // A non-const lvalue iterator is not necessarily writable, but we
         // are assuming the value_type is assignable here
         *i = v2;
 
         T& v4 = *i2;
-        HPX_TEST(v2 == v4);
+        HPX_TEST_EQ(v2, v4);
         //HPX_TEST(is_lvalue_iterator<Iterator>::value);
         //HPX_TEST(is_non_const_lvalue_iterator<Iterator>::value);
     }

--- a/libs/iterator_support/tests/unit/range.cpp
+++ b/libs/iterator_support/tests/unit/range.cpp
@@ -14,12 +14,12 @@
 void array_range()
 {
     int r[3] = {0, 1, 2};
-    HPX_TEST_EQ(hpx::util::begin(r), &r[0]);
-    HPX_TEST_EQ(hpx::util::end(r), &r[3]);
+    HPX_TEST(hpx::util::begin(r) == &r[0]);
+    HPX_TEST(hpx::util::end(r) == &r[3]);
 
     int const cr[3] = {0, 1, 2};
-    HPX_TEST_EQ(hpx::util::begin(cr), &cr[0]);
-    HPX_TEST_EQ(hpx::util::end(cr), &cr[3]);
+    HPX_TEST(hpx::util::begin(cr) == &cr[0]);
+    HPX_TEST(hpx::util::end(cr) == &cr[3]);
     HPX_TEST_EQ(hpx::util::size(cr), 3u);
     HPX_TEST_EQ(hpx::util::empty(cr), false);
 }
@@ -53,12 +53,12 @@ struct member
 void member_range()
 {
     member r = member();
-    HPX_TEST_EQ(hpx::util::begin(r), &r.x);
-    HPX_TEST_EQ(hpx::util::end(r), &r.x + 1);
+    HPX_TEST(hpx::util::begin(r) == &r.x);
+    HPX_TEST(hpx::util::end(r) == &r.x + 1);
 
     member const cr = member();
-    HPX_TEST_EQ(hpx::util::begin(cr), &cr.x);
-    HPX_TEST_EQ(hpx::util::end(cr), &cr.x + 1);
+    HPX_TEST(hpx::util::begin(cr) == &cr.x);
+    HPX_TEST(hpx::util::end(cr) == &cr.x + 1);
     HPX_TEST_EQ(hpx::util::size(cr), 1u);
     HPX_TEST_EQ(hpx::util::empty(cr), false);
 }
@@ -94,12 +94,12 @@ namespace adl {
 void adl_range()
 {
     adl::free r = adl::free();
-    HPX_TEST_EQ(hpx::util::begin(r), &r.x);
-    HPX_TEST_EQ(hpx::util::end(r), &r.x + 1);
+    HPX_TEST(hpx::util::begin(r) == &r.x);
+    HPX_TEST(hpx::util::end(r) == &r.x + 1);
 
     adl::free const cr = adl::free();
-    HPX_TEST_EQ(hpx::util::begin(cr), &cr.x);
-    HPX_TEST_EQ(hpx::util::end(cr), &cr.x + 1);
+    HPX_TEST(hpx::util::begin(cr) == &cr.x);
+    HPX_TEST(hpx::util::end(cr) == &cr.x + 1);
     HPX_TEST_EQ(hpx::util::size(cr), 1u);
     HPX_TEST_EQ(hpx::util::empty(cr), false);
 }

--- a/libs/memory/tests/unit/intrusive_ptr.cpp
+++ b/libs/memory/tests/unit/intrusive_ptr.cpp
@@ -125,36 +125,36 @@ namespace n_constructors {
             HPX_TEST(px.get() == nullptr);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             X* p = new X;
-            HPX_TEST(p->use_count() == 0);
+            HPX_TEST_EQ(p->use_count(), 0);
 
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
 
             hpx::intrusive_ptr<X> px(p);
-            HPX_TEST(px.get() == p);
-            HPX_TEST(px->use_count() == 1);
+            HPX_TEST_EQ(px.get(), p);
+            HPX_TEST_EQ(px->use_count(), 1);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             X* p = new X;
-            HPX_TEST(p->use_count() == 0);
+            HPX_TEST_EQ(p->use_count(), 0);
 
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
 
             intrusive_ptr_add_ref(p);
-            HPX_TEST(p->use_count() == 1);
+            HPX_TEST_EQ(p->use_count(), 1);
 
             hpx::intrusive_ptr<X> px(p, false);
-            HPX_TEST(px.get() == p);
-            HPX_TEST(px->use_count() == 1);
+            HPX_TEST_EQ(px.get(), p);
+            HPX_TEST_EQ(px->use_count(), 1);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
     }
 
     void copy_constructor()
@@ -162,60 +162,60 @@ namespace n_constructors {
         {
             hpx::intrusive_ptr<X> px;
             hpx::intrusive_ptr<X> px2(px);
-            HPX_TEST(px2.get() == px.get());
+            HPX_TEST_EQ(px2.get(), px.get());
         }
 
         {
             hpx::intrusive_ptr<Y> py;
             hpx::intrusive_ptr<X> px(py);
-            HPX_TEST(px.get() == py.get());
+            HPX_TEST_EQ(px.get(), py.get());
         }
 
         {
             hpx::intrusive_ptr<X> px(nullptr);
             hpx::intrusive_ptr<X> px2(px);
-            HPX_TEST(px2.get() == px.get());
+            HPX_TEST_EQ(px2.get(), px.get());
         }
 
         {
             hpx::intrusive_ptr<Y> py(nullptr);
             hpx::intrusive_ptr<X> px(py);
-            HPX_TEST(px.get() == py.get());
+            HPX_TEST_EQ(px.get(), py.get());
         }
 
         {
             hpx::intrusive_ptr<X> px(nullptr, false);
             hpx::intrusive_ptr<X> px2(px);
-            HPX_TEST(px2.get() == px.get());
+            HPX_TEST_EQ(px2.get(), px.get());
         }
 
         {
             hpx::intrusive_ptr<Y> py(nullptr, false);
             hpx::intrusive_ptr<X> px(py);
-            HPX_TEST(px.get() == py.get());
+            HPX_TEST_EQ(px.get(), py.get());
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             hpx::intrusive_ptr<X> px(new X);
             hpx::intrusive_ptr<X> px2(px);
-            HPX_TEST(px2.get() == px.get());
+            HPX_TEST_EQ(px2.get(), px.get());
 
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             hpx::intrusive_ptr<Y> py(new Y);
             hpx::intrusive_ptr<X> px(py);
-            HPX_TEST(px.get() == py.get());
+            HPX_TEST_EQ(px.get(), py.get());
 
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
     }
 
     void test()
@@ -231,23 +231,23 @@ namespace n_destructor {
 
     void test()
     {
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             hpx::intrusive_ptr<X> px(new X);
-            HPX_TEST(px->use_count() == 1);
+            HPX_TEST_EQ(px->use_count(), 1);
 
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
 
             {
                 hpx::intrusive_ptr<X> px2(px);
-                HPX_TEST(px->use_count() == 2);
+                HPX_TEST_EQ(px->use_count(), 2);
             }
 
-            HPX_TEST(px->use_count() == 1);
+            HPX_TEST_EQ(px->use_count(), 1);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
     }
 
 }    // namespace n_destructor
@@ -256,7 +256,7 @@ namespace n_assignment {
 
     void copy_assignment()
     {
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             hpx::intrusive_ptr<X> p1;
@@ -270,7 +270,7 @@ namespace n_assignment {
 #pragma clang diagnostic pop
 #endif
 
-            HPX_TEST(p1 == p1);
+            HPX_TEST_EQ(p1, p1);
             HPX_TEST(p1 ? false : true);
             HPX_TEST(!p1);
             HPX_TEST(p1.get() == nullptr);
@@ -279,7 +279,7 @@ namespace n_assignment {
 
             p1 = p2;
 
-            HPX_TEST(p1 == p2);
+            HPX_TEST_EQ(p1, p2);
             HPX_TEST(p1 ? false : true);
             HPX_TEST(!p1);
             HPX_TEST(p1.get() == nullptr);
@@ -288,40 +288,40 @@ namespace n_assignment {
 
             p1 = p3;
 
-            HPX_TEST(p1 == p3);
+            HPX_TEST_EQ(p1, p3);
             HPX_TEST(p1 ? false : true);
             HPX_TEST(!p1);
             HPX_TEST(p1.get() == nullptr);
 
-            HPX_TEST(N::base::instances == 0);
+            HPX_TEST_EQ(N::base::instances, 0);
 
             hpx::intrusive_ptr<X> p4(new X);
 
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
 
             p1 = p4;
 
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
 
-            HPX_TEST(p1 == p4);
+            HPX_TEST_EQ(p1, p4);
 
-            HPX_TEST(p1->use_count() == 2);
+            HPX_TEST_EQ(p1->use_count(), 2);
 
             p1 = p2;
 
-            HPX_TEST(p1 == p2);
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(p1, p2);
+            HPX_TEST_EQ(N::base::instances, 1);
 
             p4 = p3;
 
-            HPX_TEST(p4 == p3);
-            HPX_TEST(N::base::instances == 0);
+            HPX_TEST_EQ(p4, p3);
+            HPX_TEST_EQ(N::base::instances, 0);
         }
     }
 
     void conversion_assignment()
     {
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             hpx::intrusive_ptr<X> p1;
@@ -330,54 +330,54 @@ namespace n_assignment {
 
             p1 = p2;
 
-            HPX_TEST(p1 == p2);
+            HPX_TEST_EQ(p1, p2);
             HPX_TEST(p1 ? false : true);
             HPX_TEST(!p1);
             HPX_TEST(p1.get() == nullptr);
 
-            HPX_TEST(N::base::instances == 0);
+            HPX_TEST_EQ(N::base::instances, 0);
 
             hpx::intrusive_ptr<Y> p4(new Y);
 
-            HPX_TEST(N::base::instances == 1);
-            HPX_TEST(p4->use_count() == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
+            HPX_TEST_EQ(p4->use_count(), 1);
 
             hpx::intrusive_ptr<X> p5(p4);
-            HPX_TEST(p4->use_count() == 2);
+            HPX_TEST_EQ(p4->use_count(), 2);
 
             p1 = p4;
 
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
 
-            HPX_TEST(p1 == p4);
+            HPX_TEST_EQ(p1, p4);
 
-            HPX_TEST(p1->use_count() == 3);
-            HPX_TEST(p4->use_count() == 3);
+            HPX_TEST_EQ(p1->use_count(), 3);
+            HPX_TEST_EQ(p4->use_count(), 3);
 
             p1 = p2;
 
-            HPX_TEST(p1 == p2);
-            HPX_TEST(N::base::instances == 1);
-            HPX_TEST(p4->use_count() == 2);
+            HPX_TEST_EQ(p1, p2);
+            HPX_TEST_EQ(N::base::instances, 1);
+            HPX_TEST_EQ(p4->use_count(), 2);
 
             p4 = p2;
             p5 = p2;
 
-            HPX_TEST(p4 == p2);
-            HPX_TEST(N::base::instances == 0);
+            HPX_TEST_EQ(p4, p2);
+            HPX_TEST_EQ(N::base::instances, 0);
         }
     }
 
     void pointer_assignment()
     {
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             hpx::intrusive_ptr<X> p1;
 
             p1 = p1.get();
 
-            HPX_TEST(p1 == p1);
+            HPX_TEST_EQ(p1, p1);
             HPX_TEST(p1 ? false : true);
             HPX_TEST(!p1);
             HPX_TEST(p1.get() == nullptr);
@@ -386,7 +386,7 @@ namespace n_assignment {
 
             p1 = p2.get();
 
-            HPX_TEST(p1 == p2);
+            HPX_TEST_EQ(p1, p2);
             HPX_TEST(p1 ? false : true);
             HPX_TEST(!p1);
             HPX_TEST(p1.get() == nullptr);
@@ -395,34 +395,34 @@ namespace n_assignment {
 
             p1 = p3.get();
 
-            HPX_TEST(p1 == p3);
+            HPX_TEST_EQ(p1, p3);
             HPX_TEST(p1 ? false : true);
             HPX_TEST(!p1);
             HPX_TEST(p1.get() == nullptr);
 
-            HPX_TEST(N::base::instances == 0);
+            HPX_TEST_EQ(N::base::instances, 0);
 
             hpx::intrusive_ptr<X> p4(new X);
 
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
 
             p1 = p4.get();
 
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
 
-            HPX_TEST(p1 == p4);
+            HPX_TEST_EQ(p1, p4);
 
-            HPX_TEST(p1->use_count() == 2);
+            HPX_TEST_EQ(p1->use_count(), 2);
 
             p1 = p2.get();
 
-            HPX_TEST(p1 == p2);
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(p1, p2);
+            HPX_TEST_EQ(N::base::instances, 1);
 
             p4 = p3.get();
 
-            HPX_TEST(p4 == p3);
-            HPX_TEST(N::base::instances == 0);
+            HPX_TEST_EQ(p4, p3);
+            HPX_TEST_EQ(N::base::instances, 0);
         }
 
         {
@@ -432,41 +432,41 @@ namespace n_assignment {
 
             p1 = p2.get();
 
-            HPX_TEST(p1 == p2);
+            HPX_TEST_EQ(p1, p2);
             HPX_TEST(p1 ? false : true);
             HPX_TEST(!p1);
             HPX_TEST(p1.get() == nullptr);
 
-            HPX_TEST(N::base::instances == 0);
+            HPX_TEST_EQ(N::base::instances, 0);
 
             hpx::intrusive_ptr<Y> p4(new Y);
 
-            HPX_TEST(N::base::instances == 1);
-            HPX_TEST(p4->use_count() == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
+            HPX_TEST_EQ(p4->use_count(), 1);
 
             hpx::intrusive_ptr<X> p5(p4);
-            HPX_TEST(p4->use_count() == 2);
+            HPX_TEST_EQ(p4->use_count(), 2);
 
             p1 = p4.get();
 
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
 
-            HPX_TEST(p1 == p4);
+            HPX_TEST_EQ(p1, p4);
 
-            HPX_TEST(p1->use_count() == 3);
-            HPX_TEST(p4->use_count() == 3);
+            HPX_TEST_EQ(p1->use_count(), 3);
+            HPX_TEST_EQ(p4->use_count(), 3);
 
             p1 = p2.get();
 
-            HPX_TEST(p1 == p2);
-            HPX_TEST(N::base::instances == 1);
-            HPX_TEST(p4->use_count() == 2);
+            HPX_TEST_EQ(p1, p2);
+            HPX_TEST_EQ(N::base::instances, 1);
+            HPX_TEST_EQ(p4->use_count(), 2);
 
             p4 = p2.get();
             p5 = p2.get();
 
-            HPX_TEST(p4 == p2);
-            HPX_TEST(N::base::instances == 0);
+            HPX_TEST_EQ(p4, p2);
+            HPX_TEST_EQ(N::base::instances, 0);
         }
     }
 
@@ -483,7 +483,7 @@ namespace n_reset {
 
     void test()
     {
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             hpx::intrusive_ptr<X> px;
@@ -493,155 +493,155 @@ namespace n_reset {
             HPX_TEST(px.get() == nullptr);
 
             X* p = new X;
-            HPX_TEST(p->use_count() == 0);
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(p->use_count(), 0);
+            HPX_TEST_EQ(N::base::instances, 1);
 
             px.reset(p);
-            HPX_TEST(px.get() == p);
-            HPX_TEST(px->use_count() == 1);
+            HPX_TEST_EQ(px.get(), p);
+            HPX_TEST_EQ(px->use_count(), 1);
 
             px.reset();
             HPX_TEST(px.get() == nullptr);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             hpx::intrusive_ptr<X> px(new X);
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
 
             px.reset(nullptr);
             HPX_TEST(px.get() == nullptr);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             hpx::intrusive_ptr<X> px(new X);
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
 
             px.reset(nullptr, false);
             HPX_TEST(px.get() == nullptr);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             hpx::intrusive_ptr<X> px(new X);
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
 
             px.reset(nullptr, true);
             HPX_TEST(px.get() == nullptr);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             X* p = new X;
-            HPX_TEST(p->use_count() == 0);
+            HPX_TEST_EQ(p->use_count(), 0);
 
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
 
             hpx::intrusive_ptr<X> px;
             HPX_TEST(px.get() == nullptr);
 
             px.reset(p, true);
-            HPX_TEST(px.get() == p);
-            HPX_TEST(px->use_count() == 1);
+            HPX_TEST_EQ(px.get(), p);
+            HPX_TEST_EQ(px->use_count(), 1);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             X* p = new X;
-            HPX_TEST(p->use_count() == 0);
+            HPX_TEST_EQ(p->use_count(), 0);
 
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
 
 #if defined(BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP)
             using hpx::intrusive_ptr_add_ref;
 #endif
             intrusive_ptr_add_ref(p);
-            HPX_TEST(p->use_count() == 1);
+            HPX_TEST_EQ(p->use_count(), 1);
 
             hpx::intrusive_ptr<X> px;
             HPX_TEST(px.get() == nullptr);
 
             px.reset(p, false);
-            HPX_TEST(px.get() == p);
-            HPX_TEST(px->use_count() == 1);
+            HPX_TEST_EQ(px.get(), p);
+            HPX_TEST_EQ(px->use_count(), 1);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             hpx::intrusive_ptr<X> px(new X);
             HPX_TEST(px.get() != nullptr);
-            HPX_TEST(px->use_count() == 1);
+            HPX_TEST_EQ(px->use_count(), 1);
 
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
 
             X* p = new X;
-            HPX_TEST(p->use_count() == 0);
+            HPX_TEST_EQ(p->use_count(), 0);
 
-            HPX_TEST(N::base::instances == 2);
+            HPX_TEST_EQ(N::base::instances, 2);
 
             px.reset(p);
-            HPX_TEST(px.get() == p);
-            HPX_TEST(px->use_count() == 1);
+            HPX_TEST_EQ(px.get(), p);
+            HPX_TEST_EQ(px->use_count(), 1);
 
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             hpx::intrusive_ptr<X> px(new X);
             HPX_TEST(px.get() != nullptr);
-            HPX_TEST(px->use_count() == 1);
+            HPX_TEST_EQ(px->use_count(), 1);
 
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
 
             X* p = new X;
-            HPX_TEST(p->use_count() == 0);
+            HPX_TEST_EQ(p->use_count(), 0);
 
-            HPX_TEST(N::base::instances == 2);
+            HPX_TEST_EQ(N::base::instances, 2);
 
             px.reset(p, true);
-            HPX_TEST(px.get() == p);
-            HPX_TEST(px->use_count() == 1);
+            HPX_TEST_EQ(px.get(), p);
+            HPX_TEST_EQ(px->use_count(), 1);
 
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             hpx::intrusive_ptr<X> px(new X);
             HPX_TEST(px.get() != nullptr);
-            HPX_TEST(px->use_count() == 1);
+            HPX_TEST_EQ(px->use_count(), 1);
 
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
 
             X* p = new X;
-            HPX_TEST(p->use_count() == 0);
+            HPX_TEST_EQ(p->use_count(), 0);
 
 #if defined(BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP)
             using hpx::intrusive_ptr_add_ref;
 #endif
             intrusive_ptr_add_ref(p);
-            HPX_TEST(p->use_count() == 1);
+            HPX_TEST_EQ(p->use_count(), 1);
 
-            HPX_TEST(N::base::instances == 2);
+            HPX_TEST_EQ(N::base::instances, 2);
 
             px.reset(p, false);
-            HPX_TEST(px.get() == p);
-            HPX_TEST(px->use_count() == 1);
+            HPX_TEST_EQ(px.get(), p);
+            HPX_TEST_EQ(px->use_count(), 1);
 
-            HPX_TEST(N::base::instances == 1);
+            HPX_TEST_EQ(N::base::instances, 1);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
     }
 
 }    // namespace n_reset
@@ -659,7 +659,7 @@ namespace n_access {
             using boost::get_pointer;
 #endif
 
-            HPX_TEST(get_pointer(px) == px.get());
+            HPX_TEST_EQ(get_pointer(px), px.get());
         }
 
         {
@@ -671,21 +671,21 @@ namespace n_access {
             using boost::get_pointer;
 #endif
 
-            HPX_TEST(get_pointer(px) == px.get());
+            HPX_TEST_EQ(get_pointer(px), px.get());
         }
 
         {
             hpx::intrusive_ptr<X> px(new X);
             HPX_TEST(px ? true : false);
             HPX_TEST(!!px);
-            HPX_TEST(&*px == px.get());
-            HPX_TEST(px.operator->() == px.get());
+            HPX_TEST_EQ(&*px, px.get());
+            HPX_TEST_EQ(px.operator->(), px.get());
 
 #if defined(BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP)
             using boost::get_pointer;
 #endif
 
-            HPX_TEST(get_pointer(px) == px.get());
+            HPX_TEST_EQ(get_pointer(px), px.get());
         }
 
         {
@@ -697,17 +697,17 @@ namespace n_access {
 
         {
             X* p = new X;
-            HPX_TEST(p->use_count() == 0);
+            HPX_TEST_EQ(p->use_count(), 0);
 
             hpx::intrusive_ptr<X> px(p);
-            HPX_TEST(px.get() == p);
-            HPX_TEST(px->use_count() == 1);
+            HPX_TEST_EQ(px.get(), p);
+            HPX_TEST_EQ(px->use_count(), 1);
 
             X* detached = px.detach();
             HPX_TEST(px.get() == nullptr);
 
-            HPX_TEST(detached == p);
-            HPX_TEST(detached->use_count() == 1);
+            HPX_TEST_EQ(detached, p);
+            HPX_TEST_EQ(detached->use_count(), 1);
 
             delete detached;
         }
@@ -743,20 +743,20 @@ namespace n_swap {
 
             px.swap(px2);
 
-            HPX_TEST(px.get() == p);
-            HPX_TEST(px->use_count() == 2);
+            HPX_TEST_EQ(px.get(), p);
+            HPX_TEST_EQ(px->use_count(), 2);
             HPX_TEST(px2.get() == nullptr);
-            HPX_TEST(px3.get() == p);
-            HPX_TEST(px3->use_count() == 2);
+            HPX_TEST_EQ(px3.get(), p);
+            HPX_TEST_EQ(px3->use_count(), 2);
 
             using std::swap;
             swap(px, px2);
 
             HPX_TEST(px.get() == nullptr);
-            HPX_TEST(px2.get() == p);
-            HPX_TEST(px2->use_count() == 2);
-            HPX_TEST(px3.get() == p);
-            HPX_TEST(px3->use_count() == 2);
+            HPX_TEST_EQ(px2.get(), p);
+            HPX_TEST_EQ(px2->use_count(), 2);
+            HPX_TEST_EQ(px3.get(), p);
+            HPX_TEST_EQ(px3->use_count(), 2);
         }
 
         {
@@ -768,22 +768,22 @@ namespace n_swap {
 
             px.swap(px2);
 
-            HPX_TEST(px.get() == p2);
-            HPX_TEST(px->use_count() == 2);
-            HPX_TEST(px2.get() == p1);
-            HPX_TEST(px2->use_count() == 1);
-            HPX_TEST(px3.get() == p2);
-            HPX_TEST(px3->use_count() == 2);
+            HPX_TEST_EQ(px.get(), p2);
+            HPX_TEST_EQ(px->use_count(), 2);
+            HPX_TEST_EQ(px2.get(), p1);
+            HPX_TEST_EQ(px2->use_count(), 1);
+            HPX_TEST_EQ(px3.get(), p2);
+            HPX_TEST_EQ(px3->use_count(), 2);
 
             using std::swap;
             swap(px, px2);
 
-            HPX_TEST(px.get() == p1);
-            HPX_TEST(px->use_count() == 1);
-            HPX_TEST(px2.get() == p2);
-            HPX_TEST(px2->use_count() == 2);
-            HPX_TEST(px3.get() == p2);
-            HPX_TEST(px3->use_count() == 2);
+            HPX_TEST_EQ(px.get(), p1);
+            HPX_TEST_EQ(px->use_count(), 1);
+            HPX_TEST_EQ(px2.get(), p2);
+            HPX_TEST_EQ(px2->use_count(), 2);
+            HPX_TEST_EQ(px3.get(), p2);
+            HPX_TEST_EQ(px3->use_count(), 2);
         }
     }
 
@@ -865,24 +865,24 @@ namespace n_static_cast {
             hpx::intrusive_ptr<X> px(new Y);
 
             hpx::intrusive_ptr<Y> py = hpx::static_pointer_cast<Y>(px);
-            HPX_TEST(px.get() == py.get());
-            HPX_TEST(px->use_count() == 2);
-            HPX_TEST(py->use_count() == 2);
+            HPX_TEST_EQ(px.get(), py.get());
+            HPX_TEST_EQ(px->use_count(), 2);
+            HPX_TEST_EQ(py->use_count(), 2);
 
             hpx::intrusive_ptr<X> px2(py);
-            HPX_TEST(px2.get() == px.get());
+            HPX_TEST_EQ(px2.get(), px.get());
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             hpx::intrusive_ptr<Y> py =
                 hpx::static_pointer_cast<Y>(hpx::intrusive_ptr<X>(new Y));
             HPX_TEST(py.get() != nullptr);
-            HPX_TEST(py->use_count() == 1);
+            HPX_TEST_EQ(py->use_count(), 1);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
     }
 
 }    // namespace n_static_cast
@@ -904,27 +904,27 @@ namespace n_const_cast {
             HPX_TEST(px2.get() == nullptr);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             hpx::intrusive_ptr<X const> px(new X);
 
             hpx::intrusive_ptr<X> px2 = hpx::const_pointer_cast<X>(px);
-            HPX_TEST(px2.get() == px.get());
-            HPX_TEST(px2->use_count() == 2);
-            HPX_TEST(px->use_count() == 2);
+            HPX_TEST_EQ(px2.get(), px.get());
+            HPX_TEST_EQ(px2->use_count(), 2);
+            HPX_TEST_EQ(px->use_count(), 2);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             hpx::intrusive_ptr<X> px =
                 hpx::const_pointer_cast<X>(hpx::intrusive_ptr<X const>(new X));
             HPX_TEST(px.get() != nullptr);
-            HPX_TEST(px->use_count() == 1);
+            HPX_TEST_EQ(px->use_count(), 1);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
     }
 
 }    // namespace n_const_cast
@@ -966,7 +966,7 @@ namespace n_dynamic_cast {
             HPX_TEST(py.get() == nullptr);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             hpx::intrusive_ptr<Y> py =
@@ -974,18 +974,18 @@ namespace n_dynamic_cast {
             HPX_TEST(py.get() == nullptr);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             hpx::intrusive_ptr<X> px(new Y);
 
             hpx::intrusive_ptr<Y> py = hpx::dynamic_pointer_cast<Y>(px);
-            HPX_TEST(py.get() == px.get());
-            HPX_TEST(py->use_count() == 2);
-            HPX_TEST(px->use_count() == 2);
+            HPX_TEST_EQ(py.get(), px.get());
+            HPX_TEST_EQ(py->use_count(), 2);
+            HPX_TEST_EQ(px->use_count(), 2);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
 
         {
             hpx::intrusive_ptr<X> px(new Y);
@@ -993,10 +993,10 @@ namespace n_dynamic_cast {
             hpx::intrusive_ptr<Y> py =
                 hpx::dynamic_pointer_cast<Y>(hpx::intrusive_ptr<X>(new Y));
             HPX_TEST(py.get() != nullptr);
-            HPX_TEST(py->use_count() == 1);
+            HPX_TEST_EQ(py->use_count(), 1);
         }
 
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
     }
 
 }    // namespace n_dynamic_cast

--- a/libs/memory/tests/unit/intrusive_ptr_move.cpp
+++ b/libs/memory/tests/unit/intrusive_ptr_move.cpp
@@ -89,90 +89,90 @@ struct Y : public X
 
 int main()
 {
-    HPX_TEST(N::base::instances == 0);
+    HPX_TEST_EQ(N::base::instances, 0);
 
     {
         hpx::intrusive_ptr<X> p(new X);
-        HPX_TEST(N::base::instances == 1);
+        HPX_TEST_EQ(N::base::instances, 1);
 
         hpx::intrusive_ptr<X> p2(std::move(p));
-        HPX_TEST(N::base::instances == 1);
+        HPX_TEST_EQ(N::base::instances, 1);
         // NOLINTNEXTLINE(bugprone-use-after-move)
         HPX_TEST(p.get() == nullptr);
 
         p2.reset();
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
     }
 
     {
         hpx::intrusive_ptr<Y> p(new Y);
-        HPX_TEST(N::base::instances == 1);
+        HPX_TEST_EQ(N::base::instances, 1);
 
         hpx::intrusive_ptr<X> p2(std::move(p));
-        HPX_TEST(N::base::instances == 1);
+        HPX_TEST_EQ(N::base::instances, 1);
         // NOLINTNEXTLINE(bugprone-use-after-move)
         HPX_TEST(p.get() == nullptr);
 
         p2.reset();
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
     }
 
     {
         hpx::intrusive_ptr<X> p(new X);
-        HPX_TEST(N::base::instances == 1);
+        HPX_TEST_EQ(N::base::instances, 1);
 
         hpx::intrusive_ptr<X> p2;
         p2 = std::move(p);
-        HPX_TEST(N::base::instances == 1);
+        HPX_TEST_EQ(N::base::instances, 1);
         // NOLINTNEXTLINE(bugprone-use-after-move)
         HPX_TEST(p.get() == nullptr);
 
         p2.reset();
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
     }
 
     {
         hpx::intrusive_ptr<X> p(new X);
-        HPX_TEST(N::base::instances == 1);
+        HPX_TEST_EQ(N::base::instances, 1);
 
         hpx::intrusive_ptr<X> p2(new X);
-        HPX_TEST(N::base::instances == 2);
+        HPX_TEST_EQ(N::base::instances, 2);
         p2 = std::move(p);
-        HPX_TEST(N::base::instances == 1);
+        HPX_TEST_EQ(N::base::instances, 1);
         // NOLINTNEXTLINE(bugprone-use-after-move)
         HPX_TEST(p.get() == nullptr);
 
         p2.reset();
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
     }
 
     {
         hpx::intrusive_ptr<Y> p(new Y);
-        HPX_TEST(N::base::instances == 1);
+        HPX_TEST_EQ(N::base::instances, 1);
 
         hpx::intrusive_ptr<X> p2;
         p2 = std::move(p);
-        HPX_TEST(N::base::instances == 1);
+        HPX_TEST_EQ(N::base::instances, 1);
         // NOLINTNEXTLINE(bugprone-use-after-move)
         HPX_TEST(p.get() == nullptr);
 
         p2.reset();
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
     }
 
     {
         hpx::intrusive_ptr<Y> p(new Y);
-        HPX_TEST(N::base::instances == 1);
+        HPX_TEST_EQ(N::base::instances, 1);
 
         hpx::intrusive_ptr<X> p2(new X);
-        HPX_TEST(N::base::instances == 2);
+        HPX_TEST_EQ(N::base::instances, 2);
         p2 = std::move(p);
-        HPX_TEST(N::base::instances == 1);
+        HPX_TEST_EQ(N::base::instances, 1);
         // NOLINTNEXTLINE(bugprone-use-after-move)
         HPX_TEST(p.get() == nullptr);
 
         p2.reset();
-        HPX_TEST(N::base::instances == 0);
+        HPX_TEST_EQ(N::base::instances, 0);
     }
 
     {
@@ -181,13 +181,13 @@ int main()
         X* px2 = px.get();
 
         hpx::intrusive_ptr<Y> py = hpx::static_pointer_cast<Y>(std::move(px));
-        HPX_TEST(py.get() == px2);
+        HPX_TEST_EQ(py.get(), px2);
         // NOLINTNEXTLINE(bugprone-use-after-move)
         HPX_TEST(px.get() == nullptr);
-        HPX_TEST(py->use_count() == 1);
+        HPX_TEST_EQ(py->use_count(), 1);
     }
 
-    HPX_TEST(N::base::instances == 0);
+    HPX_TEST_EQ(N::base::instances, 0);
 
     {
         hpx::intrusive_ptr<X const> px(new X);
@@ -195,13 +195,13 @@ int main()
         X const* px2 = px.get();
 
         hpx::intrusive_ptr<X> px3 = hpx::const_pointer_cast<X>(std::move(px));
-        HPX_TEST(px3.get() == px2);
+        HPX_TEST_EQ(px3.get(), px2);
         // NOLINTNEXTLINE(bugprone-use-after-move)
         HPX_TEST(px.get() == nullptr);
-        HPX_TEST(px3->use_count() == 1);
+        HPX_TEST_EQ(px3->use_count(), 1);
     }
 
-    HPX_TEST(N::base::instances == 0);
+    HPX_TEST_EQ(N::base::instances, 0);
 
     {
         hpx::intrusive_ptr<X> px(new Y);
@@ -209,13 +209,13 @@ int main()
         X* px2 = px.get();
 
         hpx::intrusive_ptr<Y> py = hpx::dynamic_pointer_cast<Y>(std::move(px));
-        HPX_TEST(py.get() == px2);
+        HPX_TEST_EQ(py.get(), px2);
         // NOLINTNEXTLINE(bugprone-use-after-move)
         HPX_TEST(px.get() == nullptr);
-        HPX_TEST(py->use_count() == 1);
+        HPX_TEST_EQ(py->use_count(), 1);
     }
 
-    HPX_TEST(N::base::instances == 0);
+    HPX_TEST_EQ(N::base::instances, 0);
 
     {
         hpx::intrusive_ptr<X> px(new X);
@@ -225,11 +225,11 @@ int main()
         hpx::intrusive_ptr<Y> py = hpx::dynamic_pointer_cast<Y>(std::move(px));
         HPX_TEST(py.get() == nullptr);
         // NOLINTNEXTLINE(bugprone-use-after-move)
-        HPX_TEST(px.get() == px2);
-        HPX_TEST(px->use_count() == 1);
+        HPX_TEST_EQ(px.get(), px2);
+        HPX_TEST_EQ(px->use_count(), 1);
     }
 
-    HPX_TEST(N::base::instances == 0);
+    HPX_TEST_EQ(N::base::instances, 0);
 
     return hpx::util::report_errors();
 }

--- a/libs/memory/tests/unit/ip_convertible.cpp
+++ b/libs/memory/tests/unit/ip_convertible.cpp
@@ -44,6 +44,6 @@ int f(hpx::intrusive_ptr<Y>)
 
 int main()
 {
-    HPX_TEST(1 == f(hpx::intrusive_ptr<Z>()));
+    HPX_TEST_EQ(1, f(hpx::intrusive_ptr<Z>()));
     return hpx::util::report_errors();
 }

--- a/libs/program_options/tests/regressions/commandline_options_1437.cpp
+++ b/libs/program_options/tests/regressions/commandline_options_1437.cpp
@@ -15,7 +15,7 @@ bool invoked_main = false;
 int my_hpx_main(int argc, char** argv)
 {
     // all HPX command line arguments should have been stripped here
-    HPX_TEST(argc == 1);
+    HPX_TEST_EQ(argc, 1);
 
     invoked_main = true;
     return hpx::finalize();
@@ -23,7 +23,7 @@ int my_hpx_main(int argc, char** argv)
 
 int main(int argc, char** argv)
 {
-    HPX_TEST(argc > 1);
+    HPX_TEST_LT(1, argc);
 
     HPX_TEST_EQ(hpx::init(&my_hpx_main, "testapp", argc, argv), 0);
     HPX_TEST(invoked_main);

--- a/libs/program_options/tests/unit/cmdline.cpp
+++ b/libs/program_options/tests/unit/cmdline.cpp
@@ -16,6 +16,7 @@
 #include <hpx/program_options/options_description.hpp>
 #include <hpx/program_options/value_semantic.hpp>
 
+#include <cstddef>
 #include <iostream>
 #include <sstream>
 #include <utility>
@@ -55,7 +56,7 @@ int translate_syntax_error_kind(invalid_command_line_syntax::kind_t k)
     b = table;
     e = table + sizeof(table) / sizeof(table[0]);
     i = std::find(b, e, k);
-    HPX_TEST(i != e);
+    HPX_TEST_NEQ(i, e);
     return int(std::distance(b, i)) + 3;
 }
 
@@ -434,9 +435,9 @@ void test_additional_parser()
 #if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY) ||  \
     (defined(BOOST_VERSION) && BOOST_VERSION >= 106800)
     // the long_names() API function was introduced in Boost V1.68
-    HPX_TEST(result.size() == 3);
+    HPX_TEST_EQ(result.size(), std::size_t(3));
 #else
-    HPX_TEST(result.size() == 2);
+    HPX_TEST_EQ(result.size(), std::size_t(2));
 #endif
     HPX_TEST_EQ(result[0].string_key, "response-file");
     HPX_TEST_EQ(result[0].value[0], "config");
@@ -494,7 +495,7 @@ void test_style_parser()
 
     vector<option> result = cmd.run();
 
-    HPX_TEST(result.size() == 2);
+    HPX_TEST_EQ(result.size(), std::size_t(2));
     HPX_TEST_EQ(result[0].string_key, "foo");
     HPX_TEST_EQ(result[0].value[0], "1");
     HPX_TEST_EQ(result[1].string_key, "bar");
@@ -518,7 +519,7 @@ void test_unregistered()
     cmd.allow_unregistered();
 
     vector<option> result = cmd.run();
-    HPX_TEST(result.size() == 5);
+    HPX_TEST_EQ(result.size(), std::size_t(5));
     // --foo=1
     HPX_TEST_EQ(result[0].string_key, "foo");
     HPX_TEST_EQ(result[0].unregistered, true);
@@ -530,7 +531,7 @@ void test_unregistered()
     // '1' is considered a positional option, not a value to
     // --bar
     HPX_TEST(result[2].string_key.empty());
-    HPX_TEST(result[2].position_key == 0);
+    HPX_TEST_EQ(result[2].position_key, 0);
     HPX_TEST_EQ(result[2].unregistered, false);
     HPX_TEST_EQ(result[2].value[0], "1");
     // -b
@@ -556,7 +557,7 @@ void test_unregistered()
 
     result = cmd2.run();
 
-    HPX_TEST(result.size() == 3);
+    HPX_TEST_EQ(result.size(), std::size_t(3));
     HPX_TEST_EQ(result[0].string_key, "help");
     HPX_TEST_EQ(result[0].unregistered, false);
     HPX_TEST(result[0].value.empty());

--- a/libs/program_options/tests/unit/optional.cpp
+++ b/libs/program_options/tests/unit/optional.cpp
@@ -50,10 +50,10 @@ void test_optional()
     po::notify(vm);
 
     HPX_TEST(!!foo);
-    HPX_TEST(*foo == 12);
+    HPX_TEST_EQ(*foo, 12);
 
     HPX_TEST(!!bar);
-    HPX_TEST(*bar == 1);
+    HPX_TEST_EQ(*bar, 1);
 
     HPX_TEST(!baz);
 #endif

--- a/libs/program_options/tests/unit/parsers.cpp
+++ b/libs/program_options/tests/unit/parsers.cpp
@@ -16,6 +16,7 @@
 #include <hpx/program_options/value_semantic.hpp>
 #include <hpx/program_options/variables_map.hpp>
 
+#include <cstddef>
 #include <cstdlib>    // for putenv
 #include <fstream>
 #include <functional>
@@ -43,9 +44,9 @@ pair<string, vector<vector<string>>> msp(const string& s1, const string& s2)
 
 void check_value(const option& option, const char* name, const char* value)
 {
-    HPX_TEST(option.string_key == name);
-    HPX_TEST(option.value.size() == 1);
-    HPX_TEST(option.value.front() == value);
+    HPX_TEST_EQ(option.string_key, name);
+    HPX_TEST_EQ(option.value.size(), std::size_t(1));
+    HPX_TEST_EQ(option.value.front(), value);
 }
 
 vector<string> sv(const char* array[], unsigned size)
@@ -132,7 +133,7 @@ namespace command_line {
                 .options;
         HPX_TEST_EQ(a5.size(), 3u);
         check_value(a5[0], "-p", "7");
-        HPX_TEST(a5[1].value.size() == 3);
+        HPX_TEST_EQ(a5[1].value.size(), std::size_t(3));
         HPX_TEST_EQ(a5[1].string_key, "-o");
         HPX_TEST_EQ(a5[1].value[0], "1");
         HPX_TEST_EQ(a5[1].value[1], "2");
@@ -160,7 +161,7 @@ namespace command_line {
         check_value(parsed_options[0], "foo", "one");
         check_value(parsed_options[1], "bar", "two");
         HPX_TEST_EQ(parsed_options[2].string_key, "foo");
-        HPX_TEST(parsed_options[2].value.size() == 2);
+        HPX_TEST_EQ(parsed_options[2].value.size(), std::size_t(2));
         HPX_TEST_EQ(parsed_options[2].value[0], "three");
         HPX_TEST_EQ(parsed_options[2].value[1], "four");
         check_value(parsed_options[3], "fizbaz", "five");
@@ -178,7 +179,7 @@ namespace command_line {
         check_value(parsed_options[0], "foo", "one");
         check_value(parsed_options[1], "bar", "two");
         HPX_TEST_EQ(parsed_options[2].string_key, "foo");
-        HPX_TEST(parsed_options[2].value.size() == 2);
+        HPX_TEST_EQ(parsed_options[2].value.size(), std::size_t(2));
         HPX_TEST_EQ(parsed_options[2].value[0], "three");
         HPX_TEST_EQ(parsed_options[2].value[1], "four");
         check_value(parsed_options[3], "fizbaz", "five");
@@ -207,12 +208,12 @@ namespace command_line {
                 .run()
                 .options;
         HPX_TEST_EQ(a6.size(), 2u);
-        HPX_TEST(a6[0].value.size() == 2);
+        HPX_TEST_EQ(a6[0].value.size(), std::size_t(2));
         HPX_TEST_EQ(a6[0].string_key, "multitoken");
         HPX_TEST_EQ(a6[0].value[0], "token1");
         HPX_TEST_EQ(a6[0].value[1], "token2");
         HPX_TEST_EQ(a6[1].string_key, "file");
-        HPX_TEST(a6[1].value.size() == 1);
+        HPX_TEST_EQ(a6[1].value.size(), std::size_t(1));
         HPX_TEST_EQ(a6[1].value[0], "some_file");
 #endif
     }
@@ -252,7 +253,7 @@ void test_config_file(const char* config_file)
 
     stringstream ss(content1);
     vector<option> a1 = parse_config_file(ss, desc).options;
-    HPX_TEST(a1.size() == 7);
+    HPX_TEST_EQ(a1.size(), std::size_t(7));
     check_value(a1[0], "gv1", "0");
     check_value(a1[1], "empty_value", "");
     check_value(a1[2], "plug3", "7");
@@ -263,7 +264,7 @@ void test_config_file(const char* config_file)
 
     // same test, but now options come from file
     vector<option> a2 = parse_config_file<char>(config_file, desc).options;
-    HPX_TEST(a2.size() == 7);
+    HPX_TEST_EQ(a2.size(), std::size_t(7));
     check_value(a2[0], "gv1", "0");
     check_value(a2[1], "empty_value", "");
     check_value(a2[2], "plug3", "7");
@@ -287,10 +288,10 @@ void test_environment()
 #endif
     parsed_options p = parse_environment(desc, "PO_TEST_");
 
-    HPX_TEST(p.options.size() == 1);
-    HPX_TEST(p.options[0].string_key == "foo");
-    HPX_TEST(p.options[0].value.size() == 1);
-    HPX_TEST(p.options[0].value[0] == "1");
+    HPX_TEST_EQ(p.options.size(), std::size_t(1));
+    HPX_TEST_EQ(p.options[0].string_key, "foo");
+    HPX_TEST_EQ(p.options[0].value.size(), std::size_t(1));
+    HPX_TEST_EQ(p.options[0].value[0], "1");
 
     //TODO: since 'bar' does not allow a value, it cannot appear in environment,
     // which already has a value.
@@ -309,20 +310,20 @@ void test_unregistered()
                             .run()
                             .options;
 
-    HPX_TEST(a1.size() == 3);
-    HPX_TEST(a1[0].string_key == "foo");
-    HPX_TEST(a1[0].unregistered == true);
-    HPX_TEST(a1[0].value.size() == 1);
-    HPX_TEST(a1[0].value[0] == "12");
-    HPX_TEST(a1[1].string_key == "bar");
-    HPX_TEST(a1[1].unregistered == true);
-    HPX_TEST(a1[2].string_key == "");
-    HPX_TEST(a1[2].unregistered == false);
+    HPX_TEST_EQ(a1.size(), std::size_t(3));
+    HPX_TEST_EQ(a1[0].string_key, "foo");
+    HPX_TEST_EQ(a1[0].unregistered, true);
+    HPX_TEST_EQ(a1[0].value.size(), std::size_t(1));
+    HPX_TEST_EQ(a1[0].value[0], "12");
+    HPX_TEST_EQ(a1[1].string_key, "bar");
+    HPX_TEST_EQ(a1[1].unregistered, true);
+    HPX_TEST_EQ(a1[2].string_key, "");
+    HPX_TEST_EQ(a1[2].unregistered, false);
 
     vector<string> a2 = collect_unrecognized(a1, include_positional);
-    HPX_TEST(a2[0] == "--foo=12");
-    HPX_TEST(a2[1] == "--bar");
-    HPX_TEST(a2[2] == "1");
+    HPX_TEST_EQ(a2[0], "--foo=12");
+    HPX_TEST_EQ(a2[1], "--bar");
+    HPX_TEST_EQ(a2[2], "1");
 
     // Test that storing unregistered options has no effect
     variables_map vm;
@@ -339,7 +340,7 @@ void test_unregistered()
 
     stringstream ss(content1);
     vector<option> a3 = parse_config_file(ss, desc, true).options;
-    HPX_TEST(a3.size() == 2);
+    HPX_TEST_EQ(a3.size(), std::size_t(2));
     check_value(a3[0], "gv1", "0");
     check_value(a3[1], "m1.v1", "1");
 }

--- a/libs/program_options/tests/unit/positional_options.cpp
+++ b/libs/program_options/tests/unit/positional_options.cpp
@@ -15,6 +15,7 @@
 #include <hpx/program_options/positional_options.hpp>
 #include <hpx/program_options/value_semantic.hpp>
 
+#include <cstddef>
 #include <limits>
 #include <vector>
 
@@ -72,7 +73,7 @@ void test_parsing()
     parsed_options parsed =
         command_line_parser(args).options(desc).positional(p).run();
 
-    HPX_TEST(parsed.options.size() == 5);
+    HPX_TEST_EQ(parsed.options.size(), std::size_t(5));
     HPX_TEST_EQ(parsed.options[1].string_key, "input-file");
     HPX_TEST_EQ(parsed.options[1].value[0], "file1");
     HPX_TEST_EQ(parsed.options[3].string_key, "input-file");

--- a/libs/program_options/tests/unit/split.cpp
+++ b/libs/program_options/tests/unit/split.cpp
@@ -14,6 +14,7 @@
 #include <hpx/program_options/value_semantic.hpp>
 #include <hpx/program_options/variables_map.hpp>
 
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -22,7 +23,7 @@ using namespace std;
 
 void check_value(const string& option, const string& value)
 {
-    HPX_TEST(option == value);
+    HPX_TEST_EQ(option, value);
 }
 
 void split_whitespace(const options_description& description)
@@ -32,7 +33,7 @@ void split_whitespace(const options_description& description)
 
     vector<string> tokens = split_unix(cmdline, " \t\n\r");
 
-    HPX_TEST(tokens.size() == 7);
+    HPX_TEST_EQ(tokens.size(), std::size_t(7));
 
     check_value(tokens[0], "prg");
     check_value(tokens[1], "--input");
@@ -54,7 +55,7 @@ void split_equalsign(const options_description& description)
 
     vector<string> tokens = split_unix(cmdline, "= ");
 
-    HPX_TEST(tokens.size() == 7);
+    HPX_TEST_EQ(tokens.size(), std::size_t(7));
     check_value(tokens[0], "prg");
     check_value(tokens[1], "--input");
     check_value(tokens[2], "input.txt");
@@ -74,7 +75,7 @@ void split_semi(const options_description& description)
 
     vector<string> tokens = split_unix(cmdline, "; ");
 
-    HPX_TEST(tokens.size() == 7);
+    HPX_TEST_EQ(tokens.size(), std::size_t(7));
     check_value(tokens[0], "prg");
     check_value(tokens[1], "--input");
     check_value(tokens[2], "input.txt");
@@ -95,7 +96,7 @@ void split_quotes(const options_description& description)
 
     vector<string> tokens = split_unix(cmdline, " ");
 
-    HPX_TEST(tokens.size() == 7);
+    HPX_TEST_EQ(tokens.size(), std::size_t(7));
     check_value(tokens[0], "prg");
     check_value(tokens[1], "--input");
     check_value(tokens[2], "input.txt input.txt");
@@ -116,7 +117,7 @@ void split_escape(const options_description& description)
 
     vector<string> tokens = split_unix(cmdline, " ");
 
-    HPX_TEST(tokens.size() == 7);
+    HPX_TEST_EQ(tokens.size(), std::size_t(7));
     check_value(tokens[0], "prg");
     check_value(tokens[1], "--input");
     check_value(tokens[2], "\"input.txt\"");
@@ -137,7 +138,7 @@ void split_single_quote(const options_description& description)
 
     vector<string> tokens = split_unix(cmdline, " ", "'");
 
-    HPX_TEST(tokens.size() == 7);
+    HPX_TEST_EQ(tokens.size(), std::size_t(7));
     check_value(tokens[0], "prg");
     check_value(tokens[1], "--input");
     check_value(tokens[2], "input.txt input.txt");
@@ -158,7 +159,7 @@ void split_defaults(const options_description& description)
 
     vector<string> tokens = split_unix(cmdline);
 
-    HPX_TEST(tokens.size() == 7);
+    HPX_TEST_EQ(tokens.size(), std::size_t(7));
     check_value(tokens[0], "prg");
     check_value(tokens[1], "--input");
     check_value(tokens[2], "input file.txt");

--- a/libs/program_options/tests/unit/unicode.cpp
+++ b/libs/program_options/tests/unit/unicode.cpp
@@ -14,6 +14,7 @@
 #include <hpx/program_options/value_semantic.hpp>
 #include <hpx/program_options/variables_map.hpp>
 
+#include <cstddef>
 #include <locale>
 #include <sstream>
 #include <string>
@@ -39,7 +40,7 @@ void test_unicode_to_unicode()
     store(parsed, vm);
 
     HPX_TEST(vm["foo"].as<wstring>() == L"\x044F");
-    HPX_TEST(parsed.options[0].original_tokens.size() == 1);
+    HPX_TEST_EQ(parsed.options[0].original_tokens.size(), std::size_t(1));
     HPX_TEST(parsed.options[0].original_tokens[0] == L"--foo=\x044F");
 }
 
@@ -62,7 +63,7 @@ void test_unicode_to_native()
     variables_map vm;
     store(wcommand_line_parser(args).options(desc).run(), vm);
 
-    HPX_TEST(vm["foo"].as<string>() == "\xD1\x8F");
+    HPX_TEST_EQ(vm["foo"].as<string>(), "\xD1\x8F");
 }
 
 void test_native_to_unicode()
@@ -94,8 +95,8 @@ vector<wstring> sv(const wchar_t* array[], unsigned size)
 
 void check_value(const woption& option, const char* name, const wchar_t* value)
 {
-    HPX_TEST(option.string_key == name);
-    HPX_TEST(option.value.size() == 1);
+    HPX_TEST_EQ(option.string_key, name);
+    HPX_TEST_EQ(option.value.size(), std::size_t(1));
     HPX_TEST(option.value.front() == value);
 }
 
@@ -117,7 +118,7 @@ void test_command_line()
     vector<woption> a4 =
         wcommand_line_parser(cmdline4).options(desc).run().options;
 
-    HPX_TEST(a4.size() == 5);
+    HPX_TEST_EQ(a4.size(), std::size_t(5));
 
     check_value(a4[0], "foo", L"1\u0FF52");
     check_value(a4[1], "foo", L"4");
@@ -144,7 +145,7 @@ void test_config_file()
     variables_map vm;
     store(parse_config_file(stream, desc), vm);
 
-    HPX_TEST(vm["foo"].as<string>() == "\xD1\x8F");
+    HPX_TEST_EQ(vm["foo"].as<string>(), "\xD1\x8F");
 }
 
 int main(int, char*[])

--- a/libs/program_options/tests/unit/variable_map.cpp
+++ b/libs/program_options/tests/unit/variable_map.cpp
@@ -15,6 +15,7 @@
 #include <hpx/program_options/value_semantic.hpp>
 #include <hpx/program_options/variables_map.hpp>
 
+#include <cstddef>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -51,12 +52,12 @@ void test_variable_map()
     variables_map vm;
     store(a3, vm);
     notify(vm);
-    HPX_TEST(vm.size() == 4);
-    HPX_TEST(vm["foo"].as<string>() == "'12'");
-    HPX_TEST(vm["bar"].as<string>() == "11");
-    HPX_TEST(vm.count("biz") == 1);
-    HPX_TEST(vm["biz"].as<string>() == "3");
-    HPX_TEST(vm["output"].as<string>() == "foo");
+    HPX_TEST_EQ(vm.size(), std::size_t(4));
+    HPX_TEST_EQ(vm["foo"].as<string>(), "'12'");
+    HPX_TEST_EQ(vm["bar"].as<string>(), "11");
+    HPX_TEST_EQ(vm.count("biz"), std::size_t(1));
+    HPX_TEST_EQ(vm["biz"].as<string>(), "3");
+    HPX_TEST_EQ(vm["output"].as<string>(), "foo");
 
     int i;
     // clang-format off
@@ -75,11 +76,11 @@ void test_variable_map()
     variables_map vm2;
     store(a4, vm2);
     notify(vm2);
-    HPX_TEST(vm2.size() == 3);
-    HPX_TEST(vm2["zee"].as<bool>() == true);
-    HPX_TEST(vm2["zak"].as<int>() == 13);
-    HPX_TEST(vm2["opt"].as<bool>() == false);
-    HPX_TEST(i == 13);
+    HPX_TEST_EQ(vm2.size(), std::size_t(3));
+    HPX_TEST_EQ(vm2["zee"].as<bool>(), true);
+    HPX_TEST_EQ(vm2["zak"].as<int>(), 13);
+    HPX_TEST_EQ(vm2["opt"].as<bool>(), false);
+    HPX_TEST_EQ(i, 13);
 
     options_description desc2;
     // clang-format off
@@ -98,10 +99,10 @@ void test_variable_map()
     variables_map vm3;
     store(a5, vm3);
     notify(vm3);
-    HPX_TEST(vm3.size() == 3);
-    HPX_TEST(vm3["vee"].as<string>() == "42");
-    HPX_TEST(vm3["voo"].as<string>() == "1");
-    HPX_TEST(vm3["iii"].as<int>() == 123);
+    HPX_TEST_EQ(vm3.size(), std::size_t(3));
+    HPX_TEST_EQ(vm3["vee"].as<string>(), "42");
+    HPX_TEST_EQ(vm3["voo"].as<string>(), "1");
+    HPX_TEST_EQ(vm3["iii"].as<int>(), 123);
 
     options_description desc3;
     // clang-format off
@@ -123,10 +124,10 @@ void test_variable_map()
     variables_map vm4;
     store(a6, vm4);
     notify(vm4);
-    HPX_TEST(vm4.size() == 4);
-    HPX_TEST(vm4["imp"].as<int>() == 1);
-    HPX_TEST(vm4["iim"].as<int>() == 201);
-    HPX_TEST(vm4["mmp"].as<int>() == 123);
+    HPX_TEST_EQ(vm4.size(), std::size_t(4));
+    HPX_TEST_EQ(vm4["imp"].as<int>(), 1);
+    HPX_TEST_EQ(vm4["iim"].as<int>(), 201);
+    HPX_TEST_EQ(vm4["mmp"].as<int>(), 123);
 }
 
 int stored_value;
@@ -164,8 +165,8 @@ void test_semantic_values()
     variables_map vm;
     store(parsed, vm);
     notify(vm);
-    HPX_TEST(vm.count("biz") == 1);
-    HPX_TEST(vm.count("baz") == 1);
+    HPX_TEST_EQ(vm.count("biz"), std::size_t(1));
+    HPX_TEST_EQ(vm.count("baz"), std::size_t(1));
     const vector<string> av = vm["biz"].as<vector<string>>();
     const vector<string> av2 = vm["baz"].as<vector<string>>();
     string exp1[] = {"a", "b x"};
@@ -178,7 +179,7 @@ void test_semantic_values()
     variables_map vm2;
     store(parsed, vm2);
     notify(vm2);
-    HPX_TEST(vm2.count("int") == 1);
+    HPX_TEST_EQ(vm2.count("int"), std::size_t(1));
     HPX_TEST(vm2["int"].as<vector<int>>() == vector<int>(1, 13));
     HPX_TEST_EQ(stored_value, 13);
 
@@ -226,30 +227,30 @@ void test_priority()
     variables_map vm;
     store(p1, vm);
 
-    HPX_TEST(vm.count("first") == 1);
-    HPX_TEST(vm["first"].as<vector<int>>().size() == 2);
+    HPX_TEST_EQ(vm.count("first"), std::size_t(1));
+    HPX_TEST_EQ(vm["first"].as<vector<int>>().size(), std::size_t(2));
     HPX_TEST_EQ(vm["first"].as<vector<int>>()[0], 1);
     HPX_TEST_EQ(vm["first"].as<vector<int>>()[1], 3);
 
-    HPX_TEST(vm.count("second") == 1);
-    HPX_TEST(vm["second"].as<vector<int>>().size() == 1);
+    HPX_TEST_EQ(vm.count("second"), std::size_t(1));
+    HPX_TEST_EQ(vm["second"].as<vector<int>>().size(), std::size_t(1));
     HPX_TEST_EQ(vm["second"].as<vector<int>>()[0], 1);
 
     store(p2, vm);
 
     // Value should not change.
-    HPX_TEST(vm.count("first") == 1);
-    HPX_TEST(vm["first"].as<vector<int>>().size() == 2);
+    HPX_TEST_EQ(vm.count("first"), std::size_t(1));
+    HPX_TEST_EQ(vm["first"].as<vector<int>>().size(), std::size_t(2));
     HPX_TEST_EQ(vm["first"].as<vector<int>>()[0], 1);
     HPX_TEST_EQ(vm["first"].as<vector<int>>()[1], 3);
 
     // Value should change to 7
-    HPX_TEST(vm.count("second") == 1);
-    HPX_TEST(vm["second"].as<vector<int>>().size() == 1);
+    HPX_TEST_EQ(vm.count("second"), std::size_t(1));
+    HPX_TEST_EQ(vm["second"].as<vector<int>>().size(), std::size_t(1));
     HPX_TEST_EQ(vm["second"].as<vector<int>>()[0], 7);
 
-    HPX_TEST(vm.count("include") == 1);
-    HPX_TEST(vm["include"].as<vector<int>>().size() == 2);
+    HPX_TEST_EQ(vm.count("include"), std::size_t(1));
+    HPX_TEST_EQ(vm["include"].as<vector<int>>().size(), std::size_t(2));
     HPX_TEST_EQ(vm["include"].as<vector<int>>()[0], 1);
     HPX_TEST_EQ(vm["include"].as<vector<int>>()[1], 7);
 }
@@ -286,8 +287,8 @@ void test_multiple_assignments_with_different_option_description()
     store(p2, vm);
     store(p3, vm);
 
-    HPX_TEST(vm.count("help") == 1);
-    HPX_TEST(vm.count("includes") == 1);
+    HPX_TEST_EQ(vm.count("help"), std::size_t(1));
+    HPX_TEST_EQ(vm.count("includes"), std::size_t(1));
     HPX_TEST_EQ(vm["includes"].as<vector<string>>()[0], "a");
     HPX_TEST_EQ(vm["includes"].as<vector<string>>()[1], "b");
 }

--- a/libs/serialization/tests/unit/serialize_buffer.cpp
+++ b/libs/serialization/tests/unit/serialize_buffer.cpp
@@ -51,7 +51,7 @@ void test(hpx::id_type dest, char* send_buffer, std::size_t size)
     {
         buffer_type b = f.get();
         HPX_TEST_EQ(b.size(), size);
-        HPX_TEST(0 == memcmp(b.data(), send_buffer, size));
+        HPX_TEST_EQ(0, memcmp(b.data(), send_buffer, size));
     }
 }
 
@@ -77,7 +77,7 @@ void test_stateful_allocator(hpx::id_type dest, char* send_buffer,
     {
         buffer_type b = f.get();
         HPX_TEST_EQ(b.size(), size);
-        HPX_TEST(0 == memcmp(b.data(), send_buffer, size));
+        HPX_TEST_EQ(0, memcmp(b.data(), send_buffer, size));
     }
 }
 

--- a/libs/synchronization/tests/unit/sliding_semaphore.cpp
+++ b/libs/synchronization/tests/unit/sliding_semaphore.cpp
@@ -35,7 +35,7 @@ int hpx_main()
     // Wait for all threads to finish executing.
     sem.wait(19);
 
-    HPX_TEST(count == 10);
+    HPX_TEST_EQ(count, 10);
 
     return hpx::finalize();
 }

--- a/libs/thread_support/tests/unit/range.cpp
+++ b/libs/thread_support/tests/unit/range.cpp
@@ -108,12 +108,12 @@ void adl_range()
 void vector_range()
 {
     std::vector<int> r(3);
-    HPX_TEST(hpx::util::begin(r) == r.begin());
-    HPX_TEST(hpx::util::end(r) == r.end());
+    HPX_TEST_EQ(hpx::util::begin(r), r.begin());
+    HPX_TEST_EQ(hpx::util::end(r), r.end());
 
     std::vector<int> cr(3);
-    HPX_TEST(hpx::util::begin(cr) == cr.begin());
-    HPX_TEST(hpx::util::end(cr) == cr.end());
+    HPX_TEST_EQ(hpx::util::begin(cr), cr.begin());
+    HPX_TEST_EQ(hpx::util::end(cr), cr.end());
     HPX_TEST_EQ(hpx::util::size(cr), 3u);
     HPX_TEST_EQ(hpx::util::empty(cr), false);
 }

--- a/tests/performance/local/agas_cache_timings.cpp
+++ b/tests/performance/local/agas_cache_timings.cpp
@@ -64,7 +64,7 @@ public:
     std::uint64_t get_count() const
     {
         hpx::naming::gid_type const size = key_.second - key_.first;
-        HPX_TEST(size.get_msb() == 0);
+        HPX_TEST_EQ(size.get_msb(), std::uint64_t(0));
         return size.get_lsb();
     }
 

--- a/tests/performance/local/coroutines_call_overhead.cpp
+++ b/tests/performance/local/coroutines_call_overhead.cpp
@@ -247,7 +247,7 @@ int hpx_main(
                     boost::algorithm::is_any_of(","),
                     boost::algorithm::token_compress_on);
 
-                HPX_TEST(entry.size() == 2);
+                HPX_TEST_EQ(entry.size(), 2);
 
                 counter_shortnames.push_back(entry[0]);
                 counters.push_back(entry[1]);

--- a/tests/performance/local/hpx_homogeneous_timed_task_spawn_executors.cpp
+++ b/tests/performance/local/hpx_homogeneous_timed_task_spawn_executors.cpp
@@ -105,7 +105,7 @@ int hpx_main(
             // be bound to the remaining number of cores
             if ((i + 1) * num_cores_per_executor > num_os_threads)
             {
-                HPX_TEST(i == std::size_t(num_executors) - 1);
+                HPX_TEST_EQ(i, std::size_t(num_executors) - 1);
                 num_cores_per_executor = num_os_threads - i * num_cores_per_executor;
             }
             executors.push_back(local_priority_queue_executor(num_cores_per_executor));

--- a/tests/performance/local/timed_task_spawn.cpp
+++ b/tests/performance/local/timed_task_spawn.cpp
@@ -418,7 +418,7 @@ int hpx_main(variables_map& vm)
                     boost::algorithm::is_any_of(","),
                     boost::algorithm::token_compress_on);
 
-                HPX_TEST(entry.size() == 2);
+                HPX_TEST_EQ(entry.size(), 2);
 
                 counter_shortnames.push_back(entry[0]);
                 counters.push_back(entry[1]);

--- a/tests/performance/network/network_storage/network_storage.cpp
+++ b/tests/performance/network/network_storage/network_storage.cpp
@@ -246,13 +246,13 @@ public:
 
   pointer allocate(size_type n, void const* hint = nullptr)
   {
-    HPX_TEST(n == size_);
+    HPX_TEST_EQ(n, size_);
     return static_cast<T*>(pointer_);
   }
 
   void deallocate(pointer p, size_type n)
   {
-    HPX_TEST(p == pointer_ && n == size_);
+    HPX_TEST_EQ(p == pointer_ && n, size_);
   }
 
 private:

--- a/tests/regressions/component/new_2848.cpp
+++ b/tests/regressions/component/new_2848.cpp
@@ -57,33 +57,33 @@ void test_create_single_instance()
     for (hpx::id_type const& loc: hpx::find_all_localities())
     {
         hpx::id_type id = hpx::new_<test_server>(loc, 42).get();
-        HPX_TEST(hpx::async<call_action>(id).get() == loc);
+        HPX_TEST_EQ(hpx::async<call_action>(id).get(), loc);
     }
 
     for (hpx::id_type const& loc: hpx::find_all_localities())
     {
         test_client t1 = hpx::new_<test_client>(loc, 42);
-        HPX_TEST(t1.call() == loc);
+        HPX_TEST_EQ(t1.call(), loc);
     }
 
     // make sure distribution policy is properly used
     hpx::id_type id = hpx::new_<test_server>(hpx::default_layout, 42).get();
-    HPX_TEST(hpx::async<call_action>(id).get() == hpx::find_here());
+    HPX_TEST_EQ(hpx::async<call_action>(id).get(), hpx::find_here());
 
     test_client t2 = hpx::new_<test_client>(hpx::default_layout, 42);
-    HPX_TEST(t2.call() == hpx::find_here());
+    HPX_TEST_EQ(t2.call(), hpx::find_here());
 
     for (hpx::id_type const& loc: hpx::find_all_localities())
     {
         hpx::id_type id =
             hpx::new_<test_server>(hpx::default_layout(loc), 42).get();
-        HPX_TEST(hpx::async<call_action>(id).get() == loc);
+        HPX_TEST_EQ(hpx::async<call_action>(id).get(), loc);
     }
 
     for (hpx::id_type const& loc: hpx::find_all_localities())
     {
         test_client t3 = hpx::new_<test_client>(hpx::default_layout(loc), 42);
-        HPX_TEST(t3.call() == loc);
+        HPX_TEST_EQ(t3.call(), loc);
     }
 }
 
@@ -99,7 +99,7 @@ void test_create_multiple_instances()
 
         for (hpx::id_type const& id: ids)
         {
-            HPX_TEST(hpx::async<call_action>(id).get() == loc);
+            HPX_TEST_EQ(hpx::async<call_action>(id).get(), loc);
         }
     }
 
@@ -111,7 +111,7 @@ void test_create_multiple_instances()
 
         for (test_client const& c: ids)
         {
-            HPX_TEST(c.call() == loc);
+            HPX_TEST_EQ(c.call(), loc);
         }
     }
 
@@ -121,7 +121,7 @@ void test_create_multiple_instances()
     HPX_TEST_EQ(ids.size(), std::size_t(10));
     for (hpx::id_type const& id: ids)
     {
-        HPX_TEST(hpx::async<call_action>(id).get() == hpx::find_here());
+        HPX_TEST_EQ(hpx::async<call_action>(id).get(), hpx::find_here());
     }
 
     std::vector<test_client> clients =
@@ -129,7 +129,7 @@ void test_create_multiple_instances()
     HPX_TEST_EQ(clients.size(), std::size_t(10));
     for (test_client const& c: clients)
     {
-        HPX_TEST(c.call() == hpx::find_here());
+        HPX_TEST_EQ(c.call(), hpx::find_here());
     }
 
     for (hpx::id_type const& loc: hpx::find_all_localities())
@@ -140,7 +140,7 @@ void test_create_multiple_instances()
 
         for (hpx::id_type const& id: ids)
         {
-            HPX_TEST(hpx::async<call_action>(id).get() == loc);
+            HPX_TEST_EQ(hpx::async<call_action>(id).get(), loc);
         }
     }
 
@@ -152,7 +152,7 @@ void test_create_multiple_instances()
 
         for (test_client const& c: ids)
         {
-            HPX_TEST(c.call() == loc);
+            HPX_TEST_EQ(c.call(), loc);
         }
     }
 }

--- a/tests/regressions/lcos/channel_2916.cpp
+++ b/tests/regressions/lcos/channel_2916.cpp
@@ -61,7 +61,7 @@ int hpx_main()
     // pending as the first thread exiting the loop did not request an item
     // off the channel anymore.
     std::size_t remaining_count = free_resources.close(true);
-    HPX_TEST(remaining_count <= count.load());
+    HPX_TEST_LTE(remaining_count, count.load());
 
     return hpx::finalize();
 }

--- a/tests/regressions/lcos/future_2667.cpp
+++ b/tests/regressions/lcos/future_2667.cpp
@@ -39,7 +39,7 @@ int main()
     hpx::future<void> fut2 = std::move(fut);
     fut2.get();
 
-    HPX_TEST(t.elapsed() > 1.0);
+    HPX_TEST_LT(1.0, t.elapsed());
     HPX_TEST(was_run.load());
 
     return hpx::util::report_errors();

--- a/tests/regressions/lcos/future_serialization_1898.cpp
+++ b/tests/regressions/lcos/future_serialization_1898.cpp
@@ -41,9 +41,9 @@ int main()
 {
     hpx::id_type loc = hpx::find_here();
     {
-        HPX_TEST(test_server::alive == 0);
+        HPX_TEST_EQ(test_server::alive, 0);
         hpx::id_type gid = hpx::new_<test_server>(loc).get();
-        HPX_TEST(test_server::alive == 1);
+        HPX_TEST_EQ(test_server::alive, 1);
 //         HPX_TEST(!hpx::naming::detail::gid_was_split(gid.get_gid()));
 
         auto remote_localities = hpx::find_remote_localities();
@@ -53,7 +53,7 @@ int main()
                 hpx::future<hpx::id_type> test_fid = hpx::make_ready_future(gid);
                 hpx::future<hpx::id_type> fid
                     = hpx::async(test_action(), loc, std::move(test_fid));
-                HPX_TEST(test_server::alive == 1);
+                HPX_TEST_EQ(test_server::alive, 1);
 
                 hpx::id_type new_gid = fid.get();
                 HPX_TEST_NEQ(
@@ -68,12 +68,12 @@ int main()
                 hpx::future<hpx::id_type> test_fid = pid.get_future();
                 hpx::future<hpx::id_type> fid
                     = hpx::async(test_action(), loc, std::move(test_fid));
-                HPX_TEST(test_server::alive == 1);
+                HPX_TEST_EQ(test_server::alive, 1);
 
                 hpx::this_thread::yield();
 
                 pid.set_value(gid);
-                HPX_TEST(test_server::alive == 1);
+                HPX_TEST_EQ(test_server::alive, 1);
 
                 hpx::id_type new_gid = fid.get();
                 HPX_TEST_NEQ(
@@ -83,9 +83,9 @@ int main()
             }
 
 
-            HPX_TEST(test_server::alive == 1);
+            HPX_TEST_EQ(test_server::alive, 1);
         }
-        HPX_TEST(test_server::alive == 1);
+        HPX_TEST_EQ(test_server::alive, 1);
     }
 
     return 0;

--- a/tests/regressions/lcos/future_timed_wait_1025.cpp
+++ b/tests/regressions/lcos/future_timed_wait_1025.cpp
@@ -55,7 +55,7 @@ void test_wait_for()
 
     hpx::threads::thread_state thread_state =
         hpx::threads::get_thread_state(thread.native_handle());
-    HPX_TEST(thread_state.state() == hpx::threads::suspended);
+    HPX_TEST_EQ(thread_state.state(), hpx::threads::suspended);
 
     if (thread.joinable())
     {
@@ -79,7 +79,7 @@ void test_wait_until()
 
     hpx::threads::thread_state thread_state =
         hpx::threads::get_thread_state(thread.native_handle());
-    HPX_TEST(thread_state.state() == hpx::threads::suspended);
+    HPX_TEST_EQ(thread_state.state(), hpx::threads::suspended);
 
     if (thread.joinable())
     {

--- a/tests/regressions/lcos/receive_buffer_1733.cpp
+++ b/tests/regressions/lcos/receive_buffer_1733.cpp
@@ -29,7 +29,7 @@ inline std::size_t idx(std::size_t i, int dir)
     if (i == size - 1 && dir == +1)
         return 0;
 
-    HPX_TEST((i + dir) < size);
+    HPX_TEST_LT((i + dir), size);
 
     return i + dir;
 }

--- a/tests/regressions/multiple_init.cpp
+++ b/tests/regressions/multiple_init.cpp
@@ -22,11 +22,11 @@ int main(int argc, char **argv)
 {
     // Everything is fine on the first call
     hpx::init(argc, argv);
-    HPX_TEST(invoked_init == 1);
+    HPX_TEST_EQ(invoked_init, 1);
 
     // Segfault on the call, now fixed
     hpx::init(argc, argv);
-    HPX_TEST(invoked_init == 2);
+    HPX_TEST_EQ(invoked_init, 2);
 
     return hpx::util::report_errors();
 }

--- a/tests/regressions/performance_counters/uptime_1737.cpp
+++ b/tests/regressions/performance_counters/uptime_1737.cpp
@@ -49,7 +49,7 @@ int hpx_main(int argc, char ** argv)
     hpx::this_thread::sleep_for(std::chrono::seconds(1));
     double end = uptime.get_value<double>(hpx::launch::sync);
 
-    HPX_TEST(end - start >= 1.0 && end - start < 1.1);
+    HPX_TEST_LT(end - start >= 1.0 && end - start, 1.1);
 
     // make sure start/stop return false
     HPX_TEST(!uptime.start(hpx::launch::sync));

--- a/tests/regressions/threads/block_os_threads_1036.cpp
+++ b/tests/regressions/threads/block_os_threads_1036.cpp
@@ -106,7 +106,7 @@ int hpx_main()
         started.fetch_add(1);
 
         for (std::uint64_t i = 0; i < os_thread_count; ++i)
-            HPX_TEST(blocked_threads[i].load() <= 1);
+            HPX_TEST_LTE(blocked_threads[i].load(), std::uint64_t(1));
     }
 
     return hpx::finalize();

--- a/tests/regressions/threads/thread_rescheduling.cpp
+++ b/tests/regressions/threads/thread_rescheduling.cpp
@@ -160,7 +160,7 @@ int hpx_main(variables_map& vm)
     {
         thread_id_type thread_id = register_thread_nullary(
             hpx::util::deferred_call(&test_dummy_thread, futures));
-        HPX_TEST(thread_id != hpx::threads::invalid_thread_id);
+        HPX_TEST_NEQ(thread_id, hpx::threads::invalid_thread_id);
 
         // Flood the queues with suspension operations before the rescheduling
         // attempt.

--- a/tests/regressions/traits/is_callable_1179.cpp
+++ b/tests/regressions/traits/is_callable_1179.cpp
@@ -35,7 +35,7 @@ int main(int argc, char* argv[])
     HPX_TEST_MSG((is_callable<const_mem_fun_ptr(p)>::value == true),
         "const-mem-fun-ptr");
 
-    HPX_TEST(invoke(&s::f, p()) == 42);
+    HPX_TEST_EQ(invoke(&s::f, p()), 42);
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/apex/apex_action_count.cpp
+++ b/tests/unit/apex/apex_action_count.cpp
@@ -100,7 +100,7 @@ int main(int argc, char* argv[])
 
     std::cout << "Calls to fibonacci_action: " << count << std::endl;
     apex_profile * prof = apex::get_profile("fibonacci_action");
-    HPX_TEST(prof != 0);
+    HPX_TEST(prof != nullptr);
 
     // for some reason, the APEX count is off by 3, regardless of the N value.
     // This can be tested by running fibonacci of 0, 1, 2, and 3

--- a/tests/unit/component/local_new.cpp
+++ b/tests/unit/component/local_new.cpp
@@ -59,13 +59,13 @@ struct test_client : hpx::components::client_base<test_client, test_server>
 void test_create_single_instance()
 {
     hpx::id_type id = hpx::local_new<test_server>().get();
-    HPX_TEST(hpx::async<call_action>(id).get() == hpx::find_here());
+    HPX_TEST_EQ(hpx::async<call_action>(id).get(), hpx::find_here());
 
     hpx::id_type id1 = hpx::local_new<test_server>(hpx::launch::sync);
-    HPX_TEST(hpx::async<call_action>(id1).get() == hpx::find_here());
+    HPX_TEST_EQ(hpx::async<call_action>(id1).get(), hpx::find_here());
 
     test_client t1 = hpx::local_new<test_client>();
-    HPX_TEST(t1.call() == hpx::find_here());
+    HPX_TEST_EQ(t1.call(), hpx::find_here());
 }
 
 void test_create_single_instance_non_copyable_arg()
@@ -73,13 +73,13 @@ void test_create_single_instance_non_copyable_arg()
     A a;
 
     hpx::id_type id = hpx::local_new<test_server>(a).get();
-    HPX_TEST(hpx::async<call_action>(id).get() == hpx::find_here());
+    HPX_TEST_EQ(hpx::async<call_action>(id).get(), hpx::find_here());
 
     hpx::id_type id1 = hpx::local_new<test_server>(hpx::launch::sync, a);
-    HPX_TEST(hpx::async<call_action>(id1).get() == hpx::find_here());
+    HPX_TEST_EQ(hpx::async<call_action>(id1).get(), hpx::find_here());
 
     test_client t1 = hpx::local_new<test_client>(a);
-    HPX_TEST(t1.call() == hpx::find_here());
+    HPX_TEST_EQ(t1.call(), hpx::find_here());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -92,7 +92,7 @@ void test_create_multiple_instances()
 
         for (hpx::id_type const& id: ids)
         {
-            HPX_TEST(hpx::async<call_action>(id).get() == hpx::find_here());
+            HPX_TEST_EQ(hpx::async<call_action>(id).get(), hpx::find_here());
         }
     }
 
@@ -103,7 +103,7 @@ void test_create_multiple_instances()
 
         for (hpx::id_type const& id: ids)
         {
-            HPX_TEST(hpx::async<call_action>(id).get() == hpx::find_here());
+            HPX_TEST_EQ(hpx::async<call_action>(id).get(), hpx::find_here());
         }
     }
 
@@ -113,7 +113,7 @@ void test_create_multiple_instances()
 
         for (test_client const& c: ids)
         {
-            HPX_TEST(c.call() == hpx::find_here());
+            HPX_TEST_EQ(c.call(), hpx::find_here());
         }
     }
 }

--- a/tests/unit/component/migrate_component.cpp
+++ b/tests/unit/component/migrate_component.cpp
@@ -13,6 +13,7 @@
 #include <hpx/include/iostreams.hpp>
 #include <hpx/testing.hpp>
 
+#include <cstdint>
 #include <chrono>
 #include <cstddef>
 #include <utility>
@@ -68,66 +69,66 @@ struct test_server
 
     hpx::id_type call() const
     {
-        HPX_TEST(pin_count() != 0);
+        HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
         return hpx::find_here();
     }
 
     void busy_work() const
     {
-        HPX_TEST(pin_count() != 0);
+        HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
         hpx::this_thread::sleep_for(std::chrono::seconds(1));
-        HPX_TEST(pin_count() != 0);
+        HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
     }
 
     hpx::future<void> lazy_busy_work() const
     {
-        HPX_TEST(pin_count() != 0);
+        HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
 
         auto f = hpx::make_ready_future_after(std::chrono::seconds(1));
 
         return f.then(
             [this](hpx::future<void> && f) -> void
             {
-                HPX_TEST(pin_count() != 0);
+                HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
                 f.get();
-                HPX_TEST(pin_count() != 0);
+                HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
             });
     }
 
     int get_data() const
     {
-        HPX_TEST(pin_count() != 0);
+        HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
         return data_;
     }
 
     hpx::future<int> lazy_get_data() const
     {
-        HPX_TEST(pin_count() != 0);
+        HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
 
         auto f = hpx::make_ready_future(data_);
 
         return f.then(
             [this](hpx::future<int> && f) -> int
             {
-                HPX_TEST(pin_count() != 0);
+                HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
                 auto result = f.get();
-                HPX_TEST(pin_count() != 0);
+                HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
                 return result;
             });
     }
 
     dummy_client lazy_get_client(hpx::id_type there) const
     {
-        HPX_TEST(pin_count() != 0);
+        HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
 
         auto f = dummy_client(hpx::new_<dummy_server>(there));
 
         return f.then(
             [this](dummy_client && f) -> hpx::id_type
             {
-                HPX_TEST(pin_count() != 0);
+                HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
                 auto result = f.get();
-                HPX_TEST(pin_count() != 0);
+                HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
                 return result;
             });
     }

--- a/tests/unit/component/migrate_polymorphic_component.cpp
+++ b/tests/unit/component/migrate_polymorphic_component.cpp
@@ -13,6 +13,7 @@
 #include <hpx/include/iostreams.hpp>
 #include <hpx/testing.hpp>
 
+#include <cstdint>
 #include <cstddef>
 #include <type_traits>
 #include <utility>
@@ -37,22 +38,22 @@ struct test_server_base
 
     void busy_work() const
     {
-        HPX_TEST(pin_count() != 0);
+        HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
         hpx::this_thread::sleep_for(std::chrono::seconds(1));
-        HPX_TEST(pin_count() != 0);
+        HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
     }
     HPX_DEFINE_COMPONENT_ACTION(test_server_base, busy_work, busy_work_action);
 
     hpx::future<void> lazy_busy_work() const
     {
-        HPX_TEST(pin_count() != 0);
+        HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
 
         auto f = hpx::make_ready_future_after(std::chrono::seconds(1));
 
         return f.then([this](hpx::future<void>&& f) -> void {
-            HPX_TEST(pin_count() != 0);
+            HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
             f.get();
-            HPX_TEST(pin_count() != 0);
+            HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
         });
     }
     HPX_DEFINE_COMPONENT_ACTION(
@@ -60,7 +61,7 @@ struct test_server_base
 
     int get_base_data() const
     {
-        HPX_TEST(pin_count() != 0);
+        HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
         return base_data_;
     }
     HPX_DEFINE_COMPONENT_ACTION(
@@ -68,14 +69,14 @@ struct test_server_base
 
     hpx::future<int> lazy_get_base_data() const
     {
-        HPX_TEST(pin_count() != 0);
+        HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
 
         auto f = hpx::make_ready_future(base_data_);
 
         return f.then([this](hpx::future<int>&& f) -> int {
-            HPX_TEST(pin_count() != 0);
+            HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
             auto result = f.get();
-            HPX_TEST(pin_count() != 0);
+            HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
             return result;
         });
     }
@@ -175,20 +176,20 @@ struct test_server
 
     int get_data() const override
     {
-        HPX_TEST(pin_count() != 0);
+        HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
         return data_;
     }
 
     hpx::future<int> lazy_get_data() const override
     {
-        HPX_TEST(pin_count() != 0);
+        HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
 
         auto f = hpx::make_ready_future(data_);
 
         return f.then([this](hpx::future<int>&& f) -> int {
-            HPX_TEST(pin_count() != 0);
+            HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
             auto result = f.get();
-            HPX_TEST(pin_count() != 0);
+            HPX_TEST_NEQ(pin_count(), std::uint32_t(0));
             return result;
         });
     }

--- a/tests/unit/component/new_.cpp
+++ b/tests/unit/component/new_.cpp
@@ -51,32 +51,32 @@ void test_create_single_instance()
     for (hpx::id_type const& loc: hpx::find_all_localities())
     {
         hpx::id_type id = hpx::new_<test_server>(loc).get();
-        HPX_TEST(hpx::async<call_action>(id).get() == loc);
+        HPX_TEST_EQ(hpx::async<call_action>(id).get(), loc);
     }
 
     for (hpx::id_type const& loc: hpx::find_all_localities())
     {
         test_client t1 = hpx::new_<test_client>(loc);
-        HPX_TEST(t1.call() == loc);
+        HPX_TEST_EQ(t1.call(), loc);
     }
 
     // make sure distribution policy is properly used
     hpx::id_type id = hpx::new_<test_server>(hpx::default_layout).get();
-    HPX_TEST(hpx::async<call_action>(id).get() == hpx::find_here());
+    HPX_TEST_EQ(hpx::async<call_action>(id).get(), hpx::find_here());
 
     test_client t2 = hpx::new_<test_client>(hpx::default_layout);
-    HPX_TEST(t2.call() == hpx::find_here());
+    HPX_TEST_EQ(t2.call(), hpx::find_here());
 
     for (hpx::id_type const& loc: hpx::find_all_localities())
     {
         hpx::id_type id = hpx::new_<test_server>(hpx::default_layout(loc)).get();
-        HPX_TEST(hpx::async<call_action>(id).get() == loc);
+        HPX_TEST_EQ(hpx::async<call_action>(id).get(), loc);
     }
 
     for (hpx::id_type const& loc: hpx::find_all_localities())
     {
         test_client t3 = hpx::new_<test_client>(hpx::default_layout(loc));
-        HPX_TEST(t3.call() == loc);
+        HPX_TEST_EQ(t3.call(), loc);
     }
 }
 
@@ -91,7 +91,7 @@ void test_create_multiple_instances()
 
         for (hpx::id_type const& id: ids)
         {
-            HPX_TEST(hpx::async<call_action>(id).get() == loc);
+            HPX_TEST_EQ(hpx::async<call_action>(id).get(), loc);
         }
     }
 
@@ -102,7 +102,7 @@ void test_create_multiple_instances()
 
         for (test_client const& c: ids)
         {
-            HPX_TEST(c.call() == loc);
+            HPX_TEST_EQ(c.call(), loc);
         }
     }
 
@@ -112,7 +112,7 @@ void test_create_multiple_instances()
     HPX_TEST_EQ(ids.size(), std::size_t(10));
     for (hpx::id_type const& id: ids)
     {
-        HPX_TEST(hpx::async<call_action>(id).get() == hpx::find_here());
+        HPX_TEST_EQ(hpx::async<call_action>(id).get(), hpx::find_here());
     }
 
     std::vector<test_client> clients =
@@ -120,7 +120,7 @@ void test_create_multiple_instances()
     HPX_TEST_EQ(clients.size(), std::size_t(10));
     for (test_client const& c: clients)
     {
-        HPX_TEST(c.call() == hpx::find_here());
+        HPX_TEST_EQ(c.call(), hpx::find_here());
     }
 
     for (hpx::id_type const& loc: hpx::find_all_localities())
@@ -131,7 +131,7 @@ void test_create_multiple_instances()
 
         for (hpx::id_type const& id: ids)
         {
-            HPX_TEST(hpx::async<call_action>(id).get() == loc);
+            HPX_TEST_EQ(hpx::async<call_action>(id).get(), loc);
         }
     }
 
@@ -143,7 +143,7 @@ void test_create_multiple_instances()
 
         for (test_client const& c: ids)
         {
-            HPX_TEST(c.call() == loc);
+            HPX_TEST_EQ(c.call(), loc);
         }
     }
 }

--- a/tests/unit/component/new_binpacking.cpp
+++ b/tests/unit/component/new_binpacking.cpp
@@ -63,7 +63,7 @@ std::vector<hpx::id_type> test_binpacking_multiple()
         targets.push_back(hpx::new_<test_server[]>(loc, i + 1).get());
         for (hpx::id_type const& id: targets.back())
         {
-            HPX_TEST(hpx::async<call_action>(id).get() == loc);
+            HPX_TEST_EQ(hpx::async<call_action>(id).get(), loc);
             keep_alive.push_back(id);
         }
     }
@@ -123,7 +123,7 @@ void test_binpacking_single()
         targets.push_back(hpx::new_<test_server[]>(loc, i+1).get());
         for (hpx::id_type const& id: targets.back())
         {
-            HPX_TEST(hpx::async<call_action>(id).get() == loc);
+            HPX_TEST_EQ(hpx::async<call_action>(id).get(), loc);
         }
     }
 

--- a/tests/unit/component/new_colocated.cpp
+++ b/tests/unit/component/new_colocated.cpp
@@ -51,7 +51,7 @@ void test_create_single_instance()
         hpx::id_type target = hpx::new_<test_server>(loc).get();
         hpx::id_type id = hpx::new_<test_server>(hpx::colocated(target)).get();
 
-        HPX_TEST(hpx::async<call_action>(id).get() == loc);
+        HPX_TEST_EQ(hpx::async<call_action>(id).get(), loc);
     }
 
     for (hpx::id_type const& loc: hpx::find_all_localities())
@@ -59,7 +59,7 @@ void test_create_single_instance()
         test_client target = hpx::new_<test_client>(loc);
         hpx::id_type id = hpx::new_<test_server>(hpx::colocated(target)).get();
 
-        HPX_TEST(hpx::async<call_action>(id).get() == loc);
+        HPX_TEST_EQ(hpx::async<call_action>(id).get(), loc);
     }
 
     for (hpx::id_type const& loc: hpx::find_all_localities())
@@ -67,7 +67,7 @@ void test_create_single_instance()
         test_client target = hpx::new_<test_client>(loc);
         test_client t1 = hpx::new_<test_client>(hpx::colocated(target));
 
-        HPX_TEST(t1.call() == loc);
+        HPX_TEST_EQ(t1.call(), loc);
     }
 
     for (hpx::id_type const& loc: hpx::find_all_localities())
@@ -75,7 +75,7 @@ void test_create_single_instance()
         test_client target = hpx::new_<test_client>(loc);
         test_client t2 = hpx::new_<test_client>(hpx::colocated(target));
 
-        HPX_TEST(t2.call() == loc);
+        HPX_TEST_EQ(t2.call(), loc);
     }
 }
 

--- a/tests/unit/lcos/apply_colocated.cpp
+++ b/tests/unit/lcos/apply_colocated.cpp
@@ -123,7 +123,7 @@ int main(int argc, char* argv[])
         "HPX main exited with non-zero status");
 
     HPX_TEST_NEQ(std::uint32_t(-1), locality_id);
-    HPX_TEST(on_shutdown_executed || 0 != locality_id);
+    HPX_TEST_NEQ(on_shutdown_executed || 0, locality_id);
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/lcos/future.cpp
+++ b/tests/unit/lcos/future.cpp
@@ -110,7 +110,7 @@ void test_initial_state()
         HPX_TEST(false);
     }
     catch (hpx::exception const& e) {
-        HPX_TEST(e.get_error() == hpx::no_state);
+        HPX_TEST_EQ(e.get_error(), hpx::no_state);
     }
     catch (...) {
         HPX_TEST(false);
@@ -143,7 +143,7 @@ void test_cannot_get_future_twice()
         HPX_TEST(false);
     }
     catch (hpx::exception const& e) {
-        HPX_TEST(e.get_error() == hpx::future_already_retrieved);
+        HPX_TEST_EQ(e.get_error(), hpx::future_already_retrieved);
     }
     catch (...) {
         HPX_TEST(false);
@@ -237,7 +237,7 @@ void test_invoking_a_packaged_task_twice_throws()
         HPX_TEST(false);
     }
     catch (hpx::exception const& e) {
-        HPX_TEST(e.get_error() == hpx::promise_already_satisfied);
+        HPX_TEST_EQ(e.get_error(), hpx::promise_already_satisfied);
     }
     catch (...) {
         HPX_TEST(false);
@@ -259,7 +259,7 @@ void test_cannot_get_future_twice_from_task()
         HPX_TEST(false);
     }
     catch (hpx::exception const& e) {
-        HPX_TEST(e.get_error() == hpx::future_already_retrieved);
+        HPX_TEST_EQ(e.get_error(), hpx::future_already_retrieved);
     }
     catch (...) {
         HPX_TEST(false);
@@ -472,7 +472,7 @@ void test_packaged_task_can_be_moved()
         HPX_TEST(!"Can invoke moved task!");
     }
     catch (hpx::exception const& e) {
-      HPX_TEST(e.get_error() == hpx::no_state);
+      HPX_TEST_EQ(e.get_error(), hpx::no_state);
     }
     catch (...) {
         HPX_TEST(false);
@@ -501,7 +501,7 @@ void test_destroying_a_promise_stores_broken_promise()
         HPX_TEST(false);    // shouldn't get here
     }
     catch (hpx::exception const& e) {
-        HPX_TEST(e.get_error() == hpx::broken_promise);
+        HPX_TEST_EQ(e.get_error(), hpx::broken_promise);
     }
     catch (...) {
         HPX_TEST(false);
@@ -524,7 +524,7 @@ void test_destroying_a_packaged_task_stores_broken_task()
         HPX_TEST(false);    // shouldn't get here
     }
     catch (hpx::exception const& e) {
-      HPX_TEST(e.get_error() == hpx::broken_promise);
+      HPX_TEST_EQ(e.get_error(), hpx::broken_promise);
     }
     catch (...) {
         HPX_TEST(false);

--- a/tests/unit/lcos/future_ref.cpp
+++ b/tests/unit/lcos/future_ref.cpp
@@ -19,28 +19,28 @@ void test_make_ready_future()
 {
     hpx::future<int&> f =
         hpx::make_ready_future(std::ref(global));
-    HPX_TEST(&f.get() == &global);
+    HPX_TEST_EQ(&f.get(), &global);
 
     hpx::future<int&> f_at =
         hpx::make_ready_future_at(
             std::chrono::system_clock::now() + std::chrono::seconds(1)
           , std::ref(global));
-    HPX_TEST(&f_at.get() == &global);
+    HPX_TEST_EQ(&f_at.get(), &global);
 
     hpx::future<int&> f_after =
         hpx::make_ready_future_after(
             std::chrono::seconds(1)
           , std::ref(global));
-    HPX_TEST(&f_after.get() == &global);
+    HPX_TEST_EQ(&f_after.get(), &global);
 }
 
 void test_async()
 {
     hpx::future<int&> f = hpx::async(&foo);
-    HPX_TEST(&f.get() == &global);
+    HPX_TEST_EQ(&f.get(), &global);
 
     hpx::future<int&> f_sync = hpx::async(hpx::launch::sync, &foo);
-    HPX_TEST(&f_sync.get() == &global);
+    HPX_TEST_EQ(&f_sync.get(), &global);
 }
 
 int main()

--- a/tests/unit/lcos/future_then.cpp
+++ b/tests/unit/lcos/future_then.cpp
@@ -56,7 +56,7 @@ void test_return_int()
     hpx::future<int> f2 = f1.then(&p2);
     HPX_TEST(f2.valid());
     try {
-        HPX_TEST(f2.get() == 2);
+        HPX_TEST_EQ(f2.get(), 2);
     }
     catch (hpx::exception const& /*ex*/) {
         HPX_TEST(false);
@@ -73,7 +73,7 @@ void test_return_int_launch()
     hpx::future<int> f2 = f1.then(hpx::launch::async, &p2);
     HPX_TEST(f2.valid());
     try {
-        HPX_TEST(f2.get() == 2);
+        HPX_TEST_EQ(f2.get(), 2);
     }
     catch (hpx::exception const& /*ex*/) {
         HPX_TEST(false);
@@ -155,7 +155,7 @@ void test_complex_then()
     hpx::future<int> f1 = hpx::async(p1);
     hpx::future<int> f21 = f1.then(&p2);
     hpx::future<int> f2= f21.then(&p2);
-    HPX_TEST(f2.get() == 4);
+    HPX_TEST_EQ(f2.get(), 4);
 }
 
 void test_complex_then_launch()
@@ -169,7 +169,7 @@ void test_complex_then_launch()
     hpx::future<int> f1 = hpx::async(p1);
     hpx::future<int> f21 = f1.then(policy, &p2);
     hpx::future<int> f2= f21.then(policy, &p2);
-    HPX_TEST(f2.get() == 4);
+    HPX_TEST_EQ(f2.get(), 4);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/lcos/future_then_executor.cpp
+++ b/tests/unit/lcos/future_then_executor.cpp
@@ -58,7 +58,7 @@ void test_return_int(Executor& exec)
     hpx::future<int> f2 = f1.then(exec, &p2);
     HPX_TEST(f2.valid());
     try {
-        HPX_TEST(f2.get() == 2);
+        HPX_TEST_EQ(f2.get(), 2);
     }
     catch (hpx::exception const& /*ex*/) {
         HPX_TEST(false);
@@ -96,7 +96,7 @@ void test_implicit_unwrapping(Executor& exec)
     hpx::future<int> f2 = f1.then(exec, &p4);
     HPX_TEST(f2.valid());
     try {
-        HPX_TEST(f2.get() == 2);
+        HPX_TEST_EQ(f2.get(), 2);
     }
     catch (hpx::exception const& /*ex*/) {
         HPX_TEST(false);
@@ -111,14 +111,14 @@ template <typename Executor>
 void test_simple_then(Executor& exec)
 {
     hpx::future<int> f2 = hpx::async(exec, p1).then(exec, &p2);
-    HPX_TEST(f2.get() == 2);
+    HPX_TEST_EQ(f2.get(), 2);
 }
 
 template <typename Executor>
 void test_simple_deferred_then(Executor& exec)
 {
     hpx::future<int> f2 = hpx::async(exec, p1).then(exec, &p2);
-    HPX_TEST(f2.get() == 2);
+    HPX_TEST_EQ(f2.get(), 2);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -128,7 +128,7 @@ void test_complex_then(Executor& exec)
     hpx::future<int> f1 = hpx::async(exec, p1);
     hpx::future<int> f21 = f1.then(exec, &p2);
     hpx::future<int> f2 = f21.then(exec, &p2);
-    HPX_TEST(f2.get() == 4);
+    HPX_TEST_EQ(f2.get(), 4);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -137,7 +137,7 @@ void test_complex_then_chain_one(Executor& exec)
 {
     hpx::future<int> f1 = hpx::async(exec, p1);
     hpx::future<int> f2 = f1.then(exec, &p2).then(exec, &p2);
-    HPX_TEST(f2.get() == 4);
+    HPX_TEST_EQ(f2.get(), 4);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/lcos/packaged_action.cpp
+++ b/tests/unit/lcos/packaged_action.cpp
@@ -65,7 +65,7 @@ int hpx_main(variables_map&)
 
         //test two successive 'get' from a promise
         hpx::lcos::shared_future<int> int_promise(async<int_action>(hpx::find_here()));
-        HPX_TEST(int_promise.get() == int_promise.get());
+        HPX_TEST_EQ(int_promise.get(), int_promise.get());
     }
 
     {
@@ -89,7 +89,7 @@ int hpx_main(variables_map&)
         //test two successive 'get' from a promise
         int_action do_int;
         hpx::lcos::shared_future<int> int_promise(async(do_int, hpx::find_here()));
-        HPX_TEST(int_promise.get() == int_promise.get());
+        HPX_TEST_EQ(int_promise.get(), int_promise.get());
     }
 
     hpx::finalize();       // Initiate shutdown of the runtime system.

--- a/tests/unit/lcos/remote_dataflow.cpp
+++ b/tests/unit/lcos/remote_dataflow.cpp
@@ -46,8 +46,8 @@ void plain_actions(hpx::id_type const& there)
         hpx::future<hpx::id_type> f1 = hpx::dataflow(id_f_action(), there);
         hpx::future<hpx::id_type> f2 = hpx::dataflow<id_f_action>(there);
 
-        HPX_TEST(there == f1.get());
-        HPX_TEST(there == f2.get());
+        HPX_TEST_EQ(there, f1.get());
+        HPX_TEST_EQ(there, f2.get());
     }
 
     hpx::launch policies[] =
@@ -79,8 +79,8 @@ void plain_actions(hpx::id_type const& there)
             hpx::future<hpx::id_type> f2 = hpx::dataflow<id_f_action>(
                 policies[i], there);
 
-            HPX_TEST(there == f1.get());
-            HPX_TEST(there == f2.get());
+            HPX_TEST_EQ(there, f1.get());
+            HPX_TEST_EQ(there, f2.get());
         }
     }
 
@@ -119,8 +119,8 @@ void plain_actions(hpx::id_type const& there)
         hpx::future<hpx::id_type> f2 = hpx::dataflow<id_f_action>(
             policy2, there);
 
-        HPX_TEST(there == f1.get());
-        HPX_TEST(there == f2.get());
+        HPX_TEST_EQ(there, f1.get());
+        HPX_TEST_EQ(there, f2.get());
     }
 }
 

--- a/tests/unit/lcos/shared_future.cpp
+++ b/tests/unit/lcos/shared_future.cpp
@@ -91,7 +91,7 @@ void test_initial_state()
         HPX_TEST(false);
     }
     catch (hpx::exception const& e) {
-        HPX_TEST(e.get_error() == hpx::no_state);
+        HPX_TEST_EQ(e.get_error(), hpx::no_state);
     }
     catch (...) {
         HPX_TEST(false);
@@ -124,7 +124,7 @@ void test_cannot_get_future_twice()
         HPX_TEST(false);
     }
     catch (hpx::exception const& e) {
-        HPX_TEST(e.get_error() == hpx::future_already_retrieved);
+        HPX_TEST_EQ(e.get_error(), hpx::future_already_retrieved);
     }
     catch (...) {
         HPX_TEST(false);
@@ -216,7 +216,7 @@ void test_invoking_a_packaged_task_twice_throws()
         HPX_TEST(false);
     }
     catch (hpx::exception const& e) {
-        HPX_TEST(e.get_error() == hpx::promise_already_satisfied);
+        HPX_TEST_EQ(e.get_error(), hpx::promise_already_satisfied);
     }
     catch (...) {
         HPX_TEST(false);
@@ -238,7 +238,7 @@ void test_cannot_get_future_twice_from_task()
         HPX_TEST(false);
     }
     catch (hpx::exception const& e) {
-        HPX_TEST(e.get_error() == hpx::future_already_retrieved);
+        HPX_TEST_EQ(e.get_error(), hpx::future_already_retrieved);
     }
     catch (...) {
         HPX_TEST(false);
@@ -537,7 +537,7 @@ void test_packaged_task_can_be_moved()
         HPX_TEST(!"Can invoke moved task!");
     }
     catch (hpx::exception const& e) {
-      HPX_TEST(e.get_error() == hpx::no_state);
+      HPX_TEST_EQ(e.get_error(), hpx::no_state);
     }
     catch (...) {
         HPX_TEST(false);
@@ -566,7 +566,7 @@ void test_destroying_a_promise_stores_broken_promise()
         HPX_TEST(false);    // shouldn't get here
     }
     catch (hpx::exception const& e) {
-        HPX_TEST(e.get_error() == hpx::broken_promise);
+        HPX_TEST_EQ(e.get_error(), hpx::broken_promise);
     }
     catch (...) {
         HPX_TEST(false);
@@ -589,7 +589,7 @@ void test_destroying_a_packaged_task_stores_broken_task()
         HPX_TEST(false);    // shouldn't get here
     }
     catch (hpx::exception const& e) {
-      HPX_TEST(e.get_error() == hpx::broken_promise);
+      HPX_TEST_EQ(e.get_error(), hpx::broken_promise);
     }
     catch (...) {
         HPX_TEST(false);
@@ -1262,7 +1262,7 @@ void test_wait_for_either_of_five_futures_5()
 //         hpx::lcos::shared_future<int>* const future =
 //              boost::wait_for_any(futures, futures+count);
 //
-//         HPX_TEST(future == (futures + i));
+//         HPX_TEST_EQ(future, (futures + i));
 //         for(unsigned j = 0; j < count; ++j)
 //         {
 //             if (j != i)

--- a/tests/unit/lcos/when_any.cpp
+++ b/tests/unit/lcos/when_any.cpp
@@ -666,7 +666,7 @@ void test_wait_for_either_of_five_futures_5()
 //         hpx::lcos::future<int>* const future =
 //               boost::wait_for_any(futures, futures+count);
 //
-//         HPX_TEST(future == (futures + i));
+//         HPX_TEST_EQ(future, (futures + i));
 //         for(unsigned j = 0; j < count; ++j)
 //         {
 //             if (j != i)

--- a/tests/unit/lcos/when_each.cpp
+++ b/tests/unit/lcos/when_each.cpp
@@ -41,7 +41,7 @@ void test_when_each_from_list()
 
             unsigned id = fut.get();
 
-            HPX_TEST(id < count);
+            HPX_TEST_LT(id, count);
         };
 
     auto callback_with_index =
@@ -52,7 +52,7 @@ void test_when_each_from_list()
             unsigned id = fut.get();
 
             HPX_TEST_EQ(idx, id);
-            HPX_TEST(id < count);
+            HPX_TEST_LT(id, count);
         };
 
     Container futures1;
@@ -100,7 +100,7 @@ void test_when_each_from_list_iterators()
 
             unsigned id = fut.get();
 
-            HPX_TEST(id < count);
+            HPX_TEST_LT(id, count);
         };
 
     auto callback_with_index =
@@ -111,7 +111,7 @@ void test_when_each_from_list_iterators()
             unsigned id = fut.get();
 
             HPX_TEST_EQ(idx, id);
-            HPX_TEST(id < count);
+            HPX_TEST_LT(id, count);
         };
 
     Container futures1;
@@ -163,7 +163,7 @@ void test_when_each_n_from_list_iterators()
 
             unsigned id = fut.get();
 
-            HPX_TEST(id < n);
+            HPX_TEST_LT(id, n);
         };
 
     auto callback_with_index_n =
@@ -174,7 +174,7 @@ void test_when_each_n_from_list_iterators()
             unsigned id = fut.get();
 
             HPX_TEST_EQ(idx, id);
-            HPX_TEST(id < n);
+            HPX_TEST_LT(id, n);
         };
 
     Container futures1;
@@ -229,7 +229,7 @@ void test_when_each_one_future()
 
             unsigned id = fut.get();
 
-            HPX_TEST(id < count);
+            HPX_TEST_LT(id, count);
         };
 
     auto callback_with_index =
@@ -240,7 +240,7 @@ void test_when_each_one_future()
             unsigned id = fut.get();
 
             HPX_TEST_EQ(idx, id);
-            HPX_TEST(id < count);
+            HPX_TEST_LT(id, count);
         };
 
     hpx::future<unsigned> f = hpx::make_ready_future(static_cast<unsigned>(0));
@@ -272,7 +272,7 @@ void test_when_each_two_futures()
 
             unsigned id = fut.get();
 
-            HPX_TEST(id < count);
+            HPX_TEST_LT(id, count);
         };
 
     auto callback_with_index =
@@ -283,7 +283,7 @@ void test_when_each_two_futures()
             unsigned id = fut.get();
 
             HPX_TEST_EQ(idx, id);
-            HPX_TEST(id < count);
+            HPX_TEST_LT(id, count);
         };
 
     hpx::future<unsigned> f1 = hpx::make_ready_future(static_cast<unsigned>(0));
@@ -322,7 +322,7 @@ void test_when_each_three_futures()
 
             unsigned id = fut.get();
 
-            HPX_TEST(id < count);
+            HPX_TEST_LT(id, count);
         };
 
     auto callback_with_index =
@@ -333,7 +333,7 @@ void test_when_each_three_futures()
             unsigned id = fut.get();
 
             HPX_TEST_EQ(idx, id);
-            HPX_TEST(id < count);
+            HPX_TEST_LT(id, count);
         };
 
     hpx::future<unsigned> f1 = hpx::make_ready_future(static_cast<unsigned>(0));
@@ -376,7 +376,7 @@ void test_when_each_four_futures()
 
             unsigned id = fut.get();
 
-            HPX_TEST(id < count);
+            HPX_TEST_LT(id, count);
         };
 
     auto callback_with_index =
@@ -387,7 +387,7 @@ void test_when_each_four_futures()
             unsigned id = fut.get();
 
             HPX_TEST_EQ(idx, id);
-            HPX_TEST(id < count);
+            HPX_TEST_LT(id, count);
         };
 
     hpx::future<unsigned> f1 = hpx::make_ready_future(static_cast<unsigned>(0));
@@ -434,7 +434,7 @@ void test_when_each_five_futures()
 
             unsigned id = fut.get();
 
-            HPX_TEST(id < count);
+            HPX_TEST_LT(id, count);
         };
 
     auto callback_with_index =
@@ -445,7 +445,7 @@ void test_when_each_five_futures()
             unsigned id = fut.get();
 
             HPX_TEST_EQ(idx, id);
-            HPX_TEST(id < count);
+            HPX_TEST_LT(id, count);
         };
 
     hpx::future<unsigned> f1 = hpx::make_ready_future(static_cast<unsigned>(0));
@@ -496,7 +496,7 @@ void test_when_each_late_future()
 
             unsigned id = fut.get();
 
-            HPX_TEST(id < count);
+            HPX_TEST_LT(id, count);
         };
 
     auto callback_with_index =
@@ -507,7 +507,7 @@ void test_when_each_late_future()
             unsigned id = fut.get();
 
             HPX_TEST_EQ(idx, id);
-            HPX_TEST(id < count);
+            HPX_TEST_LT(id, count);
         };
 
     hpx::lcos::local::futures_factory<unsigned()> pt0(make_unsigned_slowly<0>);
@@ -563,7 +563,7 @@ void test_when_each_deferred_futures()
 
             unsigned id = fut.get();
 
-            HPX_TEST(id < count);
+            HPX_TEST_LT(id, count);
         };
 
     auto callback_with_index =
@@ -574,7 +574,7 @@ void test_when_each_deferred_futures()
             unsigned id = fut.get();
 
             HPX_TEST_EQ(idx, id);
-            HPX_TEST(id < count);
+            HPX_TEST_LT(id, count);
         };
 
     hpx::lcos::future<unsigned> f1 =

--- a/tests/unit/parcelset/put_parcels.cpp
+++ b/tests/unit/parcelset/put_parcels.cpp
@@ -74,7 +74,7 @@ void test_plain_argument(hpx::id_type const& id)
 
     for (hpx::future<hpx::id_type>& f : results)
     {
-        HPX_TEST(f.get() == id);
+        HPX_TEST_EQ(f.get(), id);
     }
 }
 
@@ -124,7 +124,7 @@ void test_future_argument(hpx::id_type const& id)
 
     for (hpx::future<hpx::id_type>& f : results)
     {
-        HPX_TEST(f.get() == id);
+        HPX_TEST_EQ(f.get(), id);
     }
 }
 
@@ -181,7 +181,7 @@ void test_mixed_arguments(hpx::id_type const& id)
 
     for (hpx::future<hpx::id_type>& f : results)
     {
-        HPX_TEST(f.get() == id);
+        HPX_TEST_EQ(f.get(), id);
     }
 }
 

--- a/tests/unit/parcelset/put_parcels_with_coalescing.cpp
+++ b/tests/unit/parcelset/put_parcels_with_coalescing.cpp
@@ -98,7 +98,7 @@ void test_plain_argument(hpx::id_type const& id)
 
     for (hpx::future<hpx::id_type>& f : results)
     {
-        HPX_TEST(f.get() == id);
+        HPX_TEST_EQ(f.get(), id);
     }
 }
 
@@ -150,7 +150,7 @@ void test_future_argument(hpx::id_type const& id)
 
     for (hpx::future<hpx::id_type>& f : results)
     {
-        HPX_TEST(f.get() == id);
+        HPX_TEST_EQ(f.get(), id);
     }
 }
 
@@ -209,7 +209,7 @@ void test_mixed_arguments(hpx::id_type const& id)
 
     for (hpx::future<hpx::id_type>& f : results)
     {
-        HPX_TEST(f.get() == id);
+        HPX_TEST_EQ(f.get(), id);
     }
 }
 

--- a/tests/unit/parcelset/put_parcels_with_compression.cpp
+++ b/tests/unit/parcelset/put_parcels_with_compression.cpp
@@ -106,7 +106,7 @@ void test_plain_argument(hpx::id_type const& id)
 
     for (hpx::future<hpx::id_type>& f : results)
     {
-        HPX_TEST(f.get() == id);
+        HPX_TEST_EQ(f.get(), id);
     }
 }
 
@@ -167,7 +167,7 @@ void test_future_argument(hpx::id_type const& id)
 
     for (hpx::future<hpx::id_type>& f : results)
     {
-        HPX_TEST(f.get() == id);
+        HPX_TEST_EQ(f.get(), id);
     }
 }
 
@@ -226,7 +226,7 @@ void test_mixed_arguments(hpx::id_type const& id)
 
     for (hpx::future<hpx::id_type>& f : results)
     {
-        HPX_TEST(f.get() == id);
+        HPX_TEST_EQ(f.get(), id);
     }
 }
 
@@ -261,7 +261,7 @@ void verify_counters()
         if (data_val != 0 && serialize_val != 0)
         {
             // compression should reduce the transmitted amount of data
-            HPX_TEST(data_val >= serialize_val);
+            HPX_TEST_LTE(serialize_val, data_val);
         }
 
         hpx::cout

--- a/tests/unit/performance_counter/counter_raw_values.cpp
+++ b/tests/unit/performance_counter/counter_raw_values.cpp
@@ -54,7 +54,7 @@ int hpx_main(int argc, char* argv[])
 
         auto values = c.get_counter_values_array(hpx::launch::sync, false);
 
-        HPX_TEST(values.count_ == static_cast<std::uint64_t>(i + 1));
+        HPX_TEST_EQ(values.count_, static_cast<std::uint64_t>(i + 1));
 
         std::vector<std::int64_t> expected(10);
         std::iota(expected.begin(), expected.end(), i);

--- a/tests/unit/performance_counter/path_elements.cpp
+++ b/tests/unit/performance_counter/path_elements.cpp
@@ -398,68 +398,68 @@ namespace test
             using namespace hpx::performance_counters;
 
             std::string fullname;
-            HPX_TEST(status_valid_data == get_counter_name(t->path_, fullname, ec));
-            HPX_TEST(ec.value() == hpx::success);
-            HPX_TEST(fullname == t->fullname_);
+            HPX_TEST_EQ(status_valid_data, get_counter_name(t->path_, fullname, ec));
+            HPX_TEST_EQ(ec.value(), hpx::success);
+            HPX_TEST_EQ(fullname, t->fullname_);
 
             std::string type_name;
             HPX_TEST(status_valid_data ==
                 get_counter_type_name(t->path_, type_name, ec));
-            HPX_TEST(ec.value() == hpx::success);
-            HPX_TEST(type_name == t->typename_);
+            HPX_TEST_EQ(ec.value(), hpx::success);
+            HPX_TEST_EQ(type_name, t->typename_);
 
             counter_path_elements p;
 
             HPX_TEST(status_valid_data ==
                 get_counter_path_elements(t->fullname_, p, ec));
-            HPX_TEST(ec.value() == hpx::success);
-            HPX_TEST(p.objectname_ == t->path_.objectname_);
-            HPX_TEST(p.parentinstancename_ == t->path_.parentinstancename_);
-            HPX_TEST(p.instancename_ == t->path_.instancename_);
-            HPX_TEST(p.subinstancename_ == t->path_.subinstancename_);
-            HPX_TEST(p.instanceindex_ == t->path_.instanceindex_);
-            HPX_TEST(p.subinstanceindex_ == t->path_.subinstanceindex_);
-            HPX_TEST(p.countername_ == t->path_.countername_);
+            HPX_TEST_EQ(ec.value(), hpx::success);
+            HPX_TEST_EQ(p.objectname_, t->path_.objectname_);
+            HPX_TEST_EQ(p.parentinstancename_, t->path_.parentinstancename_);
+            HPX_TEST_EQ(p.instancename_, t->path_.instancename_);
+            HPX_TEST_EQ(p.subinstancename_, t->path_.subinstancename_);
+            HPX_TEST_EQ(p.instanceindex_, t->path_.instanceindex_);
+            HPX_TEST_EQ(p.subinstanceindex_, t->path_.subinstanceindex_);
+            HPX_TEST_EQ(p.countername_, t->path_.countername_);
 
             fullname.erase();
-            HPX_TEST(status_valid_data == get_counter_name(p, fullname, ec));
-            HPX_TEST(ec.value() == hpx::success);
-            HPX_TEST(fullname == t->fullname_);
+            HPX_TEST_EQ(status_valid_data, get_counter_name(p, fullname, ec));
+            HPX_TEST_EQ(ec.value(), hpx::success);
+            HPX_TEST_EQ(fullname, t->fullname_);
 
             counter_type_path_elements tp1, tp2;
 
             HPX_TEST(status_valid_data ==
                 get_counter_type_path_elements(t->fullname_, tp1, ec));
-            HPX_TEST(ec.value() == hpx::success);
-            HPX_TEST(tp1.objectname_ == t->path_.objectname_);
-            HPX_TEST(tp1.countername_ == t->path_.countername_);
+            HPX_TEST_EQ(ec.value(), hpx::success);
+            HPX_TEST_EQ(tp1.objectname_, t->path_.objectname_);
+            HPX_TEST_EQ(tp1.countername_, t->path_.countername_);
 
             type_name.erase();
-            HPX_TEST(status_valid_data == get_counter_type_name(tp1, type_name, ec));
-            HPX_TEST(ec.value() == hpx::success);
-            HPX_TEST(type_name == t->typename_);
+            HPX_TEST_EQ(status_valid_data, get_counter_type_name(tp1, type_name, ec));
+            HPX_TEST_EQ(ec.value(), hpx::success);
+            HPX_TEST_EQ(type_name, t->typename_);
 
             type_name.erase();
             HPX_TEST(status_valid_data ==
                 get_full_counter_type_name(tp1, type_name, ec));
-            HPX_TEST(ec.value() == hpx::success);
+            HPX_TEST_EQ(ec.value(), hpx::success);
             if (t->path_.parameters_.empty()) {
-                HPX_TEST(type_name == t->typename_);
+                HPX_TEST_EQ(type_name, t->typename_);
             }
             else {
-                HPX_TEST(type_name == t->typename_ + '@' + t->path_.parameters_);
+                HPX_TEST_EQ(type_name, t->typename_ + '@' + t->path_.parameters_);
             }
 
             HPX_TEST(status_valid_data ==
                 get_counter_type_path_elements(t->typename_, tp2, ec));
-            HPX_TEST(ec.value() == hpx::success);
-            HPX_TEST(tp2.objectname_ == t->path_.objectname_);
-            HPX_TEST(tp2.countername_ == t->path_.countername_);
+            HPX_TEST_EQ(ec.value(), hpx::success);
+            HPX_TEST_EQ(tp2.objectname_, t->path_.objectname_);
+            HPX_TEST_EQ(tp2.countername_, t->path_.countername_);
 
             type_name.erase();
-            HPX_TEST(status_valid_data == get_counter_type_name(tp2, type_name, ec));
-            HPX_TEST(ec.value() == hpx::success);
-            HPX_TEST(type_name == t->typename_);
+            HPX_TEST_EQ(status_valid_data, get_counter_type_name(tp2, type_name, ec));
+            HPX_TEST_EQ(ec.value(), hpx::success);
+            HPX_TEST_EQ(type_name, t->typename_);
         }
     }
 

--- a/tests/unit/threads/error_callback.cpp
+++ b/tests/unit/threads/error_callback.cpp
@@ -45,7 +45,7 @@ int main(int argc, char* argv[])
     }
 
     HPX_TEST(caught_exception);
-    HPX_TEST(count_error_handler == 1);
+    HPX_TEST_EQ(count_error_handler, std::size_t(1));
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/threads/lockfree_fifo.cpp
+++ b/tests/unit/threads/lockfree_fifo.cpp
@@ -121,7 +121,7 @@ int main(int argc, char** argv)
     }
 
     for (std::uint64_t i = 0; i < threads; ++i)
-        HPX_TEST(stolen[i] == 0);
+        HPX_TEST_EQ(stolen[i], std::uint64_t(0));
 
     for (std::uint64_t i = 0; i < threads; ++i)
         delete queues[i];

--- a/tests/unit/threads/start_stop_callbacks.cpp
+++ b/tests/unit/threads/start_stop_callbacks.cpp
@@ -68,29 +68,29 @@ int hpx_main(int argc, char* argv[])
     std::lock_guard<std::mutex> l(mtx);
 
     auto p = threads.equal_range("main-thread");
-    HPX_TEST(std::distance(p.first, p.second) == 1);
+    HPX_TEST_EQ(std::distance(p.first, p.second), 1);
 
     p = threads.equal_range("worker-thread");
-    HPX_TEST(std::size_t(std::distance(p.first, p.second)) ==
+    HPX_TEST_EQ(std::size_t(std::distance(p.first, p.second)),
         hpx::get_num_worker_threads());
 
     p = threads.equal_range("timer-thread");
     auto cfg = hpx::get_config_entry("hpx.threadpools.timer_pool_size", "0");
-    HPX_TEST(std::distance(p.first, p.second) == hpx::util::from_string<int>(cfg));
+    HPX_TEST_EQ(std::distance(p.first, p.second), hpx::util::from_string<int>(cfg));
 
 #if defined(HPX_HAVE_NETWORKING)
     if (hpx::is_networking_enabled())
     {
         p = threads.equal_range("parcel-thread");
         cfg = hpx::get_config_entry("hpx.threadpools.parcel_pool_size", "0");
-        HPX_TEST(
-            std::distance(p.first, p.second) == hpx::util::from_string<int>(cfg));
+        HPX_TEST_EQ(
+            std::distance(p.first, p.second), hpx::util::from_string<int>(cfg));
     }
 #endif
 
     p = threads.equal_range("io-thread");
     cfg = hpx::get_config_entry("hpx.threadpools.io_pool_size", "0");
-    HPX_TEST(std::distance(p.first, p.second) == hpx::util::from_string<int>(cfg));
+    HPX_TEST_EQ(std::distance(p.first, p.second), hpx::util::from_string<int>(cfg));
 
     return hpx::finalize();
 }

--- a/tests/unit/threads/thread.cpp
+++ b/tests/unit/threads/thread.cpp
@@ -185,7 +185,7 @@ void do_test_thread_no_interrupt_if_interrupts_disabled_at_interruption_point()
     }
     catch (hpx::exception& e)
     {
-        HPX_TEST(e.get_error() == hpx::thread_not_interruptable);
+        HPX_TEST_EQ(e.get_error(), hpx::thread_not_interruptable);
         caught = true;
     }
 
@@ -316,12 +316,12 @@ void test_swap()
     hpx::thread::id id2 = t2.get_id();
 
     t1.swap(t2);
-    HPX_TEST(t1.get_id() == id2);
-    HPX_TEST(t2.get_id() == id1);
+    HPX_TEST_EQ(t1.get_id(), id2);
+    HPX_TEST_EQ(t2.get_id(), id1);
 
     swap(t1, t2);
-    HPX_TEST(t1.get_id() == id1);
-    HPX_TEST(t2.get_id() == id2);
+    HPX_TEST_EQ(t1.get_id(), id1);
+    HPX_TEST_EQ(t2.get_id(), id2);
 
     b2.wait();    // wait for the tests to be completed
 
@@ -345,7 +345,7 @@ void test_double_join()
     }
     catch (hpx::exception& e)
     {
-        HPX_TEST(e.get_error() == hpx::invalid_status);
+        HPX_TEST_EQ(e.get_error(), hpx::invalid_status);
         caught = true;
     }
 

--- a/tests/unit/threads/thread_affinity.cpp
+++ b/tests/unit/threads/thread_affinity.cpp
@@ -62,7 +62,7 @@ std::size_t thread_affinity_worker(std::size_t desired)
             hwloc_cpuset_t cpuset_cmp = hwloc_bitmap_alloc();
             hwloc_bitmap_zero(cpuset_cmp);
             hwloc_bitmap_only(cpuset_cmp, unsigned(idx));
-            HPX_TEST(hwloc_bitmap_compare(cpuset, cpuset_cmp) == 0);
+            HPX_TEST_EQ(hwloc_bitmap_compare(cpuset, cpuset_cmp), 0);
             hwloc_bitmap_free(cpuset_cmp);
         }
         else

--- a/tests/unit/threads/thread_id.cpp
+++ b/tests/unit/threads/thread_id.cpp
@@ -72,9 +72,9 @@ void test_thread_ids_have_a_total_order()
     hpx::thread::id t2_id = t2.get_id();
     hpx::thread::id t3_id = t3.get_id();
 
-    HPX_TEST(t1_id != t2_id);
-    HPX_TEST(t1_id != t3_id);
-    HPX_TEST(t2_id != t3_id);
+    HPX_TEST_NEQ(t1_id, t2_id);
+    HPX_TEST_NEQ(t1_id, t3_id);
+    HPX_TEST_NEQ(t2_id, t3_id);
 
     HPX_TEST((t1_id < t2_id) != (t2_id < t1_id));
     HPX_TEST((t1_id < t3_id) != (t3_id < t1_id));
@@ -107,27 +107,27 @@ void test_thread_ids_have_a_total_order()
 
     if((t1_id < t2_id) && (t2_id < t3_id))
     {
-        HPX_TEST(t1_id < t3_id);
+        HPX_TEST_LT(t1_id, t3_id);
     }
     else if((t1_id < t3_id) && (t3_id < t2_id))
     {
-        HPX_TEST(t1_id < t2_id);
+        HPX_TEST_LT(t1_id, t2_id);
     }
     else if((t2_id < t3_id) && (t3_id < t1_id))
     {
-        HPX_TEST(t2_id < t1_id);
+        HPX_TEST_LT(t2_id, t1_id);
     }
     else if((t2_id < t1_id) && (t1_id < t3_id))
     {
-        HPX_TEST(t2_id < t3_id);
+        HPX_TEST_LT(t2_id, t3_id);
     }
     else if((t3_id < t1_id) && (t1_id < t2_id))
     {
-        HPX_TEST(t3_id < t2_id);
+        HPX_TEST_LT(t3_id, t2_id);
     }
     else if((t3_id < t2_id) && (t2_id < t1_id))
     {
-        HPX_TEST(t3_id < t1_id);
+        HPX_TEST_LT(t3_id, t1_id);
     }
     else
     {
@@ -136,13 +136,13 @@ void test_thread_ids_have_a_total_order()
 
     hpx::thread::id default_id;
 
-    HPX_TEST(default_id < t1_id);
-    HPX_TEST(default_id < t2_id);
-    HPX_TEST(default_id < t3_id);
+    HPX_TEST_LT(default_id, t1_id);
+    HPX_TEST_LT(default_id, t2_id);
+    HPX_TEST_LT(default_id, t3_id);
 
-    HPX_TEST(default_id <= t1_id);
-    HPX_TEST(default_id <= t2_id);
-    HPX_TEST(default_id <= t3_id);
+    HPX_TEST_LTE(default_id, t1_id);
+    HPX_TEST_LTE(default_id, t2_id);
+    HPX_TEST_LTE(default_id, t3_id);
 
     HPX_TEST(!(default_id > t1_id));
     HPX_TEST(!(default_id > t2_id));

--- a/tests/unit/util/bind/bind_const_test.cpp
+++ b/tests/unit/util/bind/bind_const_test.cpp
@@ -153,12 +153,12 @@ void function_test()
 {
     int const i = 1;
 
-    HPX_TEST( test( hpx::util::bind(f_0), i ) == 17041L );
-    HPX_TEST( test( hpx::util::bind(f_1, placeholders::_1), i ) == 1L );
-    HPX_TEST( test( hpx::util::bind(f_2, placeholders::_1, 2), i ) == 21L );
-    HPX_TEST( test( hpx::util::bind(f_3, placeholders::_1, 2, 3), i ) == 321L );
-    HPX_TEST( test( hpx::util::bind(f_4, placeholders::_1, 2, 3, 4), i ) == 4321L );
-    HPX_TEST( test( hpx::util::bind(f_5, placeholders::_1, 2, 3, 4, 5), i ) == 54321L );
+    HPX_TEST_EQ( test( hpx::util::bind(f_0), i ), 17041L );
+    HPX_TEST_EQ( test( hpx::util::bind(f_1, placeholders::_1), i ), 1L );
+    HPX_TEST_EQ( test( hpx::util::bind(f_2, placeholders::_1, 2), i ), 21L );
+    HPX_TEST_EQ( test( hpx::util::bind(f_3, placeholders::_1, 2, 3), i ), 321L );
+    HPX_TEST_EQ( test( hpx::util::bind(f_4, placeholders::_1, 2, 3, 4), i ), 4321L );
+    HPX_TEST_EQ( test( hpx::util::bind(f_5, placeholders::_1, 2, 3, 4, 5), i ), 54321L );
     HPX_TEST( test( hpx::util::bind(f_6, placeholders::_1, 2, 3, 4, 5,
         6), i ) == 654321L );
     HPX_TEST( test( hpx::util::bind(f_7, placeholders::_1, 2, 3, 4, 5,
@@ -168,11 +168,11 @@ void function_test()
     HPX_TEST( test( hpx::util::bind(f_9, placeholders::_1, 2, 3, 4, 5,
         6, 7, 8, 9), i ) == 987654321L );
 
-    HPX_TEST( testv( hpx::util::bind(fv_0), i ) == 17041L );
-    HPX_TEST( testv( hpx::util::bind(fv_1, placeholders::_1), i ) == 1L );
-    HPX_TEST( testv( hpx::util::bind(fv_2, placeholders::_1, 2), i ) == 21L );
-    HPX_TEST( testv( hpx::util::bind(fv_3, placeholders::_1, 2, 3), i ) == 321L );
-    HPX_TEST( testv( hpx::util::bind(fv_4, placeholders::_1, 2, 3, 4), i ) == 4321L );
+    HPX_TEST_EQ( testv( hpx::util::bind(fv_0), i ), 17041L );
+    HPX_TEST_EQ( testv( hpx::util::bind(fv_1, placeholders::_1), i ), 1L );
+    HPX_TEST_EQ( testv( hpx::util::bind(fv_2, placeholders::_1, 2), i ), 21L );
+    HPX_TEST_EQ( testv( hpx::util::bind(fv_3, placeholders::_1, 2, 3), i ), 321L );
+    HPX_TEST_EQ( testv( hpx::util::bind(fv_4, placeholders::_1, 2, 3, 4), i ), 4321L );
     HPX_TEST( testv( hpx::util::bind(fv_5, placeholders::_1, 2, 3, 4, 5),
         i ) == 54321L );
     HPX_TEST( testv( hpx::util::bind(fv_6, placeholders::_1, 2, 3, 4, 5,

--- a/tests/unit/util/bind/bind_cv_test.cpp
+++ b/tests/unit/util/bind/bind_cv_test.cpp
@@ -148,8 +148,8 @@ struct X
 template<class F> void test(F f, int r)
 {
     F const & cf = f;
-    HPX_TEST( cf() == -r );
-    HPX_TEST( f() == r );
+    HPX_TEST_EQ( cf(), -r );
+    HPX_TEST_EQ( f(), r );
 }
 
 int main()

--- a/tests/unit/util/bind/bind_dm2_test.cpp
+++ b/tests/unit/util/bind/bind_dm2_test.cpp
@@ -47,22 +47,22 @@ int main()
 
     hpx::util::bind( &X::m, placeholders::_1 )( px ) = 42;
 
-    HPX_TEST( x.m == 42 );
+    HPX_TEST_EQ( x.m, 42 );
 
     hpx::util::bind( &X::m, std::ref(x) )() = 17041;
 
-    HPX_TEST( x.m == 17041 );
+    HPX_TEST_EQ( x.m, 17041 );
 
     X const * pcx = &x;
 
-    HPX_TEST( hpx::util::bind( &X::m, placeholders::_1 )( pcx ) == 17041L );
-    HPX_TEST( hpx::util::bind( &X::m, pcx )() == 17041L );
+    HPX_TEST_EQ( hpx::util::bind( &X::m, placeholders::_1 )( pcx ), 17041L );
+    HPX_TEST_EQ( hpx::util::bind( &X::m, pcx )(), 17041L );
 
     Y y = { "test" };
     std::string v( "test" );
 
-    HPX_TEST( hpx::util::bind( &Y::m, &y )() == v );
-    HPX_TEST( hpx::util::bind( &Y::m, &y )() == v );
+    HPX_TEST_EQ( hpx::util::bind( &Y::m, &y )(), v );
+    HPX_TEST_EQ( hpx::util::bind( &Y::m, &y )(), v );
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/util/bind/bind_dm3_test.cpp
+++ b/tests/unit/util/bind/bind_dm3_test.cpp
@@ -37,7 +37,7 @@ int main()
 
     int const & x = hpx::util::bind( &pair_type::first, placeholders::_1 )( pair );
 
-    HPX_TEST( &pair.first == &x );
+    HPX_TEST_EQ( &pair.first, &x );
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/util/bind/bind_dm_test.cpp
+++ b/tests/unit/util/bind/bind_dm_test.cpp
@@ -45,23 +45,23 @@ int main()
     X x = { 17041 };
     X * px = &x;
 
-    HPX_TEST( hpx::util::bind( &X::m, placeholders::_1 )( x ) == 17041 );
-    HPX_TEST( hpx::util::bind( &X::m, placeholders::_1 )( px ) == 17041 );
+    HPX_TEST_EQ( hpx::util::bind( &X::m, placeholders::_1 )( x ), 17041 );
+    HPX_TEST_EQ( hpx::util::bind( &X::m, placeholders::_1 )( px ), 17041 );
 
-    HPX_TEST( hpx::util::bind( &X::m, x )() == 17041 );
-    HPX_TEST( hpx::util::bind( &X::m, px )() == 17041 );
-    HPX_TEST( hpx::util::bind( &X::m, std::ref(x) )() == 17041 );
+    HPX_TEST_EQ( hpx::util::bind( &X::m, x )(), 17041 );
+    HPX_TEST_EQ( hpx::util::bind( &X::m, px )(), 17041 );
+    HPX_TEST_EQ( hpx::util::bind( &X::m, std::ref(x) )(), 17041 );
 
 
     X const cx = x;
     X const * pcx = &cx;
 
-    HPX_TEST( hpx::util::bind( &X::m, placeholders::_1 )( cx ) == 17041 );
-    HPX_TEST( hpx::util::bind( &X::m, placeholders::_1 )( pcx ) == 17041 );
+    HPX_TEST_EQ( hpx::util::bind( &X::m, placeholders::_1 )( cx ), 17041 );
+    HPX_TEST_EQ( hpx::util::bind( &X::m, placeholders::_1 )( pcx ), 17041 );
 
-    HPX_TEST( hpx::util::bind( &X::m, cx )() == 17041 );
-    HPX_TEST( hpx::util::bind( &X::m, pcx )() == 17041 );
-    HPX_TEST( hpx::util::bind( &X::m, std::ref(cx) )() == 17041 );
+    HPX_TEST_EQ( hpx::util::bind( &X::m, cx )(), 17041 );
+    HPX_TEST_EQ( hpx::util::bind( &X::m, pcx )(), 17041 );
+    HPX_TEST_EQ( hpx::util::bind( &X::m, std::ref(cx) )(), 17041 );
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/util/bind/bind_rv_sp_test.cpp
+++ b/tests/unit/util/bind/bind_rv_sp_test.cpp
@@ -55,7 +55,7 @@ int main()
 {
     Y y;
 
-    HPX_TEST( hpx::util::bind( &X::f, hpx::util::bind( &Y::f, &y ) )() == 42 );
+    HPX_TEST_EQ( hpx::util::bind( &X::f, hpx::util::bind( &Y::f, &y ) )(), 42 );
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/util/bind/bind_stateful_test.cpp
+++ b/tests/unit/util/bind/bind_stateful_test.cpp
@@ -150,9 +150,9 @@ int f8(int & state_, int x1, int x2, int x3, int x4, int x5, int x6, int x7, int
 
 template<class F> void test(F f, int a, int b)
 {
-    HPX_TEST( f() == a +   b );
-    HPX_TEST( f() == a + 2*b );
-    HPX_TEST( f() == a + 3*b );
+    HPX_TEST_EQ( f(), a +   b );
+    HPX_TEST_EQ( f(), a + 2*b );
+    HPX_TEST_EQ( f(), a + 3*b );
 }
 
 void stateful_function_object_test()
@@ -204,7 +204,7 @@ void stateful_function_object_test()
         6, 7, 8, 9 ), n, 1+2+3+4+5+6+7+8+9 );
     n += 3*(1+2+3+4+5+6+7+8+9);
 
-    HPX_TEST( x.state() == n );
+    HPX_TEST_EQ( x.state(), n );
 }
 
 void stateful_function_test()

--- a/tests/unit/util/bind/bind_test.cpp
+++ b/tests/unit/util/bind/bind_test.cpp
@@ -211,7 +211,7 @@ void function_object_test()
 
     global_result = 0;
     hpx::util::bind(Y(), i, placeholders::_1, 9, 4)(k);
-    HPX_TEST( global_result == 4938 );
+    HPX_TEST_EQ( global_result, 4938 );
 
 #endif
 }
@@ -231,7 +231,7 @@ void function_object_test2()
 
     global_result = 0;
     hpx::util::bind(Y(), i, placeholders::_1, 9, 4)(k);
-    HPX_TEST( global_result == 4938 );
+    HPX_TEST_EQ( global_result, 4938 );
 }
 
 //
@@ -246,7 +246,7 @@ struct Z
 
 void adaptable_function_object_test()
 {
-    HPX_TEST( hpx::util::bind(Z(), 7, 4)() == 47 );
+    HPX_TEST_EQ( hpx::util::bind(Z(), 7, 4)(), 47 );
 }
 
 #endif
@@ -432,7 +432,7 @@ void member_function_test()
     hpx::util::bind(&X::g8, x, 1, 2, 3, 4, 5, 6, 7, 8)();
     hpx::util::bind(&X::g8, ref(x), 1, 2, 3, 4, 5, 6, 7, 8)();
 
-    HPX_TEST( x.hash == 23558 );
+    HPX_TEST_EQ( x.hash, static_cast<unsigned int>(23558) );
 }
 
 void member_function_void_test()
@@ -522,7 +522,7 @@ void member_function_void_test()
     hpx::util::bind(&V::g8, v, 1, 2, 3, 4, 5, 6, 7, 8)();
     hpx::util::bind(&V::g8, ref(v), 1, 2, 3, 4, 5, 6, 7, 8)();
 
-    HPX_TEST( v.hash == 23558 );
+    HPX_TEST_EQ( v.hash, static_cast<unsigned int>(23558) );
 }
 
 void nested_bind_test()

--- a/tests/unit/util/mem_fn/mem_fn_derived_test.cpp
+++ b/tests/unit/util/mem_fn/mem_fn_derived_test.cpp
@@ -173,8 +173,8 @@ int main()
     hpx::util::mem_fn(&X::g8)(pcx, 1, 2, 3, 4, 5, 6, 7, 8);
     hpx::util::mem_fn(&X::g8)(sp, 1, 2, 3, 4, 5, 6, 7, 8);
 
-    HPX_TEST(hpx::util::mem_fn(&X::hash)(x) == 17610);
-    HPX_TEST(hpx::util::mem_fn(&X::hash)(sp) == 2155);
+    HPX_TEST_EQ(hpx::util::mem_fn(&X::hash)(x), 17610u);
+    HPX_TEST_EQ(hpx::util::mem_fn(&X::hash)(sp), 2155u);
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/util/mem_fn/mem_fn_dm_test.cpp
+++ b/tests/unit/util/mem_fn/mem_fn_dm_test.cpp
@@ -38,26 +38,26 @@ int main()
 
     hpx::util::mem_fn( &X::m )( x ) = 401;
 
-    HPX_TEST( x.m == 401 );
-    HPX_TEST( hpx::util::mem_fn( &X::m )( x ) == 401 );
+    HPX_TEST_EQ( x.m, 401 );
+    HPX_TEST_EQ( hpx::util::mem_fn( &X::m )( x ), 401 );
 
     hpx::util::mem_fn( &X::m )( &x ) = 502;
 
-    HPX_TEST( x.m == 502 );
-    HPX_TEST( hpx::util::mem_fn( &X::m )( &x ) == 502 );
+    HPX_TEST_EQ( x.m, 502 );
+    HPX_TEST_EQ( hpx::util::mem_fn( &X::m )( &x ), 502 );
 
     X * px = &x;
 
     hpx::util::mem_fn( &X::m )( px ) = 603;
 
-    HPX_TEST( x.m == 603 );
-    HPX_TEST( hpx::util::mem_fn( &X::m )( px ) == 603 );
+    HPX_TEST_EQ( x.m, 603 );
+    HPX_TEST_EQ( hpx::util::mem_fn( &X::m )( px ), 603 );
 
     X const & cx = x;
     X const * pcx = &x;
 
-    HPX_TEST( hpx::util::mem_fn( &X::m )( cx ) == 603 );
-    HPX_TEST( hpx::util::mem_fn( &X::m )( pcx ) == 603 );
+    HPX_TEST_EQ( hpx::util::mem_fn( &X::m )( cx ), 603 );
+    HPX_TEST_EQ( hpx::util::mem_fn( &X::m )( pcx ), 603 );
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/util/mem_fn/mem_fn_eq_test.cpp
+++ b/tests/unit/util/mem_fn/mem_fn_eq_test.cpp
@@ -161,134 +161,134 @@ struct X
 
 int main()
 {
-    HPX_TEST( hpx::util::mem_fn(&X::dm_1) == hpx::util::mem_fn(&X::dm_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::dm_1) != hpx::util::mem_fn(&X::dm_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::dm_1), hpx::util::mem_fn(&X::dm_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::dm_1), hpx::util::mem_fn(&X::dm_2) );
 
     // 0
 
-    HPX_TEST( hpx::util::mem_fn(&X::mf0_1) == hpx::util::mem_fn(&X::mf0_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::mf0_1) != hpx::util::mem_fn(&X::mf0_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::mf0_1), hpx::util::mem_fn(&X::mf0_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::mf0_1), hpx::util::mem_fn(&X::mf0_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::cmf0_1) == hpx::util::mem_fn(&X::cmf0_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::cmf0_1) != hpx::util::mem_fn(&X::cmf0_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::cmf0_1), hpx::util::mem_fn(&X::cmf0_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::cmf0_1), hpx::util::mem_fn(&X::cmf0_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::mf0v_1) == hpx::util::mem_fn(&X::mf0v_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::mf0v_1) != hpx::util::mem_fn(&X::mf0v_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::mf0v_1), hpx::util::mem_fn(&X::mf0v_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::mf0v_1), hpx::util::mem_fn(&X::mf0v_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::cmf0v_1) == hpx::util::mem_fn(&X::cmf0v_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::cmf0v_1) != hpx::util::mem_fn(&X::cmf0v_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::cmf0v_1), hpx::util::mem_fn(&X::cmf0v_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::cmf0v_1), hpx::util::mem_fn(&X::cmf0v_2) );
 
     // 1
 
-    HPX_TEST( hpx::util::mem_fn(&X::mf1_1) == hpx::util::mem_fn(&X::mf1_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::mf1_1) != hpx::util::mem_fn(&X::mf1_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::mf1_1), hpx::util::mem_fn(&X::mf1_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::mf1_1), hpx::util::mem_fn(&X::mf1_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::cmf1_1) == hpx::util::mem_fn(&X::cmf1_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::cmf1_1) != hpx::util::mem_fn(&X::cmf1_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::cmf1_1), hpx::util::mem_fn(&X::cmf1_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::cmf1_1), hpx::util::mem_fn(&X::cmf1_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::mf1v_1) == hpx::util::mem_fn(&X::mf1v_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::mf1v_1) != hpx::util::mem_fn(&X::mf1v_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::mf1v_1), hpx::util::mem_fn(&X::mf1v_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::mf1v_1), hpx::util::mem_fn(&X::mf1v_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::cmf1v_1) == hpx::util::mem_fn(&X::cmf1v_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::cmf1v_1) != hpx::util::mem_fn(&X::cmf1v_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::cmf1v_1), hpx::util::mem_fn(&X::cmf1v_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::cmf1v_1), hpx::util::mem_fn(&X::cmf1v_2) );
 
     // 2
 
-    HPX_TEST( hpx::util::mem_fn(&X::mf2_1) == hpx::util::mem_fn(&X::mf2_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::mf2_1) != hpx::util::mem_fn(&X::mf2_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::mf2_1), hpx::util::mem_fn(&X::mf2_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::mf2_1), hpx::util::mem_fn(&X::mf2_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::cmf2_1) == hpx::util::mem_fn(&X::cmf2_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::cmf2_1) != hpx::util::mem_fn(&X::cmf2_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::cmf2_1), hpx::util::mem_fn(&X::cmf2_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::cmf2_1), hpx::util::mem_fn(&X::cmf2_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::mf2v_1) == hpx::util::mem_fn(&X::mf2v_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::mf2v_1) != hpx::util::mem_fn(&X::mf2v_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::mf2v_1), hpx::util::mem_fn(&X::mf2v_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::mf2v_1), hpx::util::mem_fn(&X::mf2v_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::cmf2v_1) == hpx::util::mem_fn(&X::cmf2v_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::cmf2v_1) != hpx::util::mem_fn(&X::cmf2v_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::cmf2v_1), hpx::util::mem_fn(&X::cmf2v_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::cmf2v_1), hpx::util::mem_fn(&X::cmf2v_2) );
 
     // 3
 
-    HPX_TEST( hpx::util::mem_fn(&X::mf3_1) == hpx::util::mem_fn(&X::mf3_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::mf3_1) != hpx::util::mem_fn(&X::mf3_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::mf3_1), hpx::util::mem_fn(&X::mf3_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::mf3_1), hpx::util::mem_fn(&X::mf3_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::cmf3_1) == hpx::util::mem_fn(&X::cmf3_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::cmf3_1) != hpx::util::mem_fn(&X::cmf3_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::cmf3_1), hpx::util::mem_fn(&X::cmf3_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::cmf3_1), hpx::util::mem_fn(&X::cmf3_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::mf3v_1) == hpx::util::mem_fn(&X::mf3v_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::mf3v_1) != hpx::util::mem_fn(&X::mf3v_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::mf3v_1), hpx::util::mem_fn(&X::mf3v_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::mf3v_1), hpx::util::mem_fn(&X::mf3v_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::cmf3v_1) == hpx::util::mem_fn(&X::cmf3v_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::cmf3v_1) != hpx::util::mem_fn(&X::cmf3v_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::cmf3v_1), hpx::util::mem_fn(&X::cmf3v_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::cmf3v_1), hpx::util::mem_fn(&X::cmf3v_2) );
 
     // 4
 
-    HPX_TEST( hpx::util::mem_fn(&X::mf4_1) == hpx::util::mem_fn(&X::mf4_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::mf4_1) != hpx::util::mem_fn(&X::mf4_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::mf4_1), hpx::util::mem_fn(&X::mf4_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::mf4_1), hpx::util::mem_fn(&X::mf4_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::cmf4_1) == hpx::util::mem_fn(&X::cmf4_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::cmf4_1) != hpx::util::mem_fn(&X::cmf4_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::cmf4_1), hpx::util::mem_fn(&X::cmf4_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::cmf4_1), hpx::util::mem_fn(&X::cmf4_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::mf4v_1) == hpx::util::mem_fn(&X::mf4v_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::mf4v_1) != hpx::util::mem_fn(&X::mf4v_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::mf4v_1), hpx::util::mem_fn(&X::mf4v_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::mf4v_1), hpx::util::mem_fn(&X::mf4v_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::cmf4v_1) == hpx::util::mem_fn(&X::cmf4v_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::cmf4v_1) != hpx::util::mem_fn(&X::cmf4v_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::cmf4v_1), hpx::util::mem_fn(&X::cmf4v_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::cmf4v_1), hpx::util::mem_fn(&X::cmf4v_2) );
 
     // 5
 
-    HPX_TEST( hpx::util::mem_fn(&X::mf5_1) == hpx::util::mem_fn(&X::mf5_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::mf5_1) != hpx::util::mem_fn(&X::mf5_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::mf5_1), hpx::util::mem_fn(&X::mf5_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::mf5_1), hpx::util::mem_fn(&X::mf5_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::cmf5_1) == hpx::util::mem_fn(&X::cmf5_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::cmf5_1) != hpx::util::mem_fn(&X::cmf5_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::cmf5_1), hpx::util::mem_fn(&X::cmf5_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::cmf5_1), hpx::util::mem_fn(&X::cmf5_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::mf5v_1) == hpx::util::mem_fn(&X::mf5v_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::mf5v_1) != hpx::util::mem_fn(&X::mf5v_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::mf5v_1), hpx::util::mem_fn(&X::mf5v_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::mf5v_1), hpx::util::mem_fn(&X::mf5v_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::cmf5v_1) == hpx::util::mem_fn(&X::cmf5v_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::cmf5v_1) != hpx::util::mem_fn(&X::cmf5v_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::cmf5v_1), hpx::util::mem_fn(&X::cmf5v_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::cmf5v_1), hpx::util::mem_fn(&X::cmf5v_2) );
 
     // 6
 
-    HPX_TEST( hpx::util::mem_fn(&X::mf6_1) == hpx::util::mem_fn(&X::mf6_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::mf6_1) != hpx::util::mem_fn(&X::mf6_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::mf6_1), hpx::util::mem_fn(&X::mf6_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::mf6_1), hpx::util::mem_fn(&X::mf6_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::cmf6_1) == hpx::util::mem_fn(&X::cmf6_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::cmf6_1) != hpx::util::mem_fn(&X::cmf6_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::cmf6_1), hpx::util::mem_fn(&X::cmf6_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::cmf6_1), hpx::util::mem_fn(&X::cmf6_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::mf6v_1) == hpx::util::mem_fn(&X::mf6v_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::mf6v_1) != hpx::util::mem_fn(&X::mf6v_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::mf6v_1), hpx::util::mem_fn(&X::mf6v_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::mf6v_1), hpx::util::mem_fn(&X::mf6v_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::cmf6v_1) == hpx::util::mem_fn(&X::cmf6v_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::cmf6v_1) != hpx::util::mem_fn(&X::cmf6v_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::cmf6v_1), hpx::util::mem_fn(&X::cmf6v_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::cmf6v_1), hpx::util::mem_fn(&X::cmf6v_2) );
 
     // 7
 
-    HPX_TEST( hpx::util::mem_fn(&X::mf7_1) == hpx::util::mem_fn(&X::mf7_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::mf7_1) != hpx::util::mem_fn(&X::mf7_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::mf7_1), hpx::util::mem_fn(&X::mf7_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::mf7_1), hpx::util::mem_fn(&X::mf7_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::cmf7_1) == hpx::util::mem_fn(&X::cmf7_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::cmf7_1) != hpx::util::mem_fn(&X::cmf7_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::cmf7_1), hpx::util::mem_fn(&X::cmf7_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::cmf7_1), hpx::util::mem_fn(&X::cmf7_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::mf7v_1) == hpx::util::mem_fn(&X::mf7v_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::mf7v_1) != hpx::util::mem_fn(&X::mf7v_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::mf7v_1), hpx::util::mem_fn(&X::mf7v_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::mf7v_1), hpx::util::mem_fn(&X::mf7v_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::cmf7v_1) == hpx::util::mem_fn(&X::cmf7v_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::cmf7v_1) != hpx::util::mem_fn(&X::cmf7v_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::cmf7v_1), hpx::util::mem_fn(&X::cmf7v_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::cmf7v_1), hpx::util::mem_fn(&X::cmf7v_2) );
 
     // 8
 
-    HPX_TEST( hpx::util::mem_fn(&X::mf8_1) == hpx::util::mem_fn(&X::mf8_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::mf8_1) != hpx::util::mem_fn(&X::mf8_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::mf8_1), hpx::util::mem_fn(&X::mf8_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::mf8_1), hpx::util::mem_fn(&X::mf8_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::cmf8_1) == hpx::util::mem_fn(&X::cmf8_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::cmf8_1) != hpx::util::mem_fn(&X::cmf8_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::cmf8_1), hpx::util::mem_fn(&X::cmf8_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::cmf8_1), hpx::util::mem_fn(&X::cmf8_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::mf8v_1) == hpx::util::mem_fn(&X::mf8v_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::mf8v_1) != hpx::util::mem_fn(&X::mf8v_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::mf8v_1), hpx::util::mem_fn(&X::mf8v_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::mf8v_1), hpx::util::mem_fn(&X::mf8v_2) );
 
-    HPX_TEST( hpx::util::mem_fn(&X::cmf8v_1) == hpx::util::mem_fn(&X::cmf8v_1) );
-    HPX_TEST( hpx::util::mem_fn(&X::cmf8v_1) != hpx::util::mem_fn(&X::cmf8v_2) );
+    HPX_TEST_EQ( hpx::util::mem_fn(&X::cmf8v_1), hpx::util::mem_fn(&X::cmf8v_1) );
+    HPX_TEST_NEQ( hpx::util::mem_fn(&X::cmf8v_1), hpx::util::mem_fn(&X::cmf8v_2) );
 
 
     return hpx::util::report_errors();

--- a/tests/unit/util/mem_fn/mem_fn_rv_test.cpp
+++ b/tests/unit/util/mem_fn/mem_fn_rv_test.cpp
@@ -103,7 +103,7 @@ int main()
     hpx::util::mem_fn(&X::f8)(make(), 1, 2, 3, 4, 5, 6, 7, 8);
     hpx::util::mem_fn(&X::g8)(make(), 1, 2, 3, 4, 5, 6, 7, 8);
 
-    HPX_TEST(hash == 2155);
+    HPX_TEST_EQ(hash, 2155u);
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/util/mem_fn/mem_fn_test.cpp
+++ b/tests/unit/util/mem_fn/mem_fn_test.cpp
@@ -169,8 +169,8 @@ int main()
     hpx::util::mem_fn(&X::g8)(pcx, 1, 2, 3, 4, 5, 6, 7, 8);
     hpx::util::mem_fn(&X::g8)(sp, 1, 2, 3, 4, 5, 6, 7, 8);
 
-    HPX_TEST(hpx::util::mem_fn(&X::hash)(x) == 17610);
-    HPX_TEST(hpx::util::mem_fn(&X::hash)(sp) == 2155);
+    HPX_TEST_EQ(hpx::util::mem_fn(&X::hash)(x), 17610u);
+    HPX_TEST_EQ(hpx::util::mem_fn(&X::hash)(sp), 2155u);
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/util/mem_fn/mem_fn_unary_addr_test.cpp
+++ b/tests/unit/util/mem_fn/mem_fn_unary_addr_test.cpp
@@ -122,7 +122,7 @@ int main()
     hpx::util::mem_fn(&X::f8)(px, 1, 2, 3, 4, 5, 6, 7, 8);
     hpx::util::mem_fn(&X::g8)(pcx, 1, 2, 3, 4, 5, 6, 7, 8);
 
-    HPX_TEST(hash == 2155);
+    HPX_TEST_EQ(hash, 2155u);
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/util/mem_fn/mem_fn_void_test.cpp
+++ b/tests/unit/util/mem_fn/mem_fn_void_test.cpp
@@ -169,8 +169,8 @@ int main()
     hpx::util::mem_fn(&X::g8)(pcx, 1, 2, 3, 4, 5, 6, 7, 8);
     hpx::util::mem_fn(&X::g8)(sp, 1, 2, 3, 4, 5, 6, 7, 8);
 
-    HPX_TEST(x.hash == 17610);
-    HPX_TEST(sp->hash == 2155);
+    HPX_TEST_EQ(x.hash, 17610u);
+    HPX_TEST_EQ(sp->hash, 2155u);
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/util/pack_traversal.cpp
+++ b/tests/unit/util/pack_traversal.cpp
@@ -79,7 +79,7 @@ static void test_mixed_traversal()
 
         static_assert(std::is_same<decltype(res), decltype(expected)>::value,
             "Type mismatch!");
-        HPX_TEST((res == expected));
+        HPX_TEST(res == expected);
     }
 
     {
@@ -91,7 +91,7 @@ static void test_mixed_traversal()
     {
         // Also a regression test
         auto res = map_pack(all_map{}, std::vector<std::vector<int>>{{1, 2}});
-        HPX_TEST_EQ((res[0][0]), (0));
+        HPX_TEST_EQ(res[0][0], (0));
     }
 
     {
@@ -113,21 +113,21 @@ static void test_mixed_traversal()
 
         static_assert(std::is_same<decltype(res), decltype(expected)>::value,
             "Type mismatch!");
-        HPX_TEST((res == expected));
+        HPX_TEST(res == expected);
     }
 
     {
         int count = 0;
         traverse_pack(
             [&](int el) {
-                HPX_TEST_EQ((el), (count + 1));
+                HPX_TEST_EQ(el, (count + 1));
                 count = el;
             },
             1,
             hpx::util::make_tuple(
                 2, 3, std::vector<std::vector<int>>{{4, 5}, {6, 7}}));
 
-        HPX_TEST_EQ((count), (7));
+        HPX_TEST_EQ(count, 7);
     }
 
     return;
@@ -155,7 +155,7 @@ static void test_mixed_early_unwrapping()
 
         static_assert(std::is_same<decltype(res), decltype(expected)>::value,
             "Type mismatch!");
-        HPX_TEST((res == expected));
+        HPX_TEST(res == expected);
     }
 }
 
@@ -229,7 +229,7 @@ static void test_mixed_container_remap()
             std::vector<unsigned short> source = {1, 2, 3};
             std::vector<unsigned long> dest = map_pack(remapper, source);
 
-            HPX_TEST((dest == decltype(dest){0, 1, 2}));
+            HPX_TEST(dest == (decltype(dest){0, 1, 2}));
         }
 
         // Rebinds the allocator
@@ -245,7 +245,7 @@ static void test_mixed_container_remap()
                 std::vector<unsigned long, my_allocator<unsigned long>>
                     remapped = map_pack(remapper, source);
 
-                HPX_TEST_EQ((remapped.get_allocator().state_), (canary));
+                HPX_TEST(remapped.get_allocator().state_ == canary);
             }
 
             // Non empty
@@ -254,7 +254,7 @@ static void test_mixed_container_remap()
                 std::vector<unsigned long, my_allocator<unsigned long>>
                     remapped = map_pack(remapper, source);
 
-                HPX_TEST_EQ((remapped.get_allocator().state_), (canary));
+                HPX_TEST(remapped.get_allocator().state_ == canary);
             }
         }
     }
@@ -433,7 +433,7 @@ static void test_strategic_traverse()
             map_pack([](int i) { return i + 1; }, 0, 1, 2);
 
         auto expected = make_tuple(1, 2, 3);
-        HPX_TEST((res == expected));
+        HPX_TEST(res == expected);
     }
 
     // Remapping works across types
@@ -464,13 +464,13 @@ static void test_strategic_traverse()
                 std::move(p1), std::move(p2), std::move(p3));
 
         // We expect the ownership of p1 - p3 to be invalid
-        HPX_TEST((!bool(p1)));
-        HPX_TEST((!bool(p2)));
-        HPX_TEST((!bool(p3)));
+        HPX_TEST(!bool(p1));
+        HPX_TEST(!bool(p2));
+        HPX_TEST(!bool(p3));
 
-        HPX_TEST_EQ((*get<0>(res)), 2U);
-        HPX_TEST_EQ((*get<1>(res)), 3U);
-        HPX_TEST_EQ((*get<2>(res)), 4U);
+        HPX_TEST_EQ(*get<0>(res), 2U);
+        HPX_TEST_EQ(*get<1>(res), 3U);
+        HPX_TEST_EQ(*get<2>(res), 4U);
     }
 
     // Move only types contained in a pack which was passed as l-value
@@ -525,12 +525,12 @@ static void test_strategic_traverse()
                 },
                 ptr1, ptr2);
 
-        HPX_TEST_EQ((*get<0>(ref)), 6);
-        HPX_TEST_EQ((*get<1>(ref)), 7);
+        HPX_TEST_EQ(*get<0>(ref), 6);
+        HPX_TEST_EQ(*get<1>(ref), 7);
         *ptr1 = 1;
         *ptr2 = 2;
-        HPX_TEST_EQ((*get<0>(ref)), 1);
-        HPX_TEST_EQ((*get<1>(ref)), 2);
+        HPX_TEST_EQ(*get<0>(ref), 1);
+        HPX_TEST_EQ(*get<1>(ref), 2);
     }
 }
 
@@ -664,7 +664,7 @@ static void test_strategic_container_traverse()
                 container);
 
             HPX_TEST_EQ(res.size(), 1U);
-            HPX_TEST_EQ((*res[0]), 7);
+            HPX_TEST_EQ(*res[0], 7);
         }
     }
 }
@@ -712,7 +712,7 @@ static void test_strategic_tuple_like_traverse()
 
         static_assert(std::is_same<decltype(res), decltype(expected)>::value,
             "Type mismatch!");
-        HPX_TEST((res == expected));
+        HPX_TEST(res == expected);
     }
 
     // Fixed size homogeneous container
@@ -720,7 +720,7 @@ static void test_strategic_tuple_like_traverse()
         std::array<int, 3> values{{1, 2, 3}};
         std::array<float, 3> res = map_pack([](int) { return 1.f; }, values);
 
-        HPX_TEST((res == std::array<float, 3>{{1.f, 1.f, 1.f}}));
+        HPX_TEST(res == (std::array<float, 3>{{1.f, 1.f, 1.f}}));
     }
 
     // Make it possible to pass tuples containing move only objects
@@ -739,12 +739,12 @@ static void test_strategic_tuple_like_traverse()
                 },
                 value);
 
-        HPX_TEST_EQ((*get<0>(ref)), 6);
-        HPX_TEST_EQ((*get<1>(ref)), 7);
+        HPX_TEST_EQ(*get<0>(ref), 6);
+        HPX_TEST_EQ(*get<1>(ref), 7);
         (*get<0>(ref)) = 1;
         (*get<1>(ref)) = 2;
-        HPX_TEST_EQ((*get<0>(ref)), 1);
-        HPX_TEST_EQ((*get<1>(ref)), 2);
+        HPX_TEST_EQ(*get<0>(ref), 1);
+        HPX_TEST_EQ(*get<1>(ref), 2);
     }
 }
 
@@ -776,7 +776,7 @@ static void test_spread_traverse()
 
         auto expected = make_tuple(1, 1, 2, 2);
 
-        HPX_TEST((res == expected));
+        HPX_TEST(res == expected);
     }
 
     // 1:0 mappings
@@ -796,7 +796,7 @@ static void test_spread_container_traverse()
         std::vector<tuple<int, int>> expected;
         expected.push_back(make_tuple(1, 1));
 
-        HPX_TEST((res == expected));
+        HPX_TEST(res == expected);
     }
 
     // 1:0 mappings
@@ -816,7 +816,7 @@ static void test_spread_tuple_like_traverse()
         tuple<tuple<int, int, int, int>> expected =
             make_tuple(make_tuple(1, 1, 2, 2));
 
-        HPX_TEST((res == expected));
+        HPX_TEST(res == expected);
     }
 
     // 1:0 mappings
@@ -833,7 +833,7 @@ static void test_spread_tuple_like_traverse()
 
         std::array<int, 4> expected{{1, 1, 2, 2}};
 
-        HPX_TEST((res == expected));
+        HPX_TEST(res == expected);
     }
 
     // 1:0 mappings

--- a/tests/unit/util/serializable_any.cpp
+++ b/tests/unit/util/serializable_any.cpp
@@ -69,11 +69,11 @@ int hpx_main()
         {
             any any1(7), any2(7), any3(10), any4(std::string("seven"));
 
-            HPX_TEST(any_cast<int>(any1) == 7);
-            HPX_TEST(any_cast<int>(any1) != 10);
-            HPX_TEST(any_cast<int>(any1) != 10.0f);
-            HPX_TEST(any_cast<int>(any1) == any_cast<int>(any1));
-            HPX_TEST(any_cast<int>(any1) == any_cast<int>(any2));
+            HPX_TEST_EQ(any_cast<int>(any1), 7);
+            HPX_TEST_NEQ(any_cast<int>(any1), 10);
+            HPX_TEST_NEQ(any_cast<int>(any1), 10.0f);
+            HPX_TEST_EQ(any_cast<int>(any1), any_cast<int>(any1));
+            HPX_TEST_EQ(any_cast<int>(any1), any_cast<int>(any2));
             HPX_TEST(any1.type() == any3.type());
             HPX_TEST(any1.type() != any4.type());
 
@@ -85,8 +85,8 @@ int hpx_main()
             any3 = other_str;
             any4 = 10.0f;
 
-            HPX_TEST(any_cast<std::string>(any1) == long_str);
-            HPX_TEST(any_cast<std::string>(any1) != other_str);
+            HPX_TEST_EQ(any_cast<std::string>(any1), long_str);
+            HPX_TEST_NEQ(any_cast<std::string>(any1), other_str);
             HPX_TEST(any1.type() == typeid(std::string));
             HPX_TEST(
                 any_cast<std::string>(any1) == any_cast<std::string>(any1));

--- a/tests/unit/util/unwrap.cpp
+++ b/tests/unit/util/unwrap.cpp
@@ -45,19 +45,19 @@ void test_unwrap(FutureProvider&& futurize)
     // Single values are unwrapped
     {
         int res = unwrap(futurize(0xDD));
-        HPX_TEST_EQ((res), (0xDD));
+        HPX_TEST_EQ(res, 0xDD);
     }
 
     // Futures with tuples may be unwrapped
     {
         tuple<int, int> res = unwrap(futurize(make_tuple(0xDD, 0xDF)));
-        HPX_TEST((res == make_tuple(0xDD, 0xDF)));
+        HPX_TEST(res == make_tuple(0xDD, 0xDF));
     }
 
     // The value of multiple futures is returned inside a tuple
     {
         tuple<int, int> res = unwrap(futurize(0xDD), futurize(0xDF));
-        HPX_TEST((res == make_tuple(0xDD, 0xDF)));
+        HPX_TEST(res == make_tuple(0xDD, 0xDF));
     }
 }
 
@@ -67,28 +67,28 @@ void test_unwrap_n(FutureProvider&& futurize)
     // Single values are unwrapped
     {
         int res = unwrap_n<2>(futurize(futurize(0xDD)));
-        HPX_TEST_EQ((res), (0xDD));
+        HPX_TEST_EQ(res, 0xDD);
     }
 
     // Futures with tuples may be unwrapped
     {
         tuple<int, int> res =
             unwrap_n<2>(futurize(futurize(make_tuple(0xDD, 0xDF))));
-        HPX_TEST((res == make_tuple(0xDD, 0xDF)));
+        HPX_TEST(res == make_tuple(0xDD, 0xDF));
     }
 
     // The value of multiple futures is returned inside a tuple
     {
         tuple<int, int> res =
             unwrap_n<2>(futurize(futurize(0xDD)), futurize(futurize(0xDF)));
-        HPX_TEST((res == make_tuple(0xDD, 0xDF)));
+        HPX_TEST(res == make_tuple(0xDD, 0xDF));
     }
 
     // Futures are not unwrapped beyond the given depth
     {
         FutureType<int> res =
             unwrap_n<3>(futurize(futurize(futurize(futurize(0xDD)))));
-        HPX_TEST_EQ((res.get()), (0xDD));
+        HPX_TEST(res.get() == 0xDD);
     }
 }
 
@@ -99,7 +99,7 @@ void test_unwrap_all(FutureProvider&& futurize)
     {
         int res =
             unwrap_all(futurize(futurize(futurize(futurize(futurize(0xDD))))));
-        HPX_TEST_EQ((res), (0xDD));
+        HPX_TEST_EQ(res, 0xDD);
     }
 
     // Futures with tuples may be unwrapped
@@ -107,14 +107,14 @@ void test_unwrap_all(FutureProvider&& futurize)
         tuple<int, int> res = unwrap_all(futurize(
             futurize(futurize(futurize(make_tuple(futurize(futurize(0xDD)),
                 futurize(futurize(futurize(0xDF)))))))));
-        HPX_TEST((res == make_tuple(0xDD, 0xDF)));
+        HPX_TEST(res == make_tuple(0xDD, 0xDF));
     }
 
     // The value of multiple futures is returned inside a tuple
     {
         tuple<int, int> res = unwrap_all(
             futurize(futurize(futurize(futurize(0xDD)))), futurize(0xDF));
-        HPX_TEST((res == make_tuple(0xDD, 0xDF)));
+        HPX_TEST(res == make_tuple(0xDD, 0xDF));
     }
 }
 
@@ -127,7 +127,7 @@ void test_unwrapping(FutureProvider&& futurize)
 
         int res = unwrapper(futurize(3));
 
-        HPX_TEST_EQ((res), (3));
+        HPX_TEST_EQ(res, 3);
     }
 
     /// Don't unpack single tuples which were passed to the functional unwrap
@@ -139,7 +139,7 @@ void test_unwrapping(FutureProvider&& futurize)
 
         int res = unwrapper(futurize(make_tuple(1, 2)));
 
-        HPX_TEST_EQ((res), (3));
+        HPX_TEST_EQ(res, 3);
     }
 
     // Multiple arguments are spread across the callable
@@ -148,7 +148,7 @@ void test_unwrapping(FutureProvider&& futurize)
 
         int res = unwrapper(futurize(1), futurize(2));
 
-        HPX_TEST_EQ((res), (3));
+        HPX_TEST_EQ(res, 3);
     }
 }
 
@@ -183,28 +183,28 @@ void test_unwrapping_n(FutureProvider&& futurize)
     {
         int res =
             unwrapping_n<2>(back_materializer{})(futurize(futurize(0xDD)));
-        HPX_TEST_EQ((res), (0xDD));
+        HPX_TEST_EQ(res, 0xDD);
     }
 
     // Futures with tuples may be unwrapped
     {
         tuple<int, int> res = unwrapping_n<2>(back_materializer{})(
             futurize(futurize(make_tuple(0xDD, 0xDF))));
-        HPX_TEST((res == make_tuple(0xDD, 0xDF)));
+        HPX_TEST(res == make_tuple(0xDD, 0xDF));
     }
 
     // The value of multiple futures is returned inside a tuple
     {
         tuple<int, int> res = unwrapping_n<2>(back_materializer{})(
             futurize(futurize(0xDD)), futurize(futurize(0xDF)));
-        HPX_TEST((res == make_tuple(0xDD, 0xDF)));
+        HPX_TEST(res == make_tuple(0xDD, 0xDF));
     }
 
     // Futures are not unwrapped beyond the given depth
     {
         FutureType<int> res = unwrapping_n<3>(back_materializer{})(
             futurize(futurize(futurize(futurize(0xDD)))));
-        HPX_TEST_EQ((res.get()), (0xDD));
+        HPX_TEST_EQ(res.get(), 0xDD);
     }
 }
 
@@ -215,7 +215,7 @@ void test_unwrapping_all(FutureProvider&& futurize)
     {
         int res = unwrapping_all(back_materializer{})(
             futurize(futurize(futurize(futurize(futurize(0xDD))))));
-        HPX_TEST_EQ((res), (0xDD));
+        HPX_TEST_EQ(res, 0xDD);
     }
 
     // Futures with tuples may be unwrapped
@@ -223,14 +223,14 @@ void test_unwrapping_all(FutureProvider&& futurize)
         tuple<int, int> res = unwrapping_all(
             back_materializer{})(futurize(futurize(futurize(futurize(make_tuple(
             futurize(futurize(0xDD)), futurize(futurize(futurize(0xDF)))))))));
-        HPX_TEST((res == make_tuple(0xDD, 0xDF)));
+        HPX_TEST(res == make_tuple(0xDD, 0xDF));
     }
 
     // The value of multiple futures is returned inside a tuple
     {
         tuple<int, int> res = unwrapping_all(back_materializer{})(
             futurize(futurize(futurize(futurize(0xDD)))), futurize(0xDF));
-        HPX_TEST((res == make_tuple(0xDD, 0xDF)));
+        HPX_TEST(res == make_tuple(0xDD, 0xDF));
     }
 }
 
@@ -255,7 +255,7 @@ void test_development_regressions(FutureProvider&& futurize)
         std::vector<FutureType<int>> f;
         std::vector<int> res = unwrap(f);
 
-        HPX_TEST((res.empty()));
+        HPX_TEST(res.empty());
     }
 
     // A single void future is mapped empty
@@ -283,7 +283,7 @@ void test_development_regressions(FutureProvider&& futurize)
             return a + b;
         });
 
-        HPX_TEST_EQ((callable(1, f, 2)), 3);
+        HPX_TEST_EQ(callable(1, f, 2), 3);
     }
 
     // Call callables with no arguments if the pack was mapped empty.
@@ -296,7 +296,7 @@ void test_development_regressions(FutureProvider&& futurize)
             return true;
         });
 
-        HPX_TEST((callable(f)));
+        HPX_TEST(callable(f));
     }
 
     // Map empty mappings back to void, if an empty mapping was propagated back.
@@ -327,7 +327,7 @@ void test_development_regressions(FutureProvider&& futurize)
 
         std::array<FutureType<int>, 2> in{{futurize(1), futurize(2)}};
 
-        HPX_TEST_EQ((unwrapper(in)), 3);
+        HPX_TEST_EQ(unwrapper(in), 3);
     }
 }
 


### PR DESCRIPTION
- Changes as many `HPX_TEST`s to more specific `HPX_TEST_EQ/NEQ/LT/LTE/RANGE` as possible
- Removes the `u` suffix from the version components (we end up with `1u.4u.0u` strings in some places)
- Increases the default backtrace depth to 20 to capture more useful frames (the last 5 are usually just error handling)

Not tested so will likely still need some fixing.