### PR TITLE
Module naming base

### DIFF
--- a/examples/jacobi/CMakeLists.txt
+++ b/examples/jacobi/CMakeLists.txt
@@ -11,7 +11,7 @@ set(jacobi_sources
 
 set(jacobi_FLAGS
     COMPONENT_DEPENDENCIES
-    iostreams jacobi_component)
+    iostreams jacobi)
 
 # add jacobi executable
 add_hpx_executable(jacobi_simple

--- a/examples/jacobi/jacobi_component/CMakeLists.txt
+++ b/examples/jacobi/jacobi_component/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-add_hpx_component(jacobi_component
+add_hpx_component(jacobi
     AUTOGLOB
     SOURCE_GLOB "*.c*"
     HEADER_GLOB "*.h*"

--- a/hpx/custom_exception_info.hpp
+++ b/hpx/custom_exception_info.hpp
@@ -11,7 +11,7 @@
 #include <hpx/config.hpp>
 #include <hpx/assertion.hpp>
 #include <hpx/errors.hpp>
-#include <hpx/runtime/naming_fwd.hpp>
+#include <hpx/naming_base.hpp>
 
 #include <boost/system/error_code.hpp>
 #include <boost/system/system_error.hpp>

--- a/hpx/lcos/detail/async_implementations_fwd.hpp
+++ b/hpx/lcos/detail/async_implementations_fwd.hpp
@@ -11,7 +11,6 @@
 #include <hpx/lcos/async_fwd.hpp>
 #include <hpx/lcos/future.hpp>
 #include <hpx/runtime/launch_policy.hpp>
-#include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/traits/extract_action.hpp>
 
 namespace hpx { namespace detail

--- a/hpx/lcos/detail/async_unwrap_result_implementations_fwd.hpp
+++ b/hpx/lcos/detail/async_unwrap_result_implementations_fwd.hpp
@@ -11,7 +11,6 @@
 #include <hpx/lcos/async_fwd.hpp>
 #include <hpx/lcos/future.hpp>
 #include <hpx/runtime/launch_policy.hpp>
-#include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/traits/extract_action.hpp>
 
 namespace hpx { namespace detail

--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -17,6 +17,7 @@
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/runtime/launch_policy.hpp>
+#include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/runtime/threads/thread_executor.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
 #include <hpx/thread_support/assert_owns_lock.hpp>

--- a/hpx/runtime/actions/base_action.hpp
+++ b/hpx/runtime/actions/base_action.hpp
@@ -15,7 +15,6 @@
 
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/runtime/actions_fwd.hpp>
-#include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/runtime/parcelset_fwd.hpp>
 #include <hpx/runtime/threads/thread_data_fwd.hpp>
 

--- a/hpx/runtime/components/pinned_ptr.hpp
+++ b/hpx/runtime/components/pinned_ptr.hpp
@@ -9,8 +9,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assertion.hpp>
+#include <hpx/naming_base.hpp>
 #include <hpx/runtime/get_lva.hpp>
-#include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/traits/action_decorate_function.hpp>
 #include <hpx/traits/component_pin_support.hpp>
 
@@ -32,14 +32,14 @@ namespace hpx { namespace components
               : lva_(0)
             {}
 
-            explicit pinned_ptr_base(naming::address::address_type lva) noexcept
+            explicit pinned_ptr_base(naming::address_type lva) noexcept
               : lva_(lva)
             {}
 
             virtual ~pinned_ptr_base() {}
 
         protected:
-            naming::address::address_type lva_;
+            naming::address_type lva_;
         };
 
         template <typename Component>
@@ -51,7 +51,7 @@ namespace hpx { namespace components
         public:
             pinned_ptr() noexcept {}
 
-            explicit pinned_ptr(naming::address::address_type lva) noexcept
+            explicit pinned_ptr(naming::address_type lva) noexcept
               : pinned_ptr_base(lva)
             {
                 HPX_ASSERT(0 != this->lva_);
@@ -95,7 +95,7 @@ namespace hpx { namespace components
         template <typename Component, typename Enable = void>
         struct create_helper
         {
-            static pinned_ptr call(naming::address::address_type)
+            static pinned_ptr call(naming::address_type)
             {
                 return pinned_ptr{};
             }
@@ -108,14 +108,14 @@ namespace hpx { namespace components
                 traits::component_decorates_action<Component>::value
             >::type>
         {
-            static pinned_ptr call(naming::address::address_type lva)
+            static pinned_ptr call(naming::address_type lva)
             {
                 return pinned_ptr(lva, id<Component>{});
             }
         };
 
         template <typename Component>
-        pinned_ptr(naming::address::address_type lva, id<Component>)
+        pinned_ptr(naming::address_type lva, id<Component>)
           : data_(new detail::pinned_ptr<Component>(lva))
         {
         }
@@ -130,7 +130,7 @@ namespace hpx { namespace components
         pinned_ptr& operator= (pinned_ptr && rhs) = default;
 
         template <typename Component>
-        static pinned_ptr create(naming::address::address_type lva)
+        static pinned_ptr create(naming::address_type lva)
         {
             using component_type = typename std::remove_cv<Component>::type;
             return create_helper<component_type>::call(lva);

--- a/hpx/runtime/naming_fwd.hpp
+++ b/hpx/runtime/naming_fwd.hpp
@@ -11,7 +11,6 @@
 #include <hpx/config.hpp>
 #include <hpx/naming_base.hpp>
 #include <hpx/runtime/agas_fwd.hpp>
-#include <hpx/naming_base.hpp>
 
 #include <cstdint>
 

--- a/hpx/runtime/naming_fwd.hpp
+++ b/hpx/runtime/naming_fwd.hpp
@@ -9,7 +9,9 @@
 #define HPX_RUNTIME_NAMING_FWD_HPP
 
 #include <hpx/config.hpp>
+#include <hpx/naming_base.hpp>
 #include <hpx/runtime/agas_fwd.hpp>
+#include <hpx/naming_base.hpp>
 
 #include <cstdint>
 
@@ -28,12 +30,6 @@ namespace hpx
         struct HPX_EXPORT address;
 
         HPX_API_EXPORT resolver_client& get_agas_client();
-
-        using component_type = std::int32_t;
-        using address_type = std::uint64_t;
-
-        HPX_CONSTEXPR_OR_CONST std::uint32_t invalid_locality_id =
-            ~static_cast<std::uint32_t>(0);
 
         // tag used to mark serialization archive during check-pointing
         struct checkpointing_tag {};

--- a/hpx/runtime/parcelset/parcel.hpp
+++ b/hpx/runtime/parcelset/parcel.hpp
@@ -14,6 +14,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
+#include <hpx/naming_base.hpp>
 #include <hpx/runtime/actions_fwd.hpp>
 #include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/runtime/naming/address.hpp>

--- a/hpx/runtime/threads/thread_data.hpp
+++ b/hpx/runtime/threads/thread_data.hpp
@@ -23,7 +23,6 @@
 #include <hpx/runtime/get_locality_id.hpp>
 #include <hpx/runtime/threads/thread_data_fwd.hpp>
 #include <hpx/runtime/threads/thread_init_data.hpp>
-#include <hpx/logging.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/thread_support/atomic_count.hpp>
 #include <hpx/util/backtrace.hpp>

--- a/hpx/runtime/threads/thread_data.hpp
+++ b/hpx/runtime/threads/thread_data.hpp
@@ -19,8 +19,8 @@
 #include <hpx/errors.hpp>
 #include <hpx/functional/function.hpp>
 #include <hpx/logging.hpp>
+#include <hpx/naming_base.hpp>
 #include <hpx/runtime/get_locality_id.hpp>
-#include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/runtime/threads/thread_data_fwd.hpp>
 #include <hpx/runtime/threads/thread_init_data.hpp>
 #include <hpx/logging.hpp>

--- a/hpx/runtime/threads/thread_init_data.hpp
+++ b/hpx/runtime/threads/thread_init_data.hpp
@@ -9,7 +9,6 @@
 #define HPX_RUNTIME_THREADS_THREAD_INIT_DATA_HPP
 
 #include <hpx/config.hpp>
-#include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/runtime/threads/thread_data_fwd.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/runtime/threads_fwd.hpp>

--- a/hpx/traits/action_decorate_function.hpp
+++ b/hpx/traits/action_decorate_function.hpp
@@ -9,7 +9,7 @@
 
 #include <hpx/concepts/has_xxx.hpp>
 #include <hpx/functional/unique_function.hpp>
-#include <hpx/runtime/naming_fwd.hpp>
+#include <hpx/naming_base.hpp>
 #include <hpx/runtime/threads/thread_data_fwd.hpp>
 #include <hpx/type_support/detail/wrap_int.hpp>
 

--- a/hpx/traits/action_select_direct_execution.hpp
+++ b/hpx/traits/action_select_direct_execution.hpp
@@ -8,8 +8,8 @@
 #define HPX_TRAITS_ACTION_SELECT_DIRECT_EXECUTION_MAR_22_21018_0124PM
 
 #include <hpx/config.hpp>
+#include <hpx/naming_base.hpp>
 #include <hpx/runtime/launch_policy.hpp>
-#include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/type_support/detail/wrap_int.hpp>
 
 namespace hpx { namespace traits

--- a/hpx/util/wrapper_heap_base.hpp
+++ b/hpx/util/wrapper_heap_base.hpp
@@ -8,7 +8,6 @@
 #define HPX_UTIL_WRAPPER_HEAP_BASE_HPP
 
 #include <hpx/config.hpp>
-#include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/runtime/components/component_type.hpp>
 #include <hpx/util/generate_unique_ids.hpp>
 

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -39,6 +39,7 @@ set(HPX_LIBS
   local_lcos
   logging
   memory
+  naming_base
   plugin
   preprocessor
   program_options

--- a/libs/all_modules.rst
+++ b/libs/all_modules.rst
@@ -42,6 +42,7 @@ All modules
    /libs/local_lcos/docs/index.rst
    /libs/logging/docs/index.rst
    /libs/memory/docs/index.rst
+   /libs/naming_base/docs/index.rst
    /libs/plugin/docs/index.rst
    /libs/preprocessor/docs/index.rst
    /libs/program_options/docs/index.rst

--- a/libs/create_library_skeleton.py
+++ b/libs/create_library_skeleton.py
@@ -94,10 +94,6 @@ add_hpx_module({lib_name}
   DEPENDENCIES
   CMAKE_SUBDIRS examples tests
 )
-
-include(HPX_PrintSummary)
-create_configuration_summary(
-  "  Module configuration summary ({lib_name}):" "{lib_name}")
 '''
 
 examples_cmakelists_template = cmake_header + f'''

--- a/libs/naming_base/CMakeLists.txt
+++ b/libs/naming_base/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+cmake_minimum_required(VERSION 3.3.2 FATAL_ERROR)
+
+# Default location is $HPX_ROOT/libs/naming_base/include
+set(naming_base_headers
+  hpx/naming_base.hpp
+  )
+
+# Default location is $HPX_ROOT/libs/naming_base/include_compatibility
+set(naming_base_compat_headers)
+
+set(naming_base_sources)
+
+include(HPX_AddModule)
+add_hpx_module(naming_base
+  COMPATIBILITY_HEADERS OFF
+  DEPRECATION_WARNINGS
+  FORCE_LINKING_GEN
+  GLOBAL_HEADER_GEN OFF
+  HEADERS ${naming_base_headers}
+  DEPENDENCIES
+    hpx_config
+  CMAKE_SUBDIRS examples tests
+)

--- a/libs/naming_base/README.rst
+++ b/libs/naming_base/README.rst
@@ -1,0 +1,16 @@
+
+..
+    Copyright (c) 2019 The STE||AR-Group
+
+    SPDX-License-Identifier: BSL-1.0
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+===========
+naming_base
+===========
+
+This library is part of HPX.
+
+Documentation can be found `here
+<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/naming_base/docs/index.html>`__.

--- a/libs/naming_base/docs/index.rst
+++ b/libs/naming_base/docs/index.rst
@@ -1,0 +1,19 @@
+..
+    Copyright (c) 2019 The STE||AR-Group
+
+    SPDX-License-Identifier: BSL-1.0
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+.. _libs_naming_base:
+
+===========
+naming_base
+===========
+
+This module provides a forward declaration of `address_type`, `component_type`
+and `invalid_locality_id`.
+
+See the :ref:`API reference <libs_naming_base_api>` of this module for more
+details.
+

--- a/libs/naming_base/examples/CMakeLists.txt
+++ b/libs/naming_base/examples/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if (HPX_WITH_EXAMPLES)
+  add_hpx_pseudo_target(examples.modules.naming_base)
+  add_hpx_pseudo_dependencies(examples.modules examples.modules.naming_base)
+  if (HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES AND HPX_NAMING_BASE_WITH_TESTS)
+    add_hpx_pseudo_target(tests.examples.modules.naming_base)
+    add_hpx_pseudo_dependencies(tests.examples.modules tests.examples.modules.naming_base)
+  endif()
+endif()

--- a/libs/naming_base/include/hpx/naming_base.hpp
+++ b/libs/naming_base/include/hpx/naming_base.hpp
@@ -1,0 +1,26 @@
+//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2011      Bryce Lelbach
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_RUNTIME_NAMING_TYPES_FWD_HPP
+#define HPX_RUNTIME_NAMING_TYPES_FWD_HPP
+
+#include <hpx/config.hpp>
+
+#include <cstdint>
+
+namespace hpx { namespace naming {
+
+    using component_type = std::int32_t;
+    using address_type = std::uint64_t;
+
+    HPX_CONSTEXPR_OR_CONST std::uint32_t invalid_locality_id =
+        ~static_cast<std::uint32_t>(0);
+
+}}  // namespace hpx::naming
+
+
+#endif

--- a/libs/naming_base/include/hpx/naming_base.hpp
+++ b/libs/naming_base/include/hpx/naming_base.hpp
@@ -20,7 +20,6 @@ namespace hpx { namespace naming {
     HPX_CONSTEXPR_OR_CONST std::uint32_t invalid_locality_id =
         ~static_cast<std::uint32_t>(0);
 
-}}  // namespace hpx::naming
-
+}}    // namespace hpx::naming
 
 #endif

--- a/libs/naming_base/tests/CMakeLists.txt
+++ b/libs/naming_base/tests/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+include(HPX_Message)
+include(HPX_Option)
+
+if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
+  hpx_set_option(HPX_NAMING_BASE_WITH_TESTS VALUE OFF FORCE)
+  return()
+endif()
+
+if (HPX_NAMING_BASE_WITH_TESTS)
+    if (HPX_WITH_TESTS_UNIT)
+      add_hpx_pseudo_target(tests.unit.modules.naming_base)
+      add_hpx_pseudo_dependencies(tests.unit.modules tests.unit.modules.naming_base)
+      add_subdirectory(unit)
+    endif()
+
+    if (HPX_WITH_TESTS_REGRESSIONS)
+      add_hpx_pseudo_target(tests.regressions.modules.naming_base)
+      add_hpx_pseudo_dependencies(tests.regressions.modules tests.regressions.modules.naming_base)
+      add_subdirectory(regressions)
+    endif()
+
+    if (HPX_WITH_TESTS_BENCHMARKS)
+      add_hpx_pseudo_target(tests.performance.modules.naming_base)
+      add_hpx_pseudo_dependencies(tests.performance.modules tests.performance.modules.naming_base)
+      add_subdirectory(performance)
+    endif()
+
+    if (HPX_WITH_TESTS_HEADERS)
+      add_hpx_header_tests(
+        modules.naming_base
+        HEADERS ${naming_base_headers}
+        HEADER_ROOT ${PROJECT_SOURCE_DIR}/include
+        NOLIBS
+        DEPENDENCIES hpx_naming_base)
+    endif()
+endif()

--- a/libs/naming_base/tests/performance/CMakeLists.txt
+++ b/libs/naming_base/tests/performance/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/naming_base/tests/regressions/CMakeLists.txt
+++ b/libs/naming_base/tests/regressions/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+

--- a/libs/naming_base/tests/unit/CMakeLists.txt
+++ b/libs/naming_base/tests/unit/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/serialization/CMakeLists.txt
+++ b/libs/serialization/CMakeLists.txt
@@ -159,3 +159,9 @@ add_hpx_module(serialization
     hpx_type_support
   CMAKE_SUBDIRS examples tests
 )
+
+# Temporary needs hpx_util cause still depending on custom_exception_info which
+# is itself depending on hpx/naming_base.hpp
+target_link_libraries(hpx_serialization PUBLIC
+  hpx_naming_base
+  )

--- a/src/util/init_logging.cpp
+++ b/src/util/init_logging.cpp
@@ -11,7 +11,7 @@
 #include <hpx/logging.hpp>
 #include <hpx/logging/format/named_write.hpp>
 #include <hpx/logging/format/destination/defaults.hpp>
-#include <hpx/runtime/naming_fwd.hpp>
+#include <hpx/naming_base.hpp>
 #include <hpx/runtime/get_locality_id.hpp>
 #include <hpx/runtime/naming/resolver_client.hpp>
 #include <hpx/runtime/components/console_logging.hpp>


### PR DESCRIPTION
Move the `address_type`, `component_type` and `invalid_locality_id` to a `naming_base` module to eliminates some dependencies.
