### PR TITLE
Adding test macros supporting custom output stream

### DIFF
--- a/libs/testing/include/hpx/testing.hpp
+++ b/libs/testing/include/hpx/testing.hpp
@@ -11,11 +11,12 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assertion.hpp>
+#include <hpx/preprocessor/cat.hpp>
+#include <hpx/preprocessor/expand.hpp>
+#include <hpx/preprocessor/nargs.hpp>
 #include <hpx/preprocessor/stringize.hpp>
 #include <hpx/util/ios_flags_saver.hpp>
 
-// Use smart_ptr's spinlock header because this header is used by the CMake
-// config tests, and therefore we can't include other hpx headers in this file.
 #include <boost/smart_ptr/detail/spinlock.hpp>
 
 #include <cstddef>
@@ -26,6 +27,7 @@
 #include <sstream>
 
 namespace hpx { namespace util {
+
     using test_failure_handler_type = std::function<void()>;
     HPX_EXPORT void set_test_failure_handler(test_failure_handler_type f);
 
@@ -184,108 +186,416 @@ namespace hpx { namespace util {
     HPX_EXPORT void print_cdash_timing(const char* name, std::uint64_t time);
 }}    // namespace hpx::util
 
-#define HPX_TEST(expr)                                                         \
-    ::hpx::util::detail::global_fixture.check_(__FILE__, __LINE__,             \
-        HPX_ASSERT_CURRENT_FUNCTION, ::hpx::util::counter_test, expr,          \
-        "test '" HPX_PP_STRINGIZE(expr) "'")
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_TEST(...)                                                          \
+    HPX_TEST_(__VA_ARGS__)                                                     \
+    /**/
 
-#define HPX_TEST_MSG(expr, msg)                                                \
-    ::hpx::util::detail::global_fixture.check_(__FILE__, __LINE__,             \
-        HPX_ASSERT_CURRENT_FUNCTION, ::hpx::util::counter_test, expr, msg)
+#define HPX_TEST_(...)                                                         \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_TEST_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))         \
+    /**/
+#define HPX_TEST_1(expr)                                                       \
+    HPX_TEST_IMPL(::hpx::util::detail::global_fixture, expr)
+#define HPX_TEST_2(strm, expr)                                                 \
+    HPX_TEST_IMPL(::hpx::util::detail::fixture{strm}, expr)
 
-#define HPX_TEST_EQ(expr1, expr2)                                              \
-    ::hpx::util::detail::global_fixture.check_equal(__FILE__, __LINE__,        \
-        HPX_ASSERT_CURRENT_FUNCTION, ::hpx::util::counter_test, expr1, expr2,  \
+#define HPX_TEST_IMPL(fixture, expr)                                           \
+    fixture.check_(__FILE__, __LINE__, HPX_ASSERT_CURRENT_FUNCTION,            \
+        ::hpx::util::counter_test, expr, "test '" HPX_PP_STRINGIZE(expr) "'")
+
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_TEST_MSG(...)                                                      \
+    HPX_TEST_MSG_(__VA_ARGS__)                                                 \
+    /**/
+
+#define HPX_TEST_MSG_(...)                                                     \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_TEST_MSG_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))     \
+    /**/
+#define HPX_TEST_MSG_2(expr, msg)                                              \
+    HPX_TEST_MSG_IMPL(::hpx::util::detail::global_fixture, expr, msg)
+#define HPX_TEST_MSG_3(strm, expr, msg)                                        \
+    HPX_TEST_MSG_IMPL(::hpx::util::detail::fixture{strm}, expr, msg)
+
+#define HPX_TEST_MSG_IMPL(fixture, expr, msg)                                  \
+    fixture.check_(__FILE__, __LINE__, HPX_ASSERT_CURRENT_FUNCTION,            \
+        ::hpx::util::counter_test, expr, msg)
+
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_TEST_EQ(...)                                                       \
+    HPX_TEST_EQ_(__VA_ARGS__)                                                  \
+    /**/
+
+#define HPX_TEST_EQ_(...)                                                      \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_TEST_EQ_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))      \
+    /**/
+#define HPX_TEST_EQ_2(expr1, expr2)                                            \
+    HPX_TEST_EQ_IMPL(::hpx::util::detail::global_fixture, expr1, expr2)
+#define HPX_TEST_EQ_3(strm, expr1, expr2)                                      \
+    HPX_TEST_EQ_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2)
+
+#define HPX_TEST_EQ_IMPL(fixture, expr1, expr2)                                \
+    fixture.check_equal(__FILE__, __LINE__, HPX_ASSERT_CURRENT_FUNCTION,       \
+        ::hpx::util::counter_test, expr1, expr2,                               \
         "test '" HPX_PP_STRINGIZE(expr1) " == " HPX_PP_STRINGIZE(expr2) "'")
 
-#define HPX_TEST_NEQ(expr1, expr2)                                             \
-    ::hpx::util::detail::global_fixture.check_not_equal(__FILE__, __LINE__,    \
-        HPX_ASSERT_CURRENT_FUNCTION, ::hpx::util::counter_test, expr1, expr2,  \
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_TEST_NEQ(...)                                                      \
+    HPX_TEST_NEQ_(__VA_ARGS__)                                                 \
+    /**/
+
+#define HPX_TEST_NEQ_(...)                                                     \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_TEST_NEQ_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))     \
+    /**/
+#define HPX_TEST_NEQ_2(expr1, expr2)                                           \
+    HPX_TEST_NEQ_IMPL(::hpx::util::detail::global_fixture, expr1, expr2)
+#define HPX_TEST_NEQ_3(strm, expr1, expr2)                                     \
+    HPX_TEST_NEQ_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2)
+
+#define HPX_TEST_NEQ_IMPL(fixture, expr1, expr2)                               \
+    fixture.check_not_equal(__FILE__, __LINE__, HPX_ASSERT_CURRENT_FUNCTION,   \
+        ::hpx::util::counter_test, expr1, expr2,                               \
         "test '" HPX_PP_STRINGIZE(expr1) " != " HPX_PP_STRINGIZE(expr2) "'")
 
-#define HPX_TEST_LT(expr1, expr2)                                              \
-    ::hpx::util::detail::global_fixture.check_less(__FILE__, __LINE__,         \
-        HPX_ASSERT_CURRENT_FUNCTION, ::hpx::util::counter_test, expr1, expr2,  \
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_TEST_LT(...)                                                       \
+    HPX_TEST_LT_(__VA_ARGS__)                                                  \
+    /**/
+
+#define HPX_TEST_LT_(...)                                                      \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_TEST_LT_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))      \
+    /**/
+#define HPX_TEST_LT_2(expr1, expr2)                                            \
+    HPX_TEST_LT_IMPL(::hpx::util::detail::global_fixture, expr1, expr2)
+#define HPX_TEST_LT_3(strm, expr1, expr2)                                      \
+    HPX_TEST_LT_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2)
+
+#define HPX_TEST_LT_IMPL(fixture, expr1, expr2)                                \
+    fixture.check_less(__FILE__, __LINE__, HPX_ASSERT_CURRENT_FUNCTION,        \
+        ::hpx::util::counter_test, expr1, expr2,                               \
         "test '" HPX_PP_STRINGIZE(expr1) " < " HPX_PP_STRINGIZE(expr2) "'")
 
-#define HPX_TEST_LTE(expr1, expr2)                                             \
-    ::hpx::util::detail::global_fixture.check_less_equal(__FILE__, __LINE__,   \
-        HPX_ASSERT_CURRENT_FUNCTION, ::hpx::util::counter_test, expr1, expr2,  \
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_TEST_LTE(...)                                                      \
+    HPX_TEST_LTE_(__VA_ARGS__)                                                 \
+    /**/
+
+#define HPX_TEST_LTE_(...)                                                     \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_TEST_LTE_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))     \
+    /**/
+#define HPX_TEST_LTE_2(expr1, expr2)                                           \
+    HPX_TEST_LTE_IMPL(::hpx::util::detail::global_fixture, expr1, expr2)
+#define HPX_TEST_LTE_3(strm, expr1, expr2)                                     \
+    HPX_TEST_LTE_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2)
+
+#define HPX_TEST_LTE_IMPL(fixture, expr1, expr2)                               \
+    fixture.check_less_equal(__FILE__, __LINE__, HPX_ASSERT_CURRENT_FUNCTION,  \
+        ::hpx::util::counter_test, expr1, expr2,                               \
         "test '" HPX_PP_STRINGIZE(expr1) " <= " HPX_PP_STRINGIZE(expr2) "'")
 
-#define HPX_TEST_RANGE(expr1, expr2, expr3)                                    \
-    ::hpx::util::detail::global_fixture.check_range(__FILE__, __LINE__,        \
-        HPX_ASSERT_CURRENT_FUNCTION, ::hpx::util::counter_test, expr1, expr2,  \
-        expr3,                                                                 \
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_TEST_RANGE(...)                                                    \
+    HPX_TEST_RANGE_(__VA_ARGS__)                                               \
+    /**/
+
+#define HPX_TEST_RANGE_(...)                                                   \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_TEST_RANGE_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))   \
+    /**/
+#define HPX_TEST_RANGE_3(expr1, expr2, expr3)                                  \
+    HPX_TEST_RANGE_IMPL(                                                       \
+        ::hpx::util::detail::global_fixture, expr1, expr2, expr3)
+#define HPX_TEST_RANGE_4(strm, expr1, expr2, expr3)                            \
+    HPX_TEST_RANGE_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2, expr3)
+
+#define HPX_TEST_RANGE_IMPL(fixture, expr1, expr2, expr3)                      \
+    fixture.check_range(__FILE__, __LINE__, HPX_ASSERT_CURRENT_FUNCTION,       \
+        ::hpx::util::counter_test, expr1, expr2, expr3,                        \
         "test '" HPX_PP_STRINGIZE(expr2) " <= " HPX_PP_STRINGIZE(              \
             expr1) " <= " HPX_PP_STRINGIZE(expr3) "'")
 
-#define HPX_TEST_EQ_MSG(expr1, expr2, msg)                                     \
-    ::hpx::util::detail::global_fixture.check_equal(__FILE__, __LINE__,        \
-        HPX_ASSERT_CURRENT_FUNCTION, ::hpx::util::counter_test, expr1, expr2,  \
-        msg)
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_TEST_EQ_MSG(...)                                                   \
+    HPX_TEST_EQ_MSG_(__VA_ARGS__)                                              \
+    /**/
 
-#define HPX_TEST_NEQ_MSG(expr1, expr2, msg)                                    \
-    ::hpx::util::detail::global_fixture.check_not_equal(__FILE__, __LINE__,    \
-        HPX_ASSERT_CURRENT_FUNCTION, ::hpx::util::counter_test, expr1, expr2,  \
-        msg)
+#define HPX_TEST_EQ_MSG_(...)                                                  \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_TEST_EQ_MSG_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))  \
+    /**/
+#define HPX_TEST_EQ_MSG_3(expr1, expr2, msg)                                   \
+    HPX_TEST_EQ_MSG_IMPL(::hpx::util::detail::global_fixture, expr1, expr2, msg)
+#define HPX_TEST_EQ_MSG_4(strm, expr1, expr2, msg)                             \
+    HPX_TEST_EQ_MSG_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2, msg)
 
-#define HPX_SANITY(expr)                                                       \
-    ::hpx::util::detail::global_fixture.check_(__FILE__, __LINE__,             \
-        HPX_ASSERT_CURRENT_FUNCTION, ::hpx::util::counter_sanity, expr,        \
+#define HPX_TEST_EQ_MSG_IMPL(fixture, expr1, expr2, msg)                       \
+    fixture.check_equal(__FILE__, __LINE__, HPX_ASSERT_CURRENT_FUNCTION,       \
+        ::hpx::util::counter_test, expr1, expr2, msg)
+
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_TEST_NEQ_MSG(...)                                                  \
+    HPX_TEST_NEQ_MSG_(__VA_ARGS__)                                             \
+    /**/
+
+#define HPX_TEST_NEQ_MSG_(...)                                                 \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_TEST_NEQ_MSG_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__)) \
+    /**/
+#define HPX_TEST_NEQ_MSG_3(expr1, expr2, msg)                                  \
+    HPX_TEST_NEQ_MSG_IMPL(                                                     \
+        ::hpx::util::detail::global_fixture, expr1, expr2, msg)
+#define HPX_TEST_NEQ_MSG_4(strm, expr1, expr2, msg)                            \
+    HPX_TEST_NEQ_MSG_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2, msg)
+
+#define HPX_TEST_NEQ_MSG_IMPL(fixture, expr1, expr2, msg)                      \
+    fixture.check_not_equal(__FILE__, __LINE__, HPX_ASSERT_CURRENT_FUNCTION,   \
+        ::hpx::util::counter_test, expr1, expr2, msg)
+
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_TEST_LT_MSG(...)                                                   \
+    HPX_TEST_LT_MSG_(__VA_ARGS__)                                              \
+    /**/
+
+#define HPX_TEST_LT_MSG_(...)                                                  \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_TEST_LT_MSG_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))  \
+    /**/
+#define HPX_TEST_LT_MSG_3(expr1, expr2, msg)                                   \
+    HPX_TEST_LT_MSG_IMPL(::hpx::util::detail::global_fixture, expr1, expr2, msg)
+#define HPX_TEST_LT_MSG_4(strm, expr1, expr2, msg)                             \
+    HPX_TEST_LT_MSG_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2, msg)
+
+#define HPX_TEST_LT_MSG_IMPL(fixture, expr1, expr2, msg)                       \
+    fixture.check_less(__FILE__, __LINE__, HPX_ASSERT_CURRENT_FUNCTION,        \
+        ::hpx::util::counter_test, expr1, expr2, msg)
+
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_TEST_LTE_MSG(...)                                                  \
+    HPX_TEST_LTE_MSG_(__VA_ARGS__)                                             \
+    /**/
+
+#define HPX_TEST_LTE_MSG_(...)                                                 \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_TEST_LTE_MSG_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__)) \
+    /**/
+#define HPX_TEST_LTE_MSG_3(expr1, expr2, msg)                                  \
+    HPX_TEST_LTE_MSG_IMPL(                                                     \
+        ::hpx::util::detail::global_fixture, expr1, expr2, msg)
+#define HPX_TEST_LTE_MSG_4(strm, expr1, expr2, msg)                            \
+    HPX_TEST_LTE_MSG_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2, msg)
+
+#define HPX_TEST_LTE_MSG_IMPL(fixture, expr1, expr2, msg)                      \
+    fixture.check_less_equal(__FILE__, __LINE__, HPX_ASSERT_CURRENT_FUNCTION,  \
+        ::hpx::util::counter_test, expr1, expr2, msg)
+
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_TEST_RANGE_MSG(...)                                                \
+    HPX_TEST_RANGE_MSG_(__VA_ARGS__)                                           \
+    /**/
+
+#define HPX_TEST_RANGE_MSG_(...)                                               \
+    HPX_PP_EXPAND(HPX_PP_CAT(HPX_TEST_RANGE_MSG_, HPX_PP_NARGS(__VA_ARGS__))(  \
+        __VA_ARGS__))                                                          \
+    /**/
+#define HPX_TEST_RANGE_MSG_4(expr1, expr2, expr3, msg)                         \
+    HPX_TEST_RANGE_MSG_IMPL(                                                   \
+        ::hpx::util::detail::global_fixture, expr1, expr2, expr3, msg)
+#define HPX_TEST_RANGE_MSG_5(strm, expr1, expr2, expr3, msg)                   \
+    HPX_TEST_RANGE_MSG_IMPL(                                                   \
+        ::hpx::util::detail::fixture{strm}, expr1, expr2, expr3, msg)
+
+#define HPX_TEST_RANGE_MSG_IMPL(fixture, expr1, expr2, expr3, msg)             \
+    fixture.check_range(__FILE__, __LINE__, HPX_ASSERT_CURRENT_FUNCTION,       \
+        ::hpx::util::counter_test, expr1, expr2, expr3, msg)
+
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_SANITY(...)                                                        \
+    HPX_SANITY_(__VA_ARGS__)                                                   \
+    /**/
+
+#define HPX_SANITY_(...)                                                       \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_SANITY_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))       \
+    /**/
+#define HPX_SANITY_1(expr)                                                     \
+    HPX_TEST_IMPL(::hpx::util::detail::global_fixture, expr)
+#define HPX_SANITY_2(strm, expr)                                               \
+    HPX_SANITY_IMPL(::hpx::util::detail::fixture{strm}, expr)
+
+#define HPX_SANITY_IMPL(fixture, expr)                                         \
+    fixture.check_(__FILE__, __LINE__, HPX_ASSERT_CURRENT_FUNCTION,            \
+        ::hpx::util::counter_sanity, expr,                                     \
         "sanity check '" HPX_PP_STRINGIZE(expr) "'")
 
