### PR TITLE
Testing for noexcept function specializations in in C++11/14 mode

### DIFF
--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -228,8 +228,12 @@ function(hpx_perform_cxx_feature_tests)
     hpx_check_for_cxx17_std_in_place_type_t(
       DEFINITIONS HPX_HAVE_CXX17_STD_IN_PLACE_TYPE_T)
 
-    hpx_check_for_cxx17_noexcept_functions_as_nontype_template_arguments(
-      DEFINITIONS HPX_HAVE_CXX17_NOEXCEPT_FUNCTIONS_AS_NONTYPE_TEMPLATE_ARGUMENTS)
-
   endif()
+
+  # we deliberately check for this functionality even for non-C++17
+  # configurations as some compilers (notable gcc V7.x) require for noexcept
+  # function specializations for actions even in C++11/14 mode
+  hpx_check_for_cxx17_noexcept_functions_as_nontype_template_arguments(
+    DEFINITIONS HPX_HAVE_CXX17_NOEXCEPT_FUNCTIONS_AS_NONTYPE_TEMPLATE_ARGUMENTS)
+
 endfunction()


### PR DESCRIPTION
Fixes #4263
