### PR TITLE
Clean up export macros

### DIFF
--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -251,7 +251,7 @@ function(add_hpx_module name)
 
   target_compile_definitions(
     hpx_${name} PRIVATE $<$<CONFIG:Debug>:DEBUG> $<$<CONFIG:Debug>:_DEBUG>
-                        HPX_MODULE_EXPORTS
+                        HPX_EXPORTS
   )
 
   # This is a temporary solution until all of HPX has been modularized as it

--- a/cmake/HPX_AddParcelport.cmake
+++ b/cmake/HPX_AddParcelport.cmake
@@ -62,7 +62,7 @@ function(add_parcelport name)
     hpx_export_targets(${_link_libraries})
   endif()
 
-  target_compile_definitions(${parcelport_name} PRIVATE HPX_MODULE_EXPORTS)
+  target_compile_definitions(${parcelport_name} PRIVATE HPX_EXPORTS)
 
   add_hpx_pseudo_dependencies(plugins.parcelport.${name} ${parcelport_name})
   add_hpx_pseudo_dependencies(core plugins.parcelport.${name})

--- a/hpx/lcos/base_lco.hpp
+++ b/hpx/lcos/base_lco.hpp
@@ -23,7 +23,7 @@ namespace hpx { namespace lcos
 {
     /// The \a base_lco class is the common base class for all LCO's
     /// implementing a simple set_event action
-    class HPX_API_EXPORT base_lco
+    class HPX_EXPORT base_lco
     {
     public:
         virtual void set_event() = 0;

--- a/hpx/runtime.hpp
+++ b/hpx/runtime.hpp
@@ -478,13 +478,13 @@ namespace hpx {
     namespace util {
         ///////////////////////////////////////////////////////////////////////////
         // retrieve the command line arguments for the current locality
-        HPX_API_EXPORT bool retrieve_commandline_arguments(
+        HPX_EXPORT bool retrieve_commandline_arguments(
             hpx::program_options::options_description const& app_options,
             hpx::program_options::variables_map& vm);
 
         ///////////////////////////////////////////////////////////////////////////
         // retrieve the command line arguments for the current locality
-        HPX_API_EXPORT bool retrieve_commandline_arguments(
+        HPX_EXPORT bool retrieve_commandline_arguments(
             std::string const& appname,
             hpx::program_options::variables_map& vm);
     }    // namespace util
@@ -495,7 +495,7 @@ namespace hpx {
         /// Get the readable string representing the given stack size constant.
         ///
         /// \param size this represents the stack size
-        HPX_API_EXPORT char const* get_stack_size_name(std::ptrdiff_t size);
+        HPX_EXPORT char const* get_stack_size_name(std::ptrdiff_t size);
     }    // namespace threads
 }    // namespace hpx
 

--- a/hpx/runtime/actions/manage_object_action.hpp
+++ b/hpx/runtime/actions/manage_object_action.hpp
@@ -25,7 +25,7 @@
 namespace hpx { namespace actions
 {
     ///////////////////////////////////////////////////////////////////////////
-    struct HPX_API_EXPORT manage_object_action_base
+    struct HPX_EXPORT manage_object_action_base
     {
         typedef void (*construct_function)(void*, std::size_t);
         typedef void (*clone_function)(void*, void const*, std::size_t);

--- a/hpx/runtime/actions_fwd.hpp
+++ b/hpx/runtime/actions_fwd.hpp
@@ -31,7 +31,7 @@ namespace hpx { namespace actions
 
     namespace detail
     {
-        HPX_API_EXPORT std::uint32_t get_action_id_from_name(
+        HPX_EXPORT std::uint32_t get_action_id_from_name(
             char const* action_name);
     }
 

--- a/hpx/runtime/agas/interface.hpp
+++ b/hpx/runtime/agas/interface.hpp
@@ -32,56 +32,56 @@ namespace hpx { namespace agas
 {
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT bool is_console();
+HPX_EXPORT bool is_console();
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT bool register_name(
+HPX_EXPORT bool register_name(
     launch::sync_policy
   , std::string const& name
   , naming::gid_type const& gid
   , error_code& ec = throws
     );
 
-HPX_API_EXPORT bool register_name(
+HPX_EXPORT bool register_name(
     launch::sync_policy
   , std::string const& name
   , naming::id_type const& id
   , error_code& ec = throws
     );
 
-HPX_API_EXPORT lcos::future<bool> register_name(
+HPX_EXPORT lcos::future<bool> register_name(
     std::string const& name
   , naming::id_type const& id
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT naming::id_type unregister_name(
+HPX_EXPORT naming::id_type unregister_name(
     launch::sync_policy
   , std::string const& name
   , error_code& ec = throws
     );
 
-HPX_API_EXPORT lcos::future<naming::id_type> unregister_name(
+HPX_EXPORT lcos::future<naming::id_type> unregister_name(
     std::string const& name
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT naming::id_type resolve_name(
+HPX_EXPORT naming::id_type resolve_name(
     launch::sync_policy
   , std::string const& name
   , error_code& ec = throws
     );
 
-HPX_API_EXPORT lcos::future<naming::id_type> resolve_name(
+HPX_EXPORT lcos::future<naming::id_type> resolve_name(
     std::string const& name
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-// HPX_API_EXPORT lcos::future<std::vector<naming::id_type> > get_localities(
+// HPX_EXPORT lcos::future<std::vector<naming::id_type> > get_localities(
 //     components::component_type type = components::component_invalid
 //     );
 //
-// HPX_API_EXPORT std::vector<naming::id_type> get_localities_sync(
+// HPX_EXPORT std::vector<naming::id_type> get_localities_sync(
 //     components::component_type type
 //   , error_code& ec = throws
 //     );
@@ -94,11 +94,11 @@ HPX_API_EXPORT lcos::future<naming::id_type> resolve_name(
 // }
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT lcos::future<std::uint32_t> get_num_localities(
+HPX_EXPORT lcos::future<std::uint32_t> get_num_localities(
     components::component_type type = components::component_invalid
     );
 
-HPX_API_EXPORT std::uint32_t get_num_localities(
+HPX_EXPORT std::uint32_t get_num_localities(
     launch::sync_policy
   , components::component_type type
   , error_code& ec = throws
@@ -114,35 +114,35 @@ inline std::uint32_t get_num_localities(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT std::string get_component_type_name(
+HPX_EXPORT std::string get_component_type_name(
     components::component_type type, error_code& ec = throws);
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT lcos::future<std::vector<std::uint32_t> > get_num_threads();
+HPX_EXPORT lcos::future<std::vector<std::uint32_t> > get_num_threads();
 
-HPX_API_EXPORT std::vector<std::uint32_t> get_num_threads(
+HPX_EXPORT std::vector<std::uint32_t> get_num_threads(
     launch::sync_policy
   , error_code& ec = throws
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT lcos::future<std::uint32_t> get_num_overall_threads();
+HPX_EXPORT lcos::future<std::uint32_t> get_num_overall_threads();
 
-HPX_API_EXPORT std::uint32_t get_num_overall_threads(
+HPX_EXPORT std::uint32_t get_num_overall_threads(
     launch::sync_policy
   , error_code& ec = throws
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT std::uint32_t get_locality_id(error_code& ec = throws);
+HPX_EXPORT std::uint32_t get_locality_id(error_code& ec = throws);
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT bool is_local_address_cached(
+HPX_EXPORT bool is_local_address_cached(
     naming::gid_type const& gid
   , error_code& ec = throws
     );
 
-HPX_API_EXPORT bool is_local_address_cached(
+HPX_EXPORT bool is_local_address_cached(
     naming::gid_type const& gid
   , naming::address& addr
   , error_code& ec = throws
@@ -166,7 +166,7 @@ inline bool is_local_address_cached(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT bool is_local_lva_encoded_address(
+HPX_EXPORT bool is_local_lva_encoded_address(
     naming::gid_type const& gid
     );
 
@@ -178,23 +178,23 @@ inline bool is_local_lva_encoded_address(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT hpx::future<naming::address> resolve(
+HPX_EXPORT hpx::future<naming::address> resolve(
     naming::id_type const& id
     );
 
-HPX_API_EXPORT naming::address resolve(
+HPX_EXPORT naming::address resolve(
     launch::sync_policy
   , naming::id_type const& id
   , error_code& ec = throws
     );
 
-HPX_API_EXPORT hpx::future<bool> bind(
+HPX_EXPORT hpx::future<bool> bind(
     naming::gid_type const& gid
   , naming::address const& addr
   , std::uint32_t locality_id
     );
 
-HPX_API_EXPORT bool bind(
+HPX_EXPORT bool bind(
     launch::sync_policy
   , naming::gid_type const& gid
   , naming::address const& addr
@@ -202,13 +202,13 @@ HPX_API_EXPORT bool bind(
   , error_code& ec = throws
     );
 
-HPX_API_EXPORT hpx::future<bool> bind(
+HPX_EXPORT hpx::future<bool> bind(
     naming::gid_type const& gid
   , naming::address const& addr
   , naming::gid_type const& locality_
     );
 
-HPX_API_EXPORT bool bind(
+HPX_EXPORT bool bind(
     launch::sync_policy
   , naming::gid_type const& gid
   , naming::address const& addr
@@ -216,12 +216,12 @@ HPX_API_EXPORT bool bind(
   , error_code& ec = throws
     );
 
-HPX_API_EXPORT hpx::future<naming::address> unbind(
+HPX_EXPORT hpx::future<naming::address> unbind(
     naming::gid_type const& gid
   , std::uint64_t count = 1
     );
 
-HPX_API_EXPORT naming::address unbind(
+HPX_EXPORT naming::address unbind(
     launch::sync_policy
   , naming::gid_type const& gid
   , std::uint64_t count = 1
@@ -229,56 +229,56 @@ HPX_API_EXPORT naming::address unbind(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT void garbage_collect_non_blocking(
+HPX_EXPORT void garbage_collect_non_blocking(
     error_code& ec = throws
     );
 
-HPX_API_EXPORT void garbage_collect(
+HPX_EXPORT void garbage_collect(
     error_code& ec = throws
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// \brief Invoke an asynchronous garbage collection step on the given target
 ///        locality.
-HPX_API_EXPORT void garbage_collect_non_blocking(
+HPX_EXPORT void garbage_collect_non_blocking(
     naming::id_type const& id
   , error_code& ec = throws
     );
 
 /// \brief Invoke a synchronous garbage collection step on the given target
 ///        locality.
-HPX_API_EXPORT void garbage_collect(
+HPX_EXPORT void garbage_collect(
     naming::id_type const& id
   , error_code& ec = throws
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// \brief Return an id_type referring to the console locality.
-HPX_API_EXPORT naming::id_type get_console_locality(
+HPX_EXPORT naming::id_type get_console_locality(
     error_code& ec = throws
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT naming::gid_type get_next_id(
+HPX_EXPORT naming::gid_type get_next_id(
     std::size_t count
   , error_code& ec = throws
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT void decref(
+HPX_EXPORT void decref(
     naming::gid_type const& id
   , std::int64_t credits
   , error_code& ec = throws
   );
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT hpx::future<std::int64_t> incref(
+HPX_EXPORT hpx::future<std::int64_t> incref(
     naming::gid_type const& gid
   , std::int64_t credits
   , naming::id_type const& keep_alive = naming::invalid_id
   );
 
-HPX_API_EXPORT std::int64_t incref(
+HPX_EXPORT std::int64_t incref(
     launch::sync_policy
   , naming::gid_type const& gid
   , std::int64_t credits = 1
@@ -287,38 +287,38 @@ HPX_API_EXPORT std::int64_t incref(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT hpx::future<naming::id_type> get_colocation_id(
+HPX_EXPORT hpx::future<naming::id_type> get_colocation_id(
     naming::id_type const& id);
 
-HPX_API_EXPORT naming::id_type get_colocation_id(
+HPX_EXPORT naming::id_type get_colocation_id(
     launch::sync_policy
   , naming::id_type const& id
   , error_code& ec = throws);
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT hpx::future<hpx::id_type> on_symbol_namespace_event(
+HPX_EXPORT hpx::future<hpx::id_type> on_symbol_namespace_event(
     std::string const& name, bool call_for_past_events);
 
 ///////////////////////////////////////////////////////////////////////////////
-HPX_API_EXPORT hpx::future<std::pair<naming::id_type, naming::address>>
+HPX_EXPORT hpx::future<std::pair<naming::id_type, naming::address>>
     begin_migration(naming::id_type const& id);
-HPX_API_EXPORT bool end_migration(naming::id_type const& id);
+HPX_EXPORT bool end_migration(naming::id_type const& id);
 
-HPX_API_EXPORT hpx::future<void>
+HPX_EXPORT hpx::future<void>
     mark_as_migrated(naming::gid_type const& gid,
         util::unique_function_nonser<
             std::pair<bool, hpx::future<void> >()> && f,
         bool expect_to_be_marked_as_migrating);
 
-HPX_API_EXPORT std::pair<bool, components::pinned_ptr>
+HPX_EXPORT std::pair<bool, components::pinned_ptr>
     was_object_migrated(naming::gid_type const& gid,
         util::unique_function_nonser<components::pinned_ptr()> && f);
 
-HPX_API_EXPORT void unmark_as_migrated(naming::gid_type const& gid);
+HPX_EXPORT void unmark_as_migrated(naming::gid_type const& gid);
 
-HPX_API_EXPORT hpx::future<std::map<std::string, hpx::id_type> >
+HPX_EXPORT hpx::future<std::map<std::string, hpx::id_type> >
     find_symbols(std::string const& pattern = "*");
-HPX_API_EXPORT std::map<std::string, hpx::id_type> find_symbols(
+HPX_EXPORT std::map<std::string, hpx::id_type> find_symbols(
     hpx::launch::sync_policy, std::string const& pattern = "*");
 }}
 

--- a/hpx/runtime/agas_fwd.hpp
+++ b/hpx/runtime/agas_fwd.hpp
@@ -36,6 +36,6 @@ namespace hpx { namespace agas
         struct HPX_EXPORT primary_namespace;
         struct HPX_EXPORT symbol_namespace;
     }
-    struct HPX_API_EXPORT addressing_service;
+    struct HPX_EXPORT addressing_service;
 }}
 

--- a/hpx/runtime/basename_registration_fwd.hpp
+++ b/hpx/runtime/basename_registration_fwd.hpp
@@ -25,7 +25,7 @@ namespace hpx
     /// \cond NOINTERNAL
     namespace detail
     {
-        HPX_API_EXPORT std::string name_from_basename(
+        HPX_EXPORT std::string name_from_basename(
             std::string const& basename, std::size_t idx);
     }
     /// \endcond
@@ -49,7 +49,7 @@ namespace hpx
     ///         This is important in order to reliably retrieve ids from a
     ///         name, even if the name was already registered.
     ///
-    HPX_API_EXPORT std::vector<hpx::future<hpx::id_type>>
+    HPX_EXPORT std::vector<hpx::future<hpx::id_type>>
     find_all_from_basename(std::string base_name, std::size_t num_ids);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -96,7 +96,7 @@ namespace hpx
     ///         This is important in order to reliably retrieve ids from a
     ///         name, even if the name was already registered.
     ///
-    HPX_API_EXPORT std::vector<hpx::future<hpx::id_type>> find_from_basename(
+    HPX_EXPORT std::vector<hpx::future<hpx::id_type>> find_from_basename(
         std::string base_name, std::vector<std::size_t> const& ids);
 
     /// Return registered clients from the given base name and sequence numbers.
@@ -142,7 +142,7 @@ namespace hpx
     ///         This is important in order to reliably retrieve ids from a
     ///         name, even if the name was already registered.
     ///
-    HPX_API_EXPORT hpx::future<hpx::id_type> find_from_basename(
+    HPX_EXPORT hpx::future<hpx::id_type> find_from_basename(
         std::string base_name,
         std::size_t sequence_nr = ~static_cast<std::size_t>(0));
 
@@ -192,7 +192,7 @@ namespace hpx
     /// \note    The operation will fail if the given sequence number is not
     ///          unique.
     ///
-    HPX_API_EXPORT hpx::future<bool> register_with_basename(
+    HPX_EXPORT hpx::future<bool> register_with_basename(
         std::string base_name, hpx::id_type id,
         std::size_t sequence_nr = ~static_cast<std::size_t>(0));
 
@@ -218,7 +218,7 @@ namespace hpx
     /// \note    The operation will fail if the given sequence number is not
     ///          unique.
     ///
-    HPX_API_EXPORT hpx::future<bool> register_with_basename(
+    HPX_EXPORT hpx::future<bool> register_with_basename(
         std::string base_name, hpx::future<hpx::id_type> f,
         std::size_t sequence_nr = ~static_cast<std::size_t>(0));
 
@@ -265,7 +265,7 @@ namespace hpx
     /// \returns A future representing the result of the un-registration
     ///          operation itself.
     ///
-    HPX_API_EXPORT hpx::future<hpx::id_type> unregister_with_basename(
+    HPX_EXPORT hpx::future<hpx::id_type> unregister_with_basename(
         std::string base_name,
         std::size_t sequence_nr = ~static_cast<std::size_t>(0));
 

--- a/hpx/runtime/components/server/component_base.hpp
+++ b/hpx/runtime/components/server/component_base.hpp
@@ -28,7 +28,7 @@
 
 namespace hpx { namespace detail
 {
-    HPX_API_EXPORT naming::gid_type get_next_id(std::size_t count = 1);
+    HPX_EXPORT naming::gid_type get_next_id(std::size_t count = 1);
 }}
 
 namespace hpx { namespace components

--- a/hpx/runtime/components/server/console_error_sink_singleton.hpp
+++ b/hpx/runtime/components/server/console_error_sink_singleton.hpp
@@ -54,7 +54,7 @@ namespace hpx { namespace components { namespace server
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_API_EXPORT console_error_dispatcher& get_error_dispatcher();
+    HPX_EXPORT console_error_dispatcher& get_error_dispatcher();
 }}}
 
 

--- a/hpx/runtime/components_fwd.hpp
+++ b/hpx/runtime/components_fwd.hpp
@@ -68,7 +68,7 @@ namespace hpx
         template <typename Component, typename Derived = detail::this_type>
         class managed_component;
 
-        struct HPX_API_EXPORT component_factory_base;
+        struct HPX_EXPORT component_factory_base;
 
         template <typename Component>
         struct component_factory;
@@ -86,8 +86,8 @@ namespace hpx
 
         namespace server
         {
-            class HPX_API_EXPORT runtime_support;
-            class HPX_API_EXPORT memory;
+            class HPX_EXPORT runtime_support;
+            class HPX_EXPORT memory;
         }
 
         HPX_EXPORT void console_logging(logging_destination dest,

--- a/hpx/runtime/config_entry.hpp
+++ b/hpx/runtime/config_entry.hpp
@@ -17,21 +17,21 @@ namespace hpx
 {
     ///////////////////////////////////////////////////////////////////////////
     /// Retrieve the string value of a configuration entry given by \p key.
-    HPX_API_EXPORT std::string get_config_entry(std::string const& key,
+    HPX_EXPORT std::string get_config_entry(std::string const& key,
         std::string const& dflt);
     /// Retrieve the integer value of a configuration entry given by \p key.
-    HPX_API_EXPORT std::string get_config_entry(std::string const& key,
+    HPX_EXPORT std::string get_config_entry(std::string const& key,
         std::size_t dflt);
 
     /// Set the string value of a configuration entry given by \p key.
-    HPX_API_EXPORT void set_config_entry(std::string const& key,
+    HPX_EXPORT void set_config_entry(std::string const& key,
         std::string const& value);
     /// Set the integer value of a configuration entry given by \p key.
-    HPX_API_EXPORT void set_config_entry(std::string const& key,
+    HPX_EXPORT void set_config_entry(std::string const& key,
         std::size_t value);
 
     /// Set the string value of a configuration entry given by \p key.
-    HPX_API_EXPORT void set_config_entry_callback(std::string const& key,
+    HPX_EXPORT void set_config_entry_callback(std::string const& key,
         util::function_nonser<
             void(std::string const&, std::string const&)
         > const& callback);

--- a/hpx/runtime/find_here.hpp
+++ b/hpx/runtime/find_here.hpp
@@ -42,6 +42,6 @@ namespace hpx
     ///           otherwise.
     ///
     /// \see      \a hpx::find_all_localities(), \a hpx::find_locality()
-    HPX_API_EXPORT naming::id_type find_here(error_code& ec = throws);
+    HPX_EXPORT naming::id_type find_here(error_code& ec = throws);
 }
 

--- a/hpx/runtime/find_localities.hpp
+++ b/hpx/runtime/find_localities.hpp
@@ -46,7 +46,7 @@ namespace hpx
     ///           otherwise.
     ///
     /// \see      \a hpx::find_all_localities(), \a hpx::find_locality()
-    HPX_API_EXPORT naming::id_type find_root_locality(error_code& ec = throws);
+    HPX_EXPORT naming::id_type find_root_locality(error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Return the list of global ids representing all localities
@@ -75,7 +75,7 @@ namespace hpx
     ///           from an HPX-thread. It will return an empty vector otherwise.
     ///
     /// \see      \a hpx::find_here(), \a hpx::find_locality()
-    HPX_API_EXPORT std::vector<naming::id_type> find_all_localities(
+    HPX_EXPORT std::vector<naming::id_type> find_all_localities(
         error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -112,7 +112,7 @@ namespace hpx
     ///           from an HPX-thread. It will return an empty vector otherwise.
     ///
     /// \see      \a hpx::find_here(), \a hpx::find_locality()
-    HPX_API_EXPORT std::vector<naming::id_type> find_all_localities(
+    HPX_EXPORT std::vector<naming::id_type> find_all_localities(
         components::component_type type, error_code& ec = throws);
 
     /// \brief Return the list of locality ids of remote localities supporting
@@ -143,7 +143,7 @@ namespace hpx
     ///           from an HPX-thread. It will return an empty vector otherwise.
     ///
     /// \see      \a hpx::find_here(), \a hpx::find_locality()
-    HPX_API_EXPORT std::vector<naming::id_type> find_remote_localities(
+    HPX_EXPORT std::vector<naming::id_type> find_remote_localities(
         error_code& ec = throws);
 
     /// \brief Return the list of locality ids of remote localities supporting
@@ -177,7 +177,7 @@ namespace hpx
     ///           from an HPX-thread. It will return an empty vector otherwise.
     ///
     /// \see      \a hpx::find_here(), \a hpx::find_locality()
-    HPX_API_EXPORT std::vector<naming::id_type> find_remote_localities(
+    HPX_EXPORT std::vector<naming::id_type> find_remote_localities(
         components::component_type type, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -215,7 +215,7 @@ namespace hpx
     ///           otherwise.
     ///
     /// \see      \a hpx::find_here(), \a hpx::find_all_localities()
-    HPX_API_EXPORT naming::id_type find_locality(components::component_type type,
+    HPX_EXPORT naming::id_type find_locality(components::component_type type,
         error_code& ec = throws);
 }
 

--- a/hpx/runtime/get_colocation_id.hpp
+++ b/hpx/runtime/get_colocation_id.hpp
@@ -34,7 +34,7 @@ namespace hpx
     ///           hpx::exception.
     ///
     /// \see    \a hpx::get_colocation_id()
-    HPX_API_EXPORT naming::id_type get_colocation_id(launch::sync_policy,
+    HPX_EXPORT naming::id_type get_colocation_id(launch::sync_policy,
         naming::id_type const& id, error_code& ec = throws);
 
     /// \brief Asynchronously return the id of the locality where the object
@@ -43,7 +43,7 @@ namespace hpx
     /// \param id [in] The id of the object to locate.
     ///
     /// \see    \a hpx::get_colocation_id(launch::sync_policy)
-    HPX_API_EXPORT lcos::future<naming::id_type> get_colocation_id(
+    HPX_EXPORT lcos::future<naming::id_type> get_colocation_id(
         naming::id_type const& id);
 }
 

--- a/hpx/runtime/get_locality_id.hpp
+++ b/hpx/runtime/get_locality_id.hpp
@@ -39,6 +39,6 @@ namespace hpx
     ///
     /// \note     This function needs to be executed on a HPX-thread. It will
     ///           fail otherwise (it will return -1).
-    HPX_API_EXPORT std::uint32_t get_locality_id(error_code& ec = throws);
+    HPX_EXPORT std::uint32_t get_locality_id(error_code& ec = throws);
 }
 

--- a/hpx/runtime/get_locality_name.hpp
+++ b/hpx/runtime/get_locality_name.hpp
@@ -28,7 +28,7 @@ namespace hpx
     ///           networking layer and may be different for different parcelports.
     ///
     /// \see      \a future<std::string> get_locality_name(naming::id_type const& id)
-    HPX_API_EXPORT std::string get_locality_name();
+    HPX_EXPORT std::string get_locality_name();
 
     /// \fn future<std::string> get_locality_name(naming::id_type const& id)
     ///
@@ -45,7 +45,7 @@ namespace hpx
     ///           and may be different for different parcel ports.
     ///
     /// \see      \a std::string get_locality_name()
-    HPX_API_EXPORT future<std::string> get_locality_name(
+    HPX_EXPORT future<std::string> get_locality_name(
         naming::id_type const& id);
 }
 

--- a/hpx/runtime/get_num_localities.hpp
+++ b/hpx/runtime/get_num_localities.hpp
@@ -31,7 +31,7 @@ namespace hpx
     ///           hpx::exception.
     ///
     /// \see      \a hpx::find_all_localities, \a hpx::get_num_localities
-    HPX_API_EXPORT std::uint32_t get_initial_num_localities();
+    HPX_EXPORT std::uint32_t get_initial_num_localities();
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Asynchronously return the number of localities which are
@@ -45,7 +45,7 @@ namespace hpx
     ///           from an HPX-thread. It will return 0 otherwise.
     ///
     /// \see      \a hpx::find_all_localities, \a hpx::get_num_localities
-    HPX_API_EXPORT lcos::future<std::uint32_t> get_num_localities();
+    HPX_EXPORT lcos::future<std::uint32_t> get_num_localities();
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Return the number of localities which are currently registered
@@ -67,7 +67,7 @@ namespace hpx
     ///           hpx::exception.
     ///
     /// \see      \a hpx::find_all_localities, \a hpx::get_num_localities
-    HPX_API_EXPORT std::uint32_t get_num_localities(launch::sync_policy,
+    HPX_EXPORT std::uint32_t get_num_localities(launch::sync_policy,
         error_code& ec = throws);
 
     /// \brief Asynchronously return the number of localities which are
@@ -85,7 +85,7 @@ namespace hpx
     ///           from an HPX-thread. It will return 0 otherwise.
     ///
     /// \see      \a hpx::find_all_localities, \a hpx::get_num_localities
-    HPX_API_EXPORT lcos::future<std::uint32_t> get_num_localities(
+    HPX_EXPORT lcos::future<std::uint32_t> get_num_localities(
         components::component_type t);
 
     /// \brief Synchronously return the number of localities which are
@@ -105,7 +105,7 @@ namespace hpx
     ///           from an HPX-thread. It will return 0 otherwise.
     ///
     /// \see      \a hpx::find_all_localities, \a hpx::get_num_localities
-    HPX_API_EXPORT std::uint32_t get_num_localities(launch::sync_policy,
+    HPX_EXPORT std::uint32_t get_num_localities(launch::sync_policy,
         components::component_type t, error_code& ec = throws);
 }
 

--- a/hpx/runtime/get_os_thread_count.hpp
+++ b/hpx/runtime/get_os_thread_count.hpp
@@ -17,7 +17,7 @@ namespace hpx
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Return the number of OS-threads running in the runtime instance
     ///        the current HPX-thread is associated with.
-    HPX_API_EXPORT std::size_t get_os_thread_count();
+    HPX_EXPORT std::size_t get_os_thread_count();
 
     namespace threads {
         class executor;
@@ -33,6 +33,6 @@ namespace hpx
     /// threads used by HPX.
     ///
     /// \param exec [in] The executor to be used.
-    HPX_API_EXPORT std::size_t get_os_thread_count(threads::executor const& exec);
+    HPX_EXPORT std::size_t get_os_thread_count(threads::executor const& exec);
 }
 

--- a/hpx/runtime/get_thread_name.hpp
+++ b/hpx/runtime/get_thread_name.hpp
@@ -21,6 +21,6 @@ namespace hpx
     /// This function returns the name of the calling thread. This name uniquely
     /// identifies the thread in the context of HPX. If the function is called
     /// while no HPX runtime system is active, the result will be "<unknown>".
-    HPX_API_EXPORT std::string get_thread_name();
+    HPX_EXPORT std::string get_thread_name();
 }
 

--- a/hpx/runtime/message_handler_fwd.hpp
+++ b/hpx/runtime/message_handler_fwd.hpp
@@ -33,7 +33,7 @@ namespace hpx
     ///           function doesn't throw but returns the result code using the
     ///           parameter \a ec. Otherwise it throws an instance of
     ///           hpx::exception.
-    HPX_API_EXPORT void register_message_handler(
+    HPX_EXPORT void register_message_handler(
         char const* message_handler_type, char const* action,
         error_code& ec = throws);
 
@@ -55,7 +55,7 @@ namespace hpx
     ///           function doesn't throw but returns the result code using the
     ///           parameter \a ec. Otherwise it throws an instance of
     ///           hpx::exception.
-    HPX_API_EXPORT parcelset::policies::message_handler* create_message_handler(
+    HPX_EXPORT parcelset::policies::message_handler* create_message_handler(
         char const* message_handler_type, char const* action,
         parcelset::parcelport* pp, std::size_t num_messages,
         std::size_t interval, error_code& ec = throws);

--- a/hpx/runtime/naming_fwd.hpp
+++ b/hpx/runtime/naming_fwd.hpp
@@ -27,7 +27,7 @@ namespace hpx
         struct HPX_EXPORT id_type;
         struct HPX_EXPORT address;
 
-        HPX_API_EXPORT resolver_client& get_agas_client();
+        HPX_EXPORT resolver_client& get_agas_client();
 
         // tag used to mark serialization archive during check-pointing
         struct checkpointing_tag {};

--- a/hpx/runtime/parcelset_fwd.hpp
+++ b/hpx/runtime/parcelset_fwd.hpp
@@ -22,11 +22,11 @@ namespace hpx {
     /// \namespace parcelset
     namespace parcelset
     {
-        class HPX_API_EXPORT locality;
+        class HPX_EXPORT locality;
 
-        class HPX_API_EXPORT parcel;
-        class HPX_API_EXPORT parcelport;
-        class HPX_API_EXPORT parcelhandler;
+        class HPX_EXPORT parcel;
+        class HPX_EXPORT parcelport;
+        class HPX_EXPORT parcelhandler;
 
         namespace policies
         {
@@ -59,7 +59,7 @@ namespace hpx {
         ///
         /// \param ec[int, out] this represents the error code during exit.
 
-        HPX_API_EXPORT policies::message_handler* get_message_handler(
+        HPX_EXPORT policies::message_handler* get_message_handler(
             parcelhandler* ph, char const* name, char const* type,
             std::size_t num, std::size_t interval, locality const& l,
             error_code& ec = throws);
@@ -84,7 +84,7 @@ namespace hpx {
             parcelport_background_mode_all = 0x07
         };
 
-        HPX_API_EXPORT bool do_background_work(std::size_t num_thread = 0,
+        HPX_EXPORT bool do_background_work(std::size_t num_thread = 0,
             parcelport_background_mode mode = parcelport_background_mode_all);
 
         typedef util::function_nonser<
@@ -93,11 +93,11 @@ namespace hpx {
 
         ///////////////////////////////////////////////////////////////////////
         /// Hand a parcel to the underlying parcel layer for delivery.
-        HPX_API_EXPORT void put_parcel(parcel&& p, write_handler_type&& f);
+        HPX_EXPORT void put_parcel(parcel&& p, write_handler_type&& f);
 
         /// Hand a parcel to the underlying parcel layer for delivery.
         /// Wait for the operation to finish before returning to the user.
-        HPX_API_EXPORT void sync_put_parcel(parcelset::parcel&& p);
+        HPX_EXPORT void sync_put_parcel(parcelset::parcel&& p);
     }
 }
 

--- a/hpx/runtime/report_error.hpp
+++ b/hpx/runtime/report_error.hpp
@@ -16,11 +16,11 @@
 namespace hpx
 {
     /// The function report_error reports the given exception to the console
-    HPX_API_EXPORT void report_error(std::size_t num_thread,
+    HPX_EXPORT void report_error(std::size_t num_thread,
         std::exception_ptr const& e);
 
     /// The function report_error reports the given exception to the console
-    HPX_API_EXPORT void report_error(std::exception_ptr const& e);
+    HPX_EXPORT void report_error(std::exception_ptr const& e);
 }
 
 

--- a/hpx/runtime/runtime_fwd.hpp
+++ b/hpx/runtime/runtime_fwd.hpp
@@ -12,18 +12,18 @@
 
 namespace hpx
 {
-    class HPX_API_EXPORT runtime;
+    class HPX_EXPORT runtime;
 
     /// The function \a get_runtime returns a reference to the (thread
     /// specific) runtime instance.
-    HPX_API_EXPORT runtime& get_runtime();
-    HPX_API_EXPORT runtime*& get_runtime_ptr();
+    HPX_EXPORT runtime& get_runtime();
+    HPX_EXPORT runtime*& get_runtime_ptr();
 
 
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
-    class HPX_API_EXPORT runtime_distributed;
-    HPX_API_EXPORT runtime_distributed& get_runtime_distributed();
-    HPX_API_EXPORT runtime_distributed*& get_runtime_distributed_ptr();
+    class HPX_EXPORT runtime_distributed;
+    HPX_EXPORT runtime_distributed& get_runtime_distributed();
+    HPX_EXPORT runtime_distributed*& get_runtime_distributed_ptr();
 #endif
 
     /// Return true if networking is enabled.
@@ -32,6 +32,6 @@ namespace hpx
     ///       configuration time and more than one locality is used or the
     ///       command line option `--hpx:expect-connecting-localities` was
     ///       specified
-    HPX_API_EXPORT bool is_networking_enabled();
+    HPX_EXPORT bool is_networking_enabled();
 }
 

--- a/hpx/runtime/set_parcel_write_handler.hpp
+++ b/hpx/runtime/set_parcel_write_handler.hpp
@@ -42,7 +42,7 @@ namespace hpx
     ///       terminate the application in case of any errors detected during
     ///       preparing or sending the parcel.
     ///
-    HPX_API_EXPORT parcel_write_handler_type set_parcel_write_handler(
+    HPX_EXPORT parcel_write_handler_type set_parcel_write_handler(
         parcel_write_handler_type const& f);
 }
 

--- a/hpx/runtime/shutdown_function.hpp
+++ b/hpx/runtime/shutdown_function.hpp
@@ -35,7 +35,7 @@ namespace hpx
     ///       exception.
     ///
     /// \see    \a hpx::register_shutdown_function()
-    HPX_API_EXPORT void register_pre_shutdown_function(shutdown_function_type f);
+    HPX_EXPORT void register_pre_shutdown_function(shutdown_function_type f);
 
     /// \brief Add a function to be executed by a HPX thread during
     /// \a hpx::finalize() but guaranteed after any pre-shutdown function is
@@ -54,6 +54,6 @@ namespace hpx
     ///       exception.
     ///
     /// \see    \a hpx::register_pre_shutdown_function()
-    HPX_API_EXPORT void register_shutdown_function(shutdown_function_type f);
+    HPX_EXPORT void register_shutdown_function(shutdown_function_type f);
 }
 

--- a/hpx/runtime/startup_function.hpp
+++ b/hpx/runtime/startup_function.hpp
@@ -41,7 +41,7 @@ namespace hpx
     ///       system during its initialization (if necessary).
     ///
     /// \see    \a hpx::register_startup_function()
-    HPX_API_EXPORT void register_pre_startup_function(startup_function_type f);
+    HPX_EXPORT void register_pre_startup_function(startup_function_type f);
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Add a function to be executed by a HPX thread before hpx_main
@@ -66,6 +66,6 @@ namespace hpx
     ///       system during its initialization (if necessary).
     ///
     /// \see    \a hpx::register_pre_startup_function()
-    HPX_API_EXPORT void register_startup_function(startup_function_type f);
+    HPX_EXPORT void register_startup_function(startup_function_type f);
 }
 

--- a/hpx/runtime/thread_hooks.hpp
+++ b/hpx/runtime/thread_hooks.hpp
@@ -22,7 +22,7 @@ namespace hpx
     ///
     /// \note This function can be called before the HPX runtime is initialized.
     ///
-    HPX_API_EXPORT threads::policies::callback_notifier::on_startstop_type
+    HPX_EXPORT threads::policies::callback_notifier::on_startstop_type
         get_thread_on_start_func();
 
     /// Retrieve the currently installed stop handler function. This is a
@@ -36,7 +36,7 @@ namespace hpx
     ///
     /// \note This function can be called before the HPX runtime is initialized.
     ///
-    HPX_API_EXPORT threads::policies::callback_notifier::on_startstop_type
+    HPX_EXPORT threads::policies::callback_notifier::on_startstop_type
         get_thread_on_stop_func();
 
     /// Retrieve the currently installed error handler function. This is a
@@ -50,7 +50,7 @@ namespace hpx
     ///
     /// \note This function can be called before the HPX runtime is initialized.
     ///
-    HPX_API_EXPORT threads::policies::callback_notifier::on_error_type
+    HPX_EXPORT threads::policies::callback_notifier::on_error_type
         get_thread_on_error_func();
 
     /// Set the currently installed start handler function. This is a
@@ -68,7 +68,7 @@ namespace hpx
     ///
     /// \note This function can be called before the HPX runtime is initialized.
     ///
-    HPX_API_EXPORT threads::policies::callback_notifier::on_startstop_type
+    HPX_EXPORT threads::policies::callback_notifier::on_startstop_type
     register_thread_on_start_func(
         threads::policies::callback_notifier::on_startstop_type&& f);
 
@@ -87,7 +87,7 @@ namespace hpx
     ///
     /// \note This function can be called before the HPX runtime is initialized.
     ///
-    HPX_API_EXPORT threads::policies::callback_notifier::on_startstop_type
+    HPX_EXPORT threads::policies::callback_notifier::on_startstop_type
     register_thread_on_stop_func(
         threads::policies::callback_notifier::on_startstop_type&& f);
 
@@ -106,7 +106,7 @@ namespace hpx
     ///
     /// \note This function can be called before the HPX runtime is initialized.
     ///
-    HPX_API_EXPORT threads::policies::callback_notifier::on_error_type
+    HPX_EXPORT threads::policies::callback_notifier::on_error_type
     register_thread_on_error_func(
         threads::policies::callback_notifier::on_error_type&& f);
 }

--- a/hpx/runtime/thread_pool_helpers.hpp
+++ b/hpx/runtime/thread_pool_helpers.hpp
@@ -20,39 +20,39 @@ namespace hpx { namespace resource
     ///////////////////////////////////////////////////////////////////////////
     /// Return the number of thread pools currently managed by the
     /// \a resource_partitioner
-    HPX_API_EXPORT std::size_t get_num_thread_pools();
+    HPX_EXPORT std::size_t get_num_thread_pools();
 
     /// Return the number of threads in all thread pools currently
     /// managed by the \a resource_partitioner
-    HPX_API_EXPORT std::size_t get_num_threads();
+    HPX_EXPORT std::size_t get_num_threads();
 
     /// Return the number of threads in the given thread pool currently
     /// managed by the \a resource_partitioner
-    HPX_API_EXPORT std::size_t get_num_threads(std::string const& pool_name);
+    HPX_EXPORT std::size_t get_num_threads(std::string const& pool_name);
 
     /// Return the number of threads in the given thread pool currently
     /// managed by the \a resource_partitioner
-    HPX_API_EXPORT std::size_t get_num_threads(std::size_t pool_index);
+    HPX_EXPORT std::size_t get_num_threads(std::size_t pool_index);
 
     /// Return the internal index of the pool given its name.
-    HPX_API_EXPORT std::size_t get_pool_index(std::string const& pool_name);
+    HPX_EXPORT std::size_t get_pool_index(std::string const& pool_name);
 
     /// Return the name of the pool given its internal index
-    HPX_API_EXPORT std::string const& get_pool_name(std::size_t pool_index);
+    HPX_EXPORT std::string const& get_pool_name(std::size_t pool_index);
 
     /// Return the name of the pool given its name
-    HPX_API_EXPORT threads::thread_pool_base& get_thread_pool(
+    HPX_EXPORT threads::thread_pool_base& get_thread_pool(
         std::string const& pool_name);
 
     /// Return the thread pool given its internal index
-    HPX_API_EXPORT threads::thread_pool_base& get_thread_pool(
+    HPX_EXPORT threads::thread_pool_base& get_thread_pool(
         std::size_t pool_index);
 
     /// Return true if the pool with the given name exists
-    HPX_API_EXPORT bool pool_exists(std::string const& pool_name);
+    HPX_EXPORT bool pool_exists(std::string const& pool_name);
 
     /// Return true if the pool with the given index exists
-    HPX_API_EXPORT bool pool_exists(std::size_t pool_index);
+    HPX_EXPORT bool pool_exists(std::size_t pool_index);
 }}
 
 namespace hpx { namespace threads {
@@ -66,7 +66,7 @@ namespace hpx { namespace threads {
     ///       number of currently existing threads, but will add the number
     ///       of registered task descriptions (which have not been
     ///       converted into threads yet).
-    HPX_API_EXPORT std::int64_t get_thread_count(
+    HPX_EXPORT std::int64_t get_thread_count(
         thread_state_enum state = unknown);
 
     /// The function \a get_thread_count returns the number of currently
@@ -81,7 +81,7 @@ namespace hpx { namespace threads {
     ///       number of currently existing threads, but will add the number
     ///       of registered task descriptions (which have not been
     ///       converted into threads yet).
-    HPX_API_EXPORT std::int64_t get_thread_count(
+    HPX_EXPORT std::int64_t get_thread_count(
         thread_priority priority, thread_state_enum state = unknown);
 
     /// The function \a enumerate_threads will invoke the given function \a f
@@ -92,7 +92,7 @@ namespace hpx { namespace threads {
     ///                 will stop the enumeration process.
     /// \param state    [in] This specifies the thread-state for which the
     ///                 threads should be enumerated.
-    HPX_API_EXPORT bool enumerate_threads(
+    HPX_EXPORT bool enumerate_threads(
         util::function_nonser<bool(thread_id_type)> const& f,
         thread_state_enum state = unknown);
 }}

--- a/hpx/runtime/trigger_lco.hpp
+++ b/hpx/runtime/trigger_lco.hpp
@@ -36,7 +36,7 @@ namespace hpx
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    HPX_API_EXPORT void trigger_lco_event(naming::id_type const& id,
+    HPX_EXPORT void trigger_lco_event(naming::id_type const& id,
         naming::address && addr, bool move_credits = true);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -63,7 +63,7 @@ namespace hpx
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    HPX_API_EXPORT void trigger_lco_event(naming::id_type const& id,
+    HPX_EXPORT void trigger_lco_event(naming::id_type const& id,
         naming::address && addr, naming::id_type const& cont,
         bool move_credits = true);
 
@@ -203,7 +203,7 @@ namespace hpx
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    HPX_API_EXPORT void set_lco_error(naming::id_type const& id,
+    HPX_EXPORT void set_lco_error(naming::id_type const& id,
         naming::address && addr, std::exception_ptr const& e,
         bool move_credits = true);
 
@@ -218,7 +218,7 @@ namespace hpx
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    HPX_API_EXPORT void set_lco_error(naming::id_type const& id,
+    HPX_EXPORT void set_lco_error(naming::id_type const& id,
         naming::address && addr, std::exception_ptr && e,
         bool move_credits = true);
 
@@ -264,7 +264,7 @@ namespace hpx
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    HPX_API_EXPORT void set_lco_error(naming::id_type const& id,
+    HPX_EXPORT void set_lco_error(naming::id_type const& id,
         naming::address && addr, std::exception_ptr const& e,
         naming::id_type const& cont, bool move_credits = true);
 
@@ -280,7 +280,7 @@ namespace hpx
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    HPX_API_EXPORT void set_lco_error(naming::id_type const& id,
+    HPX_EXPORT void set_lco_error(naming::id_type const& id,
         naming::address && addr, std::exception_ptr && e,
         naming::id_type const& cont, bool move_credits = true);
 

--- a/hpx/runtime_fwd.hpp
+++ b/hpx/runtime_fwd.hpp
@@ -43,24 +43,24 @@ namespace hpx {
     /// Register the current kernel thread with HPX, this should be done once
     /// for each external OS-thread intended to invoke HPX functionality.
     /// Calling this function more than once will silently fail.
-    HPX_API_EXPORT bool register_thread(
+    HPX_EXPORT bool register_thread(
         runtime* rt, char const* name, error_code& ec = throws);
 
     /// Unregister the thread from HPX, this should be done once in
     /// the end before the external thread exists.
-    HPX_API_EXPORT void unregister_thread(runtime* rt);
+    HPX_EXPORT void unregister_thread(runtime* rt);
 
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
     /// The function \a get_locality returns a reference to the locality prefix
-    HPX_API_EXPORT naming::gid_type const& get_locality();
+    HPX_EXPORT naming::gid_type const& get_locality();
 #endif
 
     /// The function \a get_runtime_instance_number returns a unique number
     /// associated with the runtime instance the current thread is running in.
-    HPX_API_EXPORT std::size_t get_runtime_instance_number();
+    HPX_EXPORT std::size_t get_runtime_instance_number();
 
     /// Register a function to be called during system shutdown
-    HPX_API_EXPORT bool register_on_exit(util::function_nonser<void()> const&);
+    HPX_EXPORT bool register_on_exit(util::function_nonser<void()> const&);
 
     /// \cond NOINTERNAL
     namespace util {
@@ -69,20 +69,20 @@ namespace hpx {
 #endif
 
         /// \brief Expand INI variables in a string
-        HPX_API_EXPORT std::string expand(std::string const& expand);
+        HPX_EXPORT std::string expand(std::string const& expand);
 
         /// \brief Expand INI variables in a string
-        HPX_API_EXPORT void expand(std::string& expand);
+        HPX_EXPORT void expand(std::string& expand);
     }    // namespace util
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_API_EXPORT bool is_scheduler_numa_sensitive();
+    HPX_EXPORT bool is_scheduler_numa_sensitive();
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_API_EXPORT util::runtime_configuration const& get_config();
+    HPX_EXPORT util::runtime_configuration const& get_config();
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_API_EXPORT hpx::util::io_service_pool* get_thread_pool(
+    HPX_EXPORT hpx::util::io_service_pool* get_thread_pool(
         char const* name, char const* pool_name_suffix = "");
 
     /// \endcond
@@ -96,14 +96,14 @@ namespace hpx {
     ///
     /// \note   This function needs to be executed on a HPX-thread. It will
     ///         return false otherwise.
-    HPX_API_EXPORT bool is_starting();
+    HPX_EXPORT bool is_starting();
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Test if HPX runs in fault-tolerant mode
     ///
     /// This function returns whether the runtime system is running
     /// in fault-tolerant mode
-    HPX_API_EXPORT bool tolerate_node_faults();
+    HPX_EXPORT bool tolerate_node_faults();
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Test whether the runtime system is currently running.
@@ -114,7 +114,7 @@ namespace hpx {
     ///
     /// \note   This function needs to be executed on a HPX-thread. It will
     ///         return false otherwise.
-    HPX_API_EXPORT bool is_running();
+    HPX_EXPORT bool is_running();
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Test whether the runtime system is currently stopped.
@@ -125,7 +125,7 @@ namespace hpx {
     ///
     /// \note   This function needs to be executed on a HPX-thread. It will
     ///         return false otherwise.
-    HPX_API_EXPORT bool is_stopped();
+    HPX_EXPORT bool is_stopped();
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Test whether the runtime system is currently being shut down.
@@ -136,7 +136,7 @@ namespace hpx {
     ///
     /// \note   This function needs to be executed on a HPX-thread. It will
     ///         return false otherwise.
-    HPX_API_EXPORT bool is_stopped_or_shutting_down();
+    HPX_EXPORT bool is_stopped_or_shutting_down();
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Return the number of worker OS- threads used to execute HPX
@@ -145,7 +145,7 @@ namespace hpx {
     /// This function returns the number of OS-threads used to execute HPX
     /// threads. If the function is called while no HPX runtime system is active,
     /// it will return zero.
-    HPX_API_EXPORT std::size_t get_num_worker_threads();
+    HPX_EXPORT std::size_t get_num_worker_threads();
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Return the system uptime measure on the thread executing this call.
@@ -153,7 +153,7 @@ namespace hpx {
     /// This function returns the system uptime measured in nanoseconds for the
     /// thread executing this call. If the function is called while no HPX
     /// runtime system is active, it will return zero.
-    HPX_API_EXPORT std::uint64_t get_system_uptime();
+    HPX_EXPORT std::uint64_t get_system_uptime();
 
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
     ///////////////////////////////////////////////////////////////////////////
@@ -172,7 +172,7 @@ namespace hpx {
     /// \note     The active counters are those which have been specified on
     ///           the command line while executing the application (see command
     ///           line option \--hpx:print-counter)
-    HPX_API_EXPORT void start_active_counters(error_code& ec = throws);
+    HPX_EXPORT void start_active_counters(error_code& ec = throws);
 
     /// \brief Resets all active performance counters.
     ///
@@ -188,7 +188,7 @@ namespace hpx {
     /// \note     The active counters are those which have been specified on
     ///           the command line while executing the application (see command
     ///           line option \--hpx:print-counter)
-    HPX_API_EXPORT void reset_active_counters(error_code& ec = throws);
+    HPX_EXPORT void reset_active_counters(error_code& ec = throws);
 
     /// \brief Re-initialize all active performance counters.
     ///
@@ -206,7 +206,7 @@ namespace hpx {
     /// \note     The active counters are those which have been specified on
     ///           the command line while executing the application (see command
     ///           line option \--hpx:print-counter)
-    HPX_API_EXPORT void reinit_active_counters(
+    HPX_EXPORT void reinit_active_counters(
         bool reset = true, error_code& ec = throws);
 
     /// \brief Stop all active performance counters.
@@ -223,7 +223,7 @@ namespace hpx {
     /// \note     The active counters are those which have been specified on
     ///           the command line while executing the application (see command
     ///           line option \--hpx:print-counter)
-    HPX_API_EXPORT void stop_active_counters(error_code& ec = throws);
+    HPX_EXPORT void stop_active_counters(error_code& ec = throws);
 
     /// \brief Evaluate and output all active performance counters, optionally
     ///        naming the point in code marked by this function.
@@ -248,7 +248,7 @@ namespace hpx {
     /// \note     The active counters are those which have been specified on
     ///           the command line while executing the application (see command
     ///           line option \--hpx:print-counter)
-    HPX_API_EXPORT void evaluate_active_counters(bool reset = false,
+    HPX_EXPORT void evaluate_active_counters(bool reset = false,
         char const* description = nullptr, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -266,7 +266,7 @@ namespace hpx {
     ///           function doesn't throw but returns the result code using the
     ///           parameter \a ec. Otherwise it throws an instance of
     ///           hpx::exception.
-    HPX_API_EXPORT serialization::binary_filter* create_binary_filter(
+    HPX_EXPORT serialization::binary_filter* create_binary_filter(
         char const* binary_filter_type, bool compress,
         serialization::binary_filter* next_filter = nullptr,
         error_code& ec = throws);
@@ -278,32 +278,32 @@ namespace hpx {
         /// \cond NOINTERNAL
         // The function get_thread_manager returns a reference to the
         // current thread manager.
-        HPX_API_EXPORT threadmanager& get_thread_manager();
+        HPX_EXPORT threadmanager& get_thread_manager();
         /// \endcond
 
         /// \cond NOINTERNAL
         /// Reset internal (round robin) thread distribution scheme
-        HPX_API_EXPORT void reset_thread_distribution();
+        HPX_EXPORT void reset_thread_distribution();
 
         /// Set the new scheduler mode
-        HPX_API_EXPORT void set_scheduler_mode(
+        HPX_EXPORT void set_scheduler_mode(
             threads::policies::scheduler_mode new_mode);
 
         /// Add the given flags to the scheduler mode
-        HPX_API_EXPORT void add_scheduler_mode(
+        HPX_EXPORT void add_scheduler_mode(
             threads::policies::scheduler_mode to_add);
 
         /// Add/remove the given flags to the scheduler mode
-        HPX_API_EXPORT void add_remove_scheduler_mode(
+        HPX_EXPORT void add_remove_scheduler_mode(
             threads::policies::scheduler_mode to_add,
             threads::policies::scheduler_mode to_remove);
 
         /// Remove the given flags from the scheduler mode
-        HPX_API_EXPORT void remove_scheduler_mode(
+        HPX_EXPORT void remove_scheduler_mode(
             threads::policies::scheduler_mode to_remove);
 
         /// Get the global topology instance
-        HPX_API_EXPORT topology const& get_topology();
+        HPX_EXPORT topology const& get_topology();
         /// \endcond
     }
 

--- a/hpx/util/init_logging.hpp
+++ b/hpx/util/init_logging.hpp
@@ -18,6 +18,6 @@ namespace hpx { namespace util { namespace detail
 {
     /// The init_logging type will be used for initialization purposes only as
     /// well.
-    HPX_API_EXPORT void init_logging(runtime_configuration& ini, bool isconsole);
+    HPX_EXPORT void init_logging(runtime_configuration& ini, bool isconsole);
 }}}
 

--- a/hpx/util/register_locks_globally.hpp
+++ b/hpx/util/register_locks_globally.hpp
@@ -14,10 +14,10 @@ namespace hpx { namespace util
     // Debug and Release builds.
 
 #if defined(HPX_HAVE_VERIFY_LOCKS_GLOBALLY) || defined(HPX_EXPORTS)
-    HPX_API_EXPORT bool register_lock_globally(void const* lock);
-    HPX_API_EXPORT bool unregister_lock_globally(void const* lock);
-    HPX_API_EXPORT void enable_global_lock_detection();
-    HPX_API_EXPORT void disable_global_lock_detection();
+    HPX_EXPORT bool register_lock_globally(void const* lock);
+    HPX_EXPORT bool unregister_lock_globally(void const* lock);
+    HPX_EXPORT void enable_global_lock_detection();
+    HPX_EXPORT void disable_global_lock_detection();
 #else
     inline bool register_lock_globally(void const*)
     {

--- a/libs/affinity/include/hpx/affinity/parse_affinity_options.hpp
+++ b/libs/affinity/include/hpx/affinity/parse_affinity_options.hpp
@@ -47,7 +47,7 @@ namespace hpx { namespace threads {
                 core,
                 pu
             };
-            HPX_API_EXPORT static char const* type_name(type t);
+            HPX_EXPORT static char const* type_name(type t);
 
             static std::int64_t all_entities()
             {
@@ -101,14 +101,14 @@ namespace hpx { namespace threads {
         typedef boost::variant<distribution_type, mappings_spec_type>
             mappings_type;
 
-        HPX_API_EXPORT bounds_type extract_bounds(
+        HPX_EXPORT bounds_type extract_bounds(
             spec_type const& m, std::size_t default_last, error_code& ec);
 
-        HPX_API_EXPORT void parse_mappings(std::string const& spec,
+        HPX_EXPORT void parse_mappings(std::string const& spec,
             mappings_type& mappings, error_code& ec = throws);
     }    // namespace detail
 
-    HPX_API_EXPORT void parse_affinity_options(std::string const& spec,
+    HPX_EXPORT void parse_affinity_options(std::string const& spec,
         std::vector<mask_type>& affinities, std::size_t used_cores,
         std::size_t max_cores, std::size_t num_threads,
         std::vector<std::size_t>& num_pus, bool use_process_mask,

--- a/libs/asio/include/hpx/asio/asio_util.hpp
+++ b/libs/asio/include/hpx/asio/asio_util.hpp
@@ -26,25 +26,25 @@
 
 namespace hpx { namespace util {
     ///////////////////////////////////////////////////////////////////////////
-    HPX_API_EXPORT bool get_endpoint(std::string const& addr,
-        std::uint16_t port, boost::asio::ip::tcp::endpoint& ep);
+    HPX_EXPORT bool get_endpoint(std::string const& addr, std::uint16_t port,
+        boost::asio::ip::tcp::endpoint& ep);
 
-    HPX_API_EXPORT std::string get_endpoint_name(
+    HPX_EXPORT std::string get_endpoint_name(
         boost::asio::ip::tcp::endpoint const& ep);
 
     ///////////////////////////////////////////////////////////////////////////
     // properly resolve a give host name to the corresponding IP address
-    HPX_API_EXPORT boost::asio::ip::tcp::endpoint resolve_hostname(
+    HPX_EXPORT boost::asio::ip::tcp::endpoint resolve_hostname(
         std::string const& hostname, std::uint16_t port,
         boost::asio::io_service& io_service);
 
     ///////////////////////////////////////////////////////////////////////////
     // return the public IP address of the local node
-    HPX_API_EXPORT std::string resolve_public_ip_address();
+    HPX_EXPORT std::string resolve_public_ip_address();
 
     ///////////////////////////////////////////////////////////////////////
     // Take an ip v4 or v6 address and "standardize" it for comparison checks
-    HPX_API_EXPORT std::string cleanup_ip_address(const std::string& addr);
+    HPX_EXPORT std::string cleanup_ip_address(const std::string& addr);
 
     typedef boost::asio::ip::tcp::resolver::iterator endpoint_iterator_type;
 
@@ -91,6 +91,6 @@ namespace hpx { namespace util {
 namespace hpx { namespace util {
     ///////////////////////////////////////////////////////////////////////
     // Addresses are supposed to have the format <hostname>[:port]
-    HPX_API_EXPORT bool split_ip_address(
+    HPX_EXPORT bool split_ip_address(
         std::string const& v, std::string& host, std::uint16_t& port);
 }}    // namespace hpx::util

--- a/libs/async/include/hpx/async/applier_fwd.hpp
+++ b/libs/async/include/hpx/async/applier_fwd.hpp
@@ -19,16 +19,16 @@ namespace hpx {
     /// class \a hpx#applier#applier and its related functionality. This
     /// namespace is part of the HPX core module.
     namespace applier {
-        class HPX_API_EXPORT applier;
+        class HPX_EXPORT applier;
 
         /// The function \a get_applier returns a reference to the (thread
         /// specific) applier instance.
-        HPX_API_EXPORT applier& get_applier();
+        HPX_EXPORT applier& get_applier();
 
         /// The function \a get_applier returns a pointer to the (thread
         /// specific) applier instance. The returned pointer is NULL if the
         /// current thread is not known to HPX or if the runtime system is not
         /// active.
-        HPX_API_EXPORT applier* get_applier_ptr();
+        HPX_EXPORT applier* get_applier_ptr();
     }    // namespace applier
 }    // namespace hpx

--- a/libs/basic_execution/include/hpx/basic_execution/register_locks.hpp
+++ b/libs/basic_execution/include/hpx/basic_execution/register_locks.hpp
@@ -33,8 +33,7 @@ namespace hpx { namespace util {
     template <typename Lock, typename Enable = void>
     struct ignore_while_checking;
 
-#if defined(HPX_HAVE_VERIFY_LOCKS) || defined(HPX_EXPORTS) ||                  \
-    defined(HPX_MODULE_EXPORTS)
+#if defined(HPX_HAVE_VERIFY_LOCKS) || defined(HPX_EXPORTS)
 
     namespace detail {
 
@@ -69,25 +68,25 @@ namespace hpx { namespace util {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_API_EXPORT bool register_lock(
+    HPX_EXPORT bool register_lock(
         void const* lock, register_lock_data* data = nullptr);
-    HPX_API_EXPORT bool unregister_lock(void const* lock);
-    HPX_API_EXPORT void verify_no_locks();
-    HPX_API_EXPORT void force_error_on_lock();
-    HPX_API_EXPORT void enable_lock_detection();
-    HPX_API_EXPORT void disable_lock_detection();
-    HPX_API_EXPORT void trace_depth_lock_detection(std::size_t value);
-    HPX_API_EXPORT void ignore_lock(void const* lock);
-    HPX_API_EXPORT void reset_ignored(void const* lock);
-    HPX_API_EXPORT void ignore_all_locks();
-    HPX_API_EXPORT void reset_ignored_all();
+    HPX_EXPORT bool unregister_lock(void const* lock);
+    HPX_EXPORT void verify_no_locks();
+    HPX_EXPORT void force_error_on_lock();
+    HPX_EXPORT void enable_lock_detection();
+    HPX_EXPORT void disable_lock_detection();
+    HPX_EXPORT void trace_depth_lock_detection(std::size_t value);
+    HPX_EXPORT void ignore_lock(void const* lock);
+    HPX_EXPORT void reset_ignored(void const* lock);
+    HPX_EXPORT void ignore_all_locks();
+    HPX_EXPORT void reset_ignored_all();
 
     using registered_locks_error_handler_type = std::function<void()>;
 
     /// Sets a handler which gets called when verifying that no locks are held
     /// fails. Can be used to print information at the point of failure such as
     /// a backtrace.
-    HPX_API_EXPORT void set_registered_locks_error_handler(
+    HPX_EXPORT void set_registered_locks_error_handler(
         registered_locks_error_handler_type);
 
     using register_locks_predicate_type = std::function<bool()>;
@@ -99,8 +98,7 @@ namespace hpx { namespace util {
     /// register, unregister, or verify locks, depending on other factors (such
     /// as if lock detection is enabled globally). The predicate may return
     /// different values depending on context.
-    HPX_API_EXPORT void set_register_locks_predicate(
-        register_locks_predicate_type);
+    HPX_EXPORT void set_register_locks_predicate(register_locks_predicate_type);
 
     ///////////////////////////////////////////////////////////////////////////
     struct ignore_all_while_checking
@@ -144,10 +142,10 @@ namespace hpx { namespace util {
     // after suspension even if the thread is being resumed on a different core.
 
     // retrieve the current thread_local data about held locks
-    HPX_API_EXPORT std::unique_ptr<held_locks_data> get_held_locks_data();
+    HPX_EXPORT std::unique_ptr<held_locks_data> get_held_locks_data();
 
     // set the current thread_local data about held locks
-    HPX_API_EXPORT void set_held_locks_data(
+    HPX_EXPORT void set_held_locks_data(
         std::unique_ptr<held_locks_data>&& data);
 
 #else

--- a/libs/command_line_handling/include/hpx/command_line_handling/parse_command_line.hpp
+++ b/libs/command_line_handling/include/hpx/command_line_handling/parse_command_line.hpp
@@ -28,7 +28,7 @@ namespace hpx { namespace util {
 
     ///////////////////////////////////////////////////////////////////////////
     // parse the command line
-    HPX_API_EXPORT bool parse_commandline(hpx::util::section const& rtcfg,
+    HPX_EXPORT bool parse_commandline(hpx::util::section const& rtcfg,
         hpx::program_options::options_description const& app_options,
         std::string const& cmdline, hpx::program_options::variables_map& vm,
         std::size_t node, int error_mode = return_on_error,
@@ -36,7 +36,7 @@ namespace hpx { namespace util {
         hpx::program_options::options_description* visible = nullptr,
         std::vector<std::string>* unregistered_options = nullptr);
 
-    HPX_API_EXPORT bool parse_commandline(hpx::util::section const& rtcfg,
+    HPX_EXPORT bool parse_commandline(hpx::util::section const& rtcfg,
         hpx::program_options::options_description const& app_options,
         std::string const& arg0, std::vector<std::string> const& args,
         hpx::program_options::variables_map& vm, std::size_t node,
@@ -46,7 +46,7 @@ namespace hpx { namespace util {
         std::vector<std::string>* unregistered_options = nullptr);
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_API_EXPORT std::string reconstruct_command_line(
+    HPX_EXPORT std::string reconstruct_command_line(
         hpx::program_options::variables_map const& vm);
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/compute_cuda/include/hpx/compute/cuda/target.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/target.hpp
@@ -135,7 +135,7 @@ namespace hpx { namespace compute { namespace cuda {
             hpx::runtime* rt_;
         };
 
-        HPX_API_EXPORT hpx::future<void> get_future(cudaStream_t);
+        HPX_EXPORT hpx::future<void> get_future(cudaStream_t);
 
         template <typename Allocator>
         hpx::future<void> get_future(Allocator const& a, cudaStream_t stream)
@@ -341,7 +341,7 @@ namespace hpx { namespace compute { namespace cuda {
     };
 
     using detail::get_future;
-    HPX_API_EXPORT target& get_default_target();
+    HPX_EXPORT target& get_default_target();
 }}}    // namespace hpx::compute::cuda
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/config/cmake/templates/config_version.hpp.in
+++ b/libs/config/cmake/templates/config_version.hpp.in
@@ -70,8 +70,7 @@ namespace hpx
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-#if !defined(HPX_EXPORTS) && !defined(HPX_MODULE_EXPORTS) &&                   \
-    !defined(HPX_NO_VERSION_CHECK)
+#if !defined(HPX_EXPORTS) && !defined(HPX_NO_VERSION_CHECK)
 
 // This is instantiated for each translation unit outside of the HPX core
 // library, forcing to resolve the variable HPX_CHECK_VERSION.
@@ -90,4 +89,3 @@ namespace hpx
         }
     }
 #endif
-

--- a/libs/config/include/hpx/config/export_definitions.hpp
+++ b/libs/config/include/hpx/config/export_definitions.hpp
@@ -21,20 +21,14 @@
 # define HPX_SYMBOL_EXPORT      __declspec(dllexport)
 # define HPX_SYMBOL_IMPORT      __declspec(dllimport)
 # define HPX_SYMBOL_INTERNAL    /* empty */
-# define HPX_APISYMBOL_EXPORT   __declspec(dllexport)
-# define HPX_APISYMBOL_IMPORT   __declspec(dllimport)
 #elif defined(__NVCC__) || defined(__CUDACC__)
 # define HPX_SYMBOL_EXPORT      /* empty */
 # define HPX_SYMBOL_IMPORT      /* empty */
 # define HPX_SYMBOL_INTERNAL    /* empty */
-# define HPX_APISYMBOL_EXPORT   /* empty */
-# define HPX_APISYMBOL_IMPORT   /* empty */
 #elif defined(HPX_HAVE_ELF_HIDDEN_VISIBILITY)
 # define HPX_SYMBOL_EXPORT      __attribute__((visibility("default")))
 # define HPX_SYMBOL_IMPORT      __attribute__((visibility("default")))
 # define HPX_SYMBOL_INTERNAL    __attribute__((visibility("hidden")))
-# define HPX_APISYMBOL_EXPORT   __attribute__((visibility("default")))
-# define HPX_APISYMBOL_IMPORT   __attribute__((visibility("default")))
 #endif
 
 // make sure we have reasonable defaults
@@ -47,23 +41,13 @@
 #if !defined(HPX_SYMBOL_INTERNAL)
 # define HPX_SYMBOL_INTERNAL    /* empty */
 #endif
-#if !defined(HPX_APISYMBOL_EXPORT)
-# define HPX_APISYMBOL_EXPORT   /* empty */
-#endif
-#if !defined(HPX_APISYMBOL_IMPORT)
-# define HPX_APISYMBOL_IMPORT   /* empty */
-#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // define the export/import helper macros used by the runtime module
-#if defined(HPX_EXPORTS) || defined(HPX_MODULE_EXPORTS)
+#if defined(HPX_EXPORTS)
 # define  HPX_EXPORT             HPX_SYMBOL_EXPORT
-# define  HPX_EXCEPTION_EXPORT   HPX_SYMBOL_EXPORT
-# define  HPX_API_EXPORT         HPX_APISYMBOL_EXPORT
 #else
 # define  HPX_EXPORT             HPX_SYMBOL_IMPORT
-# define  HPX_EXCEPTION_EXPORT   HPX_SYMBOL_IMPORT
-# define  HPX_API_EXPORT         HPX_APISYMBOL_IMPORT
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -86,8 +70,7 @@
 // helper macro for symbols which have to be exported from the runtime and all
 // components
 #if defined(HPX_EXPORTS) || defined(HPX_COMPONENT_EXPORTS) || \
-    defined(HPX_APPLICATION_EXPORTS) || defined(HPX_SERIALIZATION_EXPORTS) || \
-    defined(HPX_LIBRARY_EXPORTS) || defined(HPX_MODULE_EXPORTS)
+    defined(HPX_APPLICATION_EXPORTS) || defined(HPX_LIBRARY_EXPORTS)
 # define HPX_ALWAYS_EXPORT       HPX_SYMBOL_EXPORT
 # define HPX_ALWAYS_IMPORT       HPX_SYMBOL_IMPORT
 #else

--- a/libs/coroutines/include/hpx/coroutines/thread_enums.hpp
+++ b/libs/coroutines/include/hpx/coroutines/thread_enums.hpp
@@ -61,7 +61,7 @@ namespace hpx { namespace threads {
     /// thread_state constant.
     ///
     /// \param state this represents the thread state.
-    HPX_API_EXPORT char const* get_thread_state_name(thread_state_enum state);
+    HPX_EXPORT char const* get_thread_state_name(thread_state_enum state);
 
     ///////////////////////////////////////////////////////////////////////////
     // clang-format off
@@ -111,8 +111,7 @@ namespace hpx { namespace threads {
     /// constant.
     ///
     /// \param this represents the thread priority.
-    HPX_API_EXPORT char const* get_thread_priority_name(
-        thread_priority priority);
+    HPX_EXPORT char const* get_thread_priority_name(thread_priority priority);
 
     ///////////////////////////////////////////////////////////////////////////
     /// \enum thread_state_ex_enum
@@ -131,8 +130,7 @@ namespace hpx { namespace threads {
 
     /// Get the readable string representing the name of the given
     /// thread_state_ex_enum constant.
-    HPX_API_EXPORT char const* get_thread_state_ex_name(
-        thread_state_ex_enum state);
+    HPX_EXPORT char const* get_thread_state_ex_name(thread_state_ex_enum state);
 
     /// \cond NOINTERNAL
     // special type storing both state in one tagged structure
@@ -143,7 +141,7 @@ namespace hpx { namespace threads {
 
     /// Get the readable string representing the name of the given
     /// thread_state constant.
-    HPX_API_EXPORT char const* get_thread_state_name(thread_state state);
+    HPX_EXPORT char const* get_thread_state_name(thread_state state);
 
     ///////////////////////////////////////////////////////////////////////////
     /// \enum thread_stacksize
@@ -176,7 +174,7 @@ namespace hpx { namespace threads {
     /// constant.
     ///
     /// \param size this represents the stack size
-    HPX_API_EXPORT char const* get_stack_size_enum_name(thread_stacksize size);
+    HPX_EXPORT char const* get_stack_size_enum_name(thread_stacksize size);
 
     ///////////////////////////////////////////////////////////////////////////
     /// \enum thread_schedule_hint_mode

--- a/libs/debugging/include/hpx/debugging/backtrace/backtrace.hpp
+++ b/libs/debugging/include/hpx/debugging/backtrace/backtrace.hpp
@@ -20,11 +20,11 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace util {
     namespace stack_trace {
-        HPX_API_EXPORT std::size_t trace(void** addresses, std::size_t size);
-        HPX_API_EXPORT void write_symbols(
+        HPX_EXPORT std::size_t trace(void** addresses, std::size_t size);
+        HPX_EXPORT void write_symbols(
             void* const* addresses, std::size_t size, std::ostream&);
-        HPX_API_EXPORT std::string get_symbol(void* address);
-        HPX_API_EXPORT std::string get_symbols(
+        HPX_EXPORT std::string get_symbol(void* address);
+        HPX_EXPORT std::string get_symbols(
             void* const* address, std::size_t size);
     }    // namespace stack_trace
 

--- a/libs/debugging/src/backtrace.cpp
+++ b/libs/debugging/src/backtrace.cpp
@@ -116,7 +116,7 @@ namespace hpx { namespace util { namespace stack_trace {
         return _URC_NO_REASON;
     }
 
-    HPX_API_EXPORT std::size_t trace(void** array, std::size_t n)
+    std::size_t trace(void** array, std::size_t n)
     {
         trace_data d(array, n);
 
@@ -131,14 +131,14 @@ namespace hpx { namespace util { namespace stack_trace {
 
 #elif defined(HPX_HAVE_EXECINFO)
 
-    HPX_API_EXPORT std::size_t trace(void** array, std::size_t n)
+    std::size_t trace(void** array, std::size_t n)
     {
         return ::backtrace(array, n);
     }
 
 #elif defined(HPX_MSVC)
 
-    HPX_API_EXPORT std::size_t trace(void** array, std::size_t n)
+    std::size_t trace(void** array, std::size_t n)
     {
 #if _WIN32_WINNT < 0x0600
         // for Windows XP/Windows Server 2003
@@ -150,7 +150,7 @@ namespace hpx { namespace util { namespace stack_trace {
 
 #else
 
-    HPX_API_EXPORT std::size_t trace(void** /*array*/, std::size_t /*n*/)
+    std::size_t trace(void** /*array*/, std::size_t /*n*/)
     {
         return 0;
     }
@@ -179,7 +179,7 @@ namespace hpx { namespace util { namespace stack_trace {
 #endif
 
 #if defined(HPX_HAVE_DLFCN) && defined(HPX_HAVE_ABI_CXA_DEMANGLE)
-    HPX_API_EXPORT std::string get_symbol(void* ptr)
+    std::string get_symbol(void* ptr)
     {
         if (!ptr)
             return std::string();
@@ -245,8 +245,7 @@ namespace hpx { namespace util { namespace stack_trace {
         return res.str();
     }
 
-    HPX_API_EXPORT std::string get_symbols(
-        void* const* addresses, std::size_t size)
+    std::string get_symbols(void* const* addresses, std::size_t size)
     {
         // the first two stack frames are from the back tracing facility itself
         if (size > 2)
@@ -268,7 +267,7 @@ namespace hpx { namespace util { namespace stack_trace {
         }
         return res;
     }
-    HPX_API_EXPORT void write_symbols(
+    void write_symbols(
         void* const* addresses, std::size_t size, std::ostream& out)
     {
         out << size << ((1 == size) ? " frame:" : " frames:");
@@ -285,13 +284,12 @@ namespace hpx { namespace util { namespace stack_trace {
 
 #elif defined(HPX_HAVE_EXECINFO)
 
-    HPX_API_EXPORT std::string get_symbol(void* address)
+    std::string get_symbol(void* address)
     {
         return get_symbol_exec_info(address);
     }
 
-    HPX_API_EXPORT std::string get_symbols(
-        void* const* address, std::size_t size)
+    std::string get_symbols(void* const* address, std::size_t size)
     {
         // the first two stack frames are from the back tracing facility itself
         if (size > 2)
@@ -323,7 +321,7 @@ namespace hpx { namespace util { namespace stack_trace {
         }
     }
 
-    HPX_API_EXPORT void write_symbols(
+    void write_symbols(
         void* const* addresses, std::size_t size, std::ostream& out)
     {
         char** ptr = backtrace_symbols(addresses, size);
@@ -366,7 +364,7 @@ namespace hpx { namespace util { namespace stack_trace {
         }
     }    // namespace
 
-    HPX_API_EXPORT std::string get_symbol(void* ptr)
+    std::string get_symbol(void* ptr)
     {
         if (ptr == nullptr)
             return std::string();
@@ -398,8 +396,7 @@ namespace hpx { namespace util { namespace stack_trace {
         return ss.str();
     }
 
-    HPX_API_EXPORT std::string get_symbols(
-        void* const* addresses, std::size_t size)
+    std::string get_symbols(void* const* addresses, std::size_t size)
     {
         // the first two stack frames are from the back tracing facility itself
         if (size > 2)
@@ -422,7 +419,7 @@ namespace hpx { namespace util { namespace stack_trace {
         return res;
     }
 
-    HPX_API_EXPORT void write_symbols(
+    void write_symbols(
         void* const* addresses, std::size_t size, std::ostream& out)
     {
         out << size << ((1 == size) ? " frame:" : " frames:");    //-V128
@@ -439,7 +436,7 @@ namespace hpx { namespace util { namespace stack_trace {
 
 #else
 
-    HPX_API_EXPORT std::string get_symbol(void* ptr)
+    std::string get_symbol(void* ptr)
     {
         if (!ptr)
             return std::string();
@@ -450,7 +447,7 @@ namespace hpx { namespace util { namespace stack_trace {
         return res.str();
     }
 
-    HPX_API_EXPORT std::string get_symbols(void* const* ptrs, std::size_t size)
+    std::string get_symbols(void* const* ptrs, std::size_t size)
     {
         if (!ptrs)
             return std::string();
@@ -468,7 +465,7 @@ namespace hpx { namespace util { namespace stack_trace {
         return res.str();
     }
 
-    HPX_API_EXPORT void write_symbols(
+    void write_symbols(
         void* const* addresses, std::size_t size, std::ostream& out)
     {
         out << size << ((1 == size) ? " frame:" : " frames:");    //-V128

--- a/libs/errors/include/hpx/errors/exception.hpp
+++ b/libs/errors/include/hpx/errors/exception.hpp
@@ -37,7 +37,7 @@ namespace hpx {
     /// are either of this type or of a type derived from it. This implies that
     /// it is always safe to use this type only in catch statements guarding
     /// HPX library calls.
-    class HPX_EXCEPTION_EXPORT exception : public boost::system::system_error
+    class HPX_EXPORT exception : public boost::system::system_error
     {
     public:
         /// Construct a hpx::exception from a \a hpx::error.
@@ -182,7 +182,7 @@ namespace hpx {
     ///
     /// At any point, the interruption state for the current thread can be
     /// queried by calling \a hpx::this_thread::interruption_enabled().
-    struct HPX_EXCEPTION_EXPORT thread_interrupted : std::exception
+    struct HPX_EXPORT thread_interrupted : std::exception
     {
     };
 
@@ -203,7 +203,7 @@ namespace hpx {
         // under the [line] tag.
         HPX_DEFINE_ERROR_INFO(throw_line, long);
 
-        struct HPX_EXCEPTION_EXPORT std_exception : std::exception
+        struct HPX_EXPORT std_exception : std::exception
         {
         private:
             std::string what_;
@@ -222,7 +222,7 @@ namespace hpx {
             }
         };
 
-        struct HPX_EXCEPTION_EXPORT bad_alloc : std::bad_alloc
+        struct HPX_EXPORT bad_alloc : std::bad_alloc
         {
         private:
             std::string what_;
@@ -241,7 +241,7 @@ namespace hpx {
             }
         };
 
-        struct HPX_EXCEPTION_EXPORT bad_exception : std::bad_exception
+        struct HPX_EXPORT bad_exception : std::bad_exception
         {
         private:
             std::string what_;
@@ -260,7 +260,7 @@ namespace hpx {
             }
         };
 
-        struct HPX_EXCEPTION_EXPORT bad_cast : std::bad_cast
+        struct HPX_EXPORT bad_cast : std::bad_cast
         {
         private:
             std::string what_;
@@ -279,7 +279,7 @@ namespace hpx {
             }
         };
 
-        struct HPX_EXCEPTION_EXPORT bad_typeid : std::bad_typeid
+        struct HPX_EXPORT bad_typeid : std::bad_typeid
         {
         private:
             std::string what_;

--- a/libs/errors/include/hpx/errors/exception_fwd.hpp
+++ b/libs/errors/include/hpx/errors/exception_fwd.hpp
@@ -17,9 +17,9 @@ namespace hpx {
     // forward declaration
     class error_code;
 
-    class HPX_EXCEPTION_EXPORT exception;
+    class HPX_EXPORT exception;
 
-    struct HPX_EXCEPTION_EXPORT thread_interrupted;
+    struct HPX_EXPORT thread_interrupted;
     /// \endcond
 
     ///////////////////////////////////////////////////////////////////////////
@@ -61,7 +61,7 @@ namespace hpx {
     // the compiler.
     extern HPX_DEVICE error_code throws;
 #else
-    HPX_EXCEPTION_EXPORT extern error_code throws;
+    HPX_EXPORT extern error_code throws;
 #endif
 }    // namespace hpx
 

--- a/libs/errors/include/hpx/errors/exception_list.hpp
+++ b/libs/errors/include/hpx/errors/exception_list.hpp
@@ -31,7 +31,7 @@ namespace hpx {
     /// The type exception_list::const_iterator fulfills the requirements of
     /// a forward iterator.
     ///
-    class HPX_EXCEPTION_EXPORT exception_list : public hpx::exception
+    class HPX_EXPORT exception_list : public hpx::exception
     {
     private:
         // TODO: Does this need to be hpx::lcos::local::spinlock?

--- a/libs/errors/src/exception.cpp
+++ b/libs/errors/src/exception.cpp
@@ -140,15 +140,14 @@ namespace hpx {
 
     static custom_exception_info_handler_type custom_exception_info_handler;
 
-    HPX_EXPORT void set_custom_exception_info_handler(
-        custom_exception_info_handler_type f)
+    void set_custom_exception_info_handler(custom_exception_info_handler_type f)
     {
         custom_exception_info_handler = f;
     }
 
     static pre_exception_handler_type pre_exception_handler;
 
-    HPX_EXPORT void set_pre_exception_handler(pre_exception_handler_type f)
+    void set_pre_exception_handler(pre_exception_handler_type f)
     {
         pre_exception_handler = f;
     }

--- a/libs/execution/include/hpx/execution/executors/execution_information.hpp
+++ b/libs/execution/include/hpx/execution/executors/execution_information.hpp
@@ -28,7 +28,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace threads {
     // TODO: Specialize this for executors.
-    HPX_API_EXPORT inline threads::mask_cref_type get_pu_mask(
+    HPX_EXPORT inline threads::mask_cref_type get_pu_mask(
         threads::topology& topo, std::size_t thread_num)
     {
         auto& rp = hpx::resource::get_partitioner();

--- a/libs/executors/include/hpx/executors/current_executor.hpp
+++ b/libs/executors/include/hpx/executors/current_executor.hpp
@@ -26,7 +26,7 @@ namespace hpx { namespace threads {
     ///         running, it will throw an \a hpx#exception with an error code of
     ///         \a hpx#invalid_status.
     ///
-    HPX_API_EXPORT parallel::execution::current_executor get_executor(
+    HPX_EXPORT parallel::execution::current_executor get_executor(
         thread_id_type const& id, error_code& ec = throws);
 }}    // namespace hpx::threads
 

--- a/libs/format/include/hpx/util/bad_lexical_cast.hpp
+++ b/libs/format/include/hpx/util/bad_lexical_cast.hpp
@@ -14,7 +14,7 @@
 
 namespace hpx { namespace util {
 
-    class HPX_EXCEPTION_EXPORT bad_lexical_cast : public std::bad_cast
+    class HPX_EXPORT bad_lexical_cast : public std::bad_cast
     {
     public:
         bad_lexical_cast() noexcept

--- a/libs/local_lcos/include/hpx/local_lcos/composable_guard.hpp
+++ b/libs/local_lcos/include/hpx/local_lcos/composable_guard.hpp
@@ -126,7 +126,7 @@ namespace hpx { namespace lcos { namespace local {
 
         typedef std::atomic<guard_task*> guard_atomic;
 
-        HPX_API_EXPORT void free(guard_task* task);
+        HPX_EXPORT void free(guard_task* task);
 
         typedef util::unique_function_nonser<void()> guard_function;
     }    // namespace detail
@@ -140,7 +140,7 @@ namespace hpx { namespace lcos { namespace local {
           : task(nullptr)
         {
         }
-        HPX_API_EXPORT ~guard();
+        HPX_EXPORT ~guard();
     };
 
     class guard_set : public detail::debug_object
@@ -177,13 +177,13 @@ namespace hpx { namespace lcos { namespace local {
             return guards.size();
         }
 
-        friend HPX_API_EXPORT void run_guarded(
+        friend HPX_EXPORT void run_guarded(
             guard_set& guards, detail::guard_function task);
     };
 
     /// Conceptually, a guard acts like a mutex on an asynchronous task. The
     /// mutex is locked before the task runs, and unlocked afterwards.
-    HPX_API_EXPORT void run_guarded(guard& guard, detail::guard_function task);
+    HPX_EXPORT void run_guarded(guard& guard, detail::guard_function task);
 
     template <typename F, typename... Args>
     void run_guarded(guard& guard, F&& f, Args&&... args)
@@ -195,8 +195,7 @@ namespace hpx { namespace lcos { namespace local {
 
     /// Conceptually, a guard_set acts like a set of mutexes on an asynchronous task.
     /// The mutexes are locked before the task runs, and unlocked afterwards.
-    HPX_API_EXPORT void run_guarded(
-        guard_set& guards, detail::guard_function task);
+    HPX_EXPORT void run_guarded(guard_set& guards, detail::guard_function task);
 
     template <typename F, typename... Args>
     void run_guarded(guard_set& guards, F&& f, Args&&... args)

--- a/libs/logging/include/hpx/logging.hpp
+++ b/libs/logging/include/hpx/logging.hpp
@@ -32,7 +32,7 @@
 namespace hpx { namespace util {
     ////////////////////////////////////////////////////////////////////////////
     namespace detail {
-        HPX_API_EXPORT hpx::util::logging::level get_log_level(
+        HPX_EXPORT hpx::util::logging::level get_log_level(
             std::string const& env, bool allow_always = false);
     }
 

--- a/libs/logging/include/hpx/logging/format/named_write.hpp
+++ b/libs/logging/include/hpx/logging/format/named_write.hpp
@@ -143,7 +143,7 @@ You could have an output like this:
         // recomputes the write steps - note that this takes place after
         // each operation for instance, the user might have first set the
         // string and later added the formatters
-        void compute_write_steps();
+        HPX_EXPORT void compute_write_steps();
 
     private:
         struct write_step
@@ -259,7 +259,7 @@ In the above example, I know that the available destinations are @c out_file,
         // recomputes the write steps - note that this takes place after
         // each operation for instance, the user might have first set the
         // string and later added the formatters
-        void compute_write_steps();
+        HPX_EXPORT void compute_write_steps();
 
     private:
         std::vector<named<ptr_type>> destinations;

--- a/libs/performance_counters/include/hpx/performance_counters/counter_creators.hpp
+++ b/libs/performance_counters/include/hpx/performance_counters/counter_creators.hpp
@@ -23,7 +23,7 @@ namespace hpx { namespace performance_counters {
     /// Default discovery function for performance counters; to be registered
     /// with the counter types. It will pass the \a counter_info and the
     /// \a error_code to the supplied function.
-    HPX_API_EXPORT bool default_counter_discoverer(counter_info const&,
+    HPX_EXPORT bool default_counter_discoverer(counter_info const&,
         discover_counter_func const&, discover_counters_mode, error_code&);
 
     /// Default discoverer function for performance counters; to be registered
@@ -32,7 +32,7 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /<objectname>(locality#<locality_id>/total)/<instancename>
     ///
-    HPX_API_EXPORT bool locality_counter_discoverer(counter_info const&,
+    HPX_EXPORT bool locality_counter_discoverer(counter_info const&,
         discover_counter_func const&, discover_counters_mode, error_code&);
 
     /// Default discoverer function for performance counters; to be registered
@@ -41,7 +41,7 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /<objectname>(locality#<locality_id>/pool#<pool_name>/total)/<instancename>
     ///
-    HPX_API_EXPORT bool locality_pool_counter_discoverer(counter_info const&,
+    HPX_EXPORT bool locality_pool_counter_discoverer(counter_info const&,
         discover_counter_func const&, discover_counters_mode, error_code&);
 
     /// Default discoverer function for AGAS performance counters; to be
@@ -50,7 +50,7 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /<objectname>{locality#0/total}/<instancename>
     ///
-    HPX_API_EXPORT bool locality0_counter_discoverer(counter_info const&,
+    HPX_EXPORT bool locality0_counter_discoverer(counter_info const&,
         discover_counter_func const&, discover_counters_mode, error_code&);
 
     /// Default discoverer function for performance counters; to be registered
@@ -59,7 +59,7 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /<objectname>(locality#<locality_id>/worker-thread#<threadnum>)/<instancename>
     ///
-    HPX_API_EXPORT bool locality_thread_counter_discoverer(counter_info const&,
+    HPX_EXPORT bool locality_thread_counter_discoverer(counter_info const&,
         discover_counter_func const&, discover_counters_mode, error_code&);
 
     /// Default discoverer function for performance counters; to be registered
@@ -90,7 +90,7 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /<objectname>(locality#<locality_id>/numa-node#<threadnum>)/<instancename>
     ///
-    HPX_API_EXPORT bool locality_numa_counter_discoverer(counter_info const&,
+    HPX_EXPORT bool locality_numa_counter_discoverer(counter_info const&,
         discover_counter_func const&, discover_counters_mode, error_code&);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -100,11 +100,11 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /<objectname>(locality#<locality_id>/total)/<instancename>
     ///
-    HPX_API_EXPORT naming::gid_type locality_raw_counter_creator(
+    HPX_EXPORT naming::gid_type locality_raw_counter_creator(
         counter_info const&,
         hpx::util::function_nonser<std::int64_t(bool)> const&, error_code&);
 
-    HPX_API_EXPORT naming::gid_type locality_raw_values_counter_creator(
+    HPX_EXPORT naming::gid_type locality_raw_values_counter_creator(
         counter_info const&,
         hpx::util::function_nonser<std::vector<std::int64_t>(bool)> const&,
         error_code&);
@@ -116,7 +116,7 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /agas(<objectinstance>/total)/<instancename>
     ///
-    HPX_API_EXPORT naming::gid_type agas_raw_counter_creator(
+    HPX_EXPORT naming::gid_type agas_raw_counter_creator(
         counter_info const&, error_code&, char const* const);
 
     /// Default discoverer function for performance counters; to be registered
@@ -125,41 +125,41 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /agas(<objectinstance>/total)/<instancename>
     ///
-    HPX_API_EXPORT bool agas_counter_discoverer(counter_info const&,
+    HPX_EXPORT bool agas_counter_discoverer(counter_info const&,
         discover_counter_func const&, discover_counters_mode, error_code&);
 
     ///////////////////////////////////////////////////////////////////////////
     // Creation function for action invocation counters.
-    HPX_API_EXPORT naming::gid_type local_action_invocation_counter_creator(
+    HPX_EXPORT naming::gid_type local_action_invocation_counter_creator(
         counter_info const&, error_code&);
 
     // Discoverer function for action invocation counters.
-    HPX_API_EXPORT bool local_action_invocation_counter_discoverer(
+    HPX_EXPORT bool local_action_invocation_counter_discoverer(
         counter_info const&, discover_counter_func const&,
         discover_counters_mode, error_code&);
 
 #if defined(HPX_HAVE_NETWORKING)
-    HPX_API_EXPORT naming::gid_type remote_action_invocation_counter_creator(
+    HPX_EXPORT naming::gid_type remote_action_invocation_counter_creator(
         counter_info const&, error_code&);
 
     // Discoverer function for action invocation counters.
-    HPX_API_EXPORT bool remote_action_invocation_counter_discoverer(
+    HPX_EXPORT bool remote_action_invocation_counter_discoverer(
         counter_info const&, discover_counter_func const&,
         discover_counters_mode, error_code&);
 
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
     ///////////////////////////////////////////////////////////////////////////
     // Creation function for per-action parcel data counters
-    HPX_API_EXPORT naming::gid_type per_action_data_counter_creator(
+    HPX_EXPORT naming::gid_type per_action_data_counter_creator(
         counter_info const& info,
         hpx::util::function_nonser<std::int64_t(
             std::string const&, bool)> const& f,
         error_code& ec);
 
     // Discoverer function for per-action parcel data counters
-    HPX_API_EXPORT bool per_action_data_counter_discoverer(
-        counter_info const& info, discover_counter_func const& f,
-        discover_counters_mode mode, error_code& ec);
+    HPX_EXPORT bool per_action_data_counter_discoverer(counter_info const& info,
+        discover_counter_func const& f, discover_counters_mode mode,
+        error_code& ec);
 #endif
 #endif
 }}    // namespace hpx::performance_counters

--- a/libs/performance_counters/include/hpx/performance_counters/counter_parser.hpp
+++ b/libs/performance_counters/include/hpx/performance_counters/counter_parser.hpp
@@ -34,6 +34,6 @@ namespace hpx { namespace performance_counters {
         std::string parameters_;
     };
 
-    HPX_API_EXPORT bool parse_counter_name(
+    HPX_EXPORT bool parse_counter_name(
         std::string const& name, path_elements& elements);
 }}    // namespace hpx::performance_counters

--- a/libs/performance_counters/include/hpx/performance_counters/counters.hpp
+++ b/libs/performance_counters/include/hpx/performance_counters/counters.hpp
@@ -176,7 +176,7 @@ namespace hpx { namespace performance_counters {
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Return the readable name of a given counter type
-    HPX_API_EXPORT char const* get_counter_type_name(counter_type state);
+    HPX_EXPORT char const* get_counter_type_name(counter_type state);
 
 #if defined(DOXYGEN)
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/performance_counters/include/hpx/performance_counters/counters_fwd.hpp
+++ b/libs/performance_counters/include/hpx/performance_counters/counters_fwd.hpp
@@ -145,7 +145,7 @@ namespace hpx { namespace performance_counters {
 
     ///////////////////////////////////////////////////////////////////////////
     // Return the readable name of a given counter type
-    HPX_API_EXPORT char const* get_counter_type_name(counter_type state);
+    HPX_EXPORT char const* get_counter_type_name(counter_type state);
 
     ///////////////////////////////////////////////////////////////////////////
     // Status and error codes used by the functions related to
@@ -177,49 +177,48 @@ namespace hpx { namespace performance_counters {
     /// \brief Create a full name of a counter type from the contents of the
     ///        given \a counter_type_path_elements instance.The generated
     ///        counter type name will not contain any parameters.
-    HPX_API_EXPORT counter_status get_counter_type_name(
+    HPX_EXPORT counter_status get_counter_type_name(
         counter_type_path_elements const& path, std::string& result,
         error_code& ec = throws);
 
     /// \brief Create a full name of a counter type from the contents of the
     ///        given \a counter_type_path_elements instance. The generated
     ///        counter type name will contain all parameters.
-    HPX_API_EXPORT counter_status get_full_counter_type_name(
+    HPX_EXPORT counter_status get_full_counter_type_name(
         counter_type_path_elements const& path, std::string& result,
         error_code& ec = throws);
 
     /// \brief Create a full name of a counter from the contents of the given
     ///        \a counter_path_elements instance.
-    HPX_API_EXPORT counter_status get_counter_name(
+    HPX_EXPORT counter_status get_counter_name(
         counter_path_elements const& path, std::string& result,
         error_code& ec = throws);
 
     /// \brief Create a name of a counter instance from the contents of the
     ///        given \a counter_path_elements instance.
-    HPX_API_EXPORT counter_status get_counter_instance_name(
+    HPX_EXPORT counter_status get_counter_instance_name(
         counter_path_elements const& path, std::string& result,
         error_code& ec = throws);
 
     /// \brief Fill the given \a counter_type_path_elements instance from the
     ///        given full name of a counter type
-    HPX_API_EXPORT counter_status get_counter_type_path_elements(
+    HPX_EXPORT counter_status get_counter_type_path_elements(
         std::string const& name, counter_type_path_elements& path,
         error_code& ec = throws);
 
     /// \brief Fill the given \a counter_path_elements instance from the given
     ///        full name of a counter
-    HPX_API_EXPORT counter_status get_counter_path_elements(
-        std::string const& name, counter_path_elements& path,
-        error_code& ec = throws);
+    HPX_EXPORT counter_status get_counter_path_elements(std::string const& name,
+        counter_path_elements& path, error_code& ec = throws);
 
     /// \brief Return the canonical counter instance name from a given full
     ///        instance name
-    HPX_API_EXPORT counter_status get_counter_name(std::string const& name,
+    HPX_EXPORT counter_status get_counter_name(std::string const& name,
         std::string& countername, error_code& ec = throws);
 
     /// \brief Return the canonical counter type name from a given (full)
     ///        instance name
-    HPX_API_EXPORT counter_status get_counter_type_name(std::string const& name,
+    HPX_EXPORT counter_status get_counter_type_name(std::string const& name,
         std::string& type_name, error_code& ec = throws);
 
 // default version of performance counter structures
@@ -259,11 +258,10 @@ namespace hpx { namespace performance_counters {
 
         ///////////////////////////////////////////////////////////////////////////
         /// \brief Complement the counter info if parent instance name is missing
-        HPX_API_EXPORT counter_status complement_counter_info(
-            counter_info& info, counter_info const& type_info,
-            error_code& ec = throws);
+        HPX_EXPORT counter_status complement_counter_info(counter_info& info,
+            counter_info const& type_info, error_code& ec = throws);
 
-        HPX_API_EXPORT counter_status complement_counter_info(
+        HPX_EXPORT counter_status complement_counter_info(
             counter_info& info, error_code& ec = throws);
 
         ///////////////////////////////////////////////////////////////////////////
@@ -434,7 +432,7 @@ namespace hpx { namespace performance_counters {
 
         ///////////////////////////////////////////////////////////////////////
         // Add a new performance counter type to the (local) registry
-        HPX_API_EXPORT counter_status add_counter_type(counter_info const& info,
+        HPX_EXPORT counter_status add_counter_type(counter_info const& info,
             create_counter_func const& create_counter,
             discover_counters_func const& discover_counters,
             error_code& ec = throws);
@@ -444,25 +442,24 @@ namespace hpx { namespace performance_counters {
 
         ///////////////////////////////////////////////////////////////////////////
         /// \brief Call the supplied function for each registered counter type
-        HPX_API_EXPORT counter_status discover_counter_types(
+        HPX_EXPORT counter_status discover_counter_types(
             discover_counter_func const& discover_counter,
             discover_counters_mode mode = discover_counters_minimal,
             error_code& ec = throws);
 
         /// \brief Return a list of all available counter descriptions.
-        HPX_API_EXPORT counter_status discover_counter_types(
+        HPX_EXPORT counter_status discover_counter_types(
             std::vector<counter_info>& counters,
             discover_counters_mode mode = discover_counters_minimal,
             error_code& ec = throws);
 
         /// \brief Call the supplied function for the given registered counter type.
-        HPX_API_EXPORT counter_status discover_counter_type(
-            std::string const& name,
+        HPX_EXPORT counter_status discover_counter_type(std::string const& name,
             discover_counter_func const& discover_counter,
             discover_counters_mode mode = discover_counters_minimal,
             error_code& ec = throws);
 
-        HPX_API_EXPORT counter_status discover_counter_type(
+        HPX_EXPORT counter_status discover_counter_type(
             counter_info const& info,
             discover_counter_func const& discover_counter,
             discover_counters_mode mode = discover_counters_minimal,
@@ -470,12 +467,12 @@ namespace hpx { namespace performance_counters {
 
         /// \brief Return a list of matching counter descriptions for the given
         ///        registered counter type.
-        HPX_API_EXPORT counter_status discover_counter_type(
-            std::string const& name, std::vector<counter_info>& counters,
+        HPX_EXPORT counter_status discover_counter_type(std::string const& name,
+            std::vector<counter_info>& counters,
             discover_counters_mode mode = discover_counters_minimal,
             error_code& ec = throws);
 
-        HPX_API_EXPORT counter_status discover_counter_type(
+        HPX_EXPORT counter_status discover_counter_type(
             counter_info const& info, std::vector<counter_info>& counters,
             discover_counters_mode mode = discover_counters_minimal,
             error_code& ec = throws);
@@ -485,26 +482,26 @@ namespace hpx { namespace performance_counters {
         ///
         /// This function expands all locality#* and worker-thread#* wild
         /// cards only.
-        HPX_API_EXPORT bool expand_counter_info(
+        HPX_EXPORT bool expand_counter_info(
             counter_info const&, discover_counter_func const&, error_code&);
 
         /// \brief Remove an existing counter type from the (local) registry
         ///
         /// \note This doesn't remove existing counters of this type, it just
         ///       inhibits defining new counters using this type.
-        HPX_API_EXPORT counter_status remove_counter_type(
+        HPX_EXPORT counter_status remove_counter_type(
             counter_info const& info, error_code& ec = throws);
 
         /// \brief Retrieve the counter type for the given counter name from the
         ///        (local) registry
-        HPX_API_EXPORT counter_status get_counter_type(std::string const& name,
+        HPX_EXPORT counter_status get_counter_type(std::string const& name,
             counter_info& info, error_code& ec = throws);
 
         ///////////////////////////////////////////////////////////////////////////
         /// \brief Get the global id of an existing performance counter, if the
         ///        counter does not exist yet, the function attempts to create the
         ///        counter based on the given counter name.
-        HPX_API_EXPORT lcos::future<naming::id_type> get_counter_async(
+        HPX_EXPORT lcos::future<naming::id_type> get_counter_async(
             std::string name, error_code& ec = throws);
 
         inline naming::id_type get_counter(
@@ -513,7 +510,7 @@ namespace hpx { namespace performance_counters {
         /// \brief Get the global id of an existing performance counter, if the
         ///        counter does not exist yet, the function attempts to create the
         ///        counter based on the given counter info.
-        HPX_API_EXPORT lcos::future<naming::id_type> get_counter_async(
+        HPX_EXPORT lcos::future<naming::id_type> get_counter_async(
             counter_info const& info, error_code& ec = throws);
 
         inline naming::id_type get_counter(
@@ -521,26 +518,25 @@ namespace hpx { namespace performance_counters {
 
         ///////////////////////////////////////////////////////////////////////////
         /// \brief Retrieve the meta data specific for the given counter instance
-        HPX_API_EXPORT void get_counter_infos(counter_info const& info,
+        HPX_EXPORT void get_counter_infos(counter_info const& info,
             counter_type& type, std::string& helptext, std::uint32_t& version,
             error_code& ec = throws);
 
         /// \brief Retrieve the meta data specific for the given counter instance
-        HPX_API_EXPORT void get_counter_infos(std::string name,
-            counter_type& type, std::string& helptext, std::uint32_t& version,
+        HPX_EXPORT void get_counter_infos(std::string name, counter_type& type,
+            std::string& helptext, std::uint32_t& version,
             error_code& ec = throws);
 
         ///////////////////////////////////////////////////////////////////////////
         namespace detail {
             /// \brief Add an existing performance counter instance to the registry
-            HPX_API_EXPORT counter_status add_counter(naming::id_type const& id,
+            HPX_EXPORT counter_status add_counter(naming::id_type const& id,
                 counter_info const& info, error_code& ec = throws);
 
             /// \brief Remove an existing performance counter instance with the
             ///        given id (as returned from \a create_counter)
-            HPX_API_EXPORT counter_status remove_counter(
-                counter_info const& info, naming::id_type const& id,
-                error_code& ec = throws);
+            HPX_EXPORT counter_status remove_counter(counter_info const& info,
+                naming::id_type const& id, error_code& ec = throws);
 
             ///////////////////////////////////////////////////////////////////////
             // Helper function for creating counters encapsulating a function

--- a/libs/performance_counters/include/hpx/performance_counters/performance_counter.hpp
+++ b/libs/performance_counters/include/hpx/performance_counters/performance_counter.hpp
@@ -128,6 +128,6 @@ namespace hpx { namespace performance_counters {
     };
 
     // Return all counters matching the given name (with optional wild cards).
-    HPX_API_EXPORT std::vector<performance_counter> discover_counters(
+    HPX_EXPORT std::vector<performance_counter> discover_counters(
         std::string const& name, error_code& ec = throws);
 }}    // namespace hpx::performance_counters

--- a/libs/program_options/src/convert.cpp
+++ b/libs/program_options/src/convert.cpp
@@ -79,7 +79,7 @@ namespace hpx { namespace program_options { namespace detail {
 
 namespace hpx { namespace program_options {
 
-    HPX_EXPORT std::wstring from_8_bit(const std::string& s,
+    std::wstring from_8_bit(const std::string& s,
         const std::codecvt<wchar_t, char, std::mbstate_t>& cvt)
     {
         using namespace std::placeholders;
@@ -88,7 +88,7 @@ namespace hpx { namespace program_options {
                 _1, _2, _3, _4, _5, _6, _7));
     }
 
-    HPX_EXPORT std::string to_8_bit(const std::wstring& s,
+    std::string to_8_bit(const std::wstring& s,
         const std::codecvt<wchar_t, char, std::mbstate_t>& cvt)
     {
         using namespace std::placeholders;
@@ -101,34 +101,34 @@ namespace hpx { namespace program_options {
         hpx::program_options::detail::utf8_codecvt_facet utf8_facet;
     }
 
-    HPX_EXPORT std::wstring from_utf8(const std::string& s)
+    std::wstring from_utf8(const std::string& s)
     {
         return from_8_bit(s, utf8_facet);
     }
 
-    HPX_EXPORT std::string to_utf8(const std::wstring& s)
+    std::string to_utf8(const std::wstring& s)
     {
         return to_8_bit(s, utf8_facet);
     }
 
-    HPX_EXPORT std::wstring from_local_8_bit(const std::string& s)
+    std::wstring from_local_8_bit(const std::string& s)
     {
         using facet_type = std::codecvt<wchar_t, char, std::mbstate_t>;
         return from_8_bit(s, std::use_facet<facet_type>(std::locale()));
     }
 
-    HPX_EXPORT std::string to_local_8_bit(const std::wstring& s)
+    std::string to_local_8_bit(const std::wstring& s)
     {
         using facet_type = std::codecvt<wchar_t, char, std::mbstate_t>;
         return to_8_bit(s, std::use_facet<facet_type>(std::locale()));
     }
 
-    HPX_EXPORT std::string to_internal(const std::string& s)
+    std::string to_internal(const std::string& s)
     {
         return s;
     }
 
-    HPX_EXPORT std::string to_internal(const std::wstring& s)
+    std::string to_internal(const std::wstring& s)
     {
         return to_utf8(s);
     }

--- a/libs/program_options/src/parsers.cpp
+++ b/libs/program_options/src/parsers.cpp
@@ -158,7 +158,7 @@ namespace hpx { namespace program_options {
         const char* filename, const options_description& desc,
         bool allow_unregistered);
 
-    HPX_EXPORT parsed_options parse_environment(const options_description& desc,
+    parsed_options parse_environment(const options_description& desc,
         const std::function<std::string(std::string)>& name_mapper)
     {
         parsed_options result(&desc);
@@ -209,13 +209,13 @@ namespace hpx { namespace program_options {
         };
     }    // namespace detail
 
-    HPX_EXPORT parsed_options parse_environment(
+    parsed_options parse_environment(
         const options_description& desc, const std::string& prefix)
     {
         return parse_environment(desc, detail::prefix_name_mapper(prefix));
     }
 
-    HPX_EXPORT parsed_options parse_environment(
+    parsed_options parse_environment(
         const options_description& desc, const char* prefix)
     {
         return parse_environment(desc, string(prefix));

--- a/libs/program_options/src/split.cpp
+++ b/libs/program_options/src/split.cpp
@@ -47,14 +47,14 @@ namespace hpx { namespace program_options {
 
     // Take a command line string and splits in into tokens, according
     // to the given collection of separators chars.
-    HPX_EXPORT std::vector<std::string> split_unix(const std::string& cmdline,
+    std::vector<std::string> split_unix(const std::string& cmdline,
         const std::string& separator, const std::string& quote,
         const std::string& escape)
     {
         return detail::split_unix<char>(cmdline, separator, quote, escape);
     }
 
-    HPX_EXPORT std::vector<std::wstring> split_unix(const std::wstring& cmdline,
+    std::vector<std::wstring> split_unix(const std::wstring& cmdline,
         const std::wstring& separator, const std::wstring& quote,
         const std::wstring& escape)
     {

--- a/libs/program_options/src/value_semantic.cpp
+++ b/libs/program_options/src/value_semantic.cpp
@@ -84,7 +84,7 @@ namespace hpx { namespace program_options {
         xparse(value_store, tokens);
     }
 
-    HPX_EXPORT std::string arg("arg");
+    std::string arg("arg");
 
     std::string untyped_value::name() const
     {
@@ -117,12 +117,12 @@ namespace hpx { namespace program_options {
         value_store = new_tokens.empty() ? std::string("") : new_tokens.front();
     }
 
-    HPX_EXPORT typed_value<bool>* bool_switch()
+    typed_value<bool>* bool_switch()
     {
         return bool_switch(nullptr);
     }
 
-    HPX_EXPORT typed_value<bool>* bool_switch(bool* v)
+    typed_value<bool>* bool_switch(bool* v)
     {
         typed_value<bool>* r = new typed_value<bool>(v);
         r->default_value(false);
@@ -137,7 +137,7 @@ namespace hpx { namespace program_options {
         Case is ignored. The 'xs' vector can either be empty, in which
         case the value is 'true', or can contain explicit value.
     */
-    HPX_EXPORT void validate(
+    void validate(
         hpx::util::any_nonser& v, const vector<string>& xs, bool*, int)
     {
         check_first_occurrence(v);

--- a/libs/program_options/src/variables_map.cpp
+++ b/libs/program_options/src/variables_map.cpp
@@ -147,12 +147,12 @@ namespace hpx { namespace program_options {
         }
     }
 
-    HPX_EXPORT void store(const wparsed_options& options, variables_map& m)
+    void store(const wparsed_options& options, variables_map& m)
     {
         store(options.utf8_encoded_options, m, true);
     }
 
-    HPX_EXPORT void notify(variables_map& vm)
+    void notify(variables_map& vm)
     {
         vm.notify();
     }

--- a/libs/program_options/src/winmain.cpp
+++ b/libs/program_options/src/winmain.cpp
@@ -105,8 +105,7 @@ namespace hpx { namespace program_options {
         return result;
     }
 
-    HPX_EXPORT std::vector<std::wstring> split_winmain(
-        const std::wstring& cmdline)
+    std::vector<std::wstring> split_winmain(const std::wstring& cmdline)
     {
         std::vector<std::wstring> result;
         std::vector<std::string> aux = split_winmain(to_internal(cmdline));

--- a/libs/runtime_configuration/include/hpx/runtime_configuration/runtime_mode.hpp
+++ b/libs/runtime_configuration/include/hpx/runtime_configuration/runtime_mode.hpp
@@ -30,7 +30,7 @@ namespace hpx {
 
     /// Get the readable string representing the name of the given runtime_mode
     /// constant.
-    HPX_API_EXPORT char const* get_runtime_mode_name(runtime_mode state);
+    HPX_EXPORT char const* get_runtime_mode_name(runtime_mode state);
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Returns the internal representation (runtime_mode constant) from
@@ -40,6 +40,5 @@ namespace hpx {
     /// representing the name.
     ///
     /// \param mode this represents the runtime mode
-    HPX_API_EXPORT runtime_mode get_runtime_mode_from_name(
-        std::string const& mode);
+    HPX_EXPORT runtime_mode get_runtime_mode_from_name(std::string const& mode);
 }    // namespace hpx

--- a/libs/runtime_configuration/src/ini.cpp
+++ b/libs/runtime_configuration/src/ini.cpp
@@ -977,15 +977,15 @@ namespace hpx { namespace util {
 
     ///////////////////////////////////////////////////////////////////////////////
     // explicit instantiation for the correct archive types
-    HPX_EXPORT void serialize(serialization::output_archive& ar,
+    void serialize(serialization::output_archive& ar,
         section::entry_type const& data, unsigned int version)
     {
         ar << data.first;
         // do not handle callback function
     }
 
-    HPX_EXPORT void serialize(serialization::input_archive& ar,
-        section::entry_type& data, unsigned int version)
+    void serialize(serialization::input_archive& ar, section::entry_type& data,
+        unsigned int version)
     {
         ar >> data.first;
         // do not handle callback function

--- a/libs/static_reinit/include/hpx/static_reinit/static_reinit.hpp
+++ b/libs/static_reinit/include/hpx/static_reinit/static_reinit.hpp
@@ -15,13 +15,13 @@ namespace hpx { namespace util {
     // the runtime system is about to start and after the runtime system has
     // been terminated. This is used to initialize/reinitialize all
     // singleton instances.
-    HPX_API_EXPORT void reinit_register(
+    HPX_EXPORT void reinit_register(
         util::function_nonser<void()> const& construct,
         util::function_nonser<void()> const& destruct);
 
     // Invoke all globally registered construction functions
-    HPX_API_EXPORT void reinit_construct();
+    HPX_EXPORT void reinit_construct();
 
     // Invoke all globally registered destruction functions
-    HPX_API_EXPORT void reinit_destruct();
+    HPX_EXPORT void reinit_destruct();
 }}    // namespace hpx::util

--- a/libs/synchronization/include/hpx/synchronization/mutex.hpp
+++ b/libs/synchronization/include/hpx/synchronization/mutex.hpp
@@ -22,10 +22,10 @@ namespace hpx { namespace threads {
     using thread_self = coroutines::detail::coroutine_self;
     /// The function \a get_self_id returns the HPX thread id of the current
     /// thread (or zero if the current thread is not a HPX thread).
-    HPX_API_EXPORT thread_id_type get_self_id();
+    HPX_EXPORT thread_id_type get_self_id();
     /// The function \a get_self_ptr returns a pointer to the (OS thread
     /// specific) self reference to the current HPX thread.
-    HPX_API_EXPORT thread_self* get_self_ptr();
+    HPX_EXPORT thread_self* get_self_ptr();
 
 }}    // namespace hpx::threads
 

--- a/libs/threading/include/hpx/threading/thread.hpp
+++ b/libs/threading/include/hpx/threading/thread.hpp
@@ -232,31 +232,30 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     namespace this_thread {
-        HPX_API_EXPORT thread::id get_id() noexcept;
+        HPX_EXPORT thread::id get_id() noexcept;
 
-        HPX_API_EXPORT void yield() noexcept;
-        HPX_API_EXPORT void yield_to(thread::id) noexcept;
+        HPX_EXPORT void yield() noexcept;
+        HPX_EXPORT void yield_to(thread::id) noexcept;
 
         // extensions
-        HPX_API_EXPORT threads::thread_priority get_priority();
-        HPX_API_EXPORT std::ptrdiff_t get_stack_size();
+        HPX_EXPORT threads::thread_priority get_priority();
+        HPX_EXPORT std::ptrdiff_t get_stack_size();
 
-        HPX_API_EXPORT void interruption_point();
-        HPX_API_EXPORT bool interruption_enabled();
-        HPX_API_EXPORT bool interruption_requested();
+        HPX_EXPORT void interruption_point();
+        HPX_EXPORT bool interruption_enabled();
+        HPX_EXPORT bool interruption_requested();
 
-        HPX_API_EXPORT void interrupt();
+        HPX_EXPORT void interrupt();
 
-        HPX_API_EXPORT void sleep_until(
-            util::steady_time_point const& abs_time);
+        HPX_EXPORT void sleep_until(util::steady_time_point const& abs_time);
 
         inline void sleep_for(util::steady_duration const& rel_time)
         {
             sleep_until(rel_time.from_now());
         }
 
-        HPX_API_EXPORT std::size_t get_thread_data();
-        HPX_API_EXPORT std::size_t set_thread_data(std::size_t);
+        HPX_EXPORT std::size_t get_thread_data();
+        HPX_EXPORT std::size_t set_thread_data(std::size_t);
 
         class HPX_EXPORT disable_interruption
         {

--- a/libs/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -642,28 +642,28 @@ namespace hpx { namespace threads {
     ///////////////////////////////////////////////////////////////////////
     /// The function \a get_self returns a reference to the (OS thread
     /// specific) self reference to the current HPX thread.
-    HPX_API_EXPORT thread_self& get_self();
+    HPX_EXPORT thread_self& get_self();
 
     /// The function \a get_self_ptr returns a pointer to the (OS thread
     /// specific) self reference to the current HPX thread.
-    HPX_API_EXPORT thread_self* get_self_ptr();
+    HPX_EXPORT thread_self* get_self_ptr();
 
     /// The function \a get_ctx_ptr returns a pointer to the internal data
     /// associated with each coroutine.
-    HPX_API_EXPORT thread_self_impl_type* get_ctx_ptr();
+    HPX_EXPORT thread_self_impl_type* get_ctx_ptr();
 
     /// The function \a get_self_ptr_checked returns a pointer to the (OS
     /// thread specific) self reference to the current HPX thread.
-    HPX_API_EXPORT thread_self* get_self_ptr_checked(error_code& ec = throws);
+    HPX_EXPORT thread_self* get_self_ptr_checked(error_code& ec = throws);
 
     /// The function \a get_self_id returns the HPX thread id of the current
     /// thread (or zero if the current thread is not a HPX thread).
-    HPX_API_EXPORT thread_id_type get_self_id();
+    HPX_EXPORT thread_id_type get_self_id();
 
     /// The function \a get_self_id_data returns the data of the HPX thread id
     /// associated with the current thread (or nullptr if the current thread is
     /// not a HPX thread).
-    HPX_API_EXPORT thread_data* get_self_id_data();
+    HPX_EXPORT thread_data* get_self_id_data();
 
     /// The function \a get_parent_id returns the HPX thread id of the
     /// current thread's parent (or zero if the current thread is not a
@@ -672,7 +672,7 @@ namespace hpx { namespace threads {
     /// \note This function will return a meaningful value only if the
     ///       code was compiled with HPX_HAVE_THREAD_PARENT_REFERENCE
     ///       being defined.
-    HPX_API_EXPORT thread_id_type get_parent_id();
+    HPX_EXPORT thread_id_type get_parent_id();
 
     /// The function \a get_parent_phase returns the HPX phase of the
     /// current thread's parent (or zero if the current thread is not a
@@ -681,16 +681,16 @@ namespace hpx { namespace threads {
     /// \note This function will return a meaningful value only if the
     ///       code was compiled with HPX_HAVE_THREAD_PARENT_REFERENCE
     ///       being defined.
-    HPX_API_EXPORT std::size_t get_parent_phase();
+    HPX_EXPORT std::size_t get_parent_phase();
 
     /// The function \a get_self_stacksize returns the stack size of the
     /// current thread (or zero if the current thread is not a HPX thread).
-    HPX_API_EXPORT std::ptrdiff_t get_self_stacksize();
+    HPX_EXPORT std::ptrdiff_t get_self_stacksize();
 
     /// The function \a get_self_stacksize_enum returns the stack size of the /
     //current thread (or thread_stacksize_default if the current thread is not
     //a HPX thread).
-    HPX_API_EXPORT thread_stacksize get_self_stacksize_enum();
+    HPX_EXPORT thread_stacksize get_self_stacksize_enum();
 
     /// The function \a get_parent_locality_id returns the id of the locality of
     /// the current thread's parent (or zero if the current thread is not a
@@ -699,7 +699,7 @@ namespace hpx { namespace threads {
     /// \note This function will return a meaningful value only if the
     ///       code was compiled with HPX_HAVE_THREAD_PARENT_REFERENCE
     ///       being defined.
-    HPX_API_EXPORT std::uint32_t get_parent_locality_id();
+    HPX_EXPORT std::uint32_t get_parent_locality_id();
 
     /// The function \a get_self_component_id returns the lva of the
     /// component the current thread is acting on
@@ -707,7 +707,7 @@ namespace hpx { namespace threads {
     /// \note This function will return a meaningful value only if the
     ///       code was compiled with HPX_HAVE_THREAD_TARGET_ADDRESS
     ///       being defined.
-    HPX_API_EXPORT std::uint64_t get_self_component_id();
+    HPX_EXPORT std::uint64_t get_self_component_id();
 }}    // namespace hpx::threads
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/threading_base/include/hpx/threading_base/thread_description.hpp
+++ b/libs/threading_base/include/hpx/threading_base/thread_description.hpp
@@ -303,16 +303,16 @@ namespace hpx { namespace threads {
     ///                   throw but returns the result code using the
     ///                   parameter \a ec. Otherwise it throws an instance
     ///                   of hpx#exception.
-    HPX_API_EXPORT util::thread_description get_thread_description(
+    HPX_EXPORT util::thread_description get_thread_description(
         thread_id_type const& id, error_code& ec = throws);
-    HPX_API_EXPORT util::thread_description set_thread_description(
+    HPX_EXPORT util::thread_description set_thread_description(
         thread_id_type const& id,
         util::thread_description const& desc = util::thread_description(),
         error_code& ec = throws);
 
-    HPX_API_EXPORT util::thread_description get_thread_lco_description(
+    HPX_EXPORT util::thread_description get_thread_lco_description(
         thread_id_type const& id, error_code& ec = throws);
-    HPX_API_EXPORT util::thread_description set_thread_lco_description(
+    HPX_EXPORT util::thread_description set_thread_lco_description(
         thread_id_type const& id,
         util::thread_description const& desc = util::thread_description(),
         error_code& ec = throws);

--- a/libs/threading_base/include/hpx/threading_base/thread_helpers.hpp
+++ b/libs/threading_base/include/hpx/threading_base/thread_helpers.hpp
@@ -63,7 +63,7 @@ namespace hpx { namespace threads {
     ///                   throw but returns the result code using the
     ///                   parameter \a ec. Otherwise it throws an instance
     ///                   of hpx#exception.
-    HPX_API_EXPORT thread_state set_thread_state(thread_id_type const& id,
+    HPX_EXPORT thread_state set_thread_state(thread_id_type const& id,
         thread_state_enum state = pending,
         thread_state_ex_enum stateex = wait_signaled,
         thread_priority priority = thread_priority_normal,
@@ -98,7 +98,7 @@ namespace hpx { namespace threads {
     ///                   throw but returns the result code using the
     ///                   parameter \a ec. Otherwise it throws an instance
     ///                   of hpx#exception.
-    HPX_API_EXPORT thread_id_type set_thread_state(thread_id_type const& id,
+    HPX_EXPORT thread_id_type set_thread_state(thread_id_type const& id,
         util::steady_time_point const& abs_time, std::atomic<bool>* started,
         thread_state_enum state = pending,
         thread_state_ex_enum stateex = wait_timeout,
@@ -175,15 +175,15 @@ namespace hpx { namespace threads {
     ///                   parameter \a ec. Otherwise it throws an instance
     ///                   of hpx#exception.
 #ifdef HPX_HAVE_THREAD_FULLBACKTRACE_ON_SUSPENSION
-    HPX_API_EXPORT char const* get_thread_backtrace(
+    HPX_EXPORT char const* get_thread_backtrace(
         thread_id_type const& id, error_code& ec = throws);
-    HPX_API_EXPORT char const* set_thread_backtrace(thread_id_type const& id,
+    HPX_EXPORT char const* set_thread_backtrace(thread_id_type const& id,
         char const* bt = nullptr, error_code& ec = throws);
 #else
 #if !defined(DOXYGEN)
-    HPX_API_EXPORT util::backtrace const* get_thread_backtrace(
+    HPX_EXPORT util::backtrace const* get_thread_backtrace(
         thread_id_type const& id, error_code& ec = throws);
-    HPX_API_EXPORT util::backtrace const* set_thread_backtrace(
+    HPX_EXPORT util::backtrace const* set_thread_backtrace(
         thread_id_type const& id, util::backtrace const* bt = nullptr,
         error_code& ec = throws);
 #endif
@@ -209,7 +209,7 @@ namespace hpx { namespace threads {
     ///                   throw but returns the result code using the
     ///                   parameter \a ec. Otherwise it throws an instance
     ///                   of hpx#exception.
-    HPX_API_EXPORT thread_state get_thread_state(
+    HPX_EXPORT thread_state get_thread_state(
         thread_id_type const& id, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -232,7 +232,7 @@ namespace hpx { namespace threads {
     ///                   throw but returns the result code using the
     ///                   parameter \a ec. Otherwise it throws an instance
     ///                   of hpx#exception.
-    HPX_API_EXPORT std::size_t get_thread_phase(
+    HPX_EXPORT std::size_t get_thread_phase(
         thread_id_type const& id, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -253,7 +253,7 @@ namespace hpx { namespace threads {
     ///                   throw but returns the result code using the
     ///                   parameter \a ec. Otherwise it throws an instance
     ///                   of hpx#exception.
-    HPX_API_EXPORT bool get_thread_interruption_enabled(
+    HPX_EXPORT bool get_thread_interruption_enabled(
         thread_id_type const& id, error_code& ec = throws);
 
     /// Set whether the given thread can be interrupted at this point.
@@ -274,7 +274,7 @@ namespace hpx { namespace threads {
     ///                   throw but returns the result code using the
     ///                   parameter \a ec. Otherwise it throws an instance
     ///                   of hpx#exception.
-    HPX_API_EXPORT bool set_thread_interruption_enabled(
+    HPX_EXPORT bool set_thread_interruption_enabled(
         thread_id_type const& id, bool enable, error_code& ec = throws);
 
     /// Returns whether the given thread has been flagged for interruption.
@@ -294,7 +294,7 @@ namespace hpx { namespace threads {
     ///                   throw but returns the result code using the
     ///                   parameter \a ec. Otherwise it throws an instance
     ///                   of hpx#exception.
-    HPX_API_EXPORT bool get_thread_interruption_requested(
+    HPX_EXPORT bool get_thread_interruption_requested(
         thread_id_type const& id, error_code& ec = throws);
 
     /// Flag the given thread for interruption.
@@ -313,7 +313,7 @@ namespace hpx { namespace threads {
     ///                   throw but returns the result code using the
     ///                   parameter \a ec. Otherwise it throws an instance
     ///                   of hpx#exception.
-    HPX_API_EXPORT void interrupt_thread(
+    HPX_EXPORT void interrupt_thread(
         thread_id_type const& id, bool flag, error_code& ec = throws);
 
     inline void interrupt_thread(
@@ -337,7 +337,7 @@ namespace hpx { namespace threads {
     ///                   throw but returns the result code using the
     ///                   parameter \a ec. Otherwise it throws an instance
     ///                   of hpx#exception.
-    HPX_API_EXPORT void interruption_point(
+    HPX_EXPORT void interruption_point(
         thread_id_type const& id, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -354,7 +354,7 @@ namespace hpx { namespace threads {
     ///                   throw but returns the result code using the
     ///                   parameter \a ec. Otherwise it throws an instance
     ///                   of hpx#exception.
-    HPX_API_EXPORT threads::thread_priority get_thread_priority(
+    HPX_EXPORT threads::thread_priority get_thread_priority(
         thread_id_type const& id, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -371,29 +371,29 @@ namespace hpx { namespace threads {
     ///                   throw but returns the result code using the
     ///                   parameter \a ec. Otherwise it throws an instance
     ///                   of hpx#exception.
-    HPX_API_EXPORT std::ptrdiff_t get_stack_size(
+    HPX_EXPORT std::ptrdiff_t get_stack_size(
         thread_id_type const& id, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
     /// \cond NOINTERNAL
-    HPX_API_EXPORT void run_thread_exit_callbacks(
+    HPX_EXPORT void run_thread_exit_callbacks(
         thread_id_type const& id, error_code& ec = throws);
 
-    HPX_API_EXPORT bool add_thread_exit_callback(thread_id_type const& id,
+    HPX_EXPORT bool add_thread_exit_callback(thread_id_type const& id,
         util::function_nonser<void()> const& f, error_code& ec = throws);
 
-    HPX_API_EXPORT void free_thread_exit_callbacks(
+    HPX_EXPORT void free_thread_exit_callbacks(
         thread_id_type const& id, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_API_EXPORT std::size_t get_thread_data(
+    HPX_EXPORT std::size_t get_thread_data(
         thread_id_type const& id, error_code& ec = throws);
 
-    HPX_API_EXPORT std::size_t set_thread_data(
+    HPX_EXPORT std::size_t set_thread_data(
         thread_id_type const& id, std::size_t data, error_code& ec = throws);
 
-    HPX_API_EXPORT std::size_t& get_continuation_recursion_count();
-    HPX_API_EXPORT void reset_continuation_recursion_count();
+    HPX_EXPORT std::size_t& get_continuation_recursion_count();
+    HPX_EXPORT void reset_continuation_recursion_count();
     /// \endcond
 
     /// Returns a pointer to the pool that was used to run the current thread
@@ -429,7 +429,7 @@ namespace hpx { namespace this_thread {
     ///         running, it will throw an \a hpx#exception with an error code of
     ///         \a hpx#invalid_status.
     ///
-    HPX_API_EXPORT threads::thread_state_ex_enum suspend(
+    HPX_EXPORT threads::thread_state_ex_enum suspend(
         threads::thread_state_enum state, threads::thread_id_type const& id,
         util::thread_description const& description = util::thread_description(
             "this_thread::suspend"),
@@ -477,7 +477,7 @@ namespace hpx { namespace this_thread {
     ///         running, it will throw an \a hpx#exception with an error code of
     ///         \a hpx#invalid_status.
     ///
-    HPX_API_EXPORT threads::thread_state_ex_enum suspend(
+    HPX_EXPORT threads::thread_state_ex_enum suspend(
         util::steady_time_point const& abs_time,
         threads::thread_id_type const& id,
         util::thread_description const& description = util::thread_description(

--- a/libs/threading_base/include/hpx/threading_base/thread_init_data.hpp
+++ b/libs/threading_base/include/hpx/threading_base/thread_init_data.hpp
@@ -21,8 +21,8 @@
 #include <utility>
 
 namespace hpx { namespace threads {
-    HPX_API_EXPORT std::ptrdiff_t get_default_stack_size();
-    HPX_API_EXPORT std::ptrdiff_t get_stack_size(thread_stacksize);
+    HPX_EXPORT std::ptrdiff_t get_default_stack_size();
+    HPX_EXPORT std::ptrdiff_t get_stack_size(thread_stacksize);
 
     ///////////////////////////////////////////////////////////////////////////
     class thread_init_data

--- a/libs/threading_base/include/hpx/threading_base/thread_num_tss.hpp
+++ b/libs/threading_base/include/hpx/threading_base/thread_num_tss.hpp
@@ -79,7 +79,7 @@ namespace hpx {
     ///
     /// \note   This function needs to be executed on a HPX-thread. It will
     ///         fail otherwise (it will return -1).
-    HPX_API_EXPORT std::size_t get_worker_thread_num();
+    HPX_EXPORT std::size_t get_worker_thread_num();
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Return the number of the current OS-thread running in the
@@ -98,7 +98,7 @@ namespace hpx {
     ///
     /// \note   This function needs to be executed on a HPX-thread. It will
     ///         fail otherwise (it will return -1).
-    HPX_API_EXPORT std::size_t get_worker_thread_num(error_code& ec);
+    HPX_EXPORT std::size_t get_worker_thread_num(error_code& ec);
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Return the number of the current OS-thread running in the current
@@ -114,7 +114,7 @@ namespace hpx {
     ///
     /// \note This function needs to be executed on a HPX-thread. It will fail
     ///         otherwise (it will return -1).
-    HPX_API_EXPORT std::size_t get_local_worker_thread_num();
+    HPX_EXPORT std::size_t get_local_worker_thread_num();
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Return the number of the current OS-thread running in the current
@@ -132,7 +132,7 @@ namespace hpx {
     ///
     /// \note This function needs to be executed on a HPX-thread. It will fail
     ///         otherwise (it will return -1).
-    HPX_API_EXPORT std::size_t get_local_worker_thread_num(error_code& ec);
+    HPX_EXPORT std::size_t get_local_worker_thread_num(error_code& ec);
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Return the number of the current thread pool the current
@@ -148,7 +148,7 @@ namespace hpx {
     ///
     /// \note This function needs to be executed on a HPX-thread. It will fail
     ///         otherwise (it will return -1).
-    HPX_API_EXPORT std::size_t get_thread_pool_num();
+    HPX_EXPORT std::size_t get_thread_pool_num();
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Return the number of the current thread pool the current
@@ -166,7 +166,7 @@ namespace hpx {
     ///
     /// \note This function needs to be executed on a HPX-thread. It will fail
     ///         otherwise (it will return -1).
-    HPX_API_EXPORT std::size_t get_thread_pool_num(error_code& ec);
+    HPX_EXPORT std::size_t get_thread_pool_num(error_code& ec);
 }    // namespace hpx
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/threading_base/include/hpx/threading_base/threading_base_fwd.hpp
+++ b/libs/threading_base/include/hpx/threading_base/threading_base_fwd.hpp
@@ -62,9 +62,9 @@ namespace hpx { namespace threads {
         util::unique_function_nonser<thread_function_sig>;
 
 #if defined(HPX_HAVE_APEX)
-    HPX_API_EXPORT std::shared_ptr<hpx::util::external_timer::task_wrapper>
+    HPX_EXPORT std::shared_ptr<hpx::util::external_timer::task_wrapper>
     get_self_timer_data(void);
-    HPX_API_EXPORT void set_self_timer_data(
+    HPX_EXPORT void set_self_timer_data(
         std::shared_ptr<hpx::util::external_timer::task_wrapper> data);
 #endif
     /// \endcond

--- a/libs/threading_base/src/register_thread.cpp
+++ b/libs/threading_base/src/register_thread.cpp
@@ -24,7 +24,7 @@ namespace hpx { namespace threads { namespace detail {
         get_default_pool = f;
     }
 
-    HPX_EXPORT thread_pool_base* get_self_or_default_pool()
+    thread_pool_base* get_self_or_default_pool()
     {
         thread_pool_base* pool = nullptr;
         auto thrd_data = get_self_id_data();
@@ -56,7 +56,7 @@ namespace hpx { namespace threads { namespace detail {
         get_default_timer_service_f = f;
     }
 
-    HPX_EXPORT boost::asio::io_service* get_default_timer_service()
+    boost::asio::io_service* get_default_timer_service()
     {
         boost::asio::io_service* timer_service = nullptr;
         if (detail::get_default_timer_service_f)

--- a/libs/topology/include/hpx/topology/cpu_mask.hpp
+++ b/libs/topology/include/hpx/topology/cpu_mask.hpp
@@ -237,6 +237,6 @@ namespace hpx { namespace threads {
 
 #endif
 
-        HPX_API_EXPORT std::string to_string(mask_cref_type);
+        HPX_EXPORT std::string to_string(mask_cref_type);
         /// \endcond
 }}    // namespace hpx::threads

--- a/libs/topology/include/hpx/topology/topology.hpp
+++ b/libs/topology/include/hpx/topology/topology.hpp
@@ -418,7 +418,7 @@ namespace hpx { namespace threads {
         return topo.get();
     }
 
-    HPX_API_EXPORT HPX_NODISCARD unsigned int hardware_concurrency();
+    HPX_EXPORT HPX_NODISCARD unsigned int hardware_concurrency();
 
     ///////////////////////////////////////////////////////////////////////////
     // abstract away memory page size, calls to system functions are

--- a/src/custom_exception_info.cpp
+++ b/src/custom_exception_info.cpp
@@ -253,7 +253,7 @@ namespace hpx { namespace detail
         std::abort();
     }
 
-    HPX_EXPORT hpx::exception_info construct_exception_info(
+    hpx::exception_info construct_exception_info(
         std::string const& func, std::string const& file, long line,
         std::string const& back_trace, std::uint32_t node,
         std::string const& hostname, std::int64_t pid, std::size_t shepherd,
@@ -276,7 +276,7 @@ namespace hpx { namespace detail
     }
 
     template <typename Exception>
-    HPX_EXPORT std::exception_ptr construct_exception(
+    std::exception_ptr construct_exception(
         Exception const& e, hpx::exception_info info)
     {
         // create a std::exception_ptr object encapsulating the Exception to

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -92,7 +92,7 @@ namespace hpx {
         }
     }
 
-    HPX_EXPORT BOOL WINAPI termination_handler(DWORD ctrl_type)
+    BOOL WINAPI termination_handler(DWORD ctrl_type)
     {
         switch (ctrl_type)
         {
@@ -131,7 +131,7 @@ namespace hpx {
 
 namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT HPX_NORETURN void termination_handler(int signum)
+    HPX_NORETURN void termination_handler(int signum)
     {
         if (signum != SIGINT &&
             get_config_entry("hpx.attach_debugger", "") == "exception")
@@ -174,7 +174,7 @@ namespace hpx {
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT void HPX_CDECL new_handler()
+    void HPX_CDECL new_handler()
     {
         HPX_THROW_EXCEPTION(out_of_memory, "new_handler",
             "new allocator failed to allocate memory");
@@ -989,7 +989,7 @@ namespace hpx {
         return true;    // assume stopped
     }
 
-    bool HPX_EXPORT tolerate_node_faults()
+    bool tolerate_node_faults()
     {
 #ifdef HPX_HAVE_FAULT_TOLERANCE
         return true;
@@ -998,13 +998,13 @@ namespace hpx {
 #endif
     }
 
-    bool HPX_EXPORT is_starting()
+    bool is_starting()
     {
         runtime* rt = get_runtime_ptr();
         return nullptr != rt ? rt->get_state() <= state_startup : true;
     }
 
-    bool HPX_EXPORT is_pre_startup()
+    bool is_pre_startup()
     {
         runtime* rt = get_runtime_ptr();
         return nullptr != rt ? rt->get_state() < state_startup : true;
@@ -1046,22 +1046,22 @@ namespace hpx { namespace threads {
         return get_runtime().get_config().get_stack_size(stacksize);
     }
 
-    HPX_API_EXPORT void reset_thread_distribution()
+    void reset_thread_distribution()
     {
         get_runtime().get_thread_manager().reset_thread_distribution();
     }
 
-    HPX_API_EXPORT void set_scheduler_mode(threads::policies::scheduler_mode m)
+    void set_scheduler_mode(threads::policies::scheduler_mode m)
     {
         get_runtime().get_thread_manager().set_scheduler_mode(m);
     }
 
-    HPX_API_EXPORT void add_scheduler_mode(threads::policies::scheduler_mode m)
+    void add_scheduler_mode(threads::policies::scheduler_mode m)
     {
         get_runtime().get_thread_manager().add_scheduler_mode(m);
     }
 
-    HPX_API_EXPORT void add_remove_scheduler_mode(
+    void add_remove_scheduler_mode(
         threads::policies::scheduler_mode to_add_mode,
         threads::policies::scheduler_mode to_remove_mode)
     {
@@ -1069,13 +1069,13 @@ namespace hpx { namespace threads {
             to_add_mode, to_remove_mode);
     }
 
-    HPX_API_EXPORT void remove_scheduler_mode(
+    void remove_scheduler_mode(
         threads::policies::scheduler_mode m)
     {
         get_runtime().get_thread_manager().remove_scheduler_mode(m);
     }
 
-    HPX_API_EXPORT topology const& get_topology()
+    topology const& get_topology()
     {
         hpx::runtime* rt = hpx::get_runtime_ptr();
         if (rt == nullptr)

--- a/src/runtime/naming/name.cpp
+++ b/src/runtime/naming/name.cpp
@@ -468,7 +468,7 @@ namespace hpx { namespace naming
             return replenish_credits_locked(l, gid);
         }
 
-        HPX_EXPORT std::int64_t replenish_credits_locked(
+        std::int64_t replenish_credits_locked(
             std::unique_lock<gid_type::mutex_type>& l, gid_type& gid)
         {
             std::int64_t added_credit = 0;

--- a/src/runtime/parcelset/parcelport.cpp
+++ b/src/runtime/parcelset/parcelport.cpp
@@ -261,7 +261,7 @@ namespace hpx { namespace parcelset
 #endif
 
     ///////////////////////////////////////////////////////////////////////////
-    std::int64_t HPX_EXPORT get_max_inbound_size(parcelport& pp)
+    std::int64_t get_max_inbound_size(parcelport& pp)
     {
         return pp.get_max_inbound_message_size();
     }

--- a/src/runtime/set_parcel_write_handler.cpp
+++ b/src/runtime/set_parcel_write_handler.cpp
@@ -15,7 +15,7 @@
 
 namespace hpx
 {
-    HPX_API_EXPORT parcel_write_handler_type set_parcel_write_handler(
+    parcel_write_handler_type set_parcel_write_handler(
         parcel_write_handler_type const& f)
     {
         runtime_distributed* rt = get_runtime_distributed_ptr();


### PR DESCRIPTION
Step 1 of n in splitting up the libhpx into multiple shared libraries (also me trying to make my PRs slightly smaller...).

I'm starting by unifying the export macros wherever possible (meaning as far as I can tell we don't need all three of `HPX_EXPORT`, `HPX_API_EXPORT`, and `HPX_EXCEPTION_EXPORT`). I'll introduce new macros for exporting from the "core" and "local" libraries in follow up PRs. I've tried to remove export attributes in source files where I think they're unnecessary (the header files already have the export attributes). This is not properly tested though because I don't have access to daint at the moment.