### PR TITLE
Reestablish HPX_INCLUDE_DIRS cmake variable

### DIFF
--- a/cmake/HPX_GeneratePackage.cmake
+++ b/cmake/HPX_GeneratePackage.cmake
@@ -48,6 +48,20 @@ if (NOT MSVC)
   hpx_generate_pkgconfig_from_target(hpx::component hpx_component FALSE)
 endif()
 
+if (NOT HPX_INCLUDE_DIRS)
+  hpx_collect_usage_requirements(hpx
+    _hpx_compile_definitions
+    _hpx_compile_options
+    _hpx_pic_option
+    _hpx_include_directories
+    _hpx_system_include_directories
+    _hpx_link_libraries
+    _hpx_link_options
+    _processed_targets
+    FALSE)
+  set(HPX_INCLUDE_DIRS ${_hpx_include_directories}
+    ${_hpx_system_include_directories})
+endif()
 # Install dir
 configure_file(cmake/templates/${HPX_PACKAGE_NAME}Config.cmake.in
   "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${HPX_PACKAGE_NAME}Config.cmake"

--- a/cmake/templates/HPXConfig.cmake.in
+++ b/cmake/templates/HPXConfig.cmake.in
@@ -122,7 +122,7 @@ endif()
 
 # Set legacy variables for linking and include directories
 set(HPX_LIBRARIES "hpx;hpx_init;")
-set(HPX_INCLUDE_DIRS "")
+set(HPX_INCLUDE_DIRS "@HPX_INCLUDE_DIRS@")
 set(HPX_LIBRARY_DIR "")
 if(HPX_WITH_DYNAMIC_HPX_MAIN AND (("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux") OR (APPLE)))
   set(HPX_LINK_LIBRARIES "hpx_wrap;")


### PR DESCRIPTION
Fixes #4418

The variable `HPX_INCLUDE_DIRS` was not forwarded which breaks compatibility