### PR TITLE
Clean up compatibility header options

### DIFF
--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -48,19 +48,21 @@ function(add_hpx_module name)
       NAMESPACE ${name_upper})
   endif()
 
-  set(_compatibility_headers_default OFF)
-  if(${name}_COMPATIBILITY_HEADERS)
-    set(_compatibility_headers_default ON)
-  endif()
-  hpx_option(HPX_${name_upper}_WITH_COMPATIBILITY_HEADERS
-    BOOL
-    "Enable compatibility headers for old headers. (default: ${_compatibility_headers_default})"
-    ${_compatibility_headers_default} ADVANCED
-    CATEGORY "Modules")
-  if(HPX_${name_upper}_WITH_COMPATIBILITY_HEADERS)
-    hpx_add_config_define_namespace(
-      DEFINE HPX_${name_upper}_HAVE_COMPATIBILITY_HEADERS
-      NAMESPACE ${name_upper})
+  if(NOT "${${name}_COMPATIBILITY_HEADERS}" STREQUAL "")
+    set(_compatibility_headers_default OFF)
+    if(${name}_COMPATIBILITY_HEADERS)
+      set(_compatibility_headers_default ON)
+    endif()
+    hpx_option(HPX_${name_upper}_WITH_COMPATIBILITY_HEADERS
+      BOOL
+      "Enable compatibility headers for old headers. (default: ${_compatibility_headers_default})"
+      ${_compatibility_headers_default} ADVANCED
+      CATEGORY "Modules")
+    if(HPX_${name_upper}_WITH_COMPATIBILITY_HEADERS)
+      hpx_add_config_define_namespace(
+        DEFINE HPX_${name_upper}_HAVE_COMPATIBILITY_HEADERS
+        NAMESPACE ${name_upper})
+    endif()
   endif()
 
   # Main directories of the module

--- a/libs/basic_execution/CMakeLists.txt
+++ b/libs/basic_execution/CMakeLists.txt
@@ -28,6 +28,8 @@ set(basic_execution_sources
 
 include(HPX_AddModule)
 add_hpx_module(basic_execution
+  COMPATIBILITY_HEADERS ON
+  DEPRECATION_WARNINGS
   FORCE_LINKING_GEN
   SOURCES ${basic_execution_sources}
   HEADERS ${basic_execution_headers}

--- a/libs/compute/CMakeLists.txt
+++ b/libs/compute/CMakeLists.txt
@@ -28,8 +28,6 @@ set(compute_headers
   hpx/compute/vector.hpp
 )
 
-set(compute_compat_headers)
-
 set(compute_sources
   get_host_targets.cpp
   host_target.cpp
@@ -38,8 +36,6 @@ set(compute_sources
 
 include(HPX_AddModule)
 add_hpx_module(compute
-  COMPATIBILITY_HEADERS OFF
-  DEPRECATION_WARNINGS
   FORCE_LINKING_GEN
   GLOBAL_HEADER_GEN ON
   SOURCES ${compute_sources}

--- a/libs/compute_cuda/CMakeLists.txt
+++ b/libs/compute_cuda/CMakeLists.txt
@@ -38,14 +38,11 @@ endif()
 
 include(HPX_AddModule)
 add_hpx_module(compute_cuda
-  COMPATIBILITY_HEADERS OFF
-  DEPRECATION_WARNINGS
   FORCE_LINKING_GEN
   GLOBAL_HEADER_GEN OFF
   CUDA
   SOURCES ${compute_cuda_sources}
   HEADERS ${compute_cuda_headers}
-  COMPAT_HEADERS ${compute_cuda_compat_headers}
   DEPENDENCIES
     hpx_allocator_support
     hpx_assertion

--- a/libs/memory/CMakeLists.txt
+++ b/libs/memory/CMakeLists.txt
@@ -23,8 +23,6 @@ set(memory_sources
 
 include(HPX_AddModule)
 add_hpx_module(memory
-  COMPATIBILITY_HEADERS OFF
-  DEPRECATION_WARNINGS
   FORCE_LINKING_GEN
   GLOBAL_HEADER_GEN ON
   EXCLUDE_FROM_GLOBAL_HEADER
@@ -32,7 +30,6 @@ add_hpx_module(memory
     "hpx/memory/serialization/intrusive_ptr.hpp"
   SOURCES ${memory_sources}
   HEADERS ${memory_headers}
-  COMPAT_HEADERS ${memory_compat_headers}
   DEPENDENCIES
     hpx_config
     hpx_assertion


### PR DESCRIPTION
- Adds a missing option to `basic_execution`
- Removes the option for modules that don't need it
- Doesn't create the `HPX_X_WITH_COMPATIBILITY_HEADERS` option if it's not requested