### PR TITLE
Adding missing using placeholder::_X

### DIFF
--- a/libs/performance_counters/src/registry.cpp
+++ b/libs/performance_counters/src/registry.cpp
@@ -404,7 +404,6 @@ namespace hpx { namespace performance_counters {
     counter_status registry::create_raw_counter_value(counter_info const& info,
         std::int64_t* countervalue, naming::gid_type& id, error_code& ec)
     {
-        using util::placeholders::_1;
         hpx::util::function_nonser<std::int64_t(bool)> func(
             util::bind_front(wrap_counter, countervalue));
         return create_raw_counter(info, func, id, ec);
@@ -426,7 +425,6 @@ namespace hpx { namespace performance_counters {
         hpx::util::function_nonser<std::int64_t()> const& f,
         naming::gid_type& id, error_code& ec)
     {
-        using util::placeholders::_1;
         hpx::util::function_nonser<std::int64_t(bool)> func(
             util::bind_front(&wrap_raw_counter, f));
         return create_raw_counter(info, func, id, ec);
@@ -510,7 +508,6 @@ namespace hpx { namespace performance_counters {
         hpx::util::function_nonser<std::vector<std::int64_t>()> const& f,
         naming::gid_type& id, error_code& ec)
     {
-        using util::placeholders::_1;
         hpx::util::function_nonser<std::vector<std::int64_t>(bool)> func(
             util::bind_front(&wrap_raw_values_counter, f));
         return create_raw_counter(info, func, id, ec);

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -1865,7 +1865,6 @@ future<hpx::id_type> addressing_service::on_symbol_namespace_event(
     hpx::future<bool> f =
         symbol_ns_.on_event(name, call_for_past_events, p.get_id());
 
-    using util::placeholders::_1;
     return f.then(
         hpx::launch::sync,
         util::one_shot(util::bind_back(
@@ -2357,6 +2356,8 @@ void addressing_service::register_counter_types()
         util::bind_front(
             &addressing_service::get_cache_erase_entry_time, this));
 
+    using util::placeholders::_1;
+    using util::placeholders::_2;
     performance_counters::generic_counter_type_data const counter_types[] =
     {
         { "/agas/count/cache/entries", performance_counters::counter_raw,

--- a/tests/performance/network/network_storage/network_storage.cpp
+++ b/tests/performance/network/network_storage/network_storage.cpp
@@ -800,7 +800,6 @@ void test_read(
                 ++FuturesWaiting[send_rank];
                 std::lock_guard<hpx::lcos::local::spinlock> lk(FuturesMutex);
 #endif
-                using hpx::util::placeholders::_1;
                 std::size_t buffer_address =
                     reinterpret_cast<std::size_t>(general_buffer.data());
                 //


### PR DESCRIPTION
- flyby remove unneeded using statements

Fixes compilation problems with Boost V1.73
