### PR TITLE
Minor CUDA fixes

### DIFF
--- a/libs/datastructures/include/hpx/datastructures/tuple.hpp
+++ b/libs/datastructures/include/hpx/datastructures/tuple.hpp
@@ -149,12 +149,12 @@ namespace hpx { namespace util {
         // tuple(const tuple& u) = default;
         // Initializes each element of *this with the corresponding element
         // of u.
-        constexpr HPX_HOST_DEVICE tuple(tuple const& /*other*/) = default;
+        constexpr tuple(tuple const& /*other*/) = default;
 
         // tuple(tuple&& u) = default;
         // For all i, initializes the ith element of *this with
         // std::forward<Ti>(get<i>(u)).
-        constexpr HPX_HOST_DEVICE tuple(tuple&& /*other*/) = default;
+        constexpr tuple(tuple&& /*other*/) = default;
 
         // 20.4.2.2, tuple assignment
 

--- a/libs/errors/include/hpx/errors/exception_fwd.hpp
+++ b/libs/errors/include/hpx/errors/exception_fwd.hpp
@@ -57,7 +57,13 @@ namespace hpx {
     /// \a get_errorcode() member function returns a reference to an
     /// \a hpx::error_code object with the behavior as specified above.
     ///
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+    // We can't actually refer to this in device code. This is only to satisfy
+    // the compiler.
+    extern HPX_DEVICE error_code throws;
+#else
     HPX_EXCEPTION_EXPORT extern error_code throws;
+#endif
 }    // namespace hpx
 
 #include <hpx/errors/throw_exception.hpp>


### PR DESCRIPTION
- Add a dummy `hpx::throws` declaration to suppress errors about `hpx::throws` being undefined in device code (suggestions for better/safer ways to fix this welcome!)
- Remove `HPX_HOST_DEVICE` attribute from defaulted `tuple` constructors; this is apparently not needed (and causes annoying warnings)