### PR TITLE
Officially export HPX::wrap_main target for explicitly linking to hpx_wrap

### DIFF
--- a/wrap/CMakeLists.txt
+++ b/wrap/CMakeLists.txt
@@ -135,3 +135,19 @@ install(
 hpx_export_internal_targets(hpx_wrap)
 
 add_hpx_pseudo_dependencies(core hpx_wrap)
+
+# Add public target for unconditionally linking to hpx_wrap
+add_library(wrap_main INTERFACE)
+
+target_link_libraries(wrap_main INTERFACE hpx_wrap)
+
+install(
+  TARGETS wrap_main
+  EXPORT HPXTargets
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+          COMPONENT runtime
+)
+
+hpx_export_targets(wrap_main)


### PR DESCRIPTION
I hoped we wouldn't need this but it's clearly a thing, so now it's a public target in the `HPX::` namespace. I'll accompany this with documentation before the next release.

@weilewei would you mind giving this a try? You'll need to link to `HPX::hpx_no_wrap_main` and `HPX::wrap_main` (that's going to be fun to explain in the documentation). `HPX::wrap_main` has to be linked before any static library containing `main`.