### PR TITLE
Moving winsocket initialization to core library

### DIFF
--- a/hpx/hpx_init_impl.hpp
+++ b/hpx/hpx_init_impl.hpp
@@ -11,6 +11,7 @@
 
 #include <hpx/assertion.hpp>
 #include <hpx/hpx_init.hpp>
+#include <hpx/hpx_main_winsocket.hpp>
 #include <hpx/hpx_user_main_config.hpp>
 #include <hpx/program_options.hpp>
 #include <hpx/runtime_configuration/runtime_mode.hpp>
@@ -44,10 +45,6 @@ namespace hpx
                 int(hpx::program_options::variables_map& vm)
             > const& f, int argc, char** argv,
             init_params const& params, bool blocking);
-
-#if defined(HPX_WINDOWS)
-        void init_winsocket();
-#endif
 
         HPX_EXPORT int init_helper(
             hpx::program_options::variables_map&,

--- a/hpx/hpx_main_winsocket.hpp
+++ b/hpx/hpx_main_winsocket.hpp
@@ -1,0 +1,20 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(HPX_MAIN_WINSOCKET_MAY_08_2020_1050AM)
+#define HPX_MAIN_WINSOCKET_MAY_08_2020_1050AM
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_WINDOWS)
+
+namespace hpx { namespace detail
+{
+    HPX_EXPORT void init_winsocket();
+}}
+
+#endif
+#endif

--- a/hpx/hpx_start_impl.hpp
+++ b/hpx/hpx_start_impl.hpp
@@ -9,6 +9,7 @@
 #define HPX_HPX_START_IMPL_HPP
 
 #include <hpx/assertion.hpp>
+#include <hpx/hpx_main_winsocket.hpp>
 #include <hpx/hpx_start.hpp>
 #include <hpx/hpx_user_main_config.hpp>
 #include <hpx/program_options.hpp>
@@ -43,14 +44,9 @@ namespace hpx
             > const& f, int argc, char** argv,
             init_params const& params, bool blocking);
 
-#if defined(HPX_WINDOWS)
-        void init_winsocket();
-#endif
-
         HPX_EXPORT int init_helper(
             hpx::program_options::variables_map&,
             util::function_nonser<int(int, char**)> const&);
-
     }
     /// \endcond
 

--- a/init/CMakeLists.txt
+++ b/init/CMakeLists.txt
@@ -20,7 +20,6 @@ list(
   hpx_main.cpp
   hpx_main_argc_argv.cpp
   hpx_main_variables_map.cpp
-  hpx_main_winsocket.cpp
   hpx_user_main.cpp
   hpx_user_main_argc_argv.cpp
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ set(hpx_SOURCES
     lcos/detail/future_data.cpp
     lcos/future.cpp
     hpx_init.cpp
+    hpx_main_winsocket.cpp
     runtime.cpp
     runtime_handlers.cpp
     runtime/launch_policy.cpp
@@ -162,6 +163,7 @@ set(hpx_HEADERS
     hpx/hpx_init.hpp
     hpx/hpx_init_impl.hpp
     hpx/hpx_init_params.hpp
+    hpx/hpx_main_winsocket.hpp
     hpx/hpx_start.hpp
     hpx/hpx_start_impl.hpp
     hpx/hpx_suspend.hpp

--- a/src/hpx_main_winsocket.cpp
+++ b/src/hpx_main_winsocket.cpp
@@ -5,6 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/hpx_main_winsocket.hpp>
 
 #if defined(HPX_WINDOWS)
 


### PR DESCRIPTION
Fixes linker errors if `hpx::init` or `hpx::start` are used from a shared library.