### PR TITLE
Undefine VT1 and VT2 after boost includes.

### DIFF
--- a/hpx/plugins/parcelport/tcp/receiver.hpp
+++ b/hpx/plugins/parcelport/tcp/receiver.hpp
@@ -34,6 +34,16 @@
 #include <boost/asio/placeholders.hpp>
 #include <boost/asio/read.hpp>
 #include <boost/asio/write.hpp>
+/* The boost asio support includes termios.h.
+ * The termios.h file on ppc64le defines these macros, which
+ * are also used by blaze, blaze_tensor as Template names.
+ * Make sure we undefine them before continuing. */
+#ifdef VT1
+#undef VT1
+#endif
+#ifdef VT2
+#undef VT2
+#endif
 
 #include <cstddef>
 #include <cstdint>

--- a/hpx/plugins/parcelport/tcp/receiver.hpp
+++ b/hpx/plugins/parcelport/tcp/receiver.hpp
@@ -38,12 +38,8 @@
  * The termios.h file on ppc64le defines these macros, which
  * are also used by blaze, blaze_tensor as Template names.
  * Make sure we undefine them before continuing. */
-#ifdef VT1
 #undef VT1
-#endif
-#ifdef VT2
 #undef VT2
-#endif
 
 #include <cstddef>
 #include <cstdint>

--- a/hpx/plugins/parcelport/tcp/sender.hpp
+++ b/hpx/plugins/parcelport/tcp/sender.hpp
@@ -36,6 +36,16 @@
 #include <boost/asio/placeholders.hpp>
 #include <boost/asio/read.hpp>
 #include <boost/asio/write.hpp>
+/* The boost asio support includes termios.h.
+ * The termios.h file on ppc64le defines these macros, which
+ * are also used by blaze, blaze_tensor as Template names.
+ * Make sure we undefine them before continuing. */
+#ifdef VT1
+#undef VT1
+#endif
+#ifdef VT2
+#undef VT2
+#endif
 
 #include <cstddef>
 #include <memory>

--- a/hpx/plugins/parcelport/tcp/sender.hpp
+++ b/hpx/plugins/parcelport/tcp/sender.hpp
@@ -40,12 +40,8 @@
  * The termios.h file on ppc64le defines these macros, which
  * are also used by blaze, blaze_tensor as Template names.
  * Make sure we undefine them before continuing. */
-#ifdef VT1
 #undef VT1
-#endif
-#ifdef VT2
 #undef VT2
-#endif
 
 #include <cstddef>
 #include <memory>

--- a/hpx/util/asio_util.hpp
+++ b/hpx/util/asio_util.hpp
@@ -18,6 +18,16 @@
 
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/tcp.hpp>
+/* The boost asio support includes termios.h.
+ * The termios.h file on ppc64le defines these macros, which
+ * are also used by blaze, blaze_tensor as Template names.
+ * Make sure we undefine them before continuing. */
+#ifdef VT1
+#undef VT1
+#endif
+#ifdef VT2
+#undef VT2
+#endif
 
 namespace hpx { namespace util
 {

--- a/hpx/util/asio_util.hpp
+++ b/hpx/util/asio_util.hpp
@@ -22,12 +22,8 @@
  * The termios.h file on ppc64le defines these macros, which
  * are also used by blaze, blaze_tensor as Template names.
  * Make sure we undefine them before continuing. */
-#ifdef VT1
 #undef VT1
-#endif
-#ifdef VT2
 #undef VT2
-#endif
 
 namespace hpx { namespace util
 {

--- a/hpx/util/io_service_pool.hpp
+++ b/hpx/util/io_service_pool.hpp
@@ -21,12 +21,8 @@
  * The termios.h file on ppc64le defines these macros, which
  * are also used by blaze, blaze_tensor as Template names.
  * Make sure we undefine them before continuing. */
-#ifdef VT1
 #undef VT1
-#endif
-#ifdef VT2
 #undef VT2
-#endif
 
 #include <cstddef>
 #include <memory>

--- a/hpx/util/io_service_pool.hpp
+++ b/hpx/util/io_service_pool.hpp
@@ -17,6 +17,16 @@
 #include <hpx/runtime/threads/policies/callback_notifier.hpp>
 
 #include <boost/asio/io_service.hpp>
+/* The boost asio support includes termios.h.
+ * The termios.h file on ppc64le defines these macros, which
+ * are also used by blaze, blaze_tensor as Template names.
+ * Make sure we undefine them before continuing. */
+#ifdef VT1
+#undef VT1
+#endif
+#ifdef VT2
+#undef VT2
+#endif
 
 #include <cstddef>
 #include <memory>


### PR DESCRIPTION
The boost asio support includes termios.h.
The termios.h file on ppc64le defines these macros, which
are also used by blaze, blaze_tensor as Template names.
Make sure we undefine them before continuing.

Fixes phylanx bug https://github.com/STEllAR-GROUP/phylanx/issues/1088

## Proposed Changes

  - After boost/asio includes, undefine VT1 and VT2.

## Any background context you want to provide?

As requested by @hkaiser, this is a better solution than using `sed` on the blaze library, and it works.