### PR TITLE
Adding serialization support for std::variant (if available) and std::tuple

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -331,6 +331,13 @@ function(hpx_check_for_cxx17_noexcept_functions_as_nontype_template_arguments)
 endfunction()
 
 ###############################################################################
+function(hpx_check_for_cxx17_std_variant)
+  add_hpx_config_test(HPX_WITH_CXX17_VARIANT
+    SOURCE cmake/tests/cxx17_std_variant.cpp
+    FILE ${ARGN})
+endfunction()
+
+###############################################################################
 function(hpx_check_for_builtin_integer_pack)
   add_hpx_config_test(HPX_WITH_BUILTIN_INTEGER_PACK
     SOURCE cmake/tests/builtin_integer_pack.cpp

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -48,6 +48,9 @@ function(hpx_perform_cxx_feature_tests)
   hpx_check_for_cxx17_std_in_place_type_t(
     DEFINITIONS HPX_HAVE_CXX17_STD_IN_PLACE_TYPE_T)
 
+  hpx_check_for_cxx17_std_variant(
+    DEFINITIONS HPX_HAVE_CXX17_STD_VARIANT)
+
   # we deliberately check for this functionality even for non-C++17
   # configurations as some compilers (notable gcc V7.x) require for noexcept
   # function specializations for actions even in C++11/14 mode

--- a/cmake/tests/cxx17_std_variant.cpp
+++ b/cmake/tests/cxx17_std_variant.cpp
@@ -1,0 +1,16 @@
+////////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+////////////////////////////////////////////////////////////////////////////////
+
+#include <variant>
+
+int main()
+{
+    std::variant<int, double> p;
+
+    return 0;
+}

--- a/libs/serialization/CMakeLists.txt
+++ b/libs/serialization/CMakeLists.txt
@@ -42,6 +42,7 @@ set(serialization_headers
   hpx/serialization/set.hpp
   hpx/serialization/serialize_buffer.hpp
   hpx/serialization/string.hpp
+  hpx/serialization/std_tuple.hpp
   hpx/serialization/tuple.hpp
   hpx/serialization/unordered_map.hpp
   hpx/serialization/vector.hpp
@@ -70,6 +71,12 @@ set(serialization_headers
   hpx/serialization/traits/polymorphic_traits.hpp
   hpx/serialization/traits/serialization_access_data.hpp
 )
+
+if(HPX_SERIALIZATION_WITH_BOOST_TYPES)
+  set(serialization_headers ${serialization_headers}
+    hpx/serialization/boost_variant.hpp
+  )
+endif()
 
 # Default location is $HPX_ROOT/libs/serialization/include_compatibility
 set(serialization_compat_headers

--- a/libs/serialization/include/hpx/serialization/std_tuple.hpp
+++ b/libs/serialization/include/hpx/serialization/std_tuple.hpp
@@ -1,0 +1,55 @@
+//  Copyright (c) 2011-2013 Thomas Heller
+//  Copyright (c) 2011-2020 Hartmut Kaiser
+//  Copyright (c) 2013-2015 Agustin Berge
+//  Copyright (c) 2019 Mikael Simberg
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_SERIALIZATION_STD_TUPLE_HPP)
+#define HPX_SERIALIZATION_STD_TUPLE_HPP
+
+#include <hpx/serialization/serialization_fwd.hpp>
+#include <hpx/type_support/pack.hpp>
+
+#include <cstddef>
+#include <type_traits>
+#include <tuple>
+
+namespace hpx { namespace serialization {
+
+    namespace detail {
+
+        template <typename Archive, typename Is, typename... Ts>
+        struct std_serialize_with_index_pack;
+
+        template <typename Archive, std::size_t... Is, typename... Ts>
+        struct std_serialize_with_index_pack<Archive,
+            hpx::util::index_pack<Is...>, Ts...>
+        {
+            static void call(Archive& ar, std::tuple<Ts...>& t, unsigned int)
+            {
+                int const _sequencer[] = {((ar & std::get<Is>(t)), 0)...};
+                (void) _sequencer;
+            }
+        };
+    }    // namespace detail
+
+    template <typename Archive, typename... Ts>
+    void serialize(Archive& ar, std::tuple<Ts...>& t, unsigned int version)
+    {
+        using Is = typename hpx::util::make_index_pack<sizeof...(Ts)>::type;
+        detail::std_serialize_with_index_pack<Archive, Is, Ts...>::call(
+            ar, t, version);
+    }
+
+    template <typename Archive>
+    void serialize(Archive& ar, std::tuple<>&, unsigned int)
+    {
+    }
+
+}}    // namespace hpx::serialization
+
+#endif

--- a/libs/serialization/include/hpx/serialization/std_tuple.hpp
+++ b/libs/serialization/include/hpx/serialization/std_tuple.hpp
@@ -15,8 +15,8 @@
 #include <hpx/type_support/pack.hpp>
 
 #include <cstddef>
-#include <type_traits>
 #include <tuple>
+#include <type_traits>
 
 namespace hpx { namespace serialization {
 

--- a/libs/serialization/include/hpx/serialization/variant.hpp
+++ b/libs/serialization/include/hpx/serialization/variant.hpp
@@ -12,7 +12,7 @@
 #define HPX_SERIALIZATION_VARIANT_HPP
 
 #include <hpx/config.hpp>
-#include <hpx/serialization/boost_variant.hpp>  // for backwards compatibility
+#include <hpx/serialization/boost_variant.hpp>    // for backwards compatibility
 
 #if defined(HPX_HAVE_CXX17_STD_VARIANT)
 

--- a/libs/serialization/tests/unit/CMakeLists.txt
+++ b/libs/serialization/tests/unit/CMakeLists.txt
@@ -17,16 +17,27 @@ set(tests
     serialization_set
     serialization_simple
     serialization_smart_ptr
+    serialization_std_tuple
+    serialization_tuple
     serialization_unordered_map
     serialization_vector
-    serialization_variant
     serialize_with_incompatible_signature
 )
 
 if(HPX_WITH_CXX17_STRUCTURED_BINDINGS)
     set(tests ${tests}
         serialization_brace_initializable
-)
+    )
+endif()
+if(HPX_CXX17_WITH_STD_VARIANT)
+    set(tests ${tests}
+        serialization_std_variant
+    )
+endif()
+if(HPX_SERIALIZATION_WITH_BOOST_TYPES)
+    set(tests ${tests}
+        serialization_boost_variant
+    )
 endif()
 
 set(full_tests

--- a/libs/serialization/tests/unit/serialization_boost_variant.cpp
+++ b/libs/serialization/tests/unit/serialization_boost_variant.cpp
@@ -102,7 +102,9 @@ int main()
 
     HPX_TEST_EQ(sivar.which(), sovar.which());
     HPX_TEST_EQ(sivar, sovar);
-#endif
 
     return hpx::util::report_errors();
+#else
+    return 0;
+#endif
 }

--- a/libs/serialization/tests/unit/serialization_boost_variant.cpp
+++ b/libs/serialization/tests/unit/serialization_boost_variant.cpp
@@ -4,6 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/config.hpp>
+
+#if defined(HPX_SERIALIZATION_HAVE_BOOST_TYPES)
+
 #include <hpx/serialization/input_archive.hpp>
 #include <hpx/serialization/output_archive.hpp>
 #include <hpx/serialization/serialize.hpp>
@@ -14,6 +18,8 @@
 
 #include <string>
 #include <vector>
+
+#include <boost/variant.hpp>
 
 template <typename T>
 struct A
@@ -50,8 +56,11 @@ struct A
     }
 };
 
+#endif
+
 int main()
 {
+#if defined(HPX_SERIALIZATION_HAVE_BOOST_TYPES)
     std::vector<char> buf;
     hpx::serialization::output_archive oar(buf);
     hpx::serialization::input_archive iar(buf);
@@ -93,6 +102,7 @@ int main()
 
     HPX_TEST_EQ(sivar.which(), sovar.which());
     HPX_TEST_EQ(sivar, sovar);
+#endif
 
     return hpx::util::report_errors();
 }

--- a/libs/serialization/tests/unit/serialization_std_tuple.cpp
+++ b/libs/serialization/tests/unit/serialization_std_tuple.cpp
@@ -1,0 +1,86 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/serialization/input_archive.hpp>
+#include <hpx/serialization/output_archive.hpp>
+#include <hpx/serialization/serialize.hpp>
+#include <hpx/serialization/std_tuple.hpp>
+
+#include <hpx/testing.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <tuple>
+
+template <typename T>
+struct A
+{
+    A() = default;
+
+    explicit A(T t)
+      : t_(t)
+    {
+    }
+    T t_;
+
+    A& operator=(T t)
+    {
+        t_ = t;
+        return *this;
+    }
+
+    template <typename Archive>
+    void serialize(Archive& ar, unsigned)
+    {
+        // clang-format off
+        ar & t_;
+        // clang-format on
+    }
+
+    friend bool operator==(A const& lhs, A const& rhs)
+    {
+        return lhs.t_ == rhs.t_;
+    }
+};
+
+void test()
+{
+    {
+        std::tuple<int, double, std::string, A<int>> ot{
+            42, 42.0, "42.0", A<int>{0}};
+
+        std::vector<char> buffer;
+        std::vector<hpx::serialization::serialization_chunk> chunks;
+        hpx::serialization::output_archive oarchive(buffer, 0, &chunks);
+        oarchive << ot;
+        std::size_t size = oarchive.bytes_written();
+
+        hpx::serialization::input_archive iarchive(buffer, size, &chunks);
+        std::tuple<int, double, std::string, A<int>> it;
+        iarchive >> it;
+        HPX_TEST(ot == it);
+    }
+    {
+        std::tuple<> ot{};
+
+        std::vector<char> buffer;
+        std::vector<hpx::serialization::serialization_chunk> chunks;
+        hpx::serialization::output_archive oarchive(buffer, 0, &chunks);
+        oarchive << ot;
+        std::size_t size = oarchive.bytes_written();
+
+        hpx::serialization::input_archive iarchive(buffer, size, &chunks);
+        std::tuple<> it;
+        iarchive >> it;
+        HPX_TEST(ot == it);
+    }
+}
+
+int main()
+{
+    test();
+    return hpx::util::report_errors();
+}

--- a/libs/serialization/tests/unit/serialization_std_tuple.cpp
+++ b/libs/serialization/tests/unit/serialization_std_tuple.cpp
@@ -13,7 +13,9 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 #include <tuple>
+#include <vector>
 
 template <typename T>
 struct A

--- a/libs/serialization/tests/unit/serialization_std_variant.cpp
+++ b/libs/serialization/tests/unit/serialization_std_variant.cpp
@@ -1,0 +1,104 @@
+//  Copyright (c) 2015 Anton Bikineev
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_CXX17_HAVE_STD_VARIANT)
+#include <hpx/serialization/input_archive.hpp>
+#include <hpx/serialization/output_archive.hpp>
+#include <hpx/serialization/serialize.hpp>
+#include <hpx/serialization/string.hpp>
+#include <hpx/serialization/variant.hpp>
+
+#include <hpx/testing.hpp>
+
+#include <string>
+#include <variant>
+#include <vector>
+
+template <typename T>
+struct A
+{
+    A() {}
+
+    explicit A(T t)
+      : t_(t)
+    {
+    }
+    T t_;
+
+    A& operator=(T t)
+    {
+        t_ = t;
+        return *this;
+    }
+
+    friend bool operator==(A a, A b)
+    {
+        return a.t_ == b.t_;
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, A a)
+    {
+        os << a.t_;
+        return os;
+    }
+
+    template <typename Archive>
+    void serialize(Archive& ar, unsigned)
+    {
+        ar& t_;
+    }
+};
+#endif
+
+int main()
+{
+#if defined(HPX_CXX17_HAVE_STD_VARIANT)
+    std::vector<char> buf;
+    hpx::serialization::output_archive oar(buf);
+    hpx::serialization::input_archive iar(buf);
+
+    std::variant<int, std::string, double, A<int>> ovar = std::string("dfsdf");
+    std::variant<int, std::string, double, A<int>> ivar;
+    oar << ovar;
+    iar >> ivar;
+
+    HPX_TEST_EQ(ivar.which(), ovar.which());
+    HPX_TEST_EQ(ivar, ovar);
+
+    ovar = 2.5;
+    oar << ovar;
+    iar >> ivar;
+
+    HPX_TEST_EQ(ivar.which(), ovar.which());
+    HPX_TEST_EQ(ivar, ovar);
+
+    ovar = 1;
+    oar << ovar;
+    iar >> ivar;
+
+    HPX_TEST_EQ(ivar.which(), ovar.which());
+    HPX_TEST_EQ(ivar, ovar);
+
+    ovar = A<int>(2);
+    oar << ovar;
+    iar >> ivar;
+
+    HPX_TEST_EQ(ivar.which(), ovar.which());
+    HPX_TEST_EQ(ivar, ovar);
+
+    const std::variant<std::string> sovar = std::string("string");
+    std::variant<std::string> sivar;
+    oar << sovar;
+    iar >> sivar;
+
+    HPX_TEST_EQ(sivar.which(), sovar.which());
+    HPX_TEST_EQ(sivar, sovar);
+#endif
+
+    return hpx::util::report_errors();
+}

