### PR TITLE
Fix apex annotation for async dispatch

### DIFF
--- a/hpx/async_launch_policy_dispatch.hpp
+++ b/hpx/async_launch_policy_dispatch.hpp
@@ -90,7 +90,8 @@ namespace hpx { namespace detail
                 std::forward<F>(f), std::forward<Ts>(ts)...));
             if (hpx::detail::has_async_policy(policy))
             {
-                threads::thread_id_type tid = p.apply(pool, policy,
+                threads::thread_id_type tid = p.apply(pool,
+                    "async_launch_policy_dispatch", policy,
                     policy.priority(), threads::thread_stacksize_default, hint);
                 if (tid && policy == launch::fork)
                 {

--- a/hpx/async_launch_policy_dispatch.hpp
+++ b/hpx/async_launch_policy_dispatch.hpp
@@ -148,8 +148,8 @@ namespace hpx { namespace detail
             lcos::local::futures_factory<result_type()> p(util::deferred_call(
                 std::forward<F>(f), std::forward<Ts>(ts)...));
 
-            p.apply(pool, policy, policy.priority(),
-                threads::thread_stacksize_default, hint);
+            p.apply(pool, "async_launch_policy_dispatch::call", policy,
+                policy.priority(), threads::thread_stacksize_default, hint);
             return p.get_future();
         }
 
@@ -182,8 +182,9 @@ namespace hpx { namespace detail
                 std::forward<F>(f), std::forward<Ts>(ts)...));
 
             // make sure this thread is executed last
-            threads::thread_id_type tid = p.apply(pool, policy,
-                policy.priority(), threads::thread_stacksize_default, hint);
+            threads::thread_id_type tid = p.apply(pool,
+                "async_launch_policy_dispatch::call", policy, policy.priority(),
+                threads::thread_stacksize_default, hint);
             threads::thread_id_type tid_self = threads::get_self_id();
             if (tid && tid_self &&
                 get_thread_id_data(tid)->get_scheduler_base() ==

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -864,7 +864,9 @@ namespace hpx { namespace lcos { namespace detail {
 
         // run in a separate thread
         virtual threads::thread_id_type apply(
-            threads::thread_pool_base* /*pool*/, launch /*policy*/,
+            threads::thread_pool_base* /*pool*/,
+            const char */*annotation*/,
+            launch /*policy*/,
             threads::thread_priority /*priority*/,
             threads::thread_stacksize /*stacksize*/,
             threads::thread_schedule_hint /*schedulehint*/, error_code& /*ec*/)

--- a/hpx/lcos/local/futures_factory.hpp
+++ b/hpx/lcos/local/futures_factory.hpp
@@ -104,7 +104,9 @@ namespace hpx { namespace lcos { namespace local {
         protected:
             // run in a separate thread
             threads::thread_id_type apply(threads::thread_pool_base* pool,
-                launch policy, threads::thread_priority priority,
+                const char *annotation,
+                launch policy,
+                threads::thread_priority priority,
                 threads::thread_stacksize stacksize,
                 threads::thread_schedule_hint schedulehint,
                 error_code& ec) override
@@ -119,7 +121,7 @@ namespace hpx { namespace lcos { namespace local {
                     return threads::register_thread_nullary(pool,
                         util::deferred_call(
                             &base_type::run_impl, std::move(this_)),
-                        util::thread_description(f_, "task_object::apply"),
+                        util::thread_description(f_, annotation),
                         threads::pending_do_not_schedule, true,
                         threads::thread_priority_boost,
                         threads::thread_schedule_hint(
@@ -247,6 +249,7 @@ namespace hpx { namespace lcos { namespace local {
         protected:
             // run in a separate thread
             threads::thread_id_type apply(threads::thread_pool_base* pool,
+                const char *annotation,
                 launch policy, threads::thread_priority priority,
                 threads::thread_stacksize stacksize,
                 threads::thread_schedule_hint schedulehint,
@@ -262,7 +265,7 @@ namespace hpx { namespace lcos { namespace local {
                     parallel::execution::post(*exec_,
                         util::deferred_call(
                             &base_type::run_impl, std::move(this_)),
-                        schedulehint);
+                        schedulehint, annotation);
                     return threads::invalid_thread_id;
                 }
                 else if (policy == launch::fork)
@@ -271,7 +274,7 @@ namespace hpx { namespace lcos { namespace local {
                         util::deferred_call(
                             &base_type::run_impl, std::move(this_)),
                         util::thread_description(
-                            this->f_, "task_object::apply"),
+                            this->f_, annotation),
                         threads::pending_do_not_schedule, true,
                         threads::thread_priority_boost,
                         threads::thread_schedule_hint(
@@ -284,7 +287,7 @@ namespace hpx { namespace lcos { namespace local {
                         util::deferred_call(
                             &base_type::run_impl, std::move(this_)),
                         util::thread_description(
-                            this->f_, "task_object::apply"),
+                            this->f_, annotation),
                         threads::pending, false, priority, schedulehint,
                         stacksize, ec);
                     return threads::invalid_thread_id;
@@ -777,7 +780,9 @@ namespace hpx { namespace lcos { namespace local {
         }
 
         // asynchronous execution
-        threads::thread_id_type apply(launch policy = launch::async,
+        threads::thread_id_type apply(
+            const char *annotation = "futures_factory::apply",
+            launch policy = launch::async,
             threads::thread_priority priority =
                 threads::thread_priority_default,
             threads::thread_stacksize stacksize =
@@ -786,11 +791,13 @@ namespace hpx { namespace lcos { namespace local {
                 threads::thread_schedule_hint(),
             error_code& ec = throws) const
         {
-            return apply(threads::detail::get_self_or_default_pool(), policy,
+            return apply(threads::detail::get_self_or_default_pool(),
+                annotation, policy,
                 priority, stacksize, schedulehint, ec);
         }
 
         threads::thread_id_type apply(threads::thread_pool_base* pool,
+            const char *annotation = "futures_factory::apply",
             launch policy = launch::async,
             threads::thread_priority priority =
                 threads::thread_priority_default,
@@ -808,7 +815,7 @@ namespace hpx { namespace lcos { namespace local {
                 return threads::invalid_thread_id;
             }
             return task_->apply(
-                pool, policy, priority, stacksize, schedulehint, ec);
+                pool, annotation, policy, priority, stacksize, schedulehint, ec);
         }
 
         // This is the same as get_future, except that it moves the

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -376,12 +376,8 @@ namespace hpx { namespace lcos { namespace detail
             }
 
             hpx::intrusive_ptr<continuation> this_(this);
-            const char * annotation =
-                traits::get_function_annotation<typename hpx::util::decay<F>::type>::call(f_);
-            hpx::util::thread_description desc(
-                annotation == nullptr ?
-                "hpx::parallel::execution::parallel_executor::post" :
-                annotation);
+            hpx::util::thread_description desc(f_,
+                "hpx::parallel::execution::parallel_executor::post");
 
             parallel::execution::detail::post_policy_dispatch<
                     hpx::launch::async_policy
@@ -426,12 +422,8 @@ namespace hpx { namespace lcos { namespace detail
             }
 
             hpx::intrusive_ptr<continuation> this_(this);
-            const char * annotation =
-                traits::get_function_annotation<typename hpx::util::decay<F>::type>::call(f_);
-            hpx::util::thread_description desc(
-                annotation == nullptr ?
-                "hpx::parallel::execution::parallel_executor::post" :
-                annotation);
+            hpx::util::thread_description desc(f_,
+                "hpx::parallel::execution::parallel_executor::post");
 
             parallel::execution::detail::post_policy_dispatch<
                     hpx::launch::async_policy

--- a/hpx/lcos/local/packaged_continuation.hpp
+++ b/hpx/lcos/local/packaged_continuation.hpp
@@ -376,8 +376,12 @@ namespace hpx { namespace lcos { namespace detail
             }
 
             hpx::intrusive_ptr<continuation> this_(this);
+            const char * annotation =
+                traits::get_function_annotation<typename hpx::util::decay<F>::type>::call(f_);
             hpx::util::thread_description desc(
-                "hpx::parallel::execution::parallel_executor::post");
+                annotation == nullptr ?
+                "hpx::parallel::execution::parallel_executor::post" :
+                annotation);
 
             parallel::execution::detail::post_policy_dispatch<
                     hpx::launch::async_policy
@@ -422,8 +426,12 @@ namespace hpx { namespace lcos { namespace detail
             }
 
             hpx::intrusive_ptr<continuation> this_(this);
+            const char * annotation =
+                traits::get_function_annotation<typename hpx::util::decay<F>::type>::call(f_);
             hpx::util::thread_description desc(
-                "hpx::parallel::execution::parallel_executor::post");
+                annotation == nullptr ?
+                "hpx::parallel::execution::parallel_executor::post" :
+                annotation);
 
             parallel::execution::detail::post_policy_dispatch<
                     hpx::launch::async_policy

--- a/hpx/runtime/threads/executors/guided_pool_executor.hpp
+++ b/hpx/runtime/threads/executors/guided_pool_executor.hpp
@@ -112,18 +112,16 @@ namespace hpx { namespace threads { namespace executors
                 util::deferred_call(std::forward<F>(f), std::forward<Ts>(ts)...));
 
             if (hp_sync_ &&
-                    executor_.get_priority() == hpx::threads::thread_priority_high) {
-                p.apply(
-                    hpx::launch::sync,
-                    executor_.get_priority(),
+                executor_.get_priority() == hpx::threads::thread_priority_high)
+            {
+                p.apply("guided async", hpx::launch::sync, executor_.get_priority(),
                     executor_.get_stacksize(),
                     threads::thread_schedule_hint(
                                 thread_schedule_hint_mode_numa, domain));
             }
-            else {
-                p.apply(
-                    hpx::launch::async,
-                    executor_.get_priority(),
+            else
+            {
+                p.apply("guided async", hpx::launch::async, executor_.get_priority(),
                     executor_.get_stacksize(),
                     threads::thread_schedule_hint(
                                 thread_schedule_hint_mode_numa, domain));
@@ -174,18 +172,16 @@ namespace hpx { namespace threads { namespace executors
             );
 
             if (hp_sync_ &&
-                    executor_.get_priority() == hpx::threads::thread_priority_high) {
-                p.apply(
-                    hpx::launch::sync,
-                    executor_.get_priority(),
+                executor_.get_priority() == hpx::threads::thread_priority_high)
+            {
+                p.apply("guided then", hpx::launch::sync, executor_.get_priority(),
                     executor_.get_stacksize(),
                     threads::thread_schedule_hint(
                                 thread_schedule_hint_mode_numa, domain));
             }
-            else {
-                p.apply(
-                    hpx::launch::async,
-                    executor_.get_priority(),
+            else
+            {
+                p.apply("guided then", hpx::launch::async, executor_.get_priority(),
                     executor_.get_stacksize(),
                     threads::thread_schedule_hint(
                                 thread_schedule_hint_mode_numa, domain));
@@ -440,18 +436,17 @@ namespace hpx { namespace threads { namespace executors
             );
 
             if (hp_sync_ &&
-                    pool_executor_.get_priority() == hpx::threads::thread_priority_high) {
-                p.apply(
-                    hpx::launch::sync,
-                    pool_executor_.get_priority(),
+                pool_executor_.get_priority() ==
+                    hpx::threads::thread_priority_high)
+            {
+                p.apply("guided async", hpx::launch::sync, pool_executor_.get_priority(),
                     pool_executor_.get_stacksize(),
                     threads::thread_schedule_hint(
                                 thread_schedule_hint_mode_numa, domain));
             }
-            else {
-                p.apply(
-                    hpx::launch::async,
-                    pool_executor_.get_priority(),
+            else
+            {
+                p.apply("guided async", hpx::launch::async, pool_executor_.get_priority(),
                     pool_executor_.get_stacksize(),
                     threads::thread_schedule_hint(
                                 thread_schedule_hint_mode_numa, domain));
@@ -503,19 +498,18 @@ namespace hpx { namespace threads { namespace executors
         future<typename util::detail::invoke_deferred_result<F, Ts...>::type>
         async_execute(F && f, Ts &&... ts)
         {
-            if (guided_) return guided_exec_.async_execute(
-                std::forward<F>(f), std::forward<Ts>(ts)...);
-            else {
-                typedef typename util::detail::invoke_deferred_result<F, Ts...>::type
-                    result_type;
+            if (guided_)
+                return guided_exec_.async_execute(
+                    std::forward<F>(f), std::forward<Ts>(ts)...);
+            else
+            {
+                typedef typename util::detail::invoke_deferred_result<F,
+                    Ts...>::type result_type;
 
-                lcos::local::futures_factory<result_type()> p(
-                    pool_exec_,
-                    util::deferred_call(std::forward<F>(f), std::forward<Ts>(ts)...)
-                );
-                p.apply(
-                    hpx::launch::async,
-                    pool_exec_.get_priority(),
+                lcos::local::futures_factory<result_type()> p(pool_exec_,
+                    util::deferred_call(
+                        std::forward<F>(f), std::forward<Ts>(ts)...));
+                p.apply("guided async", hpx::launch::async, pool_exec_.get_priority(),
                     pool_exec_.get_stacksize(),
                     threads::thread_schedule_hint()
                 );

--- a/libs/affinity/tests/unit/parse_affinity_options.cpp
+++ b/libs/affinity/tests/unit/parse_affinity_options.cpp
@@ -6,8 +6,8 @@
 
 #include <hpx/hpx_init.hpp>
 
+#include <hpx/affinity/parse_affinity_options.hpp>
 #include <hpx/include/threads.hpp>
-#include <hpx/runtime/threads/policies/parse_affinity_options.hpp>
 #include <hpx/testing.hpp>
 
 #include <algorithm>

--- a/libs/execution/include/hpx/parallel/executors/thread_execution.hpp
+++ b/libs/execution/include/hpx/parallel/executors/thread_execution.hpp
@@ -119,13 +119,13 @@ namespace hpx { namespace threads {
         hpx::traits::is_threads_executor<Executor>::value &&
         std::is_same<typename hpx::util::decay<Hint>::type,
             hpx::threads::thread_schedule_hint>::value>::type
-    post(Executor&& exec, F&& f, Hint&& hint, const char *annotation, Ts&&... ts)
+    post(
+        Executor&& exec, F&& f, Hint&& hint, const char* annotation, Ts&&... ts)
     {
         exec.add(
             util::deferred_call(std::forward<F>(f), std::forward<Ts>(ts)...),
-            annotation,
-            threads::pending, true,
-            exec.get_stacksize(), std::forward<Hint>(hint), throws);
+            annotation, threads::pending, true, exec.get_stacksize(),
+            std::forward<Hint>(hint), throws);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/execution/include/hpx/parallel/executors/thread_execution.hpp
+++ b/libs/execution/include/hpx/parallel/executors/thread_execution.hpp
@@ -54,7 +54,7 @@ namespace hpx { namespace threads {
         lcos::local::futures_factory<result_type()> p(
             std::forward<Executor>(exec),
             util::deferred_call(std::forward<F>(f), std::forward<Ts>(ts)...));
-        p.apply();
+        p.apply(hpx::traits::get_function_annotation<typename hpx::util::decay<F>::type>::call(f));
         return p.get_future();
     }
 
@@ -105,7 +105,8 @@ namespace hpx { namespace threads {
     {
         exec.add(
             util::deferred_call(std::forward<F>(f), std::forward<Ts>(ts)...),
-            "hpx::parallel::execution::post", threads::pending, true,
+            hpx::traits::get_function_annotation<typename hpx::util::decay<F>::type>::call(f),
+                    threads::pending, true,
             exec.get_stacksize(), threads::thread_schedule_hint(), throws);
     }
     ///////////////////////////////////////////////////////////////////////////
@@ -115,11 +116,12 @@ namespace hpx { namespace threads {
         hpx::traits::is_threads_executor<Executor>::value &&
         std::is_same<typename hpx::util::decay<Hint>::type,
             hpx::threads::thread_schedule_hint>::value>::type
-    post(Executor&& exec, F&& f, Hint&& hint, Ts&&... ts)
+    post(Executor&& exec, F&& f, Hint&& hint, const char *annotation, Ts&&... ts)
     {
         exec.add(
             util::deferred_call(std::forward<F>(f), std::forward<Ts>(ts)...),
-            "hpx::parallel::execution::post", threads::pending, true,
+            annotation,
+            threads::pending, true,
             exec.get_stacksize(), std::forward<Hint>(hint), throws);
     }
 

--- a/libs/execution/include/hpx/parallel/executors/thread_execution.hpp
+++ b/libs/execution/include/hpx/parallel/executors/thread_execution.hpp
@@ -51,10 +51,12 @@ namespace hpx { namespace threads {
         typedef typename util::detail::invoke_deferred_result<F, Ts...>::type
             result_type;
 
+        char const* annotation = hpx::traits::get_function_annotation<
+            typename hpx::util::decay<F>::type>::call(f);
         lcos::local::futures_factory<result_type()> p(
             std::forward<Executor>(exec),
             util::deferred_call(std::forward<F>(f), std::forward<Ts>(ts)...));
-        p.apply(hpx::traits::get_function_annotation<typename hpx::util::decay<F>::type>::call(f));
+        p.apply(annotation);
         return p.get_future();
     }
 
@@ -103,11 +105,12 @@ namespace hpx { namespace threads {
         hpx::traits::is_threads_executor<Executor>::value>::type
     post(Executor&& exec, F&& f, Ts&&... ts)
     {
+        char const* annotation = hpx::traits::get_function_annotation<
+            typename hpx::util::decay<F>::type>::call(f);
         exec.add(
             util::deferred_call(std::forward<F>(f), std::forward<Ts>(ts)...),
-            hpx::traits::get_function_annotation<typename hpx::util::decay<F>::type>::call(f),
-                    threads::pending, true,
-            exec.get_stacksize(), threads::thread_schedule_hint(), throws);
+            annotation, threads::pending, true, exec.get_stacksize(),
+            threads::thread_schedule_hint(), throws);
     }
     ///////////////////////////////////////////////////////////////////////////
     // post()

--- a/libs/resource_partitioner/examples/async_customization.cpp
+++ b/libs/resource_partitioner/examples/async_customization.cpp
@@ -114,7 +114,7 @@ struct test_async_executor
         lcos::local::futures_factory<result_type()> p(executor_,
             util::deferred_call(std::forward<F>(f), std::forward<Ts>(ts)...));
 
-        p.apply(launch::async, threads::thread_priority_default,
+        p.apply("custom", launch::async, threads::thread_priority_default,
             threads::thread_stacksize_default);
 
         return p.get_future();
@@ -152,7 +152,7 @@ struct test_async_executor
             util::deferred_call(std::forward<F>(f),
                 std::forward<Future>(predecessor), std::forward<Ts>(ts)...));
 
-        p.apply(launch::async, threads::thread_priority_default,
+        p.apply("custom then", launch::async, threads::thread_priority_default,
             threads::thread_stacksize_default);
 
         return p.get_future();
@@ -212,7 +212,7 @@ struct test_async_executor
                     predecessor),
                 std::forward<Ts>(ts)...));
 
-        p.apply(launch::async, threads::thread_priority_default,
+        p.apply("custom then", launch::async, threads::thread_priority_default,
             threads::thread_stacksize_default);
 
         return p.get_future();
@@ -260,7 +260,7 @@ struct test_async_executor
             util::deferred_call(std::forward<F>(f),
                 std::forward<util::tuple<InnerFutures...>>(predecessor)));
 
-        p.apply(launch::async, threads::thread_priority_default,
+        p.apply("custom async", launch::async, threads::thread_priority_default,
             threads::thread_stacksize_default);
 
         return p.get_future();

--- a/src/lcos/detail/future_data.cpp
+++ b/src/lcos/detail/future_data.cpp
@@ -59,7 +59,7 @@ namespace hpx { namespace lcos { namespace detail
             policy = launch::async;
 
         // launch a new thread executing the given function
-        threads::thread_id_type tid = p.apply(
+        threads::thread_id_type tid = p.apply("run_on_completed_on_new_thread",
             policy, threads::thread_priority_boost,
             threads::thread_stacksize_current,
             threads::thread_schedule_hint());

--- a/src/util/backtrace/backtrace.cpp
+++ b/src/util/backtrace/backtrace.cpp
@@ -414,7 +414,7 @@ namespace hpx { namespace util {
             stack_trace::get_symbols, &frames_.front(), frames_.size()));
 
         error_code ec(lightweight);
-        threads::thread_id_type tid = p.apply(
+        threads::thread_id_type tid = p.apply("backtrace",
             launch::fork, threads::thread_priority_default,
             threads::thread_stacksize_medium,
             threads::thread_schedule_hint(),

--- a/src/util/thread_description.cpp
+++ b/src/util/thread_description.cpp
@@ -49,10 +49,15 @@ namespace hpx { namespace util
 #endif
     }
 
-    /* The priority of description is id::name, altname, id::address */
+    /* The priority of description is altname, id::name, id::address */
     void thread_description::init_from_alternative_name(char const* altname)
     {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION) && !defined(HPX_HAVE_THREAD_DESCRIPTION_FULL)
+        if (altname != nullptr) {
+            type_ = data_type_description;
+            data_.desc_ = altname;
+            return;
+        }
         hpx::threads::thread_id_type id = hpx::threads::get_self_id();
         if (id)
         {
@@ -66,19 +71,10 @@ namespace hpx { namespace util
             }
             else
             {
-                // if there is an alternate name passed in, use it.
-                if (altname != nullptr) {
-                    type_ = data_type_description;
-                    data_.desc_ = altname;
-                } else {
-                    // otherwise, use the address of the task.
-                    HPX_ASSERT(type_ == data_type_address);
-                    data_.addr_ = desc.get_address();
-                }
+                // otherwise, use the address of the task.
+                HPX_ASSERT(type_ == data_type_address);
+                data_.addr_ = desc.get_address();
             }
-        } else {
-            type_ = data_type_description;
-            data_.desc_ = altname;
         }
 #endif
     }


### PR DESCRIPTION
When an annotated task is passed though the asyn dispatch, we can strip
off the task 'name' or annotation and pass it through to the thread
creation so that it is used when the task is initialized and apex
get the right name. We make use of
traits::get_function_annotation<typename hpx::util::decay<F>::type>::call(f)
to achieve this.
