### PR TITLE
Making sure hash_any::operator()() is linked into core library

### DIFF
--- a/libs/serialization/CMakeLists.txt
+++ b/libs/serialization/CMakeLists.txt
@@ -37,6 +37,7 @@ set(serialization_headers
   hpx/serialization/datapar.hpp
   hpx/serialization/deque.hpp
   hpx/serialization/dynamic_bitset.hpp
+  hpx/serialization/force_linking.hpp
   hpx/serialization/list.hpp
   hpx/serialization/map.hpp
   hpx/serialization/multi_array.hpp
@@ -141,6 +142,7 @@ set(serialization_sources
   detail/polymorphic_id_factory.cpp
   detail/polymorphic_intrusive_factory.cpp
   detail/polymorphic_nonintrusive_factory.cpp
+  force_linking.cpp
   serializable_any.cpp
 )
 
@@ -148,7 +150,6 @@ include(HPX_AddModule)
 add_hpx_module(serialization
   COMPATIBILITY_HEADERS ON
   DEPRECATION_WARNINGS
-  FORCE_LINKING_GEN
   GLOBAL_HEADER_GEN ON
   SOURCES ${serialization_sources}
   HEADERS ${serialization_headers}

--- a/libs/serialization/include/hpx/serialization/force_linking.hpp
+++ b/libs/serialization/include/hpx/serialization/force_linking.hpp
@@ -1,0 +1,19 @@
+//  Copyright (c) 2019-2020 STE||AR Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef HPX_SERIALIZATION_FORCE_LINKING_HPP
+#define HPX_SERIALIZATION_FORCE_LINKING_HPP
+
+namespace hpx { namespace serialization {
+    struct force_linking_helper
+    {
+        void (*dummy)();
+    };
+
+    force_linking_helper& force_linking();
+}}    // namespace hpx::serialization
+
+#endif

--- a/libs/serialization/include/hpx/serialization/serializable_any.hpp
+++ b/libs/serialization/include/hpx/serialization/serializable_any.hpp
@@ -427,6 +427,9 @@ namespace hpx { namespace util {
         HPX_EXPORT std::size_t
         operator()(const basic_any<serialization::input_archive,
             serialization::output_archive, Char, std::true_type>& elem) const;
+
+        // this is just to force linking with serializable_any.cpp
+        HPX_EXPORT static void dummy();
     };
 }}    // namespace hpx::util
 

--- a/libs/serialization/src/force_linking.cpp
+++ b/libs/serialization/src/force_linking.cpp
@@ -1,0 +1,16 @@
+//  Copyright (c) 2019-2020 STE||AR Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/serialization/force_linking.hpp>
+#include <hpx/serialization/serializable_any.hpp>
+
+namespace hpx { namespace serialization {
+    force_linking_helper& force_linking()
+    {
+        static force_linking_helper helper{&hpx::util::hash_any::dummy};
+        return helper;
+    }
+}}    // namespace hpx::serialization

--- a/libs/serialization/src/serializable_any.cpp
+++ b/libs/serialization/src/serializable_any.cpp
@@ -92,4 +92,7 @@ namespace hpx { namespace util {
     hash_any::operator()(const basic_any<serialization::input_archive,
         serialization::output_archive, wchar_t, std::true_type>& elem) const;
 
+    // this is just to force linking with serializable_any.cpp
+    void hash_any::dummy() {}
+
 }}    // namespace hpx::util


### PR DESCRIPTION
Fixes Windows GitHub builder
