### PR TITLE
Adding missing #includes to fix gcc V10 linker problems

### DIFF
--- a/libs/collectives/src/latch.cpp
+++ b/libs/collectives/src/latch.cpp
@@ -11,6 +11,7 @@
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/actions/detail/action_factory.hpp>
+#include <hpx/runtime/applier/apply.hpp>
 #include <hpx/runtime/components/client_base.hpp>
 #include <hpx/runtime/components/derived_component_factory.hpp>
 #include <hpx/runtime/components/new.hpp>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -346,6 +346,10 @@ foreach(_module ${HPX_LIBS})
 
 endforeach()
 
+if((NOT HPX_WITH_STATIC_LINKING) AND (("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux") OR (APPLE)))
+  set_target_properties(hpx PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()
+
 target_compile_definitions(hpx PUBLIC HPX_ENABLE_ASSERT_HANDLER PRIVATE
   HPX_COMPONENT_NAME=hpx HPX_EXPORTS)
 
@@ -423,7 +427,6 @@ endif()
 
 if(HPX_WITH_DYNAMIC_HPX_MAIN AND (("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux") OR (APPLE)))
   if(NOT HPX_WITH_STATIC_LINKING)
-    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
     if(HPX_WITH_DEFAULT_TARGETS)
       if(HPX_WITH_CUDA)
         cuda_add_library(hpx_wrap STATIC
@@ -441,6 +444,8 @@ if(HPX_WITH_DYNAMIC_HPX_MAIN AND (("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux") OR (
           ${hpx_wrap_SOURCES})
       endif()
     endif()
+
+    set_target_properties(hpx_wrap PROPERTIES CMAKE_POSITION_INDEPENDENT_CODE ON)
 
     target_compile_definitions(hpx_wrap PUBLIC HPX_ENABLE_ASSERT_HANDLER PRIVATE
       HPX_APPLICATION_EXPORTS)

--- a/src/lcos/base_lco_with_value.cpp
+++ b/src/lcos/base_lco_with_value.cpp
@@ -7,6 +7,7 @@
 
 #include <hpx/apply.hpp>
 #include <hpx/lcos/base_lco_with_value.hpp>
+#include <hpx/runtime/applier/apply.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime/naming/name.hpp>
 #include <hpx/serialization/vector.hpp>

--- a/src/lcos/base_lco_with_value_1.cpp
+++ b/src/lcos/base_lco_with_value_1.cpp
@@ -7,6 +7,7 @@
 
 #include <hpx/apply.hpp>
 #include <hpx/lcos/base_lco_with_value.hpp>
+#include <hpx/runtime/applier/apply.hpp>
 
 #include <cstdint>
 

--- a/src/lcos/base_lco_with_value_2.cpp
+++ b/src/lcos/base_lco_with_value_2.cpp
@@ -7,6 +7,7 @@
 
 #include <hpx/apply.hpp>
 #include <hpx/lcos/base_lco_with_value.hpp>
+#include <hpx/runtime/applier/apply.hpp>
 
 #include <cstdint>
 

--- a/src/lcos/base_lco_with_value_3.cpp
+++ b/src/lcos/base_lco_with_value_3.cpp
@@ -7,6 +7,7 @@
 
 #include <hpx/apply.hpp>
 #include <hpx/lcos/base_lco_with_value.hpp>
+#include <hpx/runtime/applier/apply.hpp>
 #include <hpx/serialization/vector.hpp>
 #include <hpx/util/ini.hpp>
 

--- a/src/performance_counters/counters.cpp
+++ b/src/performance_counters/counters.cpp
@@ -21,6 +21,7 @@
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/agas/interface.hpp>
 #include <hpx/runtime/components/stubs/runtime_support.hpp>
+#include <hpx/runtime/applier/apply.hpp>
 #include <hpx/runtime/get_num_localities.hpp>
 #include <hpx/serialization/base_object.hpp>
 #include <hpx/serialization/serialize.hpp>

--- a/src/runtime/agas/component_namespace.cpp
+++ b/src/runtime/agas/component_namespace.cpp
@@ -12,6 +12,7 @@
 #include <hpx/runtime/actions/basic_action.hpp>
 #include <hpx/runtime/agas/component_namespace.hpp>
 #include <hpx/runtime/agas/server/component_namespace.hpp>
+#include <hpx/runtime/applier/apply.hpp>
 #include <hpx/runtime/components/component_factory.hpp>
 #include <hpx/serialization/vector.hpp>
 

--- a/src/runtime/agas/locality_namespace.cpp
+++ b/src/runtime/agas/locality_namespace.cpp
@@ -13,6 +13,7 @@
 #include <hpx/runtime/actions/component_action.hpp>
 #include <hpx/runtime/agas/locality_namespace.hpp>
 #include <hpx/runtime/agas/server/locality_namespace.hpp>
+#include <hpx/runtime/applier/apply.hpp>
 #include <hpx/runtime/components/component_factory.hpp>
 #include <hpx/serialization/vector.hpp>
 
@@ -30,43 +31,34 @@ HPX_REGISTER_BASE_LCO_WITH_VALUE_ID(
     hpx::actions::base_lco_with_value_parcelset_endpoints_get,
     hpx::actions::base_lco_with_value_parcelset_endpoints_set)
 
-HPX_REGISTER_ACTION_ID(
-    locality_namespace::allocate_action,
+HPX_REGISTER_ACTION_ID(locality_namespace::allocate_action,
     locality_namespace_allocate_action,
     hpx::actions::locality_namespace_allocate_action_id)
 
-HPX_REGISTER_ACTION_ID(
-    locality_namespace::free_action,
+HPX_REGISTER_ACTION_ID(locality_namespace::free_action,
     locality_namespace_free_action,
     hpx::actions::locality_namespace_free_action_id)
 
-HPX_REGISTER_ACTION_ID(
-    locality_namespace::localities_action,
+HPX_REGISTER_ACTION_ID(locality_namespace::localities_action,
     locality_namespace_localities_action,
     hpx::actions::locality_namespace_localities_action_id)
 
-HPX_REGISTER_ACTION_ID(
-    locality_namespace::resolve_locality_action,
+HPX_REGISTER_ACTION_ID(locality_namespace::resolve_locality_action,
     locality_namespace_resolve_locality_action,
     hpx::actions::locality_namespace_resolve_locality_action_id)
 
-HPX_REGISTER_ACTION_ID(
-    locality_namespace::get_num_localities_action,
+HPX_REGISTER_ACTION_ID(locality_namespace::get_num_localities_action,
     locality_namespace_get_num_localities_action,
     hpx::actions::locality_namespace_get_num_localities_action_id)
 
-HPX_REGISTER_ACTION_ID(
-    locality_namespace::get_num_threads_action,
+HPX_REGISTER_ACTION_ID(locality_namespace::get_num_threads_action,
     locality_namespace_get_num_threads_action,
     hpx::actions::locality_namespace_get_num_threads_action_id)
 
-HPX_REGISTER_ACTION_ID(
-    locality_namespace::get_num_overall_threads_action,
+HPX_REGISTER_ACTION_ID(locality_namespace::get_num_overall_threads_action,
     locality_namespace_get_num_overall_threads_action,
     hpx::actions::locality_namespace_get_num_overall_threads_action_id)
 
-HPX_REGISTER_ACTION_ID(
-    locality_namespace::statistics_counter_action,
+HPX_REGISTER_ACTION_ID(locality_namespace::statistics_counter_action,
     locality_namespace_statistics_counter_action,
     hpx::actions::locality_namespace_statistics_counter_action_id)
-

--- a/src/runtime/agas/primary_namespace.cpp
+++ b/src/runtime/agas/primary_namespace.cpp
@@ -14,6 +14,7 @@
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/agas/primary_namespace.hpp>
 #include <hpx/runtime/agas/server/primary_namespace.hpp>
+#include <hpx/runtime/applier/apply.hpp>
 #include <hpx/runtime/applier/apply_callback.hpp>
 #include <hpx/runtime/components/component_factory.hpp>
 #include <hpx/serialization/vector.hpp>

--- a/src/runtime/agas/server/symbol_namespace_server.cpp
+++ b/src/runtime/agas/server/symbol_namespace_server.cpp
@@ -21,6 +21,7 @@
 #include <hpx/runtime/agas/interface.hpp>
 #include <hpx/runtime/agas/namespace_action_code.hpp>
 #include <hpx/runtime/agas/server/symbol_namespace.hpp>
+#include <hpx/runtime/applier/apply.hpp>
 #include <hpx/runtime/naming/split_gid.hpp>
 #include <hpx/thread_support/unlock_guard.hpp>
 #include <hpx/timing/scoped_timer.hpp>


### PR DESCRIPTION
- flyby: clean up -fPIC option

Fixes #4320
