### PR TITLE
fix CMake option typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1070,7 +1070,7 @@ endif()
 # Check if the selected compiler versions are supposed to work with our codebase
 if(CMAKE_COMPILER_IS_GNUCXX AND HPX_WITH_GCC_VERSION_CHECK)
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
-    hpx_error("GCC 7.0 or higher is required. Specify HPX_GCC_VERSION_CHECK=OFF to ignore this error.")
+    hpx_error("GCC 7.0 or higher is required. Specify HPX_WITH_GCC_VERSION_CHECK=OFF to ignore this error.")
   endif()
 endif()
 


### PR DESCRIPTION
Added the missing "_WITH" in the error message.

