### PR TITLE
Link HPX::plugin and component privately in hpx_setup_target

### DIFF
--- a/cmake/HPX_SetupTarget.cmake
+++ b/cmake/HPX_SetupTarget.cmake
@@ -134,7 +134,7 @@ function(hpx_setup_target target)
 
   if("${_type}" STREQUAL "LIBRARY" AND target_PLUGIN)
     set(plugin_name "HPX_PLUGIN_NAME=hpx_${name}")
-    target_link_libraries(${target} ${__tll_public}
+    target_link_libraries(${target} ${__tll_private}
       $<TARGET_NAME_IF_EXISTS:plugin>
       $<TARGET_NAME_IF_EXISTS:HPX::plugin>)
   endif()
@@ -144,7 +144,7 @@ function(hpx_setup_target target)
       PRIVATE
       "HPX_COMPONENT_NAME=hpx_${name}"
       "HPX_COMPONENT_STRING=\"hpx_${name}\"")
-    target_link_libraries(${target} ${__tll_public}
+    target_link_libraries(${target} ${__tll_private}
       $<TARGET_NAME_IF_EXISTS:component>
       $<TARGET_NAME_IF_EXISTS:HPX::component>)
   endif()


### PR DESCRIPTION
Fix to follow up on #4246. The `component` and `plugin` targets were linked publicly in `hpx_setup_target` leading to dependent targets to also get definitions like `HPX_COMPONENT_EXPORTS` which should stay private.
