### PR TITLE
Spelling corrections and CircleCI spell check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,6 +249,23 @@ jobs:
           paths:
             - ./build/bin/inspect
 
+  # We need a full clone here to be able to compare to master.
+  spellcheck:
+    <<: *defaults
+    steps:
+      - checkout:
+          path: /hpx/source
+      - run:
+          name: Running codespell
+          command: |
+              cd /hpx/source
+              codespell $(git diff --name-only origin/master) > /tmp/spelling_suggestions.txt
+              if [ -s /tmp/spelling_suggestions.txt ]; then exit 1; fi
+          when: always
+      - store_artifacts:
+          path: /tmp/spelling_suggestions.txt
+          destination: /hpx/artifacts/spelling_suggestions.txt
+
   docs:
     <<: *defaults
     steps:
@@ -1043,6 +1060,8 @@ workflows:
           requires:
             - configure
           <<: *gh_pages_filter
+      - spellcheck:
+          <<: *gh_pages_filter
       - docs:
           requires:
             - configure
@@ -1112,6 +1131,7 @@ workflows:
       - install:
           requires:
             - inspect
+            - spellcheck
             - core
             - docs
             - tests.examples

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
           path: /tmp/circular_deps.svg
           destination: /hpx/artifacts/circular_deps.svg
 
-  # Insure that the modules stay clang-formatted
+  # Ensure that the modules stay clang-formatted
   clang_format:
     <<: *defaults
     steps:
@@ -1001,7 +1001,7 @@ jobs:
           name: Push stable tag
           command: |
               if [[ -z "$CIRCLE_PR_NUMBER" ]] && [[ "$CIRCLE_BRANCH" == "master" ]]; then
-                  # Tag the commmit
+                  # Tag the commit
                   cd /hpx/source
                   git tag -f stable
                   ##########################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,7 +458,7 @@ if(HPX_WITH_AUTOMATIC_SERIALIZATION_REGISTRATION)
 endif()
 
 hpx_option(HPX_WITH_ZERO_COPY_SERIALIZATION_THRESHOLD STRING
-  "The threshhold in bytes to when perform zero copy optimizations (default: 128)"
+  "The threshold in bytes to when perform zero copy optimizations (default: 128)"
   "128"
   ADVANCED)
 hpx_add_config_define(HPX_ZERO_COPY_SERIALIZATION_THRESHOLD ${HPX_WITH_ZERO_COPY_SERIALIZATION_THRESHOLD})
