### PR TITLE
Resume tasks where they were suspended

### DIFF
--- a/libs/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -505,7 +505,8 @@ namespace hpx { namespace threads {
             return last_worker_thread_num_;
         }
 
-        void set_last_worker_thread_num(std::size_t last_worker_thread_num) noexcept
+        void set_last_worker_thread_num(
+            std::size_t last_worker_thread_num) noexcept
         {
             last_worker_thread_num_ = last_worker_thread_num;
         }
@@ -613,6 +614,7 @@ namespace hpx { namespace threads {
 
         // reference to scheduler which created/manages this thread
         policies::scheduler_base* scheduler_base_;
+        std::size_t last_worker_thread_num_;
 
         std::ptrdiff_t stacksize_;
 

--- a/libs/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -500,6 +500,16 @@ namespace hpx { namespace threads {
             return scheduler_base_;
         }
 
+        std::size_t get_last_worker_thread_num() const noexcept
+        {
+            return last_worker_thread_num_;
+        }
+
+        void set_last_worker_thread_num(std::size_t last_worker_thread_num) noexcept
+        {
+            last_worker_thread_num_ = last_worker_thread_num;
+        }
+
         std::ptrdiff_t get_stack_size() const noexcept
         {
             return stacksize_;

--- a/libs/threading_base/include/hpx/threading_base/thread_num_tss.hpp
+++ b/libs/threading_base/include/hpx/threading_base/thread_num_tss.hpp
@@ -18,40 +18,51 @@
 #include <hpx/config/warnings_prefix.hpp>
 
 namespace hpx { namespace threads { namespace detail {
-    // set/get the global thread Id to/from thread local storage
-    HPX_EXPORT std::size_t set_thread_num_tss(std::size_t num);
-    HPX_EXPORT std::size_t get_thread_num_tss();
+    /// Set the global thread id to thread local storage.
+    HPX_EXPORT std::size_t set_global_thread_num_tss(std::size_t num);
+    /// Get the global thread id from thread local storage.
+    HPX_EXPORT std::size_t get_global_thread_num_tss();
+    /// Set the local thread id to thread local storage.
+    HPX_EXPORT std::size_t set_local_thread_num_tss(std::size_t num);
+    /// Get the local thread id from thread local storage.
+    HPX_EXPORT std::size_t get_local_thread_num_tss();
+    /// Set the thread pool id to thread local storage.
+    HPX_EXPORT std::size_t set_thread_pool_num_tss(std::size_t num);
+    /// Get the thread pool id from thread local storage.
+    HPX_EXPORT std::size_t get_thread_pool_num_tss();
 
-    // this struct holds the local thread Id and the pool index
-    // associated with the thread
-    struct thread_pool
+    /// Holds the global and local thread numbers, and the pool number
+    /// associated with the thread.
+    struct thread_nums
     {
+        std::size_t global_thread_num;
         std::size_t local_thread_num;
-        std::size_t pool_index;
+        std::size_t thread_pool_num;
     };
-    HPX_EXPORT void set_thread_pool_tss(const thread_pool&);
-    HPX_EXPORT thread_pool get_thread_pool_tss();
+
+    HPX_EXPORT void set_thread_nums_tss(const thread_nums&);
+    HPX_EXPORT thread_nums get_thread_nums_tss();
 
     ///////////////////////////////////////////////////////////////////////////
     struct reset_tss_helper
     {
-        reset_tss_helper(std::size_t thread_num)
-          : thread_num_(set_thread_num_tss(thread_num))
+        reset_tss_helper(std::size_t global_thread_num)
+          : global_thread_num_(set_global_thread_num_tss(global_thread_num))
         {
         }
 
         ~reset_tss_helper()
         {
-            set_thread_num_tss(thread_num_);
+            set_global_thread_num_tss(global_thread_num_);
         }
 
-        std::size_t previous_thread_num() const
+        std::size_t previous_global_thread_num() const
         {
-            return thread_num_;
+            return global_thread_num_;
         }
 
     private:
-        std::size_t thread_num_;
+        std::size_t global_thread_num_;
     };
 }}}    // namespace hpx::threads::detail
 
@@ -89,6 +100,74 @@ namespace hpx {
     /// \note   This function needs to be executed on a HPX-thread. It will
     ///         fail otherwise (it will return -1).
     HPX_API_EXPORT std::size_t get_worker_thread_num(error_code& ec);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// \brief Return the number of the current OS-thread running in the current
+    ///        thread pool the current HPX-thread is executed with.
+    ///
+    /// This function returns the zero based index of the OS-thread on the
+    /// current thread pool which executes the current HPX-thread.
+    ///
+    /// \note The returned value is zero based and its maximum value is smaller
+    ///       than the number of OS-threads executed on the current thread pool.
+    ///       It will return -1 if the current thread is not a known thread or
+    ///       if the runtime is not in running state.
+    ///
+    /// \note This function needs to be executed on a HPX-thread. It will fail
+    ///         otherwise (it will return -1).
+    HPX_API_EXPORT std::size_t get_local_worker_thread_num();
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// \brief Return the number of the current OS-thread running in the current
+    ///        thread pool the current HPX-thread is executed with.
+    ///
+    /// This function returns the zero based index of the OS-thread on the
+    /// current thread pool which executes the current HPX-thread.
+    ///
+    /// \param ec [in,out] this represents the error status on exit.
+    ///
+    /// \note The returned value is zero based and its maximum value is smaller
+    ///       than the number of OS-threads executed on the current thread pool.
+    ///       It will return -1 if the current thread is not a known thread or
+    ///       if the runtime is not in running state.
+    ///
+    /// \note This function needs to be executed on a HPX-thread. It will fail
+    ///         otherwise (it will return -1).
+    HPX_API_EXPORT std::size_t get_local_worker_thread_num(error_code& ec);
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// \brief Return the number of the current thread pool the current
+    /// HPX-thread is executed with.
+    ///
+    /// This function returns the zero based index of the thread pool which
+    /// executes the current HPX-thread.
+    ///
+    /// \note The returned value is zero based and its maximum value is smaller
+    ///       than the number of thread pools started by the runtime. It will
+    ///       return -1 if the current thread pool is not a known thread pool or
+    ///       if the runtime is not in running state.
+    ///
+    /// \note This function needs to be executed on a HPX-thread. It will fail
+    ///         otherwise (it will return -1).
+    HPX_API_EXPORT std::size_t get_thread_pool_num();
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// \brief Return the number of the current thread pool the current
+    /// HPX-thread is executed with.
+    ///
+    /// This function returns the zero based index of the thread pool which
+    /// executes the current HPX-thread.
+    ///
+    ///  \param ec [in,out] this represents the error status on exit.
+    ///
+    /// \note The returned value is zero based and its maximum value is smaller
+    ///       than the number of thread pools started by the runtime. It will
+    ///       return -1 if the current thread pool is not a known thread pool or
+    ///       if the runtime is not in running state.
+    ///
+    /// \note This function needs to be executed on a HPX-thread. It will fail
+    ///         otherwise (it will return -1).
+    HPX_API_EXPORT std::size_t get_thread_pool_num(error_code& ec);
 }    // namespace hpx
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/threading_base/src/execution_agent.cpp
+++ b/libs/threading_base/src/execution_agent.cpp
@@ -11,6 +11,7 @@
 #include <hpx/format.hpp>
 #include <hpx/logging.hpp>
 #include <hpx/threading_base/thread_data.hpp>
+#include <hpx/threading_base/thread_num_tss.hpp>
 
 #include <hpx/threading_base/execution_agent.hpp>
 #include <hpx/threading_base/scheduler_base.hpp>
@@ -21,6 +22,7 @@
 #endif
 
 #include <cstddef>
+#include <cstdint>
 #include <sstream>
 #include <string>
 
@@ -142,6 +144,9 @@ namespace hpx { namespace threads {
         thread_data* thrd_data = get_thread_id_data(id);
         HPX_ASSERT(thrd_data);
         thrd_data->interruption_point();
+
+        thrd_data->set_last_worker_thread_num(
+            hpx::get_local_worker_thread_num());
 
         threads::thread_state_ex_enum statex = threads::wait_unknown;
 
@@ -274,7 +279,8 @@ namespace hpx { namespace threads {
         {
             auto* data = get_thread_id_data(id);
             auto scheduler = data->get_scheduler_base();
-            auto hint = thread_schedule_hint();
+            auto hint = thread_schedule_hint(
+                static_cast<std::int16_t>(data->get_last_worker_thread_num()));
             scheduler->schedule_thread(data, hint, true, data->get_priority());
             // Wake up scheduler
             scheduler->do_some_work(hint.hint);

--- a/libs/threading_base/src/thread_data.cpp
+++ b/libs/threading_base/src/thread_data.cpp
@@ -67,6 +67,7 @@ namespace hpx { namespace threads {
         , enabled_interrupt_(true)
         , ran_exit_funcs_(false)
         , scheduler_base_(init_data.scheduler_base)
+        , last_worker_thread_num_(std::size_t(-1))
         , stacksize_(init_data.stacksize)
         , queue_(queue)
         , is_stackless_(is_stackless)
@@ -195,6 +196,7 @@ namespace hpx { namespace threads {
             ran_exit_funcs_ = false;
             exit_funcs_.clear();
             scheduler_base_ = init_data.scheduler_base;
+            last_worker_thread_num_ = std::size_t(-1);
 
             HPX_ASSERT(init_data.stacksize == get_stack_size());
 

--- a/libs/threading_base/src/thread_num_tss.cpp
+++ b/libs/threading_base/src/thread_num_tss.cpp
@@ -15,45 +15,55 @@
 
 namespace hpx { namespace threads { namespace detail {
     namespace {
-        std::size_t& thread_num_tss()
+        thread_nums& thread_nums_tss()
         {
-            static thread_local std::size_t thread_num_tss_ = std::size_t(-1);
-            return thread_num_tss_;
-        }
-
-        thread_pool& thread_pool_tss()
-        {
-            static thread_local thread_pool thread_pool_tss_ = {
-                std::uint16_t(-1), std::uint16_t(-1)};
-            return thread_pool_tss_;
+            static thread_local thread_nums thread_nums_tss_ = {
+                std::size_t(-1), std::size_t(-1), std::size_t(-1)};
+            return thread_nums_tss_;
         }
     }    // namespace
 
-    // use this to store the global thread number/id in thread local storage
-    std::size_t set_thread_num_tss(std::size_t num)
+    std::size_t set_global_thread_num_tss(std::size_t num)
     {
-        std::swap(thread_num_tss(), num);
+        std::swap(thread_nums_tss().global_thread_num, num);
         return num;
     }
 
-    // this returns the globl thread number from thread local storage
-    std::size_t get_thread_num_tss()
+    std::size_t get_global_thread_num_tss()
     {
-        return thread_num_tss();
+        return thread_nums_tss().global_thread_num;
     }
 
-    // set the local thread number and pool index associated with this
-    // system thread into thread local storage
-    void set_thread_pool_tss(const thread_pool& tup)
+    std::size_t set_local_thread_num_tss(std::size_t num)
     {
-        thread_pool_tss() = tup;
+        std::swap(thread_nums_tss().local_thread_num, num);
+        return num;
     }
 
-    // this returns a struct of the local thread number and the pool
-    // Id or index that this thread is assigned to
-    thread_pool get_thread_pool_tss()
+    std::size_t get_local_thread_num_tss()
     {
-        return thread_pool_tss();
+        return thread_nums_tss().local_thread_num;
+    }
+
+    std::size_t set_thread_pool_num_tss(std::size_t num)
+    {
+        std::swap(thread_nums_tss().thread_pool_num, num);
+        return num;
+    }
+
+    std::size_t get_thread_pool_num_tss()
+    {
+        return thread_nums_tss().thread_pool_num;
+    }
+
+    void set_thread_nums_tss(const thread_nums& t)
+    {
+        thread_nums_tss() = t;
+    }
+
+    thread_nums get_thread_nums_tss()
+    {
+        return thread_nums_tss();
     }
 
 }}}    // namespace hpx::threads::detail
@@ -61,11 +71,31 @@ namespace hpx { namespace threads { namespace detail {
 namespace hpx {
     std::size_t get_worker_thread_num(error_code& ec)
     {
-        return threads::detail::get_thread_num_tss();
+        return threads::detail::thread_nums_tss().global_thread_num;
     }
 
     std::size_t get_worker_thread_num()
     {
         return get_worker_thread_num(throws);
+    }
+
+    std::size_t get_local_worker_thread_num(error_code& ec)
+    {
+        return threads::detail::thread_nums_tss().local_thread_num;
+    }
+
+    std::size_t get_local_worker_thread_num()
+    {
+        return get_local_worker_thread_num(throws);
+    }
+
+    std::size_t get_thread_pool_num(error_code& ec)
+    {
+        return threads::detail::thread_nums_tss().thread_pool_num;
+    }
+
+    std::size_t get_thread_pool_num()
+    {
+        return get_thread_pool_num(throws);
     }
 }    // namespace hpx

--- a/libs/threadmanager/include/hpx/threadmanager.hpp
+++ b/libs/threadmanager/include/hpx/threadmanager.hpp
@@ -312,12 +312,12 @@ namespace hpx { namespace threads {
 
         void init_tss(std::size_t global_thread_num)
         {
-            detail::set_thread_num_tss(global_thread_num);
+            detail::set_global_thread_num_tss(global_thread_num);
         }
 
         void deinit_tss()
         {
-            detail::set_thread_num_tss(std::size_t(-1));
+            detail::set_global_thread_num_tss(std::size_t(-1));
         }
 
     public:

--- a/src/runtime/threads/executors/current_executor.cpp
+++ b/src/runtime/threads/executors/current_executor.cpp
@@ -146,8 +146,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
 
     hpx::state current_executor::get_state() const
     {
-        return scheduler_base_->get_state(
-            threads::detail::get_thread_num_tss());
+        return scheduler_base_->get_state(get_local_worker_thread_num());
     }
 
     void current_executor::set_scheduler_mode(

--- a/src/runtime/threads/executors/this_thread_executors.cpp
+++ b/src/runtime/threads/executors/this_thread_executors.cpp
@@ -349,7 +349,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
             HPX_ASSERT(orig_thread_num_ != std::size_t(-1));
 
             threads::detail::reset_tss_helper reset_on_exit(orig_thread_num_);
-            parent_thread_num_ = reset_on_exit.previous_thread_num();
+            parent_thread_num_ = reset_on_exit.previous_global_thread_num();
 
             // FIXME: turn these values into performance counters
             std::int64_t executed_threads = 0, executed_thread_phases = 0;
@@ -441,7 +441,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
         HPX_ASSERT(std::size_t(-1) == orig_thread_num_);
 
         thread_num_ = thread_num;
-        orig_thread_num_ = threads::detail::get_thread_num_tss();
+        orig_thread_num_ = get_worker_thread_num();
 
         std::atomic<hpx::state>& state = scheduler_.get_state(0);
         hpx::state expected = state_initialized;

--- a/src/runtime/threads/executors/thread_pool_attached_executors.cpp
+++ b/src/runtime/threads/executors/thread_pool_attached_executors.cpp
@@ -75,7 +75,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail
 
         schedulehint.mode = threads::thread_schedule_hint_mode_thread;
         schedulehint.hint =
-            static_cast<std::int16_t>(threads::detail::get_thread_num_tss());
+            static_cast<std::int16_t>(threads::detail::get_global_thread_num_tss());
         register_thread_nullary(std::move(f), desc, initial_state, run_now,
             priority_, schedulehint, stacksize, ec);
     }


### PR DESCRIPTION
Resumes tasks on the worker thread that they were suspended on. This is something I *think* will help in some cases (based on some task plots I've seen), but I don't currently have a benchmark to verify if this makes things better or worse. It does make sense to avoid invalidating caches though.

I've at the same time tried to clean up the thread number implementation. Please comment on naming, exposed functions etc.