### PR TITLE
Ignore lock in ignore_while_locked_1485 test

### DIFF
--- a/tests/regressions/lcos/ignore_while_locked_1485.cpp
+++ b/tests/regressions/lcos/ignore_while_locked_1485.cpp
@@ -76,6 +76,7 @@ void test_condition_with_mutex()
 
     {
         std::lock_guard<hpx::lcos::local::spinlock> lock(data.mutex);
+        hpx::util::ignore_all_while_checking il;
         data.cond_var.notify_one();
     }
 


### PR DESCRIPTION
Ignores yet another lock held while suspending.

The test was originally introduced in https://github.com/STEllAR-GROUP/hpx/pull/1487/files, but I can't tell if I'm actually subverting what it's supposed to be testing by ignoring the lock. @hkaiser, @sithhell do you remember what the original failure mode of that test was before it was fixed? I'm starting to get a bad feeling about this whole ignoring-locks business...