### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+* @aurianer @biddisco @hkaiser @msimberg
+
+/docs/ @msimberg
+/libs/**/*.txt @aurianer @msimberg
+/libs/**/*.rst @aurianer @msimberg
+/libs/**/*.py @aurianer @msimberg
+/libs/**/*.sh @aurianer @msimberg

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,9 @@
+# Copyright (c) 2020 STE||AR Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 * @aurianer @biddisco @hkaiser @msimberg
 
 /docs/ @msimberg


### PR DESCRIPTION
This adds a minimal `CODEOWNERS` file which is used to automatically assign reviewers to pull requests (https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners). The file follows the same syntax as `.gitiginore` with a username following the pattern. The users of the last matching pattern for changed files will be requested to review the PR.

I've added everyone who is currently paid to work on HPX as fallback reviewers, but I'll happily add others (@sithhell, @K-ballo?). The idea would be to have one or two people who are responsible for a smaller part of the codebase. This does not mean that others cannot review PRs to those parts. It just means that they will be the default reviewers for that part, but they can still ask others to comment and review when appropriate.

Please suggest parts of the codebase that you'd like to be responsible for and I'll add them to the PR. I've added two examples:

- the `docs` directory is my responsibility
- non-source files in the `libs` are @aurianer's and my responsibility