### PR TITLE
Suppress or fix clang-tidy-9 warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,7 +305,7 @@ jobs:
       - run:
           name: Building Core
           command: |
-              ninja -j2 core
+              ninja -j2 -k 0 core
       - persist_to_workspace:
           root: /hpx
           paths:
@@ -930,7 +930,7 @@ jobs:
       - run:
           name: Building Performance Tests
           command: |
-              ninja -j2 tests.performance
+              ninja -j2 -k 0 tests.performance
 
   examples:
     <<: *defaults
@@ -940,7 +940,7 @@ jobs:
       - run:
           name: Building Examples
           command: |
-              ninja -j2 examples
+              ninja -j2 -k 0 examples
       - persist_to_workspace:
           root: /hpx
           paths:

--- a/components/containers/partitioned_vector/tests/unit/coarray.cpp
+++ b/components/containers/partitioned_vector/tests/unit/coarray.cpp
@@ -34,7 +34,7 @@ void bulk_test( hpx::lcos::spmd_block block,
 
     hpx::coarray<double,3> a(block, name, {height,width,_}, elt_size);
 
-    int idx = block.this_image() * height * width;
+    std::size_t idx = block.this_image() * height * width;
 
     for (std::size_t j = 0; j<width; j++)
     for (std::size_t i = 0; i<height; i++)
@@ -48,7 +48,7 @@ void bulk_test( hpx::lcos::spmd_block block,
 
     if(block.this_image() == 0)
     {
-        int idx = 0;
+        std::size_t idx = 0;
 
         for (std::size_t k = 0; k<numlocs; k++)
         for (std::size_t j = 0; j<width; j++)

--- a/components/process/include/hpx/components/process/util/posix/initializers/close_fds_if.hpp
+++ b/components/process/include/hpx/components/process/util/posix/initializers/close_fds_if.hpp
@@ -66,7 +66,7 @@ private:
         } while (up == -1 && errno == EINTR);
         if (up == -1)
 #endif
-            up = ::sysconf(_SC_OPEN_MAX);
+            up = static_cast<int>(::sysconf(_SC_OPEN_MAX));
         if (up == -1)
             up = HPX_PROCESS_POSIX_MAX_FD;
         return up;

--- a/examples/heartbeat/heartbeat.cpp
+++ b/examples/heartbeat/heartbeat.cpp
@@ -87,11 +87,9 @@ int monitor(double runfor, std::string const& name, std::uint64_t pause)
             if (!zero_time)
                 zero_time = value.time_;
 
-            hpx::util::format_to(std::cout,
-                "  {},{},{}[s],{}\n",
-                name,
+            hpx::util::format_to(std::cout, "  {},{},{}[s],{}\n", name,
                 value.count_,
-                double((value.time_ - zero_time) * 1e-9),
+                double(static_cast<double>(value.time_ - zero_time) * 1e-9),
                 value.value_);
 
 #if defined(HPX_WINDOWS) && HPX_USE_WINDOWS_PERFORMANCE_COUNTERS != 0

--- a/examples/performance_counters/sine/sine_client.cpp
+++ b/examples/performance_counters/sine/sine_client.cpp
@@ -94,7 +94,7 @@ int monitor(std::uint64_t pause, std::uint64_t values)
                 start_time = value2.time_;
 
             hpx::util::format_to(std::cout, "{:.3}: {:.4}, {:.4}, {:.4}\n",
-                (value2.time_ - start_time) * 1e-9,
+                static_cast<double>(value2.time_ - start_time) * 1e-9,
                 value1.get_value<double>(),
                 value2.get_value<double>() / 100000.,
                 value3.get_value<double>());
@@ -103,8 +103,11 @@ int monitor(std::uint64_t pause, std::uint64_t values)
         // stop/restart the sine_explicit counter after every 5 seconds of
         // evaluation
         bool should_run =
-            (int((value2.time_ - start_time) * 1e-9) / 5) % 2 != 0;
-        if (should_run == started) {
+            (int(static_cast<double>(value2.time_ - start_time) * 1e-9) / 5) %
+                2 !=
+            0;
+        if (should_run == started)
+        {
             if (started) {
                 sine_explicit.stop();
                 started = false;

--- a/examples/quickstart/1d_wave_equation.cpp
+++ b/examples/quickstart/1d_wave_equation.cpp
@@ -206,8 +206,8 @@ int hpx_main(variables_map& vm)
 
     c = 1.0;
 
-    dt = 1.0 / (nt - 1);
-    dx = 1.0 / (nx - 1);
+    dt = 1.0 / static_cast<double>(nt - 1);
+    dx = 1.0 / static_cast<double>(nx - 1);
     alpha_squared = (c * dt / dx) * (c * dt / dx);
 
     // check that alpha_squared satisfies the stability condition

--- a/examples/quickstart/EasyBMP/EasyBMP.cpp
+++ b/examples/quickstart/EasyBMP/EasyBMP.cpp
@@ -889,7 +889,7 @@ bool BMP::ReadFromFile( const char* FileName )
 
  // skip blank data if bfOffBits so indicates
 
- int BytesToSkip = bmfh.bfOffBits - 54;;
+ int BytesToSkip = static_cast<int>(bmfh.bfOffBits) - 54;;
  if( BitDepth < 16 )
  { BytesToSkip -= 4*IntPow(2,BitDepth); }
  if( BitDepth == 16 && bmih.biCompression == 3 )

--- a/examples/quickstart/pingpong.cpp
+++ b/examples/quickstart/pingpong.cpp
@@ -93,26 +93,25 @@ int hpx_main(hpx::program_options::variables_map &b_arg)
         }
 
         double time = timer1.elapsed();
-
+        double bandwidth =
+            ((static_cast<double>(vsize * sizeof(double) * numiter) / time) /
+                1024) /
+            1024;
         if (verbose) {
             std::cout << "[hpx_pingpong]" << std::endl
-                    << "total_time(secs)=" << time << std::endl
-                    << "vsize=" << vsize << " = " << vsize * sizeof(double)
-                    << " Bytes" << std::endl
-                    << "bandwidth(MiB/s)="
-                    << (((vsize * sizeof(double) * numiter) / time) / 1024) / 1024
-                    << std::endl
-                    << "localities=" << localities.size() << std::endl
-                    << "numiter=" << numiter << std::endl;
+                      << "total_time(secs)=" << time << std::endl
+                      << "vsize=" << vsize << " = " << vsize * sizeof(double)
+                      << " Bytes" << std::endl
+                      << "bandwidth(MiB/s)=" << bandwidth << std::endl
+                      << "localities=" << localities.size() << std::endl
+                      << "numiter=" << numiter << std::endl;
         }
         else {
             std::cout << "[hpx_pingpong]"
-                    << ":total_time(secs)=" << time
-                    << ":vsize=" << vsize
-                    << ":bandwidth(MiB/s)="
-                    << (((vsize * sizeof(double) * numiter) / time) / 1024) / 1024
-                    << ":localities=" << localities.size()
-                    << ":numiter=" << numiter << std::endl;
+                      << ":total_time(secs)=" << time << ":vsize=" << vsize
+                      << ":bandwidth(MiB/s)=" << bandwidth
+                      << ":localities=" << localities.size()
+                      << ":numiter=" << numiter << std::endl;
         }
     }
 

--- a/examples/spell_check/spell_check_file.cpp
+++ b/examples/spell_check/spell_check_file.cpp
@@ -51,7 +51,7 @@ std::string search(int start, int end, std::string const &word)
             bool sub = true;
             for (int i = 0; i < size; i++)
             {
-                char check_char = tolower(check[i]);
+                char check_char = static_cast<char>(tolower(check[i]));
                 char word_char = word[i];
                 if (word_char != check_char)
                 {
@@ -83,7 +83,7 @@ std::string search(int start, int end, std::string const &word)
         size = word.length();
     for (int i = 0; i < size; i++)
     {
-        char check_char = tolower(check[i]);
+        char check_char = static_cast<char>(tolower(check[i]));
         char word_char = word[i];
         if (check_char != word_char)
         {
@@ -166,7 +166,7 @@ int hpx_main()
                     }
                     //remove any garbage characters
                     if (toupper(temp[i][j]) >= 'A' && toupper(temp[i][j]) <= 'Z')
-                        holder.push_back(tolower(temp[i][j]));
+                        holder.push_back(static_cast<char>(tolower(temp[i][j])));
                 }
                 if (holder.size() > 0)
                 {
@@ -188,7 +188,7 @@ int hpx_main()
             {
                 getline(fin, temp);
                 for (string::size_type i = 0; i < temp.length(); i++)
-                temp[i] = tolower(temp[i]);
+                temp[i] = static_cast<char>(tolower(temp[i]));
                 words.push_back(temp);
                 wordcount++;
             }

--- a/examples/spell_check/spell_check_simple.cpp
+++ b/examples/spell_check/spell_check_simple.cpp
@@ -51,7 +51,7 @@ std::string search(int start, int end, std::string const &word)
             bool sub = true;
             for (int i = 0; i < size; i++)
             {
-                char check_char = tolower(check[i]);
+                char check_char = static_cast<char>(tolower(check[i]));
                 char word_char = word[i];
                 if (word_char != check_char)
                 {
@@ -84,7 +84,7 @@ std::string search(int start, int end, std::string const &word)
         size = word.length();
     for (int i = 0; i < size; i++)
     {
-        char check_char = tolower(check[i]);
+        char check_char = static_cast<char>(tolower(check[i]));
         char word_char = word[i];
         if (check_char != word_char)
         {
@@ -129,7 +129,7 @@ int hpx_main()
             {
                 getline(fin, temp);
                 for (string::size_type i = 0; i < temp.length(); i++)
-                temp[i] = tolower(temp[i]);
+                temp[i] = static_cast<char>(tolower(temp[i]));
                 words.push_back(temp);
                 wordcount++;
             }
@@ -170,7 +170,7 @@ int hpx_main()
                     }
                     //remove any garbage characters
                     if (toupper(temp[i][j]) >= 'A' && toupper(temp[i][j]) <= 'Z')
-                        holder.push_back(tolower(temp[i][j]));
+                        holder.push_back(static_cast<char>(tolower(temp[i][j])));
                 }
                 if (holder.size() > 0)
                 {

--- a/examples/transpose/transpose_await.cpp
+++ b/examples/transpose/transpose_await.cpp
@@ -295,8 +295,10 @@ int hpx_main(hpx::program_options::variables_map& vm)
                 {
                     for(std::uint64_t j = 0; j != block_order; ++j)
                     {
-                        double col_val = COL_SHIFT * (b*block_order + j);
-                        A_ptr->data_[i * block_order + j] = col_val + ROW_SHIFT * i;
+                        double col_val = COL_SHIFT *
+                            static_cast<double>(b * block_order + j);
+                        A_ptr->data_[i * block_order + j] =
+                            col_val + ROW_SHIFT * i;
                         B_ptr->data_[i * block_order + j] = -1.0;
                     }
                 }
@@ -453,7 +455,9 @@ double test_results(std::uint64_t order, std::uint64_t block_order,
                     for(std::uint64_t j = 0; j < block_order; ++j)
                     {
                         double diff = trans_block[i * block_order + j] -
-                            (col_val + ROW_SHIFT * (b * block_order + j));
+                            (col_val +
+                                ROW_SHIFT *
+                                    static_cast<double>(b * block_order + j));
                         errsq += diff * diff;
                     }
                 }

--- a/examples/transpose/transpose_block.cpp
+++ b/examples/transpose/transpose_block.cpp
@@ -260,8 +260,10 @@ int hpx_main(hpx::program_options::variables_map& vm)
                 {
                     for(std::uint64_t j = 0; j != block_order; ++j)
                     {
-                        double col_val = COL_SHIFT * (b*block_order + j);
-                        A_ptr->data_[i * block_order + j] = col_val + ROW_SHIFT * i;
+                        double col_val = COL_SHIFT *
+                            static_cast<double>(b * block_order + j);
+                        A_ptr->data_[i * block_order + j] =
+                            col_val + ROW_SHIFT * i;
                         B_ptr->data_[i * block_order + j] = -1.0;
                     }
                 }
@@ -474,7 +476,9 @@ double test_results(std::uint64_t order, std::uint64_t block_order,
                     for(std::uint64_t j = 0; j < block_order; ++j)
                     {
                         double diff = trans_block[i * block_order + j] -
-                            (col_val + ROW_SHIFT * (b * block_order + j));
+                            (col_val +
+                                ROW_SHIFT *
+                                    static_cast<double>(b * block_order + j));
                         errsq += diff * diff;
                     }
                 }

--- a/examples/transpose/transpose_block_numa.cpp
+++ b/examples/transpose/transpose_block_numa.cpp
@@ -371,8 +371,10 @@ int hpx_main(hpx::program_options::variables_map& vm)
                 {
                     for(std::uint64_t j = 0; j != block_order; ++j)
                     {
-                        double col_val = COL_SHIFT * (b*block_order + j);
-                        A_ptr->data_[i * block_order + j] = col_val + ROW_SHIFT * i;
+                        double col_val = COL_SHIFT *
+                            static_cast<double>(b * block_order + j);
+                        A_ptr->data_[i * block_order + j] =
+                            col_val + ROW_SHIFT * i;
                         B_ptr->data_[i * block_order + j] = -1.0;
                     }
                 }
@@ -676,7 +678,9 @@ double test_results(std::uint64_t order, std::uint64_t block_order,
                     for(std::uint64_t j = 0; j < block_order; ++j)
                     {
                         double diff = trans_block[i * block_order + j] -
-                            (col_val + ROW_SHIFT * (b * block_order + j));
+                            (col_val +
+                                ROW_SHIFT *
+                                    static_cast<double>(b * block_order + j));
                         errsq += diff * diff;
                     }
                 }

--- a/examples/transpose/transpose_serial_block.cpp
+++ b/examples/transpose/transpose_serial_block.cpp
@@ -66,7 +66,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
         {
             for(std::uint64_t j = 0; j < block_order; ++j)
             {
-                double col_val = COL_SHIFT * (b*block_order + j);
+                double col_val =
+                    COL_SHIFT * static_cast<double>(b * block_order + j);
 
                 A[b][i * block_order + j] = col_val + ROW_SHIFT * i;
                 B[b][i * block_order + j] = -1.0;
@@ -211,7 +212,8 @@ double test_results(std::uint64_t order, std::uint64_t block_order,
             for(std::uint64_t j = 0; j < block_order; ++j)
             {
                 double diff = trans[b][i * block_order + j] -
-                  (col_val + ROW_SHIFT * (b * block_order + j));
+                    (col_val +
+                        ROW_SHIFT * static_cast<double>(b * block_order + j));
                 errsq += diff * diff;
             }
         }

--- a/examples/transpose/transpose_smp_block.cpp
+++ b/examples/transpose/transpose_smp_block.cpp
@@ -77,7 +77,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
             {
                 for(std::uint64_t j = 0; j < block_order; ++j)
                 {
-                    double col_val = COL_SHIFT * (b*block_order + j);
+                    double col_val =
+                        COL_SHIFT * static_cast<double>(b * block_order + j);
 
                     A[b][i * block_order + j] = col_val + ROW_SHIFT * i;
                     B[b][i * block_order + j] = -1.0;
@@ -242,7 +243,9 @@ double test_results(std::uint64_t order, std::uint64_t block_order,
                     for(std::uint64_t j = 0; j < block_order; ++j)
                     {
                         double diff = trans[b][i * block_order + j] -
-                            (col_val + ROW_SHIFT * (b * block_order + j));
+                            (col_val +
+                                ROW_SHIFT *
+                                    static_cast<double>(b * block_order + j));
                         errsq += diff * diff;
                     }
                 }

--- a/examples/tuplespace/central_tuplespace/server/simple_central_tuplespace.hpp
+++ b/examples/tuplespace/central_tuplespace/server/simple_central_tuplespace.hpp
@@ -86,7 +86,7 @@ namespace examples { namespace server
 
             // put tuple into tuplespace
             // out function
-            int write(const tuple_type& tp)
+            int write(tuple_type const& tp)
             {
                 if(tp.empty())
                 {
@@ -104,7 +104,7 @@ namespace examples { namespace server
 
             // read from tuplespace
             // rd function
-            tuple_type read(const tuple_type& tp, const long timeout) const
+            tuple_type read(tuple_type const& tp, double const timeout) const
             {
                 tuple_type result;
                 hpx::util::high_resolution_timer t;
@@ -134,7 +134,7 @@ namespace examples { namespace server
 
             // take from tuplespace
             // in function
-            tuple_type take(const tuple_type& tp, const long timeout)
+            tuple_type take(tuple_type const& tp, double const timeout)
             {
                 tuple_type result;
                 hpx::util::high_resolution_timer t;

--- a/examples/tuplespace/central_tuplespace/server/tuples_warehouse.hpp
+++ b/examples/tuplespace/central_tuplespace/server/tuples_warehouse.hpp
@@ -53,7 +53,7 @@ namespace examples { namespace server {
             return tuple_fields_[0].empty();
         }
 
-        int insert(const tuple_type& tp)
+        int insert(tuple_type const& tp)
         {
             if (tp.empty())    // empty tuple
                 return -1;
@@ -76,7 +76,7 @@ namespace examples { namespace server {
             return 0;
         }
 
-        tuple_type match(const tuple_type& tp) const
+        tuple_type match(tuple_type const& tp) const
         {
             tuple_type result;
 
@@ -99,7 +99,7 @@ namespace examples { namespace server {
             return result;
         }
 
-        tuple_type match_and_erase(const tuple_type& tp)
+        tuple_type match_and_erase(tuple_type const& tp)
         {
             tuple_type result;
 
@@ -123,7 +123,7 @@ namespace examples { namespace server {
         }
 
     private:    // private member functions
-        matched_indices_type find_matched_indices(const tuple_type& tp) const
+        matched_indices_type find_matched_indices(tuple_type const& tp) const
         {
             tuple_type::const_iterator it;
             unsigned int pos;
@@ -198,7 +198,7 @@ namespace examples { namespace server {
             return read_tuple_at(tuple_fields_[0].random_index());
         }
 
-        tuple_type read_tuple_at(const index_type& id) const
+        tuple_type read_tuple_at(index_type const& id) const
         {
             tuple_type result;
 
@@ -235,7 +235,7 @@ namespace examples { namespace server {
             return take_tuple_at(tuple_fields_[0].random_index());
         }
 
-        tuple_type take_tuple_at(const index_type& id)
+        tuple_type take_tuple_at(index_type const& id)
         {
             tuple_type result;
 
@@ -297,7 +297,7 @@ namespace examples { namespace server {
                 return field_index_map_.empty();
             }
 
-            int insert(const index_type& id, const elem_type& elem)
+            int insert(index_type const& id, elem_type const& elem)
             {
                 field_index_map_iterator_type it;
 

--- a/examples/tuplespace/central_tuplespace/simple_central_tuplespace.hpp
+++ b/examples/tuplespace/central_tuplespace/simple_central_tuplespace.hpp
@@ -111,7 +111,7 @@ namespace examples
         ///       for the action to be executed. Instead, it will return
         ///       immediately after the action has has been dispatched.
         //[simple_central_tuplespace_client_write_async
-        hpx::lcos::future<int> write_async(const tuple_type& tuple)
+        hpx::lcos::future<int> write_async(tuple_type const& tuple)
         {
             HPX_ASSERT(this->get_id());
             return this->base_type::write_async(this->get_id(), tuple);
@@ -121,7 +121,7 @@ namespace examples
         /// put \p tuple into tuplespace.
         ///
         /// \note This function is fully synchronous.
-        int write(hpx::launch::sync_policy, const tuple_type& tuple)
+        int write(hpx::launch::sync_policy, tuple_type const& tuple)
         {
             HPX_ASSERT(this->get_id());
             return this->base_type::write(hpx::launch::sync, this->get_id(), tuple);
@@ -134,7 +134,7 @@ namespace examples
         ///       for the action to be executed. Instead, it will return
         ///       immediately after the action has has been dispatched.
         hpx::lcos::future<tuple_type>
-            read_async(const tuple_type& tp, long const timeout)
+            read_async(tuple_type const& tp, double const timeout)
         {
             HPX_ASSERT(this->get_id());
             return this->base_type::read_async(this->get_id(), tp, timeout);
@@ -144,8 +144,8 @@ namespace examples
         ///
         /// \note This function is fully synchronous.
         //[simple_central_tuplespace_client_read_sync
-        tuple_type read(hpx::launch::sync_policy, const tuple_type& tp,
-            long const timeout)
+        tuple_type read(hpx::launch::sync_policy, tuple_type const& tp,
+            double const timeout)
         {
             HPX_ASSERT(this->get_id());
             return this->base_type::read(hpx::launch::sync, this->get_id(),
@@ -163,7 +163,7 @@ namespace examples
         ///          until the value is ready.
         //[simple_central_tuplespace_client_take_async
         hpx::lcos::future<tuple_type>
-            take_async(const tuple_type& tp, long const timeout)
+            take_async(tuple_type const& tp, double const timeout)
         {
             HPX_ASSERT(this->get_id());
             return this->base_type::take(hpx::launch::async, this->get_id(),
@@ -174,8 +174,8 @@ namespace examples
         /// take matching tuple from tuplespace within \p timeout.
         ///
         /// \note This function is fully synchronous.
-        tuple_type take(hpx::launch::sync_policy, const tuple_type& tp,
-            long const timeout)
+        tuple_type take(hpx::launch::sync_policy, tuple_type const& tp,
+            double const timeout)
         {
             HPX_ASSERT(this->get_id());
             return this->base_type::take(hpx::launch::sync, this->get_id(),

--- a/examples/tuplespace/central_tuplespace/stubs/simple_central_tuplespace.hpp
+++ b/examples/tuplespace/central_tuplespace/stubs/simple_central_tuplespace.hpp
@@ -55,8 +55,8 @@ namespace examples { namespace stubs
         ///       for the action to be executed. Instead, it will return
         ///       immediately after the action has has been dispatched.
         static hpx::lcos::future<tuple_type>
-        read_async(hpx::naming::id_type const& gid, const tuple_type& tp,
-            long const timeout)
+        read_async(hpx::naming::id_type const& gid, tuple_type const& tp,
+            double const timeout)
         {
             typedef server::simple_central_tuplespace::read_action action_type;
             return hpx::async<action_type>(gid, tp, timeout);
@@ -68,7 +68,7 @@ namespace examples { namespace stubs
         //[simple_central_tuplespace_stubs_read_sync
         static tuple_type
         read(hpx::launch::sync_policy, hpx::naming::id_type const& gid,
-            const tuple_type& tp, long const timeout)
+            tuple_type const& tp, double const timeout)
         {
             typedef server::simple_central_tuplespace::read_action action_type;
             return hpx::async<action_type>(gid, tp, timeout).get();
@@ -86,7 +86,7 @@ namespace examples { namespace stubs
         //[simple_central_tuplespace_stubs_take_async
         static hpx::lcos::future<tuple_type>
         take(hpx::launch::async_policy, hpx::naming::id_type const& gid,
-            const tuple_type& tp, long const timeout)
+            tuple_type const& tp, double const timeout)
         {
             typedef server::simple_central_tuplespace::take_action action_type;
             return hpx::async<action_type>(gid, tp, timeout);
@@ -97,8 +97,8 @@ namespace examples { namespace stubs
         ///
         /// \note This function is fully synchronous.
         static tuple_type take(hpx::launch::sync_policy,
-            hpx::naming::id_type const& gid, const tuple_type& tp,
-            const long timeout)
+            hpx::naming::id_type const& gid, tuple_type const& tp,
+            double const timeout)
         {
             // The following get yields control while the action is executed.
             return take(hpx::launch::async, gid, tp, timeout).get();

--- a/examples/tuplespace/simple_central_tuplespace_client.cpp
+++ b/examples/tuplespace/simple_central_tuplespace_client.cpp
@@ -23,7 +23,7 @@ typedef examples::server::simple_central_tuplespace central_tuplespace_type;
 typedef central_tuplespace_type::tuple_type tuple_type;
 typedef central_tuplespace_type::elem_type elem_type;
 
-void print_tuple(const tuple_type& tuple)
+void print_tuple(tuple_type const& tuple)
 {
     if (tuple.empty())
     {
@@ -41,7 +41,7 @@ void print_tuple(const tuple_type& tuple)
 }
 
 void simple_central_tuplespace_test(
-    const std::string& tuplespace_symbol_name, const tuple_type tuple)
+    std::string const& tuplespace_symbol_name, tuple_type const tuple)
 {
     examples::simple_central_tuplespace central_tuplespace;
 
@@ -105,7 +105,7 @@ int hpx_main()
         // Find the localities connected to this application.
         std::vector<hpx::id_type> localities = hpx::find_all_localities();
 
-        const std::string tuplespace_symbol_name = "/tuplespace";
+        std::string const tuplespace_symbol_name = "/tuplespace";
         examples::simple_central_tuplespace central_tuplespace;
 
         if (!central_tuplespace.create(

--- a/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
@@ -1796,11 +1796,8 @@ namespace hpx { namespace threads { namespace detail {
         switch (p)
         {
         case threads::detail::min_concurrency:
-            //             return min_punits_;
-            break;
-
+            HPX_FALLTHROUGH;
         case threads::detail::max_concurrency:
-            //             return max_punits_;
             break;
 
         case threads::detail::current_concurrency:

--- a/hpx/runtime/threads/policies/queue_holder_thread.hpp
+++ b/hpx/runtime/threads/policies/queue_holder_thread.hpp
@@ -55,8 +55,8 @@ namespace hpx { namespace threads { namespace policies {
     // apply the modulo operator only when needed
     // (i.e. when the input is greater than the ceiling)
     // NB: the numbers must be positive
-    HPX_FORCEINLINE int fast_mod(
-        const unsigned int input, const unsigned int ceil)
+    HPX_FORCEINLINE std::size_t fast_mod(
+        std::size_t const input, std::size_t const ceil)
     {
         return input >= ceil ? input % ceil : input;
     }
@@ -290,7 +290,7 @@ namespace hpx { namespace threads { namespace policies {
         // ------------------------------------------------------------
         // return the next round robin thread index across all workers
         // using a batching of N per worker before incrementing
-        inline unsigned int worker_next(const unsigned int workers) const
+        inline std::size_t worker_next(std::size_t const workers) const
         {
             tq_deb.debug(debug::str<>("worker_next"), "Rollover counter ",
                 debug::dec<4>(std::get<0>(rollover_counters_.data_)),

--- a/hpx/runtime/threads/policies/shared_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/shared_priority_queue_scheduler.hpp
@@ -339,7 +339,7 @@ namespace hpx { namespace threads { namespace policies {
                             // pool - we can schedule on any thread available
                             thread_num =
                                 numa_holder_[0].thread_queue(0)->worker_next(
-                                    static_cast<unsigned int>(num_workers_));
+                                    static_cast<std::size_t>(num_workers_));
                         }
                         else if (!round_robin_) /* thread parent */
                         {
@@ -368,7 +368,7 @@ namespace hpx { namespace threads { namespace policies {
                                 numa_holder_[domain_num]
                                     .thread_queue(
                                         static_cast<std::uint16_t>(q_index))
-                                    ->worker_next(static_cast<unsigned int>(
+                                    ->worker_next(static_cast<std::size_t>(
                                         num_workers_));
                         }
                         thread_num = select_active_pu(l, thread_num);
@@ -396,9 +396,8 @@ namespace hpx { namespace threads { namespace policies {
                         // Create thread on requested NUMA domain
                         debug::set(msg, "HINT_NUMA  ");
                         // TODO: This case does not handle suspended PUs.
-                        domain_num = fast_mod(
-                            static_cast<unsigned int>(data.schedulehint.hint),
-                            static_cast<unsigned int>(num_domains_));
+                        domain_num =
+                            fast_mod(data.schedulehint.hint, num_domains_);
                         // if the thread creating the new task is on the domain
                         // assigned to the new task - try to reuse the core as well
                         thread_num = local_num;
@@ -487,14 +486,13 @@ namespace hpx { namespace threads { namespace policies {
                     // High priority tasks first
                     else if (steal_hp_first_)
                     {
-                        for (std::uint16_t d = 0; d < num_domains_; ++d)
+                        for (std::size_t d = 0; d < num_domains_; ++d)
                         {
-                            std::uint16_t dom =
-                                fast_mod(static_cast<unsigned int>(domain + d),
-                                    static_cast<unsigned int>(num_domains_));
+                            std::size_t dom =
+                                fast_mod(domain + d, num_domains_);
                             q_index =
-                                fast_mod(static_cast<unsigned int>(q_index),
-                                    static_cast<unsigned int>(q_counts_[dom]));
+                                fast_mod(static_cast<std::size_t>(q_index),
+                                    static_cast<std::size_t>(q_counts_[dom]));
                             result = operation_HP(
                                 dom, q_index, origin, var, (d > 0), true);
                             if (result)
@@ -510,14 +508,12 @@ namespace hpx { namespace threads { namespace policies {
                             if (!steal_numa)
                                 break;
                         }
-                        for (std::uint16_t d = 0; d < num_domains_; ++d)
+                        for (std::size_t d = 0; d < num_domains_; ++d)
                         {
-                            std::uint16_t dom =
-                                fast_mod(static_cast<unsigned int>(domain + d),
-                                    static_cast<unsigned int>(num_domains_));
-                            q_index =
-                                fast_mod(static_cast<unsigned int>(q_index),
-                                    static_cast<unsigned int>(q_counts_[dom]));
+                            std::size_t dom =
+                                fast_mod(domain + d, num_domains_);
+                            q_index = fast_mod(q_index,
+                                static_cast<std::size_t>(q_counts_[dom]));
                             result = operation(
                                 dom, q_index, origin, var, (d > 0), true);
                             if (result)
@@ -576,14 +572,12 @@ namespace hpx { namespace threads { namespace policies {
                         else
                         {
                             // try other numa domains BP/HP
-                            for (std::uint16_t d = 1; d < num_domains_; ++d)
+                            for (std::size_t d = 1; d < num_domains_; ++d)
                             {
-                                std::uint16_t dom = fast_mod(
-                                    static_cast<unsigned int>(domain + d),
-                                    static_cast<unsigned int>(num_domains_));
-                                q_index = fast_mod(
-                                    static_cast<unsigned int>(q_index),
-                                    static_cast<unsigned int>(q_counts_[dom]));
+                                std::size_t dom =
+                                    fast_mod(domain + d, num_domains_);
+                                q_index = fast_mod(q_index,
+                                    static_cast<std::size_t>(q_counts_[dom]));
                                 result = operation_HP(
                                     dom, q_index, origin, var, true, true);
                                 if (result)
@@ -597,14 +591,12 @@ namespace hpx { namespace threads { namespace policies {
                                 }
                             }
                             // try other numa domains NP/LP
-                            for (std::uint16_t d = 1; d < num_domains_; ++d)
+                            for (std::size_t d = 1; d < num_domains_; ++d)
                             {
-                                std::uint16_t dom = fast_mod(
-                                    static_cast<unsigned int>(domain + d),
-                                    static_cast<unsigned int>(num_domains_));
-                                q_index = fast_mod(
-                                    static_cast<unsigned int>(q_index),
-                                    static_cast<unsigned int>(q_counts_[dom]));
+                                std::size_t dom =
+                                    fast_mod(domain + d, num_domains_);
+                                q_index = fast_mod(q_index,
+                                    static_cast<std::size_t>(q_counts_[dom]));
                                 result = operation(
                                     dom, q_index, origin, var, true, true);
                                 if (result)
@@ -766,7 +758,7 @@ namespace hpx { namespace threads { namespace policies {
                             // pool - we can schedule on any thread available
                             thread_num =
                                 numa_holder_[0].thread_queue(0)->worker_next(
-                                    static_cast<unsigned int>(num_workers_));
+                                    static_cast<std::size_t>(num_workers_));
                             q_index = 0;
                             // clang-format off
                             using namespace hpx::threads::detail;
@@ -799,7 +791,7 @@ namespace hpx { namespace threads { namespace policies {
                                 numa_holder_[domain_num]
                                     .thread_queue(
                                         static_cast<std::uint16_t>(q_index))
-                                    ->worker_next(static_cast<unsigned int>(
+                                    ->worker_next(static_cast<std::size_t>(
                                         num_workers_));
                             spq_deb.debug(debug::str<>("schedule_thread"),
                                 "assign_work_round_robin", "thread_num",
@@ -829,8 +821,8 @@ namespace hpx { namespace threads { namespace policies {
                         debug::set(msg, "HINT_NUMA  ");
                         // TODO: This case does not handle suspended PUs.
                         domain_num = fast_mod(
-                            static_cast<unsigned int>(schedulehint.mode),
-                            static_cast<unsigned int>(num_domains_));
+                            static_cast<std::size_t>(schedulehint.mode),
+                            static_cast<std::size_t>(num_domains_));
                         // if the thread creating the new task is on the domain
                         // assigned to the new task - try to reuse the core as well
                         if (d_lookup_[thread_num] == domain_num)

--- a/hpx/util/serializable_any.hpp
+++ b/hpx/util/serializable_any.hpp
@@ -246,6 +246,7 @@ namespace hpx { namespace util {
 
     public:
         // copy assignment operator
+        // NOLINTNEXTLINE(bugprone-unhandled-self-assignment)
         basic_any& operator=(basic_any const& x)
         {
             basic_any(x).swap(*this);
@@ -253,6 +254,7 @@ namespace hpx { namespace util {
         }
 
         // move assignment
+        // NOLINTNEXTLINE(bugprone-unhandled-self-assignment)
         basic_any& operator=(basic_any&& rhs) noexcept
         {
             rhs.swap(*this);

--- a/hpx/util/thread_aware_timer.hpp
+++ b/hpx/util/thread_aware_timer.hpp
@@ -50,7 +50,7 @@ namespace hpx { namespace util
 
         std::int64_t elapsed_microseconds() const
         {
-            return std::int64_t((take_time_stamp() - start_time_) * 1e-3);
+            return std::int64_t((take_time_stamp() - start_time_) / 1000);
         }
 
         std::int64_t elapsed_nanoseconds() const

--- a/libs/collectives/tests/performance/osu/osu_latency.cpp
+++ b/libs/collectives/tests/performance/osu/osu_latency.cpp
@@ -93,7 +93,7 @@ double receive_double(
     }
 
     double elapsed = t.elapsed();
-    return (elapsed * 1e6) / (2 * loop * window_size);
+    return (elapsed * 1e6) / static_cast<double>(2 * loop * window_size);
 }
 double receive(hpx::naming::id_type dest, char* send_buffer, std::size_t size,
     std::size_t loop, std::size_t window_size)
@@ -124,7 +124,7 @@ double receive(hpx::naming::id_type dest, char* send_buffer, std::size_t size,
     }
 
     double elapsed = t.elapsed();
-    return (elapsed * 1e6) / (2 * loop * window_size);
+    return (elapsed * 1e6) / static_cast<double>(2 * loop * window_size);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/collectives/tests/performance/osu/osu_multi_lat.cpp
+++ b/libs/collectives/tests/performance/osu/osu_multi_lat.cpp
@@ -106,7 +106,7 @@ double ireceive(
     }
 
     double elapsed = t.elapsed();
-    return (elapsed * 1e6) / (2 * loop * window_size);
+    return (elapsed * 1e6) / static_cast<double>(2 * loop * window_size);
 }
 HPX_PLAIN_ACTION(ireceive);
 

--- a/libs/compute/include/hpx/compute/detail/iterator.hpp
+++ b/libs/compute/include/hpx/compute/detail/iterator.hpp
@@ -63,6 +63,7 @@ namespace hpx { namespace compute { namespace detail {
         {
         }
 
+        // NOLINTNEXTLINE(bugprone-unhandled-self-assignment)
         HPX_HOST_DEVICE iterator& operator=(iterator const& other)
         {
             this->base_type::operator=(other);

--- a/libs/compute/tests/regressions/for_each_value_proxy.cpp
+++ b/libs/compute/tests/regressions/for_each_value_proxy.cpp
@@ -39,6 +39,7 @@ public:
         return *this;
     }
 
+    // NOLINTNEXTLINE(bugprone-unhandled-self-assignment)
     test_value_proxy& operator=(test_value_proxy const& other)
     {
         p_ = other.p_;

--- a/libs/concurrency/include/hpx/concurrency/cache_line_data.hpp
+++ b/libs/concurrency/include/hpx/concurrency/cache_line_data.hpp
@@ -45,6 +45,7 @@ namespace hpx {
             template <typename Data>
             struct needs_padding
               : std::integral_constant<bool,
+                    // NOLINTNEXTLINE(bugprone-sizeof-expression)
                     detail::get_cache_line_padding_size(sizeof(Data)) != 0>
             {
             };
@@ -84,6 +85,7 @@ namespace hpx {
 
             //  cppcheck-suppress unusedVariable
             char cacheline_pad[detail::get_cache_line_padding_size(
+                // NOLINTNEXTLINE(bugprone-sizeof-expression)
                 sizeof(Data))];
         };
 

--- a/libs/concurrency/include/hpx/concurrency/concurrentqueue.hpp
+++ b/libs/concurrency/include/hpx/concurrency/concurrentqueue.hpp
@@ -1611,6 +1611,7 @@ private:
         // arrays of Blocks all be properly aligned (not just the first one). We use a union to force
         // this.
         union {
+            // NOLINTNEXTLINE(bugprone-sizeof-expression)
             char elements[sizeof(T) * BLOCK_SIZE];
             details::max_align_t dummy;
         };
@@ -2898,6 +2899,7 @@ private:
             auto raw = static_cast<char*>((Traits::malloc)(
                 sizeof(BlockIndexHeader) +
                 std::alignment_of<BlockIndexEntry>::value - 1 + sizeof(BlockIndexEntry) * entryCount +
+                // NOLINTNEXTLINE(bugprone-sizeof-expression)
                 std::alignment_of<BlockIndexEntry*>::value - 1 + sizeof(BlockIndexEntry*) * nextBlockIndexCapacity));
             if (raw == nullptr) {
                 return false;

--- a/libs/datastructures/include/hpx/datastructures/any.hpp
+++ b/libs/datastructures/include/hpx/datastructures/any.hpp
@@ -526,6 +526,7 @@ namespace hpx { namespace util {
         struct get_table
         {
             using is_small =
+                // NOLINTNEXTLINE(bugprone-sizeof-expression)
                 std::integral_constant<bool, (sizeof(T) <= sizeof(void*))>;
 
             template <typename IArch, typename OArch, typename Char,
@@ -943,6 +944,7 @@ namespace hpx { namespace util {
 
     public:
         // copy assignment operator
+        // NOLINTNEXTLINE(bugprone-unhandled-self-assignment)
         basic_any& operator=(basic_any const& x)
         {
             basic_any(x).swap(*this);
@@ -950,6 +952,7 @@ namespace hpx { namespace util {
         }
 
         // move assignment
+        // NOLINTNEXTLINE(bugprone-unhandled-self-assignment)
         basic_any& operator=(basic_any&& rhs) noexcept
         {
             rhs.swap(*this);

--- a/libs/functional/include/hpx/functional/function_ref.hpp
+++ b/libs/functional/include/hpx/functional/function_ref.hpp
@@ -96,6 +96,7 @@ namespace hpx { namespace util {
             return *this;
         }
 
+        // NOLINTNEXTLINE(bugprone-unhandled-self-assignment)
         function_ref& operator=(function_ref const& other) noexcept
         {
             vptr = other.vptr;

--- a/libs/functional/tests/unit/function/function_arith.cpp
+++ b/libs/functional/tests/unit/function/function_arith.cpp
@@ -14,33 +14,33 @@
 #include <hpx/functional/function.hpp>
 #include <hpx/testing.hpp>
 
-float mul_ints(int x, int y)
+double mul_ints(int x, int y)
 {
-    return ((float) x) * y;
+    return ((double) x) * y;
 }
 
 struct int_div
 {
-    float operator()(int x, int y) const
+    double operator()(int x, int y) const
     {
-        return ((float) x) / y;
+        return ((double) x) / y;
     };
 };
 
 int main()
 {
-    hpx::util::function_nonser<float(int x, int y)> f;
+    hpx::util::function_nonser<double(int x, int y)> f;
 
     f = int_div();
     HPX_TEST(f);
-    HPX_TEST_EQ(f(5, 3), 5.f / 3);
+    HPX_TEST_EQ(f(5, 3), 5. / 3);
 
     f = nullptr;
     HPX_TEST(!f);
 
     f = &mul_ints;
     HPX_TEST(f);
-    HPX_TEST_EQ(f(5, 3), 5.f * 3);
+    HPX_TEST_EQ(f(5, 3), 5. * 3);
 
     return hpx::util::report_errors();
 }

--- a/libs/functional/tests/unit/function/nothrow_swap.cpp
+++ b/libs/functional/tests/unit/function/nothrow_swap.cpp
@@ -33,6 +33,7 @@ struct MaybeThrowOnCopy
             throw tried_to_copy();
     }
 
+    // NOLINTNEXTLINE(bugprone-unhandled-self-assignment)
     MaybeThrowOnCopy& operator=(const MaybeThrowOnCopy& other)
     {
         if (throwOnCopy)

--- a/libs/functional/tests/unit/function/sum_avg.cpp
+++ b/libs/functional/tests/unit/function/sum_avg.cpp
@@ -14,17 +14,17 @@
 #include <hpx/functional/function.hpp>
 #include <hpx/testing.hpp>
 
-void do_sum_avg(int values[], int n, int& sum, float& avg)
+void do_sum_avg(int values[], int n, int& sum, double& avg)
 {
     sum = 0;
     for (int i = 0; i < n; i++)
         sum += values[i];
-    avg = (float) sum / n;
+    avg = (double) sum / n;
 }
 
 int main()
 {
-    hpx::util::function_nonser<void(int values[], int n, int& sum, float& avg)>
+    hpx::util::function_nonser<void(int values[], int n, int& sum, double& avg)>
         sum_avg;
     sum_avg = &do_sum_avg;
 

--- a/libs/logging/include/hpx/logging/detail/fwd.hpp
+++ b/libs/logging/include/hpx/logging/detail/fwd.hpp
@@ -94,6 +94,7 @@ file f("out.txt", file_settings.initial_overwrite(true).do_append(false) );
                 m_val = other.m_val;
                 return *this;
             }
+            // NOLINTNEXTLINE(bugprone-unhandled-self-assignment)
             flag_with_self_type& operator=(flag_with_self_type const& other)
             {
                 m_val = other.m_val;

--- a/libs/logging/include/hpx/logging/writer/named_write.hpp
+++ b/libs/logging/include/hpx/logging/writer/named_write.hpp
@@ -329,6 +329,7 @@ This will just configure "file" twice, ending up with writing only to "two.txt" 
                         m_manipulator = '%';
                 }
                 else if (m_manipulator.empty())
+                // NOLINTNEXTLINE(bugprone-branch-clone)
                 {
                     ;    // ignore this char - not from a manipulator
                 }

--- a/libs/memory/include/hpx/memory/intrusive_ptr.hpp
+++ b/libs/memory/include/hpx/memory/intrusive_ptr.hpp
@@ -121,6 +121,7 @@ namespace hpx { namespace memory {
             return *this;
         }
 
+        // NOLINTNEXTLINE(bugprone-unhandled-self-assignment)
         intrusive_ptr& operator=(intrusive_ptr const& rhs)
         {
             this_type(rhs).swap(*this);

--- a/libs/memory/tests/unit/intrusive_ptr.cpp
+++ b/libs/memory/tests/unit/intrusive_ptr.cpp
@@ -172,7 +172,7 @@ namespace n_constructors {
         }
 
         {
-            hpx::intrusive_ptr<X> px(0);
+            hpx::intrusive_ptr<X> px(nullptr);
             hpx::intrusive_ptr<X> px2(px);
             HPX_TEST(px2.get() == px.get());
         }
@@ -510,7 +510,7 @@ namespace n_reset {
             hpx::intrusive_ptr<X> px(new X);
             HPX_TEST(N::base::instances == 1);
 
-            px.reset(0);
+            px.reset(nullptr);
             HPX_TEST(px.get() == nullptr);
         }
 
@@ -520,7 +520,7 @@ namespace n_reset {
             hpx::intrusive_ptr<X> px(new X);
             HPX_TEST(N::base::instances == 1);
 
-            px.reset(0, false);
+            px.reset(nullptr, false);
             HPX_TEST(px.get() == nullptr);
         }
 
@@ -530,7 +530,7 @@ namespace n_reset {
             hpx::intrusive_ptr<X> px(new X);
             HPX_TEST(N::base::instances == 1);
 
-            px.reset(0, true);
+            px.reset(nullptr, true);
             HPX_TEST(px.get() == nullptr);
         }
 
@@ -576,7 +576,7 @@ namespace n_reset {
 
         {
             hpx::intrusive_ptr<X> px(new X);
-            HPX_TEST(px.get() != 0);
+            HPX_TEST(px.get() != nullptr);
             HPX_TEST(px->use_count() == 1);
 
             HPX_TEST(N::base::instances == 1);
@@ -597,7 +597,7 @@ namespace n_reset {
 
         {
             hpx::intrusive_ptr<X> px(new X);
-            HPX_TEST(px.get() != 0);
+            HPX_TEST(px.get() != nullptr);
             HPX_TEST(px->use_count() == 1);
 
             HPX_TEST(N::base::instances == 1);
@@ -618,7 +618,7 @@ namespace n_reset {
 
         {
             hpx::intrusive_ptr<X> px(new X);
-            HPX_TEST(px.get() != 0);
+            HPX_TEST(px.get() != nullptr);
             HPX_TEST(px->use_count() == 1);
 
             HPX_TEST(N::base::instances == 1);
@@ -663,7 +663,7 @@ namespace n_access {
         }
 
         {
-            hpx::intrusive_ptr<X> px(0);
+            hpx::intrusive_ptr<X> px(nullptr);
             HPX_TEST(px ? false : true);
             HPX_TEST(!px);
 
@@ -692,7 +692,7 @@ namespace n_access {
             hpx::intrusive_ptr<X> px;
             X* detached = px.detach();
             HPX_TEST(px.get() == nullptr);
-            HPX_TEST(detached == 0);
+            HPX_TEST(detached == nullptr);
         }
 
         {
@@ -878,7 +878,7 @@ namespace n_static_cast {
         {
             hpx::intrusive_ptr<Y> py =
                 hpx::static_pointer_cast<Y>(hpx::intrusive_ptr<X>(new Y));
-            HPX_TEST(py.get() != 0);
+            HPX_TEST(py.get() != nullptr);
             HPX_TEST(py->use_count() == 1);
         }
 
@@ -920,7 +920,7 @@ namespace n_const_cast {
         {
             hpx::intrusive_ptr<X> px =
                 hpx::const_pointer_cast<X>(hpx::intrusive_ptr<X const>(new X));
-            HPX_TEST(px.get() != 0);
+            HPX_TEST(px.get() != nullptr);
             HPX_TEST(px->use_count() == 1);
         }
 
@@ -947,7 +947,7 @@ namespace n_dynamic_cast {
         }
 
         {
-            hpx::intrusive_ptr<X> px(static_cast<X*>(0));
+            hpx::intrusive_ptr<X> px(static_cast<X*>(nullptr));
 
             hpx::intrusive_ptr<Y> py = hpx::dynamic_pointer_cast<Y>(px);
             HPX_TEST(py.get() == nullptr);
@@ -955,7 +955,7 @@ namespace n_dynamic_cast {
 
         {
             hpx::intrusive_ptr<Y> py = hpx::dynamic_pointer_cast<Y>(
-                hpx::intrusive_ptr<X>(static_cast<X*>(0)));
+                hpx::intrusive_ptr<X>(static_cast<X*>(nullptr)));
             HPX_TEST(py.get() == nullptr);
         }
 
@@ -992,7 +992,7 @@ namespace n_dynamic_cast {
 
             hpx::intrusive_ptr<Y> py =
                 hpx::dynamic_pointer_cast<Y>(hpx::intrusive_ptr<X>(new Y));
-            HPX_TEST(py.get() != 0);
+            HPX_TEST(py.get() != nullptr);
             HPX_TEST(py->use_count() == 1);
         }
 

--- a/libs/memory/tests/unit/intrusive_ptr_move.cpp
+++ b/libs/memory/tests/unit/intrusive_ptr_move.cpp
@@ -97,6 +97,7 @@ int main()
 
         hpx::intrusive_ptr<X> p2(std::move(p));
         HPX_TEST(N::base::instances == 1);
+        // NOLINTNEXTLINE(bugprone-use-after-move)
         HPX_TEST(p.get() == nullptr);
 
         p2.reset();
@@ -109,6 +110,7 @@ int main()
 
         hpx::intrusive_ptr<X> p2(std::move(p));
         HPX_TEST(N::base::instances == 1);
+        // NOLINTNEXTLINE(bugprone-use-after-move)
         HPX_TEST(p.get() == nullptr);
 
         p2.reset();
@@ -122,6 +124,7 @@ int main()
         hpx::intrusive_ptr<X> p2;
         p2 = std::move(p);
         HPX_TEST(N::base::instances == 1);
+        // NOLINTNEXTLINE(bugprone-use-after-move)
         HPX_TEST(p.get() == nullptr);
 
         p2.reset();
@@ -136,6 +139,7 @@ int main()
         HPX_TEST(N::base::instances == 2);
         p2 = std::move(p);
         HPX_TEST(N::base::instances == 1);
+        // NOLINTNEXTLINE(bugprone-use-after-move)
         HPX_TEST(p.get() == nullptr);
 
         p2.reset();
@@ -149,6 +153,7 @@ int main()
         hpx::intrusive_ptr<X> p2;
         p2 = std::move(p);
         HPX_TEST(N::base::instances == 1);
+        // NOLINTNEXTLINE(bugprone-use-after-move)
         HPX_TEST(p.get() == nullptr);
 
         p2.reset();
@@ -163,6 +168,7 @@ int main()
         HPX_TEST(N::base::instances == 2);
         p2 = std::move(p);
         HPX_TEST(N::base::instances == 1);
+        // NOLINTNEXTLINE(bugprone-use-after-move)
         HPX_TEST(p.get() == nullptr);
 
         p2.reset();
@@ -176,6 +182,7 @@ int main()
 
         hpx::intrusive_ptr<Y> py = hpx::static_pointer_cast<Y>(std::move(px));
         HPX_TEST(py.get() == px2);
+        // NOLINTNEXTLINE(bugprone-use-after-move)
         HPX_TEST(px.get() == nullptr);
         HPX_TEST(py->use_count() == 1);
     }
@@ -189,6 +196,7 @@ int main()
 
         hpx::intrusive_ptr<X> px3 = hpx::const_pointer_cast<X>(std::move(px));
         HPX_TEST(px3.get() == px2);
+        // NOLINTNEXTLINE(bugprone-use-after-move)
         HPX_TEST(px.get() == nullptr);
         HPX_TEST(px3->use_count() == 1);
     }
@@ -202,6 +210,7 @@ int main()
 
         hpx::intrusive_ptr<Y> py = hpx::dynamic_pointer_cast<Y>(std::move(px));
         HPX_TEST(py.get() == px2);
+        // NOLINTNEXTLINE(bugprone-use-after-move)
         HPX_TEST(px.get() == nullptr);
         HPX_TEST(py->use_count() == 1);
     }
@@ -215,6 +224,7 @@ int main()
 
         hpx::intrusive_ptr<Y> py = hpx::dynamic_pointer_cast<Y>(std::move(px));
         HPX_TEST(py.get() == nullptr);
+        // NOLINTNEXTLINE(bugprone-use-after-move)
         HPX_TEST(px.get() == px2);
         HPX_TEST(px->use_count() == 1);
     }

--- a/libs/resiliency/tests/performance/replay/1d_stencil.cpp
+++ b/libs/resiliency/tests/performance/replay/1d_stencil.cpp
@@ -54,7 +54,7 @@ public:
         for (std::size_t k = 0; k != subdomain_width + 1; ++k)
             data_[k] = std::sin(2 * pi *
                 ((0.0 + subdomain_width * subdomain_index + k) /
-                    (subdomain_width * subdomains)));
+                    static_cast<double>(subdomain_width * subdomains)));
     }
 
     partition_data(partition_data&& other)
@@ -241,7 +241,9 @@ int hpx_main(hpx::program_options::variables_map& vm)
     }
 
     std::cout << "Time elapsed: "
-              << (hpx::util::high_resolution_clock::now() - t) / 1e9
+              << static_cast<double>(
+                     hpx::util::high_resolution_clock::now() - t) /
+            1e9
               << std::endl;
     std::cout << "Errors occurred: 0" << std::endl;
 

--- a/libs/resiliency/tests/performance/replay/1d_stencil_checksum.cpp
+++ b/libs/resiliency/tests/performance/replay/1d_stencil_checksum.cpp
@@ -72,7 +72,7 @@ public:
         {
             data_[k] = std::sin(2 * pi *
                 ((0.0 + subdomain_width * subdomain_index + k) /
-                    (subdomain_width * subdomains)));
+                    static_cast<double>(subdomain_width * subdomains)));
             checksum_ += data_[k];
         }
     }
@@ -336,7 +336,9 @@ int hpx_main(hpx::program_options::variables_map& vm)
     }
 
     std::cout << "Time elapsed: "
-              << (hpx::util::high_resolution_clock::now() - t) / 1e9
+              << static_cast<double>(
+                     hpx::util::high_resolution_clock::now() - t) /
+            1e9
               << std::endl;
     std::cout << "Errors occurred: " << counter << std::endl;
 

--- a/libs/resiliency/tests/performance/replay/1d_stencil_replay.cpp
+++ b/libs/resiliency/tests/performance/replay/1d_stencil_replay.cpp
@@ -66,7 +66,7 @@ public:
         {
             data_[k] = std::sin(2 * pi *
                 ((0.0 + subdomain_width * subdomain_index + k) /
-                    (subdomain_width * subdomains)));
+                    static_cast<double>(subdomain_width * subdomains)));
         }
     }
 
@@ -284,7 +284,9 @@ int hpx_main(hpx::program_options::variables_map& vm)
     }
 
     std::cout << "Time elapsed: "
-              << (hpx::util::high_resolution_clock::now() - t) / 1e9
+              << static_cast<double>(
+                     hpx::util::high_resolution_clock::now() - t) /
+            1e9
               << std::endl;
     std::cout << "Errors occurred: " << counter << std::endl;
 

--- a/libs/resiliency/tests/performance/replay/dataflow_replay.cpp
+++ b/libs/resiliency/tests/performance/replay/dataflow_replay.cpp
@@ -70,7 +70,7 @@ public:
         {
             data_[k] = std::sin(2 * pi *
                 ((0.0 + subdomain_width * subdomain_index + k) /
-                    (subdomain_width * subdomains)));
+                    static_cast<double>(subdomain_width * subdomains)));
             checksum_ += data_[k];
         }
     }
@@ -326,7 +326,9 @@ int hpx_main(hpx::program_options::variables_map& vm)
     }
 
     std::cout << "Time elapsed: "
-              << (hpx::util::high_resolution_clock::now() - t) / 1e9
+              << static_cast<double>(
+                     hpx::util::high_resolution_clock::now() - t) /
+            1e9
               << std::endl;
     std::cout << "Errors occurred: " << counter << std::endl;
 

--- a/libs/resiliency/tests/performance/replay/dataflow_replay_validate.cpp
+++ b/libs/resiliency/tests/performance/replay/dataflow_replay_validate.cpp
@@ -71,7 +71,7 @@ public:
         {
             data_[k] = std::sin(2 * pi *
                 ((0.0 + subdomain_width * subdomain_index + k) /
-                    (subdomain_width * subdomains)));
+                    static_cast<double>(subdomain_width * subdomains)));
             checksum_ += data_[k];
         }
     }
@@ -327,7 +327,9 @@ int hpx_main(hpx::program_options::variables_map& vm)
     }
 
     std::cout << "Time elapsed: "
-              << (hpx::util::high_resolution_clock::now() - t) / 1e9
+              << static_cast<double>(
+                     hpx::util::high_resolution_clock::now() - t) /
+            1e9
               << std::endl;
     std::cout << "Errors occurred: " << counter << std::endl;
 

--- a/libs/resiliency/tests/performance/replay/pure_dataflow.cpp
+++ b/libs/resiliency/tests/performance/replay/pure_dataflow.cpp
@@ -55,7 +55,7 @@ public:
         for (std::size_t k = 0; k != subdomain_width + 1; ++k)
             data_[k] = std::sin(2 * pi *
                 ((0.0 + subdomain_width * subdomain_index + k) /
-                    (subdomain_width * subdomains)));
+                    static_cast<double>(subdomain_width * subdomains)));
     }
 
     partition_data(partition_data&& other)
@@ -250,7 +250,9 @@ int hpx_main(hpx::program_options::variables_map& vm)
     }
 
     std::cout << "Time elapsed: "
-              << (hpx::util::high_resolution_clock::now() - t) / 1e9
+              << static_cast<double>(
+                     hpx::util::high_resolution_clock::now() - t) /
+            1e9
               << std::endl;
     std::cout << "Errors occurred: 0" << std::endl;
 

--- a/libs/resiliency/tests/performance/replicate/1d_stencil_replicate.cpp
+++ b/libs/resiliency/tests/performance/replicate/1d_stencil_replicate.cpp
@@ -67,7 +67,7 @@ public:
         {
             data_[k] = std::sin(2 * pi *
                 ((0.0 + subdomain_width * subdomain_index + k) /
-                    (subdomain_width * subdomains)));
+                    static_cast<double>(subdomain_width * subdomains)));
         }
     }
 
@@ -285,7 +285,9 @@ int hpx_main(hpx::program_options::variables_map& vm)
     }
 
     std::cout << "Time elapsed: "
-              << (hpx::util::high_resolution_clock::now() - t) / 1e9
+              << static_cast<double>(
+                     hpx::util::high_resolution_clock::now() - t) /
+            1e9
               << std::endl;
     std::cout << "Errors occurred: " << counter << std::endl;
 

--- a/libs/resiliency/tests/performance/replicate/1d_stencil_replicate_checksum.cpp
+++ b/libs/resiliency/tests/performance/replicate/1d_stencil_replicate_checksum.cpp
@@ -71,7 +71,7 @@ public:
         {
             data_[k] = std::sin(2 * pi *
                 ((0.0 + subdomain_width * subdomain_index + k) /
-                    (subdomain_width * subdomains)));
+                    static_cast<double>(subdomain_width * subdomains)));
             checksum_ += data_[k];
         }
     }
@@ -335,7 +335,9 @@ int hpx_main(hpx::program_options::variables_map& vm)
     }
 
     std::cout << "Time elapsed: "
-              << (hpx::util::high_resolution_clock::now() - t) / 1e9
+              << static_cast<double>(
+                     hpx::util::high_resolution_clock::now() - t) /
+            1e9
               << std::endl;
     std::cout << "Errors occurred: " << counter << std::endl;
 

--- a/libs/segmented_algorithms/include/hpx/parallel/segmented_algorithms/exclusive_scan.hpp
+++ b/libs/segmented_algorithms/include/hpx/parallel/segmented_algorithms/exclusive_scan.hpp
@@ -204,6 +204,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 OutIter>::is_segmented_iterator is_out_seg;
 
             // check if OutIter is segmented in the same way as SegIter
+            // NOLINTNEXTLINE(bugprone-branch-clone)
             if (is_segmented_the_same(first, last, dest, is_out_seg()))
             {
                 return segmented_exclusive_scan_seq(
@@ -231,6 +232,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef typename hpx::traits::segmented_iterator_traits<
                 OutIter>::is_segmented_iterator is_out_seg;
 
+            // NOLINTNEXTLINE(bugprone-branch-clone)
             if (is_segmented_the_same(first, last, dest, is_out_seg()))
             {
                 return segmented_exclusive_scan_par(

--- a/libs/segmented_algorithms/include/hpx/parallel/segmented_algorithms/inclusive_scan.hpp
+++ b/libs/segmented_algorithms/include/hpx/parallel/segmented_algorithms/inclusive_scan.hpp
@@ -204,6 +204,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 OutIter>::is_segmented_iterator is_out_seg;
 
             // check if OutIter is segmented in the same way as SegIter
+            // NOLINTNEXTLINE(bugprone-branch-clone)
             if (is_segmented_the_same(first, last, dest, is_out_seg()))
             {
                 return segmented_inclusive_scan_seq(
@@ -232,6 +233,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 OutIter>::is_segmented_iterator is_out_seg;
 
             // check if OutIter is segmented in the same way as SegIter
+            // NOLINTNEXTLINE(bugprone-branch-clone)
             if (is_segmented_the_same(first, last, dest, is_out_seg()))
             {
                 return segmented_inclusive_scan_par(

--- a/libs/serialization/include/hpx/serialization/array.hpp
+++ b/libs/serialization/include/hpx/serialization/array.hpp
@@ -82,6 +82,7 @@ namespace hpx { namespace serialization {
             bool archive_endianess_differs = ar.endian_big();
 #endif
 
+            // NOLINTNEXTLINE(bugprone-branch-clone)
             if (ar.disable_array_optimization() || archive_endianess_differs)
                 serialize_optimized(ar, v, std::false_type());
             else

--- a/libs/serialization/tests/unit/zero_copy_serialization.cpp
+++ b/libs/serialization/tests/unit/zero_copy_serialization.cpp
@@ -108,8 +108,8 @@ std::size_t get_archive_size(hpx::parcelset::parcel const& p,
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void test_parcel_serialization(
-    hpx::parcelset::parcel outp, int out_archive_flags, bool zero_copy)
+void test_parcel_serialization(hpx::parcelset::parcel outp,
+    std::uint32_t out_archive_flags, bool zero_copy)
 {
     // serialize data
     std::vector<hpx::serialization::serialization_chunk> out_chunks;
@@ -181,7 +181,7 @@ void test_normal_serialization(T& arg)
         reinterpret_cast<std::uint64_t>(&test_function1));
 
     // compose archive flags
-    unsigned out_archive_flags = hpx::serialization::disable_data_chunking;
+    std::uint32_t out_archive_flags = hpx::serialization::disable_data_chunking;
 #if BOOST_ENDIAN_BIG_BYTE
     out_archive_flags |= hpx::serialization::endian_big;
 #else
@@ -209,7 +209,7 @@ void test_normal_serialization(T1& arg1, T2& arg2)
         reinterpret_cast<std::uint64_t>(&test_function2));
 
     // compose archive flags
-    unsigned out_archive_flags = hpx::serialization::disable_data_chunking;
+    std::uint32_t out_archive_flags = hpx::serialization::disable_data_chunking;
 #if BOOST_ENDIAN_BIG_BYTE
     out_archive_flags |= hpx::serialization::endian_big;
 #else
@@ -238,7 +238,7 @@ void test_normal_serialization(
         reinterpret_cast<std::uint64_t>(&test_function2));
 
     // compose archive flags
-    unsigned out_archive_flags = hpx::serialization::disable_data_chunking;
+    std::uint32_t out_archive_flags = hpx::serialization::disable_data_chunking;
 #if BOOST_ENDIAN_BIG_BYTE
     out_archive_flags |= hpx::serialization::endian_big;
 #else
@@ -267,7 +267,7 @@ void test_zero_copy_serialization(T& arg)
         reinterpret_cast<std::uint64_t>(&test_function1));
 
     // compose archive flags
-    unsigned out_archive_flags = 0U;
+    std::uint32_t out_archive_flags = 0U;
 #if BOOST_ENDIAN_BIG_BYTE
     out_archive_flags |= hpx::serialization::endian_big;
 #else
@@ -295,7 +295,7 @@ void test_zero_copy_serialization(T1& arg1, T2& arg2)
         reinterpret_cast<std::uint64_t>(&test_function2));
 
     // compose archive flags
-    unsigned out_archive_flags = 0U;
+    std::uint32_t out_archive_flags = 0U;
 #if BOOST_ENDIAN_BIG_BYTE
     out_archive_flags |= hpx::serialization::endian_big;
 #else
@@ -324,7 +324,7 @@ void test_zero_copy_serialization(
         reinterpret_cast<std::uint64_t>(&test_function2));
 
     // compose archive flags
-    unsigned out_archive_flags = 0U;
+    std::uint32_t out_archive_flags = 0U;
 #if BOOST_ENDIAN_BIG_BYTE
     out_archive_flags |= hpx::serialization::endian_big;
 #else

--- a/libs/synchronization/tests/performance/channel_mpmc_throughput.cpp
+++ b/libs/synchronization/tests/performance/channel_mpmc_throughput.cpp
@@ -62,7 +62,7 @@ double thread_func_0(hpx::lcos::local::channel_mpmc<data>& c)
 
     std::uint64_t end = hpx::util::high_resolution_clock::now();
 
-    return (end - start) / 1e9;
+    return static_cast<double>(end - start) / 1e9;
 }
 
 // Consume
@@ -81,7 +81,7 @@ double thread_func_1(hpx::lcos::local::channel_mpmc<data>& c)
 
     std::uint64_t end = hpx::util::high_resolution_clock::now();
 
-    return (end - start) / 1e9;
+    return static_cast<double>(end - start) / 1e9;
 }
 
 int main(int argc, char* argv[])

--- a/libs/synchronization/tests/performance/channel_mpsc_throughput.cpp
+++ b/libs/synchronization/tests/performance/channel_mpsc_throughput.cpp
@@ -62,7 +62,7 @@ double thread_func_0(hpx::lcos::local::channel_mpsc<data>& c)
 
     std::uint64_t end = hpx::util::high_resolution_clock::now();
 
-    return (end - start) / 1e9;
+    return static_cast<double>(end - start) / 1e9;
 }
 
 // Consume
@@ -81,7 +81,7 @@ double thread_func_1(hpx::lcos::local::channel_mpsc<data>& c)
 
     std::uint64_t end = hpx::util::high_resolution_clock::now();
 
-    return (end - start) / 1e9;
+    return static_cast<double>(end - start) / 1e9;
 }
 
 int main(int argc, char* argv[])

--- a/libs/synchronization/tests/performance/channel_spsc_throughput.cpp
+++ b/libs/synchronization/tests/performance/channel_spsc_throughput.cpp
@@ -62,7 +62,7 @@ double thread_func_0(hpx::lcos::local::channel_spsc<data>& c)
 
     std::uint64_t end = hpx::util::high_resolution_clock::now();
 
-    return (end - start) / 1e9;
+    return static_cast<double>(end - start) / 1e9;
 }
 
 // Consume
@@ -81,7 +81,7 @@ double thread_func_1(hpx::lcos::local::channel_spsc<data>& c)
 
     std::uint64_t end = hpx::util::high_resolution_clock::now();
 
-    return (end - start) / 1e9;
+    return static_cast<double>(end - start) / 1e9;
 }
 
 int main(int argc, char* argv[])

--- a/plugins/parcel/coalescing/coalescing_message_handler.cpp
+++ b/plugins/parcel/coalescing/coalescing_message_handler.cpp
@@ -185,11 +185,7 @@ namespace hpx { namespace plugins { namespace parcel
 
         switch(s) {
         case detail::message_buffer::first_message:
-            // start deadline timer to flush buffer
-            l.unlock();
-            timer_.start(interval);
-            break;
-
+            HPX_FALLTHROUGH;
         case detail::message_buffer::normal:
             // start deadline timer to flush buffer
             l.unlock();

--- a/python/hpx/environment.py
+++ b/python/hpx/environment.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python 
+#! /usr/bin/env python3
 #
 # Copyright (c) 2011 Bryce Lelbach
 # Copyright (c) 2019 Patrick Diehl
@@ -22,9 +22,9 @@ from re import compile
 def make_component(raw, type):
   """
   Transliterate characters from an element returned by platform.uname() to
-  match the regex ``^[a-z0-9\-.]+$``. Returns ``"unknown-%s" % type`` if 
-  the transliterated string doesn't match the regex pattern. 
-  """ 
+  match the regex ``^[a-z0-9\-.]+$``. Returns ``"unknown-%s" % type`` if
+  the transliterated string doesn't match the regex pattern.
+  """
   from string import lower
 
   comp = compile(r'\s|_').sub('-', lower(raw))
@@ -39,7 +39,7 @@ def make_compiler_component(driver):
   Given the name of a compiler driver, generate a string describing the compiler
   suite and version. Returns ``"unknown-compiler"`` if the compiler cannot be
   identified.
-  """ 
+  """
   from hpx.process import process
 
   windows = 0
@@ -54,21 +54,21 @@ def make_compiler_component(driver):
     proc = process("%s --version" % driver)
 
   proc.wait()
-  raw = proc.read() 
+  raw = proc.read()
 
   if (windows):
-    compiler = compile(r'Version ([0-9.]+)').match(raw) 
- 
+    compiler = compile(r'Version ([0-9.]+)').match(raw)
+
     if (compiler):
       compiler = compiler.expand(r'msvc-\2')
       if compile(r'^[a-z0-9\-.]+$').match(compiler):
         return compiler
       else:
-        return "msvc" 
+        return "msvc"
 
   # handle GNU GCC and Intel
   compiler = compile(r'^(icc|icpc|gcc|g[+][+])[^ ]* [(][^)]+[)] ([0-9.]+)').match(raw)
-  
+
   if (compiler):
     unescaped = compiler.expand(r'\1-\2')
     compiler = compile(r'[+]').sub("x", unescaped)
@@ -78,10 +78,10 @@ def make_compiler_component(driver):
     else:
       unescaped = compile(r'^(icc|icpc|gcc|g[+][+])').match(raw).expand(r'\1')
       return compile(r'[+]').sub("x", unescaped)
- 
+
   # handle Clang
   compiler = compile(r'(clang) version ([0-9.]+)').match(raw)
-  
+
   if (compiler):
     compiler = compiler.expand(r'\1-\2')
     if compile(r'^[a-z0-9\-.]+$').match(compiler):
@@ -105,5 +105,5 @@ def identify(driver):
   return "%s_%s-%s_%s" % (make_component(machine, "processor"),
                           make_component(system, "kernel"),
                           make_component(release, "version"),
-                          make_compiler_component(absolute_path(driver))) 
+                          make_compiler_component(absolute_path(driver)))
 

--- a/python/hpx/path.py
+++ b/python/hpx/path.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python 
+#! /usr/bin/env python3
 #
 # Copyright (c) 2011 Bryce Lelbach
 #
@@ -16,5 +16,5 @@ def absolute_path(p):
     candidate = join(dirname, p)
     if isfile(candidate):
       return realpath(candidate)
-  return realpath(p) 
+  return realpath(p)
 

--- a/python/hpx/process.py
+++ b/python/hpx/process.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # Copyright (c) 2011-2012 Bryce Adelstein-Lelbach
 #
@@ -41,7 +41,7 @@ def kill_process_tree(parent_pid, signal=SIGKILL):
 
     if OS_MAC:
       cmd = "ps -o pid,ppid -ax | egrep ' %d$' | awk '{print $1}'" % pid
-    else: 
+    else:
       cmd = "ps -o pid --ppid %d --noheaders" % pid
 
     ps_command = Popen(cmd, shell=True, stdout=PIPE)

--- a/python/scripts/hpx_environment.py
+++ b/python/scripts/hpx_environment.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python 
+#! /usr/bin/env python3
 #
 # Copyright (c) 2011 Bryce Lelbach
 # Copyright (c) 2019 Patrick Diehl
@@ -20,7 +20,7 @@ if exists(join(path[0], "../share/hpx/python/hpx")):
 
 from hpx.environment import identify
 
-usage = "Usage: %prog [options] compiler-driver" 
+usage = "Usage: %prog [options] compiler-driver"
 
 parser = OptionParser(usage=usage)
 
@@ -28,7 +28,7 @@ parser = OptionParser(usage=usage)
 
 if 0 == len(driver):
   print ("No compiler driver specified.")
-  exit(1) 
+  exit(1)
 elif 1 != len(driver):
   print ("More than one compiler driver specified.")
   exit(1)

--- a/python/scripts/hpx_invoke.py
+++ b/python/scripts/hpx_invoke.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # Copyright (c) 2009 Maciej Brodowicz
 # Copyright (c) 2011 Bryce Lelbach
@@ -48,7 +48,7 @@ def rstrip_last(s, chars):
     return s
 
 # {{{ main
-usage = "Usage: %prog [options]" 
+usage = "Usage: %prog [options]"
 
 parser = OptionParser(usage=usage)
 
@@ -60,7 +60,7 @@ parser.add_option("--timeout",
 parser.add_option("--program",
                   action="store", type="string",
                   dest="program",
-                  help="Program to invoke") 
+                  help="Program to invoke")
 
 (options, cmd) = parser.parse_args()
 
@@ -75,7 +75,7 @@ if not 0 == len(output):
 
 if timed_out:
   print ("Program timed out")
-  
+
 exit(returncode)
 # }}}
 

--- a/python/scripts/hpx_optsweep.py
+++ b/python/scripts/hpx_optsweep.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # Copyright (c) 2009 Maciej Brodowicz
 # Copyright (c) 2011 Bryce Lelbach
@@ -45,7 +45,7 @@ Options:
  -x list      : exclude cases with argument tuples matching any item in the
                 "list" (python expression)
  -w seconds   : kill runs that take longer than "seconds" to complete (default
-                360). 
+                360).
  -b command   : run preprocessing "command" before starting test sequence for
                 each configuration, applying option substitution
  -p command   : run postprocessing "command" after test sequence for each
@@ -72,11 +72,11 @@ def next(ixd, opts, optv):
         if ixd[k] >= len(optv[k]): ixd[k] = 0
         else: return ixd
     return None
-        
+
 
 # run the application and optionally capture its output and error streams
 def run(cmd, outfl = None, timeout = 360):
-    start = datetime.now() 
+    start = datetime.now()
     proc = process(cmd)
     (timed_out, returncode) = proc.wait(timeout)
     now = datetime.now()
@@ -86,7 +86,7 @@ def run(cmd, outfl = None, timeout = 360):
         if s: writeres(s, outfl)
         else: break
 
-    if timed_out: 
+    if timed_out:
       writeres('Command timed out.\n', outfl)
 
     return (returncode, now - start)
@@ -145,7 +145,7 @@ def runscript(cmdlst, options, ofhs, timeout):
         if rc:
             writeres('Warning: command: "'+scr+'" returned '+str(rc)+'\n', ofhs)
 
-    
+
 if __name__ == '__main__':
     # parse command line
     try:
@@ -164,7 +164,7 @@ if __name__ == '__main__':
     runs, configs, erruns, excnt = 0, 0, 0, 0
     # separator length for pretty printing
     seplen = 78
-    # timeout 
+    # timeout
     timeout = 360
     # non-quotable characters
     nonquot = string.ascii_letters+string.digits+'-+='
@@ -252,7 +252,7 @@ if __name__ == '__main__':
       results['header']['start_date'] = start_date
       results['header']['command'] = tuple(sys.argv)
 
-    try: 
+    try:
     # test loop
       while optix != None:
         configs += 1
@@ -274,7 +274,7 @@ if __name__ == '__main__':
         if before: runscript(before, optd, ofhs)
         # build command line
         cmd = map(lambda x: x%optd, cmdproto)
- 
+
         # second pass - eval
         p = compile(r'eval\("([^"]*)"\)')
 
@@ -297,7 +297,7 @@ if __name__ == '__main__':
             outs = sepstr('-', txt)
             outs += '\nReturn code: '+str(rc)+'\n'+sepstr()+'\n'
             writeres(outs, ofhs)
-            if rf:   
+            if rf:
               if not results['data'].has_key(tuple(vallst)):
                 results['data'][tuple(vallst)] = [(walltime, rc)]
               else:
@@ -306,13 +306,13 @@ if __name__ == '__main__':
         # run postprocessor
         # TODO: add timeout options
         if after: runscript(after, optd, ofhs)
-     
+
         optix = next(optix, optnames, options)
-        
-    except: 
+
+    except:
         from traceback import print_exc
         print_exc()
-     
+
     end_date = datetime.now()
 
     # final banner
@@ -326,7 +326,7 @@ if __name__ == '__main__':
 
     if rf:
       results['header']['end_date'] = end_date
-      results['header']['configurations'] = configs 
+      results['header']['configurations'] = configs
       results['header']['exclusions'] = excnt
       results['header']['total_runs'] = runs
       results['header']['failed_runs'] = erruns

--- a/python/scripts/hpx_run_test.py
+++ b/python/scripts/hpx_run_test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # Copyright (c) 2012 Bryce Adelstein-Lelbach
 # Copyright (c) 2019 Patrick Diehl

--- a/src/runtime/naming/name.cpp
+++ b/src/runtime/naming/name.cpp
@@ -182,13 +182,10 @@ namespace hpx { namespace naming
                     // This request might come in too late and the thread manager
                     // was already stopped. We ignore the request if that's the
                     // case.
-                    if (e.get_error() != invalid_status)
+                    if (e.get_error() != invalid_status ||
+                        !threads::threadmanager_is(hpx::state_stopping))
                     {
-                        throw;    // rethrow if not invalid_status
-                    }
-                    else if (!threads::threadmanager_is(hpx::state_stopping))
-                    {
-                        throw;    // rethrow if not stopping
+                        throw;
                     }
                 }
             }

--- a/src/util/integer/int128.cpp
+++ b/src/util/integer/int128.cpp
@@ -34,6 +34,7 @@ namespace hpx { namespace util { namespace integer
 
         while (!!ii && i) {
             ii = ii.div (radix, r);
+            // NOLINTNEXTLINE(bugprone-narrowing-conversions)
             sz[--i] = r.toInt() + ((r.toInt() > 9) ? 'A' - 10 : '0');
         };
 

--- a/src/util/integer/uint128.cpp
+++ b/src/util/integer/uint128.cpp
@@ -34,6 +34,7 @@ namespace hpx { namespace util { namespace integer
 
         while (!!ii && i) {
             ii = ii.div (radix, r);
+            // NOLINTNEXTLINE(bugprone-narrowing-conversions)
             sz[--i] = r.toUint() + ((r.toUint() > 9) ? 'A' - 10 : '0');
         };
 

--- a/src/util/regex_from_pattern.cpp
+++ b/src/util/regex_from_pattern.cpp
@@ -88,6 +88,7 @@ namespace hpx { namespace util
                 break;
 
             // escape regex special characters
+            // NOLINTNEXTLINE(bugprone-branch-clone)
             case '+':
                 HPX_FALLTHROUGH;
             case '.':

--- a/src/util/serialize_exception.cpp
+++ b/src/util/serialize_exception.cpp
@@ -43,7 +43,7 @@ namespace hpx { namespace serialization
         std::string throw_function_;
         std::string throw_file_;
         std::string throw_back_trace_;
-        int throw_line_ = 0;
+        long throw_line_ = 0;
         std::string throw_env_;
         std::string throw_config_;
         std::string throw_state_;

--- a/tests/performance/local/async_overheads.cpp
+++ b/tests/performance/local/async_overheads.cpp
@@ -84,11 +84,11 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
         std::uint64_t end = hpx::util::high_resolution_clock::now();
 
-        seqential_time_per_task = (end - start) / 1e9 / num_tasks;
+        seqential_time_per_task =
+            static_cast<double>(end - start) / 1e9 / num_tasks;
         std::cout << "Elapsed sequential time: "
-                  << (end - start) / 1e9 << " [s], ("
-                  << seqential_time_per_task << " [s])"
-                  << std::endl;
+                  << static_cast<double>(end - start) / 1e9 << " [s], ("
+                  << seqential_time_per_task << " [s])" << std::endl;
         hpx::util::print_cdash_timing("AsyncSequential", seqential_time_per_task);
     }
 
@@ -102,11 +102,11 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
         std::uint64_t end = hpx::util::high_resolution_clock::now();
 
-        hierarchical_time_per_task = (end - start) / 1e9 / num_tasks;
+        hierarchical_time_per_task =
+            static_cast<double>(end - start) / 1e9 / num_tasks;
         std::cout << "Elapsed hierarchical time: "
-                  << (end - start) / 1e9 << " [s], ("
-                  << hierarchical_time_per_task << " [s])"
-                  << std::endl;
+                  << static_cast<double>(end - start) / 1e9 << " [s], ("
+                  << hierarchical_time_per_task << " [s])" << std::endl;
         hpx::util::print_cdash_timing("AsyncHierarchical", hierarchical_time_per_task);
     }
 

--- a/tests/performance/local/parent_vs_child_stealing.cpp
+++ b/tests/performance/local/parent_vs_child_stealing.cpp
@@ -45,7 +45,7 @@ double measure_one(Policy policy)
     hpx::wait_all(threads);
 
     std::uint64_t stop = hpx::util::high_resolution_clock::now();
-    return (stop - start) / 1e9;
+    return static_cast<double>(stop - start) / 1e9;
 }
 
 template <typename Policy>

--- a/tests/regressions/block_matrix/tests.cc
+++ b/tests/regressions/block_matrix/tests.cc
@@ -27,60 +27,60 @@ void test_dense()
 {
   hpx::id_type here = hpx::find_here();
   std::cout << "test_dense: running on " << here << std::endl;
-  
+
   const double alpha = 2.0, beta = 3.0;
   std::cout << "alpha=" << alpha << ", beta=" << beta << std::endl;
-  
+
   const ptrdiff_t NI=4, NJ=3, NK=2;
   std::cout << "NI=" << NI << ", NJ=" << NJ << ", NK=" << NK << std::endl;
-  
+
   vector_t x(NJ);
-  for (ptrdiff_t j=0; j<NJ; ++j) x(j) = j + 1;
+  for (ptrdiff_t j=0; j<NJ; ++j) x(j) = static_cast<double>(j + 1);
   std::cout << "x=" << x << std::endl;
   vector_t y(NI);
-  for (ptrdiff_t i=0; i<NI; ++i) y(i) = i + 2;
+  for (ptrdiff_t i=0; i<NI; ++i) y(i) = static_cast<double>(i + 2);
   std::cout << "y=" << y << std::endl;
   vector_t z(NI);
-  for (ptrdiff_t i=0; i<NI; ++i) z(i) = i + 3;
+  for (ptrdiff_t i=0; i<NI; ++i) z(i) = static_cast<double>(i + 3);
   std::cout << "z=" << z << std::endl;
-  
+
   matrix_t a(NI,NJ);
   for (ptrdiff_t i=0, n=0; i<NI; ++i)
     for (ptrdiff_t j=0; j<NJ; ++j)
-      a(i,j) = n++ + 4;
+      a(i,j) = static_cast<double>(n++ + 4);
   std::cout << "a=" << a << std::endl;
   matrix_t b(NI,NK);
   for (ptrdiff_t i=0, n=0; i<NI; ++i)
     for (ptrdiff_t k=0; k<NK; ++k)
-      b(i,k) = n++ + 5;
+      b(i,k) = static_cast<double>(n++ + 5);
   std::cout << "b=" << b << std::endl;
   matrix_t c(NK,NJ);
   for (ptrdiff_t k=0, n=0; k<NK; ++k)
     for (ptrdiff_t j=0; j<NJ; ++j)
-      c(k,j) = n++ + 6;
+      c(k,j) = static_cast<double>(n++ + 6);
   std::cout << "c=" << c << std::endl;
-  
+
   std::cout << std::endl;
-  
-  
-  
+
+
+
   vector_t yy(NI), zz(NI);
   matrix_t aa(NI,NJ);
-  
+
   copy(z, zz);
   axpy(alpha, y, zz);
   std::cout << "axpy: alpha y + z = " << zz << std::endl;
   axpy(-1.0, vector_t({7,10,13,16}), zz);
   std::cout << "   (error = " << nrm2(zz) << ")" << std::endl;
   HPX_TEST_EQ(nrm2(zz), 0.0);
-  
+
   copy(y, yy);
   gemv(false, alpha, a, x, beta, yy);
   std::cout << "gemv: alpha a x + beta y = " << yy << std::endl;
   axpy(-1.0, vector_t({70,109,148,187}), yy);
   std::cout << "   (error = " << nrm2(yy) << ")" << std::endl;
   HPX_TEST_EQ(nrm2(yy), 0.0);
-  
+
   copy(false, a, aa);
   gemm(false, false, alpha, b, c, beta, aa);
   std::cout << "gemm: alpha b c + beta a = " << aa << std::endl;
@@ -90,7 +90,7 @@ void test_dense()
        aa);
   std::cout << "   (error = " << nrm2(aa) << ")" << std::endl;
   HPX_TEST_EQ(nrm2(aa), 0.0);
-  
+
   std::cout << std::endl;
 }
 
@@ -102,13 +102,13 @@ void test_blocked()
   std::vector<hpx::id_type> locs = hpx::find_all_localities();
   hpx::id_type here = hpx::find_here();
   std::cout << "test_blocked: running on " << here << std::endl;
-  
+
   const double alpha = 2.0, beta = 3.0;
   std::cout << "alpha=" << alpha << ", beta=" << beta << std::endl;
-  
+
   const ptrdiff_t NI=10, NJ=6, NK=6;
   std::cout << "NI=" << NI << ", NJ=" << NJ << ", NK=" << NK << std::endl;
-  
+
   const ptrdiff_t BI = 3;
   const ptrdiff_t istr0[BI] = {1, 4, 9};
   const ptrdiff_t istr1[BI] = {2, 6, 10};
@@ -116,7 +116,7 @@ void test_blocked()
   for (std::ptrdiff_t i=0; i<BI; ++i) ilocs[i] = locs[i % nlocs];
   auto istr = std::make_shared<structure_t>(NI, BI, istr0, istr1, ilocs);
   std::cout << "istr=" << *istr << std::endl;
-  
+
   const ptrdiff_t BJ = 2;
   const ptrdiff_t jstr0[BJ] = {0, 4};
   const ptrdiff_t jstr1[BJ] = {2, 5};
@@ -124,7 +124,7 @@ void test_blocked()
   for (std::ptrdiff_t j=0; j<BJ; ++j) jlocs[j] = locs[(j+1) % nlocs];
   auto jstr = std::make_shared<structure_t>(NJ, BJ, jstr0, jstr1, jlocs);
   std::cout << "jstr=" << *jstr << std::endl;
-  
+
   const ptrdiff_t BK = 1;
   const ptrdiff_t kstr0[BK] = {1};
   const ptrdiff_t kstr1[BK] = {3};
@@ -132,72 +132,72 @@ void test_blocked()
   for (std::ptrdiff_t k=0; k<BK; ++k) klocs[k] = locs[(k+2) % nlocs];
   auto kstr = std::make_shared<structure_t>(NK, BK, kstr0, kstr1, klocs);
   std::cout << "kstr=" << *kstr << std::endl;
-  
+
   block_vector_t x(jstr);
   for (ptrdiff_t j=0, n=0; j<NJ; ++j) {
     if (x.str->find(j) >= 0) {
-      x.set_elt(j, n++ + 1);
+      x.set_elt(j, static_cast<double>(n++ + 1));
     }
   }
   std::cout << "x=" << x << std::endl;
-  
+
   block_vector_t y(istr);
   for (ptrdiff_t i=0, n=0; i<NI; ++i)
     if (y.str->find(i) >= 0)
-      y.set_elt(i, n++ + 2);
+      y.set_elt(i, static_cast<double>(n++ + 2));
   std::cout << "y=" << y << std::endl;
-  
+
   block_vector_t z(istr);
   for (ptrdiff_t i=0, n=0; i<NI; ++i)
     if (z.str->find(i) >= 0)
-      z.set_elt(i, n++ + 3);
+      z.set_elt(i, static_cast<double>(n++ + 3));
   std::cout << "z=" << z << std::endl;
-  
+
   block_matrix_t a(istr,jstr);
   for (ptrdiff_t i=0, n=0; i<NI; ++i)
     if (a.istr->find(i) >= 0)
       for (ptrdiff_t j=0; j<NJ; ++j)
         if (a.jstr->find(j) >= 0)
-          a.set_elt(i,j, n++ + 4);
+          a.set_elt(i,j, static_cast<double>(n++ + 4));
   std::cout << "a=" << a << std::endl;
-  
+
   block_matrix_t b(istr,kstr);
   for (ptrdiff_t i=0, n=0; i<NI; ++i)
     if (b.istr->find(i) >= 0)
       for (ptrdiff_t k=0; k<NK; ++k)
         if (b.jstr->find(k) >= 0)
-          b.set_elt(i,k, n++ + 5);
+          b.set_elt(i,k, static_cast<double>(n++ + 5));
   std::cout << "b=" << b << std::endl;
-  
+
   block_matrix_t c(kstr,jstr);
   for (ptrdiff_t k=0, n=0; k<NK; ++k)
     if (c.istr->find(k) >= 0)
       for (ptrdiff_t j=0; j<NJ; ++j)
         if (c.jstr->find(j) >= 0)
-          c.set_elt(k,j, n++ + 6);
+          c.set_elt(k,j, static_cast<double>(n++ + 6));
   std::cout << "c=" << c << std::endl;
-  
+
   std::cout << std::endl;
-  
-  
-  
+
+
+
   block_vector_t yy(istr), zz(istr);
   block_matrix_t aa(istr,jstr);
-  
+
   copy(z, zz);
   axpy(alpha, y, zz);
   std::cout << "axpy: alpha y + z = " << zz << std::endl;
   axpy(-1.0, block_vector_t(zz.str, {{1,{7}}, {4,{10,13}}, {9,{16}}}), zz);
   std::cout << "   (error = " << nrm2(zz) << ")" << std::endl;
   HPX_TEST_EQ(nrm2(zz), 0.0);
-  
+
   copy(y, yy);
   gemv(false, alpha, a, x, beta, yy);
   std::cout << "gemv: alpha a x + beta y = " << yy << std::endl;
   axpy(-1.0, block_vector_t(yy.str, {{1,{70}}, {4,{109,148}}, {9,{187}}}), yy);
   std::cout << "   (error = " << nrm2(yy) << ")" << std::endl;
   HPX_TEST_EQ(nrm2(yy), 0.0);
-  
+
   copy(false, a, aa);
   gemm(false, false, alpha, b, c, beta, aa);
   std::cout << "gemm: alpha b c + beta a = " << aa << std::endl;
@@ -216,7 +216,7 @@ void test_blocked()
        aa);
   std::cout << "   (error = " << nrm2(aa) << ")" << std::endl;
   HPX_TEST_EQ(nrm2(aa), 0.0);
-  
+
   std::cout << std::endl;
 }
 

--- a/tests/regressions/lcos/dataflow_791.cpp
+++ b/tests/regressions/lcos/dataflow_791.cpp
@@ -84,7 +84,7 @@ int hpx_main (int argc, char *argv[])
     originalA.resize(size*size); //-V106
     for(int i = 0; i < size * size; i++)
         originalA[i] = A[i];
-    printf("init done, time = %f\n", (t2-t1)/1000000.0);
+    printf("init done, time = %f\n", static_cast<double>(t2 - t1) / 1000000.0);
 
     t1 = get_tick_count();
     if(numBlocks == 1)
@@ -94,7 +94,8 @@ int hpx_main (int argc, char *argv[])
     else
         printf("Error: numBlocks must be greater than 0.\n");
     t2 = get_tick_count();
-    printf("Time for LU-decomposition in secs: %f \n", (t2-t1)/1000000.0);
+    printf("Time for LU-decomposition in secs: %f \n",
+        static_cast<double>(t2 - t1) / 1000000.0);
 
     checkResult( originalA );
 

--- a/tools/inspect/inspect_to_junit.py
+++ b/tools/inspect/inspect_to_junit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 Parsa Amini
 #
 # SPDX-License-Identifier: BSL-1.0


### PR DESCRIPTION
Attempting to fix new warnings after updating from 8 to 9.