### PR TITLE
Making sure the thread-local lock registration data is moving to the core the suspended HPX thread is resumed on

### DIFF
--- a/libs/threading_base/CMakeLists.txt
+++ b/libs/threading_base/CMakeLists.txt
@@ -94,6 +94,7 @@ add_hpx_module(
     hpx_affinity
     hpx_allocator_support
     hpx_assertion
+    hpx_basic_execution
     hpx_config
     hpx_coroutines
     hpx_errors


### PR DESCRIPTION
Currently, if a lock is actively ignored while the executing thread is suspended, then the lock is not properly de-registered if the thread is resumed on a different core. This PR fixes the issue by moving the lock registration data to a different core with the executing thread.