### PR TITLE
Small module fixes

### DIFF
--- a/libs/basic_execution/tests/CMakeLists.txt
+++ b/libs/basic_execution/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ if(HPX_BASIC_EXECUTION_WITH_TESTS)
       EXCLUDE "hpx/parallel/executors/timed_execution_fwd.hpp"
               "hpx/parallel/executors/parallel_executor.hpp"
       DEPENDENCIES hpx_basic_execution
+      NOLIBS
     )
   endif()
 endif()

--- a/libs/plugin/CMakeLists.txt
+++ b/libs/plugin/CMakeLists.txt
@@ -50,4 +50,5 @@ add_hpx_module(
   COMPAT_HEADERS ${plugin_compat_headers}
   DEPENDENCIES hpx_assertion hpx_config hpx_errors hpx_datastructures
                hpx_filesystem hpx_functional
+  CMAKE_SUBDIRS tests
 )

--- a/libs/plugin/tests/CMakeLists.txt
+++ b/libs/plugin/tests/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+include(HPX_Message)
+include(HPX_Option)
+
+if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
+  hpx_set_option(HPX_PLUGIN_WITH_TESTS VALUE OFF FORCE)
+  return()
+endif()
+
+if (HPX_PLUGIN_WITH_TESTS)
+  if (HPX_WITH_TESTS_UNIT)
+    add_hpx_pseudo_target(tests.unit.modules.plugin)
+    add_hpx_pseudo_dependencies(tests.unit.modules tests.unit.modules.plugin)
+    add_subdirectory(unit)
+  endif()
+
+  if (HPX_WITH_TESTS_REGRESSIONS)
+    add_hpx_pseudo_target(tests.regressions.modules.plugin)
+    add_hpx_pseudo_dependencies(tests.regressions.modules tests.regressions.modules.plugin)
+    add_subdirectory(regressions)
+  endif()
+
+  if (HPX_WITH_TESTS_BENCHMARKS)
+    add_hpx_pseudo_target(tests.performance.modules.plugin)
+    add_hpx_pseudo_dependencies(tests.performance.modules tests.performance.modules.plugin)
+    add_subdirectory(performance)
+  endif()
+
+  if (HPX_WITH_TESTS_HEADERS)
+    add_hpx_header_tests(
+      modules.plugin
+      HEADERS ${plugin_headers}
+      HEADER_ROOT ${PROJECT_SOURCE_DIR}/include
+      NOLIBS
+      DEPENDENCIES hpx_plugin)
+  endif()
+endif()

--- a/libs/plugin/tests/CMakeLists.txt
+++ b/libs/plugin/tests/CMakeLists.txt
@@ -7,36 +7,45 @@
 include(HPX_Message)
 include(HPX_Option)
 
-if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
-  hpx_set_option(HPX_PLUGIN_WITH_TESTS VALUE OFF FORCE)
+if(NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
+  hpx_set_option(
+    HPX_PLUGIN_WITH_TESTS
+    VALUE OFF
+    FORCE
+  )
   return()
 endif()
 
-if (HPX_PLUGIN_WITH_TESTS)
-  if (HPX_WITH_TESTS_UNIT)
+if(HPX_PLUGIN_WITH_TESTS)
+  if(HPX_WITH_TESTS_UNIT)
     add_hpx_pseudo_target(tests.unit.modules.plugin)
     add_hpx_pseudo_dependencies(tests.unit.modules tests.unit.modules.plugin)
     add_subdirectory(unit)
   endif()
 
-  if (HPX_WITH_TESTS_REGRESSIONS)
+  if(HPX_WITH_TESTS_REGRESSIONS)
     add_hpx_pseudo_target(tests.regressions.modules.plugin)
-    add_hpx_pseudo_dependencies(tests.regressions.modules tests.regressions.modules.plugin)
+    add_hpx_pseudo_dependencies(
+      tests.regressions.modules tests.regressions.modules.plugin
+    )
     add_subdirectory(regressions)
   endif()
 
-  if (HPX_WITH_TESTS_BENCHMARKS)
+  if(HPX_WITH_TESTS_BENCHMARKS)
     add_hpx_pseudo_target(tests.performance.modules.plugin)
-    add_hpx_pseudo_dependencies(tests.performance.modules tests.performance.modules.plugin)
+    add_hpx_pseudo_dependencies(
+      tests.performance.modules tests.performance.modules.plugin
+    )
     add_subdirectory(performance)
   endif()
 
-  if (HPX_WITH_TESTS_HEADERS)
+  if(HPX_WITH_TESTS_HEADERS)
     add_hpx_header_tests(
       modules.plugin
       HEADERS ${plugin_headers}
       HEADER_ROOT ${PROJECT_SOURCE_DIR}/include
       NOLIBS
-      DEPENDENCIES hpx_plugin)
+      DEPENDENCIES hpx_plugin
+    )
   endif()
 endif()

