### PR TITLE
Only test pull requests (not all branches) with GitHub actions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,7 +6,7 @@
 
 name: Linux CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,7 +6,7 @@
 
 name: macOS CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,7 +6,7 @@
 
 name: Windows CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
It seems like GitHub actions was not smart enough to only trigger one build per push when the triggers were `[push, pull_request]`. Please don't merge yet as I want to make sure that `pull_request` doesn't mean builds will be triggered only once when a pull request is opened.

If someone wants the builders to run on their branch without opening a PR, they can temporarily add `push` to the triggers.