### PR TITLE
Deprecate verbs parcelport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -780,7 +780,7 @@ if(HPX_WITH_NETWORKING)
   hpx_option(HPX_WITH_PARCELPORT_VERBS BOOL
     "Enable the ibverbs based parcelport. This is currently an experimental feature"
     OFF CATEGORY "Parcelport" ADVANCED)
-  if (NOT HPX_WITH_PARCELPORT_VERBS)
+  if (HPX_WITH_PARCELPORT_VERBS)
     hpx_warn("The verbs parcelport is deprecated. Please use the MPI or libfabric parcelports instead.")
     hpx_add_config_define(HPX_HAVE_PARCELPORT_VERBS)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -781,6 +781,7 @@ if(HPX_WITH_NETWORKING)
     "Enable the ibverbs based parcelport. This is currently an experimental feature"
     OFF CATEGORY "Parcelport" ADVANCED)
   if (NOT HPX_WITH_PARCELPORT_VERBS)
+    hpx_warn("The verbs parcelport is deprecated. Please use the MPI or libfabric parcelports instead.")
     hpx_add_config_define(HPX_HAVE_PARCELPORT_VERBS)
   endif()
 

--- a/cmake/toolchains/BGION-gcc.cmake
+++ b/cmake/toolchains/BGION-gcc.cmake
@@ -41,8 +41,8 @@ set(HPX_PLATFORM "native")
 # Disable generic coroutines (and use posix version)
 set(HPX_WITH_GENERIC_CONTEXT_COROUTINES OFF CACHE BOOL "disable generic coroutines")
 
-# BGAS nodes support ibverbs
-set(HPX_WITH_PARCELPORT_IBVERBS ON CACHE BOOL "")
+# BGAS nodes support ibverbs, but it is deprecated
+set(HPX_WITH_PARCELPORT_VERBS OFF CACHE BOOL "")
 
 # Always disable the tcp parcelport as it is non-functional on the BGQ.
 set(HPX_WITH_PARCELPORT_TCP ON CACHE BOOL "")

--- a/cmake/toolchains/BGQ.cmake
+++ b/cmake/toolchains/BGQ.cmake
@@ -49,13 +49,13 @@ set(CMAKE_CROSSCOMPILING ON)
 set(HPX_PLATFORM "BlueGeneQ")
 
 # Always disable the ibverbs parcelport as it is non-functional on the BGQ.
-set(HPX_WITH_IBVERBS_PARCELPORT OFF)
+set(HPX_WITH_PARCELPORT_VERBS OFF)
 
 # Always disable the tcp parcelport as it is non-functional on the BGQ.
-set(HPX_WITH_TCP_PARCELPORT OFF)
+set(HPX_WITH_PARCELPORT_TCP OFF)
 
-# Always enable the tcp parcelport as it is currently the only way to communicate on the BGQ.
-set(HPX_WITH_MPI_PARCELPORT ON)
+# Always enable the mpi parcelport as it is currently the only way to communicate on the BGQ.
+set(HPX_WITH_PARCELPORT_MPI ON)
 
 # We have a bunch of cores on the BGQ ...
 set(HPX_WITH_MAX_CPU_COUNT "64")

--- a/cmake/toolchains/XeonPhi.cmake
+++ b/cmake/toolchains/XeonPhi.cmake
@@ -37,7 +37,9 @@ set(CMAKE_CROSSCOMPILING ON)
 set(HPX_PLATFORM "XeonPhi")
 
 # Always disable the ibverbs parcelport as it is non-functional on the BGQ.
-set(HPX_WITH_PARCELPORT_IBVERBS OFF CACHE BOOL "Enable the ibverbs based parcelport. This is currently an experimental feature")
+set(HPX_WITH_PARCELPORT_VERBS OFF CACHE BOOL "Enable the ibverbs based parcelport. This is currently an experimental feature")
+
+set(HPX_WITH_PARCELPORT_MPI ON CACHE BOOL "Enable the MPI based parcelport.")
 
 # We have a bunch of cores on the MIC ... increase the default
 set(HPX_WITH_MAX_CPU_COUNT "256" CACHE STRING "")


### PR DESCRIPTION
Flyby: fixes verbs and other parcelport related options.