### PR TITLE
Fix compatibility of `pool_executor`

### DIFF
--- a/hpx/runtime/threads/executors/pool_executor.hpp
+++ b/hpx/runtime/threads/executors/pool_executor.hpp
@@ -11,10 +11,10 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_THREAD_EXECUTORS_COMPATIBILITY)
-#include <hpx/execution/executors/thread_pool_executor.hpp>
+#include <hpx/execution/executors/pool_executor.hpp>
 
 namespace hpx { namespace threads { namespace executors {
-    using pool_executor = parallel::execution::thread_pool_executor;
+    using pool_executor = parallel::execution::pool_executor;
 }}}    // namespace hpx::threads::executors
 
 #endif


### PR DESCRIPTION
Forwarded `thread_pool_executor` instead of `pool_executor`.