### PR TITLE
Enable compatibility headers for thread_executors module

### DIFF
--- a/libs/thread_executors/CMakeLists.txt
+++ b/libs/thread_executors/CMakeLists.txt
@@ -56,7 +56,7 @@ set(thread_executors_sources
 
 include(HPX_AddModule)
 add_hpx_module(thread_executors
-  COMPATIBILITY_HEADERS OFF
+  COMPATIBILITY_HEADERS ON
   DEPRECATION_WARNINGS
   FORCE_LINKING_GEN
   GLOBAL_HEADER_GEN ON


### PR DESCRIPTION
Fixes #4533.

I think I fixed this on another branch as well, but I can't find it now and it deserves its own PR anyway.