-#define HPX_SANITY_MSG(expr, msg)                                              \
-    ::hpx::util::detail::global_fixture.check_(__FILE__, __LINE__,             \
-        HPX_ASSERT_CURRENT_FUNCTION, ::hpx::util::counter_sanity, expr, msg)
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_SANITY_MSG(...)                                                    \
+    HPX_SANITY_MSG_(__VA_ARGS__)                                               \
+    /**/
 
-#define HPX_SANITY_EQ(expr1, expr2)                                            \
-    ::hpx::util::detail::global_fixture.check_equal(__FILE__, __LINE__,        \
-        HPX_ASSERT_CURRENT_FUNCTION, ::hpx::util::counter_sanity, expr1,       \
-        expr2,                                                                 \
+#define HPX_SANITY_MSG_(...)                                                   \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_SANITY_MSG_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))   \
+    /**/
+#define HPX_SANITY_MSG_2(expr, msg)                                            \
+    HPX_SANITY_MSG_IMPL(::hpx::util::detail::global_fixture, expr, msg)
+#define HPX_SANITY_MSG_3(strm, expr, msg)                                      \
+    HPX_SANITY_MSG_IMPL(::hpx::util::detail::fixture{strm}, expr, msg)
+
+#define HPX_SANITY_MSG_IMPL(fixture, expr, msg)                                \
+    fixture.check_(__FILE__, __LINE__, HPX_ASSERT_CURRENT_FUNCTION,            \
+        ::hpx::util::counter_sanity, expr, msg)
+
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_SANITY_EQ(...)                                                     \
+    HPX_SANITY_EQ_(__VA_ARGS__)                                                \
+    /**/
+
+#define HPX_SANITY_EQ_(...)                                                    \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_SANITY_EQ_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))    \
+    /**/
+#define HPX_SANITY_EQ_2(expr1, expr2)                                          \
+    HPX_SANITY_EQ_IMPL(::hpx::util::detail::global_fixture, expr1, expr2)
+#define HPX_SANITY_EQ_3(strm, expr1, expr2)                                    \
+    HPX_SANITY_EQ_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2)
+
+#define HPX_SANITY_EQ_IMPL(fixture, expr1, expr2)                              \
+    fixture.check_equal(__FILE__, __LINE__, HPX_ASSERT_CURRENT_FUNCTION,       \
+        ::hpx::util::counter_sanity, expr1, expr2,                             \
         "sanity check '" HPX_PP_STRINGIZE(expr1) " == " HPX_PP_STRINGIZE(      \
             expr2) "'")
 
