### PR TITLE
Cleanup modules CMakeLists.txt

### DIFF
--- a/libs/allocator_support/src/CMakeLists.txt
+++ b/libs/allocator_support/src/CMakeLists.txt
@@ -1,5 +1,0 @@
-# Copyright (c) 2019 The STE||AR-Group
-#
-# SPDX-License-Identifier: BSL-1.0
-# Distributed under the Boost Software License, Version 1.0. (See accompanying
-# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/concepts/src/CMakeLists.txt
+++ b/libs/concepts/src/CMakeLists.txt
@@ -1,5 +1,0 @@
-# Copyright (c) 2019 The STE||AR-Group
-#
-# SPDX-License-Identifier: BSL-1.0
-# Distributed under the Boost Software License, Version 1.0. (See accompanying
-# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/datastructures/src/CMakeLists.txt
+++ b/libs/datastructures/src/CMakeLists.txt
@@ -1,5 +1,0 @@
-# Copyright (c) 2019 The STE||AR-Group
-#
-# SPDX-License-Identifier: BSL-1.0
-# Distributed under the Boost Software License, Version 1.0. (See accompanying
-# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/debugging/src/CMakeLists.txt
+++ b/libs/debugging/src/CMakeLists.txt
@@ -1,5 +1,0 @@
-# Copyright (c) 2019 The STE||AR-Group
-#
-# SPDX-License-Identifier: BSL-1.0
-# Distributed under the Boost Software License, Version 1.0. (See accompanying
-# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/errors/src/CMakeLists.txt
+++ b/libs/errors/src/CMakeLists.txt
@@ -1,5 +1,0 @@
-# Copyright (c) 2019 The STE||AR-Group
-#
-# SPDX-License-Identifier: BSL-1.0
-# Distributed under the Boost Software License, Version 1.0. (See accompanying
-# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/hashing/src/CMakeLists.txt
+++ b/libs/hashing/src/CMakeLists.txt
@@ -1,5 +1,0 @@
-# Copyright (c) 2019 The STE||AR-Group
-#
-# SPDX-License-Identifier: BSL-1.0
-# Distributed under the Boost Software License, Version 1.0. (See accompanying
-# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/iterator_support/src/CMakeLists.txt
+++ b/libs/iterator_support/src/CMakeLists.txt
@@ -1,5 +1,0 @@
-# Copyright (c) 2019 The STE||AR-Group
-#
-# SPDX-License-Identifier: BSL-1.0
-# Distributed under the Boost Software License, Version 1.0. (See accompanying
-# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/program_options/src/CMakeLists.txt
+++ b/libs/program_options/src/CMakeLists.txt
@@ -1,5 +1,0 @@
-# Copyright (c) 2019 The STE||AR-Group
-#
-# SPDX-License-Identifier: BSL-1.0
-# Distributed under the Boost Software License, Version 1.0. (See accompanying
-# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/thread_support/src/CMakeLists.txt
+++ b/libs/thread_support/src/CMakeLists.txt
@@ -1,5 +1,0 @@
-# Copyright (c) 2019 The STE||AR-Group
-#
-# SPDX-License-Identifier: BSL-1.0
-# Distributed under the Boost Software License, Version 1.0. (See accompanying
-# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/type_support/CMakeLists.txt
+++ b/libs/type_support/CMakeLists.txt
@@ -50,6 +50,5 @@ add_hpx_module(type_support
   DEPENDENCIES
     hpx_assertion
     hpx_config
-    hpx_concepts
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/type_support/src/CMakeLists.txt
+++ b/libs/type_support/src/CMakeLists.txt
@@ -1,5 +1,0 @@
-# Copyright (c) 2019 The STE||AR-Group
-#
-# SPDX-License-Identifier: BSL-1.0
-# Distributed under the Boost Software License, Version 1.0. (See accompanying
-# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/util/src/CMakeLists.txt
+++ b/libs/util/src/CMakeLists.txt
@@ -1,5 +1,0 @@
-# Copyright (c) 2019 The STE||AR-Group
-#
-# SPDX-License-Identifier: BSL-1.0
-# Distributed under the Boost Software License, Version 1.0. (See accompanying
-# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)


### PR DESCRIPTION
- Removes empty `src/CMakeLists.txt` files
- Removes `concepts` dependency from the `type_support` module (this was a circular dependency only in the CMake world, in the source code there is no circular dependency)
