### PR TITLE
Fix spellcheck step in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,9 +258,13 @@ jobs:
       - run:
           name: Running codespell
           command: |
-              cd /hpx/source
-              codespell $(git diff --name-only origin/master) > /tmp/spelling_suggestions.txt
-              if [ -s /tmp/spelling_suggestions.txt ]; then exit 1; fi
+              if [ "$CIRCLE_PR_NUMBER" ]; then
+                  cd /hpx/source
+                  codespell --skip='*.h5,*.png' $(git diff --name-only origin/master) > /tmp/spelling_suggestions.txt
+                  if [ -s /tmp/spelling_suggestions.txt ]; then exit 1; fi
+              else
+                  echo "skipping spellcheck on non-PR build"
+              fi
           when: always
       - store_artifacts:
           path: /tmp/spelling_suggestions.txt


### PR DESCRIPTION
Only run the step on changed files in pull requests, not on e.g. master.
Also skip HDF5 and PNG files.