### PR TITLE
Ignoring lock in all_to_all and all_reduce

### DIFF
--- a/libs/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/collectives/include/hpx/collectives/all_reduce.hpp
@@ -138,6 +138,7 @@ namespace hpx { namespace lcos {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
 #include <hpx/assertion.hpp>
+#include <hpx/basic_execution/register_locks.hpp>
 #include <hpx/dataflow.hpp>
 #include <hpx/functional/bind_back.hpp>
 #include <hpx/lcos/future.hpp>
@@ -205,6 +206,7 @@ namespace hpx { namespace lcos {
 
                     {
                         std::unique_lock<mutex_type> l(mtx_);
+                        util::ignore_lock(&l);
                         data = data_;
                         std::swap(name, name_);
                     }

--- a/libs/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/collectives/include/hpx/collectives/all_to_all.hpp
@@ -134,6 +134,7 @@ namespace hpx { namespace lcos {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
 #include <hpx/assertion.hpp>
+#include <hpx/basic_execution/register_locks.hpp>
 #include <hpx/dataflow.hpp>
 #include <hpx/functional/bind_back.hpp>
 #include <hpx/functional/bind_front.hpp>
@@ -200,6 +201,7 @@ namespace hpx { namespace lcos {
 
                     {
                         std::unique_lock<mutex_type> l(mtx_);
+                        util::ignore_lock(&l);
                         data = data_;
                         std::swap(name, name_);
                     }


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Adding lock ignore to all_reduce and all_to_all

## Any background context you want to provide?
Related to a Phylanx issue encountered when trying to add matrices with Blaze. When the matrix size exceeded the Blaze parallelization threshold, the presence of the lock in all_reduce caused hpx to throw when suspension was attempted during the parallel add
