### PR TITLE
Move generated documentation to hpx-docs repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,9 @@
 |circleci_status| |zenodo_doi| |codacy|
 
 Documentation: `latest
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/index.html>`_,
+<https://stellar-group.github.io/hpx-docs/latest/html/index.html>`_,
 `development (master)
-<https://stellar-group.github.io/hpx/docs/sphinx/branches/master/html/index.html>`_
+<https://stellar-group.github.io/hpx-docs/branches/master/html/index.html>`_
 
 ===
 HPX
@@ -69,16 +69,16 @@ which can be downloaded `here <https://stellar.cct.lsu.edu/downloads/>`_.
 
 To quickly get started with HPX on most Linux distributions you can read the
 quick start guide `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/quickstart.html>`_.
+<https://stellar-group.github.io/hpx-docs/latest/html/quickstart.html>`_.
 Detailed instructions on building and installing HPX on various platforms can be
 found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/manual/building_hpx.html>`_.
+<https://stellar-group.github.io/hpx-docs/latest/html/manual/building_hpx.html>`_.
 The full documentation for the latest release of HPX can always be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/index.html>`_.
+<https://stellar-group.github.io/hpx-docs/latest/html/index.html>`_.
 
 If you would like to work with the cutting edge version of this repository
 (``master`` branch) the documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/branches/master/html/index.html>`_.
+<https://stellar-group.github.io/hpx-docs/branches/master/html/index.html>`_.
 We strongly recommend that you follow the current health status of the master
 branch by looking at our `continuous integration results website
 <http://rostam.cct.lsu.edu/console>`_. While we try to keep the master branch

--- a/cmake/HPX_UpdateGitDocs.cmake
+++ b/cmake/HPX_UpdateGitDocs.cmake
@@ -1,3 +1,4 @@
+# Copyright (c)      2020 Mikael Simberg
 # Copyright (c) 2011-2013 Thomas Heller
 #
 # SPDX-License-Identifier: BSL-1.0
@@ -13,7 +14,7 @@ if(NOT GIT_FOUND)
 endif()
 
 if(NOT GIT_REPOSITORY)
-  set(GIT_REPOSITORY git@github.com:STEllAR-GROUP/hpx.git --branch gh-pages)
+  set(GIT_REPOSITORY git@github.com:STEllAR-GROUP/hpx-docs.git --branch master)
 endif()
 
 if(EXISTS "${HPX_BINARY_DIR}/docs/gh-pages")
