### PR TITLE
Fix performance regression in block_executor

### DIFF
--- a/libs/compute/include/hpx/compute/host/block_executor.hpp
+++ b/libs/compute/include/hpx/compute/host/block_executor.hpp
@@ -43,9 +43,16 @@ namespace hpx { namespace compute { namespace host {
         typedef hpx::parallel::execution::static_chunk_size
             executor_parameters_type;
 
-        block_executor(std::vector<host::target> const& targets)
+        block_executor(std::vector<host::target> const& targets,
+            threads::thread_priority priority = threads::thread_priority_high,
+            threads::thread_stacksize stacksize =
+                threads::thread_stacksize_default,
+            threads::thread_schedule_hint schedulehint = {})
           : targets_(targets)
           , current_(0)
+          , priority_(priority)
+          , stacksize_(stacksize)
+          , schedulehint_(schedulehint)
         {
             init_executors();
         }
@@ -238,12 +245,17 @@ namespace hpx { namespace compute { namespace host {
             for (auto const& tgt : targets_)
             {
                 auto num_pus = tgt.num_pus();
-                executors_.emplace_back(num_pus.first, num_pus.second);
+                executors_.emplace_back(num_pus.first, num_pus.second,
+                    threads::thread_priority_high);
             }
         }
         std::vector<host::target> targets_;
         std::atomic<std::size_t> current_;
         std::vector<Executor> executors_;
+        threads::thread_priority priority_ = threads::thread_priority_high;
+        threads::thread_stacksize stacksize_ =
+            threads::thread_stacksize_default;
+        threads::thread_schedule_hint schedulehint_ = {};
     };
 }}}    // namespace hpx::compute::host
 

--- a/libs/execution/include/hpx/execution/detail/post_policy_dispatch.hpp
+++ b/libs/execution/include/hpx/execution/detail/post_policy_dispatch.hpp
@@ -33,7 +33,7 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
             threads::thread_init_data data(
                 threads::make_thread_function_nullary(hpx::util::deferred_call(
                     std::forward<F>(f), std::forward<Ts>(ts)...)),
-                desc, priority, hint, stacksize, threads::pending, false);
+                desc, priority, hint, stacksize, threads::pending);
             threads::register_work(data, pool);
         }
 
@@ -47,7 +47,7 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
             threads::thread_init_data data(
                 threads::make_thread_function_nullary(hpx::util::deferred_call(
                     std::forward<F>(f), std::forward<Ts>(ts)...)),
-                desc, priority, hint, stacksize, threads::pending, false);
+                desc, priority, hint, stacksize, threads::pending);
             threads::register_work(data);
         }
 
@@ -59,7 +59,7 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
                 threads::make_thread_function_nullary(hpx::util::deferred_call(
                     std::forward<F>(f), std::forward<Ts>(ts)...)),
                 desc, policy.priority(), threads::thread_schedule_hint(),
-                threads::thread_stacksize_default, threads::pending, false);
+                threads::thread_stacksize_default, threads::pending);
             threads::register_work(data);
         }
     };

--- a/libs/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
+++ b/libs/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
@@ -22,8 +22,11 @@
 #include <vector>
 
 namespace hpx { namespace parallel { namespace execution {
-    struct restricted_thread_pool_executor
+    class restricted_thread_pool_executor
     {
+        static constexpr std::size_t hierarchical_threshold_default_ = 6;
+
+    public:
         /// Associate the parallel_execution_tag executor tag type as a default
         /// with this executor.
         typedef parallel_execution_tag execution_category;
@@ -39,11 +42,14 @@ namespace hpx { namespace parallel { namespace execution {
                 threads::thread_priority_default,
             threads::thread_stacksize stacksize =
                 threads::thread_stacksize_default,
-            threads::thread_schedule_hint schedulehint = {})
+            threads::thread_schedule_hint schedulehint = {},
+            std::size_t hierarchical_threshold =
+                hierarchical_threshold_default_)
           : pool_(this_thread::get_pool())
           , priority_(priority)
           , stacksize_(stacksize)
           , schedulehint_(schedulehint)
+          , hierarchical_threshold_(hierarchical_threshold)
           , first_thread_(first_thread)
           , num_threads_(num_threads)
           , os_thread_(first_thread_)
@@ -132,8 +138,8 @@ namespace hpx { namespace parallel { namespace execution {
         {
             return detail::thread_pool_bulk_async_execute_helper(pool_,
                 priority_, stacksize_, schedulehint_, first_thread_,
-                num_threads_, launch::async, std::forward<F>(f), shape,
-                std::forward<Ts>(ts)...);
+                num_threads_, hierarchical_threshold_, launch::async,
+                std::forward<F>(f), shape, std::forward<Ts>(ts)...);
         }
 
         template <typename F, typename S, typename Future, typename... Ts>
@@ -155,6 +161,7 @@ namespace hpx { namespace parallel { namespace execution {
         threads::thread_stacksize stacksize_ =
             threads::thread_stacksize_default;
         threads::thread_schedule_hint schedulehint_ = {};
+        std::size_t hierarchical_threshold_ = hierarchical_threshold_default_;
 
         std::size_t first_thread_;
         std::size_t num_threads_;

--- a/libs/futures/include/hpx/futures/futures_factory.hpp
+++ b/libs/futures/include/hpx/futures/futures_factory.hpp
@@ -131,7 +131,7 @@ namespace hpx { namespace lcos { namespace local {
                     threads::make_thread_function_nullary(util::deferred_call(
                         &base_type::run_impl, std::move(this_))),
                     util::thread_description(f_, annotation), priority,
-                    schedulehint, stacksize, threads::pending, false);
+                    schedulehint, stacksize, threads::pending);
 
                 threads::register_work(data, pool, ec);
                 return threads::invalid_thread_id;


### PR DESCRIPTION
*How to make your PRs look good: Introduce a performance regression without benchmarking (#4301), followed by another PR which improves performance a bit (#4536).*

The improvements in #4536 were real, but ignore that #4301 introduced a regression. The regression was caused by the `block_executor` previously relying on thread executors which eagerly created threads for bulk execution (`run_now = true`), whereas the new underlying executor `restricted_thread_pool_executor` only creates task descriptions. In addition the `restricted_thread_pool_executor` did hierarchical spawning. Both of these seem to have caused the performance regression (fixing just one of them is not enough). This is based on the stream benchmark and @m-diers observations on his application.

In this PR I've extended the `block_executor` constructor to take priority, stacksize, and hint to be passed on to the underlying executor. The default priority is high, which forces immediate thread creation, and thus restores the old behaviour (mostly, the old threads were normal priority). I've also removed the hierarchical spawning from the `restricted_thread_pool_executor`.

The question is if this (controlling thread creation with the priority) nicely models what we want. I think it is a reasonable design as I wouldn't want to expose something like the `run_now` parameter to users. I also wouldn't want to force bulk execution to always create threads. The notion of a tight numerical parallel for loop like those in the stream benchmark being high priority feels more or less right (we want all of the for loop tasks to be executed asap without being interrupted by otherwise spawned regular tasks).

This is a draft as I want to redo the benchmarks in #4301 and #4536.