### PR TITLE
Fixing APEX shutdown by explicitly shutting down throttling

### DIFF
--- a/examples/1d_stencil/1d_stencil_4_throttle.cpp
+++ b/examples/1d_stencil/1d_stencil_4_throttle.cpp
@@ -293,6 +293,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
     // We're done with the periodic policy now, so disable it.
     apex::deregister_policy(periodic_policy_handle);
+    apex::shutdown_throttling();
 
     // Print the final solution
     if (vm.count("results"))


### PR DESCRIPTION
Fixes last APEX test that only fails when Active Harmony is used and the system has lm_sensors and/or RAPL power measurement support

## Proposed Changes

  - explicitly stop the periodic policy that controls number of active workers
  -
  -

## Any background context you want to provide?
