### PR TITLE
Enable static symbols for stacktraces in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,6 +204,7 @@ jobs:
                 -DCMAKE_CXX_CLANG_TIDY=clang-tidy \
                 -DHPX_WITH_THREAD_LOCAL_STORAGE=On \
                 -DHPX_WITH_STACKTRACES_STATIC_SYMBOLS=On \
+                -DHPX_WITH_STACKTRACES_DEMANGLE_SYMBOLS=Off \
                 -DHPX_WITH_TESTS_DEBUG_LOG=On \
                 -DHPX_WITH_TESTS_DEBUG_LOG_DESTINATION=/hpx/build/debug-log.txt \
                 -DHPX_WITH_SPINLOCK_DEADLOCK_DETECTION=On \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,6 +203,7 @@ jobs:
                 -DHPX_WITH_DEPRECATION_WARNINGS=On \
                 -DCMAKE_CXX_CLANG_TIDY=clang-tidy \
                 -DHPX_WITH_THREAD_LOCAL_STORAGE=On \
+                -DHPX_WITH_STACKTRACES_STATIC_SYMBOLS=On \
                 -DHPX_WITH_TESTS_DEBUG_LOG=On \
                 -DHPX_WITH_TESTS_DEBUG_LOG_DESTINATION=/hpx/build/debug-log.txt \
                 -DHPX_WITH_SPINLOCK_DEADLOCK_DETECTION=On \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -714,6 +714,16 @@ if(HPX_WITH_STACKTRACES OR HPX_WITH_THREAD_BACKTRACE_ON_SUSPENSION)
       HPX_HAVE_STACKTRACES_STATIC_SYMBOLS
       ${HPX_WITH_STACKTRACES_STATIC_SYMBOLS}
     )
+
+    # Demangling can segfault in certain configurations.
+    hpx_option(
+      HPX_WITH_STACKTRACES_DEMANGLE_SYMBOLS BOOL
+      "Thread stack back trace symbols will be demangled (default: ON)" ON
+      CATEGORY "Thread Manager" ADVANCED
+    )
+    if(HPX_WITH_STACKTRACES_DEMANGLE_SYMBOLS)
+      hpx_add_config_define(HPX_HAVE_STACKTRACES_DEMANGLE_SYMBOLS)
+    endif()
   endif()
 endif()
 

--- a/libs/debugging/src/backtrace.cpp
+++ b/libs/debugging/src/backtrace.cpp
@@ -203,6 +203,7 @@ namespace hpx { namespace util { namespace stack_trace {
         {
             if (info.dli_sname)
             {
+#if defined(HPX_HAVE_STACKTRACES_DEMANGLE_SYMBOLS)
                 int status = 0;
                 char* demangled = abi::__cxa_demangle(
                     info.dli_sname, nullptr, nullptr, &status);
@@ -215,6 +216,9 @@ namespace hpx { namespace util { namespace stack_trace {
                 {
                     res << info.dli_sname;
                 }
+#else
+                res << info.dli_sname;
+#endif
             }
             else
             {


### PR DESCRIPTION
@hkaiser you mentioned that this lead to segfaults in some tests. Did you notice if that was reproducible? If this causes problems let's not merge it, but if things work well this is really helpful for seeing where failures happen.