--- a/libs/plugin/tests/performance/CMakeLists.txt
+++ b/libs/plugin/tests/performance/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/plugin/tests/regressions/CMakeLists.txt
+++ b/libs/plugin/tests/regressions/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+

--- a/libs/plugin/tests/regressions/CMakeLists.txt
+++ b/libs/plugin/tests/regressions/CMakeLists.txt
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-

--- a/libs/plugin/tests/unit/CMakeLists.txt
+++ b/libs/plugin/tests/unit/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/prefix/CMakeLists.txt
+++ b/libs/prefix/CMakeLists.txt
@@ -31,5 +31,5 @@ add_hpx_module(
     hpx_plugin
     hpx_string_util
     hpx_type_support
-  CMAKE_SUBDIRS
+  CMAKE_SUBDIRS tests
 )

--- a/libs/prefix/tests/CMakeLists.txt
+++ b/libs/prefix/tests/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+include(HPX_Message)
+include(HPX_Option)
+
+if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
+  hpx_set_option(HPX_PREFIX_WITH_TESTS VALUE OFF FORCE)
+  return()
+endif()
+
+if (HPX_PREFIX_WITH_TESTS)
+  if (HPX_WITH_TESTS_UNIT)
+    add_hpx_pseudo_target(tests.unit.modules.prefix)
+    add_hpx_pseudo_dependencies(tests.unit.modules tests.unit.modules.prefix)
+    add_subdirectory(unit)
+  endif()
+
+  if (HPX_WITH_TESTS_REGRESSIONS)
+    add_hpx_pseudo_target(tests.regressions.modules.prefix)
+    add_hpx_pseudo_dependencies(tests.regressions.modules tests.regressions.modules.prefix)
+    add_subdirectory(regressions)
+  endif()
+
+  if (HPX_WITH_TESTS_BENCHMARKS)
+    add_hpx_pseudo_target(tests.performance.modules.prefix)
+    add_hpx_pseudo_dependencies(tests.performance.modules tests.performance.modules.prefix)
+    add_subdirectory(performance)
+  endif()
+
+  if (HPX_WITH_TESTS_HEADERS)
+    add_hpx_header_tests(
+      modules.prefix
+      HEADERS ${prefix_headers}
+      HEADER_ROOT ${PROJECT_SOURCE_DIR}/include
+      NOLIBS
+      DEPENDENCIES hpx_prefix)
+  endif()
+endif()

--- a/libs/prefix/tests/CMakeLists.txt
+++ b/libs/prefix/tests/CMakeLists.txt
@@ -7,36 +7,45 @@
 include(HPX_Message)
 include(HPX_Option)
 
