### PR TITLE
Add more descriptive error message when using x86 coroutines on non-x86 platforms

### DIFF
--- a/libs/coroutines/src/swapcontext.cpp
+++ b/libs/coroutines/src/swapcontext.cpp
@@ -18,7 +18,9 @@
     defined(__i686__)
 #include "swapcontext32.ipp"
 #else
-#error Unsupported platform
+#error You are trying to use x86 context switching on a non-x86 platform. Your \
+    platform may be supported with the CMake option \
+    HPX_WITH_GENERIC_CONTEXT_COROUTINES=ON.
 #endif
 
 #endif


### PR DESCRIPTION
Bare minimum. I think we could do more to detect this automatically, but I'm scared of the complexities it'll introduce in our CMake (cross-compilation etc.).