### PR TITLE
Make mismatching build types a hard error in CMake

### DIFF
--- a/cmake/templates/HPXMacros.cmake.in
+++ b/cmake/templates/HPXMacros.cmake.in
@@ -102,8 +102,18 @@ function(hpx_check_cmake_build_type)
   if (NOT _GENERATOR_IS_MULTI_CONFIG AND
       NOT "${HPX_BUILD_TYPE}" STREQUAL "${CMAKE_BUILD_TYPE}" AND
       ("${HPX_BUILD_TYPE}" STREQUAL "Debug" OR "${CMAKE_BUILD_TYPE}" STREQUAL "Debug"))
-    message(WARNING "CMAKE_BUILD_TYPE does not match ${HPX_BUILD_TYPE}: "
-      "this project uses '${CMAKE_BUILD_TYPE}', HPX uses '${HPX_BUILD_TYPE}'. "
-      "Please add -DCMAKE_BUILD_TYPE=${HPX_BUILD_TYPE} to your cmake command")
+    if(HPX_IGNORE_CMAKE_BUILD_TYPE_COMPATIBILITY)
+      hpx_warn("CMAKE_BUILD_TYPE does not match ${HPX_BUILD_TYPE}: "
+        "this project uses '${CMAKE_BUILD_TYPE}', HPX uses '${HPX_BUILD_TYPE}'. "
+        "HPX is not ABI compatible between release and debug modes and it is "
+        "recommended that you use the same build type for HPX and your project.")
+    else()
+      hpx_error("CMAKE_BUILD_TYPE does not match ${HPX_BUILD_TYPE}: "
+        "this project uses '${CMAKE_BUILD_TYPE}', HPX uses '${HPX_BUILD_TYPE}'. "
+        "Please add -DCMAKE_BUILD_TYPE=${HPX_BUILD_TYPE} to your cmake command "
+        "or add -DHPX_IGNORE_CMAKE_BUILD_TYPE_COMPATIBILITY=OFF to ignore this "
+        "check (not recommended; HPX is not ABI compatible between release and "
+        "debug modes).")
+    endif()
   endif()
 endfunction()


### PR DESCRIPTION
Makes it an error (in CMake) to mix Debug and Release builds, with an option to ignore the check. I left the warning there even if the check is ignored to make sure users remember it's a bad idea to mix build types.