### PR TITLE
Remove leftover queue compatibility checks

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -30,12 +30,6 @@ set(subdirs
     transpose
    )
 
-if(HPX_WITH_QUEUE_COMPATIBILITY)
-  set(subdirs ${subdirs}
-      queue
-     )
-endif()
-
 if(HPX_WITH_EXAMPLES_HDF5)
   set(subdirs ${subdirs}
     interpolate1d

--- a/hpx/include/lcos.hpp
+++ b/hpx/include/lcos.hpp
@@ -21,9 +21,6 @@
 #include <hpx/collectives/reduce.hpp>
 #include <hpx/collectives/gather.hpp>
 #include <hpx/lcos/channel.hpp>
-#if defined(HPX_HAVE_QUEUE_COMPATIBILITY)
-#include <hpx/lcos/queue.hpp>
-#endif
 
 #include <hpx/include/async.hpp>
 #include <hpx/include/dataflow.hpp>


### PR DESCRIPTION
The option was already removed in the previous version.