### PR TITLE
Local workrequesting scheduler

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,5 @@
 # Copyright (c) 2016 Thomas Heller
-# Copyright (c) 2016-2018 Hartmut Kaiser
+# Copyright (c) 2016-2019 Hartmut Kaiser
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -42,9 +42,11 @@ AlwaysBreakTemplateDeclarations: true
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
+#    AfterCaseLabel: true       # added in V10
     AfterClass: true
     AfterControlStatement: true
     AfterEnum: true
+#    AfterExternBlock: true     # added in V10
     AfterFunction: true
     AfterNamespace: false
     AfterStruct: true
@@ -52,6 +54,9 @@ BraceWrapping:
     BeforeCatch: true
     BeforeElse: true
     IndentBraces: false
+#    SplitEmptyFunction: true   # added in V10
+#    SplitEmptyNamespace: true  # added in V10
+#    SplitEmptyRecord: true     # added in V10
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
 BreakBeforeInheritanceComma: true
@@ -102,7 +107,7 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
 ReflowComments: false
-SortIncludes:    true
+SortIncludes: true
 SpaceAfterCStyleCast: true
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true

--- a/.clang-format
+++ b/.clang-format
@@ -42,11 +42,9 @@ AlwaysBreakTemplateDeclarations: true
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
-#    AfterCaseLabel: true       # added in V10
     AfterClass: true
     AfterControlStatement: true
     AfterEnum: true
-#    AfterExternBlock: true     # added in V10
     AfterFunction: true
     AfterNamespace: false
     AfterStruct: true
@@ -54,9 +52,6 @@ BraceWrapping:
     BeforeCatch: true
     BeforeElse: true
     IndentBraces: false
-#    SplitEmptyFunction: true   # added in V10
-#    SplitEmptyNamespace: true  # added in V10
-#    SplitEmptyRecord: true     # added in V10
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
 BreakBeforeInheritanceComma: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -694,7 +694,7 @@ endif()
 # Scheduler configuration
 ################################################################################
 hpx_option(HPX_WITH_THREAD_SCHEDULERS STRING
-  "Which thread schedulers are built. Options are: all, abp-priority, local, static-priority, static, shared-priority. For multiple enabled schedulers, separate with a semicolon (default: all)"
+  "Which thread schedulers are built. Options are: all, abp-priority, local, workstealing, static-priority, static, shared-priority. For multiple enabled schedulers, separate with a semicolon (default: all)"
   "all"
   CATEGORY "Thread Manager" ADVANCED)
 
@@ -711,6 +711,10 @@ foreach(_scheduler ${HPX_WITH_THREAD_SCHEDULERS_UC})
   if(_scheduler STREQUAL "LOCAL" OR _all)
     hpx_add_config_define(HPX_HAVE_LOCAL_SCHEDULER)
     set(HPX_WITH_LOCAL_SCHEDULER ON CACHE INTERNAL "")
+  endif()
+  if(_scheduler STREQUAL "WORKSTEALING" OR _all)
+    hpx_add_config_define(HPX_HAVE_LOCAL_WORKSTEALING_SCHEDULER)
+    set(HPX_WITH_LOCAL_WORKSTEALING_SCHEDULER ON CACHE INTERNAL "")
   endif()
   if(_scheduler STREQUAL "STATIC-PRIORITY" OR _all)
     hpx_add_config_define(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -694,7 +694,7 @@ endif()
 # Scheduler configuration
 ################################################################################
 hpx_option(HPX_WITH_THREAD_SCHEDULERS STRING
-  "Which thread schedulers are built. Options are: all, abp-priority, local, workstealing, static-priority, static, shared-priority. For multiple enabled schedulers, separate with a semicolon (default: all)"
+  "Which thread schedulers are built. Options are: all, abp-priority, local, workrequesting, static-priority, static, shared-priority. For multiple enabled schedulers, separate with a semicolon (default: all)"
   "all"
   CATEGORY "Thread Manager" ADVANCED)
 
@@ -712,9 +712,9 @@ foreach(_scheduler ${HPX_WITH_THREAD_SCHEDULERS_UC})
     hpx_add_config_define(HPX_HAVE_LOCAL_SCHEDULER)
     set(HPX_WITH_LOCAL_SCHEDULER ON CACHE INTERNAL "")
   endif()
-  if(_scheduler STREQUAL "WORKSTEALING" OR _all)
-    hpx_add_config_define(HPX_HAVE_LOCAL_WORKSTEALING_SCHEDULER)
-    set(HPX_WITH_LOCAL_WORKSTEALING_SCHEDULER ON CACHE INTERNAL "")
+  if(_scheduler STREQUAL "WORKREQUESTING" OR _all)
+    hpx_add_config_define(HPX_HAVE_LOCAL_WORKREQUESTING_SCHEDULER)
+    set(HPX_WITH_LOCAL_WORKREQUESTING_SCHEDULER ON CACHE INTERNAL "")
   endif()
   if(_scheduler STREQUAL "STATIC-PRIORITY" OR _all)
     hpx_add_config_define(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)

--- a/examples/quickstart/fibonacci_local.cpp
+++ b/examples/quickstart/fibonacci_local.cpp
@@ -17,6 +17,8 @@
 
 #include <cstdint>
 #include <iostream>
+#include <string>
+#include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
 //[fibonacci
@@ -25,14 +27,10 @@ std::uint64_t fibonacci(std::uint64_t n)
     if (n < 2)
         return n;
 
-    // Invoking the Fibonacci algorithm twice is inefficient.
-    // However, we intentionally demonstrate it this way to create some
-    // heavy workload.
-
     hpx::future<std::uint64_t> n1 = hpx::async(fibonacci, n - 1);
-    hpx::future<std::uint64_t> n2 = hpx::async(fibonacci, n - 2);
+    std::uint64_t n2 = fibonacci(n - 2);
 
-    return n1.get() + n2.get();   // wait for the Futures to return their values
+    return n1.get() + n2;   // wait for the Future to return their values
 }
 //fibonacci]
 
@@ -40,6 +38,8 @@ std::uint64_t fibonacci(std::uint64_t n)
 //[hpx_main
 int hpx_main(hpx::program_options::variables_map& vm)
 {
+    hpx::threads::add_scheduler_mode(hpx::threads::policies::fast_idle_mode);
+
     // extract command line argument, i.e. fib(N)
     std::uint64_t n = vm["n-value"].as<std::uint64_t>();
 
@@ -71,7 +71,12 @@ int main(int argc, char* argv[])
           "n value for the Fibonacci function")
         ;
 
+    // use LIFO scheduler
+    std::vector<std::string> cfg = {
+        "--hpx:queuing=local-priority-lifo"
+    };
+
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    return hpx::init(desc_commandline, argc, argv, cfg);
 }
 //main]

--- a/hpx/async.hpp
+++ b/hpx/async.hpp
@@ -47,8 +47,8 @@ namespace hpx { namespace detail
         call(F && f, Ts &&... ts)
         {
             parallel::execution::parallel_executor exec;
-            return parallel::execution::async_execute(
-                exec, std::forward<F>(f), std::forward<Ts>(ts)...);
+            return exec.async_execute(
+                std::forward<F>(f), std::forward<Ts>(ts)...);
         }
     };
 

