### PR TITLE
Usage of temporary allocator in assignment operator of compute::vector

### DIFF
--- a/libs/compute/include/hpx/compute/vector.hpp
+++ b/libs/compute/include/hpx/compute/vector.hpp
@@ -168,11 +168,10 @@ namespace hpx { namespace compute {
         {
             if (this == &other)
                 return *this;
-            
+
             allocator_type tmp_alloc = other.alloc_;
 
-            pointer data =
-                alloc_traits::allocate(tmp_alloc, other.capacity_);
+            pointer data = alloc_traits::allocate(tmp_alloc, other.capacity_);
             hpx::parallel::util::copy(other.begin(), other.end(),
                 iterator(data, 0, alloc_traits::target(tmp_alloc)));
 

--- a/libs/compute/include/hpx/compute/vector.hpp
+++ b/libs/compute/include/hpx/compute/vector.hpp
@@ -184,7 +184,7 @@ namespace hpx { namespace compute {
 
             size_ = other.size_;
             capacity_ = other.capacity_;
-            alloc_ = other.alloc_;
+            alloc_ = std::move(tmp_alloc);
             data_ = std::move(data);
 
             return *this;

--- a/libs/compute/include/hpx/compute/vector.hpp
+++ b/libs/compute/include/hpx/compute/vector.hpp
@@ -168,11 +168,13 @@ namespace hpx { namespace compute {
         {
             if (this == &other)
                 return *this;
+            
+            allocator_type tmp_alloc = other.alloc_;
 
             pointer data =
-                alloc_traits::allocate(other.alloc_, other.capacity_);
+                alloc_traits::allocate(tmp_alloc, other.capacity_);
             hpx::parallel::util::copy(other.begin(), other.end(),
-                iterator(data, 0, alloc_traits::target(other.alloc_)));
+                iterator(data, 0, alloc_traits::target(tmp_alloc)));
 
             if (data_ != nullptr)
             {


### PR DESCRIPTION
Fix of issue #4323.

## Proposed Changes

  - Addition of a temporary allocator, which stores the assigned vector's allocator

## Any background context you want to provide?
As discussed on the #ste||ar IRC channel with @K-ballo.