-if (NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
-  hpx_set_option(HPX_PREFIX_WITH_TESTS VALUE OFF FORCE)
+if(NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
+  hpx_set_option(
+    HPX_PREFIX_WITH_TESTS
+    VALUE OFF
+    FORCE
+  )
   return()
 endif()
 
-if (HPX_PREFIX_WITH_TESTS)
-  if (HPX_WITH_TESTS_UNIT)
+if(HPX_PREFIX_WITH_TESTS)
+  if(HPX_WITH_TESTS_UNIT)
     add_hpx_pseudo_target(tests.unit.modules.prefix)
     add_hpx_pseudo_dependencies(tests.unit.modules tests.unit.modules.prefix)
     add_subdirectory(unit)
   endif()
 
-  if (HPX_WITH_TESTS_REGRESSIONS)
+  if(HPX_WITH_TESTS_REGRESSIONS)
     add_hpx_pseudo_target(tests.regressions.modules.prefix)
-    add_hpx_pseudo_dependencies(tests.regressions.modules tests.regressions.modules.prefix)
+    add_hpx_pseudo_dependencies(
+      tests.regressions.modules tests.regressions.modules.prefix
+    )
     add_subdirectory(regressions)
   endif()
 
-  if (HPX_WITH_TESTS_BENCHMARKS)
+  if(HPX_WITH_TESTS_BENCHMARKS)
     add_hpx_pseudo_target(tests.performance.modules.prefix)
-    add_hpx_pseudo_dependencies(tests.performance.modules tests.performance.modules.prefix)
+    add_hpx_pseudo_dependencies(
+      tests.performance.modules tests.performance.modules.prefix
+    )
     add_subdirectory(performance)
   endif()
 
-  if (HPX_WITH_TESTS_HEADERS)
+  if(HPX_WITH_TESTS_HEADERS)
     add_hpx_header_tests(
       modules.prefix
       HEADERS ${prefix_headers}
       HEADER_ROOT ${PROJECT_SOURCE_DIR}/include
       NOLIBS
-      DEPENDENCIES hpx_prefix)
+      DEPENDENCIES hpx_prefix
+    )
   endif()
 endif()

--- a/libs/prefix/tests/performance/CMakeLists.txt
+++ b/libs/prefix/tests/performance/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/prefix/tests/regressions/CMakeLists.txt
+++ b/libs/prefix/tests/regressions/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+

--- a/libs/prefix/tests/regressions/CMakeLists.txt
+++ b/libs/prefix/tests/regressions/CMakeLists.txt
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-

--- a/libs/prefix/tests/unit/CMakeLists.txt
+++ b/libs/prefix/tests/unit/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/schedulers/tests/CMakeLists.txt
+++ b/libs/schedulers/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ if(HPX_SCHEDULERS_WITH_TESTS)
       HEADERS ${schedulers_headers}
       HEADER_ROOT ${PROJECT_SOURCE_DIR}/include
       DEPENDENCIES hpx_schedulers
+      NOLIBS
     )
   endif()
 endif()

--- a/libs/version/include/hpx/version.hpp
+++ b/libs/version/include/hpx/version.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/util_fwd.hpp>
 
 #include <cstdint>
 #include <string>


### PR DESCRIPTION
This fixes a couple of dependencies on the main headers from the modules and makes their header tests use `NOLIBS`. This also adds header tests for the `plugin` and `prefix` modules.

Incidentally, this means that I was able to build the following libs into a standalone library without any dependencies from the main library:
```
  affinity
  allocator_support
  asio
  assertion
  basic_execution
  concepts
  concurrency
  config
  coroutines
  datastructures
  debugging
  errors
  filesystem
  format
  functional
  hardware
  hashing
  io_service
  iterator_support
  logging
  memory
  naming_base
  pack_traversal
  plugin
  prefix
  preprocessor
  schedulers
  serialization
  static_reinit
  string_util
  testing
  thread_pools
  thread_support
  threading_base
  timing
  topology
  type_support
  util
  version
```

I think this is pretty close to what I think a core library could look like (#4593), except for a few modules (`plugin` and `prefix` maybe aren't needed here, `execution` and `futures` would be nice to have here). Small enough that it builds quite quickly but still contains all the lower level bits that one would need to build something useful (`hpx::thread`, thread pools, and executors).