### PR TITLE
Fix stack size

### DIFF
--- a/examples/quickstart/component_with_executor.cpp
+++ b/examples/quickstart/component_with_executor.cpp
@@ -24,9 +24,8 @@ struct hello_world_server
             executor_type, hpx::components::component_base<hello_world_server>
         > base_type;
 
-    // run on all available cores
     hello_world_server()
-      : base_type(executor_type(hpx::get_num_worker_threads()))
+      : base_type(executor_type{})
     {}
 
     void print() const

--- a/libs/coroutines/include/hpx/coroutines/thread_enums.hpp
+++ b/libs/coroutines/include/hpx/coroutines/thread_enums.hpp
@@ -199,7 +199,7 @@ namespace hpx { namespace threads {
         {
         }
 
-        constexpr thread_schedule_hint(std::int16_t thread_hint)
+        constexpr explicit thread_schedule_hint(std::int16_t thread_hint)
           : mode(thread_schedule_hint_mode_thread)
           , hint(thread_hint)
         {

--- a/libs/threading/src/thread.cpp
+++ b/libs/threading/src/thread.cpp
@@ -164,11 +164,14 @@ namespace hpx {
         util::unique_function_nonser<void()>&& func)
     {
         HPX_ASSERT(pool);
+        threads::policies::scheduler_base* scheduler = pool->get_scheduler();
 
         threads::thread_init_data data(
             util::one_shot(
                 util::bind(&thread::thread_function_nullary, std::move(func))),
-            "thread::thread_function_nullary");
+            "thread::thread_function_nullary", threads::thread_priority_normal,
+            threads::thread_schedule_hint(),
+            scheduler->get_stack_size(threads::thread_stacksize_default));
 
         // create the new thread, note that id_ is guaranteed to be valid
         // before the thread function is executed

--- a/libs/threading_base/include/hpx/threading_base/set_thread_state.hpp
+++ b/libs/threading_base/include/hpx/threading_base/set_thread_state.hpp
@@ -142,10 +142,14 @@ namespace hpx { namespace threads { namespace detail {
                         << "), new state(" << get_thread_state_name(new_state)
                         << ")";
 
+                    auto* scheduler =
+                        get_thread_id_data(thrd)->get_scheduler_base();
                     thread_init_data data(
                         util::bind(&set_active_state, thrd, new_state,
                             new_state_ex, priority, previous_state),
-                        "set state for active thread", priority);
+                        "set state for active thread", priority,
+                        thread_schedule_hint(),
+                        scheduler->get_stack_size(thread_stacksize_small));
 
                     create_work(get_thread_id_data(thrd)->get_scheduler_base(),
                         data, pending, ec);
@@ -348,7 +352,8 @@ namespace hpx { namespace threads { namespace detail {
         thread_init_data data(
             util::bind_front(&wake_timer_thread, thrd, newstate, newstate_ex,
                 priority, self_id, triggered, retry_on_active),
-            "wake_timer", priority);
+            "wake_timer", priority, thread_schedule_hint(),
+            scheduler.get_stack_size(thread_stacksize_small));
 
         thread_id_type wake_id = invalid_thread_id;
         create_thread(&scheduler, data, wake_id, suspended);
@@ -424,7 +429,8 @@ namespace hpx { namespace threads { namespace detail {
             util::bind(&at_timer<SchedulingPolicy>, std::ref(scheduler),
                 abs_time.value(), thrd, newstate, newstate_ex, priority,
                 started, retry_on_active),
-            "at_timer (expire at)", priority, schedulehint);
+            "at_timer (expire at)", priority, schedulehint,
+            scheduler.get_stack_size(thread_stacksize_small));
 
         thread_id_type newid = invalid_thread_id;
         create_thread(&scheduler, data, newid, pending, true, ec);    //-V601

--- a/tests/regressions/CMakeLists.txt
+++ b/tests/regressions/CMakeLists.txt
@@ -28,6 +28,7 @@ set(tests
     multiple_init
     multiple_init_2918
     options_as_config_3339
+    stack_size_config_4543
     unhandled_exception_582
    )
 

--- a/tests/regressions/stack_size_config_4543.cpp
+++ b/tests/regressions/stack_size_config_4543.cpp
@@ -1,0 +1,38 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+
+#include <chrono>
+
+// This test ensures that thread creation uses the correct stack sizes. We
+// slightly change all the stack sizes in the configuration to catch problems
+// with the used stack sizes not matching the configured sizes.
+
+int hpx_main(int argc, char** argv)
+{
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    hpx::thread t([]() {});
+    t.join();
+
+    return hpx::finalize();
+}
+
+int main(int argc, char** argv)
+{
+    hpx::init_params p;
+    p.cfg = {"hpx.stacks.small_size=" +
+            std::to_string(HPX_SMALL_STACK_SIZE + 0x1000),
+        "hpx.stacks.medium_size=" +
+            std::to_string(HPX_MEDIUM_STACK_SIZE + 0x1000),
+        "hpx.stacks.large_size=" +
+            std::to_string(HPX_LARGE_STACK_SIZE + 0x1000),
+        "hpx.stacks.huge_size=" + std::to_string(HPX_HUGE_STACK_SIZE + 0x1000)};
+
+    return hpx::init(argc, argv, p);
+}


### PR DESCRIPTION
Fixes #4543. The changes are a bit awkard, so as I said in #4543 I'll change `thread_init_data` to use the enum stacksize along with #4542. I also changed the `thread_schedule_hint` one-argument constructor to be explicit to avoid having me pass a stack size for the hint...