### PR TITLE
Adding an API function that exposes the number of idle cores

### DIFF
--- a/hpx/runtime/thread_pool_helpers.hpp
+++ b/hpx/runtime/thread_pool_helpers.hpp
@@ -84,6 +84,10 @@ namespace hpx { namespace threads {
     HPX_API_EXPORT std::int64_t get_thread_count(
         thread_priority priority, thread_state_enum state = unknown);
 
+    /// The function \a get_idle_core_count returns the number of currently
+    /// idling threads (cores).
+    HPX_API_EXPORT std::int64_t get_idle_core_count();
+
     /// The function \a enumerate_threads will invoke the given function \a f
     /// for each thread with a matching thread state.
     ///

--- a/libs/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
@@ -882,6 +882,23 @@ namespace hpx { namespace threads { namespace policies {
             return count;
         }
 
+        // Queries whether a given core is idle
+        bool is_core_idle(std::size_t num_thread) const override
+        {
+            if (num_thread < num_queues_ &&
+                queues_[num_thread].data_->get_thread_count(unknown) != 0)
+            {
+                return false;
+            }
+            if (num_thread < num_high_priority_queues_ &&
+                high_priority_queues_[num_thread].data_->get_thread_count(
+                    unknown) != 0)
+            {
+                return false;
+            }
+            return true;
+        }
+
         ///////////////////////////////////////////////////////////////////////
         // Enumerate matching threads from all queues
         bool enumerate_threads(

--- a/libs/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
+++ b/libs/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
@@ -606,6 +606,12 @@ namespace hpx { namespace threads { namespace policies {
             return count;
         }
 
+        // Queries whether a given core is idle
+        bool is_core_idle(std::size_t num_thread) const override
+        {
+            return queues_[num_thread]->get_thread_count(unknown) == 0;
+        }
+
         ///////////////////////////////////////////////////////////////////////
         // Enumerate matching threads from all queues
         bool enumerate_threads(

--- a/libs/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
@@ -968,6 +968,16 @@ namespace hpx { namespace threads { namespace policies {
                     }
                 }
 
+                // Queries whether a given core is idle
+                bool is_core_idle(std::size_t num_thread) const override
+                {
+                    std::size_t domain_num = d_lookup_[num_thread];
+                    std::size_t q_index = q_lookup_[num_thread];
+                    return numa_holder_[domain_num]
+                               .thread_queue(q_index)
+                               ->get_thread_count(unknown) == 0;
+                }
+
                 //---------------------------------------------------------------------
                 // Enumerate matching threads from all queues
                 bool enumerate_threads(

--- a/libs/thread_pools/include/hpx/thread_pools/scheduled_thread_pool.hpp
+++ b/libs/thread_pools/include/hpx/thread_pools/scheduled_thread_pool.hpp
@@ -104,6 +104,8 @@ namespace hpx { namespace threads { namespace detail {
                 state, priority, num, reset);
         }
 
+        std::int64_t get_idle_core_count() const override;
+
         std::int64_t get_background_thread_count() override
         {
             return sched_->Scheduler::get_background_thread_count();

--- a/libs/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
+++ b/libs/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
@@ -1776,6 +1776,21 @@ namespace hpx { namespace threads { namespace detail {
             thread_count_.load();
     }
 
+    template <typename Scheduler>
+    std::int64_t scheduled_thread_pool<Scheduler>::get_idle_core_count() const
+    {
+        std::int64_t count = 0;
+        std::size_t i = 0;
+        for (auto const& data : counter_data_)
+        {
+            if (!data.tasks_active_ && sched_->Scheduler::is_core_idle(i++))
+            {
+                ++count;
+            }
+        }
+        return count;
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename Scheduler>
     void scheduled_thread_pool<Scheduler>::init_perf_counter_data(

--- a/libs/threading_base/include/hpx/threading_base/scheduler_base.hpp
+++ b/libs/threading_base/include/hpx/threading_base/scheduler_base.hpp
@@ -186,6 +186,9 @@ namespace hpx { namespace threads { namespace policies {
             std::size_t num_thread = std::size_t(-1),
             bool reset = false) const = 0;
 
+        // Queries whether a given core is idle
+        virtual bool is_core_idle(std::size_t num_thread) const = 0;
+
         // count active background threads
         std::int64_t get_background_thread_count();
         void increment_background_thread_count();

--- a/libs/threading_base/include/hpx/threading_base/thread_pool_base.hpp
+++ b/libs/threading_base/include/hpx/threading_base/thread_pool_base.hpp
@@ -437,6 +437,11 @@ namespace hpx { namespace threads {
             return 0;
         }
 
+        virtual std::int64_t get_idle_core_count() const
+        {
+            return 0;
+        }
+
         virtual std::int64_t get_background_thread_count()
         {
             return 0;

--- a/libs/threadmanager/include/hpx/threadmanager.hpp
+++ b/libs/threadmanager/include/hpx/threadmanager.hpp
@@ -163,6 +163,8 @@ namespace hpx { namespace threads {
             thread_priority priority = thread_priority_default,
             std::size_t num_thread = std::size_t(-1), bool reset = false);
 
+        std::int64_t get_idle_core_count();
+
         std::int64_t get_background_thread_count();
 
         // Enumerate all matching threads

--- a/libs/threadmanager/src/threadmanager.cpp
+++ b/libs/threadmanager/src/threadmanager.cpp
@@ -690,6 +690,19 @@ namespace hpx { namespace threads {
         return total_count;
     }
 
+    std::int64_t threadmanager::get_idle_core_count()
+    {
+        std::int64_t total_count = 0;
+        std::lock_guard<mutex_type> lk(mtx_);
+
+        for (auto& pool_iter : pools_)
+        {
+            total_count += pool_iter->get_idle_core_count();
+        }
+
+        return total_count;
+    }
+
     std::int64_t threadmanager::get_background_thread_count()
     {
         std::int64_t total_count = 0;

--- a/src/runtime/thread_pool_helpers.cpp
+++ b/src/runtime/thread_pool_helpers.cpp
@@ -86,6 +86,11 @@ namespace hpx { namespace threads {
         return get_thread_manager().get_thread_count(state, priority);
     }
 
+    std::int64_t get_idle_core_count()
+    {
+        return get_thread_manager().get_idle_core_count();
+    }
+
     bool enumerate_threads(util::function_nonser<bool(thread_id_type)> const& f,
         thread_state_enum state)
     {


### PR DESCRIPTION
Fixes #4599

The new API function is `hpx::get_idle_core_count()`, it will return the number of cores that have no threads (staged or pending) waiting in their queues.