### PR TITLE
Enable and fix deprecation warnings in execution module

### DIFF
--- a/libs/async/include/hpx/async/async.hpp
+++ b/libs/async/include/hpx/async/async.hpp
@@ -13,7 +13,7 @@
 #include <hpx/async/async_continue.hpp>
 #include <hpx/async/async_fwd.hpp>
 #include <hpx/async/detail/async_implementations.hpp>
-#include <hpx/async_launch_policy_dispatch.hpp>
+#include <hpx/execution/detail/async_launch_policy_dispatch.hpp>
 #include <hpx/execution/executors/execution.hpp>
 #include <hpx/execution/executors/parallel_executor.hpp>
 #include <hpx/functional/bind_back.hpp>

--- a/libs/async/include/hpx/async/sync.hpp
+++ b/libs/async/include/hpx/async/sync.hpp
@@ -12,6 +12,7 @@
 #include <hpx/async/detail/sync_implementations.hpp>
 #include <hpx/async/sync.hpp>
 #include <hpx/async/sync_fwd.hpp>
+#include <hpx/execution/detail/sync_launch_policy_dispatch.hpp>
 #include <hpx/execution/sync.hpp>
 #include <hpx/functional/bind_back.hpp>
 #include <hpx/functional/traits/is_action.hpp>
@@ -19,7 +20,6 @@
 #include <hpx/runtime/components/client_base.hpp>
 #include <hpx/runtime/launch_policy.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
-#include <hpx/sync_launch_policy_dispatch.hpp>
 #include <hpx/traits/extract_action.hpp>
 #include <hpx/traits/is_client.hpp>
 #include <hpx/traits/is_distribution_policy.hpp>

--- a/libs/execution/CMakeLists.txt
+++ b/libs/execution/CMakeLists.txt
@@ -125,6 +125,7 @@ add_hpx_module(execution
   FORCE_LINKING_GEN
   SOURCES ${execution_sources}
   HEADERS ${execution_headers}
+  DEPRECATION_WARNINGS
   COMPATIBILITY_HEADERS ON    # Added in 1.5.0
   COMPAT_HEADERS ${execution_compat_headers}
   DEPENDENCIES

--- a/libs/execution/include/hpx/execution/executors/parallel_executor.hpp
+++ b/libs/execution/include/hpx/execution/executors/parallel_executor.hpp
@@ -13,8 +13,8 @@
 #include <hpx/config.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
 #include <hpx/assertion.hpp>
-#include <hpx/async_launch_policy_dispatch.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/execution/detail/async_launch_policy_dispatch.hpp>
 #include <hpx/execution/detail/post_policy_dispatch.hpp>
 #include <hpx/execution/executors/fused_bulk_execute.hpp>
 #include <hpx/execution/executors/static_chunk_size.hpp>

--- a/libs/execution/include/hpx/execution/executors/parallel_executor_aggregated.hpp
+++ b/libs/execution/include/hpx/execution/executors/parallel_executor_aggregated.hpp
@@ -12,8 +12,8 @@
 #define HPX_PARALLEL_EXECUTORS_PARALLEL_EXECUTOR_AGGREGATED_DEC_20_2018_0624PM
 
 #include <hpx/config.hpp>
-#include <hpx/async_launch_policy_dispatch.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/execution/detail/async_launch_policy_dispatch.hpp>
 #include <hpx/execution/detail/post_policy_dispatch.hpp>
 #include <hpx/execution/executors/static_chunk_size.hpp>
 #include <hpx/execution/traits/is_executor.hpp>

--- a/libs/execution/include/hpx/execution/executors/sequenced_executor.hpp
+++ b/libs/execution/include/hpx/execution/executors/sequenced_executor.hpp
@@ -10,13 +10,13 @@
 #define HPX_PARALLEL_EXECUTORS_SEQUENTIAL_EXECUTOR_MAY_11_2015_1050AM
 
 #include <hpx/config.hpp>
-#include <hpx/async_launch_policy_dispatch.hpp>
+#include <hpx/execution/detail/async_launch_policy_dispatch.hpp>
+#include <hpx/execution/detail/sync_launch_policy_dispatch.hpp>
 #include <hpx/execution/traits/is_executor.hpp>
 #include <hpx/functional/deferred_call.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/lcos/future.hpp>
 #include <hpx/pack_traversal/unwrap.hpp>
-#include <hpx/sync_launch_policy_dispatch.hpp>
 
 #include <hpx/execution/exception_list.hpp>
 

--- a/libs/execution/include/hpx/execution/executors/thread_pool_executor.hpp
+++ b/libs/execution/include/hpx/execution/executors/thread_pool_executor.hpp
@@ -13,9 +13,9 @@
 #include <hpx/config.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
 #include <hpx/assertion.hpp>
-#include <hpx/async_launch_policy_dispatch.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/execution/detail/async_launch_policy_dispatch.hpp>
 #include <hpx/execution/detail/post_policy_dispatch.hpp>
 #include <hpx/execution/executors/fused_bulk_execute.hpp>
 #include <hpx/execution/executors/static_chunk_size.hpp>


### PR DESCRIPTION
I had forgotten to turn on deprecation warnings for the `execution` module. This fixes that and the associated headers.