### PR TITLE
Fix a race condition and clean-up usage of scheduler mode

### DIFF
--- a/hpx/runtime/threads/detail/scheduled_thread_pool.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool.hpp
@@ -123,35 +123,6 @@ namespace hpx { namespace threads { namespace detail
             return sched_->Scheduler::reset_thread_distribution();
         }
 
-        void set_scheduler_mode(threads::policies::scheduler_mode mode) override
-        {
-            mode_ = mode;
-            return sched_->Scheduler::set_scheduler_mode(mode);
-        }
-
-        void add_scheduler_mode(threads::policies::scheduler_mode mode) override
-        {
-            mode_ = threads::policies::scheduler_mode(mode_ | mode);
-            return sched_->Scheduler::add_scheduler_mode(mode);
-        }
-
-        void add_remove_scheduler_mode(
-            threads::policies::scheduler_mode to_add_mode,
-            threads::policies::scheduler_mode to_remove_mode) override
-        {
-            mode_ = threads::policies::scheduler_mode(
-                (mode_ | to_add_mode) & ~to_remove_mode);
-            return sched_->Scheduler::add_remove_scheduler_mode(
-                to_add_mode, to_remove_mode);
-        }
-
-        void remove_scheduler_mode(
-            threads::policies::scheduler_mode mode) override
-        {
-            mode_ = threads::policies::scheduler_mode(mode_ & ~mode);
-            return sched_->Scheduler::remove_scheduler_mode(mode);
-        }
-
         ///////////////////////////////////////////////////////////////////
         bool run(std::unique_lock<std::mutex>& l,
             std::size_t pool_threads) override;

--- a/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
+++ b/hpx/runtime/threads/detail/scheduled_thread_pool_impl.hpp
@@ -420,7 +420,7 @@ namespace hpx { namespace threads { namespace detail {
         // needs to
         // be done in order to give the parcel pool threads higher
         // priority
-        if (mode_ & policies::reduce_thread_priority)
+        if (get_scheduler()->has_scheduler_mode(policies::reduce_thread_priority))
         {
             topo.reduce_thread_priority(ec);
             if (ec)
@@ -490,7 +490,7 @@ namespace hpx { namespace threads { namespace detail {
                     nullptr, nullptr, max_background_threads_,
                     max_idle_loop_count_, max_busy_loop_count_);
 
-                if ((mode_ & policies::do_background_work) &&
+                if (get_scheduler()->has_scheduler_mode(policies::do_background_work) &&
                     network_background_callback_)
                 {
 #if defined(HPX_HAVE_BACKGROUND_THREAD_COUNTERS) &&                            \
@@ -505,7 +505,6 @@ namespace hpx { namespace threads { namespace detail {
 #endif
                 }
 
-                sched_->Scheduler::set_scheduler_mode(mode_);
                 detail::scheduling_loop(
                     thread_num, *sched_, counters, callbacks);
 
@@ -1862,7 +1861,7 @@ namespace hpx { namespace threads { namespace detail {
     void scheduled_thread_pool<Scheduler>::add_processing_unit(
         std::size_t virt_core, std::size_t thread_num, error_code& ec)
     {
-        if (!(mode_ & threads::policies::enable_elasticity))
+        if (!get_scheduler()->has_scheduler_mode(policies::enable_elasticity))
         {
             HPX_THROW_EXCEPTION(invalid_status,
                 "scheduled_thread_pool<Scheduler>::add_processing_unit",
@@ -1882,7 +1881,7 @@ namespace hpx { namespace threads { namespace detail {
     void scheduled_thread_pool<Scheduler>::remove_processing_unit(
         std::size_t virt_core, error_code& ec)
     {
-        if (!(mode_ & threads::policies::enable_elasticity))
+        if (!get_scheduler()->has_scheduler_mode(policies::enable_elasticity))
         {
             HPX_THROW_EXCEPTION(invalid_status,
                 "scheduled_thread_pool<Scheduler>::remove_processing_unit",

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -565,8 +565,7 @@ namespace hpx { namespace threads { namespace detail
         std::shared_ptr<bool> background_running = nullptr;
         thread_id_type background_thread;
 
-        if ((scheduler.SchedulingPolicy::get_scheduler_mode() &
-                policies::do_background_work) &&
+        if (scheduler.SchedulingPolicy::has_scheduler_mode(policies::do_background_work) &&
             num_thread < params.max_background_threads_ &&
             !params.background_.empty())
         {
@@ -591,16 +590,14 @@ namespace hpx { namespace threads { namespace detail
 
             // extract the stealing mode once per loop iteration
             bool enable_stealing =
-                scheduler.SchedulingPolicy::get_scheduler_mode() &
-                    policies::enable_stealing;
+                scheduler.SchedulingPolicy::has_scheduler_mode(policies::enable_stealing);
 
             // stealing staged threads is enabled if:
             // - fast idle mode is on: same as normal stealing
             // - fast idle mode off: only after normal stealing has failed for
             //                       a while
             bool enable_stealing_staged = enable_stealing;
-            if (!(scheduler.SchedulingPolicy::get_scheduler_mode() &
-                    policies::fast_idle_mode))
+            if (!scheduler.SchedulingPolicy::has_scheduler_mode(policies::fast_idle_mode))
             {
                 enable_stealing_staged = enable_stealing_staged &&
                     idle_loop_count < params.max_idle_loop_count_ / 2;
@@ -849,8 +846,7 @@ namespace hpx { namespace threads { namespace detail
 
                         if (can_exit)
                         {
-                            if (!(scheduler.SchedulingPolicy::get_scheduler_mode()
-                                  & policies::delay_exit))
+                            if (!scheduler.SchedulingPolicy::has_scheduler_mode(policies::delay_exit))
                             {
                                 // If this is an inner scheduler, try to exit immediately
 #if defined(HPX_HAVE_NETWORKING)
@@ -892,8 +888,7 @@ namespace hpx { namespace threads { namespace detail
                     }
                 }
                 else if (!may_exit && added == 0 &&
-                    (scheduler.SchedulingPolicy::get_scheduler_mode() &
-                        policies::fast_idle_mode))
+                    (scheduler.SchedulingPolicy::has_scheduler_mode(policies::fast_idle_mode)))
                 {
                     // speed up idle suspend if no work was stolen
                     idle_loop_count -= params.max_idle_loop_count_ / 256;

--- a/hpx/runtime/threads/detail/scheduling_loop.hpp
+++ b/hpx/runtime/threads/detail/scheduling_loop.hpp
@@ -565,7 +565,8 @@ namespace hpx { namespace threads { namespace detail
         std::shared_ptr<bool> background_running = nullptr;
         thread_id_type background_thread;
 
-        if (scheduler.SchedulingPolicy::has_scheduler_mode(policies::do_background_work) &&
+        if (scheduler.SchedulingPolicy::has_scheduler_mode(
+            policies::do_background_work) &&
             num_thread < params.max_background_threads_ &&
             !params.background_.empty())
         {
@@ -846,7 +847,8 @@ namespace hpx { namespace threads { namespace detail
 
                         if (can_exit)
                         {
-                            if (!scheduler.SchedulingPolicy::has_scheduler_mode(policies::delay_exit))
+                            if (!scheduler.SchedulingPolicy::has_scheduler_mode(
+                                policies::delay_exit))
                             {
                                 // If this is an inner scheduler, try to exit immediately
 #if defined(HPX_HAVE_NETWORKING)
@@ -888,7 +890,8 @@ namespace hpx { namespace threads { namespace detail
                     }
                 }
                 else if (!may_exit && added == 0 &&
-                    (scheduler.SchedulingPolicy::has_scheduler_mode(policies::fast_idle_mode)))
+                    (scheduler.SchedulingPolicy::has_scheduler_mode(
+                        policies::fast_idle_mode)))
                 {
                     // speed up idle suspend if no work was stolen
                     idle_loop_count -= params.max_idle_loop_count_ / 256;

--- a/hpx/runtime/threads/executors/thread_pool_os_executors.hpp
+++ b/hpx/runtime/threads/executors/thread_pool_os_executors.hpp
@@ -85,7 +85,7 @@ namespace hpx { namespace threads { namespace executors {
             void set_scheduler_mode(
                 threads::policies::scheduler_mode mode) override
             {
-                pool_->set_scheduler_mode(mode);
+                pool_->get_scheduler()->set_scheduler_mode(mode);
             }
 
         protected:

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -1244,7 +1244,7 @@ namespace hpx { namespace threads { namespace policies {
             });
 
             // check for the rest and if we are NUMA aware
-            if (has_work_stealing_numa() && any(first_mask & pu_mask))
+            if (has_scheduler_mode(policies::enable_stealing_numa) && any(first_mask & pu_mask))
             {
                 iterate([&](std::size_t other_num_thread) {
                     return !any(numa_mask & numa_masks[other_num_thread]);

--- a/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_priority_queue_scheduler.hpp
@@ -1244,7 +1244,8 @@ namespace hpx { namespace threads { namespace policies {
             });
 
             // check for the rest and if we are NUMA aware
-            if (has_scheduler_mode(policies::enable_stealing_numa) && any(first_mask & pu_mask))
+            if (has_scheduler_mode(policies::enable_stealing_numa) &&
+                any(first_mask & pu_mask))
             {
                 iterate([&](std::size_t other_num_thread) {
                     return !any(numa_mask & numa_masks[other_num_thread]);

--- a/hpx/runtime/threads/policies/local_queue_scheduler.hpp
+++ b/hpx/runtime/threads/policies/local_queue_scheduler.hpp
@@ -356,7 +356,7 @@ namespace hpx { namespace threads { namespace policies {
                 return false;
             }
 
-            bool numa_stealing = has_work_stealing_numa();
+            bool numa_stealing = has_scheduler_mode(policies::enable_stealing_numa);
             if (!numa_stealing)
             {
                 // steal work items: first try to steal from other cores in
@@ -706,7 +706,7 @@ namespace hpx { namespace threads { namespace policies {
                 return true;
             }
 
-            bool numa_stealing_ = has_work_stealing_numa();
+            bool numa_stealing_ = has_scheduler_mode(policies::enable_stealing_numa);
             // limited or no stealing across domains
             if (!numa_stealing_)
             {
@@ -880,7 +880,7 @@ namespace hpx { namespace threads { namespace policies {
             else
                 first_mask = core_mask;
 
-            bool numa_stealing = has_work_stealing_numa();
+            bool numa_stealing = has_scheduler_mode(policies::enable_stealing_numa);
             if (numa_stealing && any(first_mask & core_mask))
             {
 #if !defined(HPX_NATIVE_MIC)    // we know that the MIC has one NUMA domain only

--- a/libs/threading_base/include/hpx/threading_base/scheduler_base.hpp
+++ b/libs/threading_base/include/hpx/threading_base/scheduler_base.hpp
@@ -105,20 +105,16 @@ namespace hpx { namespace threads { namespace policies {
         std::pair<hpx::state, hpx::state> get_minmax_state() const;
 
         ///////////////////////////////////////////////////////////////////////
-        bool has_work_stealing() const
-        {
-            return (get_scheduler_mode() & policies::enable_stealing);
-        }
-
-        bool has_work_stealing_numa() const
-        {
-            return (get_scheduler_mode() & policies::enable_stealing_numa);
-        }
-
         // get/set scheduler mode
         scheduler_mode get_scheduler_mode() const
         {
             return mode_.data_.load(std::memory_order_relaxed);
+        }
+
+        // get/set scheduler mode
+        bool has_scheduler_mode(scheduler_mode mode) const
+        {
+            return (mode_.data_.load(std::memory_order_relaxed) & mode) != 0;
         }
 
         // set mode flags that control scheduler behaviour

--- a/libs/threading_base/include/hpx/threading_base/thread_pool_base.hpp
+++ b/libs/threading_base/include/hpx/threading_base/thread_pool_base.hpp
@@ -493,16 +493,6 @@ namespace hpx { namespace threads {
 
         virtual void reset_thread_distribution() {}
 
-        virtual void set_scheduler_mode(threads::policies::scheduler_mode) {}
-        virtual void add_scheduler_mode(threads::policies::scheduler_mode) {}
-        virtual void add_remove_scheduler_mode(
-            threads::policies::scheduler_mode,
-            threads::policies::scheduler_mode)
-        {
-        }
-        virtual void remove_scheduler_mode(threads::policies::scheduler_mode) {}
-
-        //
         virtual void abort_all_suspended_threads() {}
         virtual bool cleanup_terminated(bool /*delete_all*/)
         {
@@ -546,13 +536,6 @@ namespace hpx { namespace threads {
 
         /// \endcond
 
-        /// \cond NOINTERNAL
-        policies::scheduler_mode get_scheduler_mode() const
-        {
-            return mode_;
-        }
-        /// \endcond
-
     protected:
         /// \cond NOINTERNAL
         void init_pool_time_scale();
@@ -561,9 +544,6 @@ namespace hpx { namespace threads {
     protected:
         /// \cond NOINTERNAL
         pool_id_type id_;
-
-        // Mode of operation of the pool
-        policies::scheduler_mode mode_;
 
         // The thread_offset is equal to the accumulated number of
         // threads in all pools preceding this pool

--- a/libs/threading_base/src/thread_pool_base.cpp
+++ b/libs/threading_base/src/thread_pool_base.cpp
@@ -27,7 +27,6 @@ namespace hpx { namespace threads {
     ///////////////////////////////////////////////////////////////////////////
     thread_pool_base::thread_pool_base(thread_pool_init_parameters const& init)
       : id_(init.index_, init.name_)
-      , mode_(init.mode_)
       , thread_offset_(init.thread_offset_)
       , affinity_data_(init.affinity_data_)
       , timestamp_scale_(1.0)

--- a/libs/threadmanager/include/hpx/threadmanager.hpp
+++ b/libs/threadmanager/include/hpx/threadmanager.hpp
@@ -271,7 +271,7 @@ namespace hpx { namespace threads {
         {
             for (auto& pool_iter : pools_)
             {
-                pool_iter->set_scheduler_mode(mode);
+                pool_iter->get_scheduler()->set_scheduler_mode(mode);
             }
         }
 
@@ -279,7 +279,7 @@ namespace hpx { namespace threads {
         {
             for (auto& pool_iter : pools_)
             {
-                pool_iter->add_scheduler_mode(mode);
+                pool_iter->get_scheduler()->add_scheduler_mode(mode);
             }
         }
 
@@ -289,7 +289,7 @@ namespace hpx { namespace threads {
         {
             for (auto& pool_iter : pools_)
             {
-                pool_iter->add_remove_scheduler_mode(
+                pool_iter->get_scheduler()->add_remove_scheduler_mode(
                     to_add_mode, to_remove_mode);
             }
         }
@@ -298,7 +298,7 @@ namespace hpx { namespace threads {
         {
             for (auto& pool_iter : pools_)
             {
-                pool_iter->remove_scheduler_mode(mode);
+                pool_iter->get_scheduler()->remove_scheduler_mode(mode);
             }
         }
 

--- a/src/runtime/threads/thread_pool_suspension_helpers.cpp
+++ b/src/runtime/threads/thread_pool_suspension_helpers.cpp
@@ -25,8 +25,7 @@ namespace hpx { namespace threads {
                 "cannot call resume_processing_unit from outside HPX, use"
                 "resume_processing_unit_cb instead");
         }
-        else if (!(pool.get_scheduler_mode() &
-                     threads::policies::enable_elasticity))
+        else if (!pool.get_scheduler()->has_scheduler_mode(threads::policies::enable_elasticity))
         {
             return hpx::make_exceptional_future<void>(
                 HPX_GET_EXCEPTION(invalid_status, "resume_processing_unit",
@@ -43,7 +42,7 @@ namespace hpx { namespace threads {
         std::function<void(void)> callback, std::size_t virt_core,
         error_code& ec)
     {
-        if (!(pool.get_scheduler_mode() & threads::policies::enable_elasticity))
+        if (!pool.get_scheduler()->has_scheduler_mode(policies::enable_elasticity))
         {
             HPX_THROWS_IF(ec, invalid_status, "resume_processing_unit_cb",
                 "this thread pool does not support suspending "
@@ -76,15 +75,14 @@ namespace hpx { namespace threads {
                 "cannot call suspend_processing_unit from outside HPX, use"
                 "suspend_processing_unit_cb instead");
         }
-        else if (!(pool.get_scheduler_mode() &
-                     threads::policies::enable_elasticity))
+        else if (!pool.get_scheduler()->has_scheduler_mode(policies::enable_elasticity))
         {
             return hpx::make_exceptional_future<void>(
                 HPX_GET_EXCEPTION(invalid_status, "suspend_processing_unit",
                     "this thread pool does not support suspending "
                     "processing units"));
         }
-        else if (!pool.get_scheduler()->has_work_stealing() &&
+        else if (!pool.get_scheduler()->has_scheduler_mode(policies::enable_stealing) &&
             hpx::this_thread::get_pool() == &pool)
         {
             return hpx::make_exceptional_future<void>(
@@ -102,7 +100,7 @@ namespace hpx { namespace threads {
         std::function<void(void)> callback, std::size_t virt_core,
         error_code& ec)
     {
-        if (!(pool.get_scheduler_mode() & threads::policies::enable_elasticity))
+        if (!pool.get_scheduler()->has_scheduler_mode(policies::enable_elasticity))
         {
             HPX_THROWS_IF(ec, invalid_status, "suspend_processing_unit_cb",
                 "this thread pool does not support suspending processing "
@@ -118,7 +116,7 @@ namespace hpx { namespace threads {
 
         if (threads::get_self_ptr())
         {
-            if (!pool.get_scheduler()->has_work_stealing() &&
+            if (!pool.get_scheduler()->has_scheduler_mode(policies::enable_stealing) &&
                 hpx::this_thread::get_pool() == &pool)
             {
                 HPX_THROW_EXCEPTION(invalid_status,

--- a/src/runtime/threads/thread_pool_suspension_helpers.cpp
+++ b/src/runtime/threads/thread_pool_suspension_helpers.cpp
@@ -25,7 +25,8 @@ namespace hpx { namespace threads {
                 "cannot call resume_processing_unit from outside HPX, use"
                 "resume_processing_unit_cb instead");
         }
-        else if (!pool.get_scheduler()->has_scheduler_mode(threads::policies::enable_elasticity))
+        else if (!pool.get_scheduler()->has_scheduler_mode(
+                  policies::enable_elasticity))
         {
             return hpx::make_exceptional_future<void>(
                 HPX_GET_EXCEPTION(invalid_status, "resume_processing_unit",


### PR DESCRIPTION
The pool and the scheduler both kept copies of the scheduler
mode and it was set on startup in different places. Some user
code that wished to set the scheduler mode to a non default
value at the start of hpx_main suffered from a race that allowed
the pool to overwrite the mode flags.

This commit removes the copy of the scheduler mode that was held
by the pool as well as some unnecessary set/get calls to the mode.

This also tidies up a lot of calls to if (get_scheduler_mode() & xxx)
and replaces them with a has_scheduler_mode(xxx) call that makes the
code a little more readable and maintainable.
