### PR TITLE
Fix duplicate linking in tests (ODR violations)

### DIFF
--- a/libs/checkpoint/tests/unit/CMakeLists.txt
+++ b/libs/checkpoint/tests/unit/CMakeLists.txt
@@ -18,7 +18,6 @@ foreach(test ${tests})
     INTERNAL_FLAGS
     SOURCES ${sources}
     ${${test}_FLAGS}
-    DEPENDENCIES hpx_checkpoint hpx_testing
     EXCLUDE_FROM_ALL
     FOLDER "Tests/Unit/Modules/Checkpoint/")
 

--- a/libs/errors/tests/unit/CMakeLists.txt
+++ b/libs/errors/tests/unit/CMakeLists.txt
@@ -9,7 +9,7 @@ set(tests
   exception
 )
 
-set(exception_LIBS DEPENDENCIES hpx_errors hpx_testing)
+set(exception_LIBS NOLIBS DEPENDENCIES hpx_errors hpx_testing)
 
 foreach(test ${tests})
   set(sources

--- a/libs/iterator_support/tests/unit/CMakeLists.txt
+++ b/libs/iterator_support/tests/unit/CMakeLists.txt
@@ -18,10 +18,7 @@ set(tests
 )
 
 # Set the dependencies of each test
-set(is_iterator_FLAGS NOLIBS)
-set(is_iterator_LIBS
-  DEPENDENCIES hpx_config hpx_iterator_support partitioned_vector_component
-    hpx_testing)
+set(is_iterator_LIBS DEPENDENCIES partitioned_vector_component)
 
 set(is_range_FLAGS NOLIBS)
 set(is_range_LIBS DEPENDENCIES hpx_config hpx_iterator_support hpx_testing)

--- a/libs/synchronization/tests/performance/CMakeLists.txt
+++ b/libs/synchronization/tests/performance/CMakeLists.txt
@@ -10,14 +10,8 @@ set(benchmarks
   channel_spsc_throughput
 )
 
-set(channel_mpmc_throughput_FLAGS DEPENDENCIES
-    hpx_assertion hpx_concurrency hpx_errors hpx_synchronization hpx_timing hpx_thread_support)
 set(channel_mpmc_throughput_PARAMETERS THREADS_PER_LOCALITY 2)
-set(channel_mpsc_throughput_FLAGS DEPENDENCIES
-    hpx_assertion hpx_concurrency hpx_errors hpx_synchronization hpx_timing hpx_thread_support)
 set(channel_mpsc_throughput_PARAMETERS THREADS_PER_LOCALITY 2)
-set(channel_spsc_throughput_FLAGS DEPENDENCIES
-    hpx_assertion hpx_concurrency hpx_errors hpx_synchronization hpx_timing hpx_thread_support)
 set(channel_spsc_throughputs_PARAMETERS THREADS_PER_LOCALITY 2)
 
 foreach(benchmark ${benchmarks})


### PR DESCRIPTION
The branch name was more optimistic than the results. Something is still not quite right with our sanitizer integration, and I managed to get it to report the ODR violations fixed in this PR. In doing so I broke other things in the sanitizer integration so those changes will have to wait. The ODR violations are real though, but not as serious as they sound. They are just a result of some tests linking to both `libhpx` and some of the static module libraries (`hpx_testing`).