### PR TITLE
Make sure module API docs show up in correct order

### DIFF
--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -124,7 +124,7 @@ api_ref_file = '''
 '''
 
 
-for lib in breathe_projects_source:
+for lib in sorted(breathe_projects_source.keys()):
     lib_sources = breathe_projects_source[lib]
     if len(lib_sources[1]) == 0:
         continue


### PR DESCRIPTION
Fixes this funny order: https://stellar-group.github.io/hpx-docs/tags/1.4.1/html/api.html#modules-reference.