### PR TITLE
Adding overload for `hpx::init`/`hpx::start` for use with resource partitioner

### DIFF
--- a/hpx/hpx_init.hpp
+++ b/hpx/hpx_init.hpp
@@ -780,6 +780,40 @@ namespace hpx
         hpx::runtime_mode mode = hpx::runtime_mode_default);
 
 /// \cond NOINTERNAL
+    namespace resource {
+
+        // forward declaration only
+        class partitioner;
+    }
+/// \endcond
+
+    /// \brief Main entry point for launching the HPX runtime system.
+    ///
+    /// This is a simplified main entry point, which can be used to set up the
+    /// runtime for an HPX application. All initialization parameters for the
+    /// runtime are taken from the resource partitioner object provided.
+    ///
+    /// \param rp           [in] The resource partitioner object to use for
+    ///                     initializing the runtime.
+    /// \param startup      [in] A function to be executed inside a HPX
+    ///                     thread before \p f is called. If this parameter
+    ///                     is not given no function will be executed.
+    /// \param shutdown     [in] A function to be executed inside an HPX
+    ///                     thread while hpx::finalize is executed. If this
+    ///                     parameter is not given no function will be
+    ///                     executed.
+    ///
+    /// \returns            The function returns the value, which has been
+    ///                     returned from the user supplied function \p f.
+    ///
+    /// \note               The created runtime system instance will be
+    ///                     executed in console or worker mode depending on the
+    ///                     configuration passed in `cfg`.
+    inline int init(resource::partitioner& rp,
+        startup_function_type startup = startup_function_type(),
+        shutdown_function_type shutdown = shutdown_function_type());
+
+/// \cond NOINTERNAL
     inline int init(std::nullptr_t f, std::string const& app_name, int argc,
         char** argv, hpx::runtime_mode mode = hpx::runtime_mode_default);
 

--- a/hpx/hpx_init_impl.hpp
+++ b/hpx/hpx_init_impl.hpp
@@ -46,6 +46,10 @@ namespace hpx
             startup_function_type startup, shutdown_function_type shutdown,
             hpx::runtime_mode mode, bool blocking);
 
+        HPX_EXPORT int run_or_start(resource::partitioner& rp,
+            startup_function_type startup, shutdown_function_type shutdown,
+            bool blocking);
+
 #if defined(HPX_WINDOWS)
         void init_winsocket();
 #endif
@@ -396,9 +400,32 @@ namespace hpx
     init(std::nullptr_t, std::vector<std::string> const& cfg,
          hpx::runtime_mode mode)
     {
-      char *dummy_argv[2] = { const_cast<char*>(HPX_APPLICATION_STRING), nullptr };
+        char* dummy_argv[2] = {
+            const_cast<char*>(HPX_APPLICATION_STRING), nullptr};
 
-      return init(nullptr, 1, dummy_argv, cfg, mode);
+        return init(nullptr, 1, dummy_argv, cfg, mode);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    inline int init(resource::partitioner& rp, startup_function_type startup,
+        shutdown_function_type shutdown)
+    {
+#if defined(HPX_WINDOWS)
+        detail::init_winsocket();
+#endif
+        util::set_hpx_prefix(HPX_PREFIX);
+#if defined(__FreeBSD__)
+        freebsd_environ = environ;
+#endif
+        // set a handler for std::abort
+        std::signal(SIGABRT, detail::on_abort);
+        std::atexit(detail::on_exit);
+#if defined(HPX_HAVE_CXX11_STD_QUICK_EXIT)
+        std::at_quick_exit(detail::on_exit);
+#endif
+
+        return detail::run_or_start(
+            rp, std::move(startup), std::move(shutdown), true);
     }
 }
 

--- a/hpx/hpx_start.hpp
+++ b/hpx/hpx_start.hpp
@@ -807,6 +807,40 @@ namespace hpx
         hpx::runtime_mode mode = hpx::runtime_mode_default);
 
 /// \cond NOINTERNAL
+    namespace resource {
+
+        // forward declaration only
+        class partitioner;
+    }
+/// \endcond
+
+    /// \brief Main non-blocking entry point for launching the HPX runtime system.
+    ///
+    /// This is a simplified main entry point, which can be used to set up the
+    /// runtime for an HPX application. All initialization parameters for the
+    /// runtime are taken from the resource partitioner object provided.
+    ///
+    /// \param rp           [in] The resource partitioner object to use for
+    ///                     initializing the runtime.
+    /// \param startup      [in] A function to be executed inside a HPX
+    ///                     thread before \p f is called. If this parameter
+    ///                     is not given no function will be executed.
+    /// \param shutdown     [in] A function to be executed inside an HPX
+    ///                     thread while hpx::finalize is executed. If this
+    ///                     parameter is not given no function will be
+    ///                     executed.
+    ///
+    /// \returns            The function returns the value, which has been
+    ///                     returned from the user supplied function \p f.
+    ///
+    /// \note               The created runtime system instance will be
+    ///                     executed in console or worker mode depending on the
+    ///                     configuration passed in `cfg`.
+    inline bool start(resource::partitioner& rp,
+        startup_function_type startup = startup_function_type(),
+        shutdown_function_type shutdown = shutdown_function_type());
+
+/// \cond NOINTERNAL
     inline bool start(std::nullptr_t f,
         std::string const& app_name, int argc, char** argv,
         hpx::runtime_mode mode = hpx::runtime_mode_default);

--- a/libs/resource_partitioner/examples/guided_pool_test.cpp
+++ b/libs/resource_partitioner/examples/guided_pool_test.cpp
@@ -304,5 +304,5 @@ int main(int argc, char* argv[])
 
     std::cout << "[main] resources added to thread_pools \n";
 
