### PR TITLE
Updating APEX tag, don't create new task_wrapper on operator= of hpx_thread object

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,6 @@ jobs:
                 -G "Ninja" \
                 -DHPX_WITH_MALLOC=system \
                 -DHPX_WITH_APEX=On \
-                -DHPX_WITH_APEX_TAG=develop \
                 -DHPX_WITH_TESTS=On \
                 -DHPX_WITH_EXAMPLES=On
             rm -rf *

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -657,7 +657,7 @@ if(HPX_WITH_APEX)
   hpx_option(HPX_WITH_APEX_NO_UPDATE BOOL
     "Do not update code from remote APEX repository." OFF CATEGORY "Profiling")
   hpx_option(HPX_WITH_APEX_TAG STRING
-    "APEX repository tag or branch" "v2.1.6" CATEGORY "Profiling")
+    "APEX repository tag or branch" "v2.1.7" CATEGORY "Profiling")
 endif()
 hpx_option(HPX_WITH_PAPI BOOL
   "Enable the PAPI based performance counter." OFF CATEGORY "Profiling")

--- a/hpx/runtime/threads/thread_init_data.hpp
+++ b/hpx/runtime/threads/thread_init_data.hpp
@@ -66,8 +66,7 @@ namespace hpx { namespace threads
 #ifdef HPX_HAVE_APEX
         // HPX_HAVE_APEX forces the HPX_HAVE_THREAD_DESCRIPTION
         // and HPX_HAVE_THREAD_PARENT_REFERENCE settings to be on
-            timer_data = util::external_timer::new_task(description,
-                parent_locality_id, parent_id);
+            timer_data = rhs.timer_data;
 #endif
             return *this;
         }


### PR DESCRIPTION
Updating APEX tag, don't create new task_wrapper on operator= of hpx_thread object

## Proposed Changes

  - Update APEX tag to 2.1.7
  - Don't create new apex_wrapper object when hpx_thread operator=() is used.
  -

## Any background context you want to provide?
