### PR TITLE
Adding a parameter to auto_chunk_size allowing to control the amount of iterations to measure

### DIFF
--- a/libs/algorithms/include/hpx/parallel/algorithms/partition.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/partition.hpp
@@ -177,7 +177,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                         std::size_t chunk_size = execution::get_chunk_size(
                             policy.parameters(), policy.executor(),
-                            [] { return 0; }, cores, size);
+                            [](std::size_t) { return 0; }, cores, size);
 
                         std::size_t max_chunks =
                             execution::maximal_number_of_chunks(

--- a/libs/algorithms/include/hpx/parallel/algorithms/sort.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/sort.hpp
@@ -187,8 +187,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 policy.parameters(), policy.executor(), cores, count);
 
             std::size_t chunk_size = execution::get_chunk_size(
-                policy.parameters(), policy.executor(), [] { return 0; }, cores,
-                count);
+                policy.parameters(), policy.executor(),
+                [](std::size_t) { return 0; }, cores, count);
 
             util::detail::adjust_chunk_size_and_max_chunks(
                 cores, count, max_chunks, chunk_size);

--- a/libs/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -127,8 +127,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         std::advance(last, count);
 
         Stride stride = parallel::v1::detail::abs(s);
-        auto test_function = [&]() -> std::size_t {
-            std::size_t test_chunk_size = count / 100;
+        auto test_function = [&](std::size_t test_chunk_size) -> std::size_t {
             if (test_chunk_size == 0)
                 return 0;
 
@@ -197,8 +196,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         while (count != 0)
         {
             std::size_t chunk_size = execution::get_chunk_size(
-                policy.parameters(), policy.executor(), []() { return 0; },
-                cores, count);
+                policy.parameters(), policy.executor(),
+                [](std::size_t) { return 0; }, cores, count);
 
             // make sure, chunk size and max_chunks are consistent
             adjust_chunk_size_and_max_chunks(
@@ -267,8 +266,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
         Stride stride = parallel::v1::detail::abs(s);
         std::size_t base_idx = 0;
-        auto test_function = [&]() -> std::size_t {
-            std::size_t test_chunk_size = count / 100;
+        auto test_function = [&](std::size_t test_chunk_size) -> std::size_t {
             if (test_chunk_size == 0)
                 return 0;
 
@@ -340,8 +338,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         while (count != 0)
         {
             std::size_t chunk_size = execution::get_chunk_size(
-                policy.parameters(), policy.executor(), []() { return 0; },
-                cores, count);
+                policy.parameters(), policy.executor(),
+                [](std::size_t) { return 0; }, cores, count);
 
             // make sure, chunk size and max_chunks are consistent
             adjust_chunk_size_and_max_chunks(

--- a/libs/execution/include/hpx/execution/executors/auto_chunk_size.hpp
+++ b/libs/execution/include/hpx/execution/executors/auto_chunk_size.hpp
@@ -39,8 +39,9 @@ namespace hpx { namespace parallel { namespace execution {
         ///       types will use 80 microseconds as the minimal time for which
         ///       any of the scheduled chunks should run.
         ///
-        constexpr auto_chunk_size()
-          : min_time_(80000)
+        constexpr auto_chunk_size(std::uint64_t num_iters_for_timing = 0)
+          : min_time_(200000)
+          , num_iters_for_timing_(num_iters_for_timing)
         {
         }
 
@@ -50,8 +51,10 @@ namespace hpx { namespace parallel { namespace execution {
         ///                     to decide how many loop iterations should be
         ///                     combined.
         ///
-        explicit auto_chunk_size(hpx::util::steady_duration const& rel_time)
+        explicit auto_chunk_size(hpx::util::steady_duration const& rel_time,
+            std::uint64_t num_iters_for_timing = 0)
           : min_time_(rel_time.value().count())
+          , num_iters_for_timing_(num_iters_for_timing)
         {
         }
 
@@ -61,12 +64,19 @@ namespace hpx { namespace parallel { namespace execution {
         std::size_t get_chunk_size(
             Executor&& exec, F&& f, std::size_t cores, std::size_t count)
         {
-            if (count > 100 * cores)
+            // by default use 1% of the iterations
+            if (num_iters_for_timing_ == 0)
+            {
+                num_iters_for_timing_ = count / 100;
+            }
+
+            // perform measurements only if necessary
+            if (num_iters_for_timing_ > 0)
             {
                 using hpx::util::high_resolution_clock;
                 std::uint64_t t = high_resolution_clock::now();
 
-                std::size_t test_chunk_size = f();
+                std::size_t test_chunk_size = f(num_iters_for_timing_);
                 if (test_chunk_size != 0)
                 {
                     t = (high_resolution_clock::now() - t) / test_chunk_size;
@@ -90,13 +100,19 @@ namespace hpx { namespace parallel { namespace execution {
         template <typename Archive>
         void serialize(Archive& ar, const unsigned int version)
         {
-            ar& min_time_;
+            // clang-format off
+            ar & min_time_ & num_iters_for_timing_;
+            // clang-format on
         }
         /// \endcond
 
     private:
         /// \cond NOINTERNAL
-        std::uint64_t min_time_;    // nanoseconds
+        // target time for on thread (nanoseconds)
+        std::uint64_t min_time_;
+
+        // number of iteration to use for timing
+        std::uint64_t num_iters_for_timing_;
         /// \endcond
     };
 }}}    // namespace hpx::parallel::execution


### PR DESCRIPTION
- note, this is a breaking change (with minimal potential impact) that adds
  an argument to the callback function that is used by get_chunk_size()
- this also removes unnecessary limitations from `auto_chunk_size` such that 
  the measurement is now always performed