@@ -1596,7 +1596,7 @@ hpx_option(HPX_FILESYSTEM_WITH_BOOST_FILESYSTEM_COMPATIBILITY
 # Find Our dependencies:
 #   These are all dependencies needed to build the core library. Dependencies
 #   that are only needed by plugins, examples or tests should be found
-#   seperately in the appropriate subdirectory.
+#   separately in the appropriate subdirectory.
 
 # Setup our required Boost libraries.
 include(HPX_SetupBoost)

--- a/docs/sphinx/contributing/modules.rst
+++ b/docs/sphinx/contributing/modules.rst
@@ -93,7 +93,7 @@ Optional multi-value arguments-are:
 The ``include`` directory should contain only headers that other libraries need.
 For each of those headers, an automatic header test to check for self
 containment will be generated. Private headers should be placed under the
-``src`` directory. This allows for clear seperation. The ``cmake`` subdirectory
+``src`` directory. This allows for clear separation. The ``cmake`` subdirectory
 may include additional |cmake|_ scripts needed to generate the respective build
 configurations.
 

--- a/docs/sphinx/contributing/release_procedure.rst
+++ b/docs/sphinx/contributing/release_procedure.rst
@@ -175,7 +175,7 @@ are completed to avoid confusion.
       release. Set the date to "unreleased". Make sure you add it to the table
       of contents in ``docs/sphinx/releases.rst``.
 
-   #. Modify the the release procedure if necessary.
+   #. Modify the release procedure if necessary.
 
    #. Merge new branch containing next version numbers to master; resolve conflicts
       if necessary.

--- a/docs/sphinx/examples/1d_stencil.rst
+++ b/docs/sphinx/examples/1d_stencil.rst
@@ -162,7 +162,7 @@ functions to run on.
 
 In example 6, we begin to distribute the partition data on different nodes. This
 is accomplished in ``stepper::do_work()`` by passing the GID of the
-:term:`locality` where we wish to create the partition to the the partition
+:term:`locality` where we wish to create the partition to the partition
 constructor.
 
 .. literalinclude:: ../../examples/1d_stencil/1d_stencil_6.cpp

--- a/docs/sphinx/manual/creating_hpx_projects.rst
+++ b/docs/sphinx/manual/creating_hpx_projects.rst
@@ -402,7 +402,7 @@ To build the program, type:
 
    make
 
-A successfull build should result in hello_world binary. To test, type:
+A successful build should result in hello_world binary. To test, type:
 
 .. code-block:: bash
 
@@ -470,7 +470,7 @@ To build the program, type:
 
    make
 
-A successfull build should result in hello_world binary. To test, type:
+A successful build should result in hello_world binary. To test, type:
 
 .. code-block:: bash
 

--- a/docs/sphinx/manual/hpx_runtime_and_resources.rst
+++ b/docs/sphinx/manual/hpx_runtime_and_resources.rst
@@ -176,7 +176,7 @@ thread pool.
 
 .. note::
 
-   It is simpler in some situations to to schedule important tasks with high
+   It is simpler in some situations to schedule important tasks with high
    priority instead of using a separate thread pool.
 
 Using the resource partitioner

--- a/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
+++ b/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
@@ -366,8 +366,8 @@ The ``hpx.thread_queue`` configuration section
        converted into |hpx| threads whenever the thread queues for a core have
        run empty.
    * * ``hpx.thread_queue.max_delete_count``
-     * The value of this property defines the number number of terminated |hpx|
-       threads to discard during each invocation of the corresponding function.
+     * The value of this property defines the number of terminated |hpx| threads
+       to discard during each invocation of the corresponding function.
 
 The ``hpx.components`` configuration section
 ............................................
@@ -598,7 +598,7 @@ equivalent cmake variable is ``HPX_WITH_PARCELPORT_MPI`` and has to be set to
    * * ``hpx.parcel.mpi.enable``
      * Enable the use of the MPI parcelport. HPX tries to detect if the
        application was started within a parallel MPI environment. If the
-       detection was succesful, the MPI parcelport is enabled by default. To
+       detection was successful, the MPI parcelport is enabled by default. To
        explicitly disable the MPI parcelport, set to 0. Note that the initial
        bootstrap of the overall |hpx| application will be performed using MPI as
        well.
@@ -1498,7 +1498,7 @@ The predefined command line options for any application using
 
 
 |hpx| configuration options
---------------------------
+---------------------------
 
 .. option:: --hpx:app-config arg
 

--- a/docs/sphinx/manual/optimizing_hpx_applications.rst
+++ b/docs/sphinx/manual/optimizing_hpx_applications.rst
@@ -1021,9 +1021,9 @@ system and application performance.
 
        Please see :ref:`cmake_variables` for more details.
      * If the configure-time option ``-DHPX_WITH_PARCELPORT_ACTION_COUNTERS=On``
-       was specified, this counter allows to specify an optional action name as
-       its parameter. In this case the counter will report the number of bytes
-       transmitted for the given action only.
+       was specified, this counter allows one to specify an optional action name
+       as its parameter. In this case the counter will report the number of
+       bytes transmitted for the given action only.
    * * ``/serialize/time/<connection_type>/<operation>``
 
        where:
@@ -1050,8 +1050,8 @@ system and application performance.
 
        Please see :ref:`cmake_variables` for more details.
      * If the configure-time option ``-DHPX_WITH_PARCELPORT_ACTION_COUNTERS=On``
-       was specified, this counter allows to specify an optional action name as
-       its parameter. In this case the counter will report the serialization
+       was specified, this counter allows one to specify an optional action name
+       as its parameter. In this case the counter will report the serialization
        time for the given action only.
    * * ``/parcels/count/routed``
      * ``locality#*/total``
@@ -1072,9 +1072,9 @@ system and application performance.
        :term:`AGAS` service component will deliver the parcel to its final
        target.
      * If the configure-time option ``-DHPX_WITH_PARCELPORT_ACTION_COUNTERS=On``
-       was specified, this counter allows to specify an optional action name as
-       its parameter. In this case the counter will report the number of parcels
-       for the given action only.
+       was specified, this counter allows one to specify an optional action name
+       as its parameter. In this case the counter will report the number of
+       parcels for the given action only.
    * * ``/parcels/count/<connection_type>/<operation>``
 
        where:

--- a/docs/sphinx/manual/writing_distributed_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_distributed_hpx_applications.rst
@@ -1129,7 +1129,7 @@ number of images per :term:`locality` to create::
         bulk_action act;
         std::size_t images_per_locality = 4;
 
-        // Instanciate the parallel section
+        // Instantiate the parallel section
         hpx::lcos::define_spmd_block(
             "some_name", images_per_locality, std::move(act) /*, arg0, arg1, ... */);
 
@@ -1216,7 +1216,7 @@ Here are some examples of using subscripts in the 2-D view case::
     {
         std::size_t height, width;
 
-        // Instanciate the view
+        // Instantiate the view
         View_2D vv(block, v.begin(), v.end(), {height,width});
 
         // The l-value is a view subscript, the image that owns vv(1,0)
@@ -1255,7 +1255,7 @@ Here are some examples of using iterators in the 3-D view case::
     {
         std::size_t sixe_x, size_y, size_z;
 
-        // Instanciate the views
+        // Instantiate the views
         View_3D vv1(block, v1.begin(), v1.end(), {sixe_x,size_y,size_z});
         View_3D vv2(block, v2.begin(), v2.end(), {sixe_x,size_y,size_z});
 
@@ -1310,10 +1310,10 @@ owned by the current image::
     {
         std::size_t num_segments;
 
-        // Instanciate the view
+        // Instantiate the view
         View_1D vv(block, v.begin(), v.end(), {num_segments});
 
-        // Instanciate the local view from the view
+        // Instantiate the local view from the view
         auto local_vv = hpx::local_view(vv);
 
         for ( auto i = localvv.begin(); i != localvv.end(); i++ )
@@ -1327,7 +1327,7 @@ owned by the current image::
 
 .. _sub_views:
 
-Instanciating sub-views
+Instantiating sub-views
 ,,,,,,,,,,,,,,,,,,,,,,,
 
 It is possible to construct views from other views: we call it sub-views. The
@@ -1355,10 +1355,10 @@ sub-view::
         std::size_t N = 20;
         std::size_t tilesize = 5;
 
-        // Instanciate the view
+        // Instantiate the view
         View_2D vv(block, v.begin(), v.end(), {N,N});
 
-        // Instanciate the subview
+        // Instantiate the subview
         View_2D svv(
             block,&vv(tilesize,0),&vv(2*tilesize-1,tilesize-1),{tilesize,tilesize},{N,N});
 
@@ -1397,7 +1397,7 @@ Preface: co-array, a segmented container tied to a SPMD multidimensional views
 As mentioned before, a co-array is a distributed array whose segments are
 accessible through an array-inspired access mode. We have previously seen that
 it is possible to reproduce such access mode using the concept of views.
-Nevertheless, the user must pre-create a segmented container to instanciate this
+Nevertheless, the user must pre-create a segmented container to instantiate this
 view. We illustrate below how a single constructor call can perform those two
 operations::
 

--- a/docs/sphinx/releases/whats_new_0_9_11.rst
+++ b/docs/sphinx/releases/whats_new_0_9_11.rst
@@ -51,9 +51,9 @@ General changes
   supported by the used compiler.
 * The API for creating instances of components has been consolidated. All
   component instances should be created using the :cpp:func:`hpx::new_` only. It
-  allows to instantiate both, single component instances and multiple component
-  instances. The placement of the created components can be controlled by
-  special distribution policies. Please see the corresponding documentation
+  allows one to instantiate both, single component instances and multiple
+  component instances. The placement of the created components can be controlled
+  by special distribution policies. Please see the corresponding documentation
   outlining the use of :cpp:func:`hpx::new_`.
 * Introduced four new distribution policies which can be used with many API
   functions which traditionally expected to be used with a locality id. The new
@@ -66,7 +66,7 @@ General changes
   * :cpp:class:`hpx::components::binpacking_distribution_policy` which will
     place multiple component instances as evenly as possible based on any
     performance counter.
-  * :cpp:class:`hpx::components::target_distribution_policy` which allows to
+  * :cpp:class:`hpx::components::target_distribution_policy` which allows one to
     represent a given locality in the context of a distrwibution policy.
 * The new distribution policies can now be also used with ``hpx::async``. This
   change also deprecates ``hpx::async_colocated(id, ...)`` which now is replaced
@@ -119,7 +119,7 @@ Breaking changes
   performance benefit when using stackless threads. As such, we decided to clean
   up our codebase. This feature was not documented.
 * The CMake project name has changed from 'hpx' to 'HPX' for consistency and
-  compatibilty with naming conventions and other CMake projects. Generated
+  compatibility with naming conventions and other CMake projects. Generated
   config files go into <prefix>/lib/cmake/HPX and not <prefix>/lib/cmake/hpx.
 * The macro ``HPX_REGISTER_MINIMAL_COMPONENT_FACTORY`` has been deprecated.
   Please use :c:macro:`HPX_REGISTER_COMPONENT`.
@@ -196,7 +196,7 @@ Here is a list of the important tickets we closed for this release.
   implementation
 * :hpx-pr:`1838` - Update version rc1
 * :hpx-pr:`1837` - Removing broken lcos::local::channel
-* :hpx-pr:`1835` - Adding exlicit move constructor and assignment operator to
+* :hpx-pr:`1835` - Adding explicit move constructor and assignment operator to
   hpx::lcos::promise
 * :hpx-pr:`1834` - Making hpx::lcos::promise move-only
 * :hpx-pr:`1833` - Adding fedora docs
@@ -583,7 +583,7 @@ Here is a list of the important tickets we closed for this release.
 * :hpx-issue:`1481` - Sync primitives safe destruction
 * :hpx-issue:`1480` - Move external/boost/endian into hpx/util
 * :hpx-issue:`1478` - Boost inspect violations
-* :hpx-pr:`1479` - Adds serialization for arrays; some futher/minor fixes
+* :hpx-pr:`1479` - Adds serialization for arrays; some further/minor fixes
 * :hpx-pr:`1477` - Fixing problems with the Intel compiler using a GCC 4.4 std
   library
 * :hpx-pr:`1476` - Adding ``hpx::lcos::latch`` and ``hpx::lcos::local::latch``

--- a/docs/sphinx/releases/whats_new_0_9_5.rst
+++ b/docs/sphinx/releases/whats_new_0_9_5.rst
@@ -160,7 +160,7 @@ HPX' releases so far.
 * :hpx-issue:`545` - ``AUTOGLOB`` broken for add_hpx_component
 * :hpx-issue:`542` - FindHPX_HDF5 still searches multiple times
 * :hpx-issue:`541` - Quotes around application name in hpx::init
-* :hpx-issue:`539` - Race conditition occuring with new lightweight threads
+* :hpx-issue:`539` - Race conditition occurring with new lightweight threads
 * :hpx-issue:`535` - hpx_run_tests.py exits with no error code when tests are
   missing
 * :hpx-issue:`530` - Thread description(<unknown>) in logs

--- a/docs/sphinx/releases/whats_new_0_9_6.rst
+++ b/docs/sphinx/releases/whats_new_0_9_6.rst
@@ -31,7 +31,7 @@ The major new fetures in this release are:
 * Major efforts have been dedicated to improving the performance counter
   framework, numerous new counters were implemented and new APIs were added.
 * We added a modular parcel compression system allowing to improve bandwidth
-  utilization (by reducing the overall size of the tranferred data).
+  utilization (by reducing the overall size of the transferred data).
 * We added a modular parcel coalescing system allowing to combine several
   parcels into larger messages. This reduces latencies introduced by the
   communication layer.

--- a/docs/sphinx/releases/whats_new_0_9_7.rst
+++ b/docs/sphinx/releases/whats_new_0_9_7.rst
@@ -48,7 +48,7 @@ Bug fixes (closed tickets)
 
 Here is a list of the important tickets we closed for this release.
 
-* :hpx-issue:`1005` - Allow to disable array optimizations and zero copy
+* :hpx-issue:`1005` - Allow one to disable array optimizations and zero copy
   optimizations for each parcelport
 * :hpx-issue:`1004` - Generate new HPX logo image for the docs
 * :hpx-issue:`1002` - If MPI parcelport is not available, running HPX under

--- a/docs/sphinx/releases/whats_new_0_9_8.rst
+++ b/docs/sphinx/releases/whats_new_0_9_8.rst
@@ -31,8 +31,8 @@ of using |hpx|:
   programmers know about the concurrency primitives of the standard C++ library
   is still valid in the context of |hpx|.
 * It provides a competitive, high performance implementation of modern,
-  future-proof ideas which gives an smooth migration path from todays mainstream
-  techniques
+  future-proof ideas which gives an smooth migration path from today's
+  mainstream techniques
 * There is no need for the programmer to worry about lower level parallelization
   paradigms like threads or message passing; no need to understand pthreads,
   MPI, OpenMP, or Windows threads, etc.
@@ -115,7 +115,7 @@ Here is a list of the important tickets we closed for this release.
 * :hpx-issue:`1065` - AGAS cache isn't used/populated on worker localities
 * :hpx-issue:`1064` - Reorder includes to ensure ws2 includes early
 * :hpx-issue:`1063` - Add ``hpx::runtime::suspend`` and ``hpx::runtime::resume``
-* :hpx-issue:`1062` - Fix ``async_continue`` to propery handle return types
+* :hpx-issue:`1062` - Fix ``async_continue`` to properly handle return types
 * :hpx-issue:`1061` - Implement ``async_colocated`` and ``apply_colocated``
 * :hpx-issue:`1060` - Implement minimal component migration
 * :hpx-issue:`1058` - Remove ``HPX_UTIL_TUPLE`` from code base

--- a/docs/sphinx/releases/whats_new_0_9_9.rst
+++ b/docs/sphinx/releases/whats_new_0_9_9.rst
@@ -201,7 +201,7 @@ Here is a list of the important tickets we closed for this release.
 * :hpx-issue:`1153` - Standard manipulators (like std::endl) do not work with
   hpx::ostream
 * :hpx-issue:`1152` - Functions revamp
-* :hpx-issue:`1151` - Supressing cmake 3.0 policy warning for CMP0026
+* :hpx-issue:`1151` - Suppressing cmake 3.0 policy warning for CMP0026
 * :hpx-issue:`1150` - Client Serialization error
 * :hpx-issue:`1149` - Segfault on Stampede
 * :hpx-issue:`1148` - Refactoring mini-ghost

--- a/docs/sphinx/releases/whats_new_0_9_99.rst
+++ b/docs/sphinx/releases/whats_new_0_9_99.rst
@@ -498,7 +498,7 @@ Here is a list of the important tickets we closed for this release.
 * :hpx-pr:`1927` - Using ninja for circle-ci builds
 * :hpx-pr:`1926` - Fixing serialization of std::array
 * :hpx-issue:`1925` - Issues with static HPX libraries
-* :hpx-issue:`1924` - Peformance degrading over time
+* :hpx-issue:`1924` - Performance degrading over time
 * :hpx-issue:`1923` - serialization of std::array appears broken in latest
   commit
 * :hpx-pr:`1922` - Container algorithms

--- a/docs/sphinx/releases/whats_new_1_0_0.rst
+++ b/docs/sphinx/releases/whats_new_1_0_0.rst
@@ -17,10 +17,10 @@ General changes
 Here are some of the main highlights and changes for this release (in no
 particular order):
 
-* Added the facility ``hpx::split_future`` which allows to convert a
+* Added the facility ``hpx::split_future`` which allows one to convert a
   ``future<tuple<Ts...>>`` into a ``tuple<future<Ts>...>``. This functionality
   is not available when compiling |hpx| with VS2012.
-* Added a new type of performance counter which allows to return a list of
+* Added a new type of performance counter which allows one to return a list of
   values for each invocation. We also added a first counter of this type which
   collects a histogram of the times between parcels being created.
 * Added new LCOs: ``hpx::lcos::channel`` and ``hpx::lcos::local::channel`` which
@@ -67,8 +67,8 @@ particular order):
   those.
 * We have consolidated all of the code in HPX.Compute related to the integration
   of CUDA. ``hpx::partitioned_vector`` has been enabled to be usable with
-  ``hpx::compute::vector`` which allows to place the partitions on one or more
-  GPU devices.
+  ``hpx::compute::vector`` which allows one to place the partitions on one or
+  more GPU devices.
 * Added new performance counters exposing various internals of the thread
   scheduling subsystem, such as the current idle- and busy-loop counters and
   instantaneous scheduler utilization.
@@ -109,7 +109,7 @@ Here is a list of the important tickets we closed for this release.
 * :hpx-pr:`2588` - Daint fixes
 * :hpx-pr:`2587` - Fixing transfer_(continuation)_action::schedule
 * :hpx-pr:`2585` - Work around MSVC having an ICE when compiling with -Ob2
-* :hpx-pr:`2583` - chaning 7zip command to 7za in roll_release.sh
+* :hpx-pr:`2583` - changing 7zip command to 7za in roll_release.sh
 * :hpx-pr:`2582` - First attempt to introduce spmd_block in hpx
 * :hpx-pr:`2581` - Enable annotated function for parallel algorithms
 * :hpx-pr:`2580` - First attempt to introduce spmd_block in hpx

--- a/docs/sphinx/releases/whats_new_1_1_0.rst
+++ b/docs/sphinx/releases/whats_new_1_1_0.rst
@@ -60,7 +60,7 @@ particular order):
   parallel algorithms was supporting input iterators (and output iterators) as
   well by simply falling back to sequential execution. We have now made our
   implementations conforming by requiring at least forward iterators. In order
-  to enable the old behavior use the the compatibility option
+  to enable the old behavior use the compatibility option
   ``-DHPX_WITH_ALGORITHM_INPUT_ITERATOR_SUPPORT=On`` on the |cmake|_ command
   line.
 * We have added the functionalities allowing for LCOs being implemented using
@@ -69,9 +69,9 @@ particular order):
 * User defined components don't have to be default-constructible anymore. Return
   types from actions don't have to be default-constructible anymore either. Our
   serialization layer now in general supports non-default-constructible types.
-* We have added a new launch policy ``hpx::launch::lazy`` that allows to defer
-  the decision on what launch policy to use to the point of execution. This
-  policy is initialized with a function (object) that -- when invoked -- is
+* We have added a new launch policy ``hpx::launch::lazy`` that allows oneto
+  defer the decision on what launch policy to use to the point of execution.
+  This policy is initialized with a function (object) that -- when invoked -- is
   expected to produce the desired launch policy.
 
 Breaking changes
@@ -120,7 +120,7 @@ Here is a list of the important tickets we closed for this release.
 * :hpx-pr:`3245` - Apex refactoring with guids
 * :hpx-pr:`3242` - Modify task counting in thread_queue.hpp
 * :hpx-pr:`3240` - Fixed typos
-* :hpx-pr:`3238` - Readding accidently removed std::abort
+* :hpx-pr:`3238` - Readding accidentally removed std::abort
 * :hpx-pr:`3237` - Adding Pipeline example
 * :hpx-pr:`3236` - Fixing memory_block
 * :hpx-pr:`3233` - Make schedule_thread take suspended threads into account
@@ -470,7 +470,7 @@ Here is a list of the important tickets we closed for this release.
 * :hpx-pr:`2909` - Fix typo in include path
 * :hpx-pr:`2908` - Use proper container according to iterator tag in benchmarks
   of parallel algorithms
-* :hpx-pr:`2907` - Optionaly force-delete remaining channel items on close
+* :hpx-pr:`2907` - Optionally force-delete remaining channel items on close
 * :hpx-pr:`2906` - Making sure generated performance counter names are correct
 * :hpx-issue:`2905` - collecting idle-rate performance counters on multiple
   localities produces an error
@@ -513,7 +513,7 @@ Here is a list of the important tickets we closed for this release.
 * :hpx-pr:`2870` - Disambiguate use of base_lco_with_value macros with channel
 * :hpx-issue:`2869` - Difficulty compiling
   ``HPX_REGISTER_CHANNEL_DECLARATION(double)``
-* :hpx-pr:`2868` - Removing uneeded assert
+* :hpx-pr:`2868` - Removing unneeded assert
 * :hpx-pr:`2867` - Implement parallel::unique
 * :hpx-issue:`2866` - The chunk_size_iterator violates multipass guarantee
 * :hpx-pr:`2865` - Only use sched_getcpu on linux machines
@@ -651,7 +651,7 @@ Here is a list of the important tickets we closed for this release.
 * :hpx-issue:`2746` - HPX segfaulting with valgrind
 * :hpx-pr:`2745` - Adding extended arithmetic performance counters
 * :hpx-pr:`2744` - Adding ability to statistics counters to reset base counter
-* :hpx-issue:`2743` - Statistics counter does not support reseting
+* :hpx-issue:`2743` - Statistics counter does not support resetting
 * :hpx-pr:`2742` - Making sure Vc V2 builds without additional HPX configuration
   flags
 * :hpx-pr:`2741` - Deprecate unwrapped and implement unwrap and unwrapping
@@ -660,7 +660,7 @@ Here is a list of the important tickets we closed for this release.
 * :hpx-pr:`2739` - Add files via upload
 * :hpx-pr:`2738` - Appveyor support
 * :hpx-pr:`2737` - Fixing 2735
-* :hpx-issue:`2736` - 1d_hydro example does't work
+* :hpx-issue:`2736` - 1d_hydro example doesn't work
 * :hpx-issue:`2735` - partitioned_vector_subview test failing
 * :hpx-pr:`2734` - Add C++11 range utilities
 * :hpx-pr:`2733` - Adapting iterator requirements for parallel algorithms
@@ -735,7 +735,7 @@ Here is a list of the important tickets we closed for this release.
 * :hpx-pr:`2672` - C++17 invoke forms
 * :hpx-pr:`2671` - Adding uninitialized_value_construct and
   uninitialized_value_construct_n
-* :hpx-pr:`2670` - Integrate spmd multidimensionnal views for
+* :hpx-pr:`2670` - Integrate spmd multidimensional views for
   partitioned_vectors
 * :hpx-pr:`2669` - Adding uninitialized_default_construct and
   uninitialized_default_construct_n
@@ -763,7 +763,7 @@ Here is a list of the important tickets we closed for this release.
   properly handled
 * :hpx-pr:`2649` - Update docs (Table 18) - move transform to end
 * :hpx-issue:`2647` - hpx::parcelset::detail::parcel_data::has_continuation_ is
-  unitialized
+  uninitialized
 * :hpx-issue:`2644` - Some .vcxproj in the HPX.sln fail to build
 * :hpx-issue:`2641` - ``hpx::lcos::queue`` should be deprecated
 * :hpx-pr:`2640` - A new throttling policy with public APIs to suspend/resume

--- a/docs/sphinx/releases/whats_new_1_2_0.rst
+++ b/docs/sphinx/releases/whats_new_1_2_0.rst
@@ -181,7 +181,7 @@ Closed pull requests
 * :hpx-pr:`3485` - Use BUILD_INTERFACE generator expression to fix cmake flag exports
 * :hpx-pr:`3483` - Fixing type attribute warning for transfer_action
 * :hpx-pr:`3481` - Remove unused variables
-* :hpx-pr:`3480` - Towards a more lightweigh transfer action
+* :hpx-pr:`3480` - Towards a more lightweight transfer action
 * :hpx-pr:`3479` - Fix FLAGS - Use correct version of target_compile_options
 * :hpx-pr:`3478` - Making sure the application's exit code is properly propagated back to the OS
 * :hpx-pr:`3476` - Don't print docker credentials as part of the environment.
@@ -231,7 +231,7 @@ Closed pull requests
 * :hpx-pr:`3407` - Fix unused param and extra ; warnings emitted by gcc 8.x
 * :hpx-pr:`3406` - Adding thread local allocator and use it for future shared states
 * :hpx-pr:`3405` - Adding DHPX_HAVE_THREAD_LOCAL_STORAGE=ON to builds
-* :hpx-pr:`3404` - fixing multiple difinition of main() in linux
+* :hpx-pr:`3404` - fixing multiple definition of main() in linux
 * :hpx-pr:`3402` - Allow debug option to be enabled only for Linux systems with dynamic main on
 * :hpx-pr:`3401` - Fix cuda_future_helper.h when compiling with C++11
 * :hpx-pr:`3400` - Fix floating point exception scheduler_base idle backoff

--- a/docs/sphinx/releases/whats_new_1_3_0.rst
+++ b/docs/sphinx/releases/whats_new_1_3_0.rst
@@ -97,7 +97,7 @@ Closed issues
 * :hpx-issue:`3676` - HPX master built from source, cmake fails to link main.cpp
   example in docs
 * :hpx-issue:`3673` - HPX build fails with ``std::atomic`` missing error
-* :hpx-issue:`3670` - Generate PDF again from documention (with Sphinx)
+* :hpx-issue:`3670` - Generate PDF again from documentation (with Sphinx)
 * :hpx-issue:`3643` - Warnings when compiling HPX 1.2.1 with gcc 9
 * :hpx-issue:`3641` - Trouble with using ranges-v3 and ``hpx::parallel::reduce``
 * :hpx-issue:`3639` - ``util::unwrapping`` does not work well with member
@@ -108,7 +108,7 @@ Closed issues
 * :hpx-issue:`3616` - HPX Fails to Build with CUDA 10
 * :hpx-issue:`3612` - False sharing of scheduling counters
 * :hpx-issue:`3609` - executor_parameters timeout with gcc <= 7 and Debug mode
-* :hpx-issue:`3601` - Missleading error message on power pc for rdtsc and rdtscp
+* :hpx-issue:`3601` - Misleading error message on power pc for rdtsc and rdtscp
 * :hpx-issue:`3598` - Build of some examples fails when using Vc
 * :hpx-issue:`3594` - Error: The number of OS threads requested (20) does not
   match the number of threads to bind (12): HPX(bad_parameter)
@@ -290,8 +290,8 @@ Closed pull requests
 * :hpx-pr:`3685` - Revise quickstart CMakeLists.txt explanation
 * :hpx-pr:`3684` - Provide concept emulation for Ranges-TS concepts
 * :hpx-pr:`3683` - Ignore uninitialized chunks
-* :hpx-pr:`3682` - Ignore unitialized chunks. Check proper indices.
-* :hpx-pr:`3680` - Ignore unitialized chunks. Check proper range indices
+* :hpx-pr:`3682` - Ignore uninitialized chunks. Check proper indices.
+* :hpx-pr:`3680` - Ignore uninitialized chunks. Check proper range indices
 * :hpx-pr:`3679` - Simplify basic action implementations
 * :hpx-pr:`3678` - Making sure ``HPX_HAVE_LIBATOMIC`` is unset before checking
 * :hpx-pr:`3677` - Fix generated full version number to be usable in expressions
@@ -344,7 +344,7 @@ Closed pull requests
 * :hpx-pr:`3610` - Don't wait for ``stop_condition`` in main thread
 * :hpx-pr:`3608` - Add inline keyword to ``invalid_thread_id`` definition for
   nvcc
-* :hpx-pr:`3607` - Adding configuration key that allows to explicitly add a
+* :hpx-pr:`3607` - Adding configuration key that allows one to explicitly add a
   directory to the component search path
 * :hpx-pr:`3606` - Add nvcc to exclude constexpress since is it not supported by
   nvcc

--- a/docs/sphinx/releases/whats_new_1_4_0.rst
+++ b/docs/sphinx/releases/whats_new_1_4_0.rst
@@ -115,7 +115,7 @@ Closed issues
   ``invalid_thread_id``
 * :hpx-issue:`4151` - build error with MPI code
 * :hpx-issue:`4150` - hpx won't build on POWER9 with clang 8
-* :hpx-issue:`4148` - ``cacheline_data`` delivers poor perfomance with C++17
+* :hpx-issue:`4148` - ``cacheline_data`` delivers poor performance with C++17
   compared to C++14
 * :hpx-issue:`4144` - target general in ``HPX_LIBRARIES`` does not exist
 * :hpx-issue:`4134` - CMake Error when ``-DHPX_WITH_HPXMP=ON``
@@ -184,7 +184,7 @@ Closed pull requests
 * :hpx-pr:`4272` - Fix pushing of documentation
 * :hpx-pr:`4271` - Updating APEX tag, don't create new task_wrapper on
   ``operator=`` of hpx_thread object
-* :hpx-pr:`4268` - Testing for noexcept function specializations in in C++11/14
+* :hpx-pr:`4268` - Testing for noexcept function specializations in C++11/14
   mode
 * :hpx-pr:`4267` - Fixing MSVC warning
 * :hpx-pr:`4266` - Make sure macOS Travis CI fails if build step fails
@@ -201,7 +201,7 @@ Closed pull requests
 * :hpx-pr:`4253` - Move ``partlit.hpp`` to affinity module
 * :hpx-pr:`4252` - Make mismatching build types a hard error in CMake
 * :hpx-pr:`4249` - Scheduler improvement
-* :hpx-pr:`4248` - update hpxmp tage to v0.3.0
+* :hpx-pr:`4248` - update hpxmp tag to v0.3.0
 * :hpx-pr:`4245` - Adding high performance channels
 * :hpx-pr:`4244` - Ignore lock in ignore_while_locked_1485 test
 * :hpx-pr:`4243` - Fix PAPI command line option documentation
@@ -422,7 +422,7 @@ Closed pull requests
 * :hpx-pr:`3996` - Attempt to solve issue where ``-latomic`` does not support
   128bit atomics
 * :hpx-pr:`3993` - Make sure ``__LINE__`` is an unsigned
-* :hpx-pr:`3991` - Fix dependencies and flags for for header tests
+* :hpx-pr:`3991` - Fix dependencies and flags for header tests
 * :hpx-pr:`3990` - Documentation tags fixes
 * :hpx-pr:`3988` - Adding missing solution folder for format module test
 * :hpx-pr:`3987` - Move runtime-dependent functions out of command line handling
@@ -513,8 +513,8 @@ Closed pull requests
 * :hpx-pr:`3877` - Documentation
 * :hpx-pr:`3876` - Module hardware
 * :hpx-pr:`3875` - Converted typedefs in actions submodule to using directives
-* :hpx-pr:`3874` - Allow to suppress target keywords in ``hpx_setup_target`` for
-  backwards compatibility
+* :hpx-pr:`3874` - Allow one to suppress target keywords in ``hpx_setup_target``
+  for backwards compatibility
 * :hpx-pr:`3873` - Add scripts to create releases and generate lists of PRs and
   issues
 * :hpx-pr:`3872` - Fix latest HTML docs location

--- a/examples/async_io/async_io_simple.cpp
+++ b/examples/async_io/async_io_simple.cpp
@@ -41,8 +41,8 @@ int async_io(char const* string_to_write)
 
     // Note that the destructor of the scheduler object will wait for
     // the scheduled task to finish executing. This might be
-    // undesireable, in which case the technique demonstrated in
-    // the example async_io_low_level.cpp is preferrable.
+    // undesirable, in which case the technique demonstrated in
+    // the example async_io_low_level.cpp is preferable.
     }
 
     return result;   // this will be executed only after result has been set

