### PR TITLE
Improve spinlock implementation to perform better in high-contention situations

### DIFF
--- a/hpx/runtime/naming/name.hpp
+++ b/hpx/runtime/naming/name.hpp
@@ -326,17 +326,10 @@ namespace hpx { namespace naming
         {
             HPX_ITT_SYNC_PREPARE(this);
 
-            for (;;)
+            while (!acquire_lock())
             {
-                if (acquire_lock())
-                {
-                    break;
-                }
-
-                for (std::size_t k = 0; is_locked(); ++k)
-                {
-                    util::detail::yield_k(k, "hpx::naming::gid_type::lock");
-                }
+                util::yield_while([this] { return is_locked(); },
+                    "hpx::naming::gid_type::lock");
             }
 
             util::register_lock(this);

--- a/hpx/runtime/naming/name.hpp
+++ b/hpx/runtime/naming/name.hpp
@@ -326,9 +326,17 @@ namespace hpx { namespace naming
         {
             HPX_ITT_SYNC_PREPARE(this);
 
-            for (std::size_t k = 0; !acquire_lock(); ++k)
+            for (;;)
             {
-                util::detail::yield_k(k, "hpx::naming::gid_type::lock");
+                if (acquire_lock())
+                {
+                    break;
+                }
+
+                for (std::size_t k = 0; is_locked(); ++k)
+                {
+                    util::detail::yield_k(k, "hpx::naming::gid_type::lock");
+                }
             }
 
             util::register_lock(this);

--- a/libs/basic_execution/include/hpx/basic_execution/this_thread.hpp
+++ b/libs/basic_execution/include/hpx/basic_execution/this_thread.hpp
@@ -94,7 +94,7 @@ namespace hpx { namespace util {
         {
             for (std::size_t k = 0; predicate(); ++k)
             {
-                detail::yield_k(k % 32, thread_name);
+                detail::yield_k(k % 16, thread_name);
             }
         }
     }

--- a/libs/synchronization/include/hpx/synchronization/spinlock.hpp
+++ b/libs/synchronization/include/hpx/synchronization/spinlock.hpp
@@ -50,18 +50,10 @@ namespace hpx { namespace lcos { namespace local {
         {
             HPX_ITT_SYNC_PREPARE(this);
 
-            for (;;)
+            while (!acquire_lock())
             {
-                if (acquire_lock())
-                {
-                    break;
-                }
-
-                for (std::size_t k = 0; is_locked(); ++k)
-                {
-                    util::detail::yield_k(
-                        k, "hpx::lcos::local::spinlock::lock");
-                }
+                util::yield_while([this] { return is_locked(); },
+                    "hpx::lcos::local::spinlock::lock");
             }
 
             HPX_ITT_SYNC_ACQUIRED(this);

--- a/libs/synchronization/include/hpx/synchronization/spinlock.hpp
+++ b/libs/synchronization/include/hpx/synchronization/spinlock.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 //  Copyright (c) 2011 Bryce Lelbach
-//  Copyright (c) 2011-2018 Hartmut Kaiser
+//  Copyright (c) 2011-2020 Hartmut Kaiser
 //  Copyright (c) 2014 Thomas Heller
 //  Copyright (c) 2008 Peter Dimov
 //  Copyright (c) 2018 Patrick Diehl
@@ -19,24 +19,9 @@
 #include <hpx/basic_execution/this_thread.hpp>
 #include <hpx/concurrency/itt_notify.hpp>
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
-
-// clang-format off
-#if defined(HPX_WINDOWS)
-#  include <boost/smart_ptr/detail/spinlock.hpp>
-#  if !defined(BOOST_SP_HAS_SYNC)
-#    include <boost/detail/interlocked.hpp>
-#  endif
-#else
-#  if !defined(__ANDROID__) && !defined(ANDROID)
-#    include <boost/smart_ptr/detail/spinlock.hpp>
-#    if defined(__ia64__) && defined(__INTEL_COMPILER)
-#      include <ia64intrin.h>
-#    endif
-#  endif
-#endif
-// clang-format on
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace lcos { namespace local {
@@ -47,15 +32,11 @@ namespace hpx { namespace lcos { namespace local {
         HPX_NON_COPYABLE(spinlock);
 
     private:
-#if defined(__ANDROID__) && defined(ANDROID)
-        int v_;
-#else
-        std::uint64_t v_;
-#endif
+        std::atomic<bool> v_;
 
     public:
         spinlock(char const* const desc = "hpx::lcos::local::spinlock")
-          : v_(0)
+          : v_(false)
         {
             HPX_ITT_SYNC_CREATE(this, desc, "");
         }
@@ -69,9 +50,18 @@ namespace hpx { namespace lcos { namespace local {
         {
             HPX_ITT_SYNC_PREPARE(this);
 
-            for (std::size_t k = 0; !acquire_lock(); ++k)
+            for (;;)
             {
-                util::detail::yield_k(k, "hpx::lcos::local::spinlock::lock");
+                if (acquire_lock())
+                {
+                    break;
+                }
+
+                for (std::size_t k = 0; is_locked(); ++k)
+                {
+                    util::detail::yield_k(
+                        k, "hpx::lcos::local::spinlock::lock");
+                }
             }
 
             HPX_ITT_SYNC_ACQUIRED(this);
@@ -109,23 +99,18 @@ namespace hpx { namespace lcos { namespace local {
         // returns whether the mutex has been acquired
         bool acquire_lock()
         {
-#if !defined(BOOST_SP_HAS_SYNC)
-            std::uint64_t r = BOOST_INTERLOCKED_EXCHANGE(&v_, 1);
-            HPX_COMPILER_FENCE;
-#else
-            std::uint64_t r = __sync_lock_test_and_set(&v_, 1);
-#endif
-            return r == 0;
+            return !v_.exchange(true, std::memory_order_acquire);
         }
 
+        // relinquish lock
         void relinquish_lock()
         {
-#if !defined(BOOST_SP_HAS_SYNC)
-            HPX_COMPILER_FENCE;
-            *const_cast<std::uint64_t volatile*>(&v_) = 0;
-#else
-            __sync_lock_release(&v_);
-#endif
+            v_.store(false, std::memory_order_release);
+        }
+
+        bool is_locked() const
+        {
+            return v_.load(std::memory_order_relaxed);
         }
     };
 }}}    // namespace hpx::lcos::local

--- a/libs/synchronization/include/hpx/synchronization/spinlock_no_backoff.hpp
+++ b/libs/synchronization/include/hpx/synchronization/spinlock_no_backoff.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 //  Copyright (c) 2011 Bryce Lelbach
-//  Copyright (c) 2011-2012 Hartmut Kaiser
+//  Copyright (c) 2011-2020 Hartmut Kaiser
 //  Copyright (c) 2008 Peter Dimov
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -15,23 +15,7 @@
 #include <hpx/basic_execution/register_locks.hpp>
 #include <hpx/concurrency/itt_notify.hpp>
 
-// clang-format off
-#if defined(HPX_WINDOWS)
-#  include <boost/smart_ptr/detail/spinlock.hpp>
-#  if !defined( BOOST_SP_HAS_SYNC )
-#    include <hpx/config/compiler_fence.hpp>
-#    include <boost/detail/interlocked.hpp>
-#  endif
-#else
-#  if !defined(__ANDROID__) && !defined(ANDROID) && !defined(__arm__)
-#    include <boost/smart_ptr/detail/spinlock.hpp>
-#    if defined( __ia64__ ) && defined( __INTEL_COMPILER )
-#      include <ia64intrin.h>
-#    endif
-#  endif
-#endif
-// clang-format on
-
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 
@@ -44,7 +28,7 @@ namespace hpx { namespace lcos { namespace local {
         HPX_NON_COPYABLE(spinlock_no_backoff);
 
     private:
-        std::uint64_t v_;
+        std::atomic<bool> v_;
 
     public:
         spinlock_no_backoff()
@@ -63,8 +47,17 @@ namespace hpx { namespace lcos { namespace local {
         {
             HPX_ITT_SYNC_PREPARE(this);
 
-            for (std::size_t k = 0; !try_lock(); ++k)
+            for (;;)
             {
+                if (acquire_lock())
+                {
+                    break;
+                }
+
+                while (is_locked())
+                {
+                    /**/;
+                }
             }
 
             HPX_ITT_SYNC_ACQUIRED(this);
@@ -75,12 +68,7 @@ namespace hpx { namespace lcos { namespace local {
         {
             HPX_ITT_SYNC_PREPARE(this);
 
-#if !defined(BOOST_SP_HAS_SYNC)
-            std::uint64_t r = BOOST_INTERLOCKED_EXCHANGE(&v_, 1);
-            HPX_COMPILER_FENCE;
-#else
-            std::uint64_t r = __sync_lock_test_and_set(&v_, 1);
-#endif
+            bool r = acquire_lock();    //-V707
 
             if (r == 0)
             {
@@ -97,15 +85,28 @@ namespace hpx { namespace lcos { namespace local {
         {
             HPX_ITT_SYNC_RELEASING(this);
 
-#if !defined(BOOST_SP_HAS_SYNC)
-            HPX_COMPILER_FENCE;
-            *const_cast<std::uint64_t volatile*>(&v_) = 0;
-#else
-            __sync_lock_release(&v_);
-#endif
+            relinquish_lock();
 
             HPX_ITT_SYNC_RELEASED(this);
             util::unregister_lock(this);
+        }
+
+    private:
+        // returns whether the mutex has been acquired
+        bool acquire_lock()
+        {
+            return !v_.exchange(true, std::memory_order_acquire);
+        }
+
+        // relinquish lock
+        void relinquish_lock()
+        {
+            v_.store(false, std::memory_order_release);
+        }
+
+        bool is_locked() const
+        {
+            return v_.load(std::memory_order_relaxed);
         }
     };
 }}}    // namespace hpx::lcos::local

--- a/libs/synchronization/include/hpx/synchronization/spinlock_no_backoff.hpp
+++ b/libs/synchronization/include/hpx/synchronization/spinlock_no_backoff.hpp
@@ -13,6 +13,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/basic_execution/register_locks.hpp>
+#include <hpx/basic_execution/this_thread.hpp>
 #include <hpx/concurrency/itt_notify.hpp>
 
 #include <atomic>
@@ -47,17 +48,10 @@ namespace hpx { namespace lcos { namespace local {
         {
             HPX_ITT_SYNC_PREPARE(this);
 
-            for (;;)
+            while (!acquire_lock())
             {
-                if (acquire_lock())
-                {
-                    break;
-                }
-
-                while (is_locked())
-                {
-                    /**/;
-                }
+                util::yield_while([this] { return is_locked(); },
+                    "hpx::lcos::local::spinlock_no_backoff::lock", false);
             }
 
             HPX_ITT_SYNC_ACQUIRED(this);


### PR DESCRIPTION
This reduces the cache-pressure while acquiring highly contented spinlock instances by mostly reading from it instead of constantly trying to write to it.

As a flyby, this removes the dependency on `boost/smart_ptr/detail/spinlock.hpp` and related Boost facilities.