### PR TITLE
Add API to check if a thread pool exists

### DIFF
--- a/hpx/runtime/thread_pool_helpers.hpp
+++ b/hpx/runtime/thread_pool_helpers.hpp
@@ -48,6 +48,12 @@ namespace hpx { namespace resource
     /// Return the thread pool given its internal index
     HPX_API_EXPORT threads::thread_pool_base& get_thread_pool(
         std::size_t pool_index);
+
+    /// Return true if the pool with the given name exists
+    HPX_API_EXPORT bool pool_exists(std::string const& pool_name);
+
+    /// Return true if the pool with the given index exists
+    HPX_API_EXPORT bool pool_exists(std::size_t pool_index);
 }}
 
 namespace hpx { namespace threads {

--- a/libs/execution/include/hpx/execution/executors/pool_executor.hpp
+++ b/libs/execution/include/hpx/execution/executors/pool_executor.hpp
@@ -24,7 +24,7 @@ namespace hpx { namespace parallel { namespace execution {
     class HPX_EXPORT pool_executor : public thread_pool_executor
     {
     public:
-        pool_executor(std::string const& pool_name,
+        pool_executor(std::string const& pool_name = "default",
             threads::thread_stacksize stacksize =
                 threads::thread_stacksize_default)
           : thread_pool_executor(

--- a/libs/execution/include/hpx/execution/executors/pool_executor.hpp
+++ b/libs/execution/include/hpx/execution/executors/pool_executor.hpp
@@ -24,7 +24,7 @@ namespace hpx { namespace parallel { namespace execution {
     class HPX_EXPORT pool_executor : public thread_pool_executor
     {
     public:
-        pool_executor(std::string const& pool_name = "default",
+        explicit pool_executor(std::string const& pool_name = "default",
             threads::thread_stacksize stacksize =
                 threads::thread_stacksize_default)
           : thread_pool_executor(

--- a/libs/resource_partitioner/tests/unit/named_pool_executor.cpp
+++ b/libs/resource_partitioner/tests/unit/named_pool_executor.cpp
@@ -40,6 +40,14 @@ int hpx_main(int argc, char* argv[])
     HPX_TEST_EQ(std::size_t(4), hpx::resource::get_num_thread_pools());
     HPX_TEST_EQ(std::size_t(0), hpx::resource::get_pool_index("default"));
     HPX_TEST_EQ(std::size_t(0), hpx::resource::get_pool_index("pool-0"));
+    HPX_TEST(hpx::resource::pool_exists("default"));
+    HPX_TEST(hpx::resource::pool_exists("pool-0"));
+    HPX_TEST(!hpx::resource::pool_exists("nonexistent"));
+    for (int pool_index = 0; pool_index < max_threads; ++pool_index)
+    {
+        HPX_TEST(hpx::resource::pool_exists(pool_index));
+    }
+    HPX_TEST(!hpx::resource::pool_exists(max_threads));
 
     for (int i = 0; i < max_threads; ++i)
     {

--- a/libs/resource_partitioner/tests/unit/named_pool_executor.cpp
+++ b/libs/resource_partitioner/tests/unit/named_pool_executor.cpp
@@ -56,6 +56,9 @@ int hpx_main(int argc, char* argv[])
         HPX_TEST_EQ(std::size_t(1), hpx::resource::get_num_threads(i));
     }
 
+    // Make sure default construction works
+    hpx::parallel::execution::pool_executor exec_default;
+
     // setup executors for different task priorities on the pools
     // segfaults or exceptions in any of the following will cause
     // the test to fail

--- a/libs/threadmanager/include/hpx/threadmanager.hpp
+++ b/libs/threadmanager/include/hpx/threadmanager.hpp
@@ -80,6 +80,9 @@ namespace hpx { namespace threads {
         thread_pool_base& get_pool(pool_id_type const& pool_id) const;
         thread_pool_base& get_pool(std::size_t thread_index) const;
 
+        bool pool_exists(std::string const& pool_name) const;
+        bool pool_exists(std::size_t pool_index) const;
+
         /// The function \a register_work adds a new work item to the thread
         /// manager. It doesn't immediately create a new \a thread, it just adds
         /// the task parameters (function, initial state and description) to

--- a/libs/threadmanager/src/threadmanager.cpp
+++ b/libs/threadmanager/src/threadmanager.cpp
@@ -761,6 +761,35 @@ namespace hpx { namespace threads {
         return get_pool(threads_lookup_[thread_index]);
     }
 
+    bool threadmanager::pool_exists(std::string const& pool_name) const
+    {
+        // if the given pool_name is default, we don't need to look for it
+        // we must always return pool 0
+        if (pool_name == "default" ||
+            pool_name == resource::get_partitioner().get_default_pool_name())
+        {
+            return true;
+        }
+
+        // now check the other pools - no need to check pool 0 again, so ++begin
+        auto pool = std::find_if(++pools_.begin(), pools_.end(),
+            [&pool_name](pool_type const& itp) -> bool {
+                return (itp->get_pool_name() == pool_name);
+            });
+
+        if (pool != pools_.end())
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    bool threadmanager::pool_exists(std::size_t pool_index) const
+    {
+        return pool_index < pools_.size();
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     std::int64_t threadmanager::get_thread_count(thread_state_enum state,
         thread_priority priority, std::size_t num_thread, bool reset)

--- a/src/runtime/thread_pool_helpers.cpp
+++ b/src/runtime/thread_pool_helpers.cpp
@@ -61,6 +61,17 @@ namespace hpx { namespace resource
     {
         return get_thread_pool(get_pool_name(pool_index));
     }
+
+    bool pool_exists(
+        std::string const& pool_name)
+    {
+        return get_runtime().get_thread_manager().pool_exists(pool_name);
+    }
+
+    bool pool_exists(std::size_t pool_index)
+    {
+        return get_runtime().get_thread_manager().pool_exists(pool_index);
+    }
 }}    // namespace hpx::resource
 
 namespace hpx { namespace threads {


### PR DESCRIPTION
Fixes #4535. Also adds a default constructor `pool_executor`.