### PR TITLE
Changing return type of hardware_concurrency() to unsigned int

### DIFF
--- a/libs/threading/include/hpx/threading/thread.hpp
+++ b/libs/threading/include/hpx/threading/thread.hpp
@@ -109,7 +109,7 @@ namespace hpx {
             return id_;
         }
 
-        static std::size_t hardware_concurrency() noexcept;
+        HPX_NODISCARD static unsigned int hardware_concurrency() noexcept;
 
         // extensions
         void interrupt(bool flag = true);

--- a/libs/threading/src/thread.cpp
+++ b/libs/threading/src/thread.cpp
@@ -155,7 +155,7 @@ namespace hpx {
         return id(native_handle());
     }
 
-    std::size_t thread::hardware_concurrency() noexcept
+    unsigned int thread::hardware_concurrency() noexcept
     {
         return hpx::threads::hardware_concurrency();
     }

--- a/libs/topology/include/hpx/topology/topology.hpp
+++ b/libs/topology/include/hpx/topology/topology.hpp
@@ -419,7 +419,7 @@ namespace hpx { namespace threads {
         return topo.get();
     }
 
-    HPX_API_EXPORT HPX_NODISCARD std::size_t hardware_concurrency();
+    HPX_API_EXPORT HPX_NODISCARD unsigned int hardware_concurrency();
 
     ///////////////////////////////////////////////////////////////////////////
     // abstract away memory page size, calls to system functions are

--- a/libs/topology/src/topology.cpp
+++ b/libs/topology/src/topology.cpp
@@ -1521,9 +1521,9 @@ namespace hpx { namespace threads {
         std::size_t num_of_cores_;
     };
 
-    std::size_t hardware_concurrency()
+    unsigned int hardware_concurrency()
     {
         util::static_<hw_concurrency, hardware_concurrency_tag> hwc;
-        return hwc.get().num_of_cores_;
+        return static_cast<std::size_t>(hwc.get().num_of_cores_);
     }
 }}    // namespace hpx::threads


### PR DESCRIPTION
Fixes #4569

- flyby: making the return value `[[nodiscard]]`
