### PR TITLE
Attempting to fix missing symbols in stack trace 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -541,6 +541,19 @@ if(HPX_WITH_STACKTRACES OR HPX_WITH_THREAD_BACKTRACE_ON_SUSPENSION)
     CATEGORY "Thread Manager" ADVANCED)
   hpx_add_config_define(HPX_HAVE_THREAD_BACKTRACE_DEPTH
     ${HPX_WITH_THREAD_BACKTRACE_DEPTH})
+
+  if(("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux") AND
+     ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"))
+
+    # This option is OFF by default as we have seen random segfaults out in the
+    # wild if this is enabled.
+    hpx_option(HPX_WITH_STACKTRACES_STATIC_SYMBOLS BOOL
+      "Thread stack back trace will resolve static symbols (default: OFF)"
+      OFF
+      CATEGORY "Thread Manager" ADVANCED)
+    hpx_add_config_define(HPX_HAVE_STACKTRACES_STATIC_SYMBOLS
+      ${HPX_WITH_STACKTRACES_STATIC_SYMBOLS})
+  endif()
 endif()
 
 if(HPX_WITH_THREAD_BACKTRACE_ON_SUSPENSION)

--- a/init/CMakeLists.txt
+++ b/init/CMakeLists.txt
@@ -100,6 +100,15 @@ if(HPX_WITH_DYNAMIC_HPX_MAIN AND (("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux") OR (
   endif()
 endif()
 
+if(HPX_WITH_STACKTRACES)
+  # Add -Wl,-E to linker for executables on Linux(Clang or gcc)
+  # this will add all symbols to the dynamic symbol table
+  if(("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux") AND
+     ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"))
+    target_link_libraries(hpx_init INTERFACE "-Wl,-E")
+  endif()
+endif()
+
 install(
   TARGETS hpx_init
   EXPORT HPXTargets

--- a/init/CMakeLists.txt
+++ b/init/CMakeLists.txt
@@ -100,7 +100,7 @@ if(HPX_WITH_DYNAMIC_HPX_MAIN AND (("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux") OR (
   endif()
 endif()
 
-if(HPX_WITH_STACKTRACES)
+if(HPX_WITH_STACKTRACES AND HPX_WITH_STACKTRACES_STATIC_SYMBOLS)
   # Add -Wl,-E to linker for executables on Linux(Clang or gcc)
   # this will add all symbols to the dynamic symbol table
   if(("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux") AND

--- a/libs/basic_execution/include/hpx/basic_execution/register_locks.hpp
+++ b/libs/basic_execution/include/hpx/basic_execution/register_locks.hpp
@@ -11,6 +11,7 @@
 #include <hpx/config.hpp>
 #include <hpx/concepts/has_member_xxx.hpp>
 
+#include <cstddef>
 #include <functional>
 #include <type_traits>
 #include <utility>
@@ -39,6 +40,7 @@ namespace hpx { namespace util {
     HPX_API_EXPORT void force_error_on_lock();
     HPX_API_EXPORT void enable_lock_detection();
     HPX_API_EXPORT void disable_lock_detection();
+    HPX_API_EXPORT void trace_depth_lock_detection(std::size_t value);
     HPX_API_EXPORT void ignore_lock(void const* lock);
     HPX_API_EXPORT void reset_ignored(void const* lock);
     HPX_API_EXPORT void ignore_all_locks();
@@ -113,23 +115,25 @@ namespace hpx { namespace util {
         ignore_all_while_checking() {}
     };
 
-    inline bool register_lock(void const*, util::register_lock_data* = nullptr)
+    constexpr inline bool register_lock(
+        void const*, util::register_lock_data* = nullptr)
     {
         return true;
     }
-    inline bool unregister_lock(void const*)
+    constexpr inline bool unregister_lock(void const*)
     {
         return true;
     }
-    inline void verify_no_locks() {}
-    inline void force_error_on_lock() {}
-    inline void enable_lock_detection() {}
-    inline void disable_lock_detection() {}
-    inline void ignore_lock(void const* /*lock*/) {}
-    inline void reset_ignored(void const* /*lock*/) {}
+    constexpr inline void verify_no_locks() {}
+    constexpr inline void force_error_on_lock() {}
+    constexpr inline void enable_lock_detection() {}
+    constexpr inline void disable_lock_detection() {}
+    constexpr inline void trace_depth_lock_detection(std::size_t /*value*/) {}
+    constexpr inline void ignore_lock(void const* /*lock*/) {}
+    constexpr inline void reset_ignored(void const* /*lock*/) {}
 
-    inline void ignore_all_locks() {}
-    inline void reset_ignored_all() {}
+    constexpr inline void ignore_all_locks() {}
+    constexpr inline void reset_ignored_all() {}
 #endif
 }}    // namespace hpx::util
 

--- a/libs/debugging/include/hpx/debugging/backtrace/backtrace.hpp
+++ b/libs/debugging/include/hpx/debugging/backtrace/backtrace.hpp
@@ -37,6 +37,7 @@ namespace hpx { namespace util {
         {
             if (frames_no == 0)
                 return;
+            frames_no += 2;    // we omit two frames from printing
             frames_.resize(frames_no, nullptr);
             std::size_t size = stack_trace::trace(&frames_.front(), frames_no);
             if (size != 0)

--- a/libs/debugging/src/backtrace.cpp
+++ b/libs/debugging/src/backtrace.cpp
@@ -244,6 +244,13 @@ namespace hpx { namespace util { namespace stack_trace {
     HPX_API_EXPORT std::string get_symbols(
         void* const* addresses, std::size_t size)
     {
+        // the first two stack frames are from the back tracing facility itself
+        if (size > 2)
+        {
+            addresses += 2;
+            size -= 2;
+        }
+
         std::string res =
             std::to_string(size) + ((1 == size) ? " frame:" : " frames:");
         for (std::size_t i = 0; i < size; i++)
@@ -282,6 +289,13 @@ namespace hpx { namespace util { namespace stack_trace {
     HPX_API_EXPORT std::string get_symbols(
         void* const* address, std::size_t size)
     {
+        // the first two stack frames are from the back tracing facility itself
+        if (size > 2)
+        {
+            addresses += 2;
+            size -= 2;
+        }
+
         char** ptr = backtrace_symbols(address, size);
         try
         {
@@ -383,6 +397,13 @@ namespace hpx { namespace util { namespace stack_trace {
     HPX_API_EXPORT std::string get_symbols(
         void* const* addresses, std::size_t size)
     {
+        // the first two stack frames are from the back tracing facility itself
+        if (size > 2)
+        {
+            addresses += 2;
+            size -= 2;
+        }
+
         std::string res =
             std::to_string(size) + ((1 == size) ? " frame:" : " frames:");
         for (std::size_t i = 0; i < size; i++)
@@ -429,6 +450,14 @@ namespace hpx { namespace util { namespace stack_trace {
     {
         if (!ptrs)
             return std::string();
+
+        // the first two stack frames are from the back tracing facility itself
+        if (size > 2)
+        {
+            ptrs += 2;
+            size -= 2;
+        }
+
         std::ostringstream res;
         res.imbue(std::locale::classic());
         write_symbols(ptrs, size, res);

--- a/libs/runtime_configuration/include/hpx/runtime_configuration/runtime_configuration.hpp
+++ b/libs/runtime_configuration/include/hpx/runtime_configuration/runtime_configuration.hpp
@@ -110,6 +110,9 @@ namespace hpx { namespace util {
         bool use_stack_guard_pages() const;
 #endif
 
+        // return trace_depth for stack-backtraces
+        std::size_t trace_depth() const;
+
         // Returns the number of OS threads this locality is running.
         std::size_t get_os_thread_count() const;
 

--- a/libs/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/runtime_configuration/src/runtime_configuration.cpp
@@ -180,6 +180,8 @@ namespace hpx { namespace util {
             "attach_debugger = ${HPX_ATTACH_DEBUGGER}",
 #endif
             "exception_verbosity = ${HPX_EXCEPTION_VERBOSITY:2}",
+            "trace_depth = ${HPX_TRACE_DEPTH:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_HAVE_THREAD_BACKTRACE_DEPTH)) "}",
 
             // arity for collective operations implemented in a tree fashion
             "[hpx.lcos.collectives]",
@@ -1072,6 +1074,20 @@ namespace hpx { namespace util {
 #else
         return std::size_t(-1);
 #endif
+    }
+
+    std::size_t runtime_configuration::trace_depth() const
+    {
+        if (has_section("hpx"))
+        {
+            util::section const* sec = get_section("hpx");
+            if (nullptr != sec)
+            {
+                return hpx::util::get_entry_as<std::size_t>(
+                    *sec, "trace_depth", HPX_HAVE_THREAD_BACKTRACE_DEPTH);
+            }
+        }
+        return HPX_HAVE_THREAD_BACKTRACE_DEPTH;
     }
 
     std::size_t runtime_configuration::get_os_thread_count() const

--- a/src/custom_exception_info.cpp
+++ b/src/custom_exception_info.cpp
@@ -383,7 +383,12 @@ namespace hpx { namespace detail
         std::string const& file, long line, std::string const& auxinfo)
     {
         std::int64_t pid = ::getpid();
-        std::string back_trace(hpx::util::trace_on_new_stack());
+
+        std::size_t const trace_depth =
+            util::from_string<std::size_t>(get_config_entry(
+                "hpx.trace_depth", HPX_HAVE_THREAD_BACKTRACE_DEPTH));
+
+        std::string back_trace(hpx::util::trace_on_new_stack(trace_depth));
 
         std::string state_name("not running");
         std::string hostname;

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -365,6 +365,7 @@ namespace hpx
             if (cms.rtcfg_.enable_lock_detection())
             {
                 util::enable_lock_detection();
+                util::trace_depth_lock_detection(cms.rtcfg_.trace_depth());
             }
             else
             {

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -79,7 +79,11 @@ namespace hpx {
 #if defined(HPX_HAVE_STACKTRACES)
             if (verbosity >= 1)
             {
-                std::cerr << "{stack-trace}: " << hpx::util::trace() << "\n";
+                std::size_t const trace_depth =
+                    util::from_string<std::size_t>(get_config_entry(
+                        "hpx.trace_depth", HPX_HAVE_THREAD_BACKTRACE_DEPTH));
+                std::cerr << "{stack-trace}: " << hpx::util::trace(trace_depth)
+                          << "\n";
             }
 #endif
 
@@ -150,7 +154,11 @@ namespace hpx {
 #if defined(HPX_HAVE_STACKTRACES)
             if (verbosity >= 1)
             {
-                std::cerr << "{stack-trace}: " << hpx::util::trace() << "\n";
+                std::size_t const trace_depth =
+                    util::from_string<std::size_t>(get_config_entry(
+                        "hpx.trace_depth", HPX_HAVE_THREAD_BACKTRACE_DEPTH));
+                std::cerr << "{stack-trace}: " << hpx::util::trace(trace_depth)
+                          << "\n";
             }
 #endif
 


### PR DESCRIPTION
Fixes #4580

This also adds a runtime configuration option to specify the stack trace depth: `--hpx:ini=hpx.trace_depth=<N>`.

Note: the symbol lookup fix proposed here was not actually tested. @teonnik, @msimberg would you be able to verify this, please?