--- a/libs/serialization/tests/unit/serialization_std_variant.cpp
+++ b/libs/serialization/tests/unit/serialization_std_variant.cpp
@@ -98,6 +98,25 @@ int main()
 
     HPX_TEST_EQ(sivar.which(), sovar.which());
     HPX_TEST_EQ(sivar, sovar);
+
+    bool caught_exception = false;
+    try
+    {
+        std::variant<std::string, int> sovar = 42;
+        std::variant<std::string> sivar;
+        oar << sovar;
+        iar >> sivar;
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception const& e)
+    {
+        if (e.get_error() == hpx::serialization_error)
+        {
+            caught_exception = true;
+        }
+    }
+    HPX_TEST(caught_exception);
 #endif
 
     return hpx::util::report_errors();

--- a/libs/serialization/tests/unit/serialization_tuple.cpp
+++ b/libs/serialization/tests/unit/serialization_tuple.cpp
@@ -1,0 +1,86 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/datatypes/tuple.hpp>
+#include <hpx/serialization/input_archive.hpp>
+#include <hpx/serialization/output_archive.hpp>
+#include <hpx/serialization/serialize.hpp>
+#include <hpx/serialization/tuple.hpp>
+
+#include <hpx/testing.hpp>
+
+#include <cstddef>
+#include <cstdint>
+
+template <typename T>
+struct A
+{
+    A() = default;
+
+    explicit A(T t)
+      : t_(t)
+    {
+    }
+    T t_;
+
+    A& operator=(T t)
+    {
+        t_ = t;
+        return *this;
+    }
+
+    template <typename Archive>
+    void serialize(Archive& ar, unsigned)
+    {
+        // clang-format off
+        ar & t_;
+        // clang-format on
+    }
+
+    friend bool operator==(A const& lhs, A const& rhs)
+    {
+        return lhs.t_ == rhs.t_;
+    }
+};
+
+void test()
+{
+    {
+        hpx::util::tuple<int, double, std::string, A<int>> ot{
+            42, 42.0, "42.0", A<int>{0}};
+
+        std::vector<char> buffer;
+        std::vector<hpx::serialization::serialization_chunk> chunks;
+        hpx::serialization::output_archive oarchive(buffer, 0, &chunks);
+        oarchive << ot;
+        std::size_t size = oarchive.bytes_written();
+
+        hpx::serialization::input_archive iarchive(buffer, size, &chunks);
+        hpx::util::tuple<int, double, std::string, A<int>> it;
+        iarchive >> it;
+        HPX_TEST(ot == it);
+    }
+    {
+        hpx::util::tuple<> ot{};
+
+        std::vector<char> buffer;
+        std::vector<hpx::serialization::serialization_chunk> chunks;
+        hpx::serialization::output_archive oarchive(buffer, 0, &chunks);
+        oarchive << ot;
+        std::size_t size = oarchive.bytes_written();
+
+        hpx::serialization::input_archive iarchive(buffer, size, &chunks);
+        hpx::util::tuple<> it;
+        iarchive >> it;
+        HPX_TEST(ot == it);
+    }
+}
+
+int main()
+{
+    test();
+    return hpx::util::report_errors();
+}

--- a/libs/serialization/tests/unit/serialization_tuple.cpp
+++ b/libs/serialization/tests/unit/serialization_tuple.cpp
@@ -4,7 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/datatypes/tuple.hpp>
+#include <hpx/datastructures/tuple.hpp>
 #include <hpx/serialization/input_archive.hpp>
 #include <hpx/serialization/output_archive.hpp>
 #include <hpx/serialization/serialize.hpp>

--- a/libs/serialization/tests/unit/serialization_tuple.cpp
+++ b/libs/serialization/tests/unit/serialization_tuple.cpp
@@ -14,6 +14,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
+#include <vector>
 
 template <typename T>
 struct A


### PR DESCRIPTION
- adding missing tests for tuple serialization

Fixes #4416

@McKillroy please verify whether this fixes the issue you reported
