### PR TITLE
Fix cross pool injection test, use default scheduler as falback

### DIFF
--- a/tests/unit/resource/cross_pool_injection.cpp
+++ b/tests/unit/resource/cross_pool_injection.cpp
@@ -238,8 +238,13 @@ int main(int argc, char* argv[])
                         st_rand(
                             0, ((std::max)(std::size_t(1), max_threads / 2)));
                     pool_name = "pool-" + std::to_string(num_pools);
+#if defined(HPX_HAVE_SHARED_PRIORITY_SCHEDULER)
                     rp.create_thread_pool(pool_name,
                         hpx::resource::scheduling_policy::shared_priority);
+#else
+                    rp.create_thread_pool(pool_name,
+                        hpx::resource::scheduling_policy::local_priority_fifo);
+#endif
                     num_pools++;
                 }
                 std::cout << "Added pu " << p.id() << " to " << pool_name


### PR DESCRIPTION
The cross pool scheduler test fails for some builds because the shared priority scheduler is not enabled.

This fix should drop down to the default scheduler if the other is not available.

In future I'd like to extend the test to test all schedulers in turn.