### PR TITLE
Use configure_file for HPXCacheVariables.cmake

### DIFF
--- a/cmake/HPX_ForwardCacheVariables.cmake
+++ b/cmake/HPX_ForwardCacheVariables.cmake
@@ -8,36 +8,29 @@
 # be forwarded to projects using HPX (the file is included in the
 # HPXConfig.cmake)
 
-function(write_license_header filename)
-  file(WRITE ${filename}
-"# Copyright (c) 2019 Ste||ar Group\n\
-#\n\
-# SPDX-License-Identifier: BSL-1.0\n\
-# Distributed under the Boost Software License, Version 1.0. (See accompanying\n\
-# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)\n\n"
-    )
-endfunction(write_license_header)
-
 get_cmake_property(cache_vars CACHE_VARIABLES)
 
 # Keep only the HPX_* like variables
 list(FILTER cache_vars INCLUDE REGEX HPX_)
 list(FILTER cache_vars EXCLUDE REGEX "Category$")
 
-# Write the HPXCacheVariables.cmake in the BUILD directory
+# Generate HPXCacheVariables.cmake in the BUILD directory
 set(_cache_var_file
   ${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}/${HPX_PACKAGE_NAME}CacheVariables.cmake)
-write_license_header(${_cache_var_file})
-file(APPEND ${_cache_var_file} "# File to store the HPX_* cache variables\n")
+set(_cache_var_file_template
+  "${HPX_SOURCE_DIR}/cmake/templates/${HPX_PACKAGE_NAME}CacheVariables.cmake.in")
+set(_cache_variables)
 foreach(_var IN LISTS cache_vars)
-  file(APPEND ${_cache_var_file} "set(${_var} ${${_var}})\n")
+  set(_cache_variables "${_cache_variables}set(${_var} ${${_var}})\n")
 endforeach()
-file(INSTALL ${_cache_var_file}
-  DESTINATION ${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY})
+
+configure_file(
+  ${_cache_var_file_template}
+  ${_cache_var_file})
 
 # Install the HPXCacheVariables.cmake in the INSTALL directory
 install(
-  FILES ${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${HPX_PACKAGE_NAME}CacheVariables.cmake
+  FILES ${_cache_var_file}
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}
   COMPONENT cmake
   )

--- a/cmake/templates/HPXCacheVariables.cmake.in
+++ b/cmake/templates/HPXCacheVariables.cmake.in
@@ -1,0 +1,9 @@
+# Copyright (c) 2019 Ste||ar Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# File to store the HPX_* cache variables
+
+@_cache_variables@


### PR DESCRIPTION
Mainly just to get rid of the message `Installing: .../HPXCacheVariables.cmake` when configuring HPX.