### PR TITLE
Enable compatibility headers option for execution module

### DIFF
--- a/libs/execution/CMakeLists.txt
+++ b/libs/execution/CMakeLists.txt
@@ -126,6 +126,7 @@ include(HPX_AddModule)
 add_hpx_module(execution
   FORCE_LINKING_GEN
   HEADERS ${execution_headers}
+  COMPATIBILITY_HEADERS ON    # Added in 1.5.0
   COMPAT_HEADERS ${execution_compat_headers}
   DEPENDENCIES
     hpx_assertion


### PR DESCRIPTION
Enables the option for compatibility headers in the execution module.