### PR TITLE
Clean up and correct minimum required versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1085,8 +1085,8 @@ endif()
 
 # Check if the selected compiler versions are supposed to work with our codebase
 if(CMAKE_COMPILER_IS_GNUCXX AND HPX_WITH_GCC_VERSION_CHECK)
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
-    hpx_error("GCC 5.0 or higher is required. Specify HPX_GCC_VERSION_CHECK=OFF to ignore this error.")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
+    hpx_error("GCC 7.0 or higher is required. Specify HPX_GCC_VERSION_CHECK=OFF to ignore this error.")
   endif()
 endif()
 

--- a/docs/sphinx/contributing/release_procedure.rst
+++ b/docs/sphinx/contributing/release_procedure.rst
@@ -100,6 +100,9 @@ are completed to avoid confusion.
    The main CMakeLists.txt contains a comment indicating for which version
    the breaking change was introduced first.
 
+#. Update the minimum required versions if necessary (compilers, dependencies,
+   etc.).
+
 #. Switch Buildbot over to test the release branch.
 
    * ``https://github.com/STEllAR-GROUP/hermione-buildbot/blob/rostam/master/master.cfg``

--- a/docs/sphinx/manual/building_hpx.rst
+++ b/docs/sphinx/manual/building_hpx.rst
@@ -153,14 +153,14 @@ work, but we do not test |hpx| with other platforms, so please be warned.
 
 .. table:: Supported Platforms for |hpx|
 
-   ========= =================== ================== ====================
-   Name      Recommended Version Minimum Version    Architectures
-   ========= =================== ================== ====================
-   Linux     3.2                 2.6                x86-32, x86-64, k1om
-   BlueGeneQ V1R2M0              V1R2M0             PowerPC A2
-   Windows   7, Server 2008 R2   Any Windows system x86-32, x86-64
-   Mac OSX                       Any OSX system     x86-64
-   ========= =================== ================== ====================
+   ========= ================== ====================
+   Name      Minimum Version    Architectures
+   ========= ================== ====================
+   Linux     2.6                x86-32, x86-64, k1om
+   BlueGeneQ V1R2M0             PowerPC A2
+   Windows   Any Windows system x86-32, x86-64
+   Mac OSX   Any OSX system     x86-64
+   ========= ================== ====================
 
 Software and libraries
 ----------------------
@@ -196,7 +196,6 @@ favorite compiler with |hpx| visit |hpx_buildbot|_.
 .. list-table:: Software prerequisites for |hpx| on Linux systems.
 
    * * Name
-     * Recommended version
      * Minimum version
      * Notes
    * * **Compilers**
@@ -204,23 +203,19 @@ favorite compiler with |hpx| visit |hpx_buildbot|_.
      *
      *
    * * |gcc|_
-     * 4.9 or newer
-     * 4.9
+     * 7.0
      *
    * * |icpc|_
-     * 2014 or newer
      * 2014
      *
    * * |clang|_
-     * 3.8 or newer
-     * 3.8
+     * 4.0
      *
    * * **Build System**
      *
      *
      *
    * * |cmake|_
-     * 3.9.0
      * 3.3.2
      * Cuda support 3.9
    * * **Required Libraries**
@@ -228,48 +223,32 @@ favorite compiler with |hpx| visit |hpx_buildbot|_.
      *
      *
    * * |boost_libraries|_
-     * 1.67.0 or newer
      * 1.61.0
      *
    * * |hwloc|_
-     * 1.11
      * 1.2 (Xeon Phi: 1.6)
      *
 
 .. note::
 
-   When compiling with the Intel Compiler on Linux systems, we only support C++
-   Standard Libraries provided by gcc 4.8 and upwards. If the ``g++`` in your
-   path is older than 4.8, please specify the path of a newer ``g++`` by setting
-   ``CMAKE_CXX_FLAGS='-gxx-name=/path/to/g++'`` via |cmake|_.
-
-.. note::
-
-   When building Boost using gcc, please note that it is always a good idea to
-   specify a ``cxxflags=-std=c++11`` command line argument to ``b2`` (``bjam``).
-   Note, however, that this is absolutely necessary when using gcc V5.2 and
-   above.
+   When building Boost using gcc, please note that it is required to specify a
+   ``cxxflags=-std=c++14`` command line argument to ``b2`` (``bjam``).
 
 .. list-table:: Software prerequisites for |hpx| on Windows systems
 
    * * Name
