### PR TITLE
Ignore warnings about name mangling changing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1395,6 +1395,10 @@ if(HPX_WITH_COMPILER_WARNINGS)
     hpx_add_compile_flag_if_available(-Wno-sign-promo LANGUAGES CXX)
     hpx_add_compile_flag_if_available(-Wno-attributes LANGUAGES CXX)
     hpx_add_compile_flag_if_available(-Wno-cast-align LANGUAGES CXX)
+    
+    # We do not in general guarantee ABI compatibility between C++ standards, so
+    # we ignore this warning
+    hpx_add_compile_flag_if_available(-Wno-noexcept-type LANGUAGES CXX)
 
     # These are usually benign and can't be suppressed because of
     # interface requirements


### PR DESCRIPTION
To fix warnings like these: https://cdash.cscs.ch/viewBuildError.php?buildid=98781.