--- a/hpx/async_launch_policy_dispatch.hpp
+++ b/hpx/async_launch_policy_dispatch.hpp
@@ -98,7 +98,7 @@ namespace hpx { namespace detail
                     // make sure this thread is executed last
                     // yield_to
                     hpx::this_thread::suspend(threads::pending, tid,
-                        "async_launch_policy_dispatch<fork>");
+                        "async_launch_policy_dispatch<launch>");
                 }
             }
             return p.get_future();

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -819,9 +819,10 @@ namespace hpx { namespace threads { namespace detail
             {
                 --idle_loop_count;
 
+                next_thrd = nullptr;
                 if (scheduler.SchedulingPolicy::wait_or_add_new(
                         num_thread, running, idle_loop_count,
-                        enable_stealing_staged, added))
+                        enable_stealing_staged, added, &next_thrd))
                 {
                     // Clean up terminated threads before trying to exit
                     bool can_exit =
@@ -896,6 +897,12 @@ namespace hpx { namespace threads { namespace detail
                     // speed up idle suspend if no work was stolen
                     idle_loop_count -= params.max_idle_loop_count_ / 256;
                     added = std::size_t(-1);
+                }
+
+                // if stealing yielded a new task, run it first
+                if (next_thrd != nullptr)
+                {
+                    continue;
                 }
 
 #if defined(HPX_HAVE_NETWORKING)

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -895,7 +895,7 @@ namespace hpx { namespace threads { namespace detail
                         policies::fast_idle_mode))
                 {
                     // speed up idle suspend if no work was stolen
-                    idle_loop_count -= params.max_idle_loop_count_ / 256;
+                    idle_loop_count -= params.max_idle_loop_count_ / 1024;
                     added = std::size_t(-1);
                 }
 

--- a/hpx/runtime/threads/detail/set_thread_state.hpp
+++ b/hpx/runtime/threads/detail/set_thread_state.hpp
@@ -103,10 +103,10 @@ namespace hpx { namespace threads { namespace detail
 
         // we know that the id is actually the pointer to the thread
         if (!thrd) {
+            // this thread has already been terminated
             if (&ec != &throws)
                 ec = make_success_code();
             return thread_state(terminated, wait_unknown);
-            // this thread has already been terminated
         }
 
         thread_state previous_state;

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -157,7 +157,7 @@ namespace hpx { namespace threads { namespace policies {
             }
         }
 
-        virtual ~local_priority_queue_scheduler()
+        ~local_priority_queue_scheduler() override
         {
             for (std::size_t i = 0; i != num_queues_; ++i)
             {
@@ -1029,7 +1029,7 @@ namespace hpx { namespace threads { namespace policies {
         /// has to be terminated (i.e. no more work has to be done).
         bool wait_or_add_new(std::size_t num_thread, bool running,
             std::int64_t& idle_loop_count, bool enable_stealing,
-            std::size_t& added) override
+            std::size_t& added, thread_data** next_thrd = nullptr) override
         {
             bool result = true;
 
@@ -1284,7 +1284,7 @@ namespace hpx { namespace threads { namespace policies {
 
         void reset_thread_distribution() override
         {
-            curr_queue_.store(0);
+            curr_queue_.store(0, std::memory_order_release);
         }
 
     protected:

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2019 Hartmut Kaiser
+//  Copyright (c) 2007-2020 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -128,7 +128,7 @@ namespace hpx { namespace threads { namespace policies {
           , affinity_data_(init.affinity_data_)
           , num_queues_(init.num_queues_)
           , num_high_priority_queues_(init.num_high_priority_queues_)
-          , low_priority_queue_(init.num_queues_ - 1, thread_queue_init_)
+          , low_priority_queue_(thread_queue_init_)
           , queues_(num_queues_)
           , high_priority_queues_(num_queues_)
           , victim_threads_(num_queues_)
@@ -139,7 +139,7 @@ namespace hpx { namespace threads { namespace policies {
                 for (std::size_t i = 0; i != num_queues_; ++i)
                 {
                     queues_[i].data_ =
-                        new thread_queue_type(i, thread_queue_init_);
+                        new thread_queue_type(thread_queue_init_);
                 }
 
                 HPX_ASSERT(num_high_priority_queues_ != 0);
@@ -147,7 +147,7 @@ namespace hpx { namespace threads { namespace policies {
                 for (std::size_t i = 0; i != num_high_priority_queues_; ++i)
                 {
                     high_priority_queues_[i].data_ =
-                        new thread_queue_type(i, thread_queue_init_);
+                        new thread_queue_type(thread_queue_init_);
                 }
                 for (std::size_t i = num_high_priority_queues_;
                      i != num_queues_; ++i)
@@ -1144,12 +1144,12 @@ namespace hpx { namespace threads { namespace policies {
             if (nullptr == queues_[num_thread].data_)
             {
                 queues_[num_thread].data_ =
-                    new thread_queue_type(num_thread, thread_queue_init_);
+                    new thread_queue_type(thread_queue_init_);
 
                 if (num_thread < num_high_priority_queues_)
                 {
                     high_priority_queues_[num_thread].data_ =
-                        new thread_queue_type(num_thread, thread_queue_init_);
+                        new thread_queue_type(thread_queue_init_);
                 }
             }
 

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -128,7 +128,7 @@ namespace hpx { namespace threads { namespace policies {
           , affinity_data_(init.affinity_data_)
           , num_queues_(init.num_queues_)
           , num_high_priority_queues_(init.num_high_priority_queues_)
-          , low_priority_queue_(0, thread_queue_init_)
+          , low_priority_queue_(init.num_queues_ - 1, thread_queue_init_)
           , queues_(num_queues_)
           , high_priority_queues_(num_queues_)
           , victim_threads_(num_queues_)
@@ -832,8 +832,7 @@ namespace hpx { namespace threads { namespace policies {
                 case thread_priority_unknown:
                 {
                     HPX_THROW_EXCEPTION(bad_parameter,
-                        "local_priority_queue_scheduler::get_thread_"
-                        "count",
+                        "local_priority_queue_scheduler::get_thread_count",
                         "unknown thread priority value "
                         "(thread_priority_unknown)");
                     return 0;

--- a/hpx/runtime/threads/policies/local_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_queue_scheduler.hpp
@@ -109,9 +109,8 @@ namespace hpx { namespace threads { namespace policies {
           , queues_(init.num_queues_)
           , curr_queue_(0)
           , affinity_data_(init.affinity_data_)
-          ,
 #ifndef HPX_NATIVE_MIC    // we know that the MIC has one NUMA domain only
-          steals_in_numa_domain_()
+          , steals_in_numa_domain_()
           , steals_outside_numa_domain_()
 #endif
           , numa_domain_masks_(
@@ -132,7 +131,7 @@ namespace hpx { namespace threads { namespace policies {
             }
         }
 
-        virtual ~local_queue_scheduler()
+        ~local_queue_scheduler()
         {
             for (std::size_t i = 0; i != queues_.size(); ++i)
                 delete queues_[i];
@@ -327,7 +326,7 @@ namespace hpx { namespace threads { namespace policies {
 
         /// Return the next thread to be executed, return false if none is
         /// available
-        virtual bool get_next_thread(std::size_t num_thread, bool running,
+        bool get_next_thread(std::size_t num_thread, bool running,
             threads::thread_data*& thrd, bool /*enable_stealing*/) override
         {
             std::size_t queues_size = queues_.size();
@@ -686,9 +685,9 @@ namespace hpx { namespace threads { namespace policies {
         /// manager to allow for maintenance tasks to be executed in the
         /// scheduler. Returns true if the OS thread calling this function
         /// has to be terminated (i.e. no more work has to be done).
-        virtual bool wait_or_add_new(std::size_t num_thread, bool running,
+        bool wait_or_add_new(std::size_t num_thread, bool running,
             std::int64_t& idle_loop_count, bool /*enable_stealing*/,
-            std::size_t& added) override
+            std::size_t& added, thread_data** next_thrd = nullptr) override
         {
             std::size_t queues_size = queues_.size();
             HPX_ASSERT(num_thread < queues_.size());

--- a/hpx/runtime/threads/policies/local_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_queue_scheduler.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2020 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -127,7 +127,7 @@ namespace hpx { namespace threads { namespace policies {
             {
                 HPX_ASSERT(init.num_queues_ != 0);
                 for (std::size_t i = 0; i < init.num_queues_; ++i)
-                    queues_[i] = new thread_queue_type(i, thread_queue_init_);
+                    queues_[i] = new thread_queue_type(thread_queue_init_);
             }
         }
 
@@ -849,8 +849,7 @@ namespace hpx { namespace threads { namespace policies {
         {
             if (nullptr == queues_[num_thread])
             {
-                queues_[num_thread] =
-                    new thread_queue_type(num_thread, thread_queue_init_);
+                queues_[num_thread] = new thread_queue_type(thread_queue_init_);
             }
 
             queues_[num_thread]->on_start_thread(num_thread);

--- a/hpx/runtime/threads/policies/local_workrequesting_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_workrequesting_scheduler.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2019 Hartmut Kaiser
+//  Copyright (c) 2007-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -199,11 +199,11 @@ namespace hpx { namespace threads { namespace policies {
                     num_thread_ = static_cast<std::uint16_t>(num_thread);
 
                     // initialize queues
-                    queue_.reset(new thread_queue_type(num_thread, queue_init));
+                    queue_.reset(new thread_queue_type(queue_init));
                     if (need_high_priority_queue)
                     {
                         high_priority_queue_.reset(
-                            new thread_queue_type(num_thread, queue_init));
+                            new thread_queue_type(queue_init));
                     }
 
                     // initialize channels needed for work stealing
@@ -260,7 +260,7 @@ namespace hpx { namespace threads { namespace policies {
           : scheduler_base(init.num_queues_, init.description_,
                 init.thread_queue_init_, policies::fast_idle_mode)
           , data_(init.num_queues_)
-          , low_priority_queue_(init.num_queues_ - 1, thread_queue_init_)
+          , low_priority_queue_(thread_queue_init_)
           , curr_queue_(0)
           , gen_(random_seed())
           , uniform_int_()

--- a/hpx/runtime/threads/policies/local_workrequesting_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_workrequesting_scheduler.hpp
@@ -4,12 +4,12 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(HPX_THREADMANAGER_SCHEDULING_LOCAL_WORKSTEALING_NOV_26_2019_0145PM)
-#define HPX_THREADMANAGER_SCHEDULING_LOCAL_WORKSTEALING_NOV_26_2019_0145PM
+#if !defined(HPX_THREADMANAGER_SCHEDULING_LOCAL_WORKREQUESTING_NOV_26_2019_0145PM)
+#define HPX_THREADMANAGER_SCHEDULING_LOCAL_WORKREQUESTING_NOV_26_2019_0145PM
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_LOCAL_WORKSTEALING_SCHEDULER)
+#if defined(HPX_HAVE_LOCAL_WORKREQUESTING_SCHEDULER)
 #include <hpx/affinity.hpp>
 #include <hpx/assertion.hpp>
 #include <hpx/concurrency.hpp>
@@ -49,21 +49,23 @@ namespace hpx { namespace threads { namespace policies {
 
     ///////////////////////////////////////////////////////////////////////////
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
-    using default_local_workstealing_scheduler_terminated_queue = lockfree_lifo;
+    using default_local_workrequesting_scheduler_terminated_queue =
+        lockfree_lifo;
 #else
-    using default_local_workstealing_scheduler_terminated_queue = lockfree_fifo;
+    using default_local_workrequesting_scheduler_terminated_queue =
+        lockfree_fifo;
 #endif
 
     ///////////////////////////////////////////////////////////////////////////
-    /// The local_workstealing_scheduler maintains exactly one queue of work
+    /// The local_workrequesting_scheduler maintains exactly one queue of work
     /// items (threads) per OS thread, where this OS thread pulls its next work
     /// from.
     template <typename Mutex = std::mutex,
         typename PendingQueuing = lockfree_fifo,
         typename StagedQueuing = lockfree_fifo,
         typename TerminatedQueuing =
-            default_local_workstealing_scheduler_terminated_queue>
-    class HPX_EXPORT local_workstealing_scheduler : public scheduler_base
+            default_local_workrequesting_scheduler_terminated_queue>
+    class HPX_EXPORT local_workrequesting_scheduler : public scheduler_base
     {
     public:
         using has_periodic_maintenance = std::false_type;
@@ -78,7 +80,7 @@ namespace hpx { namespace threads { namespace policies {
                 detail::affinity_data const& affinity_data,
                 std::size_t num_high_priority_queues = std::size_t(-1),
                 thread_queue_init_parameters const& thread_queue_init = {},
-                char const* description = "local_workstealing_scheduler")
+                char const* description = "local_workrequesting_scheduler")
               : num_queues_(num_queues)
               , num_high_priority_queues_(
                     num_high_priority_queues == std::size_t(-1) ?
@@ -164,7 +166,7 @@ namespace hpx { namespace threads { namespace policies {
             scheduler_data() noexcept
               : requested_(0)
               , num_thread_(static_cast<std::uint16_t>(-1))
-#if defined(HPX_HAVE_WORKSTEALING_LAST_VICTIM)
+#if defined(HPX_HAVE_WORKREQUESTING_LAST_VICTIM)
               , last_victim_(static_cast<std::uint16_t>(-1))
 #endif
               , victims_()
@@ -218,7 +220,7 @@ namespace hpx { namespace threads { namespace policies {
             // core number this scheduler data instance refers to
             std::uint16_t num_thread_;
 
-#if defined(HPX_HAVE_WORKSTEALING_LAST_VICTIM)
+#if defined(HPX_HAVE_WORKREQUESTING_LAST_VICTIM)
             // core number the last stolen tasks originated from
             std::uint16_t last_victim_;
 #endif
@@ -253,7 +255,7 @@ namespace hpx { namespace threads { namespace policies {
             return rd();
         }
 
-        local_workstealing_scheduler(init_parameter_type const& init,
+        local_workrequesting_scheduler(init_parameter_type const& init,
             bool deferred_initialization = true)
           : scheduler_base(init.num_queues_, init.description_,
                 init.thread_queue_init_, policies::fast_idle_mode)
@@ -281,11 +283,11 @@ namespace hpx { namespace threads { namespace policies {
             }
         }
 
-        ~local_workstealing_scheduler() override = default;
+        ~local_workrequesting_scheduler() override = default;
 
         static std::string get_scheduler_name()
         {
-            return "local_workstealing_scheduler";
+            return "local_workrequesting_scheduler";
         }
 
 #ifdef HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES
@@ -1054,7 +1056,7 @@ namespace hpx { namespace threads { namespace policies {
                 case thread_priority_unknown:
                 {
                     HPX_THROW_EXCEPTION(bad_parameter,
-                        "local_workstealing_scheduler::get_thread_count",
+                        "local_workrequesting_scheduler::get_thread_count",
                         "unknown thread priority value "
                         "(thread_priority_unknown)");
                     return 0;
@@ -1111,7 +1113,7 @@ namespace hpx { namespace threads { namespace policies {
             case thread_priority_unknown:
             {
                 HPX_THROW_EXCEPTION(bad_parameter,
-                    "local_workstealing_scheduler::get_thread_count",
+                    "local_workrequesting_scheduler::get_thread_count",
                     "unknown thread priority value "
                     "(thread_priority_unknown)");
                 return 0;
@@ -1313,7 +1315,7 @@ namespace hpx { namespace threads { namespace policies {
                     (req.attempt_ == 0 && req.num_thread_ == d.num_thread_) ||
                     (req.attempt_ > 0 && req.num_thread_ != d.num_thread_));
 
-#if defined(HPX_HAVE_WORKSTEALING_LAST_VICTIM)
+#if defined(HPX_HAVE_WORKREQUESTING_LAST_VICTIM)
                 if (d.last_victim_ != std::uint16_t(-1))
                 {
                     victim = d.last_victim_;
@@ -1409,7 +1411,7 @@ namespace hpx { namespace threads { namespace policies {
                         ++added;
                     }
 
-#if defined(HPX_HAVE_WORKSTEALING_LAST_VICTIM)
+#if defined(HPX_HAVE_WORKREQUESTING_LAST_VICTIM)
                     // store the originating core for the next stealing
                     // operation
                     d.last_victim_ = thrds.num_thread_;

--- a/hpx/runtime/threads/policies/local_workstealing_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_workstealing_scheduler.hpp
@@ -23,6 +23,7 @@
 #include <hpx/synchronization.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <exception>
@@ -237,8 +238,8 @@ namespace hpx { namespace threads { namespace policies {
 
         local_workstealing_scheduler(init_parameter_type const& init,
             bool deferred_initialization = true)
-          : scheduler_base(
-                init.num_queues_, init.description_, init.thread_queue_init_)
+          : scheduler_base(init.num_queues_, init.description_,
+                init.thread_queue_init_, policies::fast_idle_mode)
           , data_(init.num_queues_)
           , low_priority_queue_(init.num_queues_ - 1, thread_queue_init_)
           , curr_queue_(0)
@@ -531,17 +532,39 @@ namespace hpx { namespace threads { namespace policies {
             bool empty = true;
             for (std::size_t i = 0; i != num_queues_; ++i)
             {
-                empty = data_[i].data_.queue_->cleanup_terminated(delete_all) &&
-                    empty;
+                auto& d = data_[i].data_;
+                if (i < num_high_priority_queues_)
+                {
+                    empty = d.high_priority_queue_->cleanup_terminated(
+                                delete_all) &&
+                        empty;
+                }
+                empty = d.queue_->cleanup_terminated(delete_all) && empty;
             }
-            return empty;
+            return low_priority_queue_.cleanup_terminated(delete_all) && empty;
         }
 
         bool cleanup_terminated(
             std::size_t num_thread, bool delete_all) override
         {
-            return data_[num_thread].data_.queue_->cleanup_terminated(
-                delete_all);
+            auto& d = data_[num_thread].data_;
+            bool empty = d.queue_->cleanup_terminated(delete_all);
+            if (!delete_all)
+                return empty;
+
+            if (num_thread < num_high_priority_queues_)
+            {
+                empty =
+                    d.high_priority_queue_->cleanup_terminated(delete_all) &&
+                    empty;
+            }
+
+            if (num_thread == num_queues_ - 1)
+            {
+                return low_priority_queue_.cleanup_terminated(delete_all) &&
+                    empty;
+            }
+            return empty;
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -589,8 +612,10 @@ namespace hpx { namespace threads { namespace policies {
                     num %= num_high_priority_queues_;
                 }
 
+                // we never stage high priority threads, so there is no need to
+                // call wait_or_add_new for those.
                 data_[num].data_.high_priority_queue_->create_thread(
-                    data, id, initial_state, run_now, ec);
+                    data, id, initial_state, true, ec);
                 return;
             }
 
@@ -629,7 +654,7 @@ namespace hpx { namespace threads { namespace policies {
         }
 
         // Pass steal request on to another worker.
-        // Returns true if we handled our own steal request.
+        // Returns true if we have handled our own steal request.
         bool decline_or_forward_steal_request(
             scheduler_data& d, steal_request& req) noexcept
         {
@@ -719,7 +744,7 @@ namespace hpx { namespace threads { namespace policies {
 
                 thread_data* thrd = nullptr;
                 while (--max_num_to_steal != 0 &&
-                    d.queue_->get_next_thread(thrd, true, true))
+                    d.queue_->get_next_thread(thrd, false, true))
                 {
                     d.queue_->increment_num_stolen_from_pending();
                     thrds.tasks_.push_back(thrd);
@@ -728,9 +753,15 @@ namespace hpx { namespace threads { namespace policies {
                 // we are ready to send at least one task
                 if (!thrds.tasks_.empty())
                 {
-                    // send these tasks to the core that has sent the steal request
+                    // send these tasks to the core that has sent the steal
+                    // request
                     thrds.num_thread_ = d.num_thread_;
                     req.channel_->set(std::move(thrds));
+
+                    // wake the thread up so that it can pick up the stolen
+                    // tasks
+                    do_some_work(req.num_thread_);
+
                     return true;
                 }
             }
@@ -1339,9 +1370,10 @@ namespace hpx { namespace threads { namespace policies {
                     else
                     {
                         d.queue_->schedule_thread(thrds.tasks_.back(), true);
+                        d.queue_->increment_num_stolen_to_pending();
+                        ++added;
                     }
 
-                    d.queue_->increment_num_stolen_to_pending();
                     return true;
                 }
             }
@@ -1360,21 +1392,13 @@ namespace hpx { namespace threads { namespace policies {
 
             added = 0;
 
-            bool result = true;
             auto& d = data_[num_thread].data_;
 
-            if (num_thread < num_high_priority_queues_)
-            {
-                result = d.high_priority_queue_->wait_or_add_new(
-                             running, added, enable_stealing) &&
-                    result;
-                if (0 != added)
-                    return result;
-            }
+            // We don't need to call wait_or_add_new for high priority threads
+            // as these threads are never created 'staged'.
 
-            result =
-                d.queue_->wait_or_add_new(running, added, enable_stealing) &&
-                result;
+            bool result =
+                d.queue_->wait_or_add_new(running, added, enable_stealing);
 
             // check if work was available
             if (0 != added)
@@ -1440,6 +1464,7 @@ namespace hpx { namespace threads { namespace policies {
                 }
             }
 #endif
+
             return result;
         }
 

--- a/hpx/runtime/threads/policies/local_workstealing_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_workstealing_scheduler.hpp
@@ -1,0 +1,1143 @@
+//  Copyright (c) 2007-2019 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_THREADMANAGER_SCHEDULING_LOCAL_WORKSTEALING_NOV_26_2019_0145PM)
+#define HPX_THREADMANAGER_SCHEDULING_LOCAL_WORKSTEALING_NOV_26_2019_0145PM
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_LOCAL_WORKSTEALING_SCHEDULER)
+#include <hpx/affinity.hpp>
+#include <hpx/assertion.hpp>
+#include <hpx/concurrency.hpp>
+#include <hpx/errors.hpp>
+#include <hpx/logging.hpp>
+#include <hpx/runtime/threads/policies/lockfree_queue_backends.hpp>
+#include <hpx/runtime/threads/policies/scheduler_base.hpp>
+#include <hpx/runtime/threads/policies/thread_queue.hpp>
+#include <hpx/runtime/threads/policies/thread_queue_init_parameters.hpp>
+#include <hpx/runtime/threads/thread_data.hpp>
+#include <hpx/synchronization.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <random>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <hpx/config/warnings_prefix.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace threads { namespace policies {
+#ifdef HPX_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
+    ///////////////////////////////////////////////////////////////////////////
+    // We globally control whether to do minimal deadlock detection using this
+    // global bool variable. It will be set once by the runtime configuration
+    // startup code
+    extern bool minimal_deadlock_detection;
+#endif
+
+    ///////////////////////////////////////////////////////////////////////////
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+    using default_local_workstealing_scheduler_terminated_queue = lockfree_lifo;
+#else
+    using default_local_workstealing_scheduler_terminated_queue = lockfree_fifo;
+#endif
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// The local_workstealing_scheduler maintains exactly one queue of work
+    /// items (threads) per OS thread, where this OS thread pulls its next work
+    /// from.
+    template <typename Mutex = std::mutex,
+        typename PendingQueuing = lockfree_fifo,
+        typename StagedQueuing = lockfree_fifo,
+        typename TerminatedQueuing =
+            default_local_workstealing_scheduler_terminated_queue>
+    class HPX_EXPORT local_workstealing_scheduler : public scheduler_base
+    {
+    public:
+        using has_periodic_maintenance = std::false_type;
+
+        using thread_queue_type = thread_queue<Mutex, PendingQueuing,
+            StagedQueuing, TerminatedQueuing>;
+
+    private:
+        ////////////////////////////////////////////////////////////////////////
+        struct task_data
+        {
+            // core number this task data originated from
+            std::uint16_t num_thread_;
+            std::vector<thread_data*> tasks_;
+        };
+
+        ////////////////////////////////////////////////////////////////////////
+        struct steal_request
+        {
+            enum class state : std::uint16_t
+            {
+                working = 0,
+                idle = 2,
+                failed = 4
+            };
+
+            steal_request()
+              : channel_(nullptr)
+              , victims_()
+              , num_thread_(static_cast<std::uint16_t>(-1))
+              , attempt_(0)
+              , state_(state::failed)
+            {
+            }
+
+            steal_request(std::size_t num_thread,
+                lcos::local::channel_spsc<task_data>* channel,
+                mask_cref_type victims, bool idle)
+              : channel_(channel)
+              , victims_(victims)
+              , num_thread_(static_cast<std::uint16_t>(num_thread))
+              , attempt_(0)
+              , state_(idle ? state::idle : state::working)
+            {
+            }
+
+            lcos::local::channel_spsc<task_data>* channel_;
+            mask_type victims_;
+            std::uint16_t num_thread_;
+            std::uint16_t attempt_;
+            state state_;
+        };
+
+        ////////////////////////////////////////////////////////////////////////
+        struct scheduler_data
+        {
+            scheduler_data() noexcept
+              : requested_(0)
+              , num_thread_(static_cast<std::uint16_t>(-1))
+#if defined(HPX_HAVE_WORKSTEALING_LAST_VICTIM)
+              , last_victim_(static_cast<std::uint16_t>(-1))
+#endif
+              , victims_()
+              , queue_(nullptr)
+              , requests_(nullptr)
+              , steal_requests_sent_(0)
+              , steal_requests_received_(0)
+              , steal_requests_discarded_(0)
+            {
+            }
+
+            ~scheduler_data() = default;
+
+            void init(std::size_t num_thread, std::size_t size,
+                thread_queue_init_parameters const& init)
+            {
+                if (queue_ == nullptr)
+                {
+                    num_thread_ = static_cast<std::uint16_t>(num_thread);
+
+                    queue_.reset(new thread_queue_type(num_thread, init));
+
+                    requests_.reset(
+                        new lcos::local::base_channel_mpsc<steal_request>(
+                            size));
+
+                    // max_num_to_steal_ is preset to half of the initial max
+                    // queue length
+                    tasks_.reset(new lcos::local::channel_spsc<task_data>(1));
+                }
+            }
+
+            // the number of outstanding steal requests
+            std::uint16_t requested_;
+
+            // core number this scheduler data instance refers to
+            std::uint16_t num_thread_;
+
+#if defined(HPX_HAVE_WORKSTEALING_LAST_VICTIM)
+            // core number the last stolen tasks originated from
+            std::uint16_t last_victim_;
+#endif
+            // initial affinity mask for this core
+            mask_type victims_;
+
+            // queue for threads scheduled on this core
+            std::unique_ptr<thread_queue_type> queue_;
+
+            // channel for posting steal requests to this core
+            std::unique_ptr<lcos::local::base_channel_mpsc<steal_request>>
+                requests_;
+
+            // one channel per steal request per core
+            std::unique_ptr<lcos::local::channel_spsc<task_data>> tasks_;
+
+            std::uint32_t steal_requests_sent_;
+            std::uint32_t steal_requests_received_;
+            std::uint32_t steal_requests_discarded_;
+        };
+
+    public:
+        struct init_parameter
+        {
+            init_parameter(std::size_t num_queues,
+                detail::affinity_data const& affinity_data,
+                std::size_t numa_sensitive = 0,
+                thread_queue_init_parameters const& thread_queue_init = {},
+                char const* description = "local_workstealing_scheduler")
+              : num_data_(num_queues)
+              , thread_queue_init_(thread_queue_init)
+              , affinity_data_(affinity_data)
+              , description_(description)
+            {
+            }
+
+            init_parameter(std::size_t num_queues,
+                detail::affinity_data const& affinity_data,
+                char const* description)
+              : num_data_(num_queues)
+              , thread_queue_init_()
+              , affinity_data_(affinity_data)
+              , description_(description)
+            {
+            }
+
+            std::size_t num_data_;
+            thread_queue_init_parameters thread_queue_init_;
+            detail::affinity_data const& affinity_data_;
+            char const* description_;
+        };
+        typedef init_parameter init_parameter_type;
+
+        static unsigned int random_seed() noexcept
+        {
+            static std::random_device rd;
+            return rd();
+        }
+
+        local_workstealing_scheduler(init_parameter_type const& init,
+            bool deferred_initialization = true)
+          : scheduler_base(
+                init.num_data_, init.description_, init.thread_queue_init_)
+          , data_(init.num_data_)
+          , curr_queue_(0)
+          , gen_(random_seed())
+          , uniform_int_()
+          , affinity_data_(init.affinity_data_)
+        {
+            if (!deferred_initialization)
+            {
+                HPX_ASSERT(init.num_data_ != 0);
+                for (std::size_t i = 0; i < init.num_data_; ++i)
+                {
+                    data_[i].data_.init(
+                        i, init.num_data_, this->thread_queue_init_);
+                }
+            }
+        }
+
+        ~local_workstealing_scheduler() override
+        {
+            int i = 0;
+            (void) i;
+        }
+
+        static std::string get_scheduler_name()
+        {
+            return "local_workstealing_scheduler";
+        }
+
+#ifdef HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES
+        std::uint64_t get_creation_time(bool reset)
+        {
+            std::uint64_t time = 0;
+
+            for (std::size_t i = 0; i != data_.size(); ++i)
+                time += data_[i].data_.queue_->get_creation_time(reset);
+
+            return time;
+        }
+
+        std::uint64_t get_cleanup_time(bool reset)
+        {
+            std::uint64_t time = 0;
+
+            for (std::size_t i = 0; i != data_.size(); ++i)
+                time += data_[i].data_.queue_->get_cleanup_time(reset);
+
+            return time;
+        }
+#endif
+
+#ifdef HPX_HAVE_THREAD_STEALING_COUNTS
+        std::int64_t get_num_pending_misses(
+            std::size_t num_thread, bool reset) override
+        {
+            std::int64_t num_pending_misses = 0;
+            if (num_thread == std::size_t(-1))
+            {
+                for (std::size_t i = 0; i != data_.size(); ++i)
+                {
+                    num_pending_misses +=
+                        data_[i].data_.queue_->get_num_pending_misses(reset);
+                }
+                return num_pending_misses;
+            }
+
+            num_pending_misses +=
+                data_[num_thread].data_.queue_->get_num_pending_misses(reset);
+            return num_pending_misses;
+        }
+
+        std::int64_t get_num_pending_accesses(
+            std::size_t num_thread, bool reset) override
+        {
+            std::int64_t num_pending_accesses = 0;
+            if (num_thread == std::size_t(-1))
+            {
+                for (std::size_t i = 0; i != data_.size(); ++i)
+                {
+                    num_pending_accesses +=
+                        data_[i].data_.queue_->get_num_pending_accesses(reset);
+                }
+                return num_pending_accesses;
+            }
+
+            num_pending_accesses +=
+                data_[num_thread].data_.queue_->get_num_pending_accesses(reset);
+            return num_pending_accesses;
+        }
+
+        std::int64_t get_num_stolen_from_pending(
+            std::size_t num_thread, bool reset) override
+        {
+            std::int64_t num_stolen_threads = 0;
+            if (num_thread == std::size_t(-1))
+            {
+                for (std::size_t i = 0; i != data_.size(); ++i)
+                {
+                    num_stolen_threads +=
+                        data_[i].data_.queue_->get_num_stolen_from_pending(
+                            reset);
+                }
+                return num_stolen_threads;
+            }
+
+            num_stolen_threads +=
+                data_[num_thread].data_.queue_->get_num_stolen_from_pending(
+                    reset);
+            return num_stolen_threads;
+        }
+
+        std::int64_t get_num_stolen_to_pending(
+            std::size_t num_thread, bool reset) override
+        {
+            std::int64_t num_stolen_threads = 0;
+            if (num_thread == std::size_t(-1))
+            {
+                for (std::size_t i = 0; i != data_.size(); ++i)
+                {
+                    num_stolen_threads +=
+                        data_[i].data_.queue_->get_num_stolen_to_pending(reset);
+                }
+                return num_stolen_threads;
+            }
+
+            num_stolen_threads +=
+                data_[num_thread].data_.queue_->get_num_stolen_to_pending(
+                    reset);
+            return num_stolen_threads;
+        }
+
+        std::int64_t get_num_stolen_from_staged(
+            std::size_t num_thread, bool reset) override
+        {
+            std::int64_t num_stolen_threads = 0;
+            if (num_thread == std::size_t(-1))
+            {
+                for (std::size_t i = 0; i != data_.size(); ++i)
+                {
+                    num_stolen_threads +=
+                        data_[i].data_.queue_->get_num_stolen_from_staged(
+                            reset);
+                }
+                return num_stolen_threads;
+            }
+
+            num_stolen_threads +=
+                data_[num_thread].data_.queue_->get_num_stolen_from_staged(
+                    reset);
+            return num_stolen_threads;
+        }
+
+        std::int64_t get_num_stolen_to_staged(
+            std::size_t num_thread, bool reset) override
+        {
+            std::int64_t num_stolen_threads = 0;
+            if (num_thread == std::size_t(-1))
+            {
+                for (std::size_t i = 0; i != data_.size(); ++i)
+                {
+                    num_stolen_threads +=
+                        data_[i].data_.queue_->get_num_stolen_to_staged(reset);
+                }
+                return num_stolen_threads;
+            }
+
+            num_stolen_threads +=
+                data_[num_thread].data_.queue_->get_num_stolen_to_staged(reset);
+            return num_stolen_threads;
+        }
+#endif
+
+        ///////////////////////////////////////////////////////////////////////
+        void abort_all_suspended_threads() override
+        {
+            for (std::size_t i = 0; i != data_.size(); ++i)
+                data_[i].data_.queue_->abort_all_suspended_threads();
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        bool cleanup_terminated(bool delete_all) override
+        {
+            bool empty = true;
+            for (std::size_t i = 0; i != data_.size(); ++i)
+            {
+                empty = data_[i].data_.queue_->cleanup_terminated(delete_all) &&
+                    empty;
+            }
+            return empty;
+        }
+
+        bool cleanup_terminated(
+            std::size_t num_thread, bool delete_all) override
+        {
+            return data_[num_thread].data_.queue_->cleanup_terminated(
+                delete_all);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        // create a new thread and schedule it if the initial state is equal to
+        // pending
+        void create_thread(thread_init_data& data, thread_id_type* id,
+            thread_state_enum initial_state, bool run_now,
+            error_code& ec) override
+        {
+            // by default we always schedule new threads on our own queue
+            std::size_t num_thread = std::size_t(-1);
+            if (data.schedulehint.mode == thread_schedule_hint_mode_thread)
+            {
+                num_thread = data.schedulehint.hint;
+            }
+
+            std::size_t data_size = data_.size();
+            if (std::size_t(-1) == num_thread)
+            {
+                num_thread = curr_queue_++ % data_size;
+            }
+            else if (num_thread >= data_size)
+            {
+                num_thread %= data_size;
+            }
+
+            std::unique_lock<pu_mutex_type> l;
+            num_thread = select_active_pu(l, num_thread);
+
+            data.schedulehint.mode = thread_schedule_hint_mode_thread;
+            data.schedulehint.hint = static_cast<std::int16_t>(num_thread);
+
+            HPX_ASSERT(num_thread < data_size);
+            data_[num_thread].data_.queue_->create_thread(
+                data, id, initial_state, run_now, ec);
+        }
+
+        // Retrieve the next viable steal request from our channel
+        bool try_receiving_steal_request(
+            scheduler_data& d, steal_request& req) noexcept
+        {
+            bool ret = d.requests_->get(&req);
+            while (ret && req.state_ == steal_request::state::failed)
+            {
+                // forget the received steal request
+                --data_[req.num_thread_].data_.requested_;
+                HPX_ASSERT(data_[req.num_thread_].data_.requested_ == 0);
+
+                // try to retrieve next steal request
+                ret = d.requests_->get(&req);
+            }
+
+            // No special treatment for other states
+            HPX_ASSERT(
+                (ret && req.state_ != steal_request::state::failed) || !ret);
+
+            return ret;
+        }
+
+        // Pass steal request on to another worker.
+        // Returns true if we handled our own steal request.
+        bool decline_or_forward_steal_request(
+            scheduler_data& d, steal_request& req) noexcept
+        {
+            HPX_ASSERT(req.attempt_ < data_.size());
+
+            if (req.num_thread_ == d.num_thread_)
+            {
+                // Steal request was either returned by another worker or
+                // picked up by us.
+
+                if (d.queue_->get_pending_queue_length(
+                        std::memory_order_relaxed) > 0 ||
+                    req.state_ == steal_request::state::idle)
+                {
+                    // we have work now, drop this steal request
+                    ++d.steal_requests_discarded_;
+                    --d.requested_;
+                    HPX_ASSERT(d.requested_ == 0);
+                }
+                else
+                {
+                    // Continue circulating the steal request if it makes sense
+                    req.attempt_ = 0;
+                    req.state_ = steal_request::state::idle;
+                    req.victims_ = d.victims_;
+
+                    std::size_t victim = next_victim(d, req);
+                    data_[victim].data_.requests_->set(std::move(req));
+
+                    ++d.steal_requests_sent_;
+                }
+
+                return true;
+            }
+
+            // send this steal request on to the next (random) core
+            ++req.attempt_;
+            set(req.victims_, d.num_thread_);    // don't ask a core twice
+
+            std::size_t victim = next_victim(d, req);
+            data_[victim].data_.requests_->set(std::move(req));
+
+            ++d.steal_requests_sent_;
+            return false;
+        }
+
+        // decline_or_forward_all_steal_requests is only called when a worker
+        // has nothing else to do but relay steal requests, which means the
+        /// worker is idle.
+        void decline_or_forward_all_steal_requests(scheduler_data& d) noexcept
+        {
+            steal_request req;
+            while (try_receiving_steal_request(d, req))
+            {
+                ++d.steal_requests_received_;
+                decline_or_forward_steal_request(d, req);
+            }
+        }
+
+        // Handle a steal request by sending tasks in return or passing it on to
+        // another worker. Returns true if the request was satisfied.
+        bool handle_steal_request(
+            scheduler_data& d, steal_request& req) noexcept
+        {
+            ++d.steal_requests_received_;
+
+            if (req.num_thread_ == d.num_thread_)
+            {
+                // got back our own steal request.
+                HPX_ASSERT(req.state_ != steal_request::state::failed);
+
+                // Defer the decision to decline_steal_request
+                decline_or_forward_steal_request(d, req);
+                return false;
+            }
+
+            // Send at max HPX_MAX_STOLEN_TASKS from our queue to the requesting
+            // core, but not more than half of the available tasks.
+            std::size_t max_num_to_steal =
+                d.queue_->get_pending_queue_length(std::memory_order_relaxed) /
+                2;
+
+            if (max_num_to_steal != 0)
+            {
+                task_data thrds;
+                thrds.tasks_.reserve(max_num_to_steal);
+
+                thread_data* thrd = nullptr;
+                while (--max_num_to_steal != 0 &&
+                    d.queue_->get_next_thread(thrd, true, true))
+                {
+                    d.queue_->increment_num_stolen_from_pending();
+                    thrds.tasks_.push_back(thrd);
+                }
+
+                // we are ready to send at least one task
+                if (!thrds.tasks_.empty())
+                {
+                    // send these tasks to the core that has sent the steal request
+                    thrds.num_thread_ = d.num_thread_;
+                    req.channel_->set(std::move(thrds));
+                    return true;
+                }
+            }
+
+            // There's nothing we can do with this steal request except pass
+            // it on to a different worker
+            decline_or_forward_steal_request(d, req);
+            return false;
+        }
+
+        // Return the next thread to be executed, return false if none is
+        // available
+        bool get_next_thread(std::size_t num_thread, bool running,
+            threads::thread_data*& thrd, bool enable_stealing) override
+        {
+            HPX_ASSERT(num_thread < data_.size());
+
+            auto& d = data_[num_thread].data_;
+            bool result = d.queue_->get_next_thread(thrd);
+
+            d.queue_->increment_num_pending_accesses();
+            if (enable_stealing && result)
+            {
+                // We found a task to run, however before running it we handle
+                // steal requests (assuming that that there is more work left
+                // that could be used to satisfy steal requests).
+
+                steal_request req;
+                while (try_receiving_steal_request(d, req))
+                {
+                    if (!handle_steal_request(d, req))
+                        break;
+                }
+                return true;
+            }
+
+            d.queue_->increment_num_pending_misses();
+            return false;
+        }
+
+        // Schedule the passed thread
+        void schedule_thread(threads::thread_data* thrd,
+            threads::thread_schedule_hint schedulehint, bool allow_fallback,
+            thread_priority priority = thread_priority_normal) override
+        {
+            std::size_t num_thread = std::size_t(-1);
+            if (schedulehint.mode == thread_schedule_hint_mode_thread)
+            {
+                num_thread = schedulehint.hint;
+            }
+            else
+            {
+                allow_fallback = false;
+            }
+
+            std::size_t data_size = data_.size();
+            if (std::size_t(-1) == num_thread)
+            {
+                num_thread = curr_queue_++ % data_size;
+            }
+            else if (num_thread >= data_size)
+            {
+                num_thread %= data_size;
+            }
+
+            std::unique_lock<pu_mutex_type> l;
+            num_thread = select_active_pu(l, num_thread, allow_fallback);
+
+            HPX_ASSERT(thrd->get_scheduler_base() == this);
+            HPX_ASSERT(num_thread < data_size);
+
+            data_[num_thread].data_.queue_->schedule_thread(thrd);
+        }
+
+        void schedule_thread_last(threads::thread_data* thrd,
+            threads::thread_schedule_hint schedulehint, bool allow_fallback,
+            thread_priority priority = thread_priority_normal) override
+        {
+            std::size_t num_thread = std::size_t(-1);
+            if (schedulehint.mode == thread_schedule_hint_mode_thread)
+            {
+                num_thread = schedulehint.hint;
+            }
+            else
+            {
+                allow_fallback = false;
+            }
+
+            std::size_t data_size = data_.size();
+            if (std::size_t(-1) == num_thread)
+            {
+                num_thread = curr_queue_++ % data_size;
+            }
+            else if (num_thread >= data_size)
+            {
+                num_thread %= data_size;
+            }
+
+            std::unique_lock<pu_mutex_type> l;
+            num_thread = select_active_pu(l, num_thread, allow_fallback);
+
+            HPX_ASSERT(thrd->get_scheduler_base() == this);
+            HPX_ASSERT(num_thread < num_queues_);
+
+            data_[num_thread].data_.queue_->schedule_thread(thrd, true);
+        }
+
+        /// Destroy the passed thread as it has been terminated
+        void destroy_thread(
+            threads::thread_data* thrd, std::int64_t& busy_count) override
+        {
+            HPX_ASSERT(thrd->get_scheduler_base() == this);
+            thrd->get_queue<thread_queue_type>().destroy_thread(
+                thrd, busy_count);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        // This returns the current length of the queues (work items and new items)
+        std::int64_t get_queue_length(
+            std::size_t num_thread = std::size_t(-1)) const override
+        {
+            // Return queue length of one specific queue.
+            std::int64_t count = 0;
+            if (std::size_t(-1) != num_thread)
+            {
+                HPX_ASSERT(num_thread < data_.size());
+
+                return data_[num_thread].data_.queue_->get_queue_length();
+            }
+
+            for (std::size_t i = 0; i != data_.size(); ++i)
+            {
+                count += data_[i].data_.queue_->get_queue_length();
+            }
+            return count;
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        // Queries the current thread count of the queues.
+        std::int64_t get_thread_count(thread_state_enum state = unknown,
+            thread_priority priority = thread_priority_default,
+            std::size_t num_thread = std::size_t(-1),
+            bool reset = false) const override
+        {
+            // Return thread count of one specific queue.
+            std::int64_t count = 0;
+            if (std::size_t(-1) != num_thread)
+            {
+                HPX_ASSERT(num_thread < data_.size());
+
+                switch (priority)
+                {
+                case thread_priority_default:
+                case thread_priority_low:
+                case thread_priority_normal:
+                case thread_priority_boost:
+                case thread_priority_high:
+                case thread_priority_high_recursive:
+                    return data_[num_thread].data_.queue_->get_thread_count(
+                        state);
+
+                default:
+                case thread_priority_unknown: {
+                    HPX_THROW_EXCEPTION(bad_parameter,
+                        "local_workstealing_scheduler::get_thread_count",
+                        "unknown thread priority value "
+                        "(thread_priority_unknown)");
+                    return 0;
+                }
+                }
+                return 0;
+            }
+
+            // Return the cumulative count for all queues.
+            switch (priority)
+            {
+            case thread_priority_default:
+            case thread_priority_low:
+            case thread_priority_normal:
+            case thread_priority_boost:
+            case thread_priority_high:
+            case thread_priority_high_recursive: {
+                for (std::size_t i = 0; i != data_.size(); ++i)
+                    count += data_[i].data_.queue_->get_thread_count(state);
+                break;
+            }
+
+            default:
+            case thread_priority_unknown: {
+                HPX_THROW_EXCEPTION(bad_parameter,
+                    "local_workstealing_scheduler::get_thread_count",
+                    "unknown thread priority value "
+                    "(thread_priority_unknown)");
+                return 0;
+            }
+            }
+            return count;
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        // Enumerate matching threads from all queues
+        bool enumerate_threads(
+            util::function_nonser<bool(thread_id_type)> const& f,
+            thread_state_enum state = unknown) const override
+        {
+            bool result = true;
+            for (std::size_t i = 0; i != data_.size(); ++i)
+            {
+                result = result &&
+                    data_[i].data_.queue_->enumerate_threads(f, state);
+            }
+            return result;
+        }
+
+#ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
+        ///////////////////////////////////////////////////////////////////////
+        // Queries the current average thread wait time of the queues.
+        std::int64_t get_average_thread_wait_time(
+            std::size_t num_thread = std::size_t(-1)) const
+        {
+            // Return average thread wait time of one specific queue.
+            std::uint64_t wait_time = 0;
+            std::uint64_t count = 0;
+            if (std::size_t(-1) != num_thread)
+            {
+                HPX_ASSERT(num_thread < data_.size());
+
+                wait_time += data_[num_thread]
+                                 .data_.queue_->get_average_thread_wait_time();
+                return wait_time / (count + 1);
+            }
+
+            for (std::size_t i = 0; i != data_.size(); ++i)
+            {
+                wait_time +=
+                    data_[i].data_.queue_->get_average_thread_wait_time();
+                ++count;
+            }
+
+            return wait_time / (count + 1);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        // Queries the current average task wait time of the queues.
+        std::int64_t get_average_task_wait_time(
+            std::size_t num_thread = std::size_t(-1)) const
+        {
+            // Return average task wait time of one specific queue.
+            std::uint64_t wait_time = 0;
+            std::uint64_t count = 0;
+            if (std::size_t(-1) != num_thread)
+            {
+                HPX_ASSERT(num_thread < data_.size());
+
+                wait_time += data_[num_thread]
+                                 .data_.queue_->get_average_task_wait_time();
+                return wait_time / (count + 1);
+            }
+
+            for (std::size_t i = 0; i != data_.size(); ++i)
+            {
+                wait_time +=
+                    data_[i].data_.queue_->get_average_task_wait_time();
+                ++count;
+            }
+
+            return wait_time / (count + 1);
+        }
+#endif
+
+        // return a random victim for the current stealing operation
+        std::size_t random_victim(steal_request const& req) noexcept
+        {
+            std::size_t const data_size = data_.size();
+            std::size_t bucket_size =
+                (std::numeric_limits<std::int16_t>::max)() / data_size;
+
+            // generate 3 random numbers max before resorting to more expensive
+            // algorithm
+            std::size_t result = 0;
+            int attempts = 0;
+            do
+            {
+                result = uniform_int_(gen_) / bucket_size;
+                if (result < data_size && result != req.num_thread_ &&
+                    !test(req.victims_, result))
+                {
+                    return result;
+                }
+            } while (++attempts < 3);
+
+            // to avoid infinite trials we randomly select one of the possible
+            // victims
+            std::size_t const num_victims = data_size - count(req.victims_);
+
+            // generate one more random number
+            std::size_t selected_victim = 0;
+            bucket_size =
+                (std::numeric_limits<std::int16_t>::max)() / num_victims;
+            do
+            {
+                selected_victim = uniform_int_(gen_) / bucket_size;
+            } while (selected_victim >= num_victims);
+
+            for (std::size_t i = 0; i != data_size; ++i)
+            {
+                if (!test(req.victims_, i))
+                {
+                    if (--selected_victim == 0)
+                    {
+                        result = i;
+                        break;
+                    }
+                }
+            }
+
+            HPX_ASSERT(
+                result >= 0 && result < data_size && result != req.num_thread_);
+
+            return result;
+        }
+
+        // return the number of the next victim core
+        std::size_t next_victim(
+            scheduler_data& d, steal_request const& req) noexcept
+        {
+            std::size_t victim = std::size_t(-1);
+
+            // return thief if max steal attempts has been reached
+            if (req.attempt_ == data_.size() - 1)
+            {
+                // Return steal request to thief
+                victim = req.num_thread_;
+            }
+            else
+            {
+                HPX_ASSERT(
+                    (req.attempt_ == 0 && req.num_thread_ == d.num_thread_) ||
+                    (req.attempt_ > 0 && req.num_thread_ != d.num_thread_));
+
+#if defined(HPX_HAVE_WORKSTEALING_LAST_VICTIM)
+                if (d.last_victim_ != std::uint16_t(-1))
+                {
+                    victim = d.last_victim_;
+                }
+                else
+#endif
+                {
+                    victim = random_victim(req);
+                }
+            }
+
+            // couldn't find victim, return steal request to thief
+            if (victim == std::size_t(-1))
+            {
+                victim = req.num_thread_;
+                HPX_ASSERT(victim != d.num_thread_);
+            }
+
+            HPX_ASSERT(victim < data_.size());
+            HPX_ASSERT(0 <= req.attempt_ && req.attempt_ < data_.size());
+
+            return victim;
+        }
+
+        // Every worker can have at most MAXSTEAL pending steal requests. A
+        // steal request with idle == false indicates that the requesting worker
+        // is still busy working on some tasks. A steal request with idle == true
+        // indicates that the requesting worker is in fact idle and has nothing
+        // to work on.
+        void send_steal_request(scheduler_data& d, bool idle = true) noexcept
+        {
+            if (d.requested_ == 0)
+            {
+                steal_request req(
+                    d.num_thread_, d.tasks_.get(), d.victims_, idle);
+                std::size_t victim = next_victim(d, req);
+
+                ++d.requested_;
+                data_[victim].data_.requests_->set(std::move(req));
+
+                ++d.steal_requests_sent_;
+            }
+        }
+
+        // Try receiving tasks that are sent by another core as a response to
+        // one of our steal requests.
+        bool try_receiving_tasks(
+            scheduler_data& d, std::size_t& added, thread_data** next_thrd)
+        {
+            task_data thrds;
+            if (d.tasks_->get(&thrds))
+            {
+                --d.requested_;
+                HPX_ASSERT(d.requested_ == 0);
+
+                // if at least one thrd was received
+                if (!thrds.tasks_.empty())
+                {
+                    // schedule all but the last thread
+                    std::size_t received_threads = thrds.tasks_.size() - 1;
+                    for (std::size_t i = 0; i != received_threads; ++i)
+                    {
+                        // schedule the received task to be picked up by the
+                        // scheduler
+                        HPX_ASSERT(thrds.tasks_[i] != nullptr);
+                        d.queue_->schedule_thread(thrds.tasks_[i], true);
+                        d.queue_->increment_num_stolen_to_pending();
+                        ++added;
+                    }
+
+#if defined(HPX_HAVE_WORKSTEALING_LAST_VICTIM)
+                    // store the originating core for the next stealing
+                    // operation
+                    d.last_victim_ = thrds.num_thread_;
+                    HPX_ASSERT(d.last_victim_ != d.num_thread_);
+#endif
+
+                    if (next_thrd != nullptr)
+                    {
+                        // directly return the last thread as it should be run
+                        // immediately
+                        *next_thrd = thrds.tasks_.back();
+                    }
+                    else
+                    {
+                        d.queue_->schedule_thread(thrds.tasks_.back(), true);
+                    }
+
+                    d.queue_->increment_num_stolen_to_pending();
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // This is a function which gets called periodically by the thread
+        // manager to allow for maintenance tasks to be executed in the
+        // scheduler. Returns true if the OS thread calling this function
+        // has to be terminated (i.e. no more work has to be done).
+        bool wait_or_add_new(std::size_t num_thread, bool running,
+            std::int64_t& idle_loop_count, bool enable_stealing,
+            std::size_t& added, thread_data** next_thrd = nullptr) override
+        {
+            HPX_ASSERT(num_thread < data_.size());
+
+            added = 0;
+
+            auto& d = data_[num_thread].data_;
+            bool result =
+                d.queue_->wait_or_add_new(running, added, enable_stealing);
+
+            // check if work was available
+            if (0 != added)
+                return result;
+
+            // check if we have been disabled
+            if (!running)
+                return true;
+
+            // return if no stealing is requested (or not possible)
+            if (data_.size() == 1 || !enable_stealing)
+                return result;
+
+            // attempt to steal more work
+            send_steal_request(d);
+            HPX_ASSERT(d.requested_ != 0);
+
+            // now try to handle steal requests again if we have not received a
+            // task from some other core yet
+            if (!try_receiving_tasks(d, added, next_thrd))
+            {
+                // decline or forward all pending steal requests
+                decline_or_forward_all_steal_requests(d);
+            }
+
+#ifdef HPX_HAVE_THREAD_MINIMAL_DEADLOCK_DETECTION
+            // no new work is available, are we deadlocked?
+            if (HPX_UNLIKELY(minimal_deadlock_detection && LHPX_ENABLED(error)))
+            {
+                bool suspended_only = true;
+
+                for (std::size_t i = 0; suspended_only && i != data_.size();
+                     ++i)
+                {
+                    suspended_only =
+                        data_[i].data_.queue_->dump_suspended_threads(
+                            i, idle_loop_count, running);
+                }
+
+                if (HPX_UNLIKELY(suspended_only))
+                {
+                    if (running)
+                    {
+                        LTM_(error)    //-V128
+                            << "queue(" << num_thread << "): "
+                            << "no new work available, are we "
+                               "deadlocked?";
+                    }
+                    else
+                    {
+                        LHPX_CONSOLE_(
+                            hpx::util::logging::level::error)    //-V128
+                            << "  [TM] "                         //-V128
+                            << "queue(" << num_thread << "): "
+                            << "no new work available, are we "
+                               "deadlocked?\n";
+                    }
+                }
+            }
+#endif
+            return result;
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        void on_start_thread(std::size_t num_thread) override
+        {
+            auto& d = data_[num_thread].data_;
+            d.init(num_thread, data_.size(), this->thread_queue_init_);
+            d.queue_->on_start_thread(num_thread);
+
+            // create an empty mask that is properly sized
+            resize(d.victims_, HPX_HAVE_MAX_CPU_COUNT);
+            reset(d.victims_);
+            set(d.victims_, num_thread);
+        }
+
+        void on_stop_thread(std::size_t num_thread) override
+        {
+            data_[num_thread].data_.queue_->on_stop_thread(num_thread);
+        }
+
+        void on_error(
+            std::size_t num_thread, std::exception_ptr const& e) override
+        {
+            data_[num_thread].data_.queue_->on_error(num_thread, e);
+        }
+
+        void reset_thread_distribution() override
+        {
+            curr_queue_.store(0, std::memory_order_release);
+        }
+
+    protected:
+        std::vector<util::cache_line_data<scheduler_data>> data_;
+
+        std::atomic<std::size_t> curr_queue_;
+
+        std::mt19937 gen_;
+        std::uniform_int_distribution<std::int16_t> uniform_int_;
+
+        detail::affinity_data const& affinity_data_;
+    };
+}}}       // namespace hpx::threads::policies
+
+#include <hpx/config/warnings_suffix.hpp>
+
+#endif
+#endif

--- a/hpx/runtime/threads/policies/lockfree_queue_backends.hpp
+++ b/hpx/runtime/threads/policies/lockfree_queue_backends.hpp
@@ -63,6 +63,8 @@ namespace hpx { namespace threads { namespace policies {
         bool pop(reference val, bool steal = true)
         {
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+            if (steal)
+                return queue_.pop_left(val);
             return queue_.pop_right(val);
 #else
             return queue_.pop(val);
@@ -168,6 +170,8 @@ namespace hpx { namespace threads { namespace policies {
 
         bool pop(reference val, bool steal = true)
         {
+            if (steal)
+                return queue_.pop_right(val);
             return queue_.pop_left(val);
         }
 

--- a/hpx/runtime/threads/policies/lockfree_queue_backends.hpp
+++ b/hpx/runtime/threads/policies/lockfree_queue_backends.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 //  Copyright (c) 2012 Bryce Adelstein-Lelbach
-//  Copyright (c) 2019 Hartmut Kaiser
+//  Copyright (c) 2019-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -45,8 +45,7 @@ namespace hpx { namespace threads { namespace policies {
         using const_reference = T const&;
         using size_type = std::uint64_t;
 
-        lockfree_fifo_backend(
-            size_type initial_size = 0, size_type num_thread = size_type(-1))
+        lockfree_fifo_backend(size_type initial_size = 0)
           : queue_(std::size_t(initial_size))
         {
         }
@@ -102,8 +101,7 @@ namespace hpx { namespace threads { namespace policies {
         using rval_reference = T&&;
         using size_type = std::uint64_t;
 
-        moodycamel_fifo_backend(
-            size_type initial_size = 0, size_type num_thread = size_type(-1))
+        moodycamel_fifo_backend(size_type initial_size = 0)
           : queue_(std::size_t(initial_size))
         {
         }
@@ -155,8 +153,7 @@ namespace hpx { namespace threads { namespace policies {
         using const_reference = T const&;
         using size_type = std::uint64_t;
 
-        lockfree_lifo_backend(
-            size_type initial_size = 0, size_type num_thread = size_type(-1))
+        lockfree_lifo_backend(size_type initial_size = 0)
           : queue_(std::size_t(initial_size))
         {
         }
@@ -209,8 +206,7 @@ namespace hpx { namespace threads { namespace policies {
         using const_reference = T const&;
         using size_type = std::uint64_t;
 
-        lockfree_abp_fifo_backend(
-            size_type initial_size = 0, size_type num_thread = size_type(-1))
+        lockfree_abp_fifo_backend(size_type initial_size = 0)
           : queue_(std::size_t(initial_size))
         {
         }
@@ -259,8 +255,7 @@ namespace hpx { namespace threads { namespace policies {
         using const_reference = T const&;
         using size_type = std::uint64_t;
 
-        lockfree_abp_lifo_backend(
-            size_type initial_size = 0, size_type num_thread = size_type(-1))
+        lockfree_abp_lifo_backend(size_type initial_size = 0)
           : queue_(std::size_t(initial_size))
         {
         }

--- a/hpx/runtime/threads/policies/scheduler_base.hpp
+++ b/hpx/runtime/threads/policies/scheduler_base.hpp
@@ -48,7 +48,7 @@ namespace hpx { namespace threads { namespace policies {
         typedef std::mutex pu_mutex_type;
 
         scheduler_base(std::size_t num_threads, char const* description = "",
-            thread_queue_init_parameters thread_queue_init = {},
+            thread_queue_init_parameters const& thread_queue_init = {},
             scheduler_mode mode = nothing_special);
 
         virtual ~scheduler_base() = default;
@@ -226,7 +226,7 @@ namespace hpx { namespace threads { namespace policies {
 
         virtual bool wait_or_add_new(std::size_t num_thread, bool running,
             std::int64_t& idle_loop_count, bool enable_stealing,
-            std::size_t& added) = 0;
+            std::size_t& added, thread_data** next_thrd = nullptr) = 0;
 
         virtual void on_start_thread(std::size_t num_thread) = 0;
         virtual void on_stop_thread(std::size_t num_thread) = 0;

--- a/hpx/runtime/threads/policies/schedulers.hpp
+++ b/hpx/runtime/threads/policies/schedulers.hpp
@@ -16,6 +16,9 @@
 #include <hpx/runtime/threads/policies/static_queue_scheduler.hpp>
 #endif
 #include <hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp>
+#if defined(HPX_HAVE_LOCAL_WORKSTEALING_SCHEDULER)
+#include <hpx/runtime/threads/policies/local_workstealing_scheduler.hpp>
+#endif
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
 #include <hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp>
 #endif

--- a/hpx/runtime/threads/policies/schedulers.hpp
+++ b/hpx/runtime/threads/policies/schedulers.hpp
@@ -16,8 +16,8 @@
 #include <hpx/runtime/threads/policies/static_queue_scheduler.hpp>
 #endif
 #include <hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp>
-#if defined(HPX_HAVE_LOCAL_WORKSTEALING_SCHEDULER)
-#include <hpx/runtime/threads/policies/local_workstealing_scheduler.hpp>
+#if defined(HPX_HAVE_LOCAL_WORKREQUESTING_SCHEDULER)
+#include <hpx/runtime/threads/policies/local_workrequesting_scheduler.hpp>
 #endif
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
 #include <hpx/runtime/threads/policies/static_priority_queue_scheduler.hpp>

--- a/hpx/runtime/threads/policies/shared_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/shared_priority_queue_scheduler.hpp
@@ -183,7 +183,7 @@ namespace hpx { namespace threads { namespace policies {
                     HPX_ASSERT(num_workers_ != 0);
                 }
 
-                virtual ~shared_priority_queue_scheduler() {}
+                ~shared_priority_queue_scheduler() override = default;
 
                 static std::string get_scheduler_name()
                 {
@@ -623,7 +623,7 @@ namespace hpx { namespace threads { namespace policies {
                 }
 
                 /// Return the next thread to be executed, return false if none available
-                virtual bool get_next_thread(std::size_t thread_num,
+                bool get_next_thread(std::size_t thread_num,
                     bool running, threads::thread_data*& thrd,
                     bool enable_stealing) override
                 {
@@ -682,9 +682,10 @@ namespace hpx { namespace threads { namespace policies {
                 }
 
                 /// Return the next thread to be executed, return false if none available
-                virtual bool wait_or_add_new(std::size_t thread_num,
-                    bool running, std::int64_t& idle_loop_count,
-                    bool /*enable_stealing*/, std::size_t& added) override
+                bool wait_or_add_new(std::size_t thread_num, bool running,
+                    std::int64_t& idle_loop_count, bool /*enable_stealing*/,
+                    std::size_t& added,
+                    thread_data** next_thrd = nullptr) override
                 {
                     int this_thread = local_thread_number();
                     HPX_ASSERT(

--- a/hpx/runtime/threads/policies/static_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/static_queue_scheduler.hpp
@@ -114,7 +114,7 @@ namespace hpx { namespace threads { namespace policies
         /// has to be terminated (i.e. no more work has to be done).
         bool wait_or_add_new(std::size_t num_thread, bool running,
             std::int64_t& idle_loop_count, bool /*enable_stealing*/,
-            std::size_t& added) override
+            std::size_t& added, thread_data** next_thrd = nullptr) override
         {
             HPX_ASSERT(num_thread < this->queues_.size());
 

--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2019 Hartmut Kaiser
+//  Copyright (c) 2007-202020 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -457,11 +457,10 @@ namespace hpx { namespace threads { namespace policies {
             return cleanup_terminated_locked(false);
         }
 
-        thread_queue(std::size_t queue_num = std::size_t(-1),
-            thread_queue_init_parameters parameters = {})
+        thread_queue(thread_queue_init_parameters parameters = {})
           : parameters_(parameters)
           , thread_map_count_(0)
-          , work_items_(128, queue_num)
+          , work_items_(128)
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
           , work_items_wait_(0)
           , work_items_wait_count_(0)

--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -532,20 +532,23 @@ namespace hpx { namespace threads { namespace policies {
 
         ///////////////////////////////////////////////////////////////////////
         // This returns the current length of the queues (work items and new items)
-        std::int64_t get_queue_length() const
+        std::int64_t get_queue_length(
+            std::memory_order order = std::memory_order_acquire) const
         {
-            return work_items_count_.data_ + new_tasks_count_.data_;
+            return work_items_count_.data_.load(order) +
+                new_tasks_count_.data_.load(order);
         }
 
         // This returns the current length of the pending queue
-        std::int64_t get_pending_queue_length() const
+        std::int64_t get_pending_queue_length(
+            std::memory_order order = std::memory_order_acquire) const
         {
-            return work_items_count_.data_;
+            return work_items_count_.data_.load(order);
         }
 
         // This returns the current length of the staged queue
         std::int64_t get_staged_queue_length(
-            std::memory_order order = std::memory_order_seq_cst) const
+            std::memory_order order = std::memory_order_acquire) const
         {
             return new_tasks_count_.data_.load(order);
         }
@@ -957,7 +960,8 @@ namespace hpx { namespace threads { namespace policies {
         /// manager to allow for maintenance tasks to be executed in the
         /// scheduler. Returns true if the OS thread calling this function
         /// has to be terminated (i.e. no more work has to be done).
-        inline bool wait_or_add_new(bool, std::size_t& added) HPX_HOT
+        inline bool wait_or_add_new(
+            bool, std::size_t& added, bool steal = false) HPX_HOT
         {
             if (0 == new_tasks_count_.data_.load(std::memory_order_relaxed))
             {
@@ -978,7 +982,7 @@ namespace hpx { namespace threads { namespace policies {
                 return false;    // avoid long wait on lock
 
             // stop running after all HPX threads have been terminated
-            return add_new_always(added, this, lk);
+            return !add_new_always(added, this, lk, steal);
         }
 
         inline bool wait_or_add_new(bool running, std::size_t& added,
@@ -1074,30 +1078,30 @@ namespace hpx { namespace threads { namespace policies {
         mutable mutex_type mtx_;    // mutex protecting the members
 
         thread_map_type thread_map_;    // mapping of thread id's to HPX-threads
-        std::atomic<std::int64_t>
-            thread_map_count_;    // overall count of work items
+
+        // overall count of work items
+        std::atomic<std::int64_t> thread_map_count_;
 
         work_items_type work_items_;    // list of active work items
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
-        std::atomic<std::int64_t>
-            work_items_wait_;    // overall wait time of work items
-        std::atomic<std::int64_t>
-            work_items_wait_count_;    // overall number of
-                                       // work items in queue
+        // overall wait time of work items
+        std::atomic<std::int64_t> work_items_wait_;
+        // overall number of work items in queue
+        std::atomic<std::int64_t> work_items_wait_count_;
 #endif
-        terminated_items_type
-            terminated_items_;    // list of terminated threads
-        std::atomic<std::int64_t>
-            terminated_items_count_;    // count of terminated items
+        // list of terminated threads
+        terminated_items_type terminated_items_;
+        // count of terminated items
+        std::atomic<std::int64_t> terminated_items_count_;
 
         task_items_type new_tasks_;    // list of new tasks to run
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
-        std::atomic<std::int64_t>
-            new_tasks_wait_;    // overall wait time of new tasks
-        std::atomic<std::int64_t>
-            new_tasks_wait_count_;    // overall number tasks waited
+        // overall wait time of new tasks
+        std::atomic<std::int64_t> new_tasks_wait_;
+        // overall number tasks waited
+        std::atomic<std::int64_t> new_tasks_wait_count_;
 #endif
 
         thread_heap_type thread_heap_small_;

--- a/hpx/runtime/threads/policies/thread_queue.hpp
+++ b/hpx/runtime/threads/policies/thread_queue.hpp
@@ -312,12 +312,12 @@ namespace hpx { namespace threads { namespace policies {
                 }
                 else if (work_items_.empty())
                 {
-                    add_count =
-                        parameters_
-                            .min_add_new_count_;    // add this number of threads
+                    // add this number of threads
+                    add_count = parameters_.min_add_new_count_;
+
+                    // increase max_thread_count
                     parameters_.max_thread_count_ +=
-                        parameters_
-                            .min_add_new_count_;    // increase max_thread_count //-V101
+                        parameters_.min_add_new_count_;    //-V101
                 }
                 else
                 {

--- a/hpx/runtime/threads/policies/thread_queue_mc.hpp
+++ b/hpx/runtime/threads/policies/thread_queue_mc.hpp
@@ -138,7 +138,7 @@ namespace hpx { namespace threads { namespace policies {
         }
 
     public:
-        explicit thread_queue_mc(const thread_queue_init_parameters& parameters,
+        explicit thread_queue_mc(thread_queue_init_parameters const& parameters,
             std::size_t queue_num = std::size_t(-1))
           : parameters_(parameters)
           , queue_index_(static_cast<int>(queue_num))

--- a/libs/concurrency/include/hpx/concurrency/cache_line_data.hpp
+++ b/libs/concurrency/include/hpx/concurrency/cache_line_data.hpp
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <type_traits>
 #include <utility>
+#include <type_traits>
 
 namespace hpx {
 

--- a/libs/concurrency/include/hpx/concurrency/cache_line_data.hpp
+++ b/libs/concurrency/include/hpx/concurrency/cache_line_data.hpp
@@ -13,7 +13,6 @@
 #include <cstddef>
 #include <type_traits>
 #include <utility>
-#include <type_traits>
 
 namespace hpx {
 
@@ -106,7 +105,7 @@ namespace hpx {
             {
             }
 
-            // no ned to pad to cache line size
+            // no need to pad to cache line size bytes
             Data data_;
         };
 

--- a/libs/resource_partitioner/include/hpx/resource_partitioner/partitioner_fwd.hpp
+++ b/libs/resource_partitioner/include/hpx/resource_partitioner/partitioner_fwd.hpp
@@ -72,7 +72,8 @@ namespace hpx { namespace resource {
         abp_priority_fifo = 5,
         abp_priority_lifo = 6,
         shared_priority = 7,
-        local_workstealing = 8,
+        local_workstealing_fifo = 8,
+        local_workstealing_lifo = 9,
     };
 }}    // namespace hpx::resource
 

--- a/libs/resource_partitioner/include/hpx/resource_partitioner/partitioner_fwd.hpp
+++ b/libs/resource_partitioner/include/hpx/resource_partitioner/partitioner_fwd.hpp
@@ -72,8 +72,8 @@ namespace hpx { namespace resource {
         abp_priority_fifo = 5,
         abp_priority_lifo = 6,
         shared_priority = 7,
-        local_workstealing_fifo = 8,
-        local_workstealing_lifo = 9,
+        local_workrequesting_fifo = 8,
+        local_workrequesting_lifo = 9,
     };
 }}    // namespace hpx::resource
 

--- a/libs/resource_partitioner/include/hpx/resource_partitioner/partitioner_fwd.hpp
+++ b/libs/resource_partitioner/include/hpx/resource_partitioner/partitioner_fwd.hpp
@@ -72,6 +72,7 @@ namespace hpx { namespace resource {
         abp_priority_fifo = 5,
         abp_priority_lifo = 6,
         shared_priority = 7,
+        local_workstealing = 8,
     };
 }}    // namespace hpx::resource
 

--- a/libs/resource_partitioner/src/detail_partitioner.cpp
+++ b/libs/resource_partitioner/src/detail_partitioner.cpp
@@ -132,6 +132,9 @@ namespace hpx { namespace resource { namespace detail {
         case resource::local_priority_lifo:
             sched = "local_priority_lifo";
             break;
+        case resource::local_workstealing:
+            sched = "local_workstealing";
+            break;
         case resource::static_:
             sched = "static";
             break;
@@ -443,6 +446,10 @@ namespace hpx { namespace resource { namespace detail {
         else if (0 == std::string("local-priority-lifo").find(cfg_.queuing_))
         {
             default_scheduler = scheduling_policy::local_priority_lifo;
+        }
+        else if (0 == std::string("local-workstealing").find(cfg_.queuing_))
+        {
+            default_scheduler = scheduling_policy::local_workstealing;
         }
         else if (0 == std::string("static").find(cfg_.queuing_))
         {

--- a/libs/resource_partitioner/src/detail_partitioner.cpp
+++ b/libs/resource_partitioner/src/detail_partitioner.cpp
@@ -132,8 +132,11 @@ namespace hpx { namespace resource { namespace detail {
         case resource::local_priority_lifo:
             sched = "local_priority_lifo";
             break;
-        case resource::local_workstealing:
-            sched = "local_workstealing";
+        case resource::local_workstealing_fifo:
+            sched = "local_workstealing_fifo";
+            break;
+        case resource::local_workstealing_lifo:
+            sched = "local_workstealing_lifo";
             break;
         case resource::static_:
             sched = "static";
@@ -447,9 +450,15 @@ namespace hpx { namespace resource { namespace detail {
         {
             default_scheduler = scheduling_policy::local_priority_lifo;
         }
-        else if (0 == std::string("local-workstealing").find(cfg_.queuing_))
+        else if (0 ==
+            std::string("local-workstealing-fifo").find(cfg_.queuing_))
         {
-            default_scheduler = scheduling_policy::local_workstealing;
+            default_scheduler = scheduling_policy::local_workstealing_fifo;
+        }
+        else if (0 ==
+            std::string("local-workstealing-lifo").find(cfg_.queuing_))
+        {
+            default_scheduler = scheduling_policy::local_workstealing_lifo;
         }
         else if (0 == std::string("static").find(cfg_.queuing_))
         {

--- a/libs/resource_partitioner/src/detail_partitioner.cpp
+++ b/libs/resource_partitioner/src/detail_partitioner.cpp
@@ -132,11 +132,11 @@ namespace hpx { namespace resource { namespace detail {
         case resource::local_priority_lifo:
             sched = "local_priority_lifo";
             break;
-        case resource::local_workstealing_fifo:
-            sched = "local_workstealing_fifo";
+        case resource::local_workrequesting_fifo:
+            sched = "local_workrequesting_fifo";
             break;
-        case resource::local_workstealing_lifo:
-            sched = "local_workstealing_lifo";
+        case resource::local_workrequesting_lifo:
+            sched = "local_workrequesting_lifo";
             break;
         case resource::static_:
             sched = "static";
@@ -451,14 +451,14 @@ namespace hpx { namespace resource { namespace detail {
             default_scheduler = scheduling_policy::local_priority_lifo;
         }
         else if (0 ==
-            std::string("local-workstealing-fifo").find(cfg_.queuing_))
+            std::string("local-workrequesting-fifo").find(cfg_.queuing_))
         {
-            default_scheduler = scheduling_policy::local_workstealing_fifo;
+            default_scheduler = scheduling_policy::local_workrequesting_fifo;
         }
         else if (0 ==
-            std::string("local-workstealing-lifo").find(cfg_.queuing_))
+            std::string("local-workrequesting-lifo").find(cfg_.queuing_))
         {
-            default_scheduler = scheduling_policy::local_workstealing_lifo;
+            default_scheduler = scheduling_policy::local_workrequesting_lifo;
         }
         else if (0 == std::string("static").find(cfg_.queuing_))
         {

--- a/libs/threadmanager/src/threadmanager.cpp
+++ b/libs/threadmanager/src/threadmanager.cpp
@@ -480,6 +480,40 @@ namespace hpx { namespace threads {
                 break;
             }
 
+            case resource::local_workstealing:
+            {
+#if defined(HPX_HAVE_LOCAL_WORKSTEALING_SCHEDULER)
+                // set parameters for scheduler and pool instantiation and
+                // perform compatibility checks
+                std::string affinity_desc;
+                std::size_t numa_sensitive =
+                    hpx::util::get_affinity_description(cfg_, affinity_desc);
+
+                // instantiate the scheduler
+                using local_sched_type =
+                    hpx::threads::policies::local_workstealing_scheduler<>;
+
+                local_sched_type::init_parameter_type init(
+                    thread_pool_init.num_threads_,
+                    thread_pool_init.affinity_data_, numa_sensitive,
+                    thread_queue_init, "core-local_workstealing_scheduler");
+                std::unique_ptr<local_sched_type> sched(
+                    new local_sched_type(init));
+
+                // instantiate the pool
+                std::unique_ptr<thread_pool_base> pool(
+                    new hpx::threads::detail::scheduled_thread_pool<
+                        local_sched_type>(std::move(sched), thread_pool_init));
+                pools_.push_back(std::move(pool));
+#else
+                throw hpx::detail::command_line_error(
+                    "Command line option --hpx:queuing=local-workstealing "
+                    "is not configured in this build. Please rebuild with "
+                    "'cmake -DHPX_WITH_THREAD_SCHEDULERS=local-workstealing'.");
+#endif
+                break;
+            }
+
             case resource::static_:
             {
 #if defined(HPX_HAVE_STATIC_SCHEDULER)

--- a/libs/threadmanager/src/threadmanager.cpp
+++ b/libs/threadmanager/src/threadmanager.cpp
@@ -480,9 +480,9 @@ namespace hpx { namespace threads {
                 break;
             }
 
-            case resource::local_workstealing_fifo:
+            case resource::local_workrequesting_fifo:
             {
-#if defined(HPX_HAVE_LOCAL_WORKSTEALING_SCHEDULER)
+#if defined(HPX_HAVE_LOCAL_WORKREQUESTING_SCHEDULER)
                 // set parameters for scheduler and pool instantiation and
                 // perform compatibility checks
                 std::size_t num_high_priority_queues =
@@ -491,12 +491,12 @@ namespace hpx { namespace threads {
 
                 // instantiate the scheduler
                 using local_sched_type =
-                    hpx::threads::policies::local_workstealing_scheduler<>;
+                    hpx::threads::policies::local_workrequesting_scheduler<>;
 
                 local_sched_type::init_parameter_type init(
                     thread_pool_init.num_threads_,
                     thread_pool_init.affinity_data_, num_high_priority_queues,
-                    thread_queue_init, "core-local_workstealing_scheduler");
+                    thread_queue_init, "core-local_workrequesting_scheduler");
                 std::unique_ptr<local_sched_type> sched(
                     new local_sched_type(init));
 
@@ -507,16 +507,16 @@ namespace hpx { namespace threads {
                 pools_.push_back(std::move(pool));
 #else
                 throw hpx::detail::command_line_error(
-                    "Command line option --hpx:queuing=local-workstealing-fifo "
+                    "Command line option --hpx:queuing=local-workrequesting-fifo "
                     "is not configured in this build. Please rebuild with "
-                    "'cmake -DHPX_WITH_THREAD_SCHEDULERS=local-workstealing'.");
+                    "'cmake -DHPX_WITH_THREAD_SCHEDULERS=local-workrequesting'.");
 #endif
                 break;
             }
 
-            case resource::local_workstealing_lifo:
+            case resource::local_workrequesting_lifo:
             {
-#if defined(HPX_HAVE_LOCAL_WORKSTEALING_SCHEDULER)
+#if defined(HPX_HAVE_LOCAL_WORKREQUESTING_SCHEDULER)
                 // set parameters for scheduler and pool instantiation and
                 // perform compatibility checks
                 std::size_t num_high_priority_queues =
@@ -525,13 +525,13 @@ namespace hpx { namespace threads {
 
                 // instantiate the scheduler
                 using local_sched_type =
-                    hpx::threads::policies::local_workstealing_scheduler<
+                    hpx::threads::policies::local_workrequesting_scheduler<
                         std::mutex, hpx::threads::policies::lockfree_lifo>;
 
                 local_sched_type::init_parameter_type init(
                     thread_pool_init.num_threads_,
                     thread_pool_init.affinity_data_, num_high_priority_queues,
-                    thread_queue_init, "core-local_workstealing_scheduler");
+                    thread_queue_init, "core-local_workrequesting_scheduler");
                 std::unique_ptr<local_sched_type> sched(
                     new local_sched_type(init));
 
@@ -542,9 +542,9 @@ namespace hpx { namespace threads {
                 pools_.push_back(std::move(pool));
 #else
                 throw hpx::detail::command_line_error(
-                    "Command line option --hpx:queuing=local-workstealing-lifo "
+                    "Command line option --hpx:queuing=local-workrequesting-lifo "
                     "is not configured in this build. Please rebuild with "
-                    "'cmake -DHPX_WITH_THREAD_SCHEDULERS=local-workstealing'.");
+                    "'cmake -DHPX_WITH_THREAD_SCHEDULERS=local-workrequesting'.");
 #endif
                 break;
             }

--- a/libs/threadmanager/src/threadmanager.cpp
+++ b/libs/threadmanager/src/threadmanager.cpp
@@ -485,9 +485,9 @@ namespace hpx { namespace threads {
 #if defined(HPX_HAVE_LOCAL_WORKSTEALING_SCHEDULER)
                 // set parameters for scheduler and pool instantiation and
                 // perform compatibility checks
-                std::string affinity_desc;
-                std::size_t numa_sensitive =
-                    hpx::util::get_affinity_description(cfg_, affinity_desc);
+                std::size_t num_high_priority_queues =
+                    hpx::util::get_num_high_priority_queues(
+                        cfg_, rp.get_num_threads(name));
 
                 // instantiate the scheduler
                 using local_sched_type =
@@ -495,7 +495,7 @@ namespace hpx { namespace threads {
 
                 local_sched_type::init_parameter_type init(
                     thread_pool_init.num_threads_,
-                    thread_pool_init.affinity_data_, numa_sensitive,
+                    thread_pool_init.affinity_data_, num_high_priority_queues,
                     thread_queue_init, "core-local_workstealing_scheduler");
                 std::unique_ptr<local_sched_type> sched(
                     new local_sched_type(init));

--- a/src/runtime/threads/detail/scheduled_thread_pool.cpp
+++ b/src/runtime/threads/detail/scheduled_thread_pool.cpp
@@ -44,6 +44,13 @@ template class HPX_EXPORT hpx::threads::detail::scheduled_thread_pool<
         hpx::threads::policies::lockfree_lifo>>;
 #endif
 
+#if defined(HPX_HAVE_LOCAL_WORKSTEALING_SCHEDULER)
+#include <hpx/runtime/threads/policies/local_workstealing_scheduler.hpp>
+template class HPX_EXPORT hpx::threads::policies::local_workstealing_scheduler<>;
+template class HPX_EXPORT hpx::threads::detail::scheduled_thread_pool<
+    hpx::threads::policies::local_workstealing_scheduler<>>;
+#endif
+
 #if defined(HPX_HAVE_ABP_SCHEDULER) && defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
 template class HPX_EXPORT hpx::threads::policies::local_priority_queue_scheduler<
     std::mutex, hpx::threads::policies::lockfree_abp_fifo>;

--- a/src/runtime/threads/detail/scheduled_thread_pool.cpp
+++ b/src/runtime/threads/detail/scheduled_thread_pool.cpp
@@ -44,15 +44,15 @@ template class HPX_EXPORT hpx::threads::detail::scheduled_thread_pool<
         hpx::threads::policies::lockfree_lifo>>;
 #endif
 
-#if defined(HPX_HAVE_LOCAL_WORKSTEALING_SCHEDULER)
-#include <hpx/runtime/threads/policies/local_workstealing_scheduler.hpp>
-template class HPX_EXPORT hpx::threads::policies::local_workstealing_scheduler<>;
+#if defined(HPX_HAVE_LOCAL_WORKREQUESTING_SCHEDULER)
+#include <hpx/runtime/threads/policies/local_workrequesting_scheduler.hpp>
+template class HPX_EXPORT hpx::threads::policies::local_workrequesting_scheduler<>;
 template class HPX_EXPORT hpx::threads::detail::scheduled_thread_pool<
-    hpx::threads::policies::local_workstealing_scheduler<>>;
-template class HPX_EXPORT hpx::threads::policies::local_workstealing_scheduler<
+    hpx::threads::policies::local_workrequesting_scheduler<>>;
+template class HPX_EXPORT hpx::threads::policies::local_workrequesting_scheduler<
     std::mutex, hpx::threads::policies::lockfree_lifo>;
 template class HPX_EXPORT hpx::threads::detail::scheduled_thread_pool<
-    hpx::threads::policies::local_workstealing_scheduler<std::mutex,
+    hpx::threads::policies::local_workrequesting_scheduler<std::mutex,
         hpx::threads::policies::lockfree_lifo>>;
 #endif
 

--- a/src/runtime/threads/detail/scheduled_thread_pool.cpp
+++ b/src/runtime/threads/detail/scheduled_thread_pool.cpp
@@ -49,6 +49,11 @@ template class HPX_EXPORT hpx::threads::detail::scheduled_thread_pool<
 template class HPX_EXPORT hpx::threads::policies::local_workstealing_scheduler<>;
 template class HPX_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::local_workstealing_scheduler<>>;
+template class HPX_EXPORT hpx::threads::policies::local_workstealing_scheduler<
+    std::mutex, hpx::threads::policies::lockfree_lifo>;
+template class HPX_EXPORT hpx::threads::detail::scheduled_thread_pool<
+    hpx::threads::policies::local_workstealing_scheduler<std::mutex,
+        hpx::threads::policies::lockfree_lifo>>;
 #endif
 
 #if defined(HPX_HAVE_ABP_SCHEDULER) && defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)

--- a/src/runtime/threads/policies/scheduler_base.cpp
+++ b/src/runtime/threads/policies/scheduler_base.cpp
@@ -38,7 +38,8 @@
 namespace hpx { namespace threads { namespace policies
 {
     scheduler_base::scheduler_base(std::size_t num_threads,
-        char const* description, thread_queue_init_parameters thread_queue_init,
+        char const* description,
+        thread_queue_init_parameters const& thread_queue_init,
         scheduler_mode mode)
       : suspend_mtxs_(num_threads)
       , suspend_conds_(num_threads)

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -1012,7 +1012,7 @@ namespace hpx { namespace util
 #endif
 
         // handle setting related to schedulers
-        queuing_ = detail::handle_queuing(cfgmap, vm, "local-priority-fifo");
+        queuing_ = detail::handle_queuing(cfgmap, vm, "local-workstealing");
         ini_config.emplace_back("hpx.scheduler=" + queuing_);
 
         affinity_domain_ = detail::handle_affinity(cfgmap, vm, "pu");

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -1012,7 +1012,7 @@ namespace hpx { namespace util
 #endif
 
         // handle setting related to schedulers
-        queuing_ = detail::handle_queuing(cfgmap, vm, "local-workstealing");
+        queuing_ = detail::handle_queuing(cfgmap, vm, "local-workstealing-fifo");
         ini_config.emplace_back("hpx.scheduler=" + queuing_);
 
         affinity_domain_ = detail::handle_affinity(cfgmap, vm, "pu");

--- a/src/util/command_line_handling.cpp
+++ b/src/util/command_line_handling.cpp
@@ -1012,7 +1012,8 @@ namespace hpx { namespace util
 #endif
 
         // handle setting related to schedulers
-        queuing_ = detail::handle_queuing(cfgmap, vm, "local-workstealing-fifo");
+        queuing_ =
+            detail::handle_queuing(cfgmap, vm, "local-workrequesting-fifo");
         ini_config.emplace_back("hpx.scheduler=" + queuing_);
 
         affinity_domain_ = detail::handle_affinity(cfgmap, vm, "pu");

--- a/src/util/parse_command_line.cpp
+++ b/src/util/parse_command_line.cpp
@@ -484,7 +484,7 @@ namespace hpx { namespace util
                 ("hpx:queuing", value<std::string>(),
                   "the queue scheduling policy to use, options are "
                   "'local', 'local-priority-fifo','local-priority-lifo', "
-                  "'local-workstealing', "
+                  "'local-workstealing-fifo', 'local-workstealing-lifo' "
                   "'abp-priority-fifo', 'abp-priority-lifo', 'static', and "
                   "'static-priority' (default: 'local-priority'; "
                   "all option values can be abbreviated)")

--- a/src/util/parse_command_line.cpp
+++ b/src/util/parse_command_line.cpp
@@ -484,6 +484,7 @@ namespace hpx { namespace util
                 ("hpx:queuing", value<std::string>(),
                   "the queue scheduling policy to use, options are "
                   "'local', 'local-priority-fifo','local-priority-lifo', "
+                  "'local-workstealing', "
                   "'abp-priority-fifo', 'abp-priority-lifo', 'static', and "
                   "'static-priority' (default: 'local-priority'; "
                   "all option values can be abbreviated)")

--- a/src/util/parse_command_line.cpp
+++ b/src/util/parse_command_line.cpp
@@ -484,7 +484,7 @@ namespace hpx { namespace util
                 ("hpx:queuing", value<std::string>(),
                   "the queue scheduling policy to use, options are "
                   "'local', 'local-priority-fifo','local-priority-lifo', "
-                  "'local-workstealing-fifo', 'local-workstealing-lifo' "
+                  "'local-workrequesting-fifo', 'local-workrequesting-lifo' "
                   "'abp-priority-fifo', 'abp-priority-lifo', 'static', and "
                   "'static-priority' (default: 'local-priority'; "
                   "all option values can be abbreviated)")

--- a/src/util/runtime_configuration.cpp
+++ b/src/util/runtime_configuration.cpp
@@ -190,7 +190,7 @@ namespace hpx { namespace util
             "localities = 1",
             "first_pu = 0",
             "runtime_mode = console",
-            "scheduler = local-workstealing-fifo",
+            "scheduler = local-workrequesting-fifo",
             "affinity = core",
             "pu_step = 1",
             "pu_offset = 0",

--- a/src/util/runtime_configuration.cpp
+++ b/src/util/runtime_configuration.cpp
@@ -190,7 +190,7 @@ namespace hpx { namespace util
             "localities = 1",
             "first_pu = 0",
             "runtime_mode = console",
-            "scheduler = local-workstealing",
+            "scheduler = local-workstealing-fifo",
             "affinity = core",
             "pu_step = 1",
             "pu_offset = 0",

--- a/src/util/runtime_configuration.cpp
+++ b/src/util/runtime_configuration.cpp
@@ -190,7 +190,7 @@ namespace hpx { namespace util
             "localities = 1",
             "first_pu = 0",
             "runtime_mode = console",
-            "scheduler = local-priority-fifo",
+            "scheduler = local-workstealing",
             "affinity = core",
             "pu_step = 1",
             "pu_offset = 0",

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -230,11 +230,12 @@ void measure_function_futures_thread_count(
     });
 
     // stop the clock
-    const double duration = walltime.elapsed();
+    double const duration = walltime.elapsed();
 
     if (sanity_check != 0)
     {
-        auto count = this_pool->get_thread_count_unknown(std::size_t(-1), false);
+        std::size_t count =
+            this_pool->get_thread_count_unknown(std::size_t(-1), false);
         throw std::runtime_error(
             "This test is faulty " + std::to_string(count));
     }
@@ -278,7 +279,8 @@ void measure_function_futures_limiting_executor(
         hpx::threads::executors::limiting_executor<Executor> signal_exec(
             exec, tasks, tasks + 1000);
         hpx::parallel::for_loop(
-            hpx::parallel::execution::par.with(fixed), 0, count, [&](std::uint64_t) {
+            hpx::parallel::execution::par.with(fixed), 0, std::uint64_t(count), 
+            [&](std::uint64_t) {
                 hpx::apply(signal_exec, [&]() {
                     null_function();
                     sanity_check--;
@@ -452,8 +454,9 @@ void measure_function_futures_create_thread_hierarchical_placement(
             for (std::uint64_t i = count_start; i < count_end; ++i)
             {
                 hpx::threads::thread_init_data init(
-                    hpx::threads::thread_function_type(thread_func), desc, prio,
-                    hint, stack_size, sched);
+                    hpx::threads::thread_function_type(thread_func), desc,
+                    hpx::threads::thread_priority_normal, hint, stack_size,
+                    sched);
                 sched->create_thread(
                     init, nullptr, hpx::threads::pending, false, ec);
             }
@@ -463,8 +466,8 @@ void measure_function_futures_create_thread_hierarchical_placement(
                 spawn_func};
 
         hpx::threads::thread_init_data init(
-            hpx::threads::thread_function_type(thread_spawn_func), desc, prio,
-            hint, stack_size, sched);
+            hpx::threads::thread_function_type(thread_spawn_func), desc,
+            hpx::threads::thread_priority_normal, hint, stack_size, sched);
         sched->create_thread(init, nullptr, hpx::threads::pending, false, ec);
     }
     l.wait();

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -279,7 +279,7 @@ void measure_function_futures_limiting_executor(
         hpx::threads::executors::limiting_executor<Executor> signal_exec(
             exec, tasks, tasks + 1000);
         hpx::parallel::for_loop(
-            hpx::parallel::execution::par.with(fixed), 0, std::uint64_t(count), 
+            hpx::parallel::execution::par.with(fixed), 0, std::uint64_t(count),
             [&](std::uint64_t) {
                 hpx::apply(signal_exec, [&]() {
                     null_function();
@@ -454,9 +454,8 @@ void measure_function_futures_create_thread_hierarchical_placement(
             for (std::uint64_t i = count_start; i < count_end; ++i)
             {
                 hpx::threads::thread_init_data init(
-                    hpx::threads::thread_function_type(thread_func), desc,
-                    hpx::threads::thread_priority_normal, hint, stack_size,
-                    sched);
+                    hpx::threads::thread_function_type(thread_func), desc, prio,
+                    hint, stack_size, sched);
                 sched->create_thread(
                     init, nullptr, hpx::threads::pending, false, ec);
             }
@@ -467,7 +466,7 @@ void measure_function_futures_create_thread_hierarchical_placement(
 
         hpx::threads::thread_init_data init(
             hpx::threads::thread_function_type(thread_spawn_func), desc,
-            hpx::threads::thread_priority_normal, hint, stack_size, sched);
+            prio, hint, stack_size, sched);
         sched->create_thread(init, nullptr, hpx::threads::pending, false, ec);
     }
     l.wait();


### PR DESCRIPTION
This adds a new experimental scheduler that works on a different basic principle compared to the others we have. Instead of actively stealing tasks from neighboring cores, with this scheduler a core that ran out of work posts a 'steal request' to the other cores which in turn respond with sending tasks that can be 'spared' back to the requesting core. This drastically reduces the contention in the scheduling loop itself. Essentially, the thread queues are not shared between cores anymore.

Currently this scheduler produces slightly worse results (about 10%) compared to the local priority scheduler we use by default. I'm sure there are ways to improve things, however.  

This relies on #4245

Please note that this PR also sets the new scheduler as the default for all applications. This is done to ensure all tests pass when run with this PR. 