### PR TITLE
Fix configuration with CUDA and older CMake versions

### DIFF
--- a/cmake/HPX_SetupCUDA.cmake
+++ b/cmake/HPX_SetupCUDA.cmake
@@ -62,5 +62,7 @@ if(HPX_WITH_CUDA AND NOT TARGET hpx::cuda)
     target_link_libraries(hpx::cuda INTERFACE cudart)
   endif()
 
-  target_link_libraries(hpx_base_libraries INTERFACE hpx::cuda)
+  if(NOT HPX_FIND_PACKAGE)
+    target_link_libraries(hpx_base_libraries INTERFACE hpx::cuda)
+  endif()
 endif()


### PR DESCRIPTION
Newer CMake (3.15 tested) accepted the old code, but older ones (3.10 tested) complain rightfully that `hpx_base_libraries` is not built by the dependent project when calling `find_package(HPX)`.

I've already added this change to the 1.4.1 release.