### PR TITLE
Add API guarantee notes to API reference documentation

### DIFF
--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -417,6 +417,8 @@ rst_prolog += '''
 .. |cpp20_p0443| replace:: P0443
 .. _cpp20_p0443: https://github.com/executors/issaquah_2016
 
+.. |semver| replace:: semver
+.. _semver: https://semver.org
 
 .. |ini_file_format| replace:: Windows INI file format
 .. _ini_file_format: https://en.wikipedia.org/wiki/INI_file

--- a/docs/sphinx/api.rst
+++ b/docs/sphinx/api.rst
@@ -9,6 +9,39 @@
 API reference
 =============
 
+|hpx| follows a versioning scheme with three numbers: ``major.minor.patch``. We
+guarantee no breaking changes in the API for patch releases. Minor releases may
+remove or break existing APIs, but only after a deprecation period of at least
+two minor releases. In rare cases do we outright remove old and unused
+functionality without a deprecation period.
+
+We do not provide any ABI compatibility guarantees between any versions, debug
+and release builds, and builds with different C++ standards.
+
+..
+
+   We follow |semver|_ for our API (starting from |hpx| 2.0.0). This means that
+   patch releases never change the public API, neither with additions nor
+   removals. Minor releases may add new functionality to the public API. Major
+   releases may both remove and add functionality to the public API.
+
+   We define the public API as any functionality in the ``hpx`` namespace,
+   excluding any ``detail`` or ``experimental`` namespace within the ``hpx``
+   namespace. We reserve the right to change any functionality in the ``detail``
+   and ``experimental`` namespaces even in patch releases. However, any
+   functionality in ``experimental`` is intended for eventual inclusion in the
+   public API, and we avoid excessively breaking APIs in the ``experimental``
+   namespace. In addition to the above, any macros starting with ``HPX_`` are
+   part of the public API.
+
+   We do not provide any ABI compatibility guarantees between any versions,
+   debug and release builds, and builds with different C++ standards.
+
+   Our build system provides compatibility guarantees only for |cmake| support.
+   Any other build system support may change even in patch releases. The public
+   API in terms of our build system are the ``HPX::`` targets provided by
+   ``find_package(HPX)``.
+
 Main |hpx| library reference
 ============================
 


### PR DESCRIPTION
Related to #4329. Location, wording etc. can all be changed. Just wanted to get this up for people to comment. Contains one section for our current guarantees (i.e. close to none), and a commented out section for a potential 2.0.0.

We can discuss this at tomorrow's meeting.