### PR TITLE
Fix launch process test with APEX enabled

### DIFF
--- a/src/runtime_handlers.cpp
+++ b/src/runtime_handlers.cpp
@@ -52,7 +52,7 @@ namespace hpx { namespace detail {
 #if defined(HPX_HAVE_APEX)
     bool enable_parent_task_handler()
     {
-        return hpx::get_initial_num_localities() == 1;
+        return !hpx::is_networking_enabled();
     }
 #endif
 


### PR DESCRIPTION
The test segfaulted trying to access parent task information from another
locality. This happened because parent task handling was enabled when the
initial number of localities was 1. However, even when the initial number of
localities is 1 additional localities can connect later (as in the launch
process test) leading to APEX trying to acccess task information from another
locality. This changes the behaviour to only enable parent task handling when
networking is disabled.