### PR TITLE
Fix error message when HPX_IGNORE_CMAKE_BUILD_TYPE_COMPATIBILITY=OFF

### DIFF
--- a/cmake/templates/HPXMacros.cmake.in
+++ b/cmake/templates/HPXMacros.cmake.in
@@ -111,7 +111,7 @@ function(hpx_check_cmake_build_type)
       hpx_error("CMAKE_BUILD_TYPE does not match ${HPX_BUILD_TYPE}: "
         "this project uses '${CMAKE_BUILD_TYPE}', HPX uses '${HPX_BUILD_TYPE}'. "
         "Please add -DCMAKE_BUILD_TYPE=${HPX_BUILD_TYPE} to your cmake command "
-        "or add -DHPX_IGNORE_CMAKE_BUILD_TYPE_COMPATIBILITY=OFF to ignore this "
+        "or add -DHPX_IGNORE_CMAKE_BUILD_TYPE_COMPATIBILITY=ON to ignore this "
         "check (not recommended; HPX is not ABI compatible between release and "
         "debug modes).")
     endif()


### PR DESCRIPTION
It should advise users to set it to `ON` to ignore the build type.