### PR TITLE
Move channel documentation examples to examples directory

### DIFF
--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -42,64 +42,36 @@ Channels
 
 Channels combine communication (the exchange of a value) with synchronization
 (guaranteeing that two calculations (tasks) are in a known state). A channel can
-transport any number of values of a given type from a sender to a receiver::
+transport any number of values of a given type from a sender to a receiver:
 
-    hpx::lcos::local::channel<int> c;
-    c.set(42);
-    cout << c.get();      // will print '42'
+.. literalinclude:: ../../examples/quickstart/local_channel_docs.cpp
+   :language: c++
+   :start-after: //[local_channel_minimal
+   :end-before: //]
 
 Channels can be handed to another thread (or in case of channel components, to
 other localities), thus establishing a communication channel between two
-independent places in the program::
+independent places in the program:
 
-    void do_something(
-        hpx::lcos::local::receive_channel<int> c,
-        hpx::lcos::local::send_channel<> done)
-    {
-        cout << c.get();        // prints 42
-        done.set();             // signal back
-    }
+.. literalinclude:: ../../examples/quickstart/local_channel_docs.cpp
+   :language: c++
+   :start-after: //[local_channel_send_receive
+   :end-before: //]
 
-    {
-        hpx::lcos::local::channel<int> c;
-        hpx::lcos::local::channel<> done;
-
-        hpx::apply(&do_something, c, done);
-
-        c.set(42);              // send some value
-        done.get();             // wait for thread to be done
-    }
+Note how :cpp:member:`hpx::lcos::local::channel::get` without any arguments
+returns a future which is ready when a value has been set on the channel. The
+launch policy ``hpx::launch::sync`` can be used to make
+:cpp:member:`hpx::lcos::local::channel::get` block until a value is set and
+return the value directly.
 
 A channel component is created on one :term:`locality` and can be sent to
 another :term:`locality` using an action. This example also demonstrates how a
-channel can be used as a range of values::
+channel can be used as a range of values:
 
-    // channel components need to be registered for each used type (not needed
-    // for hpx::lcos::local::channel)
-    HPX_REGISTER_CHANNEL(double);
-
-    void some_action(hpx::lcos::channel<double> c)
-    {
-        for (double d : c)
-            hpx::cout << d << std::endl;
-    }
-    HPX_REGISTER_ACTION(some_action);
-
-    {
-        // create the channel on this locality
-        hpx::lcos::channel<double> c(hpx::find_here());
-
-        // pass the channel to a (possibly remote invoked) action
-        hpx::apply(some_action(), hpx::find_here(), c);
-
-        // send some values to the receiver
-        std::vector<double> v = { 1.2, 3.4, 5.0 };
-        for (double d : v)
-            c.set(d);
-
-        // explicitly close the communication channel (implicit at destruction)
-        c.close();
-    }
+.. literalinclude:: ../../examples/quickstart/channel_docs.cpp
+   :language: c++
+   :start-after: //[channel
+   :end-before: //]
 
 Composable guards
 -----------------

