### PR TITLE
Attempting to fix hpx_init linking on macOS

### DIFF
--- a/init/src/hpx_wrap.cpp
+++ b/init/src/hpx_wrap.cpp
@@ -25,8 +25,8 @@ namespace hpx_start
     // by this code.
     HPX_SYMBOL_EXPORT extern bool include_libhpx_wrap;
     HPX_SYMBOL_EXPORT bool include_libhpx_wrap __attribute__((weak)) = false;
-    HPX_SYMBOL_EXPORT extern std::string app_name_libhpx_wrap
-        __attribute__((weak));
+    HPX_SYMBOL_EXPORT extern std::string app_name_libhpx_wrap;
+    HPX_SYMBOL_EXPORT std::string app_name_libhpx_wrap __attribute__((weak));
 }
 
 #include <hpx/hpx_finalize.hpp>


### PR DESCRIPTION
There were still some linking errors on macOS that we didn't notice with the previous PR (#4475). This seems to fix them, but I don't know yet if I've broken Linux in return.