### PR TITLE
Give a hard error if IO counters are enabled on non-Linux systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,6 +354,9 @@ hpx_option(HPX_WITH_IO_COUNTERS BOOL
   "Enable IO counters (default: ${HPX_WITH_IO_COUNTERS_DEFAULT})"
   ${HPX_WITH_IO_COUNTERS_DEFAULT} ADVANCED CATEGORY "Build Targets")
 if(HPX_WITH_IO_COUNTERS)
+  if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+    hpx_error("HPX_WITH_IO_COUNTERS was set to ON, but IO counters are only available on Linux (this is \"${CMAKE_SYSTEM_NAME}\")")
+  endif()
   hpx_add_config_define(HPX_HAVE_IO_COUNTERS)
 endif()
 


### PR DESCRIPTION
"Fixes" #4336.

@McKillroy how does this look to you?