### PR TITLE
Changing sub-name sequencing for experimental namespace

### DIFF
--- a/libs/mpi/include/hpx/mpi/mpi_executor.hpp
+++ b/libs/mpi/include/hpx/mpi/mpi_executor.hpp
@@ -17,7 +17,7 @@
 
 #include <mpi.h>
 
-namespace hpx { namespace mpi { namespace experimental {
+namespace hpx { namespace experimental { namespace mpi {
 
     struct executor
     {
@@ -58,7 +58,7 @@ namespace hpx { namespace mpi { namespace experimental {
     private:
         MPI_Comm communicator_;
     };
-}}}    // namespace hpx::mpi::experimental
+}}}    // namespace hpx::experimental::mpi
 
 namespace hpx { namespace parallel { namespace execution {
 

--- a/libs/mpi/include/hpx/mpi/mpi_future.hpp
+++ b/libs/mpi/include/hpx/mpi/mpi_future.hpp
@@ -24,7 +24,7 @@
 
 #include <mpi.h>
 
-namespace hpx { namespace mpi { namespace experimental {
+namespace hpx { namespace experimental { namespace mpi {
 
     using print_on = debug::enable_print<false>;
     static constexpr print_on mpi_debug("MPI_FUT");
@@ -229,6 +229,6 @@ namespace hpx { namespace mpi { namespace experimental {
     {
         mpi_debug.debug(detail::get_mpi_info(), std::forward<Args>(args)...);
     }
-}}}    // namespace hpx::mpi::experimental
+}}}    // namespace hpx::experimental::mpi
 
 #endif

--- a/libs/mpi/src/force_linking.cpp
+++ b/libs/mpi/src/force_linking.cpp
@@ -17,7 +17,7 @@ namespace hpx { namespace mpi {
         static force_linking_helper helper
         {
 #if defined(HPX_DEBUG)
-            &experimental::detail::hpx_mpi_errhandler
+            &hpx::experimental::mpi::detail::hpx_mpi_errhandler
 #endif
         };
         return helper;

--- a/libs/mpi/src/mpi_future.cpp
+++ b/libs/mpi/src/mpi_future.cpp
@@ -20,7 +20,7 @@
 
 #include <mpi.h>
 
-namespace hpx { namespace mpi { namespace experimental {
+namespace hpx { namespace experimental { namespace mpi {
     namespace detail {
 
         // extract MPI error message
@@ -161,7 +161,7 @@ namespace hpx { namespace mpi { namespace experimental {
     }
 
     // Background progress function for MPI async operations
-    // Checks for completed MPI_Requests and sets mpi::experimental::future
+    // Checks for completed MPI_Requests and sets experimental::mpi::future
     // ready when found
     void poll()
     {
@@ -309,7 +309,7 @@ namespace hpx { namespace mpi { namespace experimental {
                     detail::get_active_futures().size())
                 {
                     HPX_THROW_EXCEPTION(invalid_status,
-                        "hpx::mpi::experimental::poll",
+                        "hpx::experimental::mpi::poll",
                         "Fatal Error: Mismatch in vectors");
                 }
 
@@ -337,7 +337,7 @@ namespace hpx { namespace mpi { namespace experimental {
             }
 
             // always set polling function before enabling polling
-            sched->set_user_polling_function(&hpx::mpi::experimental::poll);
+            sched->set_user_polling_function(&hpx::experimental::mpi::poll);
             sched->add_remove_scheduler_mode(
                 threads::policies::enable_user_polling,
                 threads::policies::do_background_work);
@@ -365,10 +365,10 @@ namespace hpx { namespace mpi { namespace experimental {
             MPI_Init_thread(nullptr, nullptr, required, &provided);
             if (provided < MPI_THREAD_FUNNELED)
             {
-                mpi_debug.error(debug::str<>("hpx::mpi::experimental::init"),
+                mpi_debug.error(debug::str<>("hpx::experimental::mpi::init"),
                     "init failed");
                 HPX_THROW_EXCEPTION(invalid_status,
-                    "hpx::mpi::experimental::init",
+                    "hpx::experimental::mpi::init",
                     "the MPI installation doesn't allow multiple threads");
             }
             MPI_Comm_rank(MPI_COMM_WORLD, &detail::get_mpi_info().rank_);
@@ -378,7 +378,7 @@ namespace hpx { namespace mpi { namespace experimental {
 
         if (mpi_debug.is_enabled())
         {
-            mpi_debug.debug(debug::str<>("hpx::mpi::experimental::init"),
+            mpi_debug.debug(debug::str<>("hpx::experimental::mpi::init"),
                 detail::get_mpi_info());
         }
 
@@ -441,4 +441,4 @@ namespace hpx { namespace mpi { namespace experimental {
                 hpx::resource::get_thread_pool(pool_name));
         }
     }
-}}}    // namespace hpx::mpi::experimental
+}}}    // namespace hpx::experimental::mpi

--- a/libs/mpi/tests/unit/mpi_ring_async.cpp
+++ b/libs/mpi/tests/unit/mpi_ring_async.cpp
@@ -60,10 +60,10 @@ int hpx_main(hpx::program_options::variables_map& vm)
     {
         //
         // tell the scheduler that we want to handle mpi in the background
-        // here we use the provided hpx::mpi::experimental::poll function but
+        // here we use the provided hpx::experimental::mpi::poll function but
         // a user provided function or lambda may be supplied
         //
-        hpx::mpi::experimental::enable_user_polling enable_polling;
+        hpx::experimental::mpi::enable_user_polling enable_polling;
 
         if (rank == 0)
         {
@@ -92,7 +92,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
             // all ranks pre-post a receive
             hpx::future<int> f_recv =
-                hpx::mpi::experimental::detail::async(MPI_Irecv, &tokens[i], 1,
+                hpx::experimental::mpi::detail::async(MPI_Irecv, &tokens[i], 1,
                     MPI_INT, rank_from, i, MPI_COMM_WORLD);
 
             // when the recv completes,
@@ -103,7 +103,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
                     // send the incremented token to the next rank
                     ++tokens[i];
                     hpx::future<void> f_send =
-                        hpx::mpi::experimental::detail::async(MPI_Isend,
+                        hpx::experimental::mpi::detail::async(MPI_Isend,
                             &tokens[i], 1, MPI_INT, rank_to, i, MPI_COMM_WORLD);
                     // when the send completes
                     f_send.then([=, &tokens, &counter](auto&&) {
@@ -122,7 +122,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
             // rank 0 starts the process with a send
             if (rank == 0)
             {
-                auto f_send = hpx::mpi::experimental::detail::async(MPI_Isend,
+                auto f_send = hpx::experimental::mpi::detail::async(MPI_Isend,
                     &tokens[i], 1, MPI_INT, rank_to, i, MPI_COMM_WORLD);
                 f_send.then([=, &tokens, &counter](auto&&) {
                     msg_send(rank, size, rank_to, rank_from, tokens[i], i);
@@ -131,7 +131,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         }
 
         // Our simple counter should reach zero when all send/recv pairs are done
-        hpx::mpi::experimental::wait([&]() { return counter != 0; });
+        hpx::experimental::mpi::wait([&]() { return counter != 0; });
 
         // let the user polling go out of scope
     }

--- a/libs/mpi/tests/unit/mpi_ring_async_executor.cpp
+++ b/libs/mpi/tests/unit/mpi_ring_async_executor.cpp
@@ -64,14 +64,14 @@ int hpx_main(hpx::program_options::variables_map& vm)
     }
 
     {
-        // this needs to scope all uses of hpx::mpi::experimental::executor
-        hpx::mpi::experimental::enable_user_polling enable_polling;
+        // this needs to scope all uses of hpx::experimental::mpi::executor
+        hpx::experimental::mpi::enable_user_polling enable_polling;
 
         // Ring send/recv around N ranks
         // Rank 0      : Send then Recv
         // Rank 1->N-1 : Recv then Send
 
-        hpx::mpi::experimental::executor exec(MPI_COMM_WORLD);
+        hpx::experimental::mpi::executor exec(MPI_COMM_WORLD);
 
         constexpr unsigned int n_loops = 20;
         std::atomic<int> counter(n_loops);
@@ -121,7 +121,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         }
 
         // Our simple counter should reach zero when all send/recv pairs are done
-        hpx::mpi::experimental::wait([&]() { return counter != 0; });
+        hpx::experimental::mpi::wait([&]() { return counter != 0; });
 
         // let the user polling go out of scope
     }


### PR DESCRIPTION
This change will simplify pulling things from the experimental namespace into the main namespace down the road as it makes different things in the experimental namespace more granular. I.e. if we at some point want to start the process of moving the facilities that are now in `namespace hpx::experimental::mpi` into the main namespace, this can be easiliy done with:
```
#if defined(HPX_EXPERIMENTAL_MPI_COMPATIBILITY
namespace hpx { namespace mpi {
    using namespace hpx::experimental::mpi;
}}
#endif
```
This wouldn't be possible with the current naming scheme.