### PR TITLE
Fix schedule hint not being taken from executor

### DIFF
--- a/hpx/lcos/local/futures_factory.hpp
+++ b/hpx/lcos/local/futures_factory.hpp
@@ -264,7 +264,7 @@ namespace hpx { namespace lcos { namespace local {
                     parallel::execution::post(*exec_,
                         util::deferred_call(
                             &base_type::run_impl, std::move(this_)),
-                        schedulehint, annotation);
+                        exec_->get_schedulehint(), annotation);
                     return threads::invalid_thread_id;
                 }
 

--- a/libs/schedulers/include/hpx/schedulers/queue_holder_thread.hpp
+++ b/libs/schedulers/include/hpx/schedulers/queue_holder_thread.hpp
@@ -700,7 +700,7 @@ namespace hpx { namespace threads { namespace policies {
             std::int64_t add_count, thread_holder_type* addfrom, bool stealing)
         {
             std::size_t added;
-            if (owns_bp_queue())
+            if (owns_bp_queue() && !stealing)
             {
                 added =
                     bp_queue_->add_new(add_count, addfrom->bp_queue_, stealing);

--- a/libs/thread_executors/CMakeLists.txt
+++ b/libs/thread_executors/CMakeLists.txt
@@ -56,7 +56,7 @@ set(thread_executors_sources
 
 include(HPX_AddModule)
 add_hpx_module(thread_executors
-  COMPATIBILITY_HEADERS OFF
+  COMPATIBILITY_HEADERS ON
   DEPRECATION_WARNINGS
   FORCE_LINKING_GEN
   GLOBAL_HEADER_GEN ON

--- a/libs/thread_executors/include/hpx/thread_executors/thread_executor.hpp
+++ b/libs/thread_executors/include/hpx/thread_executors/thread_executor.hpp
@@ -255,6 +255,10 @@ namespace hpx { namespace threads {
             {
                 return stacksize_;
             }
+            thread_schedule_hint get_schedulehint() const
+            {
+                return schedulehint_;
+            }
 
         protected:
             thread_stacksize stacksize_;
@@ -460,6 +464,11 @@ namespace hpx { namespace threads {
             return static_cast<detail::scheduled_executor_base*>(
                 executor_data_.get())
                 ->get_stacksize();
+        }
+
+        thread_schedule_hint get_schedulehint() const {
+            return static_cast<detail::scheduled_executor_base*>
+                    (executor_data_.get())->get_schedulehint();
         }
     };
 }}    // namespace hpx::threads

--- a/libs/thread_executors/include/hpx/thread_executors/thread_executor.hpp
+++ b/libs/thread_executors/include/hpx/thread_executors/thread_executor.hpp
@@ -466,9 +466,11 @@ namespace hpx { namespace threads {
                 ->get_stacksize();
         }
 
-        thread_schedule_hint get_schedulehint() const {
-            return static_cast<detail::scheduled_executor_base*>
-                    (executor_data_.get())->get_schedulehint();
+        thread_schedule_hint get_schedulehint() const
+        {
+            return static_cast<detail::scheduled_executor_base*>(
+                executor_data_.get())
+                ->get_schedulehint();
         }
     };
 }}    // namespace hpx::threads

--- a/tests/unit/resource/CMakeLists.txt
+++ b/tests/unit/resource/CMakeLists.txt
@@ -5,6 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    scheduler_binding_check
     scheduler_priority_check
     shutdown_suspended_pus
     suspend_disabled
@@ -27,6 +28,7 @@ endif()
 # NB. threads = -1 = threads = 'all'
 
 set(scheduler_priority_check_PARAMETERS THREADS_PER_LOCALITY -1)
+set(scheduler_binding_check_PARAMETERS THREADS_PER_LOCALITY -1)
 set(shutdown_suspended_pus_PARAMETERS THREADS_PER_LOCALITY 4)
 set(suspend_disabled_PARAMETERS THREADS_PER_LOCALITY 4)
 set(suspend_pool_PARAMETERS THREADS_PER_LOCALITY 4)

--- a/tests/unit/resource/CMakeLists.txt
+++ b/tests/unit/resource/CMakeLists.txt
@@ -5,7 +5,6 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
-    scheduler_binding_check
     scheduler_priority_check
     shutdown_suspended_pus
     suspend_disabled
@@ -20,15 +19,16 @@ set(tests
 if(HPX_WITH_SHARED_PRIORITY_SCHEDULER)
   set(tests ${tests}
       cross_pool_injection
+      scheduler_binding_check
     )
   set(cross_pool_injection_PARAMETERS THREADS_PER_LOCALITY -1)
+  set(scheduler_binding_check_PARAMETERS THREADS_PER_LOCALITY -1)
 endif()
 
 # NB. threads = -2 = threads = 'cores'
 # NB. threads = -1 = threads = 'all'
 
 set(scheduler_priority_check_PARAMETERS THREADS_PER_LOCALITY -1)
-set(scheduler_binding_check_PARAMETERS THREADS_PER_LOCALITY -1)
 set(shutdown_suspended_pus_PARAMETERS THREADS_PER_LOCALITY 4)
 set(suspend_disabled_PARAMETERS THREADS_PER_LOCALITY 4)
 set(suspend_pool_PARAMETERS THREADS_PER_LOCALITY 4)

--- a/tests/unit/resource/scheduler_binding_check.cpp
+++ b/tests/unit/resource/scheduler_binding_check.cpp
@@ -1,0 +1,86 @@
+#include <hpx/hpx_init.hpp>
+#include <hpx/async.hpp>
+#include <hpx/runtime/threads/executors/default_executor.hpp>
+#include <hpx/testing.hpp>
+#include <hpx/parallel/executors/thread_pool_executors.hpp>
+#include <hpx/runtime/threads/executors/pool_executor.hpp>
+#include <hpx/runtime/threads/policies/shared_priority_queue_scheduler.hpp>
+#include <hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp>
+
+// counts down on destruction
+struct dec_counter
+{
+    explicit dec_counter(std::atomic<int>& counter)
+      : counter_(counter)
+    {
+    }
+    ~dec_counter()
+    {
+        --counter_;
+    }
+    //
+    std::atomic<int>& counter_;
+};
+
+void threadLoop()
+{
+   const unsigned iterations = 256;
+   std::atomic<int> count_down(iterations);
+
+   auto f = [&count_down](std::size_t threadnum) {
+      dec_counter dec(count_down);
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      std::size_t thread_num = hpx::get_worker_thread_num();
+      std::cout << "Running on thread num: " << thread_num
+                << " Expected  " << threadnum << std::endl;
+      HPX_TEST_EQ(thread_num, threadnum);
+   };
+
+   std::size_t threads = hpx::get_num_worker_threads();
+   // launch tasks on threads using numbering 0,1,2,3...0,1,2,3
+   for(std::size_t i=0; i<iterations; ++i){
+       auto exec = hpx::threads::executors::default_executor(
+                        hpx::threads::thread_priority_bound,
+                        hpx::threads::thread_stacksize_default,
+                        hpx::threads::thread_schedule_hint(std::int16_t(i % threads)));
+      hpx::async(exec, f, (i % threads)).get();
+   }
+
+   do
+   {
+       hpx::this_thread::yield();
+   } while (count_down > 0);
+
+   return;
+}
+
+int hpx_main(boost::program_options::variables_map &)
+{
+    auto const current = hpx::threads::get_self_id_data()->get_scheduler_base();
+    std::cout << "Scheduler is " << current->get_description() << std::endl;
+    if (std::string("core-shared_priority_queue_scheduler") != current->get_description()) {
+        std::cout << "The scheduler won't work properly " << std::endl;
+    }
+
+    threadLoop();
+    hpx::finalize();
+    return hpx::util::report_errors();
+}
+
+int main(int argc, char* argv[])
+{
+    // Configure application-specific options.
+    hpx::program_options::options_description
+       desc_cmdline("Usage: " HPX_APPLICATION_STRING " [options]");
+
+    // Create the resource partitioner
+    hpx::resource::partitioner rp(desc_cmdline, argc, argv);
+
+    // setup the default pool with a numa/binding aware scheduler
+    rp.create_thread_pool("default",
+        hpx::resource::scheduling_policy::shared_priority,
+        hpx::threads::policies::scheduler_mode(
+            hpx::threads::policies::default_mode));
+
+    return hpx::init(desc_cmdline, argc, argv);
+}

--- a/tests/unit/resource/scheduler_binding_check.cpp
+++ b/tests/unit/resource/scheduler_binding_check.cpp
@@ -1,3 +1,13 @@
+//  Copyright (c) 2020 John Biddiscombe
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Test that loops over each core assigned to the program and launches
+// tasks bound to that core incrementally.
+// Tasks should always report the right core number when they run.
+
 #include <hpx/hpx_init.hpp>
 #include <hpx/async.hpp>
 #include <hpx/runtime/threads/executors/default_executor.hpp>

--- a/tests/unit/resource/scheduler_binding_check.cpp
+++ b/tests/unit/resource/scheduler_binding_check.cpp
@@ -13,10 +13,8 @@
 #include <hpx/execution/executors/execution.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/threads.hpp>
-#include <hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp>
-#include <hpx/runtime/threads/executors/default_executor.hpp>
-#include <hpx/runtime/threads/executors/pool_executor.hpp>
-#include <hpx/runtime/threads/policies/shared_priority_queue_scheduler.hpp>
+#include <hpx/thread_executors/default_executor.hpp>
+#include <hpx/schedulers/shared_priority_queue_scheduler.hpp>
 #include <hpx/testing.hpp>
 
 #include <atomic>

--- a/tests/unit/resource/scheduler_binding_check.cpp
+++ b/tests/unit/resource/scheduler_binding_check.cpp
@@ -57,11 +57,6 @@ void threadLoop()
         std::size_t thread_actual = hpx::get_worker_thread_num();
         hpx::deb_schbin.debug(hpx::debug::str<>("Running on thread"),
             thread_actual, "Expected", thread_expected);
-        if (thread_actual != thread_expected)
-        {
-            hpx::deb_schbin.error(hpx::debug::str<>("actual!=expected"), "Got",
-                thread_actual, "Expected", thread_expected);
-        }
         HPX_TEST_EQ(thread_actual, thread_expected);
     };
 


### PR DESCRIPTION
A user on IRC posted a request to bind tasks to threads, but when using the default executor, the schedulehint was not being taken from the executor, instead the default was being used.