### PR TITLE
Add a helper function to get a future from a cuda stream

### DIFF
--- a/hpx/lcos/detail/future_data.hpp
+++ b/hpx/lcos/detail/future_data.hpp
@@ -680,6 +680,13 @@ namespace hpx { namespace lcos { namespace detail {
         {
         }
 
+        future_data_allocator(
+            init_no_addref no_addref, other_allocator const& alloc)
+          : future_data<Result>(no_addref)
+          , alloc_(alloc)
+        {
+        }
+
         template <typename... T>
         future_data_allocator(init_no_addref no_addref, in_place in_place,
             other_allocator const& alloc, T&&... ts)

--- a/libs/compute_cuda/include/hpx/compute/cuda/target.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/target.hpp
@@ -33,6 +33,11 @@
 
 namespace hpx { namespace compute { namespace cuda {
     ///////////////////////////////////////////////////////////////////////////
+    namespace detail {
+        HPX_API_EXPORT hpx::future<void> get_future(cudaStream_t);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     struct target
     {
     public:
@@ -204,6 +209,7 @@ namespace hpx { namespace compute { namespace cuda {
         hpx::id_type locality_;
     };
 
+    using detail::get_future;
     HPX_API_EXPORT target& get_default_target();
 }}}    // namespace hpx::compute::cuda
 

--- a/libs/compute_cuda/include/hpx/compute/cuda/target.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/target.hpp
@@ -41,24 +41,8 @@ namespace hpx { namespace compute { namespace cuda {
     namespace detail {
         struct runtime_registration_wrapper
         {
-            runtime_registration_wrapper(hpx::runtime* rt)
-              : rt_(rt)
-            {
-                HPX_ASSERT(rt);
-
-                // Register this thread with HPX, this should be done once for
-                // each external OS-thread intended to invoke HPX functionality.
-                // Calling this function more than once on the same thread will
-                // report an error.
-                hpx::error_code ec(hpx::lightweight);    // ignore errors
-                hpx::register_thread(rt_, "cuda", ec);
-            }
-            ~runtime_registration_wrapper()
-            {
-                // Unregister the thread from HPX, this should be done once in
-                // the end before the external thread exists.
-                hpx::unregister_thread(rt_);
-            }
+            runtime_registration_wrapper(hpx::runtime* rt);
+            ~runtime_registration_wrapper();
 
             hpx::runtime* rt_;
         };

--- a/libs/compute_cuda/include/hpx/compute/cuda/target.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/target.hpp
@@ -14,6 +14,7 @@
 
 #if defined(HPX_HAVE_CUDA)
 #include <hpx/allocator_support/allocator_deleter.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/compute/cuda/get_targets.hpp>
 #include <hpx/lcos/future.hpp>
 #include <hpx/runtime/find_here.hpp>

--- a/libs/compute_cuda/include/hpx/compute/cuda/target.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/target.hpp
@@ -120,7 +120,7 @@ namespace hpx { namespace compute { namespace cuda {
             future_data(init_no_addref no_addref, other_allocator const& alloc,
                 cudaStream_t stream)
               : lcos::detail::future_data_allocator<void, Allocator>(
-                    no_addref, lcos::detail::in_place{}, alloc)
+                    no_addref, alloc)
               , rt_(hpx::get_runtime_ptr())
             {
                 init(stream);

--- a/libs/compute_cuda/src/cuda_target.cpp
+++ b/libs/compute_cuda/src/cuda_target.cpp
@@ -8,8 +8,8 @@
 
 #if defined(HPX_HAVE_CUDA)
 
-#include <hpx/assertion.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/compute/cuda/target.hpp>
 #include <hpx/errors.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>
@@ -39,128 +39,6 @@
 
 namespace hpx { namespace compute { namespace cuda {
     namespace detail {
-        struct runtime_registration_wrapper
-        {
-            runtime_registration_wrapper(hpx::runtime* rt)
-              : rt_(rt)
-            {
-                HPX_ASSERT(rt);
-
-                // Register this thread with HPX, this should be done once for
-                // each external OS-thread intended to invoke HPX functionality.
-                // Calling this function more than once on the same thread will
-                // report an error.
-                hpx::error_code ec(hpx::lightweight);    // ignore errors
-                hpx::register_thread(rt_, "cuda", ec);
-            }
-            ~runtime_registration_wrapper()
-            {
-                // Unregister the thread from HPX, this should be done once in
-                // the end before the external thread exists.
-                hpx::unregister_thread(rt_);
-            }
-
-            hpx::runtime* rt_;
-        };
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename Allocator>
-        struct future_data
-          : lcos::detail::future_data_allocator<void, Allocator>
-        {
-        private:
-            using init_no_addref =
-                typename lcos::detail::future_data_allocator<void,
-                    Allocator>::init_no_addref;
-            using other_allocator = typename std::allocator_traits<
-                Allocator>::template rebind_alloc<future_data>;
-
-            static void CUDART_CB stream_callback(
-                cudaStream_t stream, cudaError_t error, void* user_data);
-
-        public:
-            future_data();
-            future_data(init_no_addref no_addref, other_allocator const& alloc,
-                cudaStream_t stream);
-
-            void init(cudaStream_t stream);
-
-        private:
-            hpx::runtime* rt_;
-        };
-
-        struct release_on_exit
-        {
-            release_on_exit(future_data* data)
-              : data_(data)
-            {
-            }
-
-            ~release_on_exit()
-            {
-                // release the shared state
-                lcos::detail::intrusive_ptr_release(data_);
-            }
-
-            future_data* data_;
-        };
-
-        ///////////////////////////////////////////////////////////////////////
-        void CUDART_CB future_data::stream_callback(
-            cudaStream_t stream, cudaError_t error, void* user_data)
-        {
-            future_data* this_ = static_cast<future_data*>(user_data);
-
-            runtime_registration_wrapper wrap(this_->rt_);
-            release_on_exit on_exit(this_);
-
-            if (error != cudaSuccess)
-            {
-                this_->set_exception(HPX_GET_EXCEPTION(kernel_error,
-                    "cuda::detail::future_data::stream_callback()",
-                    std::string("cudaStreamAddCallback failed: ") +
-                        cudaGetErrorString(error)));
-                return;
-            }
-
-            this_->set_data(hpx::util::unused);
-        }
-
-        future_data::future_data()
-          : rt_(hpx::get_runtime_ptr())
-        {
-        }
-
-        future_data::future_data(init_no_addref no_addref,
-            other_allocator const& alloc, cudaStream_t stream)
-          : lcos::detail::future_data_allocator<void>(
-                no_addref, lcos::detail::in_place{}, alloc)
-          , rt_(hpx::get_runtime_ptr())
-        {
-            init(stream);
-        }
-
-        void future_data::init(cudaStream_t stream)
-        {
-            // Hold on to the shared state on behalf of the cuda runtime
-            // right away as the callback could be called immediately.
-            lcos::detail::intrusive_ptr_add_ref(this);
-
-            cudaError_t error =
-                cudaStreamAddCallback(stream, stream_callback, this, 0);
-            if (error != cudaSuccess)
-            {
-                // callback was not called, release object
-                lcos::detail::intrusive_ptr_release(this);
-
-                // report error
-                HPX_THROW_EXCEPTION(kernel_error,
-                    "cuda::detail::future_data::future_data()",
-                    std::string("cudaStreamAddCallback failed: ") +
-                        cudaGetErrorString(error));
-            }
-        }
-
         hpx::future<void> get_future(cudaStream_t stream)
         {
             return get_future(hpx::util::internal_allocator<>{}, stream);

--- a/libs/compute_cuda/src/cuda_target.cpp
+++ b/libs/compute_cuda/src/cuda_target.cpp
@@ -39,6 +39,27 @@
 
 namespace hpx { namespace compute { namespace cuda {
     namespace detail {
+        runtime_registration_wrapper::runtime_registration_wrapper(
+            hpx::runtime* rt)
+          : rt_(rt)
+        {
+            HPX_ASSERT(rt);
+
+            // Register this thread with HPX, this should be done once for
+            // each external OS-thread intended to invoke HPX functionality.
+            // Calling this function more than once on the same thread will
+            // report an error.
+            hpx::error_code ec(hpx::lightweight);    // ignore errors
+            hpx::register_thread(rt_, "cuda", ec);
+        }
+
+        runtime_registration_wrapper::~runtime_registration_wrapper()
+        {
+            // Unregister the thread from HPX, this should be done once in
+            // the end before the external thread exists.
+            hpx::unregister_thread(rt_);
+        }
+
         hpx::future<void> get_future(cudaStream_t stream)
         {
             return get_future(hpx::util::internal_allocator<>{}, stream);


### PR DESCRIPTION
Adds a free function to get a future from a stream (instead of requiring a `hpx::compute::cuda::target`).

@G-071

@biddisco I didn't get to creating a module yet, but can add that as well.