### PR TITLE
Skip MPI_Finalize if MPI_Init is not called from HPX

### DIFF
--- a/plugins/parcelport/mpi/mpi_environment.cpp
+++ b/plugins/parcelport/mpi/mpi_environment.cpp
@@ -101,7 +101,7 @@ namespace hpx { namespace util
         }
         else
         {
-            has_called_init_ = true;
+            has_called_init_ = false;
         }
 
         MPI_Comm_dup(MPI_COMM_WORLD, &communicator_);


### PR DESCRIPTION
## Expected Behavior

I am running HPX with the MPI parcelport inside another application that also uses MPI. If my application calls `MPI_Init` or `MPI_Init_thread` before starting the HPX runtime with `hpx::start`, `mpi_environment::init` correctly detects this and skips `MPI_Init`. In that case, I would expect HPX to not call `MPI_Finalize` when `hpx::stop` is called.

## Actual Behavior

I get the error: `Attempting to use an MPI routine after finalizing MPI` when the rest of my application tries to make other MPI calls after `hpx::stop`.

Related to: https://github.com/STEllAR-GROUP/hpx/issues/1066