### PR TITLE
Fix PAPI command line option documentation

### DIFF
--- a/docs/sphinx/manual/optimizing_hpx_applications.rst
+++ b/docs/sphinx/manual/optimizing_hpx_applications.rst
@@ -2356,7 +2356,7 @@ system and application performance.
        events changes depending on the used architecture.
 
        For a full list of available PAPI events and their (short) description
-       use the ``--hpx:list-counters`` and ``--papi-event-info=all`` command
+       use the ``--hpx:list-counters`` and ``--hpx:papi-event-info=all`` command
        line options.
 
      * ``locality#*/total`` or

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -1089,7 +1089,7 @@ namespace hpx { namespace components { namespace server
                     &still_unregistered_options);
 
                 std::string still_unknown_commandline;
-                for (std::size_t i = 1; i != still_unregistered_options.size();
+                for (std::size_t i = 1; i < still_unregistered_options.size();
                      ++i)
                 {
                     if (i != 1)


### PR DESCRIPTION
Fixes #4123.

- Fixes command line option documentation.
- Fixes loop condition for handling unregistered options.