-#define HPX_SANITY_NEQ(expr1, expr2)                                           \
-    ::hpx::util::detail::global_fixture.check_not_equal(__FILE__, __LINE__,    \
-        HPX_ASSERT_CURRENT_FUNCTION, ::hpx::util::counter_sanity, expr1,       \
-        expr2,                                                                 \
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_SANITY_NEQ(...)                                                    \
+    HPX_SANITY_NEQ_(__VA_ARGS__)                                               \
+    /**/
+
+#define HPX_SANITY_NEQ_(...)                                                   \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_SANITY_NEQ_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))   \
+    /**/
+#define HPX_SANITY_NEQ_2(expr1, expr2)                                         \
+    HPX_SANITY_NEQ_IMPL(::hpx::util::detail::global_fixture, expr1, expr2)
+#define HPX_SANITY_NEQ_3(strm, expr1, expr2)                                   \
+    HPX_SANITY_NEQ_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2)
+
+#define HPX_SANITY_NEQ_IMPL(fixture, expr1, expr2)                             \
+    fixture.check_not_equal(__FILE__, __LINE__, HPX_ASSERT_CURRENT_FUNCTION,   \
+        ::hpx::util::counter_sanity, expr1, expr2,                             \
         "sanity check '" HPX_PP_STRINGIZE(expr1) " != " HPX_PP_STRINGIZE(      \
             expr2) "'")
 
