### PR TITLE
Clean up Boost dependencies and copy string algorithms to new module

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -19,7 +19,7 @@ function(add_hpx_config_test variable)
   cmake_parse_arguments(${variable} "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
 
   set(_run_msg)
-  # Check CMake feature tests iff the user didn't override the value
+  # Check CMake feature tests if the user didn't override the value
   # of this variable:
   if(NOT DEFINED ${variable})
     if(${variable}_CMAKECXXFEATURE)

--- a/components/process/include/hpx/components/process/util/windows/initializers/set_args.hpp
+++ b/components/process/include/hpx/components/process/util/windows/initializers/set_args.hpp
@@ -17,8 +17,8 @@
 #if defined(HPX_WINDOWS)
 #include <hpx/components/process/util/windows/initializers/initializer_base.hpp>
 #include <hpx/serialization/string.hpp>
+#include <hpx/string_util/predicate.hpp>
 
-#include <boost/algorithm/string/predicate.hpp>
 #include <boost/range/algorithm/copy.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>

--- a/examples/accumulators/accumulator_client.cpp
+++ b/examples/accumulators/accumulator_client.cpp
@@ -7,13 +7,12 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
+#include <hpx/string_util/split.hpp>
+#include <hpx/string_util/trim.hpp>
+#include <hpx/string_util/classification.hpp>
 #include <hpx/util/from_string.hpp>
 
 #include "accumulator.hpp"
-
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/trim.hpp>
-#include <boost/algorithm/string/classification.hpp>
 
 #include <iostream>
 #include <string>
@@ -44,12 +43,12 @@ int hpx_main()
         std::string line;
         while (std::getline(std::cin, line))
         {
-            boost::algorithm::trim(line);
+            hpx::string_util::trim(line);
 
             std::vector<std::string> cmd;
-            boost::algorithm::split(cmd, line,
-                boost::algorithm::is_any_of(" \t\n"),
-                boost::algorithm::token_compress_on);
+            hpx::string_util::split(cmd, line,
+                hpx::string_util::is_any_of(" \t\n"),
+                hpx::string_util::token_compress_mode::on);
 
             if (!cmd.empty() && !cmd[0].empty())
             {

--- a/examples/accumulators/template_accumulator_client.cpp
+++ b/examples/accumulators/template_accumulator_client.cpp
@@ -5,13 +5,12 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
+#include <hpx/string_util/split.hpp>
+#include <hpx/string_util/trim.hpp>
+#include <hpx/string_util/classification.hpp>
 #include <hpx/util/from_string.hpp>
 
 #include "template_accumulator.hpp"
-
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/trim.hpp>
-#include <boost/algorithm/string/classification.hpp>
 
 #include <iostream>
 #include <string>
@@ -49,12 +48,12 @@ void run_template_accumulator(char const* type)
     std::string line;
     while (std::getline(std::cin, line))
     {
-        boost::algorithm::trim(line);
+        hpx::string_util::trim(line);
 
         std::vector<std::string> cmd;
-        boost::algorithm::split(cmd, line,
-            boost::algorithm::is_any_of(" \t\n"),
-            boost::algorithm::token_compress_on);
+        hpx::string_util::split(cmd, line,
+            hpx::string_util::is_any_of(" \t\n"),
+            hpx::string_util::token_compress_mode::on);
 
         if (!cmd.empty() && !cmd[0].empty())
         {

--- a/examples/accumulators/template_function_accumulator_client.cpp
+++ b/examples/accumulators/template_function_accumulator_client.cpp
@@ -7,13 +7,12 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/actions.hpp>
+#include <hpx/string_util/split.hpp>
+#include <hpx/string_util/trim.hpp>
+#include <hpx/string_util/classification.hpp>
 #include <hpx/util/from_string.hpp>
 
 #include "template_function_accumulator.hpp"
-
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/trim.hpp>
-#include <boost/algorithm/string/classification.hpp>
 
 #include <iostream>
 #include <string>
@@ -49,11 +48,11 @@ int hpx_main()
         {
             std::vector<std::string> cmd;
 
-            boost::algorithm::trim(line);
+            hpx::string_util::trim(line);
 
-            boost::algorithm::split(cmd, line,
-                boost::algorithm::is_any_of(" \t\n"),
-                boost::algorithm::token_compress_on);
+            hpx::string_util::split(cmd, line,
+                hpx::string_util::is_any_of(" \t\n"),
+                hpx::string_util::token_compress_mode::on);
 
             if (!cmd.empty() && !cmd[0].empty())
             {

--- a/examples/quickstart/pipeline1.cpp
+++ b/examples/quickstart/pipeline1.cpp
@@ -6,6 +6,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_main.hpp>
+#include <hpx/string_util/trim.hpp>
 
 #include <iostream>
 #include <iterator>
@@ -13,8 +14,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <boost/algorithm/string/trim.hpp>
 
 struct pipeline
 {
@@ -28,7 +27,7 @@ struct pipeline
             {
                 auto trim = [](std::string const& s)
                 {
-                    return boost::algorithm::trim_copy(s);
+                    return hpx::string_util::trim_copy(s);
                 };
 
                 hpx::async(trim, std::move(item))

--- a/examples/spell_check/spell_check_file.cpp
+++ b/examples/spell_check/spell_check_file.cpp
@@ -6,19 +6,16 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ////////////////////////////////////////////////////////////////////////////////
 
-// make inspect happy: hpxinspect:nodeprecatedname:boost::is_any_of
-
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/actions.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/include/lcos.hpp>
+#include <hpx/string_util.hpp>
 
 #include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
-
-#include <boost/algorithm/string.hpp>
 
 std::vector<std::string> words;
 
@@ -146,7 +143,7 @@ int hpx_main()
         vector<string> strs;
         {
             vector<string> temp;
-            boost::split(temp, word, boost::is_any_of("\n\t -"));
+            hpx::string_util::split(temp, word, hpx::string_util::is_any_of("\n\t -"));
             for (string::size_type i = 0; i < temp.size(); i++)
             {
                 bool isContraction = false;

--- a/examples/spell_check/spell_check_simple.cpp
+++ b/examples/spell_check/spell_check_simple.cpp
@@ -6,19 +6,16 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ////////////////////////////////////////////////////////////////////////////////
 
-// make inspect happy: hpxinspect:nodeprecatedname:boost::is_any_of
-
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/actions.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/include/lcos.hpp>
+#include <hpx/string_util.hpp>
 
 #include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
-
-#include <boost/algorithm/string.hpp>
 
 std::vector<std::string> words;
 
@@ -149,7 +146,7 @@ int hpx_main()
         vector<string> strs;
         {
             vector<string> temp;
-            boost::split(temp, word, boost::is_any_of("\n\t -"));
+            hpx::string_util::split(temp, word, hpx::string_util::is_any_of("\n\t -"));
             for (string::size_type i = 0; i < temp.size(); i++)
             {
                 bool isContraction = false;

--- a/examples/throttle/throttle_client.cpp
+++ b/examples/throttle/throttle_client.cpp
@@ -9,11 +9,10 @@
 #include <hpx/include/components.hpp>
 #include <hpx/runtime/agas/interface.hpp>
 #include <hpx/format.hpp>
+#include <hpx/string_util/classification.hpp>
+#include <hpx/string_util/split.hpp>
 
 #include "throttle/throttle.hpp"
-
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
 
 #include <iostream>
 #include <sstream>
@@ -22,8 +21,8 @@
 
 using hpx::program_options::variables_map;
 
-using boost::algorithm::is_space;
-using boost::algorithm::split;
+using hpx::string_util::is_space;
+using hpx::string_util::split;
 
 using hpx::naming::get_agas_client;
 

--- a/examples/tuplespace/simple_central_tuplespace_client.cpp
+++ b/examples/tuplespace/simple_central_tuplespace_client.cpp
@@ -8,10 +8,9 @@
 #include <hpx/include/actions.hpp>
 #include <hpx/include/iostreams.hpp>
 #include <hpx/include/lcos.hpp>
-
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/trim.hpp>
+#include <hpx/string_util/classification.hpp>
+#include <hpx/string_util/split.hpp>
+#include <hpx/string_util/trim.hpp>
 
 #include <string>
 #include <vector>

--- a/hpx/lcos/dataflow.hpp
+++ b/hpx/lcos/dataflow.hpp
@@ -4,9 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// hpxinspect:nodeprecatedinclude:boost/ref.hpp
-// hpxinspect:nodeprecatedname:boost::reference_wrapper
-
 #include <hpx/config.hpp>
 
 // #if defined(HPX_COMPUTE_DEVICE_CODE)
@@ -48,8 +45,6 @@
 
 #include <hpx/execution/executors/execution.hpp>
 #include <hpx/execution/executors/parallel_executor.hpp>
-
-#include <boost/ref.hpp>
 
 #include <atomic>
 #include <cstddef>

--- a/hpx/lcos/wait_all.hpp
+++ b/hpx/lcos/wait_all.hpp
@@ -5,9 +5,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// hpxinspect:nodeprecatedinclude:boost/ref.hpp
-// hpxinspect:nodeprecatedname:boost::reference_wrapper
-
 /// \file lcos/wait_all.hpp
 
 #if !defined(HPX_LCOS_WAIT_ALL_APR_19_2012_1140AM)
@@ -119,8 +116,6 @@ namespace hpx
 #include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/unwrap_ref.hpp>
 
-#include <boost/ref.hpp>
-
 #include <algorithm>
 #include <array>
 #include <cstddef>
@@ -149,11 +144,6 @@ namespace hpx { namespace lcos
 
         template <typename R>
         struct is_future_or_shared_state<std::reference_wrapper<R> >
-          : is_future_or_shared_state<R>
-        {};
-
-        template <typename R>
-        struct is_future_or_shared_state<boost::reference_wrapper<R> >
           : is_future_or_shared_state<R>
         {};
 

--- a/hpx/plugins/parcelport_factory.hpp
+++ b/hpx/plugins/parcelport_factory.hpp
@@ -5,8 +5,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// make inspect happy: hpxinspect:nodeprecatedname:boost::is_any_of
-
 #if !defined(HPX_PLUGINS_PARCELPORT_FACTORY_HPP)
 #define HPX_PLUGINS_PARCELPORT_FACTORY_HPP
 
@@ -19,9 +17,8 @@
 #include <hpx/runtime/parcelset/parcelhandler.hpp>
 #include <hpx/prefix/find_prefix.hpp>
 #include <hpx/runtime_configuration/runtime_configuration.hpp>
-
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
+#include <hpx/string_util/classification.hpp>
+#include <hpx/string_util/split.hpp>
 
 #include <algorithm>
 #include <cctype>
@@ -121,7 +118,7 @@ namespace hpx { namespace plugins
             if (more != nullptr)    // -V547
             {
                 std::vector<std::string> data;
-                boost::split(data, more, boost::is_any_of("\n"));
+                hpx::string_util::split(data, more, hpx::string_util::is_any_of("\n"));
                 std::copy(data.begin(), data.end(), std::back_inserter(fillini));
             }
         }

--- a/hpx/plugins/plugin_registry.hpp
+++ b/hpx/plugins/plugin_registry.hpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// make inspect happy: hpxinspect:nodeprecatedname:boost::is_any_of
-
 #if !defined(HPX_PLUGIN_REGISTRY_MAR_24_2013_0235PM)
 #define HPX_PLUGIN_REGISTRY_MAR_24_2013_0235PM
 
@@ -20,9 +18,8 @@
 #include <hpx/preprocessor/stringize.hpp>
 #include <hpx/prefix/find_prefix.hpp>
 #include <hpx/runtime_configuration/ini.hpp>
-
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
+#include <hpx/string_util/classification.hpp>
+#include <hpx/string_util/split.hpp>
 
 #include <string>
 #include <vector>
@@ -64,7 +61,7 @@ namespace hpx { namespace plugins
             if (more != nullptr)    // -V547
             {
                 std::vector<std::string> data;
-                boost::split(data, more, boost::is_any_of("\n"));
+                hpx::string_util::split(data, more, hpx::string_util::is_any_of("\n"));
                 std::copy(data.begin(), data.end(), std::back_inserter(fillini));
             }
             return true;

--- a/hpx/runtime/agas/namespace_action_code.hpp
+++ b/hpx/runtime/agas/namespace_action_code.hpp
@@ -13,8 +13,6 @@
 #include <hpx/config.hpp>
 #include <hpx/errors.hpp>
 
-#include <boost/utility/binary.hpp>
-
 #include <cstddef>
 #include <string>
 
@@ -29,48 +27,48 @@ enum namespace_action_code
 {
     invalid_request                         = 0,
 
-    locality_ns_service                     = BOOST_BINARY_U(1100000),
-    locality_ns_bulk_service                = BOOST_BINARY_U(1100001),
-    locality_ns_allocate                    = BOOST_BINARY_U(1100010),
-    locality_ns_free                        = BOOST_BINARY_U(1100011),
-    locality_ns_localities                  = BOOST_BINARY_U(1100100),
-    locality_ns_num_localities              = BOOST_BINARY_U(1100101),
-    locality_ns_num_threads                 = BOOST_BINARY_U(1100110),
-    locality_ns_statistics_counter          = BOOST_BINARY_U(1100111),
-    locality_ns_resolve_locality            = BOOST_BINARY_U(1101000),
+    locality_ns_service                     = 0b1100000,
+    locality_ns_bulk_service                = 0b1100001,
+    locality_ns_allocate                    = 0b1100010,
+    locality_ns_free                        = 0b1100011,
+    locality_ns_localities                  = 0b1100100,
+    locality_ns_num_localities              = 0b1100101,
+    locality_ns_num_threads                 = 0b1100110,
+    locality_ns_statistics_counter          = 0b1100111,
+    locality_ns_resolve_locality            = 0b1101000,
 
-    primary_ns_service                      = BOOST_BINARY_U(1000000),
-    primary_ns_bulk_service                 = BOOST_BINARY_U(1000001),
-    primary_ns_route                        = BOOST_BINARY_U(1000010),
-    primary_ns_bind_gid                     = BOOST_BINARY_U(1000011),
-    primary_ns_resolve_gid                  = BOOST_BINARY_U(1000100),
-    primary_ns_unbind_gid                   = BOOST_BINARY_U(1000101),
-    primary_ns_increment_credit             = BOOST_BINARY_U(1000110),
-    primary_ns_decrement_credit             = BOOST_BINARY_U(1000111),
-    primary_ns_allocate                     = BOOST_BINARY_U(1001000),
-    primary_ns_begin_migration              = BOOST_BINARY_U(1001001),
-    primary_ns_end_migration                = BOOST_BINARY_U(1001010),
-    primary_ns_statistics_counter           = BOOST_BINARY_U(1001011),
+    primary_ns_service                      = 0b1000000,
+    primary_ns_bulk_service                 = 0b1000001,
+    primary_ns_route                        = 0b1000010,
+    primary_ns_bind_gid                     = 0b1000011,
+    primary_ns_resolve_gid                  = 0b1000100,
+    primary_ns_unbind_gid                   = 0b1000101,
+    primary_ns_increment_credit             = 0b1000110,
+    primary_ns_decrement_credit             = 0b1000111,
+    primary_ns_allocate                     = 0b1001000,
+    primary_ns_begin_migration              = 0b1001001,
+    primary_ns_end_migration                = 0b1001010,
+    primary_ns_statistics_counter           = 0b1001011,
 
-    component_ns_service                    = BOOST_BINARY_U(0100000),
-    component_ns_bulk_service               = BOOST_BINARY_U(0100001),
-    component_ns_bind_prefix                = BOOST_BINARY_U(0100010),
-    component_ns_bind_name                  = BOOST_BINARY_U(0100011),
-    component_ns_resolve_id                 = BOOST_BINARY_U(0100100),
-    component_ns_unbind_name                = BOOST_BINARY_U(0100101),
-    component_ns_iterate_types              = BOOST_BINARY_U(0100110),
-    component_ns_get_component_type_name    = BOOST_BINARY_U(0100111),
-    component_ns_num_localities             = BOOST_BINARY_U(0101000),
-    component_ns_statistics_counter         = BOOST_BINARY_U(0101001),
+    component_ns_service                    = 0b0100000,
+    component_ns_bulk_service               = 0b0100001,
+    component_ns_bind_prefix                = 0b0100010,
+    component_ns_bind_name                  = 0b0100011,
+    component_ns_resolve_id                 = 0b0100100,
+    component_ns_unbind_name                = 0b0100101,
+    component_ns_iterate_types              = 0b0100110,
+    component_ns_get_component_type_name    = 0b0100111,
+    component_ns_num_localities             = 0b0101000,
+    component_ns_statistics_counter         = 0b0101001,
 
-    symbol_ns_service                       = BOOST_BINARY_U(0010000),
-    symbol_ns_bulk_service                  = BOOST_BINARY_U(0010001),
-    symbol_ns_bind                          = BOOST_BINARY_U(0010010),
-    symbol_ns_resolve                       = BOOST_BINARY_U(0010011),
-    symbol_ns_unbind                        = BOOST_BINARY_U(0010100),
-    symbol_ns_iterate_names                 = BOOST_BINARY_U(0010101),
-    symbol_ns_on_event                      = BOOST_BINARY_U(0010110),
-    symbol_ns_statistics_counter            = BOOST_BINARY_U(0010111)
+    symbol_ns_service                       = 0b0010000,
+    symbol_ns_bulk_service                  = 0b0010001,
+    symbol_ns_bind                          = 0b0010010,
+    symbol_ns_resolve                       = 0b0010011,
+    symbol_ns_unbind                        = 0b0010100,
+    symbol_ns_iterate_names                 = 0b0010101,
+    symbol_ns_on_event                      = 0b0010110,
+    symbol_ns_statistics_counter            = 0b0010111
 };
 
 namespace detail

--- a/hpx/traits/is_future.hpp
+++ b/hpx/traits/is_future.hpp
@@ -4,15 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// hpxinspect:nodeprecatedinclude:boost/ref.hpp
-// hpxinspect:nodeprecatedname:boost::reference_wrapper
-
 #if !defined(HPX_TRAITS_IS_FUTURE_APR_20_2012_0536PM)
 #define HPX_TRAITS_IS_FUTURE_APR_20_2012_0536PM
 
 #include <hpx/config.hpp>
-
-#include <boost/ref.hpp>
 
 #include <functional>
 #include <type_traits>
@@ -61,11 +56,6 @@ namespace hpx { namespace traits
     template <typename Future>
     struct is_ref_wrapped_future
       : std::false_type
-    {};
-
-    template <typename Future>
-    struct is_ref_wrapped_future<boost::reference_wrapper<Future> >
-      : is_future<Future>
     {};
 
     template <typename Future>

--- a/hpx/traits/is_future_range.hpp
+++ b/hpx/traits/is_future_range.hpp
@@ -5,16 +5,11 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// hpxinspect:nodeprecatedinclude:boost/ref.hpp
-// hpxinspect:nodeprecatedname:boost::reference_wrapper
-
 #ifndef HPX_TRAITS_IS_FUTURE_RANGE_HPP
 #define HPX_TRAITS_IS_FUTURE_RANGE_HPP
 
 #include <hpx/traits/is_future.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
-
-#include <boost/ref.hpp>
 
 #include <functional>
 #include <type_traits>
@@ -37,11 +32,6 @@ namespace hpx { namespace traits
     template <typename R, typename Enable = void>
     struct is_ref_wrapped_future_range
       : std::false_type
-    {};
-
-    template <typename R>
-    struct is_ref_wrapped_future_range< ::boost::reference_wrapper<R> >
-      : is_future_range<R>
     {};
 
     template <typename R>

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -54,10 +54,11 @@ set(HPX_LIBS
   serialization
   static_reinit
   statistics
+  string_util
   synchronization
   testing
-  threading_base
   thread_support
+  threading_base
   threadmanager
   timing
   topology

--- a/libs/affinity/src/parse_affinity_options.cpp
+++ b/libs/affinity/src/parse_affinity_options.cpp
@@ -13,8 +13,6 @@
 
 #include <hwloc.h>
 
-#include <boost/variant.hpp>
-
 // #define BOOST_SPIRIT_DEBUG
 #define BOOST_SPIRIT_USE_PHOENIX_V3
 #include <boost/fusion/include/adapt_struct.hpp>

--- a/libs/all_modules.rst
+++ b/libs/all_modules.rst
@@ -57,6 +57,7 @@ All modules
    /libs/serialization/docs/index.rst
    /libs/static_reinit/docs/index.rst
    /libs/statistics/docs/index.rst
+   /libs/string_util/docs/index.rst
    /libs/synchronization/docs/index.rst
    /libs/testing/docs/index.rst
    /libs/thread_support/docs/index.rst

--- a/libs/batch_environments/CMakeLists.txt
+++ b/libs/batch_environments/CMakeLists.txt
@@ -44,6 +44,7 @@ add_hpx_module(batch_environments
     hpx_config
     hpx_errors
     hpx_format
+    hpx_string_util
     hpx_util
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/batch_environments/src/slurm_environment.cpp
+++ b/libs/batch_environments/src/slurm_environment.cpp
@@ -5,17 +5,15 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// make inspect happy: hpxinspect:nodeprecatedname:boost::is_any_of
-
 #include <hpx/config.hpp>
 #include <hpx/assertion.hpp>
 #include <hpx/batch_environments/slurm_environment.hpp>
+#include <hpx/string_util/classification.hpp>
+#include <hpx/string_util/split.hpp>
 #include <hpx/util/from_string.hpp>
 
 #define BOOST_SPIRIT_USE_PHOENIX_V3
 
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
 #include <boost/fusion/include/pair.hpp>
 #include <boost/phoenix/bind.hpp>
 #include <boost/phoenix/core.hpp>
@@ -86,8 +84,8 @@ namespace hpx { namespace util { namespace batch_environments {
         if (slurm_step_tasks_per_node)
         {
             std::vector<std::string> tokens;
-            boost::split(
-                tokens, slurm_step_tasks_per_node, boost::is_any_of(","));
+            hpx::string_util::split(tokens, slurm_step_tasks_per_node,
+                hpx::string_util::is_any_of(","));
 
             char* slurm_node_id = std::getenv("SLURM_NODEID");
             HPX_ASSERT(slurm_node_id != nullptr);
@@ -317,8 +315,8 @@ namespace hpx { namespace util { namespace batch_environments {
             if (slurm_job_cpus_on_node)
             {
                 std::vector<std::string> tokens;
-                boost::split(
-                    tokens, slurm_job_cpus_on_node, boost::is_any_of(","));
+                hpx::string_util::split(tokens, slurm_job_cpus_on_node,
+                    hpx::string_util::is_any_of(","));
 
                 char* slurm_node_id = std::getenv("SLURM_NODEID");
                 HPX_ASSERT(slurm_node_id != nullptr);

--- a/libs/collectives/tests/performance/osu/osu_bcast.cpp
+++ b/libs/collectives/tests/performance/osu/osu_bcast.cpp
@@ -14,8 +14,6 @@
 #include <hpx/local_lcos/and_gate.hpp>
 #include <hpx/util/serializable_any.hpp>
 
-#include <boost/assert.hpp>
-
 #include <cstddef>
 #include <memory>
 #include <numeric>

--- a/libs/collectives/tests/performance/osu/osu_scatter.cpp
+++ b/libs/collectives/tests/performance/osu/osu_scatter.cpp
@@ -11,8 +11,6 @@
 #include <hpx/include/iostreams.hpp>
 #include <hpx/serialization/serialize_buffer.hpp>
 
-#include <boost/assert.hpp>
-
 #include <cstddef>
 #include <memory>
 #include <utility>

--- a/libs/datastructures/include/hpx/datastructures/tuple.hpp
+++ b/libs/datastructures/include/hpx/datastructures/tuple.hpp
@@ -15,8 +15,6 @@
 #include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/pack.hpp>
 
-#include <boost/array.hpp>
-
 #include <algorithm>
 #include <array>
 #include <cstddef>    // for size_t
@@ -458,12 +456,6 @@ namespace hpx { namespace util {
     };
 
     template <typename Type, std::size_t Size>
-    struct tuple_size<boost::array<Type, Size>>
-      : std::integral_constant<std::size_t, Size>
-    {
-    };
-
-    template <typename Type, std::size_t Size>
     struct tuple_size<std::array<Type, Size>>
       : std::integral_constant<std::size_t, Size>
     {
@@ -552,24 +544,6 @@ namespace hpx { namespace util {
             std::pair<T0, T1> const& tuple) noexcept
         {
             return tuple.second;
-        }
-    };
-
-    template <std::size_t I, typename Type, std::size_t Size>
-    struct tuple_element<I, boost::array<Type, Size>>
-    {
-        using type = Type;
-
-        static constexpr HPX_HOST_DEVICE HPX_FORCEINLINE type& get(
-            boost::array<Type, Size>& tuple) noexcept
-        {
-            return tuple[I];
-        }
-
-        static constexpr HPX_HOST_DEVICE HPX_FORCEINLINE type const& get(
-            boost::array<Type, Size> const& tuple) noexcept
-        {
-            return tuple[I];
         }
     };
 

--- a/libs/datastructures/tests/unit/tuple.cpp
+++ b/libs/datastructures/tests/unit/tuple.cpp
@@ -518,8 +518,10 @@ void tuple_length_test()
 // ----------------------------------------------------------------------------
 void tuple_swap_test()
 {
+    using std::swap;
+
     hpx::util::tuple<int, float, double> t1(1, 2.0f, 3.0), t2(4, 5.0f, 6.0);
-    boost::swap(t1, t2);
+    swap(t1, t2);
     HPX_TEST_EQ(hpx::util::get<0>(t1), 4);
     HPX_TEST_EQ(hpx::util::get<1>(t1), 5.0f);
     HPX_TEST_EQ(hpx::util::get<2>(t1), 6.0);
@@ -530,7 +532,7 @@ void tuple_swap_test()
     int i = 1, j = 2;
 
     hpx::util::tuple<int&> t3(i), t4(j);
-    boost::swap(t3, t4);
+    swap(t3, t4);
     HPX_TEST_EQ(hpx::util::get<0>(t3), 2);
     HPX_TEST_EQ(hpx::util::get<0>(t4), 1);
     HPX_TEST_EQ(i, 2);

--- a/libs/execution/include/hpx/execution/executors/execution_parameters.hpp
+++ b/libs/execution/include/hpx/execution/executors/execution_parameters.hpp
@@ -5,9 +5,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// hpxinspect:nodeprecatedinclude:boost/ref.hpp
-// hpxinspect:nodeprecatedname:boost::reference_wrapper
-
 #if !defined(HPX_PARALLEL_EXECUTORS_EXECUTION_PARAMETERS_AUG_21_2017_0750PM)
 #define HPX_PARALLEL_EXECUTORS_EXECUTION_PARAMETERS_AUG_21_2017_0750PM
 
@@ -26,8 +23,6 @@
 
 #include <hpx/execution/executors/execution.hpp>
 #include <hpx/execution/executors/execution_parameters_fwd.hpp>
-
-#include <boost/ref.hpp>
 
 #include <cstddef>
 #include <functional>
@@ -620,26 +615,6 @@ namespace hpx { namespace parallel { namespace execution {
         };
 
         ///////////////////////////////////////////////////////////////////////
-        template <typename T>
-        struct unwrapper<::boost::reference_wrapper<T>>
-          : base_member_helper<boost::reference_wrapper<T>>
-          , maximal_number_of_chunks_call_helper<T, boost::reference_wrapper<T>>
-          , get_chunk_size_call_helper<T, boost::reference_wrapper<T>>
-          , mark_begin_execution_call_helper<T, boost::reference_wrapper<T>>
-          , mark_end_of_scheduling_call_helper<T, boost::reference_wrapper<T>>
-          , mark_end_execution_call_helper<T, boost::reference_wrapper<T>>
-          , processing_units_count_call_helper<T, boost::reference_wrapper<T>>
-          , reset_thread_distribution_call_helper<T,
-                boost::reference_wrapper<T>>
-        {
-            using wrapper_type = boost::reference_wrapper<T>;
-
-            unwrapper(wrapper_type wrapped_param)
-              : base_member_helper<wrapper_type>(wrapped_param)
-            {
-            }
-        };
-
         template <typename T>
         struct unwrapper<::std::reference_wrapper<T>>
           : base_member_helper<std::reference_wrapper<T>>

--- a/libs/execution/include/hpx/execution/traits/is_executor_parameters.hpp
+++ b/libs/execution/include/hpx/execution/traits/is_executor_parameters.hpp
@@ -5,9 +5,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// hpxinspect:nodeprecatedinclude:boost/ref.hpp
-// hpxinspect:nodeprecatedname:boost::reference_wrapper
-
 #if !defined(HPX_TRAITS_IS_EXECUTOR_PARAMETERS_MAY_19_2017_0232PM)
 #define HPX_TRAITS_IS_EXECUTOR_PARAMETERS_MAY_19_2017_0232PM
 
@@ -16,8 +13,6 @@
 
 #include <functional>
 #include <type_traits>
-
-#include <boost/ref.hpp>
 
 namespace hpx { namespace traits {
     // new executor framework
@@ -85,12 +80,6 @@ namespace hpx { namespace parallel { namespace execution {
 
         template <typename T>
         struct is_executor_parameters<::std::reference_wrapper<T>>
-          : hpx::traits::is_executor_parameters<T>
-        {
-        };
-
-        template <typename T>
-        struct is_executor_parameters<::boost::reference_wrapper<T>>
           : hpx::traits::is_executor_parameters<T>
         {
         };

--- a/libs/execution/tests/unit/executor_parameters.cpp
+++ b/libs/execution/tests/unit/executor_parameters.cpp
@@ -4,9 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// hpxinspect:nodeprecatedinclude:boost/ref.hpp
-// hpxinspect:nodeprecatedname:boost::reference_wrapper
-
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/parallel_executor_parameters.hpp>
@@ -23,8 +20,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <boost/ref.hpp>
 
 #include "foreach_tests.hpp"
 
@@ -59,7 +54,6 @@ template <typename... Parameters>
 void parameters_test(Parameters&&... params)
 {
     parameters_test_impl(std::ref(params)...);
-    parameters_test_impl(boost::ref(params)...);
     parameters_test_impl(std::forward<Parameters>(params)...);
 }
 

--- a/libs/functional/include/hpx/functional/invoke.hpp
+++ b/libs/functional/include/hpx/functional/invoke.hpp
@@ -4,17 +4,12 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// hpxinspect:nodeprecatedinclude:boost/ref.hpp
-// hpxinspect:nodeprecatedname:boost::reference_wrapper
-
 #ifndef HPX_UTIL_INVOKE_HPP
 #define HPX_UTIL_INVOKE_HPP
 
 #include <hpx/config.hpp>
 #include <hpx/functional/result_of.hpp>
 #include <hpx/type_support/void_guard.hpp>
-
-#include <boost/ref.hpp>
 
 #include <functional>
 #include <type_traits>
@@ -102,13 +97,6 @@ namespace hpx { namespace util {
         // flatten std::[c]ref
         template <typename F, typename X>
         struct dispatch_invoke<F, ::std::reference_wrapper<X>>
-        {
-            using type = X&;
-        };
-
-        // support boost::[c]ref, which is not callable as std::[c]ref
-        template <typename F, typename X>
-        struct dispatch_invoke<F, ::boost::reference_wrapper<X>>
         {
             using type = X&;
         };

--- a/libs/functional/include/hpx/functional/result_of.hpp
+++ b/libs/functional/include/hpx/functional/result_of.hpp
@@ -4,15 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// hpxinspect:nodeprecatedinclude:boost/ref.hpp
-// hpxinspect:nodeprecatedname:boost::reference_wrapper
-
 #ifndef HPX_UTIL_RESULT_OF_HPP
 #define HPX_UTIL_RESULT_OF_HPP
 
 #include <hpx/config.hpp>
-
-#include <boost/ref.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -127,13 +122,6 @@ namespace hpx { namespace util {
             typename... Ts>
         struct result_of_impl<R (C::*)(Ps...) const, F(Ts...)>
           : result_of_member_pointer<C, R (C::*(Ts...))(Ps...) const>
-        {
-        };
-
-        // support boost::[c]ref, which is not callable as std::[c]ref
-        template <typename X, typename F, typename... Ts>
-        struct result_of_impl<::boost::reference_wrapper<X>, F(Ts...)>
-          : result_of_impl<X, X&(Ts...)>
         {
         };
     }    // namespace detail

--- a/libs/performance_counters/src/server/arithmetics_counter.cpp
+++ b/libs/performance_counters/src/server/arithmetics_counter.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// make inspect happy: hpxinspect:nodeprecatedname:boost::is_any_of
-
 #include <hpx/config.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>
@@ -16,9 +14,8 @@
 #include <hpx/runtime/components/derived_component_factory.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/runtime/runtime_fwd.hpp>
+#include <hpx/string_util.hpp>
 #include <hpx/timing/high_resolution_clock.hpp>
-
-#include <boost/algorithm/string.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -228,7 +225,8 @@ namespace hpx { namespace performance_counters { namespace detail {
                 // try to interpret the additional parameter as a list of
                 // two performance counter names
                 std::vector<std::string> names;
-                boost::split(names, paths.parameters_, boost::is_any_of(","));
+                hpx::string_util::split(
+                    names, paths.parameters_, hpx::string_util::is_any_of(","));
 
                 if (names.empty())
                 {

--- a/libs/performance_counters/src/server/arithmetics_counter_extended.cpp
+++ b/libs/performance_counters/src/server/arithmetics_counter_extended.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// make inspect happy: hpxinspect:nodeprecatedname:boost::is_any_of
-
 #include <hpx/config.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>
@@ -14,6 +12,7 @@
 #include <hpx/runtime/components/derived_component_factory.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/runtime/runtime_fwd.hpp>
+#include <hpx/string_util.hpp>
 
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/count.hpp>
@@ -23,7 +22,6 @@
 #include <boost/accumulators/statistics/min.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/variance.hpp>
-#include <boost/algorithm/string.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -274,7 +272,8 @@ namespace hpx { namespace performance_counters { namespace detail {
                 // try to interpret the additional parameter as a list of
                 // two performance counter names
                 std::vector<std::string> names;
-                boost::split(names, paths.parameters_, boost::is_any_of(","));
+                hpx::string_util::split(
+                    names, paths.parameters_, hpx::string_util::is_any_of(","));
 
                 if (names.empty())
                 {

--- a/libs/prefix/CMakeLists.txt
+++ b/libs/prefix/CMakeLists.txt
@@ -35,6 +35,7 @@ add_hpx_module(prefix
     hpx_errors
     hpx_filesystem
     hpx_plugin
+    hpx_string_util
     hpx_type_support
   CMAKE_SUBDIRS
 )

--- a/libs/prefix/src/find_prefix.cpp
+++ b/libs/prefix/src/find_prefix.cpp
@@ -13,6 +13,8 @@
 #include <hpx/filesystem.hpp>
 #include <hpx/plugin.hpp>
 #include <hpx/prefix/find_prefix.hpp>
+#include <hpx/string_util/classification.hpp>
+#include <hpx/string_util/split.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #if defined(HPX_WINDOWS)
@@ -32,8 +34,6 @@
 #include <vector>
 #endif
 
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
 #include <boost/tokenizer.hpp>
 
 #include <cstdint>
@@ -183,9 +183,9 @@ namespace hpx { namespace util {
             {
                 std::vector<std::string> path_dirs;
 
-                boost::algorithm::split(path_dirs, epath,
-                    boost::algorithm::is_any_of(":"),
-                    boost::algorithm::token_compress_on);
+                hpx::string_util::split(path_dirs, epath,
+                    hpx::string_util::is_any_of(":"),
+                    hpx::string_util::token_compress_mode::on);
 
                 for (std::uint64_t i = 0; i < path_dirs.size(); ++i)
                 {

--- a/libs/runtime_configuration/CMakeLists.txt
+++ b/libs/runtime_configuration/CMakeLists.txt
@@ -53,6 +53,7 @@ add_hpx_module(runtime_configuration
     hpx_plugin
     hpx_prefix
     hpx_serialization
+    hpx_string_util
     hpx_thread_support
     hpx_version
   CMAKE_SUBDIRS examples tests

--- a/libs/runtime_configuration/src/ini.cpp
+++ b/libs/runtime_configuration/src/ini.cpp
@@ -6,8 +6,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// make inspect happy: hpxinspect:nodeprecatedname:boost::is_any_of
-
 #include <hpx/config.hpp>
 
 // System Header Files
@@ -30,11 +28,9 @@
 #include <hpx/runtime_configuration/ini.hpp>
 #include <hpx/serialization/map.hpp>
 #include <hpx/serialization/serialize.hpp>
+#include <hpx/string_util/classification.hpp>
+#include <hpx/string_util/split.hpp>
 #include <hpx/thread_support/unlock_guard.hpp>
-
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/replace.hpp>
-#include <boost/algorithm/string/split.hpp>
 
 #ifdef __APPLE__
 #include <crt_externs.h>
@@ -667,7 +663,8 @@ namespace hpx { namespace util {
         typedef std::vector<std::string> string_vector;
 
         string_vector split_key;
-        boost::split(split_key, key, boost::is_any_of("."));
+        hpx::string_util::split(
+            split_key, key, hpx::string_util::is_any_of("."));
 
         std::string sk = split_key.back();
         split_key.pop_back();

--- a/libs/serialization/include/hpx/serialization/input_archive.hpp
+++ b/libs/serialization/include/hpx/serialization/input_archive.hpp
@@ -5,8 +5,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// hpxinspect:nodeprecatedinclude:boost/cstdint.hpp
-
 #ifndef HPX_SERIALIZATION_BASIC_INPUT_ARCHIVE_HPP
 #define HPX_SERIALIZATION_BASIC_INPUT_ARCHIVE_HPP
 
@@ -18,7 +16,6 @@
 #include <hpx/serialization/input_container.hpp>
 #include <hpx/serialization/traits/is_bitwise_serializable.hpp>
 
-#include <boost/cstdint.hpp>
 #include <boost/predef/other/endian.h>
 
 #include <cstddef>
@@ -180,41 +177,6 @@ namespace hpx { namespace serialization {
             load_integral_impl(ul);
             val = static_cast<T>(ul);
         }
-
-#if defined(BOOST_HAS_INT128) && !defined(__NVCC__) && !defined(__CUDACC__)
-        void load_integral(boost::int128_type& t, std::false_type)
-        {
-            load_integral_impl(t);
-        }
-
-        void load_integral(boost::uint128_type& t, std::true_type)
-        {
-            load_integral_impl(t);
-        }
-
-        // On some platforms (gcc) std::is_integral<int128>::value
-        // evaluates to false. Thus, these functions re-route the
-        // serialization for those types to the proper implementation
-        void load_bitwise(boost::int128_type& t, std::false_type)
-        {
-            load_integral_impl(t);
-        }
-
-        void load_bitwise(boost::int128_type& t, std::true_type)
-        {
-            load_integral_impl(t);
-        }
-
-        void load_bitwise(boost::uint128_type& t, std::false_type)
-        {
-            load_integral_impl(t);
-        }
-
-        void load_bitwise(boost::uint128_type& t, std::true_type)
-        {
-            load_integral_impl(t);
-        }
-#endif
         template <class Promoted>
         void load_integral_impl(Promoted& l)
         {

--- a/libs/serialization/include/hpx/serialization/output_archive.hpp
+++ b/libs/serialization/include/hpx/serialization/output_archive.hpp
@@ -5,8 +5,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// hpxinspect:nodeprecatedinclude:boost/cstdint.hpp
-
 #ifndef HPX_SERIALIZATION_OUTPUT_ARCHIVE_HPP
 #define HPX_SERIALIZATION_OUTPUT_ARCHIVE_HPP
 
@@ -18,9 +16,6 @@
 #include <hpx/serialization/output_container.hpp>
 #include <hpx/serialization/traits/is_bitwise_serializable.hpp>
 
-#if defined(BOOST_HAS_INT128) && !defined(__NVCC__) && !defined(__CUDACC__)
-#include <boost/cstdint.hpp>
-#endif
 #include <boost/predef/other/endian.h>
 
 #include <cstddef>
@@ -270,41 +265,6 @@ namespace hpx { namespace serialization {
         {
             save_integral_impl(static_cast<std::uint64_t>(val));
         }
-
-#if defined(BOOST_HAS_INT128) && !defined(__NVCC__) && !defined(__CUDACC__)
-        void save_integral(boost::int128_type t, std::false_type)
-        {
-            save_integral_impl(t);
-        }
-
-        void save_integral(boost::uint128_type t, std::true_type)
-        {
-            save_integral_impl(t);
-        }
-
-        // On some platforms (gcc) std::is_integral<int128>::value
-        // evaluates to false. Thus these functions re-route the
-        // serialization for those types to the proper implementation
-        void save_bitwise(boost::int128_type t, std::false_type)
-        {
-            save_integral_impl(t);
-        }
-
-        void save_bitwise(boost::int128_type t, std::true_type)
-        {
-            save_integral_impl(t);
-        }
-
-        void save_bitwise(boost::uint128_type t, std::false_type)
-        {
-            save_integral_impl(t);
-        }
-
-        void save_bitwise(boost::uint128_type t, std::true_type)
-        {
-            save_integral_impl(t);
-        }
-#endif
 
         template <class Promoted>
         void save_integral_impl(Promoted l)

--- a/libs/serialization/tests/unit/serialization_builtins.cpp
+++ b/libs/serialization/tests/unit/serialization_builtins.cpp
@@ -4,13 +4,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// hpxinspect:nodeprecatedinclude:boost/cstdint.hpp
-
 #include <hpx/serialization/input_archive.hpp>
 #include <hpx/serialization/output_archive.hpp>
 #include <hpx/serialization/serialize.hpp>
-
-#include <boost/cstdint.hpp>
 
 #include <cstdint>
 #include <vector>
@@ -38,26 +34,6 @@ struct A
         ar& t_;
     }
 };
-
-#if defined(BOOST_HAS_INT128)
-std::ostream& operator<<(std::ostream& s, boost::int128_type i)
-{
-    std::int64_t low = i;
-    i >>= 64;
-    std::int64_t high = i;
-    s << std::hex << "high: i" << high << "; low: " << low;
-    return s;
-}
-
-std::ostream& operator<<(std::ostream& s, boost::uint128_type i)
-{
-    std::uint64_t low = i;
-    i >>= 64;
-    std::uint64_t high = i;
-    s << std::hex << "high: i" << high << "; low: " << low;
-    return s;
-}
-#endif
 
 #include <hpx/testing.hpp>
 
@@ -208,14 +184,6 @@ int main()
         (std::numeric_limits<unsigned long>::min)() + 100);
     test<unsigned long>((std::numeric_limits<unsigned long>::max)() - 100,
         (std::numeric_limits<unsigned long>::max)());
-#if defined(BOOST_HAS_INT128)
-    test<boost::int128_type>(
-        (std::numeric_limits<boost::int128_type>::max)() - 100,
-        (std::numeric_limits<boost::int128_type>::max)());
-    test<boost::uint128_type>(
-        (std::numeric_limits<boost::uint128_type>::max)() - 100,
-        (std::numeric_limits<boost::uint128_type>::max)());
-#endif
     test_fp<float>((std::numeric_limits<float>::min)(),
         (std::numeric_limits<float>::min)() + 100);
     test_fp<float>(-100, 100);

--- a/libs/string_util/CMakeLists.txt
+++ b/libs/string_util/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+cmake_minimum_required(VERSION 3.3.2 FATAL_ERROR)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+set(string_util_headers
+    hpx/string_util/case_conv.hpp
+    hpx/string_util/classification.hpp
+    hpx/string_util/split.hpp
+    hpx/string_util/trim.hpp
+    )
+
+include(HPX_AddModule)
+add_hpx_module(string_util
+  GLOBAL_HEADER_GEN ON
+  FORCE_LINKING_GEN
+  HEADERS ${string_util_headers}
+  DEPENDENCIES
+  CMAKE_SUBDIRS examples tests
+)

--- a/libs/string_util/README.rst
+++ b/libs/string_util/README.rst
@@ -1,0 +1,16 @@
+
+..
+    Copyright (c) 2019 The STE||AR-Group
+
+    SPDX-License-Identifier: BSL-1.0
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+===========
+string_util
+===========
+
+This library is part of HPX.
+
+Documentation can be found `here
+<https://stellar-group.github.io/hpx/docs/sphinx/latest/html/libs/string_util/docs/index.html>`__.

--- a/libs/string_util/docs/index.rst
+++ b/libs/string_util/docs/index.rst
@@ -1,0 +1,19 @@
+..
+    Copyright (c) 2019 The STE||AR-Group
+
+    SPDX-License-Identifier: BSL-1.0
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+.. _libs_string_util:
+
+===========
+string_util
+===========
+
+This module contains string utilities inspired by the Boost string algorithms
+library.
+
+See the :ref:`API reference <libs_string_util_api>` of this module for more
+details.
+

--- a/libs/string_util/examples/CMakeLists.txt
+++ b/libs/string_util/examples/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if (HPX_WITH_EXAMPLES)
+  add_hpx_pseudo_target(examples.modules.string_util)
+  add_hpx_pseudo_dependencies(examples.modules examples.modules.string_util)
+  if (HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES AND HPX_STRING_UTIL_WITH_TESTS)
+    add_hpx_pseudo_target(tests.examples.modules.string_util)
+    add_hpx_pseudo_dependencies(tests.examples.modules tests.examples.modules.string_util)
+  endif()
+endif()

--- a/libs/string_util/include/hpx/string_util/case_conv.hpp
+++ b/libs/string_util/include/hpx/string_util/case_conv.hpp
@@ -1,0 +1,23 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_STRING_UTIL_TO_LOWER_HPP
+#define HPX_STRING_UTIL_TO_LOWER_HPP
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+namespace hpx { namespace string_util {
+    template <typename CharT, class Traits, class Alloc>
+    void to_lower(std::basic_string<CharT, Traits, Alloc>& s)
+    {
+        std::transform(std::begin(s), std::end(s), std::begin(s),
+            [](int c) { return std::tolower(c); });
+    }
+}}    // namespace hpx::string_util
+
+#endif

--- a/libs/string_util/include/hpx/string_util/classification.hpp
+++ b/libs/string_util/include/hpx/string_util/classification.hpp
@@ -1,0 +1,49 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_STRING_UTIL_CLASSIFICATION_HPP
+#define HPX_STRING_UTIL_CLASSIFICATION_HPP
+
+#include <cctype>
+#include <string>
+
+namespace hpx { namespace string_util {
+    namespace detail {
+        template <typename CharT, typename Traits, typename Allocator>
+        struct is_any_of_pred
+        {
+            bool operator()(int c) const noexcept
+            {
+                return chars.find(c) != std::string::npos;
+            }
+
+            std::basic_string<CharT, Traits, Allocator> chars;
+        };
+    }    // namespace detail
+
+    template <typename CharT, typename Traits, typename Allocator>
+    detail::is_any_of_pred<CharT, Traits, Allocator> is_any_of(
+        std::basic_string<CharT, Traits, Allocator> const& chars)
+    {
+        return detail::is_any_of_pred<CharT, Traits, Allocator>{chars};
+    }
+
+    inline auto is_any_of(char const* chars)
+    {
+        return detail::is_any_of_pred<char, std::char_traits<char>,
+            std::allocator<char>>{std::string{chars}};
+    }
+
+    struct is_space
+    {
+        bool operator()(int c) const noexcept
+        {
+            return std::isspace(c);
+        }
+    };
+}}    // namespace hpx::string_util
+
+#endif

--- a/libs/string_util/include/hpx/string_util/split.hpp
+++ b/libs/string_util/include/hpx/string_util/split.hpp
@@ -1,0 +1,80 @@
+//  Copyright (c) 2020 ETH Zurich
+//  Copyright (c) 2002-2006 Pavol Droba
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_STRING_UTIL_SPLIT_HPP
+#define HPX_STRING_UTIL_SPLIT_HPP
+
+#include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <string>
+#include <utility>
+
+namespace hpx { namespace string_util {
+    namespace detail {
+        template <typename It, typename CharT, typename Traits,
+            typename Allocator>
+        std::basic_string<CharT, Traits, Allocator> substr(
+            std::basic_string<CharT, Traits, Allocator> const& s,
+            It const& first, It const& last)
+        {
+            std::size_t const pos = std::distance(std::begin(s), first);
+            std::size_t const count = std::distance(first, last);
+            return s.substr(pos, count);
+        }
+    }    // namespace detail
+
+    enum class token_compress_mode
+    {
+        off,
+        on
+    };
+
+    template <typename Container, typename Predicate, typename CharT,
+        typename Traits, typename Allocator>
+    void split(Container& container,
+        std::basic_string<CharT, Traits, Allocator> const& str,
+        Predicate&& pred,
+        token_compress_mode compress_mode = token_compress_mode::off)
+    {
+        container.clear();
+
+        auto token_begin = std::begin(str);
+        auto token_end = std::end(str);
+
+        do
+        {
+            token_end = std::find_if(token_begin, std::end(str), pred);
+
+            container.push_back(detail::substr(str, token_begin, token_end));
+
+            if (token_end != std::end(str))
+            {
+                token_begin = token_end + 1;
+            }
+
+            if (compress_mode == token_compress_mode::on)
+            {
+                // Skip contiguous separators
+                while (token_end != std::end(str) && pred(int(*token_begin)))
+                {
+                    ++token_begin;
+                }
+            }
+        } while (token_end != std::end(str));
+    }
+
+    template <typename Container, typename Predicate>
+    void split(Container& container, char const* str, Predicate&& pred,
+        token_compress_mode compress_mode = token_compress_mode::off)
+    {
+        split(container, std::string{str}, std::forward<Predicate>(pred),
+            compress_mode);
+    }
+}}    // namespace hpx::string_util
+
+#endif

--- a/libs/string_util/include/hpx/string_util/trim.hpp
+++ b/libs/string_util/include/hpx/string_util/trim.hpp
@@ -1,0 +1,38 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_STRING_UTIL_TRIM_HPP
+#define HPX_STRING_UTIL_TRIM_HPP
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+
+namespace hpx { namespace string_util {
+    template <typename CharT, class Traits, class Alloc>
+    void trim(std::basic_string<CharT, Traits, Alloc>& s)
+    {
+        auto first = std::find_if_not(std::cbegin(s), std::cend(s),
+            [](int c) { return std::isspace(c); });
+        s.erase(std::begin(s), first);
+
+        auto last = std::find_if_not(std::crbegin(s), std::crend(s),
+            [](int c) { return std::isspace(c); });
+        s.erase(last.base(), std::end(s));
+    }
+
+    template <typename CharT, class Traits, class Alloc>
+    std::basic_string<CharT, Traits, Alloc> trim_copy(
+        std::basic_string<CharT, Traits, Alloc> const& s)
+    {
+        auto t = s;
+        trim(t);
+
+        return t;
+    }
+}}    // namespace hpx::string_util
+
+#endif

--- a/libs/string_util/tests/CMakeLists.txt
+++ b/libs/string_util/tests/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+include(HPX_Message)
+include(HPX_Option)
+
+if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
+  hpx_set_option(HPX_STRING_UTIL_WITH_TESTS VALUE OFF FORCE)
+  return()
+endif()
+
+if (HPX_STRING_UTIL_WITH_TESTS)
+    if (HPX_WITH_TESTS_UNIT)
+      add_hpx_pseudo_target(tests.unit.modules.string_util)
+      add_hpx_pseudo_dependencies(tests.unit.modules tests.unit.modules.string_util)
+      add_subdirectory(unit)
+    endif()
+
+    if (HPX_WITH_TESTS_REGRESSIONS)
+      add_hpx_pseudo_target(tests.regressions.modules.string_util)
+      add_hpx_pseudo_dependencies(tests.regressions.modules tests.regressions.modules.string_util)
+      add_subdirectory(regressions)
+    endif()
+
+    if (HPX_WITH_TESTS_BENCHMARKS)
+      add_hpx_pseudo_target(tests.performance.modules.string_util)
+      add_hpx_pseudo_dependencies(tests.performance.modules tests.performance.modules.string_util)
+      add_subdirectory(performance)
+    endif()
+
+    if (HPX_WITH_TESTS_HEADERS)
+      add_hpx_header_tests(
+        modules.string_util
+        HEADERS ${string_util_headers}
+        HEADER_ROOT ${PROJECT_SOURCE_DIR}/include
+        NOLIBS
+        DEPENDENCIES hpx_string_util)
+    endif()
+endif()

--- a/libs/string_util/tests/performance/CMakeLists.txt
+++ b/libs/string_util/tests/performance/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/string_util/tests/regressions/CMakeLists.txt
+++ b/libs/string_util/tests/regressions/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+

--- a/libs/string_util/tests/unit/CMakeLists.txt
+++ b/libs/string_util/tests/unit/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests
+    string_to_lower
+    string_split
+    string_trim
+)
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  set(folder_name "Tests/Unit/Modules/StringUtil")
+
+  add_hpx_executable(${test}_test
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    NOLIBS
+    DEPENDENCIES hpx_string_util hpx_testing
+    FOLDER ${folder_name})
+
+  add_hpx_unit_test("modules.string_util" ${test} ${${test}_PARAMETERS})
+endforeach()

--- a/libs/string_util/tests/unit/string_split.cpp
+++ b/libs/string_util/tests/unit/string_split.cpp
@@ -1,0 +1,138 @@
+//  Copyright (c) 2020      ETH Zurich
+//  Copyright (c) 2002-2003 Pavol Droba
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/string_util/classification.hpp>
+#include <hpx/string_util/split.hpp>
+#include <hpx/testing.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <list>
+#include <string>
+#include <vector>
+
+template <typename T1, typename T2>
+void deep_compare(const T1& X, const T2& Y)
+{
+    HPX_TEST_EQ(X.size(), Y.size());
+    for (unsigned int nIndex = 0; nIndex < X.size(); ++nIndex)
+    {
+        HPX_TEST_EQ(X[nIndex], Y[nIndex]);
+    }
+}
+
+int main()
+{
+    std::string str2("Xx-abc--xX-abb-xx");
+    std::string str3("xx");
+    std::string strempty("");
+    const char* pch1 = "xx-abc--xx-abb";
+    std::vector<std::string> tokens;
+
+    // split tests
+    hpx::string_util::split(tokens, str2, hpx::string_util::is_any_of("xX"),
+        hpx::string_util::token_compress_mode::on);
+
+    HPX_TEST_EQ(tokens.size(), std::size_t(4));
+    HPX_TEST_EQ(tokens[0], std::string(""));
+    HPX_TEST_EQ(tokens[1], std::string("-abc--"));
+    HPX_TEST_EQ(tokens[2], std::string("-abb-"));
+    HPX_TEST_EQ(tokens[3], std::string(""));
+
+    hpx::string_util::split(tokens, str2, hpx::string_util::is_any_of("xX"),
+        hpx::string_util::token_compress_mode::off);
+
+    HPX_TEST_EQ(tokens.size(), std::size_t(7));
+    HPX_TEST_EQ(tokens[0], std::string(""));
+    HPX_TEST_EQ(tokens[1], std::string(""));
+    HPX_TEST_EQ(tokens[2], std::string("-abc--"));
+    HPX_TEST_EQ(tokens[3], std::string(""));
+    HPX_TEST_EQ(tokens[4], std::string("-abb-"));
+    HPX_TEST_EQ(tokens[5], std::string(""));
+    HPX_TEST_EQ(tokens[6], std::string(""));
+
+    hpx::string_util::split(tokens, pch1, hpx::string_util::is_any_of("x"),
+        hpx::string_util::token_compress_mode::on);
+
+    HPX_TEST_EQ(tokens.size(), std::size_t(3));
+    HPX_TEST_EQ(tokens[0], std::string(""));
+    HPX_TEST_EQ(tokens[1], std::string("-abc--"));
+    HPX_TEST_EQ(tokens[2], std::string("-abb"));
+
+    hpx::string_util::split(tokens, pch1, hpx::string_util::is_any_of("x"),
+        hpx::string_util::token_compress_mode::off);
+
+    HPX_TEST_EQ(tokens.size(), std::size_t(5));
+    HPX_TEST_EQ(tokens[0], std::string(""));
+    HPX_TEST_EQ(tokens[1], std::string(""));
+    HPX_TEST_EQ(tokens[2], std::string("-abc--"));
+    HPX_TEST_EQ(tokens[3], std::string(""));
+    HPX_TEST_EQ(tokens[4], std::string("-abb"));
+
+    hpx::string_util::split(tokens, str3, hpx::string_util::is_any_of(","),
+        hpx::string_util::token_compress_mode::on);
+
+    HPX_TEST_EQ(tokens.size(), std::size_t(1));
+    HPX_TEST_EQ(tokens[0], std::string("xx"));
+
+    hpx::string_util::split(tokens, str3, hpx::string_util::is_any_of(","),
+        hpx::string_util::token_compress_mode::off);
+
+    hpx::string_util::split(tokens, str3, hpx::string_util::is_any_of("xX"),
+        hpx::string_util::token_compress_mode::on);
+
+    HPX_TEST_EQ(tokens.size(), std::size_t(2));
+    HPX_TEST_EQ(tokens[0], std::string(""));
+    HPX_TEST_EQ(tokens[1], std::string(""));
+
+    hpx::string_util::split(tokens, str3, hpx::string_util::is_any_of("xX"),
+        hpx::string_util::token_compress_mode::off);
+
+    HPX_TEST_EQ(tokens.size(), std::size_t(3));
+    HPX_TEST_EQ(tokens[0], std::string(""));
+    HPX_TEST_EQ(tokens[1], std::string(""));
+    HPX_TEST_EQ(tokens[2], std::string(""));
+
+    split(tokens, strempty, hpx::string_util::is_any_of(".:,;"),
+        hpx::string_util::token_compress_mode::on);
+
+    HPX_TEST(tokens.size() == 1);
+    HPX_TEST(tokens[0] == std::string(""));
+
+    split(tokens, strempty, hpx::string_util::is_any_of(".:,;"),
+        hpx::string_util::token_compress_mode::off);
+
+    HPX_TEST(tokens.size() == 1);
+    HPX_TEST(tokens[0] == std::string(""));
+
+    // If using a compiler that supports forwarding references, we should be
+    // able to use rvalues, too
+    hpx::string_util::split(tokens, std::string("Xx-abc--xX-abb-xx"),
+        hpx::string_util::is_any_of("xX"),
+        hpx::string_util::token_compress_mode::on);
+
+    HPX_TEST_EQ(tokens.size(), std::size_t(4));
+    HPX_TEST_EQ(tokens[0], std::string(""));
+    HPX_TEST_EQ(tokens[1], std::string("-abc--"));
+    HPX_TEST_EQ(tokens[2], std::string("-abb-"));
+    HPX_TEST_EQ(tokens[3], std::string(""));
+
+    hpx::string_util::split(tokens, std::string("Xx-abc--xX-abb-xx"),
+        hpx::string_util::is_any_of("xX"),
+        hpx::string_util::token_compress_mode::off);
+
+    HPX_TEST_EQ(tokens.size(), std::size_t(7));
+    HPX_TEST_EQ(tokens[0], std::string(""));
+    HPX_TEST_EQ(tokens[1], std::string(""));
+    HPX_TEST_EQ(tokens[2], std::string("-abc--"));
+    HPX_TEST_EQ(tokens[3], std::string(""));
+    HPX_TEST_EQ(tokens[4], std::string("-abb-"));
+    HPX_TEST_EQ(tokens[5], std::string(""));
+    HPX_TEST_EQ(tokens[6], std::string(""));
+
+    return hpx::util::report_errors();
+}

--- a/libs/string_util/tests/unit/string_to_lower.cpp
+++ b/libs/string_util/tests/unit/string_to_lower.cpp
@@ -1,0 +1,29 @@
+//  Copyright (c) 2020      ETH Zurich
+//  Copyright (c) 2002-2003 Pavol Droba
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/string_util/case_conv.hpp>
+#include <hpx/testing.hpp>
+
+#include <string>
+
+int main()
+{
+    std::string str1("AbCdEfG 123 xxxYYYzZzZ");
+    std::string str2("");
+
+    hpx::string_util::to_lower(str1);
+    HPX_TEST(str1 == "abcdefg 123 xxxyyyzzzz");
+
+    // to_lower is idempotent
+    hpx::string_util::to_lower(str1);
+    HPX_TEST(str1 == "abcdefg 123 xxxyyyzzzz");
+
+    hpx::string_util::to_lower(str2);
+    HPX_TEST(str2 == "");
+
+    return hpx::util::report_errors();
+}

--- a/libs/string_util/tests/unit/string_trim.cpp
+++ b/libs/string_util/tests/unit/string_trim.cpp
@@ -1,0 +1,52 @@
+//  Copyright (c) 2020      ETH Zurich
+//  Copyright (c) 2002-2003 Pavol Droba
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/string_util/trim.hpp>
+#include <hpx/testing.hpp>
+
+#include <string>
+
+int main()
+{
+    std::string str1("     1x x x x1     ");
+    std::string str2("     2x x x x2     ");
+    std::string str3("x     ");
+    std::string str4("     x");
+    std::string str5("    ");
+
+    // general string test
+    HPX_TEST_EQ(hpx::string_util::trim_copy(str1), "1x x x x1");
+    HPX_TEST_EQ(hpx::string_util::trim_copy(str3), "x");
+    HPX_TEST_EQ(hpx::string_util::trim_copy(str4), "x");
+
+    // spaces-only string test
+    HPX_TEST_EQ(hpx::string_util::trim_copy(str5), "");
+
+    // empty string check
+    HPX_TEST_EQ(hpx::string_util::trim_copy(std::string("")), "");
+
+    // general string test
+    hpx::string_util::trim(str2);
+    HPX_TEST_EQ(str2, "2x x x x2");
+
+    hpx::string_util::trim(str3);
+    HPX_TEST_EQ(str3, "x");
+
+    hpx::string_util::trim(str4);
+    HPX_TEST_EQ(str4, "x");
+
+    // spaces-only string test
+    hpx::string_util::trim(str5);
+    HPX_TEST_EQ(str5, "");
+
+    // empty string check
+    str5 = "";
+    hpx::string_util::trim(str5);
+    HPX_TEST_EQ(str5, "");
+
+    return hpx::util::report_errors();
+}

--- a/libs/type_support/include/hpx/type_support/decay.hpp
+++ b/libs/type_support/include/hpx/type_support/decay.hpp
@@ -5,15 +5,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// hpxinspect:nodeprecatedinclude:boost/ref.hpp
-// hpxinspect:nodeprecatedname:boost::reference_wrapper
-
 #ifndef HPX_UTIL_DECAY_HPP
 #define HPX_UTIL_DECAY_HPP
 
 #include <hpx/config.hpp>
-
-#include <boost/ref.hpp>
 
 #include <functional>
 #include <type_traits>
@@ -31,12 +26,6 @@ namespace hpx { namespace util {
         struct decay_unwrap_impl
         {
             typedef TD type;
-        };
-
-        template <typename X>
-        struct decay_unwrap_impl<::boost::reference_wrapper<X>>
-        {
-            typedef X& type;
         };
 
         template <typename X>

--- a/libs/type_support/include/hpx/type_support/unwrap_ref.hpp
+++ b/libs/type_support/include/hpx/type_support/unwrap_ref.hpp
@@ -4,33 +4,16 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// hpxinspect:nodeprecatedinclude:boost/ref.hpp
-// hpxinspect:nodeprecatedname:boost::reference_wrapper
-
 #if !defined(HPX_UTIL_UNWRAP_REF_JAN_05_2017_0356PM)
 #define HPX_UTIL_UNWRAP_REF_JAN_05_2017_0356PM
 
 #include <hpx/config.hpp>
-
-#include <boost/ref.hpp>
 
 #include <functional>
 
 namespace hpx { namespace util {
     template <typename T>
     struct unwrap_reference
-    {
-        typedef T type;
-    };
-
-    template <typename T>
-    struct unwrap_reference<boost::reference_wrapper<T>>
-    {
-        typedef T type;
-    };
-
-    template <typename T>
-    struct unwrap_reference<boost::reference_wrapper<T> const>
     {
         typedef T type;
     };

--- a/plugins/parcel/coalescing/performance_counters.cpp
+++ b/plugins/parcel/coalescing/performance_counters.cpp
@@ -15,11 +15,10 @@
 #include <hpx/runtime/components/component_startup_shutdown.hpp>
 #include <hpx/runtime/naming/name.hpp>
 #include <hpx/util/from_string.hpp>
+#include <hpx/string_util/classification.hpp>
+#include <hpx/string_util/split.hpp>
 
 #include <hpx/plugins/parcel/coalescing_counter_registry.hpp>
-
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
 
 #include <cstdint>
 #include <exception>
@@ -449,9 +448,9 @@ namespace hpx { namespace plugins { namespace parcel
 
                 // split parameters, extract separate values
                 std::vector<std::string> params;
-                boost::algorithm::split(params, paths.parameters_,
-                    boost::algorithm::is_any_of(","),
-                    boost::algorithm::token_compress_off);
+                hpx::string_util::split(params, paths.parameters_,
+                    hpx::string_util::is_any_of(","),
+                    hpx::string_util::token_compress_mode::off);
 
                 std::int64_t min_boundary = 0;
                 std::int64_t max_boundary = 1000000;  // 1ms

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -35,6 +35,8 @@
 #include <hpx/runtime/threads/policies/schedulers.hpp>
 #include <hpx/runtime_handlers.hpp>
 #include <hpx/runtime_impl.hpp>
+#include <hpx/string_util/split.hpp>
+#include <hpx/string_util/classification.hpp>
 #include <hpx/testing.hpp>
 #include <hpx/timing.hpp>
 #include <hpx/type_support/pack.hpp>
@@ -49,9 +51,6 @@
 #if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_MPI)
 #include <hpx/plugins/parcelport/mpi/mpi_environment.hpp>
 #endif
-
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/classification.hpp>
 
 #include <hpx/program_options/options_description.hpp>
 #include <hpx/program_options/parsers.hpp>
@@ -472,9 +471,9 @@ namespace hpx
                     if (counter_format == "csv-short"){
                         for (std::size_t i = 0; i != counters.size() ; ++i) {
                             std::vector<std::string> entry;
-                            boost::algorithm::split(entry, counters[i],
-                                boost::algorithm::is_any_of(","),
-                                boost::algorithm::token_compress_on);
+                            hpx::string_util::split(entry, counters[i],
+                                hpx::string_util::is_any_of(","),
+                                hpx::string_util::token_compress_mode::on);
 
                             if (entry.size() != 2)
                             {

--- a/src/runtime/components/component_registry.cpp
+++ b/src/runtime/components/component_registry.cpp
@@ -6,8 +6,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// make inspect happy: hpxinspect:nodeprecatedname:boost::is_any_of
-
 #include <hpx/runtime/components/component_registry.hpp>
 
 #include <hpx/runtime_fwd.hpp>
@@ -15,9 +13,8 @@
 #include <hpx/prefix/find_prefix.hpp>
 #include <hpx/logging.hpp>
 #include <hpx/runtime_configuration/runtime_configuration.hpp>
-
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
+#include <hpx/string_util/classification.hpp>
+#include <hpx/string_util/split.hpp>
 
 #include <algorithm>
 #include <string>
@@ -63,7 +60,7 @@ namespace hpx { namespace components { namespace detail
 
         if (more) {
             std::vector<std::string> data;
-            boost::split(data, more, boost::is_any_of("\n"));
+            hpx::string_util::split(data, more, hpx::string_util::is_any_of("\n"));
             std::copy(data.begin(), data.end(), std::back_inserter(fillini));
         }
     }

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -16,6 +16,7 @@
 #include <hpx/util/from_string.hpp>
 #include <hpx/prefix/find_prefix.hpp>
 #include <hpx/runtime_configuration/ini.hpp>
+#include <hpx/string_util/case_conv.hpp>
 
 #include <hpx/lcos/wait_all.hpp>
 #include <hpx/performance_counters/counters.hpp>
@@ -54,7 +55,6 @@
 #include <hpx/plugins/parcelport/mpi/mpi_environment.hpp>
 #endif
 
-#include <boost/algorithm/string/case_conv.hpp>
 #include <boost/tokenizer.hpp>
 
 #include <algorithm>
@@ -1567,7 +1567,7 @@ namespace hpx { namespace components { namespace server
             bool isenabled = true;
             if (sect.has_entry("enabled")) {
                 std::string tmp = sect.get_entry("enabled");
-                boost::algorithm::to_lower (tmp);
+                hpx::string_util::to_lower (tmp);
                 if (tmp == "no" || tmp == "false" || tmp == "0") {
                     LRT_(info) << "component factory disabled: " << instance;
                     isenabled = false;     // this component has been disabled
@@ -1578,7 +1578,7 @@ namespace hpx { namespace components { namespace server
             bool isdefault = false;
             if (sect.has_entry("isdefault")) {
                 std::string tmp = sect.get_entry("isdefault");
-                boost::algorithm::to_lower (tmp);
+                hpx::string_util::to_lower (tmp);
                 if (tmp == "true")
                     isdefault = true;
             }
@@ -2010,7 +2010,7 @@ namespace hpx { namespace components { namespace server
             bool isenabled = true;
             if (sect.has_entry("enabled")) {
                 std::string tmp = sect.get_entry("enabled");
-                boost::algorithm::to_lower (tmp);
+                hpx::string_util::to_lower (tmp);
                 if (tmp == "no" || tmp == "false" || tmp == "0") {
                     LRT_(info) << "plugin factory disabled: " << instance;
                     isenabled = false;     // this component has been disabled

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -45,10 +45,10 @@
 #include <hpx/logging.hpp>
 #include <hpx/runtime_configuration/runtime_configuration.hpp>
 #include <hpx/thread_support/unlock_guard.hpp>
+#include <hpx/string_util.hpp>
 
 #include <hpx/plugins/parcelport_factory_base.hpp>
 
-#include <boost/algorithm/string.hpp>
 #include <boost/asio/error.hpp>
 #include <boost/assign/std/vector.hpp>
 #include <boost/predef/other/endian.h>

--- a/tests/performance/local/coroutines_call_overhead.cpp
+++ b/tests/performance/local/coroutines_call_overhead.cpp
@@ -9,9 +9,8 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/format.hpp>
-
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/classification.hpp>
+#include <hpx/string_util/split.hpp>
+#include <hpx/string_util/classification.hpp>
 
 #include <chrono>
 #include <cstdint>
@@ -243,9 +242,9 @@ int hpx_main(
             for (std::uint64_t i = 0; i < raw_counters.size(); ++i)
             {
                 std::vector<std::string> entry;
-                boost::algorithm::split(entry, raw_counters[i],
-                    boost::algorithm::is_any_of(","),
-                    boost::algorithm::token_compress_on);
+                hpx::string_util::split(entry, raw_counters[i],
+                    hpx::string_util::is_any_of(","),
+                    hpx::string_util::token_compress_mode::on);
 
                 HPX_TEST_EQ(entry.size(), 2);
 

--- a/tests/performance/local/timed_task_spawn.cpp
+++ b/tests/performance/local/timed_task_spawn.cpp
@@ -16,9 +16,9 @@
 #include <hpx/format.hpp>
 #include <hpx/functional/bind.hpp>
 #include <hpx/testing.hpp>
+#include <hpx/string_util/classification.hpp>
+#include <hpx/string_util/split.hpp>
 
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
 #include <boost/integer/common_factor.hpp>
 
 #include <chrono>
@@ -414,9 +414,9 @@ int hpx_main(variables_map& vm)
             for (auto& raw_counter : raw_counters)
             {
                 std::vector<std::string> entry;
-                boost::algorithm::split(entry, raw_counter,
-                    boost::algorithm::is_any_of(","),
-                    boost::algorithm::token_compress_on);
+                hpx::string_util::split(entry, raw_counter,
+                    hpx::string_util::is_any_of(","),
+                    hpx::string_util::token_compress_mode::on);
 
                 HPX_TEST_EQ(entry.size(), 2);
 

--- a/tools/inspect/CMakeLists.txt
+++ b/tools/inspect/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 # Set the basic search paths for the generated HPX headers
 target_include_directories(inspect PRIVATE ${PROJECT_BINARY_DIR})
 target_link_libraries(inspect PRIVATE hpx::boost::regex hpx::boost hpx_config
-  hpx_filesystem hpx_program_options)
+  hpx_filesystem hpx_program_options hpx_string_util)
 target_compile_definitions(inspect PRIVATE HPX_MODULE_STATIC_LINKING)
 
 # add dependencies to pseudo-target

--- a/tools/inspect/link_check.cpp
+++ b/tools/inspect/link_check.cpp
@@ -9,11 +9,11 @@
 
 #include <hpx/config.hpp>
 #include <hpx/filesystem.hpp>
+#include <hpx/string_util.hpp>
 
 #include "link_check.hpp"
 #include "function_hyper.hpp"
 #include "boost/regex.hpp"
-#include <boost/algorithm/string/case_conv.hpp>
 #include <cstdlib>
 #include <set>
 
@@ -165,9 +165,9 @@ namespace boost
           if (a_what[4].matched)
           {
             string tag( a_what[1].first, a_what[1].second );
-            boost::algorithm::to_lower(tag);
+            hpx::string_util::to_lower(tag);
             string attribute( a_what[2].first, a_what[2].second );
-            boost::algorithm::to_lower(attribute);
+            hpx::string_util::to_lower(attribute);
             string bookmark( a_what[4].first, a_what[4].second );
 
             bool name_following_id = ( attribute == "name" && previous_id == bookmark );
@@ -182,7 +182,7 @@ namespace boost
               // w3.org recommends case-insensitive checking for duplicate bookmarks
               // since some browsers do a case-insensitive match.
               string bookmark_lowercase( bookmark );
-              boost::algorithm::to_lower(bookmark_lowercase);
+              hpx::string_util::to_lower(bookmark_lowercase);
 
               std::pair<bookmark_set::iterator, bool> result
                 = bookmarks_lowercase.insert( bookmark_lowercase );
@@ -220,7 +220,7 @@ namespace boost
           if(what[3].matched)
           {
             string type( what[1].first, what[1].second );
-            boost::algorithm::to_lower(type);
+            hpx::string_util::to_lower(type);
 
             // TODO: Complain if 'link' tags use external stylesheets.
             do_url( string( what[3].first, what[3].second ),


### PR DESCRIPTION
This cleans up some unused Boost headers, and overloads for Boost types that I deem unnecessary. Please speak up if you think it's essential to keep any of these around.

I've also copied the string algorithms from Boost.Algorithm into a new module. In the first pass this still uses Boost.Range and other utilities from Boost. I attempted to replace `iterator_range` with ours from `iterator_support` but failed. Our ranges don't seem to quite match Boost's. However, I think it's definitely feasible to do the replacement, given a bit more knowledge about how things work in Boost (which I don't have at the moment...). 