### PR TITLE
fixing annotated task to use the name, not the desc

### DIFF
--- a/hpx/util/annotated_function.hpp
+++ b/hpx/util/annotated_function.hpp
@@ -83,7 +83,7 @@ namespace hpx { namespace util
             /* update the task wrapper in APEX to use the specified name */
             threads::set_self_timer_data(
                 external_timer::update_task(threads::get_self_timer_data(),
-                desc_));
+                std::string(name)));
 #endif
         }
 

--- a/hpx/util/annotated_function.hpp
+++ b/hpx/util/annotated_function.hpp
@@ -30,6 +30,7 @@
 #include <cstdint>
 #include <type_traits>
 #include <utility>
+#include <string>
 
 namespace hpx { namespace util
 {


### PR DESCRIPTION
Fixes annotating HPX threads with APEX

## Proposed Changes

  - minor change to use the passed in name