-#define HPX_SANITY_LT(expr1, expr2)                                            \
-    ::hpx::util::detail::global_fixture.check_less(__FILE__, __LINE__,         \
-        HPX_ASSERT_CURRENT_FUNCTION, ::hpx::util::counter_sanity, expr1,       \
-        expr2,                                                                 \
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_SANITY_LT(...)                                                     \
+    HPX_SANITY_LT_(__VA_ARGS__)                                                \
+    /**/
+
+#define HPX_SANITY_LT_(...)                                                    \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_SANITY_LT_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))    \
+    /**/
+#define HPX_SANITY_LT_2(expr1, expr2)                                          \
+    HPX_SANITY_LT_IMPL(::hpx::util::detail::global_fixture, expr1, expr2)
+#define HPX_SANITY_LT_3(strm, expr1, expr2)                                    \
+    HPX_SANITY_LT_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2)
+
+#define HPX_SANITY_LT_IMPL(fixture, expr1, expr2)                              \
+    fixture.check_less(__FILE__, __LINE__, HPX_ASSERT_CURRENT_FUNCTION,        \
+        ::hpx::util::counter_sanity, expr1, expr2,                             \
         "sanity check '" HPX_PP_STRINGIZE(expr1) " < " HPX_PP_STRINGIZE(       \
             expr2) "'")
 
