### PR TITLE
Add OS X builds to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@
 
 language: cpp
 
-os: windows
+os:
+  - windows
+  - osx
 
 git:
   depth: 1
@@ -16,12 +18,10 @@ branches:
   - gh-pages
 
 install:
-  - mkdir 'C:/projects'
-  - wget --output-document='C:/projects/vcpkg-export-hpx-dependencies.7z' 'http://stellar-group.org/files/vcpkg-export-hpx-dependencies.7z'
-  - 7z x 'C:/projects/vcpkg-export-hpx-dependencies.7z' -y -o'C:/projects/vcpkg' >NUL
+  - ./tools/travis/install_dependencies.sh
 
 before_script:
-  - cmake -H. -Bbuild -G'Visual Studio 15 2017 Win64' -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE='C:/projects/vcpkg/scripts/buildsystems/vcpkg.cmake' -DHPX_WITH_PSEUDO_DEPENDENCIES=On -DHPX_WITH_EXAMPLES=Off -DHPX_WITH_TESTS=Off -DHPX_WITH_DEPRECATION_WARNINGS=Off
+  - ./tools/travis/configure.sh
 
 script:
-  - cmake --build build --config Debug --target core -- -verbosity:minimal -maxcpucount:4 -nologo
+  - ./tools/travis/build_and_run_tests.sh

--- a/tools/travis/build_and_run_tests.sh
+++ b/tools/travis/build_and_run_tests.sh
@@ -1,0 +1,22 @@
+#/usr/bin/env bash
+#
+# Copyright (c) 2019 Mikael Simberg
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file BOOST_LICENSE_1_0.rst or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if [ "$TRAVIS_OS_NAME" = "windows" ]; then
+    cmake \
+        --build build \
+        --config Debug \
+        --target core \
+        -- -verbosity:minimal -maxcpucount:4 -nologo
+elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
+    cmake --build build --target core
+    cmake --build build --target examples
+    ctest --output-on-failure -R tests.examples
+else
+    echo "no scripts set up for \"$TRAVIS_OS_NAME\""
+    exit 1
+fi

--- a/tools/travis/configure.sh
+++ b/tools/travis/configure.sh
@@ -1,0 +1,31 @@
+#/usr/bin/env bash
+#
+# Copyright (c) 2019 Mikael Simberg
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file BOOST_LICENSE_1_0.rst or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if [ "$TRAVIS_OS_NAME" = "windows" ]; then
+    cmake \
+        -H. \
+        -Bbuild \
+        -G'Visual Studio 15 2017 Win64' \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_TOOLCHAIN_FILE='C:/projects/vcpkg/scripts/buildsystems/vcpkg.cmake' \
+        -DHPX_WITH_PSEUDO_DEPENDENCIES=ON \
+        -DHPX_WITH_EXAMPLES=OFF \
+        -DHPX_WITH_TESTS=OFF \
+        -DHPX_WITH_DEPRECATION_WARNINGS=OFF
+elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
+    cmake \
+        -H. \
+        -Bbuild \
+        -GNinja \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DHPX_WITH_EXAMPLES=ON \
+        -DHPX_WITH_TESTS=ON
+else
+    echo "no scripts set up for \"$TRAVIS_OS_NAME\""
+    exit 1
+fi

--- a/tools/travis/install_dependencies.sh
+++ b/tools/travis/install_dependencies.sh
@@ -1,0 +1,27 @@
+#/usr/bin/env bash
+#
+# Copyright (c) 2019 Mikael Simberg
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file BOOST_LICENSE_1_0.rst or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if [ "$TRAVIS_OS_NAME" = "windows" ]; then
+    mkdir 'C:/projects'
+    wget \
+        --output-document='C:/projects/vcpkg-export-hpx-dependencies.7z' \
+        'http://stellar-group.org/files/vcpkg-export-hpx-dependencies.7z'
+    7z x \
+        'C:/projects/vcpkg-export-hpx-dependencies.7z' \
+        -y \
+        -o'C:/projects/vcpkg' \
+        >NUL
+elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
+    # We do not upgrade Boost because it takes a long time
+    brew update && \
+        brew install hwloc gperftools ninja &&
+        brew upgrade cmake
+else
+    echo "no scripts set up for \"$TRAVIS_OS_NAME\""
+    exit 1
+fi


### PR DESCRIPTION
Travis CI has a timeout of 50 minutes per build which is not enough to build everything, but this will at least build the core libraries and perhaps examples.