### PR TITLE
Making auto_chunk_size execute the given function using the given executor

### DIFF
--- a/libs/basic_execution/src/agent_ref.cpp
+++ b/libs/basic_execution/src/agent_ref.cpp
@@ -34,7 +34,7 @@ namespace hpx { namespace basic_execution {
 #ifdef HPX_HAVE_VERIFY_LOCKS
         util::verify_no_locks();
 #endif
-        impl_->yield(desc);
+        impl_->yield_k(k, desc);
     }
 
     void agent_ref::suspend(const char* desc)

--- a/libs/basic_execution/src/agent_ref.cpp
+++ b/libs/basic_execution/src/agent_ref.cpp
@@ -34,7 +34,7 @@ namespace hpx { namespace basic_execution {
 #ifdef HPX_HAVE_VERIFY_LOCKS
         util::verify_no_locks();
 #endif
-        impl_->yield_k(k, desc);
+        impl_->yield(desc);
     }
 
     void agent_ref::suspend(const char* desc)

--- a/libs/execution/include/hpx/execution/executors/auto_chunk_size.hpp
+++ b/libs/execution/include/hpx/execution/executors/auto_chunk_size.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -13,6 +13,7 @@
 #include <hpx/serialization/serialize.hpp>
 #include <hpx/timing.hpp>
 
+#include <hpx/execution/executors/execution_fwd.hpp>
 #include <hpx/execution/executors/execution_parameters.hpp>
 
 #include <algorithm>
@@ -75,7 +76,10 @@ namespace hpx { namespace parallel { namespace execution {
                 using hpx::util::high_resolution_clock;
                 std::uint64_t t = high_resolution_clock::now();
 
-                std::size_t test_chunk_size = f(num_iters_for_timing_);
+                // use executor to launch given function for measurements
+                std::size_t test_chunk_size = sync_execute(
+                    std::forward<Executor>(exec), f, num_iters_for_timing_);
+
                 if (test_chunk_size != 0)
                 {
                     t = (high_resolution_clock::now() - t) / test_chunk_size;

--- a/libs/execution/include/hpx/execution/executors/auto_chunk_size.hpp
+++ b/libs/execution/include/hpx/execution/executors/auto_chunk_size.hpp
@@ -20,6 +20,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
+#include <utility>
 
 namespace hpx { namespace parallel { namespace execution {
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/execution/tests/unit/parallel_executor.cpp
+++ b/libs/execution/tests/unit/parallel_executor.cpp
@@ -28,7 +28,7 @@ void test_sync()
     typedef hpx::parallel::execution::parallel_executor executor;
 
     executor exec;
-    HPX_TEST(hpx::parallel::execution::sync_execute(exec, &test, 42) !=
+    HPX_TEST(hpx::parallel::execution::sync_execute(exec, &test, 42) ==
         hpx::this_thread::get_id());
 }
 
@@ -152,8 +152,8 @@ void static_check_executor()
     using namespace hpx::traits;
     using executor = hpx::parallel::execution::parallel_executor;
 
-    static_assert(!has_sync_execute_member<executor>::value,
-        "!has_sync_execute_member<executor>::value");
+    static_assert(has_sync_execute_member<executor>::value,
+        "has_sync_execute_member<executor>::value");
     static_assert(has_async_execute_member<executor>::value,
         "has_async_execute_member<executor>::value");
     static_assert(has_then_execute_member<executor>::value,

--- a/libs/execution/tests/unit/parallel_fork_executor.cpp
+++ b/libs/execution/tests/unit/parallel_fork_executor.cpp
@@ -28,7 +28,7 @@ void test_sync()
     typedef hpx::parallel::execution::parallel_executor executor;
 
     executor exec(hpx::launch::fork);
-    HPX_TEST(hpx::parallel::execution::sync_execute(exec, &test, 42) !=
+    HPX_TEST(hpx::parallel::execution::sync_execute(exec, &test, 42) ==
         hpx::this_thread::get_id());
 }
 
@@ -151,8 +151,8 @@ void static_check_executor()
     using namespace hpx::traits;
     using executor = hpx::parallel::execution::parallel_executor;
 
-    static_assert(!has_sync_execute_member<executor>::value,
-        "!has_sync_execute_member<executor>::value");
+    static_assert(has_sync_execute_member<executor>::value,
+        "has_sync_execute_member<executor>::value");
     static_assert(has_async_execute_member<executor>::value,
         "has_async_execute_member<executor>::value");
     static_assert(has_then_execute_member<executor>::value,

--- a/libs/execution/tests/unit/parallel_policy_executor.cpp
+++ b/libs/execution/tests/unit/parallel_policy_executor.cpp
@@ -24,15 +24,13 @@ hpx::thread::id test(int passed_through)
 }
 
 template <typename Policy>
-void test_sync(bool sync)
+void test_sync()
 {
     typedef hpx::parallel::execution::parallel_policy_executor<Policy> executor;
 
     executor exec;
-    bool result = hpx::parallel::execution::sync_execute(exec, &test, 42) ==
-        hpx::this_thread::get_id();
-
-    HPX_TEST_EQ(sync, result);
+    HPX_TEST(hpx::parallel::execution::sync_execute(exec, &test, 42) ==
+        hpx::this_thread::get_id());
 }
 
 template <typename Policy>
@@ -189,8 +187,8 @@ void static_check_executor()
     using namespace hpx::traits;
     using executor = hpx::parallel::execution::parallel_policy_executor<Policy>;
 
-    static_assert(!has_sync_execute_member<executor>::value,
-        "!has_sync_execute_member<executor>::value");
+    static_assert(has_sync_execute_member<executor>::value,
+        "has_sync_execute_member<executor>::value");
     static_assert(has_async_execute_member<executor>::value,
         "has_async_execute_member<executor>::value");
     static_assert(has_then_execute_member<executor>::value,
@@ -211,7 +209,7 @@ void policy_test(bool sync = false)
 {
     static_check_executor<Policy>();
 
-    test_sync<Policy>(sync);
+    test_sync<Policy>();
     test_async<Policy>(sync);
     test_then<Policy>(sync);
 

--- a/libs/executors/CMakeLists.txt
+++ b/libs/executors/CMakeLists.txt
@@ -64,10 +64,7 @@ set(executors_compat_headers
     hpx/parallel/executors/thread_pool_attached_executors.hpp
 )
 
-set(executors_sources
-    current_executor.cpp
-    force_linking.cpp
-)
+set(executors_sources current_executor.cpp force_linking.cpp)
 
 include(HPX_AddModule)
 add_hpx_module(

--- a/libs/executors/CMakeLists.txt
+++ b/libs/executors/CMakeLists.txt
@@ -21,6 +21,7 @@ set(executors_headers
     hpx/executors/exception_list.hpp
     hpx/executors/execution_policy_fwd.hpp
     hpx/executors/execution_policy.hpp
+    hpx/executors/force_linking.hpp
     hpx/executors/limiting_executor.hpp
     hpx/executors/parallel_executor_aggregated.hpp
     hpx/executors/parallel_executor.hpp
@@ -63,13 +64,16 @@ set(executors_compat_headers
     hpx/parallel/executors/thread_pool_attached_executors.hpp
 )
 
-set(executors_sources current_executor.cpp)
+set(executors_sources
+    current_executor.cpp
+    force_linking.cpp
+)
 
 include(HPX_AddModule)
 add_hpx_module(
   executors
   COMPATIBILITY_HEADERS ON
-  DEPRECATION_WARNINGS FORCE_LINKING_GEN
+  DEPRECATION_WARNINGS
   GLOBAL_HEADER_GEN OFF
   SOURCES ${executors_sources}
   HEADERS ${executors_headers}

--- a/libs/executors/include/hpx/executors/force_linking.hpp
+++ b/libs/executors/include/hpx/executors/force_linking.hpp
@@ -6,17 +6,13 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/thread_executors/embedded_thread_pool_executors.hpp>
-#include <hpx/thread_executors/thread_pool_os_executors.hpp>
+#include <hpx/executors/current_executor.hpp>
 
-namespace hpx { namespace thread_executors {
-
+namespace hpx { namespace executors {
     struct force_linking_helper
     {
-        void (*dummy1_ptr)();
-        void (*dummy2_ptr)();
+        parallel::execution::current_executor (*get_executor)(error_code&);
     };
 
     force_linking_helper& force_linking();
-}}    // namespace hpx::thread_executors
+}}    // namespace hpx::executors

--- a/libs/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/executors/include/hpx/executors/parallel_executor.hpp
@@ -15,6 +15,7 @@
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/execution/detail/async_launch_policy_dispatch.hpp>
 #include <hpx/execution/detail/post_policy_dispatch.hpp>
+#include <hpx/execution/detail/sync_launch_policy_dispatch.hpp>
 #include <hpx/execution/executors/fused_bulk_execute.hpp>
 #include <hpx/execution/executors/static_chunk_size.hpp>
 #include <hpx/execution/traits/is_executor.hpp>
@@ -166,6 +167,17 @@ namespace hpx { namespace parallel { namespace execution {
         /// \endcond
 
         /// \cond NOINTERNAL
+
+        // OneWayExecutor interface
+        template <typename F, typename... Ts>
+        static
+            typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
+            sync_execute(F&& f, Ts&&... ts)
+        {
+            return hpx::detail::sync_launch_policy_dispatch<
+                launch::sync_policy>::call(launch::sync, std::forward<F>(f),
+                std::forward<Ts>(ts)...);
+        }
 
         // TwoWayExecutor interface
         template <typename F, typename... Ts>

--- a/libs/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/executors/include/hpx/executors/parallel_executor.hpp
@@ -174,9 +174,8 @@ namespace hpx { namespace parallel { namespace execution {
             typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
             sync_execute(F&& f, Ts&&... ts)
         {
-            return hpx::detail::sync_launch_policy_dispatch<
-                launch::sync_policy>::call(launch::sync, std::forward<F>(f),
-                std::forward<Ts>(ts)...);
+            return hpx::detail::sync_launch_policy_dispatch<Policy>::call(
+                launch::sync, std::forward<F>(f), std::forward<Ts>(ts)...);
         }
 
         // TwoWayExecutor interface

--- a/libs/executors/include/hpx/executors/parallel_executor_aggregated.hpp
+++ b/libs/executors/include/hpx/executors/parallel_executor_aggregated.hpp
@@ -14,6 +14,7 @@
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/execution/detail/async_launch_policy_dispatch.hpp>
 #include <hpx/execution/detail/post_policy_dispatch.hpp>
+#include <hpx/execution/detail/sync_launch_policy_dispatch.hpp>
 #include <hpx/execution/executors/static_chunk_size.hpp>
 #include <hpx/execution/traits/is_executor.hpp>
 #include <hpx/functional/invoke.hpp>

--- a/libs/executors/include/hpx/executors/parallel_executor_aggregated.hpp
+++ b/libs/executors/include/hpx/executors/parallel_executor_aggregated.hpp
@@ -86,6 +86,15 @@ namespace hpx { namespace parallel { namespace execution {
 
         /// \cond NOINTERNAL
 
+        // OneWayExecutor interface
+        template <typename F, typename... Ts>
+        static void sync_execute(F&& f, Ts&&... ts)
+        {
+            return hpx::detail::sync_launch_policy_dispatch<
+                launch::sync_policy>::call(launch::sync, std::forward<F>(f),
+                std::forward<Ts>(ts)...);
+        }
+
         // TwoWayExecutor interface
         template <typename F, typename... Ts>
         static hpx::future<void> async_execute(F&& f, Ts&&... ts)
@@ -288,6 +297,15 @@ namespace hpx { namespace parallel { namespace execution {
         /// \endcond
 
         /// \cond NOINTERNAL
+
+        // OneWayExecutor interface
+        template <typename F, typename... Ts>
+        static void sync_execute(F&& f, Ts&&... ts)
+        {
+            return hpx::detail::sync_launch_policy_dispatch<
+                launch::sync_policy>::call(launch::sync, std::forward<F>(f),
+                std::forward<Ts>(ts)...);
+        }
 
         // TwoWayExecutor interface
         template <typename F, typename... Ts>

--- a/libs/executors/src/force_linking.cpp
+++ b/libs/executors/src/force_linking.cpp
@@ -1,0 +1,19 @@
+//  Copyright (c) 2019 STE||AR Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/executors/current_executor.hpp>
+#include <hpx/executors/force_linking.hpp>
+
+namespace hpx { namespace executors {
+
+    // reference all symbols that have to be explicitly linked with the core
+    // library
+    force_linking_helper& force_linking()
+    {
+        static force_linking_helper helper{&hpx::this_thread::get_executor};
+        return helper;
+    }
+}}    // namespace hpx::executors

--- a/libs/thread_executors/include/hpx/thread_executors/thread_pool_os_executors.hpp
+++ b/libs/thread_executors/include/hpx/thread_executors/thread_pool_os_executors.hpp
@@ -148,6 +148,9 @@ namespace hpx { namespace threads { namespace executors {
             policies::detail::affinity_data const& affinity_data,
             util::optional<policies::callback_notifier> notifier =
                 util::nullopt);
+
+        // this is defined to force linking only
+        static void dummy();
     };
 
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)

--- a/libs/thread_executors/src/force_linking.cpp
+++ b/libs/thread_executors/src/force_linking.cpp
@@ -13,7 +13,8 @@ namespace hpx { namespace thread_executors {
     force_linking_helper& force_linking()
     {
         static force_linking_helper helper{
-            &hpx::threads::executors::local_priority_queue_executor::dummy};
+            &hpx::threads::executors::local_priority_queue_executor::dummy,
+            &hpx::threads::executors::local_priority_queue_os_executor::dummy};
         return helper;
     }
 }}    // namespace hpx::thread_executors

--- a/libs/thread_executors/src/thread_pool_os_executors.cpp
+++ b/libs/thread_executors/src/thread_pool_os_executors.cpp
@@ -296,6 +296,9 @@ namespace hpx { namespace threads { namespace executors {
     {
     }
 
+    // this is defined to force linking only
+    void local_priority_queue_os_executor::dummy() {}
+
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     ///////////////////////////////////////////////////////////////////////////
     static_priority_queue_os_executor::static_priority_queue_os_executor(


### PR DESCRIPTION

- flyby: adding sync_execute to parallel_executor and parallel_aggregated_executor

@McKillroy this should fix your issue with the wrapping executor not being invoked when the auto_chunker is used. This however requires that you implement the `sync_execute` method on your executor.
