### PR TITLE
Add handler for serializing custom exceptions

### DIFF
--- a/hpx/util/serialize_exception.hpp
+++ b/hpx/util/serialize_exception.hpp
@@ -8,53 +8,15 @@
 
 #include <hpx/config.hpp>
 
+#include <hpx/serialization/exception_ptr.hpp>
 #include <hpx/serialization/serialization_fwd.hpp>
 
 #include <exception>
 
-namespace hpx { namespace util
-{
-    enum exception_type
-    {
-        // unknown exception
-        unknown_exception = 0,
-
-        // standard exceptions
-        std_runtime_error = 1,
-        std_invalid_argument = 2,
-        std_out_of_range = 3,
-        std_logic_error = 4,
-        std_bad_alloc = 5,
-        std_bad_cast = 6,
-        std_bad_typeid = 7,
-        std_bad_exception = 8,
-        std_exception = 9,
-
-        // boost::system::system_error
-        boost_system_error = 10,
-
-        // hpx::exception
-        hpx_exception = 11,
-        hpx_thread_interrupted_exception = 12,
-
-#if BOOST_ASIO_HAS_BOOST_THROW_EXCEPTION != 0
-        // boost exceptions
-        boost_exception = 13
-#endif
-    };
-}}  // namespace hpx::util
-
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace serialization
-{
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename Archive>
-    void save(Archive& ar, std::exception_ptr const& e, unsigned int);
-
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename Archive>
-    void load(Archive& ar, std::exception_ptr& e, unsigned int);
-
-    HPX_SERIALIZATION_SPLIT_FREE(std::exception_ptr)
-}}
-
+namespace hpx { namespace runtime_local { namespace detail {
+    HPX_EXPORT void save_custom_exception(hpx::serialization::output_archive&,
+        std::exception_ptr const&, unsigned int);
+    HPX_EXPORT void load_custom_exception(
+        hpx::serialization::input_archive&, std::exception_ptr&, unsigned int);
+}}}    // namespace hpx::runtime_local::detail

