### PR TITLE
Ignore lock in target_distribution_policy

### DIFF
--- a/libs/compute/include/hpx/compute/detail/target_distribution_policy.hpp
+++ b/libs/compute/include/hpx/compute/detail/target_distribution_policy.hpp
@@ -93,7 +93,10 @@ namespace hpx { namespace compute { namespace detail {
         {
             std::lock_guard<mutex_type> l(mtx_);
             if (targets_.empty())
+            {
+                hpx::util::ignore_lock(&mtx_);
                 targets_ = Target::get_local_targets();
+            }
 
             std::size_t num_parts = (num_partitions_ == std::size_t(-1)) ?
                 targets_.size() :


### PR DESCRIPTION
Fixes a harmless error from holding a lock while suspending in the `partitioned_vector_target` test. The error message is usually this:
```
terminate called after throwing an instance of 'hpx::detail::exception_with_info<hpx::exception>'
  what():  suspending thread while at least one lock is being held, stack backtrace: 37 frames:
0x2aaaac0d3833  : ??? + 0x2aaaac0d3833 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaac135c40  : ??? + 0x2aaaac135c40 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaac1419e2  : ??? + 0x2aaaac1419e2 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaac0f969a  : std::_Function_handler<void (), void (*)()>::_M_invoke(std::_Any_data const&) + 0x1d in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaac7a50c4  : std::function<void ()>::operator()() const + 0x32 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaacab77ab  : hpx::util::verify_no_locks() + 0xd4 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaacab6bcb  : hpx::basic_execution::agent_ref::yield_k(unsigned long, char const*) + 0xaf in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaacab9fc1  : hpx::basic_execution::this_thread::yield_k(unsigned long, char const*) + 0x30 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaac0eb425  : ??? + 0x2aaaac0eb425 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaac0eb539  : ??? + 0x2aaaac0eb539 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaac0f4dd7  : ??? + 0x2aaaac0f4dd7 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaac0f0350  : ??? + 0x2aaaac0f0350 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaac519e93  : hpx::util::section::has_section(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const + 0x2b in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaac9925aa  : hpx::util::runtime_configuration::get_os_thread_count() const + 0x52 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaac133ec2  : hpx::get_os_thread_count() + 0xc5 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaacb29db7  : hpx::compute::host::get_local_targets() + 0x12 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x45b94a        : ??? + 0x45b94a in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/bin/partitioned_vector_target_test
0x465a4e        : ??? + 0x465a4e in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/bin/partitioned_vector_target_test
0x45e651        : ??? + 0x45e651 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/bin/partitioned_vector_target_test
0x48ac72        : ??? + 0x48ac72 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/bin/partitioned_vector_target_test
0x480a36        : ??? + 0x480a36 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/bin/partitioned_vector_target_test
0x4786db        : ??? + 0x4786db in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/bin/partitioned_vector_target_test
0x466ec9        : ??? + 0x466ec9 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/bin/partitioned_vector_target_test
0x4577d8        : ??? + 0x4577d8 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/bin/partitioned_vector_target_test
0x58d2e2        : ??? + 0x58d2e2 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/bin/partitioned_vector_target_test
0x58fa17        : ??? + 0x58fa17 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/bin/partitioned_vector_target_test
0x2aaaac0e877c  : hpx::detail::init_helper(boost::program_options::variables_map&, hpx::util::function<int (int, char**), false> const&) + 0x47b in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x58fcb5        : ??? + 0x58fcb5 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/bin/partitioned_vector_target_test
0x58f83d        : ??? + 0x58f83d in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/bin/partitioned_vector_target_test
0x2aaaac107394  : ??? + 0x2aaaac107394 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaac103cda  : ??? + 0x2aaaac103cda in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaac14410b  : hpx::runtime_impl::run_helper(hpx::util::function<int (), false> const&, int&) + 0x53b in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaac154031  : ??? + 0x2aaaac154031 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaac154205  : ??? + 0x2aaaac154205 in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaac1524ff  : ??? + 0x2aaaac1524ff in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaacb496fb  : hpx::threads::coroutines::detail::coroutine_impl::operator()() + 0xdf in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1
0x2aaaac6c414d  : ??? + 0x2aaaac6c414d in /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/lib/libhpxd.so.1: HPX(invalid_status)
Base command is "/scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/bin/partitioned_vector_target_test --hpx:ini=hpx.parcel.tcp.enable=1 --hpx:threads=4 --hpx:localities=2"
Executing command: /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/bin/partitioned_vector_target_test --hpx:ini=hpx.parcel.tcp.enable=1 --hpx:threads=4 --hpx:localities=2 --hpx:node=0
Executing command: /scratch/snx3000/simbergm/pycicle/instance-gcc-oldest/build/hpx-master-gcc-oldest/bin/partitioned_vector_target_test --hpx:ini=hpx.parcel.tcp.enable=1 --hpx:threads=4 --hpx:localities=2 --hpx:node=1
```