### PR TITLE
Add configuration option for making exceptions less noisy

### DIFF
--- a/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
+++ b/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
@@ -182,6 +182,7 @@ The ``hpx`` configuration section
    max_idle_loop_count = ${HPX_MAX_IDLE_LOOP_COUNT:<hpx_idle_loop_count_max>}
    max_busy_loop_count = ${HPX_MAX_BUSY_LOOP_COUNT:<hpx_busy_loop_count_max>}
    max_idle_backoff_time = ${HPX_MAX_IDLE_BACKOFF_TIME:<hpx_idle_backoff_time_max>}
+   exception_verbosity = ${HPX_EXCEPTION_VERBOSITY:2}
 
    [hpx.stacks]
    small_size = ${HPX_SMALL_STACK_SIZE:<hpx_small_stack_size>}
@@ -272,6 +273,14 @@ The ``hpx`` configuration section
        |cmake|. By default this is defined by the preprocessor constant
        ``HPX_IDLE_BACKOFF_TIME_MAX``. This is an internal setting which you
        should change only if you know exactly what you are doing.
+   * * ``hpx.exception_verbosity``
+     * This setting defines the verbosity of exceptions. Valid values are
+       integers. A setting of ``2`` or higher prints all available information.
+       A setting of ``1`` leaves out the build configuration and environment
+       variables. A setting of ``0`` or lower prints only the description of the
+       thrown exception and the file name, function, and line number where the
+       exception was thrown. The default value is ``2`` or the value of the
+       environment variable ``HPX_EXCEPTION_VERBOSITY``.
    * * ``hpx.stacks.small_size``
      * This is initialized to the small stack size to be used by |hpx|-threads.
        Set by default to the value of the compile time preprocessor constant

