### PR TITLE
Adding missing exception test for for_loop()

### DIFF
--- a/libs/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -49,7 +49,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
 
         ///////////////////////////////////////////////////////////////////////
         template <typename... Ts, std::size_t... Is>
-        HPX_HOST_DEVICE HPX_FORCEINLINE void init_iteration(
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void init_iteration(
             hpx::util::tuple<Ts...>& args, hpx::util::index_pack<Is...>,
             std::size_t part_index)
         {
@@ -59,7 +59,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
         }
 
         template <typename... Ts, std::size_t... Is, typename F, typename B>
-        HPX_HOST_DEVICE HPX_FORCEINLINE void invoke_iteration(
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void invoke_iteration(
             hpx::util::tuple<Ts...>& args, hpx::util::index_pack<Is...>, F&& f,
             B part_begin)
         {
@@ -68,7 +68,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
         }
 
         template <typename... Ts, std::size_t... Is>
-        HPX_HOST_DEVICE HPX_FORCEINLINE void next_iteration(
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void next_iteration(
             hpx::util::tuple<Ts...>& args, hpx::util::index_pack<Is...>,
             std::size_t part_index)
         {
@@ -78,7 +78,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
         }
 
         template <typename... Ts, std::size_t... Is>
-        HPX_HOST_DEVICE HPX_FORCEINLINE void exit_iteration(
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void exit_iteration(
             hpx::util::tuple<Ts...>& args, hpx::util::index_pack<Is...>,
             std::size_t size)
         {

--- a/libs/algorithms/include/hpx/parallel/algorithms/for_loop_induction.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/for_loop_induction.hpp
@@ -27,32 +27,32 @@ namespace hpx { namespace parallel { inline namespace v2 {
         template <typename T>
         struct induction_helper
         {
-            induction_helper(T var) noexcept
+            constexpr induction_helper(T var) noexcept
               : var_(var)
               , curr_(var)
             {
             }
 
             HPX_HOST_DEVICE
-            void init_iteration(std::size_t index) noexcept
+            constexpr void init_iteration(std::size_t index) noexcept
             {
                 curr_ = parallel::v1::detail::next(var_, index);
             }
 
             HPX_HOST_DEVICE
-            T const& iteration_value() const noexcept
+            constexpr T const& iteration_value() const noexcept
             {
                 return curr_;
             }
 
             HPX_HOST_DEVICE
-            void next_iteration(std::size_t /*index*/) noexcept
+            constexpr void next_iteration(std::size_t /*index*/) noexcept
             {
                 ++curr_;
             }
 
             HPX_HOST_DEVICE
-            void exit_iteration(std::size_t /*index*/) noexcept {}
+            constexpr void exit_iteration(std::size_t /*index*/) noexcept {}
 
         private:
             typename std::decay<T>::type var_;
@@ -62,7 +62,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
         template <typename T>
         struct induction_helper<T&>
         {
-            induction_helper(T& var) noexcept
+            constexpr induction_helper(T& var) noexcept
               : live_out_var_(var)
               , var_(var)
               , curr_(var)
@@ -70,25 +70,25 @@ namespace hpx { namespace parallel { inline namespace v2 {
             }
 
             HPX_HOST_DEVICE
-            void init_iteration(std::size_t index) noexcept
+            constexpr void init_iteration(std::size_t index) noexcept
             {
                 curr_ = parallel::v1::detail::next(var_, index);
             }
 
             HPX_HOST_DEVICE
-            T const& iteration_value() const noexcept
+            constexpr T const& iteration_value() const noexcept
             {
                 return curr_;
             }
 
             HPX_HOST_DEVICE
-            void next_iteration(std::size_t /*index*/) noexcept
+            constexpr void next_iteration(std::size_t /*index*/) noexcept
             {
                 ++curr_;
             }
 
             HPX_HOST_DEVICE
-            void exit_iteration(std::size_t index) noexcept
+            constexpr void exit_iteration(std::size_t index) noexcept
             {
                 live_out_var_ =
                     parallel::v1::detail::next(live_out_var_, index);
@@ -104,7 +104,8 @@ namespace hpx { namespace parallel { inline namespace v2 {
         template <typename T>
         struct induction_stride_helper
         {
-            induction_stride_helper(T var, std::size_t stride) noexcept
+            constexpr induction_stride_helper(
+                T var, std::size_t stride) noexcept
               : var_(var)
               , curr_(var)
               , stride_(stride)
@@ -112,25 +113,25 @@ namespace hpx { namespace parallel { inline namespace v2 {
             }
 
             HPX_HOST_DEVICE
-            void init_iteration(std::size_t index) noexcept
+            constexpr void init_iteration(std::size_t index) noexcept
             {
                 curr_ = parallel::v1::detail::next(var_, stride_ * index);
             }
 
             HPX_HOST_DEVICE
-            T const& iteration_value() const noexcept
+            constexpr T const& iteration_value() const noexcept
             {
                 return curr_;
             }
 
             HPX_HOST_DEVICE
-            void next_iteration(std::size_t /*index*/) noexcept
+            constexpr void next_iteration(std::size_t /*index*/) noexcept
             {
                 curr_ = parallel::v1::detail::next(curr_, stride_);
             }
 
             HPX_HOST_DEVICE
-            void exit_iteration(std::size_t /*index*/) noexcept {}
+            constexpr void exit_iteration(std::size_t /*index*/) noexcept {}
 
         private:
             typename std::decay<T>::type var_;
@@ -141,7 +142,8 @@ namespace hpx { namespace parallel { inline namespace v2 {
         template <typename T>
         struct induction_stride_helper<T&>
         {
-            induction_stride_helper(T& var, std::size_t stride) noexcept
+            constexpr induction_stride_helper(
+                T& var, std::size_t stride) noexcept
               : live_out_var_(var)
               , var_(var)
               , curr_(var)
@@ -150,25 +152,25 @@ namespace hpx { namespace parallel { inline namespace v2 {
             }
 
             HPX_HOST_DEVICE
-            void init_iteration(std::size_t index) noexcept
+            constexpr void init_iteration(std::size_t index) noexcept
             {
                 curr_ = parallel::v1::detail::next(var_, stride_ * index);
             }
 
             HPX_HOST_DEVICE
-            T const& iteration_value() const noexcept
+            constexpr T const& iteration_value() const noexcept
             {
                 return curr_;
             }
 
             HPX_HOST_DEVICE
-            void next_iteration(std::size_t /*index*/) noexcept
+            constexpr void next_iteration(std::size_t /*index*/) noexcept
             {
                 curr_ = parallel::v1::detail::next(curr_, stride_);
             }
 
             HPX_HOST_DEVICE
-            void exit_iteration(std::size_t index) noexcept
+            constexpr void exit_iteration(std::size_t index) noexcept
             {
                 live_out_var_ =
                     parallel::v1::detail::next(live_out_var_, stride_ * index);
@@ -214,7 +216,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
     ///          object.
     ///
     template <typename T>
-    HPX_FORCEINLINE detail::induction_stride_helper<T> induction(
+    HPX_FORCEINLINE constexpr detail::induction_stride_helper<T> induction(
         T&& value, std::size_t stride)
     {
         return detail::induction_stride_helper<T>(
@@ -223,7 +225,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
 
     /// \cond NOINTERNAL
     template <typename T>
-    HPX_FORCEINLINE detail::induction_helper<T> induction(T&& value)
+    HPX_FORCEINLINE constexpr detail::induction_helper<T> induction(T&& value)
     {
         return detail::induction_helper<T>(std::forward<T>(value));
     }

--- a/libs/algorithms/include/hpx/parallel/algorithms/for_loop_reduction.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/for_loop_reduction.hpp
@@ -35,7 +35,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
         struct reduction_helper
         {
             template <typename Op_>
-            reduction_helper(T& var, T const& identity, Op_&& op)
+            constexpr reduction_helper(T& var, T const& identity, Op_&& op)
               : var_(var)
               , op_(std::forward<Op_>(op))
             {
@@ -45,18 +45,18 @@ namespace hpx { namespace parallel { inline namespace v2 {
                     data_[i].data_ = identity;
             }
 
-            void init_iteration(std::size_t)
+            constexpr void init_iteration(std::size_t)
             {
                 HPX_ASSERT(
                     hpx::get_worker_thread_num() < hpx::get_os_thread_count());
             }
 
-            T& iteration_value()
+            constexpr T& iteration_value()
             {
                 return data_[hpx::get_worker_thread_num()].data_;
             }
 
-            void next_iteration(std::size_t /*index*/) noexcept {}
+            constexpr void next_iteration(std::size_t /*index*/) noexcept {}
 
             void exit_iteration(std::size_t /*index*/)
             {
@@ -124,7 +124,8 @@ namespace hpx { namespace parallel { inline namespace v2 {
     ///          it the two views to be combined.
     ///
     template <typename T, typename Op>
-    HPX_FORCEINLINE detail::reduction_helper<T, typename std::decay<Op>::type>
+    HPX_FORCEINLINE constexpr detail::reduction_helper<T,
+        typename std::decay<Op>::type>
     reduction(T& var, T const& identity, Op&& combiner)
     {
         return detail::reduction_helper<T, typename std::decay<Op>::type>(
@@ -133,98 +134,98 @@ namespace hpx { namespace parallel { inline namespace v2 {
 
     /// \cond NOINTERNAL
     template <typename T>
-    HPX_FORCEINLINE detail::reduction_helper<T, std::plus<T>> reduction_plus(
-        T& var)
+    HPX_FORCEINLINE constexpr detail::reduction_helper<T, std::plus<T>>
+    reduction_plus(T& var)
     {
         return reduction(var, T(), std::plus<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE detail::reduction_helper<T, std::plus<T>> reduction_plus(
-        T& var, T const& identity)
+    HPX_FORCEINLINE constexpr detail::reduction_helper<T, std::plus<T>>
+    reduction_plus(T& var, T const& identity)
     {
         return reduction(var, identity, std::plus<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE detail::reduction_helper<T, std::multiplies<T>>
+    HPX_FORCEINLINE constexpr detail::reduction_helper<T, std::multiplies<T>>
     reduction_multiplies(T& var)
     {
         return reduction(var, T(1), std::multiplies<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE detail::reduction_helper<T, std::multiplies<T>>
+    HPX_FORCEINLINE constexpr detail::reduction_helper<T, std::multiplies<T>>
     reduction_multiplies(T& var, T const& identity)
     {
         return reduction(var, identity, std::multiplies<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE detail::reduction_helper<T, std::bit_and<T>>
+    HPX_FORCEINLINE constexpr detail::reduction_helper<T, std::bit_and<T>>
     reduction_bit_and(T& var)
     {
         return reduction(var, ~(T()), std::bit_and<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE detail::reduction_helper<T, std::bit_and<T>>
+    HPX_FORCEINLINE constexpr detail::reduction_helper<T, std::bit_and<T>>
     reduction_bit_and(T& var, T const& identity)
     {
         return reduction(var, identity, std::bit_and<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE detail::reduction_helper<T, std::bit_or<T>>
+    HPX_FORCEINLINE constexpr detail::reduction_helper<T, std::bit_or<T>>
     reduction_bit_or(T& var)
     {
         return reduction(var, T(), std::bit_or<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE detail::reduction_helper<T, std::bit_or<T>>
+    HPX_FORCEINLINE constexpr detail::reduction_helper<T, std::bit_or<T>>
     reduction_bit_or(T& var, T const& identity)
     {
         return reduction(var, identity, std::bit_or<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE detail::reduction_helper<T, std::bit_xor<T>>
+    HPX_FORCEINLINE constexpr detail::reduction_helper<T, std::bit_xor<T>>
     reduction_bit_xor(T& var)
     {
         return reduction(var, T(), std::bit_xor<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE detail::reduction_helper<T, std::bit_xor<T>>
+    HPX_FORCEINLINE constexpr detail::reduction_helper<T, std::bit_xor<T>>
     reduction_bit_xor(T& var, T const& identity)
     {
         return reduction(var, identity, std::bit_xor<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE detail::reduction_helper<T, v1::detail::min_of<T>>
+    HPX_FORCEINLINE constexpr detail::reduction_helper<T, v1::detail::min_of<T>>
     reduction_min(T& var)
     {
         return reduction(var, var, v1::detail::min_of<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE detail::reduction_helper<T, v1::detail::min_of<T>>
+    HPX_FORCEINLINE constexpr detail::reduction_helper<T, v1::detail::min_of<T>>
     reduction_min(T& var, T const& identity)
     {
         return reduction(var, identity, v1::detail::min_of<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE detail::reduction_helper<T, v1::detail::max_of<T>>
+    HPX_FORCEINLINE constexpr detail::reduction_helper<T, v1::detail::max_of<T>>
     reduction_max(T& var)
     {
         return reduction(var, var, v1::detail::max_of<T>());
     }
 
     template <typename T>
-    HPX_FORCEINLINE detail::reduction_helper<T, v1::detail::max_of<T>>
+    HPX_FORCEINLINE constexpr detail::reduction_helper<T, v1::detail::max_of<T>>
     reduction_max(T& var, T const& identity)
     {
         return reduction(var, identity, v1::detail::max_of<T>());

--- a/libs/algorithms/tests/unit/algorithms/CMakeLists.txt
+++ b/libs/algorithms/tests/unit/algorithms/CMakeLists.txt
@@ -54,6 +54,7 @@ set(tests
     foreachn_projection_exception
     foreachn_projection_bad_alloc
     for_loop
+    for_loop_exception
     for_loop_induction
     for_loop_induction_async
     for_loop_n

--- a/libs/algorithms/tests/unit/algorithms/for_loop_exception.cpp
+++ b/libs/algorithms/tests/unit/algorithms/for_loop_exception.cpp
@@ -1,0 +1,442 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/testing.hpp>
+
+#include <hpx/include/parallel_for_loop.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "test_utils.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+struct throw_always
+{
+    throw_always(std::size_t throw_after)
+    {
+        throw_after_ = throw_after;
+    }
+
+    template <typename T>
+    void operator()(T v)
+    {
+        if (--throw_after_ == 0)
+            throw std::runtime_error("test");
+    }
+
+    static std::atomic<std::size_t> throw_after_;
+};
+
+std::atomic<std::size_t> throw_always::throw_after_(0);
+
+struct throw_bad_alloc
+{
+    throw_bad_alloc(std::size_t throw_after)
+    {
+        throw_after_ = throw_after;
+    }
+
+    template <typename T>
+    void operator()(T v)
+    {
+        if (--throw_after_ == 0)
+            throw std::bad_alloc();
+    }
+
+    static std::atomic<std::size_t> throw_after_;
+};
+
+std::atomic<std::size_t> throw_bad_alloc::throw_after_(0);
+
+///////////////////////////////////////////////////////////////////////////////
+unsigned int seed = std::random_device{}();
+std::mt19937 gen(seed);
+
+template <typename ExPolicy, typename IteratorTag>
+void test_for_loop_exception(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::uniform_int_distribution<std::size_t> dis(1, c.size());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::parallel::for_loop(std::forward<ExPolicy>(policy),
+            iterator(std::begin(c)), iterator(std::end(c)),
+            throw_always(dis(gen)));
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_for_loop_exception_async(ExPolicy&& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::uniform_int_distribution<std::size_t> dis(1, c.size());
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try
+    {
+        auto f = hpx::parallel::for_loop(std::forward<ExPolicy>(p),
+            iterator(std::begin(c)), iterator(std::end(c)),
+            throw_always(dis(gen)));
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_for_loop_bad_alloc(ExPolicy policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::uniform_int_distribution<std::size_t> dis(1, c.size());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::parallel::for_loop(std::forward<ExPolicy>(policy),
+            iterator(std::begin(c)), iterator(std::end(c)),
+            throw_bad_alloc(dis(gen)));
+
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_exception = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_for_loop_bad_alloc_async(ExPolicy p, IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::uniform_int_distribution<std::size_t> dis(1, c.size());
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try
+    {
+        auto f = hpx::parallel::for_loop(std::forward<ExPolicy>(p),
+            iterator(std::begin(c)), iterator(std::end(c)),
+            throw_bad_alloc(dis(gen)));
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_exception = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_for_loop_exception()
+{
+    using namespace hpx::parallel;
+
+    // If the execution policy object is of type vector_execution_policy,
+    // std::terminate shall be called. therefore we do not test exceptions
+    // with a vector execution policy
+    test_for_loop_exception(execution::seq, IteratorTag());
+    test_for_loop_exception(execution::par, IteratorTag());
+
+    test_for_loop_bad_alloc(execution::seq, IteratorTag());
+    test_for_loop_bad_alloc(execution::par, IteratorTag());
+
+    test_for_loop_exception_async(
+        execution::seq(execution::task), IteratorTag());
+    test_for_loop_exception_async(
+        execution::par(execution::task), IteratorTag());
+
+    test_for_loop_bad_alloc_async(
+        execution::seq(execution::task), IteratorTag());
+    test_for_loop_bad_alloc_async(
+        execution::par(execution::task), IteratorTag());
+}
+
+void for_loop_exception_test()
+{
+    test_for_loop_exception<std::random_access_iterator_tag>();
+    test_for_loop_exception<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy, typename IteratorTag>
+void test_for_loop_idx_exception(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::uniform_int_distribution<std::size_t> dis(1, c.size());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::parallel::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+            throw_always(dis(gen)));
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(policy, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_for_loop_idx_exception_async(ExPolicy&& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::uniform_int_distribution<std::size_t> dis(1, c.size());
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try
+    {
+        auto f = hpx::parallel::for_loop(
+            std::forward<ExPolicy>(p), 0, c.size(), throw_always(dis(gen)));
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy>
+void test_for_loop_idx_bad_alloc(ExPolicy&& policy)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::uniform_int_distribution<std::size_t> dis(1, c.size());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::parallel::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+            throw_bad_alloc(dis(gen)));
+
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const& e)
+    {
+        caught_exception = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy>
+void test_for_loop_idx_bad_alloc_async(ExPolicy&& p)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    std::uniform_int_distribution<std::size_t> dis(1, c.size());
+
+    bool caught_exception = false;
+    bool returned_from_algorithm = false;
+    try
+    {
+        auto f = hpx::parallel::for_loop(
+            std::forward<ExPolicy>(p), 0, c.size(), throw_bad_alloc(dis(gen)));
+        returned_from_algorithm = true;
+        f.get();
+
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const& e)
+    {
+        caught_exception = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST(returned_from_algorithm);
+}
+
+template <typename IteratorTag>
+void test_for_loop_exception_idx()
+{
+    using namespace hpx::parallel;
+
+    test_for_loop_idx_exception(execution::seq, IteratorTag());
+    test_for_loop_idx_exception(execution::par, IteratorTag());
+
+    test_for_loop_idx_bad_alloc(execution::seq);
+    test_for_loop_idx_bad_alloc(execution::par);
+
+    test_for_loop_idx_exception_async(
+        execution::seq(execution::task), IteratorTag());
+    test_for_loop_idx_exception_async(
+        execution::par(execution::task), IteratorTag());
+
+    test_for_loop_idx_bad_alloc_async(execution::seq(execution::task));
+    test_for_loop_idx_bad_alloc_async(execution::par(execution::task));
+}
+
+void for_loop_exception_test_idx()
+{
+    test_for_loop_exception_idx<std::random_access_iterator_tag>();
+    test_for_loop_exception_idx<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    gen.seed(seed);
+
+    for_loop_exception_test();
+    for_loop_exception_test_idx();
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/execution/include/hpx/execution/algorithms/detail/predicates.hpp
+++ b/libs/execution/include/hpx/execution/algorithms/detail/predicates.hpp
@@ -22,14 +22,14 @@
 
 namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     template <typename InputIterator, typename Distance>
-    HPX_HOST_DEVICE void advance_impl(
+    HPX_HOST_DEVICE constexpr void advance_impl(
         InputIterator& i, Distance n, std::random_access_iterator_tag)
     {
         i += n;
     }
 
     template <typename InputIterator, typename Distance>
-    HPX_HOST_DEVICE void advance_impl(
+    HPX_HOST_DEVICE constexpr void advance_impl(
         InputIterator& i, Distance n, std::bidirectional_iterator_tag)
     {
         if (n < 0)
@@ -45,7 +45,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     }
 
     template <typename InputIterator, typename Distance>
-    HPX_HOST_DEVICE void advance_impl(
+    HPX_HOST_DEVICE constexpr void advance_impl(
         InputIterator& i, Distance n, std::input_iterator_tag)
     {
         HPX_ASSERT(n >= 0);
@@ -54,7 +54,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     }
 
     template <typename InputIterator, typename Distance>
-    HPX_HOST_DEVICE void advance(InputIterator& i, Distance n)
+    HPX_HOST_DEVICE constexpr void advance(InputIterator& i, Distance n)
     {
         advance_impl(i, n,
             typename std::iterator_traits<InputIterator>::iterator_category());
@@ -65,7 +65,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     struct calculate_distance
     {
         template <typename T1, typename T2>
-        HPX_FORCEINLINE static std::size_t call(T1 t1, T2 t2)
+        HPX_FORCEINLINE constexpr static std::size_t call(T1 t1, T2 t2)
         {
             return std::size_t(t2 - t1);
         }
@@ -77,14 +77,16 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             hpx::traits::is_iterator<Iterable>::value>::type>
     {
         template <typename Iter1, typename Iter2>
-        HPX_FORCEINLINE static std::size_t call(Iter1 iter1, Iter2 iter2)
+        HPX_FORCEINLINE constexpr static std::size_t call(
+            Iter1 iter1, Iter2 iter2)
         {
             return std::distance(iter1, iter2);
         }
     };
 
     template <typename Iterable>
-    HPX_FORCEINLINE std::size_t distance(Iterable iter1, Iterable iter2)
+    HPX_FORCEINLINE constexpr std::size_t distance(
+        Iterable iter1, Iterable iter2)
     {
         return calculate_distance<typename std::decay<Iterable>::type>::call(
             iter1, iter2);
@@ -95,13 +97,14 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     struct calculate_next
     {
         template <typename T, typename Stride>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static T call(T t1, Stride offset)
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr static T call(
+            T t1, Stride offset)
         {
             return T(t1 + offset);
         }
 
         template <typename T, typename Stride>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static T call(
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr static T call(
             T t, std::size_t max_count, Stride& offset, std::true_type)
         {
             if (is_negative(offset))
@@ -120,7 +123,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         }
 
         template <typename T, typename Stride>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static T call(
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr static T call(
             T t, std::size_t max_count, Stride& offset, std::false_type)
         {
             // NVCC seems to have a bug with std::min...
@@ -129,7 +132,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         }
 
         template <typename T, typename Stride>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static T call(
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr static T call(
             T t, std::size_t max_count, Stride& offset)
         {
             return call(
@@ -143,7 +146,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             !hpx::traits::is_bidirectional_iterator<Iterable>::value>::type>
     {
         template <typename Iter, typename Stride>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static Iter call(
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr static Iter call(
             Iter iter, Stride offset)
         {
 #if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
@@ -155,7 +158,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         }
 
         template <typename Iter, typename Stride>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static Iter call(
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr static Iter call(
             Iter iter, std::size_t max_count, Stride& offset)
         {
             // anything less than a bidirectional iterator does not support
@@ -181,7 +184,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             hpx::traits::is_bidirectional_iterator<Iterable>::value>::type>
     {
         template <typename Iter, typename Stride>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static Iter call(
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr static Iter call(
             Iter iter, Stride offset)
         {
 #if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
@@ -193,7 +196,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         }
 
         template <typename Iter, typename Stride>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static Iter call(
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr static Iter call(
             Iter iter, std::size_t max_count, Stride& offset, std::true_type)
         {
             // advance through the end or max number of elements
@@ -223,7 +226,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         }
 
         template <typename Iter, typename Stride>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static Iter call(
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr static Iter call(
             Iter iter, std::size_t max_count, Stride& offset, std::false_type)
         {
             // advance through the end or max number of elements
@@ -239,7 +242,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         }
 
         template <typename Iter, typename Stride>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static Iter call(
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr static Iter call(
             Iter iter, std::size_t max_count, Stride& offset)
         {
             return call(iter, max_count, offset,
@@ -248,7 +251,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     };
 
     template <typename Iterable>
-    HPX_HOST_DEVICE HPX_FORCEINLINE Iterable next(
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iterable next(
         Iterable iter, std::size_t offset)
     {
         return calculate_next<typename std::decay<Iterable>::type>::call(
@@ -256,7 +259,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     }
 
     template <typename Iterable, typename Stride>
-    HPX_HOST_DEVICE HPX_FORCEINLINE Iterable next(
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iterable next(
         Iterable iter, std::size_t max_count, Stride& offset)
     {
         return calculate_next<typename std::decay<Iterable>::type>::call(
@@ -267,7 +270,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     struct equal_to
     {
         template <typename T1, typename T2>
-        HPX_HOST_DEVICE HPX_FORCEINLINE auto operator()(
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
             T1 const& t1, T2 const& t2) const -> decltype(t1 == t2)
         {
             return t1 == t2;
@@ -287,8 +290,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         }
 
         template <typename T>
-        HPX_HOST_DEVICE HPX_FORCEINLINE auto operator()(T const& t) const
-            -> decltype(std::declval<Value>() == t)
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
+            T const& t) const -> decltype(std::declval<Value>() == t)
         {
             return value_ == t;
         }
@@ -300,7 +303,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     struct less
     {
         template <typename T1, typename T2>
-        auto operator()(T1 const& t1, T2 const& t2) const -> decltype(t1 < t2)
+        constexpr auto operator()(T1 const& t1, T2 const& t2) const
+            -> decltype(t1 < t2)
         {
             return t1 < t2;
         }
@@ -310,7 +314,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     template <typename T>
     struct min_of
     {
-        T operator()(T const& t1, T const& t2) const
+        constexpr T operator()(T const& t1, T const& t2) const
         {
             // NVCC seems to have a bug with std::min...
             return t1 < t2 ? t1 : t2;
@@ -320,7 +324,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     template <typename T>
     struct max_of
     {
-        T operator()(T const& t1, T const& t2) const
+        constexpr T operator()(T const& t1, T const& t2) const
         {
             return (std::max)(t1, t2);
         }
@@ -330,7 +334,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     struct plus
     {
         template <typename T1, typename T2>
-        auto operator()(T1 const& t1, T2 const& t2) const -> decltype(t1 + t2)
+        constexpr auto operator()(T1 const& t1, T2 const& t2) const
+            -> decltype(t1 + t2)
         {
             return t1 + t2;
         }
@@ -339,7 +344,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     struct minus
     {
         template <typename T1, typename T2>
-        auto operator()(T1 const& t1, T2 const& t2) const -> decltype(t1 - t2)
+        constexpr auto operator()(T1 const& t1, T2 const& t2) const
+            -> decltype(t1 - t2)
         {
             return t1 - t2;
         }
@@ -348,7 +354,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     struct multiplies
     {
         template <typename T1, typename T2>
-        auto operator()(T1 const& t1, T2 const& t2) const -> decltype(t1 * t2)
+        constexpr auto operator()(T1 const& t1, T2 const& t2) const
+            -> decltype(t1 * t2)
         {
             return t1 * t2;
         }
@@ -357,7 +364,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     struct divides
     {
         template <typename T1, typename T2>
-        auto operator()(T1 const& t1, T2 const& t2) const -> decltype(t1 / t2)
+        constexpr auto operator()(T1 const& t1, T2 const& t2) const
+            -> decltype(t1 / t2)
         {
             return t1 / t2;
         }


### PR DESCRIPTION
- flyby: adding constexpr to some utility functions for for_loop
