### PR TITLE
Implementing `hpx::functional::tag_invoke`

### DIFF
--- a/cmake/tests/cxx17_inline_constexpr_variable.cpp
+++ b/cmake/tests/cxx17_inline_constexpr_variable.cpp
@@ -9,7 +9,6 @@
 inline constexpr bool test1 = true;
 
 template <typename T>
-
 inline constexpr bool test2 = true;
 
 struct foo

--- a/libs/config/include/hpx/config/constexpr.hpp
+++ b/libs/config/include/hpx/config/constexpr.hpp
@@ -26,9 +26,6 @@
 
 /// This macro evaluates to ``inline constexpr`` if the compiler supports it,
 /// ``constexpr`` otherwise.
-///
-/// This macro is deprecated. It is always replaced with the ``constexpr``
-/// keyword. Prefer using ``constexpr`` directly instead.
 #ifdef HPX_HAVE_CXX17_INLINE_CONSTEXPR_VARIABLE
 #define HPX_INLINE_CONSTEXPR_VARIABLE inline constexpr
 #else

--- a/libs/functional/CMakeLists.txt
+++ b/libs/functional/CMakeLists.txt
@@ -31,6 +31,7 @@ set(functional_headers
     hpx/functional/one_shot.hpp
     hpx/functional/protect.hpp
     hpx/functional/result_of.hpp
+    hpx/functional/tag_invoke.hpp
     hpx/functional/unique_function.hpp
     hpx/functional/serialization/detail/serializable_basic_function.hpp
     hpx/functional/serialization/detail/vtable/serializable_function_vtable.hpp

--- a/libs/functional/include/hpx/functional/tag_invoke.hpp
+++ b/libs/functional/include/hpx/functional/tag_invoke.hpp
@@ -102,8 +102,6 @@ namespace hpx { namespace functional {
 
 namespace hpx { namespace functional {
     namespace tag_invoke_t_ns {
-        void tag_invoke() = delete;
-
         struct tag_invoke_t
         {
 #define HPX_FUNCTIONAL_TAG_INVOKE_EXPRESSION                                   \

--- a/libs/functional/include/hpx/functional/tag_invoke.hpp
+++ b/libs/functional/include/hpx/functional/tag_invoke.hpp
@@ -1,0 +1,185 @@
+//  Copyright (c) 2020 Thomas Heller
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// hpxinspect:nodeprecatedname:hpx::traits::is_callable
+// hpxinspect:nodeprecatedname:hpx::util::result_of
+
+#pragma once
+
+#if defined(DOXYGEN)
+namespace hpx { namespace functional {
+    inline namespace unspecified {
+        /// The `hpx::functional::tag_invoke` name defines a constexpr opbject that is
+        /// invocable with one or more arguments. The first argument is a 'tag' (typically
+        /// a CPO). It is only invocable if an overload of tag_invoke() that accepts
+        /// the same arguments could be found via ADL.
+        ///
+        /// The evaluation of the expression `hpx::tag_invoke(tag, args...)` is
+        /// equivalent to evaluating the unqualified call to
+        /// `tag_invoke(decay-copy(tag), std::forward<Args>(args)...)`.
+        ///
+        /// `hpx::functional::tag_invoke` is implemented against P1895.
+        ///
+        /// Example:
+        /// Defining a new customization point `foo`:
+        /// ```
+        /// namespace mylib {
+        ///     inline constexpr struct foo_fn {
+        ///         template <typename T>
+        ///         constexpr auto operator()(T&& x) const
+        ///         noexcept(hpx::functional::tag_invoke(*this, std::forward<T>(x)))
+        ///             -> decltype(hpx::functional::tag_invoke(*this,  std::forward<T>(x)))
+        ///         {
+        ///             return hpx::functional::tag_invoke(*this,  std::forward<T>(x));
+        ///         }
+        ///     } foo{};
+        /// }
+        /// ```
+        ///
+        /// Defining an object `bar` which customizes `foo`:
+        /// ```
+        /// struct bar
+        /// {
+        ///     int x = 42;
+        ///
+        ///     friend constexpr int tag_invoke(mylib::foo_fn, bar const& x)
+        ///     {
+        ///         return b.x;
+        ///     }
+        /// };
+        /// ```
+        ///
+        /// Using the customization point:
+        /// ```
+        /// static_assert(42 == mylib::foo(bar{}), "The answer is 42");
+        /// ```
+        inline constexpr unspecified tag_invoke = unspecified;
+    }    // namespace unspecified
+
+    /// `hpx::functional::is_tag_invocable<Tag, Args...>` is std::true_type if an overload
+    /// of `tag_invoke(tag, args...)` can be found via ADL.
+    template <typename Tag, typename... Args>
+    struct is_tag_invocable;
+
+    /// `hpx::functional::is_tag_invocable_v<Tag, Args...>` evaluates to
+    /// `hpx::functional::is_tag_invocable<Tag, Args...>::value`
+    template <typename Tag, typename... Args>
+    constexpr bool is_tag_invocable_v = is_tag_invocable<Tag, Args...>::value;
+
+    /// `hpx::functional::is_nothrow_tag_invocable<Tag, Args...>` is std::true_type if an
+    /// overload of `tag_invoke(tag, args...)` can be found via ADL and is noexcept.
+    template <typename Tag, typename... Args>
+    struct is_nothrow_tag_invocable;
+
+    /// `hpx::functional::is_tag_invocable_v<Tag, Args...>` evaluates to
+    /// `hpx::functional::is_tag_invocable<Tag, Args...>::value`
+    template <typename Tag, typename... Args>
+    constexpr bool is_nothrow_tag_invocable_v =
+        is_nothrow_tag_invocable<Tag, Args...>::value;
+
+    /// `hpx::functional::tag_invoke_result<Tag, Args...>` is the trait returning the
+    /// result type of the call hpx::functioanl::tag_invoke. This can be used in a SFINAE
+    /// context.
+    template <typename Tag, typename... Args>
+    using tag_invoke_result = invoke_result<decltype(tag_invoke), Tag, Args...>;
+
+    /// `hpx::functional::tag_invoke_result_t<Tag, Args...>` evaluates to
+    /// `hpx::functional::tag_invoke_result_t<Tag, Args...>::type`
+    template <typename Tag, typename... Args>
+    using tag_invoke_result_t = typename tag_invoke_result<Tag, Args...>::type;
+}}    // namespace hpx::functional
+#else
+
+#include <hpx/config.hpp>
+#include <hpx/functional/result_of.hpp>
+#include <hpx/functional/traits/is_callable.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace functional {
+    namespace tag_invoke_t_ns {
+        void tag_invoke() = delete;
+
+        struct tag_invoke_t
+        {
+#define HPX_FUNCTIONAL_TAG_INVOKE_EXPRESSION                                   \
+    tag_invoke(tag, std::forward<Args>(args)...) /**/
+
+            template <typename Tag, typename... Args>
+            constexpr HPX_FORCEINLINE auto operator()(
+                Tag tag, Args&&... args) const
+                noexcept(noexcept(HPX_FUNCTIONAL_TAG_INVOKE_EXPRESSION))
+                    -> decltype(HPX_FUNCTIONAL_TAG_INVOKE_EXPRESSION)
+            {
+                return HPX_FUNCTIONAL_TAG_INVOKE_EXPRESSION;
+            }
+#undef HPX_FUNCTIONAL_TAG_INVOKE_EXPRESSION
+
+            friend constexpr bool operator==(tag_invoke_t, tag_invoke_t)
+            {
+                return true;
+            }
+
+            friend constexpr bool operator!=(tag_invoke_t, tag_invoke_t)
+            {
+                return false;
+            }
+        };
+    }    // namespace tag_invoke_t_ns
+
+    inline namespace tag_invoke_ns {
+        HPX_INLINE_CONSTEXPR_VARIABLE tag_invoke_t_ns::tag_invoke_t tag_invoke =
+            {};
+    }
+
+    template <typename Tag, typename... Args>
+    using is_tag_invocable =
+        hpx::traits::is_callable<decltype(tag_invoke)(Tag, Args...)>;
+
+    template <typename Tag, typename... Args>
+    constexpr bool is_tag_invocable_v = is_tag_invocable<Tag, Args...>::value;
+
+    namespace detail {
+        template <typename Sig, bool Invocable>
+        struct is_nothrow_tag_invocable_impl;
+
+        template <typename Sig>
+        struct is_nothrow_tag_invocable_impl<Sig, false> : std::false_type
+        {
+        };
+
+        template <typename Tag, typename... Args>
+        struct is_nothrow_tag_invocable_impl<
+            decltype(hpx::functional::tag_invoke)(Tag, Args...), true>
+          : std::integral_constant<bool,
+                noexcept(hpx::functional::tag_invoke(
+                    std::declval<Tag>(), std::declval<Args>()...))>
+        {
+        };
+    }    // namespace detail
+
+    template <typename Tag, typename... Args>
+    struct is_nothrow_tag_invocable
+      : detail::is_nothrow_tag_invocable_impl<
+            decltype(hpx::functional::tag_invoke)(Tag, Args...),
+            is_tag_invocable_v<Tag, Args...>>
+    {
+    };
+
+    template <typename Tag, typename... Args>
+    constexpr bool is_nothrow_tag_invocable_v =
+        is_nothrow_tag_invocable<Tag, Args...>::value;
+
+    template <typename Tag, typename... Args>
+    using tag_invoke_result = hpx::util::result_of<decltype(
+        hpx::functional::tag_invoke)(Tag, Args...)>;
+
+    template <typename Tag, typename... Args>
+    using tag_invoke_result_t = typename tag_invoke_result<Tag, Args...>::type;
+}}    // namespace hpx::functional
+
+#endif

--- a/libs/functional/tests/unit/CMakeLists.txt
+++ b/libs/functional/tests/unit/CMakeLists.txt
@@ -36,9 +36,8 @@ set(function_tests
     protect_test
     stateless_test
     sum_avg
+    tag_invoke
 )
-
-add_hpx_pseudo_target(tests.unit.modules.functional.function)
 
 foreach(test ${function_tests})
   set(sources ${test}.cpp)
@@ -54,20 +53,6 @@ foreach(test ${function_tests})
     FOLDER "Tests/Unit/Modules/Functional"
   )
 
-  add_hpx_unit_test("modules.functional.function" ${test})
+  add_hpx_unit_test("modules.functional" ${test})
 
 endforeach()
-add_hpx_pseudo_dependencies(
-  tests.unit.modules.functional tests.unit.modules.functional.function
-)
-
-source_group("Source Files" FILES tag_invoke.cpp)
-add_hpx_executable(tag_invoke_test
-INTERNAL_FLAGS
-SOURCES tag_invoke.cpp
-NOLIBS
-DEPENDENCIES hpx_functional hpx_testing
-EXCLUDE_FROM_ALL
-FOLDER "Tests/Unit/Modules/Functional")
-
-add_hpx_unit_test("modules.functional" tag_invoke)

--- a/libs/functional/tests/unit/CMakeLists.txt
+++ b/libs/functional/tests/unit/CMakeLists.txt
@@ -60,3 +60,14 @@ endforeach()
 add_hpx_pseudo_dependencies(
   tests.unit.modules.functional tests.unit.modules.functional.function
 )
+
+source_group("Source Files" FILES tag_invoke.cpp)
+add_hpx_executable(tag_invoke_test
+INTERNAL_FLAGS
+SOURCES tag_invoke.cpp
+NOLIBS
+DEPENDENCIES hpx_functional hpx_testing
+EXCLUDE_FROM_ALL
+FOLDER "Tests/Unit/Modules/Functional")
+
+add_hpx_unit_test("modules.functional" tag_invoke)

--- a/libs/functional/tests/unit/tag_invoke.cpp
+++ b/libs/functional/tests/unit/tag_invoke.cpp
@@ -1,0 +1,270 @@
+//  Copyright (c) 2020 Thomas Heller
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/testing.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace mylib {
+    HPX_INLINE_CONSTEXPR_VARIABLE struct foo_fn
+    {
+        template <typename T>
+        constexpr auto operator()(T&& x) const noexcept(
+            noexcept(hpx::functional::tag_invoke(*this, std::forward<T>(x))))
+            -> decltype(hpx::functional::tag_invoke(*this, std::forward<T>(x)))
+        {
+            return hpx::functional::tag_invoke(*this, std::forward<T>(x));
+        }
+    } foo;
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct bar_fn
+    {
+        template <typename T, typename U>
+        constexpr auto operator()(T&& x, U&& u) const
+            noexcept(noexcept(hpx::functional::tag_invoke(
+                *this, std::forward<T>(x), std::forward<U>(u))))
+                -> decltype(hpx::functional::tag_invoke(
+                    *this, std::forward<T>(x), std::forward<U>(u)))
+        {
+            return hpx::functional::tag_invoke(
+                *this, std::forward<T>(x), std::forward<U>(u));
+        }
+    } bar;
+
+    struct tag_invocable
+    {
+        friend constexpr bool tag_invoke(foo_fn, tag_invocable)
+        {
+            return true;
+        }
+    };
+
+    struct tag_invocable2
+    {
+        friend constexpr bool tag_invoke(foo_fn, tag_invocable, int)
+        {
+            return true;
+        }
+    };
+
+    struct tag_invocable_noexcept
+    {
+        friend constexpr bool tag_invoke(
+            foo_fn, tag_invocable_noexcept) noexcept
+        {
+            return false;
+        }
+    };
+
+    struct tag_not_invocable
+    {
+    };
+}    // namespace mylib
+
+namespace otherlib {
+    struct tag_invocable
+    {
+        friend constexpr bool tag_invoke(mylib::foo_fn, tag_invocable)
+        {
+            return true;
+        }
+    };
+
+    struct tag_invocable_noexcept
+    {
+        friend constexpr bool tag_invoke(
+            mylib::foo_fn, tag_invocable_noexcept) noexcept
+        {
+            return false;
+        }
+    };
+
+    struct tag_not_invocable
+    {
+    };
+}    // namespace otherlib
+
+namespace testlib {
+    struct tag_invocable
+    {
+        friend constexpr int tag_invoke(mylib::foo_fn, tag_invocable const&)
+        {
+            return 0;
+        }
+        friend constexpr int tag_invoke(mylib::foo_fn, tag_invocable&)
+        {
+            return 1;
+        }
+        friend constexpr int tag_invoke(mylib::foo_fn, tag_invocable const&&)
+        {
+            return 2;
+        }
+        friend constexpr int tag_invoke(mylib::foo_fn, tag_invocable&&)
+        {
+            return 3;
+        }
+    };
+
+    struct tag_invocable2
+    {
+        template <typename T>
+        friend constexpr auto tag_invoke(mylib::bar_fn, tag_invocable2, T&& t)
+            -> decltype(t)
+        {
+            return std::forward<T>(t);
+        }
+    };
+}    // namespace testlib
+
+int main()
+{
+    // Check if is_invocable trait works
+    static_assert(hpx::functional::is_tag_invocable_v<mylib::foo_fn,
+                      mylib::tag_invocable>,
+        "Should be tag invocable");
+    static_assert(hpx::functional::is_tag_invocable_v<mylib::foo_fn,
+                      mylib::tag_invocable_noexcept>,
+        "Should be tag invocable");
+    static_assert(!hpx::functional::is_tag_invocable_v<mylib::foo_fn,
+                      mylib::tag_not_invocable>,
+        "Should not be tag invocable");
+    static_assert(!hpx::functional::is_tag_invocable_v<mylib::foo_fn,
+                      mylib::tag_invocable2>,
+        "Should not be tag invocable");
+
+    static_assert(hpx::functional::is_tag_invocable_v<mylib::foo_fn,
+                      otherlib::tag_invocable>,
+        "Should be tag invocable");
+    static_assert(hpx::functional::is_tag_invocable_v<mylib::foo_fn,
+                      otherlib::tag_invocable_noexcept>,
+        "Should be tag invocable");
+    static_assert(!hpx::functional::is_tag_invocable_v<mylib::foo_fn,
+                      otherlib::tag_not_invocable>,
+        "Should not be tag invocable");
+
+    // Check if is_nothrow_invocable trait works
+    static_assert(!hpx::functional::is_nothrow_tag_invocable_v<mylib::foo_fn,
+                      mylib::tag_invocable>,
+        "Should not be nothrow tag invocable");
+    static_assert(hpx::functional::is_nothrow_tag_invocable_v<mylib::foo_fn,
+                      mylib::tag_invocable_noexcept>,
+        "Should be nothrow tag invocable");
+    static_assert(!hpx::functional::is_nothrow_tag_invocable_v<mylib::foo_fn,
+                      mylib::tag_not_invocable>,
+        "Should not be nothrow tag invocable");
+    static_assert(!hpx::functional::is_nothrow_tag_invocable_v<mylib::foo_fn,
+                      mylib::tag_invocable2>,
+        "Should not be nothrow tag invocable");
+
+    static_assert(!hpx::functional::is_nothrow_tag_invocable_v<mylib::foo_fn,
+                      otherlib::tag_invocable>,
+        "Should not be nothrow tag invocable");
+    static_assert(hpx::functional::is_nothrow_tag_invocable_v<mylib::foo_fn,
+                      otherlib::tag_invocable_noexcept>,
+        "Should be nothrow tag invocable");
+    static_assert(!hpx::functional::is_nothrow_tag_invocable_v<mylib::foo_fn,
+                      otherlib::tag_not_invocable>,
+        "Should not be nothrow tag invocable");
+
+    // Check if we properly propagate type categories
+    constexpr testlib::tag_invocable dut0;
+    static_assert(
+        mylib::foo(dut0) == 0, "Needs to call the const ref overload");
+    static_assert(mylib::foo(std::move(dut0)) == 2,
+        "Needs to call the const ref overload");
+
+    testlib::tag_invocable dut1;
+    // Needs to call the non-const ref overload
+    HPX_TEST_EQ(mylib::foo(dut1), 1);
+    // Needs to call the rvalue ref overload
+    HPX_TEST_EQ(mylib::foo(std::move(dut1)), 3);
+
+    static_assert(hpx::functional::is_tag_invocable_v<mylib::bar_fn,
+                      testlib::tag_invocable2, int>,
+        "Should be tag invocable");
+    static_assert(hpx::functional::is_tag_invocable_v<mylib::bar_fn,
+                      testlib::tag_invocable2, int&>,
+        "Should be tag invocable");
+    static_assert(hpx::functional::is_tag_invocable_v<mylib::bar_fn,
+                      testlib::tag_invocable2, int const&>,
+        "Should be tag invocable");
+    static_assert(hpx::functional::is_tag_invocable_v<mylib::bar_fn,
+                      testlib::tag_invocable2, int const&&>,
+        "Should be tag invocable");
+    static_assert(hpx::functional::is_tag_invocable_v<mylib::bar_fn,
+                      testlib::tag_invocable2, int&&>,
+        "Should be tag invocable");
+    static_assert(!hpx::functional::is_tag_invocable_v<mylib::bar_fn,
+                      testlib::tag_invocable2>,
+        "Should not be tag invocable");
+    static_assert(!hpx::functional::is_tag_invocable_v<mylib::bar_fn,
+                      testlib::tag_invocable2, int, int>,
+        "Should not be tag invocable");
+
+    int i = 0;
+    HPX_TEST_EQ(&mylib::bar(testlib::tag_invocable2{}, i), &i);
+    static_assert(
+        std::is_same_v<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
+                           testlib::tag_invocable2, int>,
+            int&&>,
+        "Result type needs to match");
+    static_assert(
+        std::is_same_v<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
+                           testlib::tag_invocable2, int const&>,
+            int const&>,
+        "Result type needs to match");
+    static_assert(
+        std::is_same_v<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
+                           testlib::tag_invocable2, int&>,
+            int&>,
+        "Result type needs to match");
+    static_assert(
+        std::is_same_v<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
+                           testlib::tag_invocable2, int const&&>,
+            int const&&>,
+        "Result type needs to match");
+    static_assert(
+        std::is_same_v<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
+                           testlib::tag_invocable2, int&&>,
+            int&&>,
+        "Result type needs to match");
+    static_assert(
+        std::is_same_v<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
+                           testlib::tag_invocable2, int>,
+            decltype(
+                mylib::bar(testlib::tag_invocable2{}, std::declval<int>()))>,
+        "Result type needs to match");
+    static_assert(
+        std::is_same_v<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
+                           testlib::tag_invocable2, int const&>,
+            decltype(mylib::bar(
+                testlib::tag_invocable2{}, std::declval<int const&>()))>,
+        "Result type needs to match");
+    static_assert(
+        std::is_same_v<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
+                           testlib::tag_invocable2, int&>,
+            decltype(
+                mylib::bar(testlib::tag_invocable2{}, std::declval<int&>()))>,
+        "Result type needs to match");
+    static_assert(
+        std::is_same_v<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
+                           testlib::tag_invocable2, int const&&>,
+            decltype(mylib::bar(
+                testlib::tag_invocable2{}, std::declval<int const&&>()))>,
+        "Result type needs to match");
+    static_assert(
+        std::is_same_v<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
+                           testlib::tag_invocable2, int&&>,
+            decltype(
+                mylib::bar(testlib::tag_invocable2{}, std::declval<int&&>()))>,
+        "Result type needs to match");
+    static_assert(mylib::bar(testlib::tag_invocable2{}, 42) == 42,
+        "This function should be constexpr evaluated");
+
+    return hpx::util::report_errors();
+}

--- a/libs/functional/tests/unit/tag_invoke.cpp
+++ b/libs/functional/tests/unit/tag_invoke.cpp
@@ -209,59 +209,59 @@ int main()
     int i = 0;
     HPX_TEST_EQ(&mylib::bar(testlib::tag_invocable2{}, i), &i);
     static_assert(
-        std::is_same_v<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
-                           testlib::tag_invocable2, int>,
-            int&&>,
+        std::is_same<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
+                         testlib::tag_invocable2, int>,
+            int&&>::value,
         "Result type needs to match");
     static_assert(
-        std::is_same_v<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
-                           testlib::tag_invocable2, int const&>,
-            int const&>,
+        std::is_same<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
+                         testlib::tag_invocable2, int const&>,
+            int const&>::value,
         "Result type needs to match");
     static_assert(
-        std::is_same_v<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
-                           testlib::tag_invocable2, int&>,
-            int&>,
+        std::is_same<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
+                         testlib::tag_invocable2, int&>,
+            int&>::value,
         "Result type needs to match");
     static_assert(
-        std::is_same_v<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
-                           testlib::tag_invocable2, int const&&>,
-            int const&&>,
+        std::is_same<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
+                         testlib::tag_invocable2, int const&&>,
+            int const&&>::value,
         "Result type needs to match");
     static_assert(
-        std::is_same_v<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
-                           testlib::tag_invocable2, int&&>,
-            int&&>,
+        std::is_same<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
+                         testlib::tag_invocable2, int&&>,
+            int&&>::value,
         "Result type needs to match");
     static_assert(
-        std::is_same_v<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
-                           testlib::tag_invocable2, int>,
-            decltype(
-                mylib::bar(testlib::tag_invocable2{}, std::declval<int>()))>,
-        "Result type needs to match");
-    static_assert(
-        std::is_same_v<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
-                           testlib::tag_invocable2, int const&>,
+        std::is_same<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
+                         testlib::tag_invocable2, int>,
             decltype(mylib::bar(
-                testlib::tag_invocable2{}, std::declval<int const&>()))>,
+                testlib::tag_invocable2{}, std::declval<int>()))>::value,
         "Result type needs to match");
     static_assert(
-        std::is_same_v<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
-                           testlib::tag_invocable2, int&>,
-            decltype(
-                mylib::bar(testlib::tag_invocable2{}, std::declval<int&>()))>,
-        "Result type needs to match");
-    static_assert(
-        std::is_same_v<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
-                           testlib::tag_invocable2, int const&&>,
+        std::is_same<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
+                         testlib::tag_invocable2, int const&>,
             decltype(mylib::bar(
-                testlib::tag_invocable2{}, std::declval<int const&&>()))>,
+                testlib::tag_invocable2{}, std::declval<int const&>()))>::value,
         "Result type needs to match");
     static_assert(
-        std::is_same_v<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
-                           testlib::tag_invocable2, int&&>,
-            decltype(
-                mylib::bar(testlib::tag_invocable2{}, std::declval<int&&>()))>,
+        std::is_same<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
+                         testlib::tag_invocable2, int&>,
+            decltype(mylib::bar(
+                testlib::tag_invocable2{}, std::declval<int&>()))>::value,
+        "Result type needs to match");
+    static_assert(
+        std::is_same<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
+                         testlib::tag_invocable2, int const&&>,
+            decltype(mylib::bar(testlib::tag_invocable2{},
+                std::declval<int const&&>()))>::value,
+        "Result type needs to match");
+    static_assert(
+        std::is_same<hpx::functional::tag_invoke_result_t<mylib::bar_fn,
+                         testlib::tag_invocable2, int&&>,
+            decltype(mylib::bar(
+                testlib::tag_invocable2{}, std::declval<int&&>()))>::value,
         "Result type needs to match");
     static_assert(mylib::bar(testlib::tag_invocable2{}, 42) == 42,
         "This function should be constexpr evaluated");


### PR DESCRIPTION
This PR introduces `hpx::functional::tag_invoke` which is an implementation
of https://wg21.link/p1895. This is needed to implement https://wg21.link/p0443.