### PR TITLE
Fix roll_release.sh

### DIFF
--- a/tools/roll_release.sh
+++ b/tools/roll_release.sh
@@ -62,6 +62,7 @@ git config user.name "STE||AR Group"
 echo ""
 echo "Tagging release."
 git tag -s -a "${VERSION_FULL_TAG}" -m "${VERSION_DESCRIPTION}"
+git push origin "${VERSION_FULL_TAG}"
 
 echo ""
 echo "Creating release."


### PR DESCRIPTION
Not pushing the created tag explicitly leads to the `hub` command creating the tag instead of using the one created by the script. This seems to have been "close enough" for me not to notice any problems (plus my local tags showed the correct commit).

The `1.4.1-rc1` and `1.4.1` tags pointed to the wrong commits. I've corrected `1.4.1-rc1` and retracted the `1.4.1` tag until I'm sure things are done correctly. Apologies for any inconvenience this may have caused.