### PR TITLE
Add generic allocator for execution policies

### DIFF
--- a/libs/algorithms/tests/regressions/count_3646.cpp
+++ b/libs/algorithms/tests/regressions/count_3646.cpp
@@ -39,6 +39,32 @@ struct BitCountingIterator : public Iterator<std::int64_t, stopValue>
         return countBits(this->state + n);
     }
 
+    BitCountingIterator& operator++()
+    {
+        ++(this->state);
+        return *this;
+    }
+
+    BitCountingIterator operator++(int)
+    {
+        auto copy = *this;
+        ++(*this);
+        return copy;
+    }
+
+    BitCountingIterator& operator--()
+    {
+        --(this->state);
+        return *this;
+    }
+
+    BitCountingIterator operator--(int)
+    {
+        auto copy = *this;
+        --(*this);
+        return copy;
+    }
+
 private:
     std::int64_t countBits(std::int64_t v) const
     {

--- a/libs/compute/include/hpx/compute/host/block_allocator.hpp
+++ b/libs/compute/include/hpx/compute/host/block_allocator.hpp
@@ -1,4 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2020 ETH Zurich
 //  Copyright (c) 2016 Thomas Heller
 //  Copyright (c) 2016 Hartmut Kaiser
 //
@@ -35,14 +36,205 @@
 #include <vector>
 
 namespace hpx { namespace compute { namespace host {
+    namespace detail {
+        /// The policy_allocator allocates blocks of memory touched according to
+        /// the distribution policy of the given executor.
+        template <typename T, typename Policy,
+            typename Enable = typename std::enable_if<hpx::parallel::execution::
+                    is_execution_policy<Policy>::value>::type>
+        struct policy_allocator
+        {
+            using policy_type = Policy;
+            using target_type = host::target;
+
+            using value_type = T;
+            using pointer = T*;
+            using const_pointer = const T*;
+            using reference = T&;
+            using const_reference = T const&;
+            using size_type = std::size_t;
+
+            using propagate_on_container_move_assignment = std::true_type;
+
+            template <typename U>
+            struct rebind
+            {
+                using other = policy_allocator<U, policy_type>;
+            };
+
+            policy_allocator(Policy&& policy)
+              : policy_(std::move(policy))
+            {
+            }
+
+            policy_allocator(Policy const& policy)
+              : policy_(policy)
+            {
+            }
+
+            policy_type const& policy() const
+            {
+                return policy_;
+            }
+
+            // Returns the actual address of x even in presence of overloaded
+            // operator&
+            pointer address(reference x) const noexcept
+            {
+                return &x;
+            }
+
+            const_pointer address(const_reference x) const noexcept
+            {
+                return &x;
+            }
+
+            // Allocates n * sizeof(T) bytes of uninitialized storage by calling
+            // topo.allocate(). The pointer hint may be used to provide locality of
+            // reference: the allocator, if supported by the implementation, will
+            // attempt to allocate the new memory block as close as possible to hint.
+            pointer allocate(
+                size_type n, std::allocator<void>::const_pointer hint = nullptr)
+            {
+                return reinterpret_cast<pointer>(
+                    hpx::threads::get_topology().allocate(n * sizeof(T)));
+            }
+
+            // Deallocates the storage referenced by the pointer p, which must be a
+            // pointer obtained by an earlier call to allocate(). The argument n
+            // must be equal to the first argument of the call to allocate() that
+            // originally produced p; otherwise, the behavior is undefined.
+            void deallocate(pointer p, size_type n)
+            {
+                hpx::threads::get_topology().deallocate(p, n);
+            }
+
+            // Returns the maximum theoretically possible value of n, for which the
+            // call allocate(n, 0) could succeed. In most implementations, this
+            // returns std::numeric_limits<size_type>::max() / sizeof(value_type).
+            size_type max_size() const noexcept
+            {
+                return (std::numeric_limits<size_type>::max)();
+            }
+
+        public:
+            // Constructs count objects of type T in allocated uninitialized
+            // storage pointed to by p, using placement-new. This will use the
+            // underlying executors to distribute the memory according to
+            // first touch memory placement.
+            template <typename U, typename... Args>
+            void bulk_construct(U* p, std::size_t count, Args&&... args)
+            {
+                if (count == std::size_t(0))
+                {
+                    return;
+                }
+
+                auto irange = boost::irange(std::size_t(0), count);
+
+                using iterator_type =
+                    boost::range_detail::integer_iterator<std::size_t>;
+                using partition_result_type =
+                    std::pair<iterator_type, iterator_type>;
+
+                using partitioner =
+                    parallel::util::partitioner_with_cleanup<decltype(policy_),
+                        void, partition_result_type>;
+                using cancellation_token = parallel::util::cancellation_token<
+                    parallel::util::detail::no_data>;
+
+                auto&& arguments =
+                    hpx::util::forward_as_tuple(std::forward<Args>(args)...);
+
+                cancellation_token tok;
+                partitioner::call(
+                    policy_, util::begin(irange), count,
+                    [&arguments, p, &tok](
+                        iterator_type it, std::size_t part_size) mutable
+                    -> partition_result_type {
+                        iterator_type last =
+                            parallel::util::loop_with_cleanup_n_with_token(
+                                it, part_size, tok,
+                                [&arguments, p](iterator_type it) {
+                                    using hpx::util::functional::
+                                        placement_new_one;
+                                    hpx::util::invoke_fused(
+                                        placement_new_one<U>(p + *it),
+                                        arguments);
+                                },
+                                // cleanup function, called for all elements of
+                                // current partition which succeeded before exception
+                                [p](iterator_type it) { (p + *it)->~U(); });
+                        return std::make_pair(it, last);
+                    },
+                    // finalize, called once if no error occurred
+                    [](std::vector<hpx::future<partition_result_type>>&&) {
+                        // do nothing
+                    },
+                    // cleanup function, called for each partition which
+                    // didn't fail, but only if at least one failed
+                    [p](partition_result_type&& r) -> void {
+                        while (r.first != r.second)
+                        {
+                            (p + *r.first)->~U();
+                            ++r.first;
+                        }
+                    });
+            }
+
+            // Constructs an object of type T in allocated uninitialized storage
+            // pointed to by p, using placement-new
+            template <typename U, typename... Args>
+            void construct(U* p, Args&&... args)
+            {
+                hpx::parallel::execution::sync_execute(
+                    hpx::util::functional::placement_new<U>(), p,
+                    std::forward<Args>(args)...);
+            }
+
+            // Calls the destructor of count objects pointed to by p
+            template <typename U>
+            void bulk_destroy(U* p, std::size_t count)
+            {
+                if (count == std::size_t(0))
+                {
+                    return;
+                }
+
+                // keep memory locality, use executor...
+                auto irange = boost::irange(std::size_t(0), count);
+                hpx::parallel::for_each(policy_, util::begin(irange),
+                    util::end(irange), [p](std::size_t i) { (p + i)->~U(); });
+            }
+
+            // Calls the destructor of the object pointed to by p
+            template <typename U>
+            void destroy(U* p)
+            {
+                p->~U();
+            }
+
+            // Required by hpx::compute::traits::allocator_traits. Return
+            // default target.
+            target_type const& target() const noexcept
+            {
+                return target_;
+            }
+
+        private:
+            target_type target_;
+            policy_type policy_;
+        };
+    }    // namespace detail
+
     /// The block_allocator allocates blocks of memory evenly divided onto the
     /// passed vector of targets. This is done by using first touch memory
-    /// placement. (maybe better methods will be used in the future...);
+    /// placement.
     ///
     /// This allocator can be used to write NUMA aware algorithms:
     ///
-    /// typedef hpx::compute::host::block_allocator<int> allocator_type;
-    /// typedef hpx::compute::vector<int, allocator_type> vector_type;
+    /// using allocator_type = hpx::compute::host::block_allocator<int>;
+    /// using vector_type = hpx::compute::vector<int, allocator_type>;
     ///
     /// auto numa_nodes = hpx::compute::host::numa_domains();
     /// std::size_t N = 2048;
@@ -52,224 +244,43 @@ namespace hpx { namespace compute { namespace host {
         typename Executor =
             hpx::parallel::execution::restricted_thread_pool_executor>
     struct block_allocator
+      : public detail::policy_allocator<T,
+            hpx::parallel::execution::parallel_policy_shim<
+                block_executor<Executor>,
+                typename block_executor<Executor>::executor_parameters_type>>
     {
-        typedef T value_type;
-        typedef T* pointer;
-        typedef const T* const_pointer;
-        typedef T& reference;
-        typedef T const& const_reference;
-        typedef std::size_t size_type;
-        typedef std::ptrdiff_t difference_type;
-
-        typedef Executor executor_type;
-
-        template <typename U>
-        struct rebind
-        {
-            typedef block_allocator<U> other;
-        };
-
-        typedef std::false_type is_always_equal;
-        typedef std::true_type propagate_on_container_move_assignment;
-
-        typedef std::vector<host::target> target_type;
+        using executor_type = block_executor<Executor>;
+        using executor_parameters_type =
+            typename executor_type::executor_parameters_type;
+        using policy_type =
+            hpx::parallel::execution::parallel_policy_shim<executor_type,
+                executor_parameters_type>;
+        using base_type = detail::policy_allocator<T, policy_type>;
+        using target_type = std::vector<host::target>;
 
         block_allocator()
-          : executor_(target_type(1))
+          : base_type(policy_type(
+                executor_type(target_type(1)), executor_parameters_type()))
         {
         }
 
         block_allocator(target_type const& targets)
-          : executor_(targets)
+          : base_type(
+                policy_type(executor_type(targets), executor_parameters_type()))
         {
         }
 
         block_allocator(target_type&& targets)
-          : executor_(targets)
+          : base_type(policy_type(
+                executor_type(std::move(targets)), executor_parameters_type()))
         {
-        }
-
-        block_allocator(block_allocator const& alloc)
-          : executor_(alloc.executor_)
-        {
-        }
-
-        block_allocator(block_allocator&& alloc)
-          : executor_(std::move(alloc.executor_))
-        {
-        }
-
-        template <typename U>
-        block_allocator(block_allocator<U> const& alloc)
-          : executor_(alloc.executor_)
-        {
-        }
-
-        template <typename U>
-        block_allocator(block_allocator<U>&& alloc)
-          : executor_(std::move(alloc.executor_))
-        {
-        }
-
-        block_allocator& operator=(block_allocator const& rhs)
-        {
-            executor_ = rhs.executor_;
-            return *this;
-        }
-        block_allocator& operator=(block_allocator&& rhs)
-        {
-            executor_ = std::move(rhs.executor_);
-            return *this;
-        }
-
-        // Returns the actual address of x even in presence of overloaded
-        // operator&
-        pointer address(reference x) const noexcept
-        {
-            return &x;
-        }
-
-        const_pointer address(const_reference x) const noexcept
-        {
-            return &x;
-        }
-
-        // Allocates n * sizeof(T) bytes of uninitialized storage by calling
-        // topo.allocate(). The pointer hint may be used to provide locality of
-        // reference: the allocator, if supported by the implementation, will
-        // attempt to allocate the new memory block as close as possible to hint.
-        pointer allocate(
-            size_type n, std::allocator<void>::const_pointer hint = nullptr)
-        {
-            return reinterpret_cast<pointer>(
-                hpx::threads::get_topology().allocate(n * sizeof(T)));
-        }
-
-        // Deallocates the storage referenced by the pointer p, which must be a
-        // pointer obtained by an earlier call to allocate(). The argument n
-        // must be equal to the first argument of the call to allocate() that
-        // originally produced p; otherwise, the behavior is undefined.
-        void deallocate(pointer p, size_type n)
-        {
-            hpx::threads::get_topology().deallocate(p, n);
-        }
-
-        // Returns the maximum theoretically possible value of n, for which the
-        // call allocate(n, 0) could succeed. In most implementations, this
-        // returns std::numeric_limits<size_type>::max() / sizeof(value_type).
-        size_type max_size() const noexcept
-        {
-            return (std::numeric_limits<size_type>::max)();
-        }
-
-    public:
-        // Constructs count objects of type T in allocated uninitialized
-        // storage pointed to by p, using placement-new. This will use the
-        // underlying executors to distribute the memory according to
-        // first touch memory placement.
-        template <typename U, typename... Args>
-        void bulk_construct(U* p, std::size_t count, Args&&... args)
-        {
-            if (count == std::size_t(0))
-            {
-                return;
-            }
-
-            auto irange = boost::irange(std::size_t(0), count);
-            auto policy =
-                hpx::parallel::execution::parallel_policy().on(executor_).with(
-                    hpx::parallel::execution::static_chunk_size());
-
-            typedef boost::range_detail::integer_iterator<std::size_t>
-                iterator_type;
-            typedef std::pair<iterator_type, iterator_type>
-                partition_result_type;
-
-            typedef parallel::util::partitioner_with_cleanup<decltype(policy),
-                void, partition_result_type>
-                partitioner;
-            typedef parallel::util::cancellation_token<
-                parallel::util::detail::no_data>
-                cancellation_token;
-
-            auto&& arguments =
-                hpx::util::forward_as_tuple(std::forward<Args>(args)...);
-
-            cancellation_token tok;
-            partitioner::call(
-                std::move(policy), util::begin(irange), count,
-                [&arguments, p, &tok](iterator_type it,
-                    std::size_t part_size) mutable -> partition_result_type {
-                    iterator_type last =
-                        parallel::util::loop_with_cleanup_n_with_token(
-                            it, part_size, tok,
-                            [&arguments, p](iterator_type it) {
-                                using hpx::util::functional::placement_new_one;
-                                hpx::util::invoke_fused(
-                                    placement_new_one<U>(p + *it), arguments);
-                            },
-                            // cleanup function, called for all elements of
-                            // current partition which succeeded before exception
-                            [p](iterator_type it) { (p + *it)->~U(); });
-                    return std::make_pair(it, last);
-                },
-                // finalize, called once if no error occurred
-                [](std::vector<hpx::future<partition_result_type>>&&) {
-                    // do nothing
-                },
-                // cleanup function, called for each partition which
-                // didn't fail, but only if at least one failed
-                [p](partition_result_type&& r) -> void {
-                    while (r.first != r.second)
-                    {
-                        (p + *r.first)->~U();
-                        ++r.first;
-                    }
-                });
-        }
-
-        // Constructs an object of type T in allocated uninitialized storage
-        // pointed to by p, using placement-new
-        template <typename U, typename... Args>
-        void construct(U* p, Args&&... args)
-        {
-            executor_.execute(hpx::util::functional::placement_new<U>(), p,
-                std::forward<Args>(args)...);
-        }
-
-        // Calls the destructor of count objects pointed to by p
-        template <typename U>
-        void bulk_destroy(U* p, std::size_t count)
-        {
-            if (count == std::size_t(0))
-            {
-                return;
-            }
-
-            // keep memory locality, use executor...
-            auto irange = boost::irange(std::size_t(0), count);
-            hpx::parallel::for_each(
-                hpx::parallel::execution::par.on(executor_).with(
-                    hpx::parallel::execution::static_chunk_size()),
-                util::begin(irange), util::end(irange),
-                [p](std::size_t i) { (p + i)->~U(); });
-        }
-
-        // Calls the destructor of the object pointed to by p
-        template <typename U>
-        void destroy(U* p)
-        {
-            p->~U();
         }
 
         // Access the underlying target (device)
         target_type const& target() const noexcept
         {
-            return executor_.targets();
+            return this->policy().executor().targets();
         }
-
-    private:
-        block_executor<executor_type> executor_;
     };
 }}}    // namespace hpx::compute::host
 

--- a/libs/compute/include/hpx/compute/traits/allocator_traits.hpp
+++ b/libs/compute/include/hpx/compute/traits/allocator_traits.hpp
@@ -80,7 +80,7 @@ namespace hpx { namespace compute { namespace traits {
         template <typename Allocator, typename Enable = void>
         struct target_helper_result
         {
-            typedef compute::host::target& type;
+            typedef compute::host::target type;
         };
 
         template <typename Allocator>
@@ -95,11 +95,10 @@ namespace hpx { namespace compute { namespace traits {
         struct target_helper
         {
             template <typename Allocator>
-            HPX_HOST_DEVICE static compute::host::target& call(
+            HPX_HOST_DEVICE static compute::host::target call(
                 hpx::traits::detail::wrap_int, Allocator const& alloc)
             {
-                static compute::host::target t;
-                return t;
+                return compute::host::target();
             }
 
             template <typename Allocator>

--- a/libs/execution/include/hpx/execution/executors/static_chunk_size.hpp
+++ b/libs/execution/include/hpx/execution/executors/static_chunk_size.hpp
@@ -64,7 +64,7 @@ namespace hpx { namespace parallel { namespace execution {
 
             if (cores == 1)
             {
-                return 1;
+                return num_tasks;
             }
 
             // Make sure the internal round robin counter of the executor is

--- a/libs/execution/include/hpx/execution/executors/static_chunk_size.hpp
+++ b/libs/execution/include/hpx/execution/executors/static_chunk_size.hpp
@@ -56,6 +56,10 @@ namespace hpx { namespace parallel { namespace execution {
         std::size_t get_chunk_size(
             Executor& exec, F&&, std::size_t cores, std::size_t num_tasks)
         {
+            // Make sure the internal round robin counter of the executor is
+            // reset
+            execution::reset_thread_distribution(*this, exec);
+
             // use the given chunk size if given
             if (chunk_size_ != 0)
             {
@@ -66,10 +70,6 @@ namespace hpx { namespace parallel { namespace execution {
             {
                 return num_tasks;
             }
-
-            // Make sure the internal round robin counter of the executor is
-            // reset
-            execution::reset_thread_distribution(*this, exec);
 
             // Return a chunk size that is a power of two; and that leads to at
             // least 2 chunks per core, and at most 4 chunks per core.

--- a/libs/execution/include/hpx/execution/executors/static_chunk_size.hpp
+++ b/libs/execution/include/hpx/execution/executors/static_chunk_size.hpp
@@ -58,16 +58,28 @@ namespace hpx { namespace parallel { namespace execution {
         {
             // use the given chunk size if given
             if (chunk_size_ != 0)
+            {
                 return chunk_size_;
+            }
+
+            if (cores == 1)
+            {
+                return 1;
+            }
 
             // Make sure the internal round robin counter of the executor is
             // reset
             execution::reset_thread_distribution(*this, exec);
 
-            // by default use static work distribution over number of
-            // available compute resources, create four times the number of
-            // chunks than we have cores
-            return (num_tasks + 4 * cores - 1) / (4 * cores);    // -V112
+            // Return a chunk size that is a power of two; and that leads to at
+            // least 2 chunks per core, and at most 4 chunks per core.
+            std::size_t chunk_size = 1;
+            while (chunk_size * cores * 4 < num_tasks)
+            {
+                chunk_size *= 2;
+            }
+
+            return chunk_size;
         }
         /// \endcond
 

--- a/tests/performance/local/stream.cpp
+++ b/tests/performance/local/stream.cpp
@@ -17,18 +17,18 @@
 #define BOOST_NO_CXX11_ALLOCATOR
 #endif
 
-#include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/version.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/compute.hpp>
+#include <hpx/include/iostreams.hpp>
 #include <hpx/include/parallel_copy.hpp>
+#include <hpx/include/parallel_executor_parameters.hpp>
+#include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/parallel_fill.hpp>
 #include <hpx/include/parallel_transform.hpp>
-#include <hpx/include/parallel_executors.hpp>
-#include <hpx/include/parallel_executor_parameters.hpp>
-#include <hpx/include/iostreams.hpp>
 #include <hpx/include/threads.hpp>
-#include <hpx/include/compute.hpp>
 #include <hpx/type_support/unused.hpp>
+#include <hpx/version.hpp>
 
 #include <cstddef>
 #include <iostream>
@@ -61,9 +61,10 @@ int checktick()
     double t1, t2, timesfound[M];
 
     // Collect a sequence of M unique time values from the system.
-    for (std::size_t i = 0; i < M; i++) {
+    for (std::size_t i = 0; i < M; i++)
+    {
         t1 = mysecond();
-        while( ((t2=mysecond()) - t1) < 1.0E-6 )
+        while (((t2 = mysecond()) - t1) < 1.0E-6)
             ;
         timesfound[i] = t1 = t2;
     }
@@ -72,34 +73,35 @@ int checktick()
     // This result will be our estimate (in microseconds) for the
     // clock granularity.
     minDelta = 1000000;
-    for (std::size_t i = 1; i < M; i++) {
-        Delta = (int)( 1.0E6 * (timesfound[i]-timesfound[i-1]));
-        minDelta = (std::min)(minDelta, (std::max)(Delta,0));
+    for (std::size_t i = 1; i < M; i++)
+    {
+        Delta = (int) (1.0E6 * (timesfound[i] - timesfound[i - 1]));
+        minDelta = (std::min)(minDelta, (std::max)(Delta, 0));
     }
 
-    return(minDelta);
+    return (minDelta);
 }
 
 template <typename Vector>
-void check_results(std::size_t iterations,
-    Vector const & a_res, Vector const & b_res, Vector const & c_res)
+void check_results(std::size_t iterations, Vector const& a_res,
+    Vector const& b_res, Vector const& c_res)
 {
     std::vector<STREAM_TYPE> a(a_res.size());
     std::vector<STREAM_TYPE> b(b_res.size());
     std::vector<STREAM_TYPE> c(c_res.size());
 
-    hpx::parallel::copy(hpx::parallel::execution::par,
-        a_res.begin(), a_res.end(), a.begin());
-    hpx::parallel::copy(hpx::parallel::execution::par,
-        b_res.begin(), b_res.end(), b.begin());
-    hpx::parallel::copy(hpx::parallel::execution::par,
-        c_res.begin(), c_res.end(), c.begin());
+    hpx::parallel::copy(
+        hpx::parallel::execution::par, a_res.begin(), a_res.end(), a.begin());
+    hpx::parallel::copy(
+        hpx::parallel::execution::par, b_res.begin(), b_res.end(), b.begin());
+    hpx::parallel::copy(
+        hpx::parallel::execution::par, c_res.begin(), c_res.end(), c.begin());
 
-    STREAM_TYPE aj,bj,cj,scalar;
-    STREAM_TYPE aSumErr,bSumErr,cSumErr;
-    STREAM_TYPE aAvgErr,bAvgErr,cAvgErr;
+    STREAM_TYPE aj, bj, cj, scalar;
+    STREAM_TYPE aSumErr, bSumErr, cSumErr;
+    STREAM_TYPE aAvgErr, bAvgErr, cAvgErr;
     double epsilon;
-    int ierr,err;
+    int ierr, err;
 
     /* reproduce initialization */
     aj = 1.0;
@@ -109,19 +111,20 @@ void check_results(std::size_t iterations,
     aj = 2.0E0 * aj;
     /* now execute timing loop */
     scalar = 3.0;
-    for (std::size_t k=0; k<iterations; k++)
-        {
-            cj = aj;
-            bj = scalar*cj;
-            cj = aj+bj;
-            aj = bj+scalar*cj;
-        }
+    for (std::size_t k = 0; k < iterations; k++)
+    {
+        cj = aj;
+        bj = scalar * cj;
+        cj = aj + bj;
+        aj = bj + scalar * cj;
+    }
 
     /* accumulate deltas between observed and expected results */
     aSumErr = 0.0;
     bSumErr = 0.0;
     cSumErr = 0.0;
-    for (std::size_t j=0; j<a.size(); j++) {
+    for (std::size_t j = 0; j < a.size(); j++)
+    {
         aSumErr += std::abs(a[j] - aj);
         bSumErr += std::abs(b[j] - bj);
         cSumErr += std::abs(c[j] - cj);
@@ -131,93 +134,110 @@ void check_results(std::size_t iterations,
     bAvgErr = bSumErr / (STREAM_TYPE) a.size();
     cAvgErr = cSumErr / (STREAM_TYPE) a.size();
 
-    if (sizeof(STREAM_TYPE) == 4) {
+    if (sizeof(STREAM_TYPE) == 4)
+    {
         epsilon = 1.e-6;
     }
-    else if (sizeof(STREAM_TYPE) == 8) {
+    else if (sizeof(STREAM_TYPE) == 8)
+    {
         epsilon = 1.e-13;
     }
-    else {
+    else
+    {
         printf("WEIRD: sizeof(STREAM_TYPE) = %zu\n", sizeof(STREAM_TYPE));
         epsilon = 1.e-6;
     }
 
     err = 0;
-    if (std::abs(aAvgErr/aj) > epsilon) {
+    if (std::abs(aAvgErr / aj) > epsilon)
+    {
         err++;
-        printf ("Failed Validation on array a[], AvgRelAbsErr > epsilon (%e)\n",
+        printf("Failed Validation on array a[], AvgRelAbsErr > epsilon (%e)\n",
             epsilon);
-        printf ("     Expected Value: %e, AvgAbsErr: %e, AvgRelAbsErr: %e\n",
-            aj,aAvgErr,std::abs(aAvgErr)/aj);
+        printf("     Expected Value: %e, AvgAbsErr: %e, AvgRelAbsErr: %e\n", aj,
+            aAvgErr, std::abs(aAvgErr) / aj);
         ierr = 0;
-        for (std::size_t j=0; j<a.size(); j++) {
-            if (std::abs(a[j]/aj-1.0) > epsilon) {
+        for (std::size_t j = 0; j < a.size(); j++)
+        {
+            if (std::abs(a[j] / aj - 1.0) > epsilon)
+            {
                 ierr++;
 #ifdef VERBOSE
-                if (ierr < 10) {
+                if (ierr < 10)
+                {
                     printf("         array a: index: %ld, expected: %e, "
-                        "observed: %e, relative error: %e\n",
-                        j,aj,a[j],std::abs((aj-a[j])/aAvgErr));
+                           "observed: %e, relative error: %e\n",
+                        j, aj, a[j], std::abs((aj - a[j]) / aAvgErr));
                 }
 #endif
             }
         }
-        printf("     For array a[], %d errors were found.\n",ierr);
+        printf("     For array a[], %d errors were found.\n", ierr);
     }
-    if (std::abs(bAvgErr/bj) > epsilon) {
+    if (std::abs(bAvgErr / bj) > epsilon)
+    {
         err++;
-        printf ("Failed Validation on array b[], AvgRelAbsErr > epsilon (%e)\n",
+        printf("Failed Validation on array b[], AvgRelAbsErr > epsilon (%e)\n",
             epsilon);
-        printf ("     Expected Value: %e, AvgAbsErr: %e, AvgRelAbsErr: %e\n",
-            bj,bAvgErr,std::abs(bAvgErr)/bj);
-        printf ("     AvgRelAbsErr > Epsilon (%e)\n",epsilon);
+        printf("     Expected Value: %e, AvgAbsErr: %e, AvgRelAbsErr: %e\n", bj,
+            bAvgErr, std::abs(bAvgErr) / bj);
+        printf("     AvgRelAbsErr > Epsilon (%e)\n", epsilon);
         ierr = 0;
-        for (std::size_t j=0; j<a.size(); j++) {
-            if (std::abs(b[j]/bj-1.0) > epsilon) {
+        for (std::size_t j = 0; j < a.size(); j++)
+        {
+            if (std::abs(b[j] / bj - 1.0) > epsilon)
+            {
                 ierr++;
 #ifdef VERBOSE
-                if (ierr < 10) {
+                if (ierr < 10)
+                {
                     printf("         array b: index: %ld, expected: %e, "
-                        "observed: %e, relative error: %e\n",
-                        j,bj,b[j],std::abs((bj-b[j])/bAvgErr));
+                           "observed: %e, relative error: %e\n",
+                        j, bj, b[j], std::abs((bj - b[j]) / bAvgErr));
                 }
 #endif
             }
         }
-        printf("     For array b[], %d errors were found.\n",ierr);
+        printf("     For array b[], %d errors were found.\n", ierr);
     }
-    if (std::abs(cAvgErr/cj) > epsilon) {
+    if (std::abs(cAvgErr / cj) > epsilon)
+    {
         err++;
-        printf ("Failed Validation on array c[], AvgRelAbsErr > epsilon (%e)\n",
+        printf("Failed Validation on array c[], AvgRelAbsErr > epsilon (%e)\n",
             epsilon);
-        printf ("     Expected Value: %e, AvgAbsErr: %e, AvgRelAbsErr: %e\n",
-            cj,cAvgErr,std::abs(cAvgErr)/cj);
-        printf ("     AvgRelAbsErr > Epsilon (%e)\n",epsilon);
+        printf("     Expected Value: %e, AvgAbsErr: %e, AvgRelAbsErr: %e\n", cj,
+            cAvgErr, std::abs(cAvgErr) / cj);
+        printf("     AvgRelAbsErr > Epsilon (%e)\n", epsilon);
         ierr = 0;
-        for (std::size_t j=0; j<a.size(); j++) {
-            if (std::abs(c[j]/cj-1.0) > epsilon) {
+        for (std::size_t j = 0; j < a.size(); j++)
+        {
+            if (std::abs(c[j] / cj - 1.0) > epsilon)
+            {
                 ierr++;
 #ifdef VERBOSE
-                if (ierr < 10) {
+                if (ierr < 10)
+                {
                     printf("         array c: index: %ld, expected: %e, "
-                        "observed: %e, relative error: %e\n",
-                        j,cj,c[j],std::abs((cj-c[j])/cAvgErr));
+                           "observed: %e, relative error: %e\n",
+                        j, cj, c[j], std::abs((cj - c[j]) / cAvgErr));
                 }
 #endif
             }
         }
-        printf("     For array c[], %d errors were found.\n",ierr);
+        printf("     For array c[], %d errors were found.\n", ierr);
     }
-    if (err == 0) {
-        printf ("Solution Validates: avg error less than %e on all three arrays\n",
+    if (err == 0)
+    {
+        printf(
+            "Solution Validates: avg error less than %e on all three arrays\n",
             epsilon);
     }
 #ifdef VERBOSE
-    printf ("Results Validation Verbose Results: \n");
-    printf ("    Expected a(1), b(1), c(1): %f %f %f \n",aj,bj,cj);
-    printf ("    Observed a(1), b(1), c(1): %f %f %f \n",a[1],b[1],c[1]);
-    printf ("    Rel Errors on a, b, c:     %e %e %e \n",std::abs(aAvgErr/aj),
-        std::abs(bAvgErr/bj),std::abs(cAvgErr/cj));
+    printf("Results Validation Verbose Results: \n");
+    printf("    Expected a(1), b(1), c(1): %f %f %f \n", aj, bj, cj);
+    printf("    Observed a(1), b(1), c(1): %f %f %f \n", a[1], b[1], c[1]);
+    printf("    Rel Errors on a, b, c:     %e %e %e \n", std::abs(aAvgErr / aj),
+        std::abs(bAvgErr / bj), std::abs(cAvgErr / cj));
 #endif
 }
 
@@ -225,13 +245,16 @@ void check_results(std::size_t iterations,
 template <typename T>
 struct multiply_step
 {
-    multiply_step(T factor) : factor_(factor) {}
+    multiply_step(T factor)
+      : factor_(factor)
+    {
+    }
 
     // FIXME : call operator of multiply_step is momentarily defined with
     //         a generic parameter to allow the host_side invoke_result<>
     //         (used in invoke()) to get the return type
 
-    template<typename U>
+    template <typename U>
     HPX_HOST_DEVICE HPX_FORCEINLINE T operator()(U val) const
     {
         return val * factor_;
@@ -247,7 +270,7 @@ struct add_step
     //         generic parameters to allow the host_side invoke_result<>
     //         (used in invoke()) to get the return type
 
-    template<typename U>
+    template <typename U>
     HPX_HOST_DEVICE HPX_FORCEINLINE T operator()(U val1, U val2) const
     {
         return val1 + val2;
@@ -257,13 +280,16 @@ struct add_step
 template <typename T>
 struct triad_step
 {
-    triad_step(T factor) : factor_(factor) {}
+    triad_step(T factor)
+      : factor_(factor)
+    {
+    }
 
     // FIXME : call operator of triad_step is momentarily defined with
     //         generic parameters to allow the host_side invoke_result<>
     //         (used in invoke()) to get the return type
 
-    template<typename U>
+    template <typename U>
     HPX_HOST_DEVICE HPX_FORCEINLINE T operator()(U val1, U val2) const
     {
         return val1 + val2 * factor_;
@@ -274,12 +300,11 @@ struct triad_step
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename Allocator, typename Policy>
-std::vector<std::vector<double> >
-run_benchmark(
-    std::size_t iterations, std::size_t size, Allocator && alloc, Policy && policy)
+std::vector<std::vector<double>> run_benchmark(std::size_t iterations,
+    std::size_t size, Allocator&& alloc, Policy&& policy)
 {
     // Allocate our data
-    typedef hpx::compute::vector<STREAM_TYPE, Allocator> vector_type;
+    using vector_type = hpx::compute::vector<STREAM_TYPE, Allocator>;
 
     vector_type a(size, alloc);
     vector_type b(size, alloc);
@@ -293,49 +318,43 @@ run_benchmark(
     // Check clock ticks ...
     double t = mysecond();
     hpx::parallel::transform(
-        policy, a.begin(), a.end(), a.begin(),
-        multiply_step<STREAM_TYPE>(2.0));
+        policy, a.begin(), a.end(), a.begin(), multiply_step<STREAM_TYPE>(2.0));
     t = 1.0E6 * (mysecond() - t);
 
     // Get initial value for system clock.
     int quantum = checktick();
-    if(quantum >= 1)
+    if (quantum >= 1)
     {
-        std::cout
-            << "Your clock granularity/precision appears to be " << quantum
-            << " microseconds.\n"
-            ;
+        std::cout << "Your clock granularity/precision appears to be "
+                  << quantum << " microseconds.\n";
     }
     else
     {
-        std::cout
-            << "Your clock granularity appears to be less than one microsecond.\n"
-            ;
+        std::cout << "Your clock granularity appears to be less than one "
+                     "microsecond.\n";
         quantum = 1;
     }
 
     std::cout
         << "Each test below will take on the order"
         << " of " << (int) t << " microseconds.\n"
-        << "   (= " << (int) (t/quantum) << " clock ticks)\n"
+        << "   (= " << (int) (t / quantum) << " clock ticks)\n"
         << "Increase the size of the arrays if this shows that\n"
         << "you are not getting at least 20 clock ticks per test.\n"
-        << "-------------------------------------------------------------\n"
-        ;
+        << "-------------------------------------------------------------\n";
 
     std::cout
         << "WARNING -- The above is only a rough guideline.\n"
         << "For best results, please be sure you know the\n"
         << "precision of your system timer.\n"
-        << "-------------------------------------------------------------\n"
-        ;
+        << "-------------------------------------------------------------\n";
 
     ///////////////////////////////////////////////////////////////////////////
     // Main Loop
-    std::vector<std::vector<double> > timing(4, std::vector<double>(iterations));
+    std::vector<std::vector<double>> timing(4, std::vector<double>(iterations));
 
     double scalar = 3.0;
-    for(std::size_t iteration = 0; iteration != iterations; ++iteration)
+    for (std::size_t iteration = 0; iteration != iterations; ++iteration)
     {
         // Copy
         timing[0][iteration] = mysecond();
@@ -344,26 +363,20 @@ run_benchmark(
 
         // Scale
         timing[1][iteration] = mysecond();
-        hpx::parallel::transform(policy,
-            c.begin(), c.end(), b.begin(),
-            multiply_step<STREAM_TYPE>(scalar)
-        );
+        hpx::parallel::transform(policy, c.begin(), c.end(), b.begin(),
+            multiply_step<STREAM_TYPE>(scalar));
         timing[1][iteration] = mysecond() - timing[1][iteration];
 
         // Add
         timing[2][iteration] = mysecond();
-        hpx::parallel::transform(policy,
-            a.begin(), a.end(), b.begin(), b.end(), c.begin(),
-            add_step<STREAM_TYPE>()
-        );
+        hpx::parallel::transform(policy, a.begin(), a.end(), b.begin(), b.end(),
+            c.begin(), add_step<STREAM_TYPE>());
         timing[2][iteration] = mysecond() - timing[2][iteration];
 
         // Triad
         timing[3][iteration] = mysecond();
-        hpx::parallel::transform(policy,
-            b.begin(), b.end(), c.begin(), c.end(), a.begin(),
-            triad_step<STREAM_TYPE>(scalar)
-        );
+        hpx::parallel::transform(policy, b.begin(), b.end(), c.begin(), c.end(),
+            a.begin(), triad_step<STREAM_TYPE>(scalar));
         timing[3][iteration] = mysecond() - timing[3][iteration];
     }
 
@@ -371,8 +384,7 @@ run_benchmark(
     check_results(iterations, a, b, c);
 
     std::cout
-        << "-------------------------------------------------------------\n"
-        ;
+        << "-------------------------------------------------------------\n";
 
     return timing;
 }
@@ -390,6 +402,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
     std::string chunker = vm["chunker"].as<std::string>();
 
+    // clang-format off
     std::cout
         << "-------------------------------------------------------------\n"
         << "Modified STREAM benchmark based on\nHPX version: "
@@ -412,117 +425,124 @@ int hpx_main(hpx::program_options::variables_map& vm)
         << "Number of Threads requested = "
             << hpx::get_os_thread_count() << "\n"
         << "Chunking policy requested: " << chunker << "\n"
+        << "Executor requested: " << executor << "\n"
         << "-------------------------------------------------------------\n"
         ;
+    // clang-format on
 
     double time_total = mysecond();
-    std::vector<std::vector<double> > timing;
+    std::vector<std::vector<double>> timing;
 
 #if defined(HPX_HAVE_COMPUTE)
     bool use_accel = false;
-    if(vm.count("use-accelerator"))
+    if (vm.count("use-accelerator"))
         use_accel = true;
 
-    if(use_accel)
+    if (use_accel)
     {
 #if defined(HPX_HAVE_CUDA)
+        using executor_type = hpx::compute::cuda::concurrent_executor<>;
+        using allocator_type = hpx::compute::cuda::allocator<STREAM_TYPE>;
+
         // Get the cuda targets we want to run on
         hpx::compute::cuda::target target;
 
         // Get the host targets we want to run on
         auto host_targets = hpx::compute::host::get_local_targets();
 
-        typedef hpx::compute::cuda::concurrent_executor<> executor_type;
-        //typedef hpx::compute::cuda::default_executor executor_type;
-        typedef hpx::compute::cuda::allocator<STREAM_TYPE> allocator_type;
+        auto numa_nodes = hpx::compute::host::numa_domains();
+        allocator_type alloc(target);
+        executor_type exec(target, host_targets);
+        auto policy = hpx::parallel::execution::par.on(exec);
+
 #else
 #error "The STREAM benchmark currently requires CUDA to run on an accelerator"
 #endif
         // perform benchmark
-        timing =
-            run_benchmark<allocator_type, executor_type>(
-                iterations, vector_size, std::move(target), std::move(host_targets));
-                //iterations, vector_size, std::move(target));
+        timing = run_benchmark<>(
+            iterations, vector_size, std::move(alloc), std::move(policy));
+        //iterations, vector_size, std::move(target));
     }
     else
 #endif
     {
-        if (executor == 3)
+        if (executor == 0)
         {
-            // perform benchmark
-            timing = run_benchmark<>(iterations, vector_size, std::allocator<STREAM_TYPE>{}, hpx::parallel::execution::par);
-        }
-        else if (executor == 0)
-        {
-            typedef hpx::compute::host::block_executor<> executor_type;
-            typedef hpx::compute::host::block_allocator<STREAM_TYPE> allocator_type;
-
-            //auto numa_nodes = hpx::compute::host::numa_domains();
-            ////allocator_type alloc(numa_nodes);
-            //std::allocator<STREAM_TYPE> alloc{};
-            //executor_type exec();//numa_nodes);
-            //auto policy = hpx::parallel::execution::par.on(exec);
-
-            //std::allocator<STREAM_TYPE> alloc{};
-            //auto policy = hpx::parallel::execution::par;
-
-            //// perform benchmark
-            //timing = run_benchmark<>(iterations, vector_size, alloc, policy);
+            // Default parallel policy with serial allocator.
+            timing = run_benchmark<>(iterations, vector_size,
+                std::allocator<STREAM_TYPE>{}, hpx::parallel::execution::par);
         }
         else if (executor == 1)
         {
-            typedef hpx::parallel::execution::parallel_executor executor_type;
-            auto policy = hpx::parallel::execution::par.on(executor_type());
+            // Block executor with block allocator.
+            using executor_type = hpx::compute::host::block_executor<>;
+            using allocator_type =
+                hpx::compute::host::block_allocator<STREAM_TYPE>;
 
-            typedef hpx::compute::host::detail::policy_allocator<STREAM_TYPE, decltype(policy)> allocator_type;
+            auto numa_nodes = hpx::compute::host::numa_domains();
+            allocator_type alloc(numa_nodes);
+            executor_type exec(numa_nodes);
+            auto policy = hpx::parallel::execution::par.on(exec);
 
-            allocator_type alloc(policy);
-
-            // perform benchmark
-            timing = run_benchmark<>(iterations, vector_size, alloc, policy);
+            timing = run_benchmark<>(
+                iterations, vector_size, std::move(alloc), std::move(policy));
         }
         else if (executor == 2)
         {
-            //typedef hpx::parallel::execution::thread_pool_executor executor_type;
-            //auto policy = hpx::parallel::execution::par.on(executor_type());
+            // Default parallel policy and allocator with default parallel policy.
+            auto policy = hpx::parallel::execution::par;
+            hpx::compute::host::detail::policy_allocator<STREAM_TYPE,
+                decltype(policy)>
+                alloc(policy);
 
-            //typedef hpx::compute::host::detail::policy_allocator<STREAM_TYPE, decltype(policy)> allocator_type;
+            timing = run_benchmark<>(
+                iterations, vector_size, std::move(alloc), std::move(policy));
+        }
+        else if (executor == 3)
+        {
+            // Thread pool executor and allocator with thread pool executor.
+            using executor_type =
+                hpx::parallel::execution::thread_pool_executor;
 
-            //allocator_type alloc(policy);
+            auto policy = hpx::parallel::execution::par.on(executor_type());
+            hpx::compute::host::detail::policy_allocator<STREAM_TYPE,
+                decltype(policy)>
+                alloc(policy);
 
-            //// perform benchmark
-            //timing = run_benchmark<>(iterations, vector_size, alloc, policy);
+            timing = run_benchmark<>(
+                iterations, vector_size, std::move(alloc), std::move(policy));
         }
         else
         {
-            // TODO
-            HPX_ASSERT(false);
+            HPX_THROW_EXCEPTION(hpx::commandline_option_error, "hpx_main",
+                "Invalid executor id given (0-3 allowed");
         }
     }
     time_total = mysecond() - time_total;
 
     /* --- SUMMARY --- */
+    // clang-format off
     const char *label[4] = {
         "Copy:      ",
         "Scale:     ",
         "Add:       ",
         "Triad:     "
     };
+    // clang-format on
 
     const double bytes[4] = {
         2 * sizeof(STREAM_TYPE) * static_cast<double>(vector_size),
         2 * sizeof(STREAM_TYPE) * static_cast<double>(vector_size),
         3 * sizeof(STREAM_TYPE) * static_cast<double>(vector_size),
-        3 * sizeof(STREAM_TYPE) * static_cast<double>(vector_size)
-    };
+        3 * sizeof(STREAM_TYPE) * static_cast<double>(vector_size)};
 
     // Note: skip first iteration
     std::vector<double> avgtime(4, 0.0);
     std::vector<double> mintime(4, (std::numeric_limits<double>::max)());
     std::vector<double> maxtime(4, 0.0);
-    for(std::size_t iteration = 1; iteration != iterations; ++iteration)
+    for (std::size_t iteration = 1; iteration != iterations; ++iteration)
     {
-        for (std::size_t j=0; j<4; j++)
+        for (std::size_t j = 0; j < 4; j++)
         {
             avgtime[j] = avgtime[j] + timing[j][iteration];
             mintime[j] = (std::min)(mintime[j], timing[j][iteration]);
@@ -531,23 +551,20 @@ int hpx_main(hpx::program_options::variables_map& vm)
     }
 
     printf("Function    Best Rate MB/s  Avg time     Min time     Max time\n");
-    for (std::size_t j=0; j<4; j++) {
-        avgtime[j] = avgtime[j]/(double)(iterations-1);
+    for (std::size_t j = 0; j < 4; j++)
+    {
+        avgtime[j] = avgtime[j] / (double) (iterations - 1);
 
         printf("%s%12.1f  %11.6f  %11.6f  %11.6f\n", label[j],
-           1.0E-06 * bytes[j]/mintime[j],
-           avgtime[j],
-           mintime[j],
-           maxtime[j]);
+            1.0E-06 * bytes[j] / mintime[j], avgtime[j], mintime[j],
+            maxtime[j]);
     }
 
-    std::cout
-        << "\nTotal time: " << time_total
-        << " (per iteration: " << time_total/iterations << ")\n";
+    std::cout << "\nTotal time: " << time_total
+              << " (per iteration: " << time_total / iterations << ")\n";
 
     std::cout
-        << "-------------------------------------------------------------\n"
-        ;
+        << "-------------------------------------------------------------\n";
 
     return hpx::finalize();
 }
@@ -558,6 +575,7 @@ int main(int argc, char* argv[])
 
     options_description cmdline("usage: " HPX_APPLICATION_STRING " [options]");
 
+    // clang-format off
     cmdline.add_options()
         (   "vector_size",
             hpx::program_options::value<std::size_t>()->default_value(1024),
@@ -576,30 +594,29 @@ int main(int argc, char* argv[])
              hpx::program_options::value<std::size_t>()->default_value(0),
             "size of vector (default: 1024)")
         (   "executor",
-             hpx::program_options::value<std::size_t>()->default_value(0),
-            "executor to use")
+            hpx::program_options::value<std::size_t>()->default_value(3),
+            "executor to use (0-3) (default: 3, thread_pool_executor)")
 
 #if defined(HPX_HAVE_COMPUTE)
         (   "use-accelerator",
             "Use this flag to run the stream benchmark on the GPU")
 #endif
         ;
+    // clang-format on
 
     // parse command line here to extract the necessary settings for HPX
-    parsed_options opts =
-        command_line_parser(argc, argv)
-            .allow_unregistered()
-            .options(cmdline)
-            .style(command_line_style::unix_style)
-            .run();
+    parsed_options opts = command_line_parser(argc, argv)
+                              .allow_unregistered()
+                              .options(cmdline)
+                              .style(command_line_style::unix_style)
+                              .run();
 
     variables_map vm;
     store(opts, vm);
 
     std::vector<std::string> cfg = {
-        "hpx.numa_sensitive=2"  // no-cross NUMA stealing
+        "hpx.numa_sensitive=2"    // no-cross NUMA stealing
     };
 
     return hpx::init(cmdline, argc, argv, cfg);
 }
-


### PR DESCRIPTION
Adds `hpx::compute::host::detail::policy_allocator` which allows creating an allocator for use with `hpx::compute::vector` with any execution policy, not just with the `block_executor`. The `block_allocator` has been rewritten to use `policy_allocator`, but the implementation itself is unchanged from `block_allocator` on master.

I have also changed the `static_chunk_size` executor parameters to only return powers of two chunk sizes (benchmarks below the fold).

I was unsure if it would be enough to make it generic over executors, but doing it over policies means that one can also switch allocation to be serial by changing the policy. `policy_allocator` is now in `detail`, and I don't know yet if we want to expose it directly.

My main motivation with this is to have be able to use the default `par` policy and get good performance on e.g. the stream benchmark. I.e. the following should be enough:

```
auto policy = par;
allocator<double> alloc(policy);
vector<double> vec(n, alloc);
foo(policy, vec.begin(), vec.end());
```

The lack of template argument deduction on e.g. the allocator (only works if *no* template arguments are specified, but we need at least the element type) means that real code wouldn't actually look this clean. Are there ways to achieve roughly the above level of (non-)verbosity?

---

The follow-up for this is that I'd like to change the default executor for `par` to be based on the `thread_pool_executor` implementation. This is based on the benchmarks in #4301 and the following stream benchmarks. I benchmarked the following combinations (on Piz Daint multicore I should add, two-socket Xeon with 18 cores each, 36 threads total, no hyperthreading; 100 iterations per test):

- `par.on(thread_pool_executor)` and `policy_allocator(thread_pool_executor)`
- `par.on(block_executor)` and `block_allocator`
- `par` and `policy_allocator(par)`
- `par` and `std::allocator`

On big arrays (100000000 elements, ~700 MB) the first two achieve roughly the same peak bandwidth, but the one based on `thread_pool_executor` has much lower variance (and average). The default `par` combination gives roughly 25% lower bandwidth. `std::allocator` gives more than 50% lower bandwidth.

The chunk size change again doesn't change the peak bandwidth (especially not for big arrays), but significantly reduces variance with small arrays. For example, with the `thread_pool_executor` and 100000 elements we get this with the old chunk size:
```
Function    Best Rate MB/s  Avg time     Min time     Max time             
Copy:           24044.9     0.000336     0.000067     0.007587             
Scale:          22141.6     0.000290     0.000072     0.007240             
Add:            37952.4     0.000286     0.000063     0.006938             
Triad:          36632.3     0.000295     0.000066     0.007082
```
and this with the new chunk size:
```
Function    Best Rate MB/s  Avg time     Min time     Max time             
Copy:           28912.1     0.000241     0.000055     0.003331             
Scale:          29232.8     0.000209     0.000055     0.003072             
Add:            46112.2     0.000208     0.000052     0.003155             
Triad:          40975.8     0.000214     0.000059     0.003560
```

The follow-up on the follow-up is to improve performance with small grain sizes.