### PR TITLE
Make sure version module uses HPX's binary dir, not the parent's

### DIFF
--- a/libs/version/CMakeLists.txt
+++ b/libs/version/CMakeLists.txt
@@ -31,4 +31,4 @@ add_hpx_module(version
   CMAKE_SUBDIRS
 )
 
-target_include_directories(hpx_version PRIVATE $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>)
+target_include_directories(hpx_version PRIVATE $<BUILD_INTERFACE:${HPX_BINARY_DIR}>)


### PR DESCRIPTION
Possibly fixes #4523. @kordejong mind giving this a try?

I'm not sure how best to test this... @kordejong with your permission I might just fork your `hello_hpx` repo and stick a CircleCI config in it and point it to the latest HPX master.