--- a/examples/quickstart/CMakeLists.txt
+++ b/examples/quickstart/CMakeLists.txt
@@ -8,6 +8,7 @@
 set(example_programs
     1d_wave_equation
     allow_unknown_options
+    channel_docs
     command_line_handling
     component_ctors
     component_in_executable
@@ -41,6 +42,7 @@ set(example_programs
     latch_local
     latch_remote
     local_channel
+    local_channel_docs
     partitioned_vector_spmd_foreach
     pingpong
     pipeline1
@@ -71,6 +73,7 @@ set(disabled_tests
 
 set(1d_wave_equation_FLAGS COMPONENT_DEPENDENCIES iostreams)
 set(allow_unknown_options_FLAGS COMPONENT_DEPENDENCIES iostreams)
+set(channel_docs_FLAGS COMPONENT_DEPENDENCIES iostreams)
 set(command_line_handling_FLAGS COMPONENT_DEPENDENCIES iostreams)
 set(component_in_executable_FLAGS COMPONENT_DEPENDENCIES iostreams)
 set(component_ctors_FLAGS COMPONENT_DEPENDENCIES iostreams)
@@ -91,6 +94,7 @@ else()
 endif()
 set(interval_timer_FLAGS COMPONENT_DEPENDENCIES iostreams)
 set(local_channel_FLAGS COMPONENT_DEPENDENCIES iostreams)
+set(local_channel_docs_FLAGS COMPONENT_DEPENDENCIES iostreams)
 set(sierpinski_FLAGS COMPONENT_DEPENDENCIES iostreams)
 set(partitioned_vector_spmd_foreach_FLAGS
     COMPONENT_DEPENDENCIES iostreams partitioned_vector)

--- a/examples/quickstart/channel_docs.cpp
+++ b/examples/quickstart/channel_docs.cpp
@@ -1,0 +1,56 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This example is meant for inclusion in the documentation.
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/actions.hpp>
+#include <hpx/include/apply.hpp>
+#include <hpx/include/iostreams.hpp>
+#include <hpx/include/lcos.hpp>
+
+#include <numeric>
+#include <string>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+//[channel
+// channel components need to be registered for each used type (not needed
+// for hpx::lcos::local::channel)
+HPX_REGISTER_CHANNEL(double);
+
+void channel_sender(hpx::lcos::channel<double> c)
+{
+    for (double d : c)
+        hpx::cout << d << std::endl;
+}
+HPX_PLAIN_ACTION(channel_sender);
+
+void channel()
+{
+    // create the channel on this locality
+    hpx::lcos::channel<double> c(hpx::find_here());
+
+    // pass the channel to a (possibly remote invoked) action
+    hpx::apply(channel_sender_action(), hpx::find_here(), c);
+
+    // send some values to the receiver
+    std::vector<double> v = {1.2, 3.4, 5.0};
+    for (double d : v)
+        c.set(d);
+
+    // explicitly close the communication channel (implicit at destruction)
+    c.close();
+}
+//]
+
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    channel();
+
+    return 0;
+}

--- a/examples/quickstart/local_channel_docs.cpp
+++ b/examples/quickstart/local_channel_docs.cpp
@@ -1,0 +1,63 @@
+//  Copyright (c) 2016 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This example is meant for inclusion in the documentation.
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/apply.hpp>
+#include <hpx/include/iostreams.hpp>
+#include <hpx/include/lcos.hpp>
+
+#include <numeric>
+#include <string>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+void minimal_channel()
+{
+    //[local_channel_minimal
+    hpx::lcos::local::channel<int> c;
+    hpx::future<int> f = c.get();
+    HPX_ASSERT(!f.is_ready());
+    c.set(42);
+    HPX_ASSERT(f.is_ready());
+    hpx::cout << f.get() << hpx::endl;
+    //]
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//[local_channel_send_receive
+void do_something(hpx::lcos::local::receive_channel<int> c,
+    hpx::lcos::local::send_channel<> done)
+{
+    // prints 43
+    hpx::cout << c.get(hpx::launch::sync) << hpx::endl;
+    // signal back
+    done.set();
+}
+
+void send_receive_channel()
+{
+    hpx::lcos::local::channel<int> c;
+    hpx::lcos::local::channel<> done;
+
+    hpx::apply(&do_something, c, done);
+
+    // send some value
+    c.set(43);
+    // wait for thread to be done
+    done.get().wait();
+}
+//]
+
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    minimal_channel();
+    send_receive_channel();
+
+    return 0;
+}


### PR DESCRIPTION
Fixes #4519. @tiagofgon would you mind looking through this (I know you can't see the final result without building it but the examples are marked with `//[start` and `//]` comments in the two new examples)?

I do wish we had a better way of doing this. It may be possible to go the other way around (i.e. examples in docs and extract them into source files).