### PR TITLE
Small CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1612,8 +1612,8 @@ add_hpx_library_sources_noglob(hpx_external)
 add_hpx_library_headers_noglob(hpx_external)
 
 # Setup packages and subprojects
+include(HPX_SetupCUDA) # CUDA needs to come before Apex, to have cuda_add_library available
 include(HPX_SetupApex)
-include(HPX_SetupCUDA)
 include(HPX_SetupPapi)
 include(HPX_SetupHpxmp)
 include(HPX_SetupGooglePerfTools)

--- a/cmake/HPX_SetupApex.cmake
+++ b/cmake/HPX_SetupApex.cmake
@@ -14,7 +14,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-if(HPX_WITH_APEX)
+if(HPX_WITH_APEX AND NOT TARGET hpx::apex)
   if(NOT HPX_FIND_PACKAGE)
     set(_hpx_apex_no_update)
     if(HPX_WITH_APEX_NO_UPDATE)

--- a/cmake/HPX_SetupBoostIostreams.cmake
+++ b/cmake/HPX_SetupBoostIostreams.cmake
@@ -4,7 +4,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-if(HPX_WITH_COMPRESSION_BZIP2 OR HPX_WITH_COMPRESSION_ZLIB)
+if((HPX_WITH_COMPRESSION_BZIP2 OR HPX_WITH_COMPRESSION_ZLIB) AND NOT TARGET hpx::boost::iostreams)
 
   find_package(Boost ${Boost_MINIMUM_VERSION} QUIET MODULE COMPONENTS iostreams)
 

--- a/cmake/HPX_SetupBoostRegex.cmake
+++ b/cmake/HPX_SetupBoostRegex.cmake
@@ -4,25 +4,27 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-find_package(Boost ${Boost_MINIMUM_VERSION}
-  QUIET MODULE
-  COMPONENTS regex)
+if(NOT TARGET hpx::boost::regex)
+  find_package(Boost ${Boost_MINIMUM_VERSION}
+    QUIET MODULE
+    COMPONENTS regex)
 
-if(Boost_REGEX_FOUND)
-  hpx_info("  regex")
-else()
-  hpx_error("Could not find Boost.Regex but HPX_WITH_TOOLS=On (the inspect \
-  tool requires Boost.Regex). Either set it to off or provide a boost \
-  installation including the regex library")
-endif()
+  if(Boost_REGEX_FOUND)
+    hpx_info("  regex")
+  else()
+    hpx_error("Could not find Boost.Regex but HPX_WITH_TOOLS=On (the inspect \
+    tool requires Boost.Regex). Either set it to off or provide a boost \
+    installation including the regex library")
+  endif()
 
-add_library(hpx::boost::regex INTERFACE IMPORTED)
+  add_library(hpx::boost::regex INTERFACE IMPORTED)
 
-set_property(TARGET hpx::boost::regex APPEND PROPERTY
-  INTERFACE_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIRS})
-if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
-  set_property(TARGET hpx::boost::regex PROPERTY INTERFACE_LINK_LIBRARIES
-    ${Boost_REGEX_LIBRARIES})
-else()
-  target_link_libraries(hpx::boost::regex INTERFACE ${Boost_REGEX_LIBRARIES})
+  set_property(TARGET hpx::boost::regex APPEND PROPERTY
+    INTERFACE_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIRS})
+  if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
+    set_property(TARGET hpx::boost::regex PROPERTY INTERFACE_LINK_LIBRARIES
+      ${Boost_REGEX_LIBRARIES})
+  else()
+    target_link_libraries(hpx::boost::regex INTERFACE ${Boost_REGEX_LIBRARIES})
+  endif()
 endif()

--- a/cmake/HPX_SetupGooglePerfTools.cmake
+++ b/cmake/HPX_SetupGooglePerfTools.cmake
@@ -14,7 +14,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-if(HPX_WITH_GOOGLE_PERFTOOLS)
+if(HPX_WITH_GOOGLE_PERFTOOLS AND NOT TARGET hpx::gperftools)
   find_package(GooglePerftools)
   if(NOT GOOGLE_PERFTOOLS_FOUND)
     hpx_error("Google Perftools could not be found and \

--- a/cmake/HPX_SetupLibfabric.cmake
+++ b/cmake/HPX_SetupLibfabric.cmake
@@ -7,7 +7,7 @@
 # FIXME : in the future put it directly inside the cmake directory of the
 # corresponding plugin
 
-if (HPX_WITH_PARCELPORT_LIBFABRIC)
+if (HPX_WITH_PARCELPORT_LIBFABRIC AND NOT TARGET hpx::libfabric)
   #------------------------------------------------------------------------------
   # Add #define to global defines.hpp
   #------------------------------------------------------------------------------

--- a/cmake/HPX_SetupMPI.cmake
+++ b/cmake/HPX_SetupMPI.cmake
@@ -11,7 +11,7 @@
 # If we compile with the MPI parcelport enabled, we need to additionally
 # add the MPI include path here, because for the main library, it's only
 # added for the plugin.
-if(HPX_WITH_NETWORKING AND HPX_WITH_PARCELPORT_MPI)
+if(HPX_WITH_NETWORKING AND HPX_WITH_PARCELPORT_MPI AND NOT TARGET hpx::mpi)
   find_package(MPI)
   # All cmake version don't have the same found variable set
   if(NOT MPI_FOUND AND NOT MPI_CXX_FOUND)

--- a/cmake/HPX_SetupValgrind.cmake
+++ b/cmake/HPX_SetupValgrind.cmake
@@ -14,7 +14,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-if(HPX_WITH_VALGRIND)
+if(HPX_WITH_VALGRIND AND NOT TARGET hpx::valgrind)
   find_package(Valgrind)
   if(NOT VALGRIND_FOUND)
     hpx_error("Valgrind could not be found and HPX_WITH_VALGRIND=On, please \

--- a/cmake/HPX_SetupVerbs.cmake
+++ b/cmake/HPX_SetupVerbs.cmake
@@ -7,7 +7,7 @@
 # FIXME : in the future put it directly inside the cmake directory of the
 # corresponding plugin
 
-if (HPX_WITH_PARCELPORT_VERBS)
+if (HPX_WITH_PARCELPORT_VERBS AND NOT TARGET hpx::verbs)
   #------------------------------------------------------------------------------
   # OFED verbs stack
   #------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes CMake configuration with APEX and CUDA enabled at the same time. Also adds more guards for targets that may be created multiple times when HPX is found multiple times.
