### PR TITLE
Attempt to fix some test build errors on Windows

### DIFF
--- a/libs/resource_partitioner/examples/async_customization.cpp
+++ b/libs/resource_partitioner/examples/async_customization.cpp
@@ -468,7 +468,7 @@ struct dummy_tag
 
 namespace hpx { namespace threads { namespace executors {
     template <>
-    struct HPX_EXPORT pool_numa_hint<dummy_tag>
+    struct pool_numa_hint<dummy_tag>
     {
         int operator()(const int, const double, const char*) const
         {

--- a/libs/resource_partitioner/examples/guided_pool_test.cpp
+++ b/libs/resource_partitioner/examples/guided_pool_test.cpp
@@ -85,7 +85,7 @@ namespace hpx { namespace threads { namespace executors {
 
     // ------------------------------------------------------------------------
     template <>
-    struct HPX_EXPORT pool_numa_hint<guided_test_tag>
+    struct pool_numa_hint<guided_test_tag>
     {
         // ------------------------------------------------------------------------
         // specialize the hint operator for params


### PR DESCRIPTION
Removes superfluous `HPX_EXPORT`s from resource partitioner examples.