### PR TITLE
Skip execution customization points when executor is known

### DIFF
--- a/libs/async_base/include/hpx/async_base/sync.hpp
+++ b/libs/async_base/include/hpx/async_base/sync.hpp
@@ -13,7 +13,7 @@
 #include <utility>
 
 namespace hpx { namespace detail {
-    // dispatch point used for async implementations
+    // dispatch point used for sync implementations
     template <typename Func, typename Enable = void>
     struct sync_dispatch;
 }}    // namespace hpx::detail

--- a/libs/execution/include/hpx/execution/apply.hpp
+++ b/libs/execution/include/hpx/execution/apply.hpp
@@ -33,8 +33,7 @@ namespace hpx { namespace detail {
         call(F&& f, Ts&&... ts)
         {
             parallel::execution::parallel_executor exec;
-            parallel::execution::post(
-                exec, std::forward<F>(f), std::forward<Ts>(ts)...);
+            exec.post(std::forward<F>(f), std::forward<Ts>(ts)...);
             return false;
         }
     };

--- a/libs/execution/include/hpx/execution/dataflow.hpp
+++ b/libs/execution/include/hpx/execution/dataflow.hpp
@@ -174,8 +174,7 @@ namespace hpx { namespace lcos { namespace detail {
             // simply schedule new thread
             parallel::execution::parallel_policy_executor<launch::async_policy>
                 exec{policy};
-            parallel::execution::post(
-                exec,
+            exec.post(
                 [this_ = std::move(this_)](Futures&& futures) -> void {
                     return this_->done(std::move(futures));
                 },
@@ -226,8 +225,7 @@ namespace hpx { namespace lcos { namespace detail {
 
             parallel::execution::parallel_policy_executor<launch::fork_policy>
                 exec{policy};
-            parallel::execution::post(
-                exec,
+            exec.post(
                 [this_ = std::move(this_)](Futures&& futures) -> void {
                     return this_->done(std::move(futures));
                 },


### PR DESCRIPTION
Fixes missed review comments on #4478. I tried this out with `apply` and the generated code ends up exactly the same (i.e. a call to `register_thread_nullary`, that speaks highly of the customization points). More complicated cases might not do the same (although one would hope so... it's templated anyway). In any case, like this we're consistent (`async` and `sync` already did the same), and protect ourselves against potential changes in the customization points.

Also fixes that one typo in `hpx/async_base/sync.hpp`...