-    return hpx::init();
+    return hpx::init(rp);
 }

--- a/libs/resource_partitioner/examples/simple_resource_partitioner.cpp
+++ b/libs/resource_partitioner/examples/simple_resource_partitioner.cpp
@@ -337,5 +337,5 @@ int main(int argc, char* argv[])
         std::cout << "[main] resources added to thread_pools \n";
     }
 
-    return hpx::init();
+    return hpx::init(rp);
 }

--- a/libs/resource_partitioner/examples/simplest_resource_partitioner_1.cpp
+++ b/libs/resource_partitioner/examples/simplest_resource_partitioner_1.cpp
@@ -19,6 +19,6 @@ int hpx_main(int argc, char* argv[])
 int main(int argc, char** argv)
 {
     hpx::resource::partitioner rp(argc, argv);
-    hpx::init();
+    hpx::init(rp);
 }
 //body]

--- a/libs/resource_partitioner/examples/simplest_resource_partitioner_2.cpp
+++ b/libs/resource_partitioner/examples/simplest_resource_partitioner_2.cpp
@@ -44,6 +44,6 @@ int main(int argc, char* argv[])
         }
     }
 
-    hpx::init();
+    hpx::init(rp);
 }
 //body]

--- a/libs/resource_partitioner/include/hpx/resource_partitioner/partitioner.hpp
+++ b/libs/resource_partitioner/include/hpx/resource_partitioner/partitioner.hpp
@@ -271,6 +271,13 @@ namespace hpx { namespace resource {
         // return the topology object managed by the internal partitioner
         HPX_EXPORT hpx::threads::topology const& get_topology() const;
 
+        // access the command line options
+        HPX_EXPORT util::command_line_handling& get_command_line_switches();
+
+        // Does initialization of all resources and internal data of the
+        // resource partitioner called in hpx_init
+        HPX_EXPORT void configure_pools();
+
     private:
         detail::partitioner& partitioner_;
     };

--- a/libs/resource_partitioner/src/partitioner.cpp
+++ b/libs/resource_partitioner/src/partitioner.cpp
@@ -257,4 +257,16 @@ namespace hpx { namespace resource {
         return partitioner_.threads_needed();
     }
 
+    util::command_line_handling& partitioner::get_command_line_switches()
+    {
+        return partitioner_.get_command_line_switches();
+    }
+
+    // Does initialization of all resources and internal data of the
+    // resource partitioner called in hpx_init
+    void partitioner::configure_pools()
+    {
+        partitioner_.configure_pools();
+    }
+
 }}    // namespace hpx::resource

--- a/libs/resource_partitioner/tests/unit/named_pool_executor.cpp
+++ b/libs/resource_partitioner/tests/unit/named_pool_executor.cpp
@@ -144,6 +144,6 @@ int main(int argc, char* argv[])
     }
 
     // now run the test
-    HPX_TEST_EQ(hpx::init(), 0);
+    HPX_TEST_EQ(hpx::init(rp), 0);
     return hpx::util::report_errors();
 }

--- a/libs/resource_partitioner/tests/unit/resource_partitioner_info.cpp
+++ b/libs/resource_partitioner/tests/unit/resource_partitioner_info.cpp
@@ -51,6 +51,6 @@ int main(int argc, char* argv[])
     hpx::resource::partitioner rp(argc, argv, std::move(cfg));
 
     // now run the test
-    HPX_TEST_EQ(hpx::init(), 0);
+    HPX_TEST_EQ(hpx::init(rp), 0);
     return hpx::util::report_errors();
 }

--- a/libs/resource_partitioner/tests/unit/used_pus.cpp
+++ b/libs/resource_partitioner/tests/unit/used_pus.cpp
@@ -42,6 +42,6 @@ int main(int argc, char* argv[])
     hpx::resource::partitioner rp(argc, argv, std::move(cfg));
 
     // now run the test
-    HPX_TEST_EQ(hpx::init(), 0);
+    HPX_TEST_EQ(hpx::init(rp), 0);
     return hpx::util::report_errors();
 }

--- a/tests/unit/resource/cross_pool_injection.cpp
+++ b/tests/unit/resource/cross_pool_injection.cpp
@@ -255,6 +255,6 @@ int main(int argc, char* argv[])
     }
 
     // now run the test
-    HPX_TEST_EQ(hpx::init(), 0);
+    HPX_TEST_EQ(hpx::init(rp), 0);
     return hpx::util::report_errors();
 }

--- a/tests/unit/resource/scheduler_priority_check.cpp
+++ b/tests/unit/resource/scheduler_priority_check.cpp
@@ -207,7 +207,7 @@ int main(int argc, char* argv[])
     // Create the resource partitioner
     hpx::resource::partitioner rp(cmdline, argc, argv);
 
-    HPX_TEST_EQ(hpx::init(), 0);
+    HPX_TEST_EQ(hpx::init(rp), 0);
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/topology/numa_allocator.cpp
+++ b/tests/unit/topology/numa_allocator.cpp
@@ -284,6 +284,6 @@ int main(int argc, char* argv[])
             return pool;
         });
 
-    hpx::init();
+    hpx::init(rp);
     return hpx::util::report_errors();
 }


### PR DESCRIPTION
- this helps resolving linker errors on Windows if the main entry point to HPX is in a shared library
- this also cleans up the API as it makes the use of the resource partitioner explicit

Note that this is a breaking API as the use of the no-argument versions of `init` and `start` is now deprecated when using an explicit resource partitioner.