@@ -46,7 +47,7 @@ string(REGEX REPLACE " " ";"
 message("HPX_WITH_GIT_BRANCH=\"${HPX_WITH_GIT_BRANCH}\"")
 if(HPX_WITH_GIT_BRANCH)
   message("Updating branch directory")
-  set(DOCS_BRANCH_DEST "${HPX_BINARY_DIR}/docs/gh-pages/docs/sphinx/branches/${HPX_WITH_GIT_BRANCH}")
+  set(DOCS_BRANCH_DEST "${HPX_BINARY_DIR}/docs/gh-pages/branches/${HPX_WITH_GIT_BRANCH}")
   file(REMOVE_RECURSE "${DOCS_BRANCH_DEST}")
   if("html" IN_LIST HPX_WITH_DOCUMENTATION_OUTPUT_FORMATS)
     file(
@@ -72,7 +73,7 @@ endif()
 message("HPX_WITH_GIT_TAG=\"${HPX_WITH_GIT_TAG}\"")
 if(HPX_WITH_GIT_TAG)
   message("Updating tag directory")
-  set(DOCS_TAG_DEST "${HPX_BINARY_DIR}/docs/gh-pages/docs/sphinx/tags/${HPX_WITH_GIT_TAG}")
+  set(DOCS_TAG_DEST "${HPX_BINARY_DIR}/docs/gh-pages/tags/${HPX_WITH_GIT_TAG}")
   file(REMOVE_RECURSE "${DOCS_TAG_DEST}")
   if("html" IN_LIST HPX_WITH_DOCUMENTATION_OUTPUT_FORMATS)
     file(
@@ -99,7 +100,7 @@ if(HPX_WITH_GIT_TAG)
   # candidates or other non-version tag names.
   if("${HPX_WITH_GIT_TAG}" MATCHES "^[0-9]+\\.[0-9]+\\.[0-9]+$")
     message("Updating latest directory")
-    set(DOCS_LATEST_DEST "${HPX_BINARY_DIR}/docs/gh-pages/docs/sphinx/latest")
+    set(DOCS_LATEST_DEST "${HPX_BINARY_DIR}/docs/gh-pages/latest")
     file(REMOVE_RECURSE "${DOCS_LATEST_DEST}")
     if("html" IN_LIST HPX_WITH_DOCUMENTATION_OUTPUT_FORMATS)
       file(
@@ -125,7 +126,7 @@ endif()
 # add all newly generated files
 execute_process(
   COMMAND "${GIT_EXECUTABLE}" add *
-  WORKING_DIRECTORY "${HPX_BINARY_DIR}/docs/gh-pages/docs/sphinx"
+  WORKING_DIRECTORY "${HPX_BINARY_DIR}/docs/gh-pages"
   RESULT_VARIABLE git_add_result)
 if(NOT "${git_add_result}" EQUAL "0")
   message(FATAL_ERROR "Adding files to the GitHub pages branch failed.")

--- a/cmake/packaging/rpm/Changelog.txt
+++ b/cmake/packaging/rpm/Changelog.txt
@@ -1,11 +1,11 @@
 * Wed Jan 15 2020 STE||AR Group <contact@stellar-group.org> 1.4.0-1
-- HPX Release 1.3.0 (https://stellar-group.github.io/hpx/docs/sphinx/tags/1.4.0/html/releases/whats_new_1_3_0.html)
+- HPX Release 1.3.0 (https://stellar-group.github.io/hpx-docs/tags/1.4.0/html/releases/whats_new_1_3_0.html)
 
 * Wed May 23 2019 STE||AR Group <contact@stellar-group.org> 1.3.0-1
-- HPX Release 1.3.0 (https://stellar-group.github.io/hpx/docs/sphinx/tags/1.3.0/html/releases/whats_new_1_3_0.html)
+- HPX Release 1.3.0 (https://stellar-group.github.io/hpx-docs/tags/1.3.0/html/releases/whats_new_1_3_0.html)
 
 * Wed Feb 19 2019 STE||AR Group <contact@stellar-group.org> 1.2.1-1
-- HPX Release 1.2.1 (https://stellar-group.github.io/hpx/docs/sphinx/tags/1.2.1/html/releases/whats_new_1_2_1.html)
+- HPX Release 1.2.1 (https://stellar-group.github.io/hpx-docs/tags/1.2.1/html/releases/whats_new_1_2_1.html)
 
 * Wed Nov 12 2018 STE||AR Group <contact@stellar-group.org> 1.2.0-1
-- HPX Release 1.2 (https://stellar-group.github.io/hpx/docs/sphinx/tags/1.2.0/html/releases/whats_new_1_2_0.html)
+- HPX Release 1.2 (https://stellar-group.github.io/hpx-docs/tags/1.2.0/html/releases/whats_new_1_2_0.html)

--- a/libs/affinity/README.rst
+++ b/libs/affinity/README.rst
@@ -13,4 +13,4 @@ affinity
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/affinity/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/affinity/docs/index.html>`__.

--- a/libs/algorithms/README.rst
+++ b/libs/algorithms/README.rst
@@ -12,4 +12,4 @@ algorithms
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/algorithms/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/algorithms/docs/index.html>`__.

--- a/libs/allocator_support/README.rst
+++ b/libs/allocator_support/README.rst
@@ -12,4 +12,4 @@ allocator_support
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/allocator_support/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/allocator_support/docs/index.html>`__.

--- a/libs/assertion/README.rst
+++ b/libs/assertion/README.rst
@@ -13,4 +13,4 @@ This library is part of HPX. It implements ``HPX_ASSERT`` and ``HPX_ASSERT_MSG``
 which are useful to implement error handling for debug builds.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/assert/docs/index.html>`_.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/assert/docs/index.html>`_.

--- a/libs/basic_execution/README.rst
+++ b/libs/basic_execution/README.rst
@@ -13,4 +13,4 @@ Basic Execution
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/basic_execution/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/basic_execution/docs/index.html>`__.

--- a/libs/batch_environments/README.rst
+++ b/libs/batch_environments/README.rst
@@ -13,4 +13,4 @@ batch_environments
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/batch_environments/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/batch_environments/docs/index.html>`__.

--- a/libs/cache/README.rst
+++ b/libs/cache/README.rst
@@ -13,4 +13,4 @@ cache
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/cache/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/cache/docs/index.html>`__.

--- a/libs/checkpoint/README.rst
+++ b/libs/checkpoint/README.rst
@@ -13,4 +13,4 @@ checkpoint
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/checkpoint/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/checkpoint/docs/index.html>`__.

--- a/libs/collectives/README.rst
+++ b/libs/collectives/README.rst
@@ -13,4 +13,4 @@ Collectives
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/collectives/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/collectives/docs/index.html>`__.

--- a/libs/compute/README.rst
+++ b/libs/compute/README.rst
@@ -13,4 +13,4 @@ compute
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/compute/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/compute/docs/index.html>`__.

--- a/libs/compute_cuda/README.rst
+++ b/libs/compute_cuda/README.rst
@@ -13,4 +13,4 @@ compute_cuda
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/compute_cuda/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/compute_cuda/docs/index.html>`__.

--- a/libs/concepts/README.rst
+++ b/libs/concepts/README.rst
@@ -13,4 +13,4 @@ concepts
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/concepts/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/concepts/docs/index.html>`__.

--- a/libs/concurrency/README.rst
+++ b/libs/concurrency/README.rst
@@ -12,4 +12,4 @@ concurrency
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/concurrency/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/concurrency/docs/index.html>`__.

--- a/libs/config/README.rst
+++ b/libs/config/README.rst
@@ -13,4 +13,4 @@ This library is part of HPX. It contains macros that identify features of a comp
 as well as platform independent macros to control inlinining, export sets and more.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/config/docs/index.html>`_.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/config/docs/index.html>`_.

--- a/libs/coroutines/README.rst
+++ b/libs/coroutines/README.rst
@@ -12,4 +12,4 @@ coroutines
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/coroutines/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/coroutines/docs/index.html>`__.

--- a/libs/datastructures/README.rst
+++ b/libs/datastructures/README.rst
@@ -13,4 +13,4 @@ datastructures
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/datastructures/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/datastructures/docs/index.html>`__.

--- a/libs/debugging/README.rst
+++ b/libs/debugging/README.rst
@@ -13,4 +13,4 @@ debugging
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/debugging/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/debugging/docs/index.html>`__.

--- a/libs/errors/README.rst
+++ b/libs/errors/README.rst
@@ -13,4 +13,4 @@ errors
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/errors/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/errors/docs/index.html>`__.

--- a/libs/execution/README.rst
+++ b/libs/execution/README.rst
@@ -13,4 +13,4 @@ execution
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/execution/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/execution/docs/index.html>`__.

--- a/libs/filesystem/README.rst
+++ b/libs/filesystem/README.rst
@@ -13,4 +13,4 @@ filesystem
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/filesystem/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/filesystem/docs/index.html>`__.

--- a/libs/format/README.rst
+++ b/libs/format/README.rst
@@ -12,4 +12,4 @@ format
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/format/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/format/docs/index.html>`__.

--- a/libs/functional/README.rst
+++ b/libs/functional/README.rst
@@ -13,4 +13,4 @@ functional
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/functional/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/functional/docs/index.html>`__.

--- a/libs/hardware/README.rst
+++ b/libs/hardware/README.rst
@@ -12,4 +12,4 @@ hardware
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/hardware/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/hardware/docs/index.html>`__.

--- a/libs/hashing/README.rst
+++ b/libs/hashing/README.rst
@@ -12,4 +12,4 @@ hashing
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/hashing/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/hashing/docs/index.html>`__.

--- a/libs/iterator_support/README.rst
+++ b/libs/iterator_support/README.rst
@@ -12,4 +12,4 @@ iterator_support
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/iterator_support/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/iterator_support/docs/index.html>`__.

--- a/libs/local_lcos/README.rst
+++ b/libs/local_lcos/README.rst
@@ -13,4 +13,4 @@ local_lcos
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/local_lcos/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/local_lcos/docs/index.html>`__.

--- a/libs/logging/README.rst
+++ b/libs/logging/README.rst
@@ -13,4 +13,4 @@ logging
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/logging/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/logging/docs/index.html>`__.

--- a/libs/memory/README.rst
+++ b/libs/memory/README.rst
@@ -13,4 +13,4 @@ memory
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/memory/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/memory/docs/index.html>`__.

--- a/libs/naming_base/README.rst
+++ b/libs/naming_base/README.rst
@@ -13,4 +13,4 @@ naming_base
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/naming_base/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/naming_base/docs/index.html>`__.

--- a/libs/plugin/README.rst
+++ b/libs/plugin/README.rst
@@ -12,4 +12,4 @@ plugin
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/plugin/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/plugin/docs/index.html>`__.

--- a/libs/preprocessor/README.rst
+++ b/libs/preprocessor/README.rst
@@ -18,4 +18,4 @@ This library contains useful preprocessor macros:
 * ``HPX_PP_STRIP_PARENS``: Strips parenthesis from a token
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/pp/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/pp/docs/index.html>`__.

--- a/libs/program_options/README.rst
+++ b/libs/program_options/README.rst
@@ -12,4 +12,4 @@ program_options
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/program_options/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/program_options/docs/index.html>`__.

--- a/libs/resiliency/README.rst
+++ b/libs/resiliency/README.rst
@@ -12,7 +12,7 @@ Resiliency
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/resiliency/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/resiliency/docs/index.html>`__.
 
 Copyright (c) 2019 National Technology & Engineering Solutions of Sandia,
 LLC (NTESS). Under the terms of the Contract DE-NA0003525 with NTESS, the

--- a/libs/resource_partitioner/README.rst
+++ b/libs/resource_partitioner/README.rst
@@ -13,4 +13,4 @@ resource_partitioner
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/resource_partitioner/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/resource_partitioner/docs/index.html>`__.

--- a/libs/segmented_algorithms/README.rst
+++ b/libs/segmented_algorithms/README.rst
@@ -12,4 +12,4 @@ segmented_algorithms
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/segmented_algorithms/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/segmented_algorithms/docs/index.html>`__.

--- a/libs/serialization/README.rst
+++ b/libs/serialization/README.rst
@@ -13,4 +13,4 @@ serialization
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/serialization/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/serialization/docs/index.html>`__.

--- a/libs/static_reinit/README.rst
+++ b/libs/static_reinit/README.rst
@@ -13,4 +13,4 @@ static_reinit
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/static_reinit/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/static_reinit/docs/index.html>`__.

--- a/libs/statistics/README.rst
+++ b/libs/statistics/README.rst
@@ -12,4 +12,4 @@ statistics
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/statistics/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/statistics/docs/index.html>`__.

--- a/libs/synchronization/README.rst
+++ b/libs/synchronization/README.rst
@@ -13,4 +13,4 @@ synchronization
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/synchronization/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/synchronization/docs/index.html>`__.

--- a/libs/testing/README.rst
+++ b/libs/testing/README.rst
@@ -12,4 +12,4 @@ testing
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/testing/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/testing/docs/index.html>`__.

--- a/libs/thread_support/README.rst
+++ b/libs/thread_support/README.rst
@@ -12,4 +12,4 @@ thread_support
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/thread_support/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/thread_support/docs/index.html>`__.

--- a/libs/threadmanager/README.rst
+++ b/libs/threadmanager/README.rst
@@ -13,4 +13,4 @@ thread_manager
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/thread_manager/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/thread_manager/docs/index.html>`__.

--- a/libs/timing/README.rst
+++ b/libs/timing/README.rst
@@ -13,4 +13,4 @@ timing
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/timing/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/timing/docs/index.html>`__.

--- a/libs/topology/README.rst
+++ b/libs/topology/README.rst
@@ -13,4 +13,4 @@ topology
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/topology/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/topology/docs/index.html>`__.

--- a/libs/type_support/README.rst
+++ b/libs/type_support/README.rst
@@ -13,4 +13,4 @@ type_support
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/type_support/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/type_support/docs/index.html>`__.

--- a/libs/util/README.rst
+++ b/libs/util/README.rst
@@ -12,4 +12,4 @@ util
 This library is part of HPX.
 
 Documentation can be found `here
-<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/util/docs/index.html>`__.
+<https://stellar-group.github.io/hpx-docs/latest/html/libs/util/docs/index.html>`__.


### PR DESCRIPTION
This is still WIP until I see that everything gets pushed correctly to the new repo. Currently it's https://github.com/STEllAR-GROUP/hpx-docs, and the docs would be at https://stellar-group.github.io/hpx-docs/latest/html/index.html, but feel free to suggest another name for it. Once this is finalized I'll clean up the `gh-pages` branch here.