-     * Recommended version
      * Minimum version
      * Notes
    * * **Compilers**
      *
      *
-     *
    * * |visual_cxx|_ (x64)
-     * 2015
      * 2015
      *
    * * **Build System**
      *
      *
-     *
    * * |cmake|_
-     * 3.9.0
      * 3.3.2
      *
    * * **Required Libraries**
@@ -277,21 +256,19 @@ favorite compiler with |hpx| visit |hpx_buildbot|_.
      *
      *
    * * |boost|_
-     * 1.67.0 or newer
      * 1.61.0
      *
    * * |hwloc|_
-     * 1.11
      * 1.5
      *
 
 .. note::
 
    You need to build the following Boost libraries for |hpx|:
-   Boost.Filesystem, Boost.ProgramOptions, Boost.Regex, and Boost.System. The
+   Boost.Filesystem, Boost.ProgramOptions, and Boost.System. The
    following are not needed by default, but are required in certain
-   configurations: Boost.Chrono, Boost.DateTime, Boost.Log, Boost.LogSetup, and
-   Boost.Thread.
+   configurations: Boost.Chrono, Boost.DateTime, Boost.Log, Boost.LogSetup,
+   Boost.Regex, and Boost.Thread.
 
 Depending on the options you chose while building and installing |hpx|,
 you will find that |hpx| may depend on several other libraries such as those
@@ -308,20 +285,16 @@ listed below.
    Linux systems
 
    * * Name
-     * Recommended version
      * Minimum version
      * Notes
    * * |google_perftools|_
      * 1.7.1
-     * 1.7.1
      * Used as a replacement for the system allocator, and for allocation
        diagnostics.
    * * |libunwind|_
-     * 0.99
      * 0.97
      * Dependency of google-perftools on x86-64, used for stack unwinding.
    * * |openmpi|_
-     * 1.10.1
      * 1.8.0
      * Can be used as a highspeed communication library backend for the
        parcelport.
@@ -335,34 +308,27 @@ listed below.
 .. list-table:: Optional software prerequisites for |hpx| on Linux systems
 
    * * Name
-     * Recommended version
      * Minimum version
      * Notes
    * * |papi|
      *
-     *
      * Used for accessing hardware performance data.
    * * |jemalloc|_
-     * 2.1.2
      * 2.1.0
      * Used as a replacement for the system allocator.
    * * |mimalloc|_
-     * latest
      * 1.0.0
      * Used as a replacement for the system allocator.
    * * |hdf5|_
-     * 1.8.7
      * 1.6.7
      * Used for data I/O in some example applications. See important note below.
 
 .. list-table:: Optional software prerequisites for |hpx| on Windows systems
 
    * * Name
-     * Recommended version
      * Minimum version
      * Notes
    * * |hdf5|_
-     * 1.8.7
      * 1.6.7
      * Used for data I/O in some example applications. See important note below.
 
@@ -422,9 +388,8 @@ Installing Boost
 
 .. important::
 
-   When building Boost using gcc, please note that it is always a good idea to
-   specify a ``cxxflags=-std=c++11`` command line argument to ``b2`` (``bjam``).
-   Doint so is absolutely necessary when using gcc V5.2 and above.
+   When building Boost using gcc, please note that it is required to specify a
+   ``cxxflags=-std=c++14`` command line argument to ``b2`` (``bjam``).
 
 .. important::
 

--- a/libs/config/include/hpx/config/threads_stack.hpp
+++ b/libs/config/include/hpx/config/threads_stack.hpp
@@ -27,11 +27,7 @@
 #    if defined(HPX_INTEL_VERSION)
 #      define HPX_THREADS_STACK_OVERHEAD 0x2800
 #    else
-#      if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 40900 && HPX_GCC_VERSION < 50000
-#        define HPX_THREADS_STACK_OVERHEAD 0x1000
-#      else
-#        define HPX_THREADS_STACK_OVERHEAD 0x800
-#      endif
+#      define HPX_THREADS_STACK_OVERHEAD 0x800
 #    endif
 #  endif
 #endif


### PR DESCRIPTION
Updates the minimum GCC version in the documentation to 7.0. Also removes the "Recommended version" column from the tables as it's usually a safe assumption to take the latest version (if we have problems with the latest versions we can add it to the notes column). Also adds a new step to the release procedure to update minimum required versions.