### PR TITLE
Add main documentation page for HEPs

### DIFF
--- a/docs/sphinx/heps.rst
+++ b/docs/sphinx/heps.rst
@@ -1,0 +1,22 @@
+..
+    Copyright (C) 2020 ETH Zurich
+
+    SPDX-License-Identifier: BSL-1.0
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+===========================
+|hpx| Enhancement Proposals
+===========================
+
+|hpx| Enhancement Proposals (HEPs) are proposals for major changes to |hpx| that
+require wider discussion with the |hpx| developers and users before being
+implemented.
+
+.. note::
+
+   As HEPs are a new process for |hpx|, HEPs archived here are currently
+   considered as the final decision regarding a topic, but may receive
+   modifications even after being accepted if deemed necessary. As the process
+   is formalized we may consider HEPs immutable, but they may be modified or
+   superceded by newer HEPs.

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -103,6 +103,7 @@ What's so special about |hpx|?
    :maxdepth: 2
 
    releases
+   heps
    about_hpx
 
 


### PR DESCRIPTION
Not sure we need the note, but thought it might be good to have in this early stage when we're still figuring out how to use these HEP-things.