### PR TITLE
Suppress MPI warnings in version.cpp

### DIFF
--- a/libs/version/src/version.cpp
+++ b/libs/version/src/version.cpp
@@ -19,9 +19,24 @@
 #include <boost/version.hpp>
 
 #if defined(HPX_HAVE_PARCELPORT_MPI)
+#if defined(__clang__)
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wcast-qual"
+#elif defined (__GNUC__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
+
 // Intel MPI does not like to be included after stdio.h. As such, we include mpi.h
 // as soon as possible.
 #include <mpi.h>
+
+#if defined(__clang__)
+#  pragma clang diagnostic pop
+#elif defined (__GNUC__)
+#  pragma GCC diagnostic pop
+#endif
+
 #endif
 
 #include <hwloc.h>


### PR DESCRIPTION
We have https://github.com/STEllAR-GROUP/hpx/blob/master/hpx/plugins/parcelport/mpi/mpi.hpp, but to avoid a dependency on the plugins in the version module, I've just included the warning suppression pragmas directly in the `version.cpp` file. With this I'll enable the MPI parcelport on pycicle again (on the `gcc-cuda` builder).