--- a/libs/runtime_configuration/src/init_ini_data.cpp
+++ b/libs/runtime_configuration/src/init_ini_data.cpp
@@ -143,8 +143,8 @@ namespace hpx { namespace util {
         }
 #endif
 
-        result = handle_ini_file_env(ini, "HOME", "/.hpx.ini") || result;
-        result = handle_ini_file_env(ini, "PWD", "/.hpx.ini") || result;
+        result = handle_ini_file_env(ini, "HOME", ".hpx.ini") || result;
+        result = handle_ini_file_env(ini, "PWD", ".hpx.ini") || result;
 
         if (!hpx_ini_file.empty())
         {

--- a/libs/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/runtime_configuration/src/runtime_configuration.cpp
@@ -179,6 +179,7 @@ namespace hpx { namespace util {
 #else
             "attach_debugger = ${HPX_ATTACH_DEBUGGER}",
 #endif
+            "exception_verbosity = ${HPX_EXCEPTION_VERBOSITY:2}",
 
             // arity for collective operations implemented in a tree fashion
             "[hpx.lcos.collectives]",

--- a/src/custom_exception_info.cpp
+++ b/src/custom_exception_info.cpp
@@ -74,76 +74,83 @@ namespace hpx
     // return a string holding a formatted message.
     std::string diagnostic_information(hpx::exception_info const& xi)
     {
+        int const verbosity = util::from_string<int>(
+            get_config_entry("hpx.exception_verbosity", ""));
+
         std::ostringstream strm;
         strm << "\n";
 
         // add full build information
-        strm << full_build_string();
-
-        std::string const* env = xi.get<hpx::detail::throw_env>();
-        if (env && !env->empty())
-            strm << "{env}: " << *env;
-
-        std::string const* back_trace =
-            xi.get<hpx::detail::throw_stacktrace>();
-        if (back_trace && !back_trace->empty()) {
-            // FIXME: add indentation to stack frame information
-            strm << "{stack-trace}: " << *back_trace << "\n";
-        }
-
-        std::uint32_t const* locality =
-            xi.get<hpx::detail::throw_locality>();
-        if (locality)
-            strm << "{locality-id}: " << *locality << "\n";
-
-        std::string const* hostname_ =
-            xi.get<hpx::detail::throw_hostname>();
-        if (hostname_ && !hostname_->empty())
-            strm << "{hostname}: " << *hostname_ << "\n";
-
-        std::int64_t const* pid_ =
-            xi.get<hpx::detail::throw_pid>();
-        if (pid_ && -1 != *pid_)
-            strm << "{process-id}: " << *pid_ << "\n";
-
-        bool thread_info = false;
-        char const* const thread_prefix = "{os-thread}: ";
-        std::size_t const* shepherd =
-            xi.get<hpx::detail::throw_shepherd>();
-        if (shepherd && std::size_t(-1) != *shepherd) {
-            strm << thread_prefix << *shepherd;
-            thread_info = true;
-        }
-
-        std::string thread_name = hpx::get_thread_name();
-        if (!thread_info)
-            strm << thread_prefix;
-        else
-            strm << ", ";
-        strm << thread_name << "\n";
-
-        std::size_t const* thread_id =
-            xi.get<hpx::detail::throw_thread_id>();
-        if (thread_id && *thread_id)
+        if (verbosity >= 2)
         {
-            strm << "{thread-id}: ";
-            hpx::util::format_to(strm, "{:016x}\n", *thread_id);
+            strm << full_build_string();
+
+            std::string const* env = xi.get<hpx::detail::throw_env>();
+            if (env && !env->empty())
+                strm << "{env}: " << *env;
         }
 
-        std::string const* thread_description =
-            xi.get<hpx::detail::throw_thread_name>();
-        if (thread_description && !thread_description->empty())
-            strm << "{thread-description}: " << *thread_description << "\n";
+        if (verbosity >= 1)
+        {
+            std::string const* back_trace =
+                xi.get<hpx::detail::throw_stacktrace>();
+            if (back_trace && !back_trace->empty())
+            {
+                // FIXME: add indentation to stack frame information
+                strm << "{stack-trace}: " << *back_trace << "\n";
+            }
 
-        std::string const* state =
-            xi.get<hpx::detail::throw_state>();
-        if (state)
-            strm << "{state}: " << *state << "\n";
+            std::uint32_t const* locality =
+                xi.get<hpx::detail::throw_locality>();
+            if (locality)
+                strm << "{locality-id}: " << *locality << "\n";
 
-        std::string const* auxinfo =
-            xi.get<hpx::detail::throw_auxinfo>();
-        if (auxinfo)
-            strm << "{auxinfo}: " << *auxinfo << "\n";
+            std::string const* hostname_ =
+                xi.get<hpx::detail::throw_hostname>();
+            if (hostname_ && !hostname_->empty())
+                strm << "{hostname}: " << *hostname_ << "\n";
+
+            std::int64_t const* pid_ = xi.get<hpx::detail::throw_pid>();
+            if (pid_ && -1 != *pid_)
+                strm << "{process-id}: " << *pid_ << "\n";
+
+            bool thread_info = false;
+            char const* const thread_prefix = "{os-thread}: ";
+            std::size_t const* shepherd = xi.get<hpx::detail::throw_shepherd>();
+            if (shepherd && std::size_t(-1) != *shepherd)
+            {
+                strm << thread_prefix << *shepherd;
+                thread_info = true;
+            }
+
+            std::string thread_name = hpx::get_thread_name();
+            if (!thread_info)
+                strm << thread_prefix;
+            else
+                strm << ", ";
+            strm << thread_name << "\n";
+
+            std::size_t const* thread_id =
+                xi.get<hpx::detail::throw_thread_id>();
+            if (thread_id && *thread_id)
+            {
+                strm << "{thread-id}: ";
+                hpx::util::format_to(strm, "{:016x}\n", *thread_id);
+            }
+
+            std::string const* thread_description =
+                xi.get<hpx::detail::throw_thread_name>();
+            if (thread_description && !thread_description->empty())
+                strm << "{thread-description}: " << *thread_description << "\n";
+
+            std::string const* state = xi.get<hpx::detail::throw_state>();
+            if (state)
+                strm << "{state}: " << *state << "\n";
+
+            std::string const* auxinfo = xi.get<hpx::detail::throw_auxinfo>();
+            if (auxinfo)
+                strm << "{auxinfo}: " << *auxinfo << "\n";
+        }
 
         std::string const* file = xi.get<hpx::detail::throw_file>();
         if (file)

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -73,12 +73,23 @@ namespace hpx
 
         if (get_config_entry("hpx.diagnostics_on_terminate", "1") == "1")
         {
-            std::cerr
+            int const verbosity = util::from_string<int>(
+                get_config_entry("hpx.exception_verbosity", ""));
+
+            if (verbosity >= 2)
+            {
+                std::cerr << full_build_string() << "\n";
+            }
+
 #if defined(HPX_HAVE_STACKTRACES)
-                << "{stack-trace}: " << hpx::util::trace() << "\n"
+            if (verbosity >= 1)
+            {
+                std::cerr << "{stack-trace}: " << hpx::util::trace() << "\n";
+            }
 #endif
-                << "{what}: " << (reason ? reason : "Unknown reason") << "\n"
-                << full_build_string();           // add full build information
+
+            std::cerr << "{what}: " << (reason ? reason : "Unknown reason")
+                      << "\n";
         }
     }
 
@@ -131,13 +142,25 @@ namespace hpx
 
         if (get_config_entry("hpx.diagnostics_on_terminate", "1") == "1")
         {
+            int const verbosity = util::from_string<int>(
+                get_config_entry("hpx.exception_verbosity", ""));
+
             char* reason = strsignal(signum);
-            std::cerr
+
+            if (verbosity >= 2)
+            {
+                std::cerr << full_build_string() << "\n";
+            }
+
 #if defined(HPX_HAVE_STACKTRACES)
-                << "{stack-trace}: " << hpx::util::trace() << "\n"
+            if (verbosity >= 1)
+            {
+                std::cerr << "{stack-trace}: " << hpx::util::trace() << "\n";
+            }
 #endif
-                << "{what}: " << (reason ? reason : "Unknown signal") << "\n"
-                << full_build_string();           // add full build information
+
+            std::cerr << "{what}: " << (reason ? reason : "Unknown reason")
+                      << "\n";
         }
         std::abort();
     }


### PR DESCRIPTION
Adds the option `hpx.exception_verbosity`. It currently takes three values:

- `0`: prints filename, line, function name, and the exception string
- `1`: prints everything except the build configuration and environment variables
- `2`: prints everything

I'm not sure if they need to be shifted to have `0` mean no output, but I don't see that being useful for anyone. We could also use names (like `minimal`, `reduced`, `full`), but using numbers for the level is similar to what we do with logging.

Flyby: fix reading of ini files from `HOME` and `PWD`.

To do:
- [x] documentation