--- a/examples/jacobi_smp/jacobi_nonuniform.cpp
+++ b/examples/jacobi_smp/jacobi_nonuniform.cpp
@@ -187,7 +187,7 @@ int hpx_main(variables_map &vm)
         }
         else
         {
-                std::cout << "Unkown mode " << mode << "\n";
+                std::cout << "Unknown mode " << mode << "\n";
 #if !defined(JACOBI_SMP_NO_HPX)
                 hpx::finalize();
 #endif

--- a/examples/sheneos/README.rst
+++ b/examples/sheneos/README.rst
@@ -57,7 +57,7 @@ Options
     The number of worker/measurement threads to create per locality.
 
 --seed : std::size_t : 0
-    The seed for the pseudo random number generator (if 0, a seed is choosen
+    The seed for the pseudo random number generator (if 0, a seed is chosen
     based on the current system time).
 
 Input File Format

--- a/examples/startup_shutdown/startup_shutdown.cpp
+++ b/examples/startup_shutdown/startup_shutdown.cpp
@@ -13,7 +13,7 @@
 // is guaranteed to be executed before hpx_main() is invoked.
 //
 // The HPX API function retrieve_commandline_arguments() demonstrated below
-// expectes 2 arguments: a) an options_description object describing any
+// expects 2 arguments: a) an options_description object describing any
 // special options to be recognized by this component and b) a variables_map
 // object which on return will be initialized with all found command line
 // options and arguments passed while invoking the application on the locality

--- a/hpx/performance_counters/parcels/data_point.hpp
+++ b/hpx/performance_counters/parcels/data_point.hpp
@@ -29,7 +29,7 @@ namespace hpx { namespace performance_counters { namespace parcels
           , buffer_allocate_time_(0)
         {}
 
-        std::size_t bytes_;           ///< number of bytes on tyhe wire for this parcel
+        std::size_t bytes_;           ///< number of bytes on the wire for this parcel
                                       ///< (possibly compressed)
         std::int64_t time_;           ///< during processing holds start timestamp
                                       ///< after processing holds elapsed time

--- a/hpx/runtime/components/new.hpp
+++ b/hpx/runtime/components/new.hpp
@@ -107,7 +107,7 @@ namespace hpx
     ///          of that type which can be used to refer to the newly created
     ///          component instance.
     ///
-    /// \note    The difference of this funtion to \a hpx::new_ is that it can
+    /// \note    The difference of this function to \a hpx::new_ is that it can
     ///          be used in cases where the supplied arguments are non-copyable
     ///          and non-movable. All operations are guaranteed to be local
     ///          only.

--- a/hpx/runtime/parcelset/parcelhandler.hpp
+++ b/hpx/runtime/parcelset/parcelhandler.hpp
@@ -91,7 +91,7 @@ namespace hpx { namespace parcelset
         ///                 transport operations the parcelhandler carries out.
         parcelhandler(util::runtime_configuration& cfg,
             threads::threadmanager* tm,
-            threads::policies::callback_notifier const& notifer);
+            threads::policies::callback_notifier const& notifier);
 
         ~parcelhandler() = default;
 

--- a/hpx/runtime/threads/policies/scheduler_base.hpp
+++ b/hpx/runtime/threads/policies/scheduler_base.hpp
@@ -122,7 +122,7 @@ namespace hpx { namespace threads { namespace policies {
         }
 
         // set mode flags that control scheduler behaviour
-        // This set function is virtual so that flags may be overriden
+        // This set function is virtual so that flags may be overridden
         // by schedulers that do not support certain operations/modes.
         // All other mode set functions should call this one to ensure
         // that flags are always consistent

--- a/hpx/runtime/threads/policies/shared_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/shared_priority_queue_scheduler.hpp
@@ -659,7 +659,7 @@ namespace hpx { namespace threads { namespace policies {
                     std::uint16_t q_index = q_lookup_[this_thread];
 
                     // first try a high priority task, allow stealing
-                    // if stealingo og HP tasks in on, this wil be fine
+                    // if stealing of HP tasks in on, this will be fine
                     // but send a null function for normal tasks
                     bool result = steal_by_function<threads::thread_data*>(
                         domain, q_index, numa_stealing_, core_stealing_,

--- a/hpx/runtime/threads/thread_data.hpp
+++ b/hpx/runtime/threads/thread_data.hpp
@@ -95,7 +95,7 @@ namespace hpx { namespace threads {
         ///
         /// \param newstate [in] The new state to be set for the thread.
         ///
-        /// \note           This function will be seldomly used directly. Most of
+        /// \note           This function will be seldom used directly. Most of
         ///                 the time the state of a thread will have to be
         ///                 changed using the threadmanager. Moreover,
         ///                 changing the thread state using this function does
@@ -164,7 +164,7 @@ namespace hpx { namespace threads {
         /// \param oldstate [in] The old state of the thread which still has to
         ///                 be the current state.
         ///
-        /// \note           This function will be seldomly used directly. Most of
+        /// \note           This function will be seldom used directly. Most of
         ///                 the time the state of a thread will have to be
         ///                 changed using the threadmanager. Moreover,
         ///                 changing the thread state using this function does

--- a/hpx/runtime_impl.hpp
+++ b/hpx/runtime_impl.hpp
@@ -306,7 +306,7 @@ namespace hpx
         void add_startup_function(startup_function_type f) override;
 
         /// Add a function to be executed inside a HPX thread during
-        /// hpx::finalize, but guaranteed before any of teh shutdown functions
+        /// hpx::finalize, but guaranteed before any of the shutdown functions
         /// is executed.
         ///
         /// \param  f   The function 'f' will be called from inside a HPX

--- a/hpx/util/pack_traversal.hpp
+++ b/hpx/util/pack_traversal.hpp
@@ -20,7 +20,7 @@ namespace util {
     ///
     /// This function tries to visit all plain elements which may be wrapped in:
     /// - homogeneous containers (`std::vector`, `std::list`)
-    /// - heterogenous containers `(hpx::tuple`, `std::pair`, `std::array`)
+    /// - heterogeneous containers `(hpx::tuple`, `std::pair`, `std::array`)
     /// and re-assembles the pack with the result of the mapper.
     /// Mapping from one type to a different one is supported.
     ///

--- a/hpx/util/runtime_configuration.hpp
+++ b/hpx/util/runtime_configuration.hpp
@@ -122,7 +122,7 @@ namespace hpx { namespace util
         // Return the configured sizes of any of the know thread pools
         std::size_t get_thread_pool_size(char const* poolname) const;
 
-        // Return the endianess to be used for out-serialization
+        // Return the endianness to be used for out-serialization
         std::string get_endian_out() const;
 
         // Return maximally allowed message sizes

--- a/libs/README.rst
+++ b/libs/README.rst
@@ -54,7 +54,7 @@ the library and a link to the generated documentation.
 
 The ``include`` directory should contain only headers that other libraries need.
 Private headers should be placed under the ``src`` directory. This allows for
-clear seperation. The ``cmake`` subdirectory may include additional |cmake|_
+clear separation. The ``cmake`` subdirectory may include additional |cmake|_
 scripts needed to generate the respective build configurations.
 
 Documentation is placed in the ``docs`` folder. A empty skeleton for the index

--- a/libs/algorithms/include/hpx/parallel/algorithms/detail/transfer.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/detail/transfer.hpp
@@ -109,7 +109,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         //           returns \a FwdIter2 otherwise.
         //           The \a move algorithm returns the output iterator to the
         //           element in the destination range, one past the last element
-        //           transfered.
+        //           transferred.
         //
         template <typename Algo, typename ExPolicy, typename FwdIter1,
             typename FwdIter2,

--- a/libs/algorithms/include/hpx/parallel/algorithms/partition.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/partition.hpp
@@ -568,7 +568,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 hpx::lcos::local::spinlock mutex_;
             };
 
-            // std::swap_ranges doens't support overlapped ranges in standard.
+            // std::swap_ranges doesn't support overlapped ranges in standard.
             // But, actually general implementations of std::swap_ranges are useful
             //     in specific cases.
             // The problem is that standard doesn't guarantee that implementation.

--- a/libs/cache/include/hpx/cache/local_cache.hpp
+++ b/libs/cache/include/hpx/cache/local_cache.hpp
@@ -180,7 +180,7 @@ namespace hpx { namespace util { namespace cache {
         ///
         /// \returns    This function returns \a true if successful. It returns
         ///             \a false if the new \a max_size is smaller than the
-        ///             current limit and the cache could not be shrinked to
+        ///             current limit and the cache could not be shrunk to
         ///             the new maximum size.
         bool reserve(size_type max_size)
         {

--- a/libs/concurrency/include/hpx/concurrency/cache_line_data.hpp
+++ b/libs/concurrency/include/hpx/concurrency/cache_line_data.hpp
@@ -105,7 +105,7 @@ namespace hpx {
             {
             }
 
-            // no ned to pad to cache line size
+            // no need to pad to cache line size
             Data data_;
         };
 

--- a/libs/datastructures/include/hpx/datastructures/tuple.hpp
+++ b/libs/datastructures/include/hpx/datastructures/tuple.hpp
@@ -74,7 +74,7 @@ namespace hpx { namespace util {
 }}    // namespace hpx::util
 
 #if defined(HPX_DATASTRUCTURES_HAVE_ADAPT_STD_TUPLE)
-// Adapt hpx::util::tuple to be useable with std::tuple
+// Adapt hpx::util::tuple to be usable with std::tuple
 namespace std {
 
     template <typename... Ts>

--- a/libs/debugging/include/hpx/debugging/print.hpp
+++ b/libs/debugging/include/hpx/debugging/print.hpp
@@ -33,7 +33,7 @@
 
 // ------------------------------------------------------------
 // This file provides a simple to use printf style debugging
-// tool that can be used on a per file basis to enable ouput.
+// tool that can be used on a per file basis to enable output.
 // It is not intended to be exposed to users, but rather as
 // an aid for hpx development.
 // ------------------------------------------------------------

--- a/libs/format/include/hpx/format.hpp
+++ b/libs/format/include/hpx/format.hpp
@@ -254,7 +254,7 @@ namespace hpx { namespace util {
         };
 
         ///////////////////////////////////////////////////////////////////////
-        // Use dedicated macro so it may be overriden
+        // Use dedicated macro so it may be overridden
 #if !defined(HPX_FORMAT_EXPORT)
 #define HPX_FORMAT_EXPORT HPX_EXPORT
 #endif

--- a/libs/iterator_support/tests/unit/is_iterator.cpp
+++ b/libs/iterator_support/tests/unit/is_iterator.cpp
@@ -573,12 +573,12 @@ void bidirectional_concept()
     {
         using iterator = bidirectional_traversal_iterator;
         HPX_TEST_MSG((bidirectional_concept<iterator>::value),
-            "bidirectional traveral input iterator");
+            "bidirectional traversal input iterator");
     }
     {
         using iterator = random_access_traversal_iterator;
         HPX_TEST_MSG((bidirectional_concept<iterator>::value),
-            "random access traveral input iterator");
+            "random access traversal input iterator");
     }
 }
 

--- a/libs/iterator_support/tests/unit/iterator_tests.hpp
+++ b/libs/iterator_support/tests/unit/iterator_tests.hpp
@@ -107,7 +107,7 @@ namespace tests {
         HPX_TEST(*i1 == v2);
         HPX_TEST(*i == v2);
 
-        // i is dereferencable, so it must be incrementable.
+        // i is dereferenceable, so it must be incrementable.
         ++i;
 
         // how to test for operator-> ?

--- a/libs/logging/include/hpx/logging/detail/manipulator.hpp
+++ b/libs/logging/include/hpx/logging/detail/manipulator.hpp
@@ -79,7 +79,7 @@ to console, a file, etc.)
 You can use a typedef - one for the formatters, and one for the destinations:
 
 @code
-// ptr_type - optional ; usualy  you don't need to worry about this
+// ptr_type - optional ; usually  you don't need to worry about this
 typedef formatter::base<  arg_type [,ptr_type] > formatter_base;
 typedef destination::base< arg_type [,ptr_type] > destination_base;
 @endcode
@@ -259,7 +259,7 @@ As long as data is constant, it's all ok - that is, no matter what functions get
 all the data in the formatter/destination
 must remain constant. We need constant functors - just like in STL - because internally,
 we copy formatters/destinations: that is, we keep
-several copies of a certain object - they all need to be syncronized.
+several copies of a certain object - they all need to be synchronized.
 In case the objects' data is constant, that's no problem.
 
 In case the data needs to be changed - it needs to be shared.

--- a/libs/logging/include/hpx/logging/format.hpp
+++ b/libs/logging/include/hpx/logging/format.hpp
@@ -140,7 +140,7 @@ and you want to define the logger classes, in a source file
     namespace msg_route {
 
         /**
-        @brief Recomended base class for message routers that
+        @brief Recommended base class for message routers that
         need access to the underlying formatter and/or destination array.
     */
         template <class formatter_array, class destination_array>

--- a/libs/logging/include/hpx/logging/format/destination/named.hpp
+++ b/libs/logging/include/hpx/logging/format/destination/named.hpp
@@ -121,7 +121,7 @@ namespace hpx { namespace util { namespace logging { namespace destination {
                 add_impl(name, holder(dest), std::false_type());
             }
 
-            // recomputes the write steps - note taht this takes place after
+            // recomputes the write steps - note that this takes place after
             // each operation for instance, the user might have first set the
             // string and later added the formatters
             void HPX_EXPORT compute_write_steps();
@@ -174,7 +174,7 @@ As an extra feature:
 
 This is useful if you want to set this format string in a config file.
 The good thing is that this way you can easily turn on/off
-certain destinations, while seing all the available destinations as well.
+certain destinations, while seeing all the available destinations as well.
 
 Example: \n <tt>+out_file -debug_window +console</tt> \n
 In the above example, I know that the available destinations are @c out_file,

--- a/libs/logging/include/hpx/logging/format/formatter/convert_format.hpp
+++ b/libs/logging/include/hpx/logging/format/formatter/convert_format.hpp
@@ -24,7 +24,7 @@
 namespace hpx { namespace util { namespace logging { namespace formatter {
 
     /**
-    @brief Allows format convertions
+    @brief Allows format conversions
     - In case you're using a formatter that does not match your string type
 
     In case you want to use a formatter developed by someone else

--- a/libs/logging/include/hpx/logging/format/formatter/named_spacer.hpp
+++ b/libs/logging/include/hpx/logging/format/formatter/named_spacer.hpp
@@ -155,7 +155,7 @@ namespace hpx { namespace util { namespace logging { namespace formatter {
                 }
             }
 
-            // recomputes the write steps - note taht this takes place after
+            // recomputes the write steps - note that this takes place after
             // each operation for instance, the user might have first set the
             // string and later added the formatters
             void HPX_EXPORT compute_write_steps();

--- a/libs/serialization/include/hpx/serialization/input_archive.hpp
+++ b/libs/serialization/include/hpx/serialization/input_archive.hpp
@@ -47,9 +47,9 @@ namespace hpx { namespace serialization {
             // properly interpret the flags
 
             // FIXME: make bool once integer compression is implemented
-            std::uint64_t endianess = 0ul;
-            load(endianess);
-            if (endianess)
+            std::uint64_t endianness = 0ul;
+            load(endianness);
+            if (endianness)
                 this->base_type::flags_ = hpx::serialization::endian_big;
 
             // load flags sent by the other end to make sure both ends have

--- a/libs/serialization/include/hpx/serialization/output_archive.hpp
+++ b/libs/serialization/include/hpx/serialization/output_archive.hpp
@@ -122,9 +122,9 @@ namespace hpx { namespace serialization {
             // properly interpret the flags
 
             // FIXME: make bool once integer compression is implemented
-            std::uint64_t endianess =
+            std::uint64_t endianness =
                 this->base_type::endian_big() ? ~0ul : 0ul;
-            save(endianess);
+            save(endianness);
 
             // send flags sent by the other end to make sure both ends have
             // the same assumptions about the archive format

--- a/plugins/parcelport/libfabric/header.hpp
+++ b/plugins/parcelport/libfabric/header.hpp
@@ -31,7 +31,7 @@ namespace libfabric
     {
         typedef serialization::serialization_chunk chunktype;
 
-        // if chunks are not piggybacked, we must send an rma handle for chunk acccess
+        // if chunks are not piggybacked, we must send an rma handle for chunk access
         // and state how many other rma chunks need to be retrieved (since this is
         // normally stored in the missing chunk info)
         struct chunk_header {

--- a/plugins/parcelport/libfabric/locality.hpp
+++ b/plugins/parcelport/libfabric/locality.hpp
@@ -17,7 +17,7 @@
 #include <array>
 #include <rdma/fabric.h>
 
-// Different providers use different address formats that we must accomodate
+// Different providers use different address formats that we must accommodate
 // in our locality object.
 #ifdef HPX_PARCELPORT_LIBFABRIC_GNI
 # define HPX_PARCELPORT_LIBFABRIC_LOCALITY_SIZE 48

--- a/plugins/parcelport/libfabric/parcelport_libfabric.cpp
+++ b/plugins/parcelport/libfabric/parcelport_libfabric.cpp
@@ -295,7 +295,7 @@ namespace libfabric
     }
 
     // --------------------------------------------------------------------
-    // the root node has spacial handlig, this returns its Id
+    // the root node has spacial handling, this returns its Id
     parcelset::locality parcelport::
     agas_locality(util::runtime_configuration const & ini) const
     {

--- a/plugins/parcelport/libfabric/receiver.cpp
+++ b/plugins/parcelport/libfabric/receiver.cpp
@@ -90,11 +90,11 @@ namespace libfabric
         static_assert(sizeof(std::uint64_t) == sizeof(std::size_t),
             "sizeof(std::uint64_t) != sizeof(std::size_t)");
 
-        // If we recieve a message of 8 bytes, we got a tag and need to handle
+        // If we receive a message of 8 bytes, we got a tag and need to handle
         // the tag completion...
         if (len <= sizeof(std::uint64_t))
         {
-            // @TODO: fixme immediate tag retreival
+            // @TODO: fixme immediate tag retrieval
             // Get the sender that has completed rma operations and signal to it
             // that it can now cleanup - all remote get operations are done.
             sender* snd = *reinterpret_cast<sender **>(header_region_->get_address());
@@ -117,7 +117,7 @@ namespace libfabric
                     // if the capacity overflowed, just delete this one
                     delete recv;
                 }
-                // Notify one possibly waiting reciever that one receive just finished
+                // Notify one possibly waiting receiver that one receive just finished
                 if (threads::threadmanager_is_at_least(state_running)
                     && hpx::threads::get_self_ptr())
                 {

--- a/plugins/parcelport/libfabric/receiver.hpp
+++ b/plugins/parcelport/libfabric/receiver.hpp
@@ -29,7 +29,7 @@ namespace libfabric
     // The receiver is responsible for handling incoming messages. For that purpose,
     // it posts receive buffers. Incoming messages can be of two kinds:
     //      1) An ACK message which has been sent from an rma_receiver, to signal
-    //         the sender about the succesful retreival of an incoming message.
+    //         the sender about the successful retrieval of an incoming message.
     //      2) An incoming parcel, that consists of an header and an eventually
     //         piggy backed message. If the message is not piggy backed or zero
     //         copy RMA chunks need to be read, a rma_receiver is created to
@@ -64,7 +64,7 @@ namespace libfabric
         // --------------------------------------------------------------------
         // the receiver posts a single receive buffer to the queue, attaching
         // itself as the context, so that when a message is received
-        // the owning reciever is called to handle processing of the buffer
+        // the owning receiver is called to handle processing of the buffer
         void pre_post_receive();
 
         // --------------------------------------------------------------------

--- a/plugins/parcelport/libfabric/rma_receiver.hpp
+++ b/plugins/parcelport/libfabric/rma_receiver.hpp
@@ -28,8 +28,8 @@ namespace libfabric
     struct parcelport;
 
 
-    // The rma_receiver is repsonsible for receiving the
-    // mising chunks of the message:
+    // The rma_receiver is responsible for receiving the
+    // missing chunks of the message:
     //      1) Non-piggy backed non-zero copy chunks (if existing)
     //      2) The zero copy chunks from serialization
     struct rma_receiver : public rma_base

--- a/plugins/parcelport/parcelport_logging.hpp
+++ b/plugins/parcelport/parcelport_logging.hpp
@@ -121,7 +121,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace libfabric {
         }
 
         // ------------------------------------------------------------------
-        // helper fuction for printing CRC32
+        // helper function for printing CRC32
         // ------------------------------------------------------------------
         inline uint32_t crc32(const void* address, size_t length)
         {
@@ -131,7 +131,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace libfabric {
         }
 
         // ------------------------------------------------------------------
-        // helper fuction for printing CRC32 and short memory dump
+        // helper function for printing CRC32 and short memory dump
         // ------------------------------------------------------------------
         inline std::string mem_crc32(
             const void* address, size_t length, const char* txt)
@@ -224,7 +224,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace libfabric {
 
 // ------------------------------------------------------------------
 // Timed log macros : used during long loops to avoid excessive output
-// only prints the log messge every N seconds
+// only prints the log message every N seconds
 // ------------------------------------------------------------------
 #ifdef HPX_PARCELPORT_LOGGING_HAVE_TIMED_LOG
 

--- a/plugins/parcelport/readers_writers_mutex.hpp
+++ b/plugins/parcelport/readers_writers_mutex.hpp
@@ -22,7 +22,7 @@
 # define RWL_DEBUG_MSG(x)
 #endif
 
-// Note that this implementaion uses 16bit counters so can handle 65536
+// Note that this implementation uses 16bit counters so can handle 65536
 // contentions on the lock without wraparound. It has not proven to be a
 // problem so far. (c.f. original description below)
 

--- a/plugins/parcelport/rma_memory_region.hpp
+++ b/plugins/parcelport/rma_memory_region.hpp
@@ -217,8 +217,8 @@ namespace parcelset
         };
 
         // --------------------------------------------------------------------
-        // A user allocated region use memory allocted by the user.
-        // on destruction, the memory is unregisterd, but not deleted
+        // A user allocated region use memory allocated by the user.
+        // on destruction, the memory is unregistered, but not deleted
         inline void set_user_region() {
             flags_ |= BLOCK_USER;
         }

--- a/plugins/parcelport/verbs/rdma/rdma_chunk_pool.hpp
+++ b/plugins/parcelport/verbs/rdma/rdma_chunk_pool.hpp
@@ -61,7 +61,7 @@
   alignment of all allocated chunks,
   and which extends and generalizes the framework provided by the simple segregated
   storage solution.
-  Also provides two UserAllocator classes which can be used in conjuction with \ref pool.
+  Also provides two UserAllocator classes which can be used in conjunction with \ref pool.
  */
 
 /*!
@@ -111,7 +111,7 @@ namespace verbs {
     };
 
 namespace details
-{  //! Implemention only.
+{  //! Implementation only.
 
     template<typename SizeType>
     class PODptr

--- a/plugins/parcelport/verbs/rdma/rdma_controller.cpp
+++ b/plugins/parcelport/verbs/rdma/rdma_controller.cpp
@@ -560,7 +560,7 @@ int rdma_controller::handle_connect_request(
         }
         else {
             // we need to delete the connection we started and replace it with a new one
-            LOG_DEVEL_MSG("Priorty to new, Aborting old from "
+            LOG_DEVEL_MSG("Priority to new, Aborting old from "
                 << sockaddress(&local_addr_) << "to "
                 << ipaddress(remote_ip)
                 << "( " << sockaddress(&local_addr_) << ")");

--- a/plugins/parcelport/verbs/rdma/rdma_controller.hpp
+++ b/plugins/parcelport/verbs/rdma/rdma_controller.hpp
@@ -49,7 +49,7 @@ namespace verbs
         typedef hpx::parcelset::policies::verbs::unique_lock<mutex_type> unique_lock;
         typedef hpx::parcelset::policies::verbs::scoped_lock<mutex_type> scoped_lock;
 
-        // constructor gets infor from device and sets up all necessary
+        // constructor gets info from device and sets up all necessary
         // maps, queues and server endpoint etc
         rdma_controller(const char *device, const char *interface, int port);
 

--- a/plugins/parcelport/verbs/rdma/verbs_endpoint.hpp
+++ b/plugins/parcelport/verbs/rdma/verbs_endpoint.hpp
@@ -272,7 +272,7 @@ namespace verbs
         // this poll for event function is used by the main server endpoint when
         // it is waiting for connection/disconnection requests etc
         // ack_event, deletes the cm_event data structure allocated by the CM,
-        // so we do not ack and alow the event handler routine to do it
+        // so we do not ack and allow the event handler routine to do it
         template<typename Func>
         int poll_for_event(Func &&f)
         {

--- a/plugins/parcelport/verbs/rdma/verbs_memory_region.hpp
+++ b/plugins/parcelport/verbs/rdma/verbs_memory_region.hpp
@@ -211,8 +211,8 @@ namespace verbs
         };
 
         // --------------------------------------------------------------------
-        // A user allocated region use memory allocted by the user.
-        // on destruction, the memory is unregisterd, but not deleted
+        // A user allocated region use memory allocated by the user.
+        // on destruction, the memory is unregistered, but not deleted
         inline void set_user_region() {
             flags_ |= BLOCK_USER;
         }

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -883,7 +883,7 @@ namespace hpx
     std::string get_thread_name()
     {
         std::string& thread_name = detail::thread_name();
-        if (thread_name.empty()) return "<unkown>";
+        if (thread_name.empty()) return "<unknown>";
         return thread_name;
     }
 

--- a/src/runtime/components/server/destroy_component.cpp
+++ b/src/runtime/components/server/destroy_component.cpp
@@ -31,7 +31,7 @@ namespace hpx { namespace components { namespace server
         {
             // Check if component was migrated, we are not interested in
             // pinning the object as it is supposed to be destroyed anyways
-            // that is, noone else has a handle to it anymore
+            // that is, no one else has a handle to it anymore
             auto r = agas::was_object_migrated(gid,
                 [](){ return pinned_ptr(); });
 

--- a/src/runtime/threads/thread_helpers.cpp
+++ b/src/runtime/threads/thread_helpers.cpp
@@ -668,7 +668,7 @@ namespace hpx { namespace this_thread {
             std::size_t(remaining_stack) >= space_needed;
 
         // We might find ourselves in the situation where we don't have enough
-        // stack space, but can't really schedule a new thread. In this sitation,
+        // stack space, but can't really schedule a new thread. In this situation,
         // it would be best to change the code that provoked this behaviour
         // instead of dynamically schedule a new thread. A such, we throw an
         // exception to point to that problem instead of silently hanging because

--- a/src/util/runtime_configuration.cpp
+++ b/src/util/runtime_configuration.cpp
@@ -1026,7 +1026,7 @@ namespace hpx { namespace util
         return 2;     // the default size for all pools is 2
     }
 
-    // Return the endianess to be used for out-serialization
+    // Return the endianness to be used for out-serialization
     std::string runtime_configuration::get_endian_out() const
     {
         if (has_section("hpx.parcel")) {

--- a/tests/performance/local/coroutines_call_overhead.cpp
+++ b/tests/performance/local/coroutines_call_overhead.cpp
@@ -289,7 +289,7 @@ int main(
         ( "seed"
         , value<std::uint64_t>(&seed)->default_value(0)
         , "seed for the pseudo random number generator (if 0, a seed is "
-          "choosen based on the current system time)")
+          "chosen based on the current system time)")
 
 /*
         ( "counter"

--- a/tests/performance/local/hpx_heterogeneous_timed_task_spawn.cpp
+++ b/tests/performance/local/hpx_heterogeneous_timed_task_spawn.cpp
@@ -261,7 +261,7 @@ int main(
         ( "seed"
         , value<std::uint64_t>(&seed)->default_value(0)
         , "seed for the pseudo random number generator (if 0, a seed is "
-          "choosen based on the current system time)")
+          "chosen based on the current system time)")
 
         ( "no-header"
         , "do not print out the csv header row")

--- a/tests/performance/local/htts_v2/htts2_hpx.cpp
+++ b/tests/performance/local/htts_v2/htts2_hpx.cpp
@@ -169,7 +169,7 @@ struct hpx_driver : htts2::driver
         ///////////////////////////////////////////////////////////////////////
         // Compute + Cooldown Phase
 
-        // The use of an atomic and live waiting here does not add any noticable
+        // The use of an atomic and live waiting here does not add any noticeable
         // overhead, as compared to the more complicated continuation-style
         // detection method that checks the threadmanager internal counters
         // (I've measured). Using this technique is preferable as it is more

--- a/tests/performance/local/partitioned_vector_foreach.cpp
+++ b/tests/performance/local/partitioned_vector_foreach.cpp
@@ -160,7 +160,7 @@ int main(int argc, char* argv[])
 
         ("test_count"
         , hpx::program_options::value<int>()->default_value(100)
-        , "number of tests to be averaged (defalt: 100)")
+        , "number of tests to be averaged (default: 100)")
 
         ("chunk_size"
         , hpx::program_options::value<int>()->default_value(0)

--- a/tests/performance/local/print_heterogeneous_payloads.cpp
+++ b/tests/performance/local/print_heterogeneous_payloads.cpp
@@ -199,7 +199,7 @@ int main(
         ( "seed"
         , value<std::uint64_t>(&seed)->default_value(0)
         , "seed for the pseudo random number generator (if 0, a seed is "
-          "choosen based on the current system time)")
+          "chosen based on the current system time)")
         ;
 
     store(command_line_parser(argc, argv).options(cmdline).run(), vm);

--- a/tests/performance/local/qthreads_heterogeneous_timed_task_spawn.cpp
+++ b/tests/performance/local/qthreads_heterogeneous_timed_task_spawn.cpp
@@ -308,7 +308,7 @@ int main(
         ( "seed"
         , value<std::uint64_t>(&seed)->default_value(0)
         , "seed for the pseudo random number generator (if 0, a seed is "
-          "choosen based on the current system time)")
+          "chosen based on the current system time)")
 
         ( "no-header"
         , "do not print out the csv header row")

--- a/tests/performance/local/stream.cpp
+++ b/tests/performance/local/stream.cpp
@@ -400,7 +400,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
     std::cout
         << "-------------------------------------------------------------\n"
-        << "Modified STREAM bechmark based on\nHPX version: "
+        << "Modified STREAM benchmark based on\nHPX version: "
             << hpx::build_string() << "\n"
         << "-------------------------------------------------------------\n"
         << "This system uses " << sizeof(STREAM_TYPE)

--- a/tests/performance/network/pingpong_performance.cpp
+++ b/tests/performance/network/pingpong_performance.cpp
@@ -43,9 +43,9 @@ int hpx_main(hpx::program_options::variables_map& vm)
     //Create instance of the actions
     pingpong_get_element_action act;
     std::vector<hpx::future<std::complex<double>>> vec;
-    std::vector<std::complex<double>> recieved;
+    std::vector<std::complex<double>> received;
     vec.reserve(n);
-    recieved.reserve(n);
+    received.reserve(n);
     //Find the other locality
     std::vector<hpx::naming::id_type> dummy = hpx::find_remote_localities();
     hpx::naming::id_type other_locality = dummy[0];
@@ -57,16 +57,16 @@ int hpx_main(hpx::program_options::variables_map& vm)
     }
 
     hpx::when_all(vec).then(
-        [&recieved, n](hpx::future<std::vector<hpx::future<std::complex<double>>>> dummy)
+        [&received, n](hpx::future<std::vector<hpx::future<std::complex<double>>>> dummy)
         {
             std::vector<hpx::future<std::complex<double>>> number = dummy.get();
             for (std::size_t i = 0; i < n; ++i)
             {
-                recieved.push_back(number[i].get());
+                received.push_back(number[i].get());
             }
             hpx::evaluate_active_counters(false, " All Futures Done");
-            hpx::cout << "Now Done With Lambda and the last recieved value is "
-                      <<recieved[n-1]<< "\n" << hpx::flush;
+            hpx::cout << "Now Done With Lambda and the last received value is "
+                      <<received[n-1]<< "\n" << hpx::flush;
         }
     ).get();
     return hpx::finalize();

--- a/tests/regressions/util/use_all_cores_2262.cpp
+++ b/tests/regressions/util/use_all_cores_2262.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 // This test verifies that 'hpx.os_threads=all' is equivalent to specifying
-// all of the avalable cores (see #2262).
+// all of the available cores (see #2262).
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/threads.hpp>

--- a/tests/unit/resource/cross_pool_injection.cpp
+++ b/tests/unit/resource/cross_pool_injection.cpp
@@ -189,7 +189,7 @@ int hpx_main(int argc, char* /*argv*/[])
         std::size_t random_pool_2 = st_rand(0, num_pools - 1);
         auto& exec_7 = NP_executors[random_pool_1];
         auto& exec_8 = HP_executors[random_pool_2];
-        // random delay up to 5 miliseconds
+        // random delay up to 5 milliseconds
         std::size_t delay = st_rand(0, 5);
         auto f7 = hpx::async(exec_7, &dummy_task, delay);
         auto f8 = hpx::async(exec_8, [f7(std::move(f7)), &counter]() mutable {

--- a/tests/unit/util/unwrap.cpp
+++ b/tests/unit/util/unwrap.cpp
@@ -235,7 +235,7 @@ void test_unwrapping_all(FutureProvider&& futurize)
 }
 
 /// This section declare some unit tests which ensure that issues
-/// that occured while developing the implementation were fixed.
+/// that occurred while developing the implementation were fixed.
 template <template <typename> class FutureType, typename FutureProvider>
 void test_development_regressions(FutureProvider&& futurize)
 {

--- a/tools/inspect/inspect.cpp
+++ b/tools/inspect/inspect.cpp
@@ -535,7 +535,7 @@ namespace
               string link = linelink(full_path, line);
               out << sep << itr->msg << "(line " << link << ") ";
               //Since the brackets are not used in inspect besides for formatting
-              //html_encode is unneccessary
+              //html_encode is unnecessary
               //out << sep << "(line " << link << ") " << html_encode(itr->msg);
           }
           else out << sep << itr->msg;

--- a/tools/inspect/license_check.cpp
+++ b/tools/inspect/license_check.cpp
@@ -16,7 +16,7 @@ namespace
 {
   boost::regex license_regex(
     //~ The next two lines change the regex so that it detects when the license
-    //~ doesn't follow the prefered statement. Disabled because it currently
+    //~ doesn't follow the preferred statement. Disabled because it currently
     //~ generates a large number of issues.
     //~ "Distributed[\\s\\W]+"
     //~ "under[\\s\\W]+the[\\s\\W]+"

--- a/tools/inspect/spdx_license_check.cpp
+++ b/tools/inspect/spdx_license_check.cpp
@@ -16,7 +16,7 @@ namespace
 {
   boost::regex spdx_license_regex(
     //~ The next two lines change the regex so that it detects when the license
-    //~ doesn't follow the prefered statement.
+    //~ doesn't follow the preferred statement.
     "spdx-license-identifier[\\s\\W]*:[\\s\\W]+bsl-",
     boost::regbase::normal | boost::regbase::icase);
 


### PR DESCRIPTION
Fixes spelling mistakes reported by codespell, and adds a CircleCI step that checks spelling on changed files using codespell. Requires https://github.com/STEllAR-GROUP/docker_build_env/pull/18.