### PR TITLE
Another attempt at fixing the integral mismatch and conversion warnings

### DIFF
--- a/hpx/runtime/threads/detail/thread_num_tss.hpp
+++ b/hpx/runtime/threads/detail/thread_num_tss.hpp
@@ -25,8 +25,8 @@ namespace hpx { namespace threads { namespace detail {
     // associated with the thread
     struct thread_pool
     {
-        std::uint16_t local_thread_num;
-        std::uint16_t pool_index;
+        std::size_t local_thread_num;
+        std::size_t pool_index;
     };
     HPX_EXPORT void set_thread_pool_tss(const thread_pool&);
     HPX_EXPORT thread_pool get_thread_pool_tss();

--- a/hpx/runtime/threads/policies/queue_holder_numa.hpp
+++ b/hpx/runtime/threads/policies/queue_holder_numa.hpp
@@ -76,7 +76,7 @@ namespace hpx { namespace threads { namespace policies {
         }
 
         // ----------------------------------------------------------------
-        void init(std::uint16_t domain, std::uint16_t queues)
+        void init(std::size_t domain, std::size_t queues)
         {
             num_queues_ = queues;
             domain_ = domain;
@@ -91,18 +91,18 @@ namespace hpx { namespace threads { namespace policies {
         }
 
         // ----------------------------------------------------------------
-        inline ThreadQueue* thread_queue(std::uint16_t id) const
+        inline ThreadQueue* thread_queue(std::size_t id) const
         {
             return queues_[id];
         }
 
         // ----------------------------------------------------------------
-        inline bool get_next_thread_HP(std::uint16_t qidx,
+        inline bool get_next_thread_HP(std::size_t qidx,
             threads::thread_data*& thrd, bool stealing, bool core_stealing)
         {
             // loop over queues and take one task,
-            std::uint16_t q = qidx;
-            for (std::uint16_t i = 0; i < num_queues_;
+            std::size_t q = qidx;
+            for (std::size_t i = 0; i < num_queues_;
                  ++i, q = fast_mod((qidx + i), num_queues_))
             {
                 if (queues_[q]->get_next_thread_HP(
@@ -127,13 +127,13 @@ namespace hpx { namespace threads { namespace policies {
         }
 
         // ----------------------------------------------------------------
-        inline bool get_next_thread(std::uint16_t qidx,
+        inline bool get_next_thread(std::size_t qidx,
             threads::thread_data*& thrd, bool stealing, bool core_stealing)
         {
             // loop over queues and take one task,
             // starting with the requested queue
-            std::uint16_t q = qidx;
-            for (std::uint16_t i = 0; i < num_queues_;
+            std::size_t q = qidx;
+            for (std::size_t i = 0; i < num_queues_;
                  ++i, q = fast_mod((qidx + i), num_queues_))
             {
                 // if we got a thread, return it, only allow stealing if i>0
@@ -155,12 +155,12 @@ namespace hpx { namespace threads { namespace policies {
         }
 
         // ----------------------------------------------------------------
-        bool add_new_HP(ThreadQueue* receiver, std::uint16_t qidx,
+        bool add_new_HP(ThreadQueue* receiver, std::size_t qidx,
             std::size_t& added, bool stealing, bool allow_stealing)
         {
             // loop over queues and take one task,
-            std::uint16_t q = qidx;
-            for (std::uint16_t i = 0; i < num_queues_;
+            std::size_t q = qidx;
+            for (std::size_t i = 0; i < num_queues_;
                  ++i, q = fast_mod((qidx + i), num_queues_))
             {
                 std::size_t added =
@@ -186,12 +186,12 @@ namespace hpx { namespace threads { namespace policies {
         }
 
         // ----------------------------------------------------------------
-        bool add_new(ThreadQueue* receiver, std::uint16_t qidx,
+        bool add_new(ThreadQueue* receiver, std::size_t qidx,
             std::size_t& added, bool stealing, bool allow_stealing)
         {
             // loop over queues and take one task,
-            std::uint16_t q = qidx;
-            for (std::uint16_t i = 0; i < num_queues_;
+            std::size_t q = qidx;
+            for (std::size_t i = 0; i < num_queues_;
                  ++i, q = fast_mod((qidx + i), num_queues_))
             {
                 std::size_t added =
@@ -256,8 +256,8 @@ namespace hpx { namespace threads { namespace policies {
         // ----------------------------------------------------------------
         // ----------------------------------------------------------------
         // ----------------------------------------------------------------
-        std::uint16_t num_queues_;
-        std::uint16_t domain_;
+        std::size_t num_queues_;
+        std::size_t domain_;
         std::vector<ThreadQueue*> queues_;
 
     public:

--- a/hpx/runtime/threads/policies/queue_holder_thread.hpp
+++ b/hpx/runtime/threads/policies/queue_holder_thread.hpp
@@ -87,11 +87,11 @@ namespace hpx { namespace threads { namespace policies {
         QueueType* const lp_queue_;
 
         // these are the domain and local thread queue ids for the container
-        const std::uint16_t domain_index_;
-        const std::uint16_t queue_index_;
-        const std::uint16_t thread_num_;
+        const std::size_t domain_index_;
+        const std::size_t queue_index_;
+        const std::size_t thread_num_;
         // a mask that hold a bit per queue to indicate ownership of the queue
-        const std::uint16_t owner_mask_;
+        const std::size_t owner_mask_;
 
         // we must use OS mutexes here because we cannot suspend an HPX
         // thread whilst processing the Queues for that thread, this code
@@ -114,16 +114,17 @@ namespace hpx { namespace threads { namespace policies {
         thread_heap_type thread_heap_nostack_;
 
         // number of terminated threads to discard
-        const int min_delete_count_;
-        const int max_delete_count_;
+        int const min_delete_count_;
+        int const max_delete_count_;
 
         // number of terminated threads to collect before cleaning them up
-        const int max_terminated_threads_;
+        int const max_terminated_threads_;
 
         // these ought to be atomic, but if we get a race and assign a thread
         // to queue N instead of N+1 it doesn't really matter
 
-        mutable util::cache_line_data<std::tuple<int, int>> rollover_counters_;
+        mutable util::cache_line_data<std::tuple<std::size_t, std::size_t>>
+            rollover_counters_;
 
         // ----------------------------------------------------------------
         // ----------------------------------------------------------------
@@ -199,8 +200,8 @@ namespace hpx { namespace threads { namespace policies {
         // ----------------------------------------------------------------
         // ----------------------------------------------------------------
         queue_holder_thread(QueueType* bp_queue, QueueType* hp_queue,
-            QueueType* np_queue, QueueType* lp_queue, std::uint16_t domain,
-            std::uint16_t queue, std::uint16_t thread_num, std::uint16_t owner,
+            QueueType* np_queue, QueueType* lp_queue, std::size_t domain,
+            std::size_t queue, std::size_t thread_num, std::size_t owner,
             const thread_queue_init_parameters& init)
           : bp_queue_(bp_queue)
           , hp_queue_(hp_queue)
@@ -411,7 +412,7 @@ namespace hpx { namespace threads { namespace policies {
 
         // ----------------------------------------------------------------
         void create_thread(thread_init_data& data, thread_id_type* tid,
-            thread_state_enum state, bool run_now, std::uint16_t thread_num,
+            thread_state_enum state, bool run_now, std::size_t thread_num,
             error_code& ec)
         {
             if (thread_num != thread_num_)
@@ -899,7 +900,7 @@ namespace hpx { namespace threads { namespace policies {
         // ------------------------------------------------------------
         /// Destroy the passed thread as it has been terminated
         void destroy_thread(
-            threads::thread_data* thrd, std::uint16_t thread_num, bool xthread)
+            threads::thread_data* thrd, std::size_t thread_num, bool xthread)
         {
             // the thread must be destroyed by the same queue holder that created it
             HPX_ASSERT(&thrd->get_queue<queue_holder_thread>() == this);

--- a/libs/debugging/include/hpx/debugging/print.hpp
+++ b/libs/debugging/include/hpx/debugging/print.hpp
@@ -119,58 +119,81 @@ namespace hpx { namespace debug {
     // ------------------------------------------------------------------
     // format as zero padded hex
     // ------------------------------------------------------------------
-    template <int N = 4, typename T = int, typename Enable = void>
-    struct hex;
+    namespace detail {
 
-    template <int N, typename T>
-    struct hex<N, T, typename std::enable_if<!std::is_pointer<T>::value>::type>
-    {
-        hex(const T& v)
-          : data(v)
-        {
-        }
-        const T& data;
-        friend std::ostream& operator<<(std::ostream& os, const hex<N, T>& d)
-        {
-            os << std::right << "0x" << std::setfill('0') << std::setw(N)
-               << std::noshowbase << std::hex << d.data;
-            return os;
-        }
-    };
+        template <int N = 4, typename T = int, typename Enable = void>
+        struct hex;
 
-    template <int N, typename T>
-    struct hex<N, T, typename std::enable_if<std::is_pointer<T>::value>::type>
+        template <int N, typename T>
+        struct hex<N, T,
+            typename std::enable_if<!std::is_pointer<T>::value>::type>
+        {
+            hex(const T& v)
+              : data(v)
+            {
+            }
+            const T& data;
+            friend std::ostream& operator<<(
+                std::ostream& os, const hex<N, T>& d)
+            {
+                os << std::right << "0x" << std::setfill('0') << std::setw(N)
+                   << std::noshowbase << std::hex << d.data;
+                return os;
+            }
+        };
+
+        template <int N, typename T>
+        struct hex<N, T,
+            typename std::enable_if<std::is_pointer<T>::value>::type>
+        {
+            hex(const T& v)
+              : data(v)
+            {
+            }
+            const T& data;
+            friend std::ostream& operator<<(
+                std::ostream& os, const hex<N, T>& d)
+            {
+                os << std::right << std::setw(N) << std::noshowbase << std::hex
+                   << d.data;
+                return os;
+            }
+        };
+    }    // namespace detail
+
+    template <int N = 4, typename T>
+    detail::hex<N, T> hex(T const& v)
     {
-        hex(const T& v)
-          : data(v)
-        {
-        }
-        const T& data;
-        friend std::ostream& operator<<(std::ostream& os, const hex<N, T>& d)
-        {
-            os << std::right << std::setw(N) << std::noshowbase << std::hex
-               << d.data;
-            return os;
-        }
-    };
+        return detail::hex<N, T>(v);
+    }
 
     // ------------------------------------------------------------------
     // format as binary bits
     // ------------------------------------------------------------------
-    template <int N = 8, typename T = int>
-    struct bin
+    namespace detail {
+
+        template <int N = 8, typename T = int>
+        struct bin
+        {
+            bin(const T& v)
+              : data(v)
+            {
+            }
+            const T& data;
+            friend std::ostream& operator<<(
+                std::ostream& os, const bin<N, T>& d)
+            {
+                os << std::bitset<N>(d.data);
+                return os;
+            }
+        };
+    }    // namespace detail
+
+    template <int N = 8, typename T>
+    detail::bin<N, T> bin(T const& v)
     {
-        bin(const T& v)
-          : data(v)
-        {
-        }
-        const T& data;
-        friend std::ostream& operator<<(std::ostream& os, const bin<N, T>& d)
-        {
-            os << std::bitset<N>(d.data);
-            return os;
-        }
-    };
+        return detail::bin<N, T>(v);
+    }
 
     // ------------------------------------------------------------------
     // format as padded string


### PR DESCRIPTION
… mostly in the shared_priority_scheduler

- flyby: changing `debug::hex` and `debug::bin` to deduce their argument types
