### PR TITLE
Making sure interval time stops underlying timer thread on termination

### DIFF
--- a/hpx/runtime.hpp
+++ b/hpx/runtime.hpp
@@ -288,7 +288,7 @@ namespace hpx
             char const* description = nullptr, error_code& ec = throws);
 
         // stop periodic evaluation of counters during shutdown
-        void stop_evaluating_counters();
+        void stop_evaluating_counters(bool terminate = false);
 
 #if defined(HPX_HAVE_NETWORKING)
         void register_message_handler(char const* message_handler_type,

--- a/hpx/util/interval_timer.hpp
+++ b/hpx/util/interval_timer.hpp
@@ -56,7 +56,7 @@ namespace hpx { namespace util { namespace detail
         ~interval_timer();
 
         bool start(bool evaluate);
-        bool stop();
+        bool stop(bool terminate = false);
 
         bool restart(bool evaluate);
 
@@ -83,6 +83,8 @@ namespace hpx { namespace util { namespace detail
         util::function_nonser<void()> on_term_; ///< function to call on termination
         std::int64_t microsecs_;    ///< time interval
         threads::thread_id_type id_;  ///< id of currently scheduled thread
+        threads::thread_id_type timerid_;  ///< id of the timer thread for the
+                                           ///< currently scheduled thread
         std::string description_;     ///< description of this interval timer
 
         bool pre_shutdown_;           ///< execute termination during pre-shutdown
@@ -125,9 +127,9 @@ namespace hpx { namespace util
         {
             return timer_->start(evaluate);
         }
-        bool stop()
+        bool stop(bool terminate = false)
         {
-            return timer_->stop();
+            return timer_->stop(terminate);
         }
 
         bool restart(bool evaluate = true)

--- a/hpx/util/query_counters.hpp
+++ b/hpx/util/query_counters.hpp
@@ -41,7 +41,7 @@ namespace hpx { namespace util
             bool csv_header, bool print_counters_locally);
 
         void start();
-        void stop_evaluating_counters();
+        void stop_evaluating_counters(bool terminate = false);
         bool evaluate();
         void terminate();
 

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -398,10 +398,10 @@ namespace hpx
             active_counters_->evaluate_counters(reset, description, ec);
     }
 
-    void runtime::stop_evaluating_counters()
+    void runtime::stop_evaluating_counters(bool terminate)
     {
         if (active_counters_.get())
-            active_counters_->stop_evaluating_counters();
+            active_counters_->stop_evaluating_counters(terminate);
     }
 
 #if defined(HPX_HAVE_NETWORKING)
@@ -1588,10 +1588,11 @@ namespace hpx
 #endif
 
     // helper function to stop evaluating counters during shutdown
-    void stop_evaluating_counters()
+    void stop_evaluating_counters(bool terminate)
     {
         runtime* rt = get_runtime_ptr();
-        if (nullptr != rt) rt->stop_evaluating_counters();
+        if (nullptr != rt)
+            rt->stop_evaluating_counters(terminate);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -134,7 +134,7 @@ HPX_DEFINE_GET_COMPONENT_TYPE_STATIC(
 namespace hpx
 {
     // helper function to stop evaluating counters during shutdown
-    void stop_evaluating_counters();
+    void stop_evaluating_counters(bool terminate = false);
 }
 
 namespace hpx { namespace components
@@ -636,7 +636,7 @@ namespace hpx { namespace components { namespace server
 
         agas_client.start_shutdown();
 
-        stop_evaluating_counters();
+        stop_evaluating_counters(true);
 
         // wake up suspended pus
         threads::threadmanager& tm = appl.get_thread_manager();

--- a/src/util/query_counters.cpp
+++ b/src/util/query_counters.cpp
@@ -105,9 +105,9 @@ namespace hpx { namespace util
         timer_.start();
     }
 
-    void query_counters::stop_evaluating_counters()
+    void query_counters::stop_evaluating_counters(bool terminate)
     {
-        timer_.stop();
+        timer_.stop(terminate);
         counters_.stop(launch::sync);
     }
 


### PR DESCRIPTION
- flyby: stopping timed counters at shutdown properly unregisters counters

Fixes #4419 

@diehlpk please verify that this solves the problem you reported.