### PR TITLE
Fix a warning caused by a misplaced HPX_EXPORT

### DIFF
--- a/hpx/runtime.hpp
+++ b/hpx/runtime.hpp
@@ -57,7 +57,7 @@ namespace hpx
         namespace server
         {
             class runtime_support;
-            class HPX_EXPORT memory;
+            class memory;
         }
     }
 

--- a/hpx/runtime/components/server/memory.hpp
+++ b/hpx/runtime/components/server/memory.hpp
@@ -23,7 +23,7 @@
 namespace hpx { namespace components { namespace server
 {
     ///////////////////////////////////////////////////////////////////////////
-    class memory
+    class HPX_EXPORT memory
     {
     public:
         typedef memory type_holder;


### PR DESCRIPTION
Put the HPX_EXPORT on the original declaration