--- a/libs/serialization/CMakeLists.txt
+++ b/libs/serialization/CMakeLists.txt
@@ -39,6 +39,7 @@ set(serialization_headers
     hpx/serialization/datapar.hpp
     hpx/serialization/deque.hpp
     hpx/serialization/dynamic_bitset.hpp
+    hpx/serialization/exception_ptr.hpp
     hpx/serialization/force_linking.hpp
     hpx/serialization/list.hpp
     hpx/serialization/map.hpp
@@ -144,6 +145,7 @@ set(serialization_sources
     detail/polymorphic_id_factory.cpp
     detail/polymorphic_intrusive_factory.cpp
     detail/polymorphic_nonintrusive_factory.cpp
+    exception_ptr.cpp
     force_linking.cpp
     serializable_any.cpp
 )
@@ -173,7 +175,3 @@ add_hpx_module(
 if(TARGET Vc::vc)
   target_link_libraries(hpx_serialization PUBLIC Vc::vc)
 endif()
-
-# Temporary needs hpx_util cause still depending on custom_exception_info which
-# is itself depending on hpx/naming_base.hpp
-target_link_libraries(hpx_serialization PUBLIC hpx_naming_base)

--- a/libs/serialization/include/hpx/serialization/exception_ptr.hpp
+++ b/libs/serialization/include/hpx/serialization/exception_ptr.hpp
@@ -1,0 +1,72 @@
+//  Copyright (c) 2007-2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <hpx/serialization/serialization_fwd.hpp>
+
+#include <exception>
+#include <functional>
+
+namespace hpx { namespace util {
+    enum exception_type
+    {
+        // unknown exception
+        unknown_exception = 0,
+
+        // standard exceptions
+        std_runtime_error = 1,
+        std_invalid_argument = 2,
+        std_out_of_range = 3,
+        std_logic_error = 4,
+        std_bad_alloc = 5,
+        std_bad_cast = 6,
+        std_bad_typeid = 7,
+        std_bad_exception = 8,
+        std_exception = 9,
+
+        // boost::system::system_error
+        boost_system_error = 10,
+
+        // hpx::exception
+        hpx_exception = 11,
+        hpx_thread_interrupted_exception = 12,
+
+#if BOOST_ASIO_HAS_BOOST_THROW_EXCEPTION != 0
+        // boost exceptions
+        boost_exception = 13
+#endif
+    };
+}}    // namespace hpx::util
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace serialization {
+    namespace detail {
+        using save_custom_exception_handler_type =
+            std::function<void(hpx::serialization::output_archive&,
+                std::exception_ptr const&, unsigned int)>;
+        using load_custom_exception_handler_type =
+            std::function<void(hpx::serialization::input_archive&,
+                std::exception_ptr&, unsigned int)>;
+
+        HPX_EXPORT void set_save_custom_exception_handler(
+            save_custom_exception_handler_type f);
+        HPX_EXPORT void set_load_custom_exception_handler(
+            load_custom_exception_handler_type f);
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Archive>
+    void save(Archive& ar, std::exception_ptr const& e, unsigned int);
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Archive>
+    void load(Archive& ar, std::exception_ptr& e, unsigned int);
+
+    HPX_SERIALIZATION_SPLIT_FREE(std::exception_ptr)
+}}    // namespace hpx::serialization

--- a/libs/serialization/src/exception_ptr.cpp
+++ b/libs/serialization/src/exception_ptr.cpp
@@ -1,0 +1,311 @@
+//  Copyright (c)      2020 ETH Zurich
+//  Copyright (c) 2007-2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/assertion.hpp>
+#include <hpx/errors.hpp>
+#include <hpx/serialization/exception_ptr.hpp>
+#include <hpx/serialization/serialize.hpp>
+
+#if BOOST_ASIO_HAS_BOOST_THROW_EXCEPTION != 0
+#include <boost/exception/diagnostic_information.hpp>
+#include <boost/exception/exception.hpp>
+#endif
+
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <typeinfo>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace serialization {
+    namespace detail {
+        static save_custom_exception_handler_type save_custom_exception_handler;
+
+        HPX_EXPORT void set_save_custom_exception_handler(
+            save_custom_exception_handler_type f)
+        {
+            save_custom_exception_handler = f;
+        }
+
+        static load_custom_exception_handler_type load_custom_exception_handler;
+
+        HPX_EXPORT void set_load_custom_exception_handler(
+            load_custom_exception_handler_type f)
+        {
+            load_custom_exception_handler = f;
+        }
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
+    // TODO: This is not scalable, and painful to update.
+    template <typename Archive>
+    void save(Archive& ar, std::exception_ptr const& ep, unsigned int version)
+    {
+        if (detail::save_custom_exception_handler)
+        {
+            return detail::save_custom_exception_handler(ar, ep, version);
+        }
+
+        hpx::util::exception_type type(hpx::util::unknown_exception);
+        std::string what;
+        int err_value = hpx::success;
+        std::string err_message;
+
+        std::string throw_function_;
+        std::string throw_file_;
+        long throw_line_ = 0;
+
+        // retrieve information related to exception_info
+        try
+        {
+            std::rethrow_exception(ep);
+        }
+        catch (exception_info const& xi)
+        {
+            std::string const* function = xi.get<hpx::detail::throw_function>();
+            if (function)
+                throw_function_ = *function;
+
+            std::string const* file = xi.get<hpx::detail::throw_file>();
+            if (file)
+                throw_file_ = *file;
+
+            long const* line = xi.get<hpx::detail::throw_line>();
+            if (line)
+                throw_line_ = *line;
+        }
+
+        // figure out concrete underlying exception type
+        try
+        {
+            std::rethrow_exception(ep);
+        }
+        catch (hpx::thread_interrupted const&)
+        {
+            type = hpx::util::hpx_thread_interrupted_exception;
+            what = "hpx::thread_interrupted";
+            err_value = hpx::thread_cancelled;
+        }
+        catch (hpx::exception const& e)
+        {
+            type = hpx::util::hpx_exception;
+            what = e.what();
+            err_value = e.get_error();
+        }
+        catch (boost::system::system_error const& e)
+        {
+            type = hpx::util::boost_system_error;
+            what = e.what();
+            err_value = e.code().value();
+            err_message = e.code().message();
+        }
+        catch (std::runtime_error const& e)
+        {
+            type = hpx::util::std_runtime_error;
+            what = e.what();
+        }
+        catch (std::invalid_argument const& e)
+        {
+            type = hpx::util::std_invalid_argument;
+            what = e.what();
+        }
+        catch (std::out_of_range const& e)
+        {
+            type = hpx::util::std_out_of_range;
+            what = e.what();
+        }
+        catch (std::logic_error const& e)
+        {
+            type = hpx::util::std_logic_error;
+            what = e.what();
+        }
+        catch (std::bad_alloc const& e)
+        {
+            type = hpx::util::std_bad_alloc;
+            what = e.what();
+        }
+        catch (std::bad_cast const& e)
+        {
+            type = hpx::util::std_bad_cast;
+            what = e.what();
+        }
+        catch (std::bad_typeid const& e)
+        {
+            type = hpx::util::std_bad_typeid;
+            what = e.what();
+        }
+        catch (std::bad_exception const& e)
+        {
+            type = hpx::util::std_bad_exception;
+            what = e.what();
+        }
+        catch (std::exception const& e)
+        {
+            type = hpx::util::std_exception;
+            what = e.what();
+        }
+#if BOOST_ASIO_HAS_BOOST_THROW_EXCEPTION != 0
+        catch (boost::exception const& e)
+        {
+            type = hpx::util::boost_exception;
+            what = boost::diagnostic_information(e);
+        }
+#endif
+        catch (...)
+        {
+            type = hpx::util::unknown_exception;
+            what = "unknown exception";
+        }
+
+        // clang-format off
+        ar & type & what & throw_function_ & throw_file_ & throw_line_;
+        // clang-format on
+
+        if (hpx::util::hpx_exception == type)
+        {
+            // clang-format off
+            ar & err_value;
+            // clang-format on
+        }
+        else if (hpx::util::boost_system_error == type)
+        {
+            // clang-format off
+            ar & err_value & err_message;
+            // clang-format on
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // TODO: This is not scalable, and painful to update.
+    template <typename Archive>
+    void load(Archive& ar, std::exception_ptr& e, unsigned int version)
+    {
+        if (detail::load_custom_exception_handler)
+        {
+            return detail::load_custom_exception_handler(ar, e, version);
+        }
+
+        hpx::util::exception_type type(hpx::util::unknown_exception);
+        std::string what;
+        int err_value = hpx::success;
+        std::string err_message;
+
+        std::string throw_function_;
+        std::string throw_file_;
+        int throw_line_ = 0;
+
+        // clang-format off
+        ar & type & what & throw_function_ & throw_file_ & throw_line_;
+        // clang-format on
+
+        if (hpx::util::hpx_exception == type)
+        {
+            // clang-format off
+            ar & err_value;
+            // clang-format on
+        }
+        else if (hpx::util::boost_system_error == type)
+        {
+            // clang-format off
+            ar & err_value& err_message;
+            // clang-format on
+        }
+
+        switch (type)
+        {
+        default:
+        case hpx::util::std_exception:
+        case hpx::util::unknown_exception:
+            e = hpx::detail::get_exception(hpx::detail::std_exception(what),
+                throw_function_, throw_file_, throw_line_);
+            break;
+
+        // standard exceptions
+        case hpx::util::std_runtime_error:
+            e = hpx::detail::get_exception(std::runtime_error(what),
+                throw_function_, throw_file_, throw_line_);
+            break;
+
+        case hpx::util::std_invalid_argument:
+            e = hpx::detail::get_exception(std::invalid_argument(what),
+                throw_function_, throw_file_, throw_line_);
+            break;
+
+        case hpx::util::std_out_of_range:
+            e = hpx::detail::get_exception(std::out_of_range(what),
+                throw_function_, throw_file_, throw_line_);
+            break;
+
+        case hpx::util::std_logic_error:
+            e = hpx::detail::get_exception(std::logic_error(what),
+                throw_function_, throw_file_, throw_line_);
+            break;
+
+        case hpx::util::std_bad_alloc:
+            e = hpx::detail::get_exception(hpx::detail::bad_alloc(what),
+                throw_function_, throw_file_, throw_line_);
+            break;
+
+        case hpx::util::std_bad_cast:
+            e = hpx::detail::get_exception(hpx::detail::bad_cast(what),
+                throw_function_, throw_file_, throw_line_);
+            break;
+
+        case hpx::util::std_bad_typeid:
+            e = hpx::detail::get_exception(hpx::detail::bad_typeid(what),
+                throw_function_, throw_file_, throw_line_);
+            break;
+        case hpx::util::std_bad_exception:
+            e = hpx::detail::get_exception(hpx::detail::bad_exception(what),
+                throw_function_, throw_file_, throw_line_);
+            break;
+
+#if BOOST_ASIO_HAS_BOOST_THROW_EXCEPTION != 0
+        // boost exceptions
+        case hpx::util::boost_exception:
+            HPX_ASSERT(false);    // shouldn't happen
+            break;
+#endif
+
+        // boost::system::system_error
+        case hpx::util::boost_system_error:
+            e = hpx::detail::get_exception(
+                boost::system::system_error(err_value,
+#if BOOST_VERSION < 106600 && !defined(BOOST_SYSTEM_NO_DEPRECATED)
+                    boost::system::get_system_category()
+#else
+                    boost::system::system_category()
+#endif
+                        ,
+                    err_message),
+                throw_function_, throw_file_, throw_line_);
+            break;
+
+        // hpx::exception
+        case hpx::util::hpx_exception:
+            e = hpx::detail::get_exception(
+                hpx::exception(
+                    static_cast<hpx::error>(err_value), what, hpx::rethrow),
+                throw_function_, throw_file_, throw_line_);
+            break;
+
+        // hpx::thread_interrupted
+        case hpx::util::hpx_thread_interrupted_exception:
+            e = hpx::detail::construct_lightweight_exception(
+                hpx::thread_interrupted());
+            break;
+        }
+    }
+
+    template HPX_EXPORT void save(hpx::serialization::output_archive&,
+        std::exception_ptr const&, unsigned int);
+
+    template HPX_EXPORT void load(
+        hpx::serialization::input_archive&, std::exception_ptr&, unsigned int);
+}}    // namespace hpx::serialization

--- a/libs/serialization/src/exception_ptr.cpp
+++ b/libs/serialization/src/exception_ptr.cpp
@@ -25,281 +25,316 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace serialization {
     namespace detail {
-        static save_custom_exception_handler_type save_custom_exception_handler;
+        ///////////////////////////////////////////////////////////////////////////
+        // TODO: This is not scalable, and painful to update.
+        void save(output_archive& ar, std::exception_ptr const& ep,
+            unsigned int version)
+        {
+            hpx::util::exception_type type(hpx::util::unknown_exception);
+            std::string what;
+            int err_value = hpx::success;
+            std::string err_message;
+
+            std::string throw_function_;
+            std::string throw_file_;
+            long throw_line_ = 0;
+
+            // retrieve information related to exception_info
+            try
+            {
+                std::rethrow_exception(ep);
+            }
+            catch (exception_info const& xi)
+            {
+                std::string const* function =
+                    xi.get<hpx::detail::throw_function>();
+                if (function)
+                    throw_function_ = *function;
+
+                std::string const* file = xi.get<hpx::detail::throw_file>();
+                if (file)
+                    throw_file_ = *file;
+
+                long const* line = xi.get<hpx::detail::throw_line>();
+                if (line)
+                    throw_line_ = *line;
+            }
+
+            // figure out concrete underlying exception type
+            try
+            {
+                std::rethrow_exception(ep);
+            }
+            catch (hpx::thread_interrupted const&)
+            {
+                type = hpx::util::hpx_thread_interrupted_exception;
+                what = "hpx::thread_interrupted";
+                err_value = hpx::thread_cancelled;
+            }
+            catch (hpx::exception const& e)
+            {
+                type = hpx::util::hpx_exception;
+                what = e.what();
+                err_value = e.get_error();
+            }
+            catch (boost::system::system_error const& e)
+            {
+                type = hpx::util::boost_system_error;
+                what = e.what();
+                err_value = e.code().value();
+                err_message = e.code().message();
+            }
+            catch (std::runtime_error const& e)
+            {
+                type = hpx::util::std_runtime_error;
+                what = e.what();
+            }
+            catch (std::invalid_argument const& e)
+            {
+                type = hpx::util::std_invalid_argument;
+                what = e.what();
+            }
+            catch (std::out_of_range const& e)
+            {
+                type = hpx::util::std_out_of_range;
+                what = e.what();
+            }
+            catch (std::logic_error const& e)
+            {
+                type = hpx::util::std_logic_error;
+                what = e.what();
+            }
+            catch (std::bad_alloc const& e)
+            {
+                type = hpx::util::std_bad_alloc;
+                what = e.what();
+            }
+            catch (std::bad_cast const& e)
+            {
+                type = hpx::util::std_bad_cast;
+                what = e.what();
+            }
+            catch (std::bad_typeid const& e)
+            {
+                type = hpx::util::std_bad_typeid;
+                what = e.what();
+            }
+            catch (std::bad_exception const& e)
+            {
+                type = hpx::util::std_bad_exception;
+                what = e.what();
+            }
+            catch (std::exception const& e)
+            {
+                type = hpx::util::std_exception;
+                what = e.what();
+            }
+#if BOOST_ASIO_HAS_BOOST_THROW_EXCEPTION != 0
+            catch (boost::exception const& e)
+            {
+                type = hpx::util::boost_exception;
+                what = boost::diagnostic_information(e);
+            }
+#endif
+            catch (...)
+            {
+                type = hpx::util::unknown_exception;
+                what = "unknown exception";
+            }
+
+            // clang-format off
+            ar & type & what & throw_function_ & throw_file_ & throw_line_;
+            // clang-format on
+
+            if (hpx::util::hpx_exception == type)
+            {
+                // clang-format off
+                ar & err_value;
+                // clang-format on
+            }
+            else if (hpx::util::boost_system_error == type)
+            {
+                // clang-format off
+                ar & err_value & err_message;
+                // clang-format on
+            }
+        }
+
+        ///////////////////////////////////////////////////////////////////////////
+        // TODO: This is not scalable, and painful to update.
+        void load(
+            input_archive& ar, std::exception_ptr& e, unsigned int version)
+        {
+            hpx::util::exception_type type(hpx::util::unknown_exception);
+            std::string what;
+            int err_value = hpx::success;
+            std::string err_message;
+
+            std::string throw_function_;
+            std::string throw_file_;
+            int throw_line_ = 0;
+
+            // clang-format off
+            ar & type & what & throw_function_ & throw_file_ & throw_line_;
+            // clang-format on
+
+            if (hpx::util::hpx_exception == type)
+            {
+                // clang-format off
+                ar & err_value;
+                // clang-format on
+            }
+            else if (hpx::util::boost_system_error == type)
+            {
+                // clang-format off
+                ar & err_value& err_message;
+                // clang-format on
+            }
+
+            switch (type)
+            {
+            default:
+            case hpx::util::std_exception:
+            case hpx::util::unknown_exception:
+                e = hpx::detail::get_exception(hpx::detail::std_exception(what),
+                    throw_function_, throw_file_, throw_line_);
+                break;
+
+            // standard exceptions
+            case hpx::util::std_runtime_error:
+                e = hpx::detail::get_exception(std::runtime_error(what),
+                    throw_function_, throw_file_, throw_line_);
+                break;
+
+            case hpx::util::std_invalid_argument:
+                e = hpx::detail::get_exception(std::invalid_argument(what),
+                    throw_function_, throw_file_, throw_line_);
+                break;
+
+            case hpx::util::std_out_of_range:
+                e = hpx::detail::get_exception(std::out_of_range(what),
+                    throw_function_, throw_file_, throw_line_);
+                break;
+
+            case hpx::util::std_logic_error:
+                e = hpx::detail::get_exception(std::logic_error(what),
+                    throw_function_, throw_file_, throw_line_);
+                break;
+
+            case hpx::util::std_bad_alloc:
+                e = hpx::detail::get_exception(hpx::detail::bad_alloc(what),
+                    throw_function_, throw_file_, throw_line_);
+                break;
+
+            case hpx::util::std_bad_cast:
+                e = hpx::detail::get_exception(hpx::detail::bad_cast(what),
+                    throw_function_, throw_file_, throw_line_);
+                break;
+
+            case hpx::util::std_bad_typeid:
+                e = hpx::detail::get_exception(hpx::detail::bad_typeid(what),
+                    throw_function_, throw_file_, throw_line_);
+                break;
+            case hpx::util::std_bad_exception:
+                e = hpx::detail::get_exception(hpx::detail::bad_exception(what),
+                    throw_function_, throw_file_, throw_line_);
+                break;
+
+#if BOOST_ASIO_HAS_BOOST_THROW_EXCEPTION != 0
+            // boost exceptions
+            case hpx::util::boost_exception:
+                HPX_ASSERT(false);    // shouldn't happen
+                break;
+#endif
+
+            // boost::system::system_error
+            case hpx::util::boost_system_error:
+                e = hpx::detail::get_exception(
+                    boost::system::system_error(err_value,
+#if BOOST_VERSION < 106600 && !defined(BOOST_SYSTEM_NO_DEPRECATED)
+                        boost::system::get_system_category()
+#else
+                        boost::system::system_category()
+#endif
+                            ,
+                        err_message),
+                    throw_function_, throw_file_, throw_line_);
+                break;
+
+            // hpx::exception
+            case hpx::util::hpx_exception:
+                e = hpx::detail::get_exception(
+                    hpx::exception(
+                        static_cast<hpx::error>(err_value), what, hpx::rethrow),
+                    throw_function_, throw_file_, throw_line_);
+                break;
+
+            // hpx::thread_interrupted
+            case hpx::util::hpx_thread_interrupted_exception:
+                e = hpx::detail::construct_lightweight_exception(
+                    hpx::thread_interrupted());
+                break;
+            }
+        }
+
+        save_custom_exception_handler_type& get_save_custom_exception_handler()
+        {
+            static save_custom_exception_handler_type f = save;
+            return f;
+        }
 
         HPX_EXPORT void set_save_custom_exception_handler(
             save_custom_exception_handler_type f)
         {
-            save_custom_exception_handler = f;
+            get_save_custom_exception_handler() = f;
         }
 
-        static load_custom_exception_handler_type load_custom_exception_handler;
+        load_custom_exception_handler_type& get_load_custom_exception_handler()
+        {
+            static load_custom_exception_handler_type f = load;
+            return f;
+        }
 
         HPX_EXPORT void set_load_custom_exception_handler(
             load_custom_exception_handler_type f)
         {
-            load_custom_exception_handler = f;
+            get_load_custom_exception_handler() = f;
         }
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
-    // TODO: This is not scalable, and painful to update.
     template <typename Archive>
     void save(Archive& ar, std::exception_ptr const& ep, unsigned int version)
     {
-        if (detail::save_custom_exception_handler)
+        if (detail::get_save_custom_exception_handler())
         {
-            return detail::save_custom_exception_handler(ar, ep, version);
+            detail::get_save_custom_exception_handler()(ar, ep, version);
         }
-
-        hpx::util::exception_type type(hpx::util::unknown_exception);
-        std::string what;
-        int err_value = hpx::success;
-        std::string err_message;
-
-        std::string throw_function_;
-        std::string throw_file_;
-        long throw_line_ = 0;
-
-        // retrieve information related to exception_info
-        try
+        else
         {
-            std::rethrow_exception(ep);
-        }
-        catch (exception_info const& xi)
-        {
-            std::string const* function = xi.get<hpx::detail::throw_function>();
-            if (function)
-                throw_function_ = *function;
-
-            std::string const* file = xi.get<hpx::detail::throw_file>();
-            if (file)
-                throw_file_ = *file;
-
-            long const* line = xi.get<hpx::detail::throw_line>();
-            if (line)
-                throw_line_ = *line;
-        }
-
-        // figure out concrete underlying exception type
-        try
-        {
-            std::rethrow_exception(ep);
-        }
-        catch (hpx::thread_interrupted const&)
-        {
-            type = hpx::util::hpx_thread_interrupted_exception;
-            what = "hpx::thread_interrupted";
-            err_value = hpx::thread_cancelled;
-        }
-        catch (hpx::exception const& e)
-        {
-            type = hpx::util::hpx_exception;
-            what = e.what();
-            err_value = e.get_error();
-        }
-        catch (boost::system::system_error const& e)
-        {
-            type = hpx::util::boost_system_error;
-            what = e.what();
-            err_value = e.code().value();
-            err_message = e.code().message();
-        }
-        catch (std::runtime_error const& e)
-        {
-            type = hpx::util::std_runtime_error;
-            what = e.what();
-        }
-        catch (std::invalid_argument const& e)
-        {
-            type = hpx::util::std_invalid_argument;
-            what = e.what();
-        }
-        catch (std::out_of_range const& e)
-        {
-            type = hpx::util::std_out_of_range;
-            what = e.what();
-        }
-        catch (std::logic_error const& e)
-        {
-            type = hpx::util::std_logic_error;
-            what = e.what();
-        }
-        catch (std::bad_alloc const& e)
-        {
-            type = hpx::util::std_bad_alloc;
-            what = e.what();
-        }
-        catch (std::bad_cast const& e)
-        {
-            type = hpx::util::std_bad_cast;
-            what = e.what();
-        }
-        catch (std::bad_typeid const& e)
-        {
-            type = hpx::util::std_bad_typeid;
-            what = e.what();
-        }
-        catch (std::bad_exception const& e)
-        {
-            type = hpx::util::std_bad_exception;
-            what = e.what();
-        }
-        catch (std::exception const& e)
-        {
-            type = hpx::util::std_exception;
-            what = e.what();
-        }
-#if BOOST_ASIO_HAS_BOOST_THROW_EXCEPTION != 0
-        catch (boost::exception const& e)
-        {
-            type = hpx::util::boost_exception;
-            what = boost::diagnostic_information(e);
-        }
-#endif
-        catch (...)
-        {
-            type = hpx::util::unknown_exception;
-            what = "unknown exception";
-        }
-
-        // clang-format off
-        ar & type & what & throw_function_ & throw_file_ & throw_line_;
-        // clang-format on
-
-        if (hpx::util::hpx_exception == type)
-        {
-            // clang-format off
-            ar & err_value;
-            // clang-format on
-        }
-        else if (hpx::util::boost_system_error == type)
-        {
-            // clang-format off
-            ar & err_value & err_message;
-            // clang-format on
+            HPX_THROW_EXCEPTION(invalid_status, "hpx::serialization::save",
+                "Attempted to save a std::exception_ptr, but there is no "
+                "handler installed. Set one with "
+                "hpx::serialization::detail::set_save_custom_exception_"
+                "handler.");
         }
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    // TODO: This is not scalable, and painful to update.
     template <typename Archive>
-    void load(Archive& ar, std::exception_ptr& e, unsigned int version)
+    void load(Archive& ar, std::exception_ptr& ep, unsigned int version)
     {
-        if (detail::load_custom_exception_handler)
+        if (detail::get_load_custom_exception_handler())
         {
-            return detail::load_custom_exception_handler(ar, e, version);
+            detail::get_load_custom_exception_handler()(ar, ep, version);
         }
-
-        hpx::util::exception_type type(hpx::util::unknown_exception);
-        std::string what;
-        int err_value = hpx::success;
-        std::string err_message;
-
-        std::string throw_function_;
-        std::string throw_file_;
-        int throw_line_ = 0;
-
-        // clang-format off
-        ar & type & what & throw_function_ & throw_file_ & throw_line_;
-        // clang-format on
-
-        if (hpx::util::hpx_exception == type)
+        else
         {
-            // clang-format off
-            ar & err_value;
-            // clang-format on
-        }
-        else if (hpx::util::boost_system_error == type)
-        {
-            // clang-format off
-            ar & err_value& err_message;
-            // clang-format on
-        }
-
-        switch (type)
-        {
-        default:
-        case hpx::util::std_exception:
-        case hpx::util::unknown_exception:
-            e = hpx::detail::get_exception(hpx::detail::std_exception(what),
-                throw_function_, throw_file_, throw_line_);
-            break;
-
-        // standard exceptions
-        case hpx::util::std_runtime_error:
-            e = hpx::detail::get_exception(std::runtime_error(what),
-                throw_function_, throw_file_, throw_line_);
-            break;
-
-        case hpx::util::std_invalid_argument:
-            e = hpx::detail::get_exception(std::invalid_argument(what),
-                throw_function_, throw_file_, throw_line_);
-            break;
-
-        case hpx::util::std_out_of_range:
-            e = hpx::detail::get_exception(std::out_of_range(what),
-                throw_function_, throw_file_, throw_line_);
-            break;
-
-        case hpx::util::std_logic_error:
-            e = hpx::detail::get_exception(std::logic_error(what),
-                throw_function_, throw_file_, throw_line_);
-            break;
-
-        case hpx::util::std_bad_alloc:
-            e = hpx::detail::get_exception(hpx::detail::bad_alloc(what),
-                throw_function_, throw_file_, throw_line_);
-            break;
-
-        case hpx::util::std_bad_cast:
-            e = hpx::detail::get_exception(hpx::detail::bad_cast(what),
-                throw_function_, throw_file_, throw_line_);
-            break;
-
-        case hpx::util::std_bad_typeid:
-            e = hpx::detail::get_exception(hpx::detail::bad_typeid(what),
-                throw_function_, throw_file_, throw_line_);
-            break;
-        case hpx::util::std_bad_exception:
-            e = hpx::detail::get_exception(hpx::detail::bad_exception(what),
-                throw_function_, throw_file_, throw_line_);
-            break;
-
-#if BOOST_ASIO_HAS_BOOST_THROW_EXCEPTION != 0
-        // boost exceptions
-        case hpx::util::boost_exception:
-            HPX_ASSERT(false);    // shouldn't happen
-            break;
-#endif
-
-        // boost::system::system_error
-        case hpx::util::boost_system_error:
-            e = hpx::detail::get_exception(
-                boost::system::system_error(err_value,
-#if BOOST_VERSION < 106600 && !defined(BOOST_SYSTEM_NO_DEPRECATED)
-                    boost::system::get_system_category()
-#else
-                    boost::system::system_category()
-#endif
-                        ,
-                    err_message),
-                throw_function_, throw_file_, throw_line_);
-            break;
-
-        // hpx::exception
-        case hpx::util::hpx_exception:
-            e = hpx::detail::get_exception(
-                hpx::exception(
-                    static_cast<hpx::error>(err_value), what, hpx::rethrow),
-                throw_function_, throw_file_, throw_line_);
-            break;
-
-        // hpx::thread_interrupted
-        case hpx::util::hpx_thread_interrupted_exception:
-            e = hpx::detail::construct_lightweight_exception(
-                hpx::thread_interrupted());
-            break;
+            HPX_THROW_EXCEPTION(invalid_status, "hpx::serialization::load",
+                "Attempted to load a std::exception_ptr, but there is no "
+                "handler installed. Set one with "
+                "hpx::serialization::detail::set_load_custom_exception_"
+                "handler.");
         }
     }
 

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -705,7 +705,12 @@ namespace hpx
             hpx::util::set_enable_parent_task_handler(
                     &detail::enable_parent_task_handler);
 #endif
-            hpx::set_custom_exception_info_handler(&detail::custom_exception_info);
+            hpx::set_custom_exception_info_handler(
+                &detail::custom_exception_info);
+            hpx::serialization::detail::set_save_custom_exception_handler(
+                &runtime_local::detail::save_custom_exception);
+            hpx::serialization::detail::set_load_custom_exception_handler(
+                &runtime_local::detail::load_custom_exception);
             hpx::set_pre_exception_handler(&detail::pre_exception_handler);
             hpx::set_thread_termination_handler(
                 [](std::exception_ptr const& e) { report_error(e); });


### PR DESCRIPTION
This takes care of the circular dependency between the runtime and futures/exceptions, but there *must* be a better way of handling this.