### PR TITLE
Update clang-format config file for version 9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
           name: Check that the modules are well clang-formatted
           command: |
               cd /hpx/source/libs && shopt -s globstar # to activate the ** globbing
-              clang-format-8 -i **/*.{cpp,hpp}
+              clang-format -i **/*.{cpp,hpp}
               git diff --exit-code > /tmp/modified_format_files.txt
       - store_artifacts:
           path: /tmp/modified_format_files.txt

--- a/.clang-format
+++ b/.clang-format
@@ -42,6 +42,7 @@ AlwaysBreakTemplateDeclarations: true
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
+    AfterCaseLabel: true
     AfterClass: true
     AfterControlStatement: true
     AfterEnum: true

--- a/libs/coroutines/include/hpx/coroutines/detail/context_generic_context.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/context_generic_context.hpp
@@ -44,13 +44,13 @@
 
 extern "C" {
 void* __splitstack_makecontext(
-    std::size_t, void * [HPX_COROUTINES_SEGMENTS], std::size_t*);
-void __splitstack_releasecontext(void * [HPX_COROUTINES_SEGMENTS]);
-void __splitstack_resetcontext(void * [HPX_COROUTINES_SEGMENTS]);
+    std::size_t, void* [HPX_COROUTINES_SEGMENTS], std::size_t*);
+void __splitstack_releasecontext(void* [HPX_COROUTINES_SEGMENTS]);
+void __splitstack_resetcontext(void* [HPX_COROUTINES_SEGMENTS]);
 void __splitstack_block_signals_context(
-    void * [HPX_COROUTINES_SEGMENTS], int* new_value, int* old_value);
-void __splitstack_getcontext(void * [HPX_COROUTINES_SEGMENTS]);
-void __splitstack_setcontext(void * [HPX_COROUTINES_SEGMENTS]);
+    void* [HPX_COROUTINES_SEGMENTS], int* new_value, int* old_value);
+void __splitstack_getcontext(void* [HPX_COROUTINES_SEGMENTS]);
+void __splitstack_setcontext(void* [HPX_COROUTINES_SEGMENTS]);
 }
 
 #if !defined(SIGSTKSZ)

--- a/libs/coroutines/include/hpx/coroutines/stackless_coroutine.hpp
+++ b/libs/coroutines/include/hpx/coroutines/stackless_coroutine.hpp
@@ -233,8 +233,8 @@ namespace hpx { namespace threads { namespace coroutines {
 
 namespace hpx { namespace threads { namespace coroutines {
 
-    HPX_FORCEINLINE stackless_coroutine::result_type stackless_coroutine::
-    operator()(arg_type arg)
+    HPX_FORCEINLINE stackless_coroutine::result_type
+    stackless_coroutine::operator()(arg_type arg)
     {
         HPX_ASSERT(is_ready());
 

--- a/libs/serialization/include/hpx/serialization/brace_initializable.hpp
+++ b/libs/serialization/include/hpx/serialization/brace_initializable.hpp
@@ -164,9 +164,8 @@ namespace hpx { namespace serialization {
     void serialize_struct(Archive& archive, T& t, const unsigned int version,
         hpx::traits::detail::size<15>)
     {
-        auto&
-            [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15] =
-            t;
+        auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14,
+            p15] = t;
         auto&& data = hpx::util::forward_as_tuple(
             p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15);
         serialize(archive, data, version);


### PR DESCRIPTION
Goes together with https://github.com/STEllAR-GROUP/docker_build_env/pull/19. Brace wrapping after case labels can be kept as it is with a new option but I don't see any obvious options to avoid the other formatting changes. They look like something that should've been applied with clang-format-8 anyway.