### PR TITLE
Adding action specializations for noexcept functions

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -760,6 +760,14 @@ function(hpx_check_for_cxx17_if_constexpr)
 endfunction()
 
 ###############################################################################
+function(hpx_check_for_cxx17_noexcept_functions_as_nontype_template_arguments)
+  add_hpx_config_test(
+    HPX_WITH_CXX17_NOEXCEPT_FUNCTIONS_AS_NONTYPE_TEMPLATE_ARGUMENTS
+    SOURCE cmake/tests/cxx17_noexcept_function.cpp
+    FILE ${ARGN})
+endfunction()
+
+###############################################################################
 function(hpx_check_for_mm_prefetch)
   add_hpx_config_test(HPX_WITH_MM_PREFETCH
     SOURCE cmake/tests/mm_prefetch.cpp

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -227,5 +227,9 @@ function(hpx_perform_cxx_feature_tests)
 
     hpx_check_for_cxx17_std_in_place_type_t(
       DEFINITIONS HPX_HAVE_CXX17_STD_IN_PLACE_TYPE_T)
+
+    hpx_check_for_cxx17_noexcept_functions_as_nontype_template_arguments(
+      DEFINITIONS HPX_HAVE_CXX17_NOEXCEPT_FUNCTIONS_AS_NONTYPE_TEMPLATE_ARGUMENTS)
+
   endif()
 endfunction()

--- a/cmake/tests/cxx17_noexcept_function.cpp
+++ b/cmake/tests/cxx17_noexcept_function.cpp
@@ -1,0 +1,29 @@
+//  Copyright (c) 2019 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This tests whether noexcept function used a non-type template arguments are
+// properly supported by the compiler.
+
+template <typename F, F f>
+struct action;
+
+template <typename R, typename... Args, R (*F)(Args...)>
+struct action<R (*)(Args...), F>
+{
+};
+
+template <typename R, typename... Args, R (*F)(Args...) noexcept>
+struct action<R (*)(Args...) noexcept, F>
+{
+};
+
+void foo() noexcept {}
+
+int main()
+{
+    action<decltype(&foo), &foo> t;
+    return 0;
+}

--- a/hpx/runtime/actions/plain_action.hpp
+++ b/hpx/runtime/actions/plain_action.hpp
@@ -96,6 +96,41 @@ namespace hpx { namespace actions
         }
     };
 
+#if defined(HPX_HAVE_CXX17_NOEXCEPT_FUNCTIONS_AS_NONTYPE_TEMPLATE_ARGUMENTS)
+    template <
+        typename R, typename ...Ps,
+        R (*F)(Ps...) noexcept, typename Derived>
+    struct action<R (*)(Ps...) noexcept, F, Derived>
+      : public basic_action<detail::plain_function, R(Ps...),
+            typename detail::action_type<
+                action<R (*)(Ps...) noexcept, F, Derived>,
+                Derived
+            >::type
+        >
+    {
+    public:
+        typedef typename detail::action_type<
+            action, Derived
+        >::type derived_type;
+
+        static std::string get_action_name(naming::address::address_type /*lva*/)
+        {
+            return detail::make_plain_action_name(
+                detail::get_action_name<derived_type>());
+        }
+
+        template <typename ...Ts>
+        static R invoke(
+            naming::address::address_type /*lva*/,
+            naming::address::component_type comptype, Ts&&... vs)
+        {
+            basic_action<detail::plain_function, R(Ps...),
+                derived_type>::increment_invocation_count();
+            return F(std::forward<Ts>(vs)...);
+        }
+    };
+#endif
+
     /// \endcond
 }}
 

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -102,7 +102,7 @@ double global_scratch = 0;
 std::uint64_t num_iterations = 0;
 
 ///////////////////////////////////////////////////////////////////////////////
-double null_function()
+double null_function() noexcept
 {
     if (num_iterations > 0)
     {


### PR DESCRIPTION
Fixes compilation errors in C++17 mode if noexcept functions are bound to actions