-#define HPX_SANITY_LTE(expr1, expr2)                                           \
-    ::hpx::util::detail::global_fixture.check_less_equal(__FILE__, __LINE__,   \
-        HPX_ASSERT_CURRENT_FUNCTION, ::hpx::util::counter_sanity, expr1,       \
-        expr2,                                                                 \
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_SANITY_LTE(...)                                                    \
+    HPX_SANITY_LTE_(__VA_ARGS__)                                               \
+    /**/
+
+#define HPX_SANITY_LTE_(...)                                                   \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_SANITY_LTE_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))   \
+    /**/
+#define HPX_SANITY_LTE_2(expr1, expr2)                                         \
+    HPX_SANITY_LTE_IMPL(::hpx::util::detail::global_fixture, expr1, expr2)
+#define HPX_SANITY_LTE_3(strm, expr1, expr2)                                   \
+    HPX_SANITY_LTE_IMPL(::hpx::util::detail::fixture{strm}, expr1, expr2)
+
+#define HPX_SANITY_LTE_IMPL(fixture, expr1, expr2)                             \
+    fixture.check_less_equal(__FILE__, __LINE__, HPX_ASSERT_CURRENT_FUNCTION,  \
+        ::hpx::util::counter_sanity, expr1, expr2,                             \
         "sanity check '" HPX_PP_STRINGIZE(expr1) " <= " HPX_PP_STRINGIZE(      \
             expr2) "'")
 
-#define HPX_SANITY_RANGE(expr1, expr2, expr3)                                  \
-    ::hpx::util::detail::global_fixture.check_range(__FILE__, __LINE__,        \
-        HPX_ASSERT_CURRENT_FUNCTION, ::hpx::util::counter_sanity, expr1,       \
-        expr2, expr3,                                                          \
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_SANITY_RANGE(...)                                                  \
+    HPX_SANITY_RANGE_(__VA_ARGS__)                                             \
+    /**/
+
+#define HPX_SANITY_RANGE_(...)                                                 \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_SANITY_RANGE_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__)) \
+    /**/
+#define HPX_SANITY_RANGE_3(expr1, expr2, expr3)                                \
+    HPX_SANITY_RANGE_IMPL(                                                     \
+        ::hpx::util::detail::global_fixture, expr1, expr2, expr3)
+#define HPX_SANITY_RANGE_4(strm, expr1, expr2, expr3)                          \
+    HPX_SANITY_RANGE_IMPL(                                                     \
+        ::hpx::util::detail::fixture{strm}, expr1, expr2, expr3)
+
+#define HPX_SANITY_RANGE_IMPL(fixture, expr1, expr2, expr3)                    \
+    fixture.check_range(__FILE__, __LINE__, HPX_ASSERT_CURRENT_FUNCTION,       \
+        ::hpx::util::counter_sanity, expr1, expr2, expr3,                      \
         "sanity check '" HPX_PP_STRINGIZE(expr2) " <= " HPX_PP_STRINGIZE(      \
             expr1) " <= " HPX_PP_STRINGIZE(expr3) "'")
 
-#define HPX_SANITY_EQ_MSG(expr1, expr2, msg)                                   \
-    ::hpx::util::detail::global_fixture.check_equal(__FILE__, __LINE__,        \
-        HPX_ASSERT_CURRENT_FUNCTION, ::hpx::util::counter_sanity, expr1,       \
-        expr2)
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_SANITY_EQ_MSG(...)                                                 \
+    HPX_SANITY_EQ_MSG_(__VA_ARGS__)                                            \
+    /**/
 
-#define HPX_TEST_THROW(expression, exception)                                  \
+#define HPX_SANITY_EQ_MSG_(...)                                                \
+    HPX_PP_EXPAND(HPX_PP_CAT(HPX_SANITY_EQ_MSG_, HPX_PP_NARGS(__VA_ARGS__))(   \
+        __VA_ARGS__))                                                          \
+    /**/
+#define HPX_SANITY_EQ_MSG_3(expr1, expr2, msg)                                 \
+    HPX_SANITY_EQ_MSG_IMPL(                                                    \
+        ::hpx::util::detail::global_fixture, expr1, expr2, msg)
+#define HPX_SANITY_EQ_MSG_4(strm, expr1, expr2, msg)                           \
+    HPX_SANITY_EQ_MSG_IMPL(                                                    \
+        ::hpx::util::detail::fixture{strm}, expr1, expr2, msg)
+
+#define HPX_SANITY_EQ_MSG_IMPL(fixture, expr1, expr2, msg)                     \
+    fixture.check_equal(__FILE__, __LINE__, HPX_ASSERT_CURRENT_FUNCTION,       \
+        ::hpx::util::counter_sanity, expr1, expr2, msg)
+
+////////////////////////////////////////////////////////////////////////////////
+#define HPX_TEST_THROW(...)                                                    \
+    HPX_TEST_THROW_(__VA_ARGS__)                                               \
+    /**/
+
+#define HPX_TEST_THROW_(...)                                                   \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_TEST_THROW_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))   \
+    /**/
+#define HPX_TEST_THROW_2(expression, exception)                                \
+    HPX_TEST_THROW_IMPL(                                                       \
+        ::hpx::util::detail::global_fixture, expression, exception)
+#define HPX_TEST_THROW_3(strm, expression, exception)                          \
+    HPX_TEST_THROW_IMPL(                                                       \
+        ::hpx::util::detail::fixture{strm}, expression, exception)
+
+#define HPX_TEST_THROW_IMPL(fixture, expression, exception)                    \
     {                                                                          \
         bool caught_exception = false;                                         \
         try                                                                    \
         {                                                                      \
             expression;                                                        \
-            HPX_TEST_MSG(false, "expected exception not thrown");              \
+            HPX_TEST_MSG_IMPL(                                                 \
+                fixture, false, "expected exception not thrown");              \
         }                                                                      \
         catch (exception&)                                                     \
         {                                                                      \
@@ -293,9 +603,9 @@ namespace hpx { namespace util {
         }                                                                      \
         catch (...)                                                            \
         {                                                                      \
-            HPX_TEST_MSG(false, "unexpected exception caught");                \
+            HPX_TEST_MSG_IMPL(fixture, false, "unexpected exception caught");  \
         }                                                                      \
-        HPX_TEST(caught_exception);                                            \
+        HPX_TEST_IMPL(fixture, caught_exception);                              \
     }                                                                          \
     /**/
 

--- a/libs/testing/include/hpx/testing.hpp
+++ b/libs/testing/include/hpx/testing.hpp
@@ -19,6 +19,7 @@
 
 #include <boost/smart_ptr/detail/spinlock.hpp>
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -45,15 +46,13 @@ namespace hpx { namespace util {
 
         private:
             std::ostream& stream_;
-            std::size_t sanity_failures_;
-            std::size_t test_failures_;
+            static std::atomic<std::size_t> sanity_failures_;
+            static std::atomic<std::size_t> test_failures_;
             mutex_type mutex_ = BOOST_DETAIL_SPINLOCK_INIT;
 
         public:
             fixture(std::ostream& stream)
               : stream_(stream)
-              , sanity_failures_(0)
-              , test_failures_(0)
             {
             }
 

--- a/libs/testing/src/testing.cpp
+++ b/libs/testing/src/testing.cpp
@@ -11,6 +11,7 @@
 #include <hpx/testing.hpp>
 #include <hpx/util.hpp>
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -26,6 +27,10 @@ namespace hpx { namespace util {
     }
 
     namespace detail {
+
+        std::atomic<std::size_t> fixture::sanity_failures_(0);
+        std::atomic<std::size_t> fixture::test_failures_(0);
+
         void fixture::increment(counter_type c)
         {
             if (test_failure_handler)

--- a/libs/testing/tests/unit/CMakeLists.txt
+++ b/libs/testing/tests/unit/CMakeLists.txt
@@ -1,5 +1,29 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2020 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests
+    test_macros
+  )
+
+foreach(test ${tests})
+
+  set(sources
+      ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  # add example executable
+  add_hpx_executable(${test}_test
+    INTERNAL_FLAGS
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Modules/Testing")
+
+  add_hpx_unit_test("modules.testing" ${test} ${${test}_PARAMETERS})
+
+endforeach()

--- a/libs/testing/tests/unit/test_macros.cpp
+++ b/libs/testing/tests/unit/test_macros.cpp
@@ -8,17 +8,18 @@
 #include <hpx/testing.hpp>
 
 #include <sstream>
+#include <string>
 
 int main(int argc, char* argv[])
 {
     std::stringstream strm;
 
     // testing macros
-    HPX_TEST(0 == 0);
-    HPX_TEST(strm, 0 == 0);
+    HPX_TEST(true);
+    HPX_TEST(strm, true);
 
-    HPX_TEST_MSG(0 == 0, "should be true");
-    HPX_TEST_MSG(strm, 0 == 0, "should be true");
+    HPX_TEST_MSG(true, "should be true");
+    HPX_TEST_MSG(strm, true, "should be true");
 
     HPX_TEST_EQ(0, 0);
     HPX_TEST_EQ(strm, 0, 0);
@@ -51,11 +52,11 @@ int main(int argc, char* argv[])
     HPX_TEST_RANGE_MSG(strm, 1, 1, 1, "should be in range");
 
     // sanity macro tests
-    HPX_SANITY(0 == 0);
-    HPX_SANITY(strm, 0 == 0);
+    HPX_SANITY(true);
+    HPX_SANITY(strm, true);
 
-    HPX_SANITY_MSG(0 == 0, "should be true");
-    HPX_SANITY_MSG(strm, 0 == 0, "should be true");
+    HPX_SANITY_MSG(true, "should be true");
+    HPX_SANITY_MSG(strm, true, "should be true");
 
     HPX_SANITY_EQ(0, 0);
     HPX_SANITY_EQ(strm, 0, 0);
@@ -78,5 +79,10 @@ int main(int argc, char* argv[])
     // there shouldn't be any output being generated
     HPX_TEST(strm.str().empty());
 
-    return hpx::util::report_errors();
+    // now test that something gets written to the stream if an error occurs
+    HPX_TEST(strm, false);
+    HPX_TEST(strm.str().find("test 'false'") != std::string::npos);
+
+    // we have intentionally generated one error
+    return (hpx::util::report_errors() == 1) ? 0 : -1;
 }

--- a/libs/testing/tests/unit/test_macros.cpp
+++ b/libs/testing/tests/unit/test_macros.cpp
@@ -1,0 +1,82 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/testing.hpp>
+
+#include <sstream>
+
+int main(int argc, char* argv[])
+{
+    std::stringstream strm;
+
+    // testing macros
+    HPX_TEST(0 == 0);
+    HPX_TEST(strm, 0 == 0);
+
+    HPX_TEST_MSG(0 == 0, "should be true");
+    HPX_TEST_MSG(strm, 0 == 0, "should be true");
+
+    HPX_TEST_EQ(0, 0);
+    HPX_TEST_EQ(strm, 0, 0);
+
+    HPX_TEST_EQ_MSG(0, 0, "should be equal");
+    HPX_TEST_EQ_MSG(strm, 0, 0, "should be equal");
+
+    HPX_TEST_NEQ(0, 1);
+    HPX_TEST_NEQ(strm, 0, 1);
+
+    HPX_TEST_NEQ_MSG(0, 1, "should not be equal");
+    HPX_TEST_NEQ_MSG(strm, 0, 1, "should not be equal");
+
+    HPX_TEST_LT(0, 1);
+    HPX_TEST_LT(strm, 0, 1);
+
+    HPX_TEST_LT_MSG(0, 1, "should be less");
+    HPX_TEST_LT_MSG(strm, 0, 1, "should be less");
+
+    HPX_TEST_LTE(1, 1);
+    HPX_TEST_LTE(strm, 1, 1);
+
+    HPX_TEST_LTE_MSG(1, 1, "should be less equal");
+    HPX_TEST_LTE_MSG(strm, 1, 1, "should be less equal");
+
+    HPX_TEST_RANGE(1, 1, 1);
+    HPX_TEST_RANGE(strm, 1, 1, 1);
+
+    HPX_TEST_RANGE_MSG(1, 1, 1, "should be in range");
+    HPX_TEST_RANGE_MSG(strm, 1, 1, 1, "should be in range");
+
+    // sanity macro tests
+    HPX_SANITY(0 == 0);
+    HPX_SANITY(strm, 0 == 0);
+
+    HPX_SANITY_MSG(0 == 0, "should be true");
+    HPX_SANITY_MSG(strm, 0 == 0, "should be true");
+
+    HPX_SANITY_EQ(0, 0);
+    HPX_SANITY_EQ(strm, 0, 0);
+
+    HPX_SANITY_EQ_MSG(0, 0, "should be equal");
+    HPX_SANITY_EQ_MSG(strm, 0, 0, "should be equal");
+
+    HPX_SANITY_NEQ(0, 1);
+    HPX_SANITY_NEQ(strm, 0, 1);
+
+    HPX_SANITY_LT(0, 1);
+    HPX_SANITY_LT(strm, 0, 1);
+
+    HPX_SANITY_LTE(1, 1);
+    HPX_SANITY_LTE(strm, 1, 1);
+
+    HPX_SANITY_RANGE(1, 1, 1);
+    HPX_SANITY_RANGE(strm, 1, 1, 1);
+
+    // there shouldn't be any output being generated
+    HPX_TEST(strm.str().empty());
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Fixes #4554

This adds macro overloads to all `HPX_TEST()` macros allowing to pass any output stream as the respective first arguments. For instance:
```
    HPX_TEST(true);             // uses std::cerr as before
    HPX_TEST(hpx::cout, true);  // uses hpx::cout for generated output
```
