### PR TITLE
Checks for MPI_Init being called twice

### DIFF
--- a/hpx/plugins/parcelport/mpi/mpi_environment.hpp
+++ b/hpx/plugins/parcelport/mpi/mpi_environment.hpp
@@ -67,6 +67,8 @@ namespace hpx { namespace util
         static bool has_called_init_;
         static int provided_threading_flag_;
         static MPI_Comm communicator_;
+
+        static int is_initialized_;
     };
 }}
 


### PR DESCRIPTION
### Bit of Background

`MPI_Init` called twice now throws error:

```
--------------------------------------------------------------------------
Open MPI has detected that this process has attempted to initialize
MPI (via MPI_INIT or MPI_INIT_THREAD) more than once.  This is
erroneous.
--------------------------------------------------------------------------
[72238f88c12e:44621] *** An error occurred in MPI_Init
[72238f88c12e:44621] *** reported by process [3814129665,0]
[72238f88c12e:44621] *** on a NULL communicator
[72238f88c12e:44621] *** Unknown error
[72238f88c12e:44621] *** MPI_ERRORS_ARE_FATAL (processes in this communicator will now abort,
[72238f88c12e:44621] ***    and potentially your MPI job)
```

This PR adds `MPI_Initialized` to the mpi parcelport before calling the MPI_Init function. This allows to check if MPI_Init has been called previously and sets up the variables accordingly.