### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -149,6 +149,21 @@ the distributed aspects of |hpx|.
    It is also possible to build e.g. all quickstart examples using ``make
    examples.quickstart``.
 
+Installing and building |hpx| via vcpkg
+=======================================
+
+You can download and install hpx using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+.. code-block:: sh
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install hpx
+
+The hpx port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 Hello, World!
 =============
 

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -152,7 +152,8 @@ the distributed aspects of |hpx|.
 Installing and building |hpx| via vcpkg
 =======================================
 
-You can download and install hpx using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+You can download and install |hpx| using the `vcpkg <https://github.com/Microsoft/vcpkg>` 
+dependency manager:
 
 .. code-block:: sh
 
@@ -162,7 +163,9 @@ You can download and install hpx using the [vcpkg](https://github.com/Microsoft/
     ./vcpkg integrate install
     vcpkg install hpx
 
-The hpx port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+The |hpx| port in vcpkg is kept up to date by Microsoft team members and community 
+contributors. If the version is out of date, please `create an issue or pull request 
+<https://github.com/Microsoft/vcpkg>` on the vcpkg repository.
 
 Hello, World!
 =============


### PR DESCRIPTION
hpx is available as a port in vcpkg, a C++ library manager that simplifies installation for hpx and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build hpx , ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.
Note: Currently only support dynamic build on Windows.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.