### PR TITLE
HEP 2: Public API for HPX 2.0.0

### DIFF
--- a/docs/sphinx/heps.rst
+++ b/docs/sphinx/heps.rst
@@ -20,3 +20,7 @@ implemented.
    modifications even after being accepted if deemed necessary. As the process
    is formalized we may consider HEPs immutable, but they may be modified or
    superceded by newer HEPs.
+
+.. toctree::
+
+   /heps/hep2.rst

--- a/docs/sphinx/heps.rst
+++ b/docs/sphinx/heps.rst
@@ -1,0 +1,22 @@
+..
+    Copyright (C) 2020 ETH Zurich
+
+    SPDX-License-Identifier: BSL-1.0
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+===========================
+|hpx| Enhancement Proposals
+===========================
+
+|hpx| Enhancement Proposals (HEPs) are proposals for major changes to |hpx| that
+require wider discussion with the |hpx| developers and users before being
+implemented.
+
+.. note::
+
+   As HEPs are a new process for |hpx|, HEPs archived here are currently
+   considered as the final decision regarding a topic, but may receive
+   modifications even after being accepted if deemed necessary. As the process
+   is formalized we may consider HEPs immutable, but they may be modified or
+   superceded by newer HEPs.

--- a/docs/sphinx/heps/hep2.rst
+++ b/docs/sphinx/heps/hep2.rst
@@ -1,0 +1,310 @@
+HEP 2: The public API for |hpx| 2.0.0
+=====================================
+
+Motivation
+----------
+
+|hpx| has evolved to have a rather ad-hoc organization of functionality into
+namespaces, headers, and libraries. This HEP specifies the public API, and
+through which namespaces and headers the public API is accessible, for |hpx|
+2.0.0.
+
+Implementation
+--------------
+
+The public API is presented as
+
+- ``header name``
+  - ``hpx::x``
+  - ``hpx::y``
+
+where including ``header name`` gives you access to at least ``hpx::x`` and
+``hpx::y``. Functionality may be organized differently internally (both headers
+and namespaces).
+
+Functionality that corresponds to, or extends, standard library functionality,
+will be in the same namespace as in the standard library with ``std`` replaced
+by ``hpx``, and a header ``abc`` replaced by ``hpx/abc.hpp``. Functionality that
+is proposed for the standard library, and may thus be in ``std::experimental``
+and a header ``experimental/abc`` does not need to be in the
+``hpx::experimental`` namespace or a ``hpx/experimental`` header if the
+functionality is considered stable in |hpx|. Distributed extensions to local
+parallelism and concurrency will be in the ``hpx::distributed`` namespace and
+``hpx/distributed`` headers.
+
+Utilities
+.........
+
+- ``hpx/functional.hpp``
+  - ``hpx::function``
+  - ``hpx::unique_function``
+  - ``hpx::function_nonser``
+  - ``hpx::unique_function_nonser``
+  - ``hpx::bind``
+  - ``hpx::bind_front``
+  - ``hpx::bind_back``
+  - ``hpx::invoke``
+  - ``hpx::invoke_fused``
+  - ``hpx::result_of``
+  - more?
+
+- ``hpx/tuple.hpp``
+  - ``hpx::tuple``
+
+- ``hpx/any.hpp``
+  - ``hpx::any``
+
+- ``hpx/optional.hpp``
+  - ``hpx::optional``
+
+- ``hpx/format.hpp``
+  - ``hpx::format``?
+  - other utilities that go with ``format``
+
+- ``hpx/chrono.hpp``
+  - ``hpx::high_resolution_clock``?
+  - ``hpx::high_resolution_timer``?
+  - ``hpx::scoped_timer``?
+
+- ``hpx/exception.hpp``
+  - ``hpx::exception``
+  - ``HPX_THROW_EXCEPTION``
+
+- ``hpx/system_error.hpp``
+  - ``hpx::error_code``
+
+- ``hpx/assert.hpp``
+  - ``HPX_ASSERT``
+
+- ``hpx/serialization.hpp``
+  - what functionality actually needs to be public?
+  - Some classes have intrusive serialization in which case there's no need to
+    include ``serialization.hpp`` to get the serialization support; others have
+    it implemented in the serialization module. Should we just state that using
+    serialization for any class requires including ``hpx/serialization.hpp``
+    even though it may already be included transitively?
+
+Local concurrency and parallelism
+.................................
+
+- ``hpx/future.hpp``
+  - ``hpx::future``
+  - ``hpx::promise``
+  - ``hpx::shared_future``
+  - ``hpx::async``
+  - ``hpx::sync``
+  - ``hpx::apply``
+  - ``hpx::dataflow``
+  - ``hpx::launch_policy`` (or ``hpx::execution::launch_policy``?)
+  - ``hpx::is_future`` and friends
+
+- ``hpx/future.hpp``?
+  - ``hpx::when_all``
+  - ``hpx::wait_all``
+  - ``hpx::when_any``
+  - ``hpx::wait_any``
+  - ``hpx::when_some``
+  - ``hpx::wait_some``
+  - ``hpx::when_each``
+  - ``hpx::wait_each``
+  - ``hpx::split_future``
+
+- ``hpx/thread.hpp``
+  - ``hpx::thread``
+  - ``hpx::this_thread::yield``
+  - ``hpx::this_thread::get_id``
+  - ``hpx::this_thread::sleep_for``
+  - ``hpx::this_thread::sleep_until``
+
+- ``hpx/algorithm.hpp``
+  - ``hpx::for_loop`` and all the other parallel algorithms
+
+- ``hpx/algorithm/for_loop.hpp``
+  - ``hpx::for_loop`` and the same for all other individual algorithms (no need to separate range-based and iterator-based, I believe)
+
+- ``hpx/execution.hpp``
+  - ``hpx::execution::sequenced_policy``
+  - ``hpx::execution::unsequenced_policy``
+  - ``hpx::execution::parallel_sequenced_policy``
+  - ``hpx::execution::parallel_unsequenced_policy``
+  - ``hpx::execution::sequenced_task_policy``
+  - ``hpx::execution::parallel_task_policy``
+  - ``hpx::execution::seq``
+  - ``hpx::execution::unseq`` (or is it ``datapar``...?)
+  - ``hpx::execution::par``
+  - ``hpx::execution::par_unseq``
+  - ``hpx::execution::task``
+
+- ``hpx/execution.hpp``? these should probably be public, despite upcoming changes to executors?
+  - ``hpx::execution::post``?
+  - ``hpx::execution::sync_execute``?
+  - ``hpx::execution::async_execute``?
+  - ``hpx::execution::then_execute``?
+  - ``hpx::execution::bulk_sync_execute``?
+  - ``hpx::execution::bulk_async_execute``?
+  - ``hpx::execution::bulk_then_execute``?
+
+- ``hpx/execution.hpp``?
+  - ``hpx::execution::sequenced_executor``
+  - ``hpx::execution::parallel_executor``
+  - all the other executors? or just a selected subset?
+  - ``hpx::execution::service_executor``
+  - ``hpx::experimental::execution::thread_pool_executor``?
+  - ``hpx::execution::current_executor`` (not sure we need this)
+  - ``hpx::execution::is_executor`` and friends
+
+- ``hpx/execution.hpp``
+  - ``hpx::execution::static_chunk_size`` and other executor parameters
+
+- ``hpx/mutex.hpp``
+  - ``hpx::mutex``
+  - ``hpx::no_mutex``
+  - ``hpx::recursive_mutex``
+  - ``hpx::shared_mutex``
+  - ``hpx::spinlock``
+  - ``hpx::call_once``
+
+- ``hpx/condition_variable.hpp``
+  - ``hpx::condition_variable``
+
+- ``hpx/semaphore.hpp``
+  - ``hpx::counting_semaphore``
+  - ``hpx::sliding_semaphore``
+
+- ``hpx/barrier.hpp``
+  - ``hpx::barrier``
+
+- ``hpx/latch.hpp``
+  - ``hpx::latch``
+
+- ``hpx/channel.hpp``?
+  - ``hpx::channel`` (``hpx::channel_*``?)
+
+- ``hpx/spmd_block.hpp``?
+  - ``hpx::spmd_block``
+
+- ``hpx/task_block.hpp``?
+  - ``hpx::task_block``
+
+Distributed
+...........
+
+- ``hpx/distributed/future.hpp``?
+  - distributed equivalents of ``hpx::promise``, ``hpx::async``, etc.
+
+- ``hpx/distributed/algorithm.hpp``?
+  - distributed equivalents of parallel algorithms
+
+- ``hpx/distributed/latch.hpp``
+  - ``hpx::distributed::latch``
+- ``hpx/distributed/barrier.hpp``
+  - ``hpx::distributed::barrier``
+- etc. to match local headers and namespaces
+
+- ``hpx/distributed/components.hpp``?
+  - ``HPX_REGISTER_COMPONENT``
+  - any other classes, functions, and macros that might be required to write components?
+
+- ``hpx/distributed/actions.hpp``?
+  - ``HPX_REGISTER_ACTION``
+  - any other classes, functions, and macros that might be required to write actions?
+
+- ``hpx/distributed/channel.hpp``?
+  - ``hpx::distributed::channel``
+
+- ``???`` each in a separate header like channel, latch, etc.?
+  - ``hpx::distributed::all_to_all``
+  - ``hpx::distributed::all_reduce``
+  - ``hpx::distributed::broadcast``
+  - ``hpx::distributed::fold``
+  - ``hpx::distributed::gather``
+  - ``hpx::distributed::reduce``
+  - ``hpx::distributed::spmd_block``
+
+- ``hpx/distributed/checkpoint.hpp``?
+  - ``hpx::distributed::checkpoint`` stable?
+  - this is not necessarily distributed only...
+
+- ``hpx/experimental/distributed/resiliency.hpp``?
+  - ``hpx::experimental::distributed::async_replay`` and other resiliency?
+  - ready for public use or still experimental?
+  - the standard libraries use ``std::experimental::x``, perhaps we should just
+    follow that instead? the argument for ``hpx::x::experimental`` wasn't that
+    strong anyway...
+  - this is not necessarily distributed only...
+
+- ``hpx/distributed.hpp``
+  - all above headers
+
+Runtime
+.......
+
+- ``hpx/runtime.hpp``?
+  - ``hpx::get_os_thread_count``
+  - ``hpx::get_worker_thread_num``
+  - ``hpx::get_thread_name``
+  - other ``hpx::get_*`` functions
+  - ``hpx::register_thread``
+  - ``hpx::unregister_thread``
+  - ``hpx::register_startup_function``
+  - ``hpx::register_shutdown_function``
+  - ``hpx::is_*``
+  - ``hpx::state`` (rename to ``hpx::runtime_state`` for the runtime?)
+  - ``hpx::get_locality_id`` this and the following are not quite right here,
+    but they can return reasonable defaults even in the local case...
+  - ``hpx::get_locality_name``
+  - ``hpx::get_num_localities``
+  - note: ``hpx::runtime`` does not need to be public; the above global
+    functions should be enough for interacting with the runtime. They also allow
+    us to have checks that the runtime is created or running (as we already do).
+
+- ``hpx/distributed/runtime.hpp``?
+  - all of the above and (should they be in ``hpx::distributed`` or not?)
+  - ``hpx::find_localities``
+  - ``hpx::find_here``
+
+- ``hpx/init.hpp``?
+  - ``hpx::init`` (rename to ``hpx::start_stop`` or something similar? only
+    leave ``hpx::start`` and ``hpx::stop``? I found the relationship between
+    ``start``, ``stop``, ``init``, and ``finalize`` confusing at least in the
+    beginning.)
+  - ``hpx::start``
+  - ``hpx::stop``
+  - ``hpx::finalize``
+  - ``hpx::resume``?
+  - ``hpx::suspend``?
+  - ``hpx::init_parameters``
+
+- performance counters?
+
+- ``hpx/wrap_main.hpp`` (I propose to rename ``hpx_main.hpp`` to
+  ``wrap_main.hpp`` to avoid confusion with the implicit entry point used by
+  ``hpx::init`` and ``hpx::start`` being ``hpx_main``)
+
+- There is a lot of scheduler and thread pool functionality that we could make
+  public, but I think they're not stable (or conformant?) enough to be
+  considered for the public API. Users may still use them but we don't give the
+  same stability guarantees as for the public API. We could consider putting
+  ``scheduler_base`` and ``thread_pool_base`` in ``hpx::experimental::`` and
+  ``hpx/experimental/execution.hpp`` as they should eventually be stable?
+  - ``hpx::experimental::get_pool``
+  - ``hpx::experimental::partitioner``
+
+Other
+.....
+
+- ``hpx/version.hpp``
+  - ``hpx::major_version`` and all the other version functions
+  - ``HPX_VERSION_MAJOR`` and all the other version macros
+
+|cmake| targets
+...............
+
+TODO
+
+- ``HPX::hpx_core``
+- ``HPX::hpx_local``
+- ``HPX::hpx`` (does not wrap main automatically)
+- ``HPX::wrap_main``
+- ``HPX::x_component``
+- ...

--- a/docs/sphinx/heps/hep2.rst
+++ b/docs/sphinx/heps/hep2.rst
@@ -62,9 +62,9 @@ Utilities
   - other utilities that go with ``format``
 
 - ``hpx/chrono.hpp``
-  - ``hpx::high_resolution_clock``?
-  - ``hpx::high_resolution_timer``?
-  - ``hpx::scoped_timer``?
+  - ``hpx::high_resolution_clock``
+  - ``hpx::high_resolution_timer``
+  - ``hpx::scoped_timer``
 
 - ``hpx/exception.hpp``
   - ``hpx::exception``
@@ -97,8 +97,6 @@ Local concurrency and parallelism
   - ``hpx::dataflow``
   - ``hpx::launch_policy`` (or ``hpx::execution::launch_policy``?)
   - ``hpx::is_future`` and friends
-
-- ``hpx/future.hpp``?
   - ``hpx::when_all``
   - ``hpx::wait_all``
   - ``hpx::when_any``
@@ -119,7 +117,7 @@ Local concurrency and parallelism
 - ``hpx/algorithm.hpp``
   - ``hpx::for_loop`` and all the other parallel algorithms
 
-- ``hpx/algorithm/for_loop.hpp``
+- ``hpx/algorithm/for_loop.hpp``: this is a bonus (i.e. the standard library does not have headers for each individual algorithm)
   - ``hpx::for_loop`` and the same for all other individual algorithms (no need to separate range-based and iterator-based, I believe)
 
 - ``hpx/execution.hpp``
@@ -134,8 +132,6 @@ Local concurrency and parallelism
   - ``hpx::execution::par``
   - ``hpx::execution::par_unseq``
   - ``hpx::execution::task``
-
-- ``hpx/execution.hpp``? these should probably be public, despite upcoming changes to executors?
   - ``hpx::execution::post``?
   - ``hpx::execution::sync_execute``?
   - ``hpx::execution::async_execute``?
@@ -143,8 +139,6 @@ Local concurrency and parallelism
   - ``hpx::execution::bulk_sync_execute``?
   - ``hpx::execution::bulk_async_execute``?
   - ``hpx::execution::bulk_then_execute``?
-
-- ``hpx/execution.hpp``?
   - ``hpx::execution::sequenced_executor``
   - ``hpx::execution::parallel_executor``
   - all the other executors? or just a selected subset?
@@ -152,8 +146,6 @@ Local concurrency and parallelism
   - ``hpx::experimental::execution::thread_pool_executor``?
   - ``hpx::execution::current_executor`` (not sure we need this)
   - ``hpx::execution::is_executor`` and friends
-
-- ``hpx/execution.hpp``
   - ``hpx::execution::static_chunk_size`` and other executor parameters
 
 - ``hpx/mutex.hpp``
@@ -177,42 +169,47 @@ Local concurrency and parallelism
 - ``hpx/latch.hpp``
   - ``hpx::latch``
 
-- ``hpx/channel.hpp``?
-  - ``hpx::channel`` (``hpx::channel_*``?)
+- ``hpx/channel.hpp``
+  - ``hpx::channel``
 
-- ``hpx/spmd_block.hpp``?
+- ``hpx/spmd_block.hpp``
   - ``hpx::spmd_block``
 
-- ``hpx/task_block.hpp``?
+- ``hpx/task_block.hpp``
   - ``hpx::task_block``
 
 Distributed
 ...........
 
-- ``hpx/distributed/future.hpp``?
+- ``hpx/distributed/future.hpp``
   - distributed equivalents of ``hpx::promise``, ``hpx::async``, etc.
 
-- ``hpx/distributed/algorithm.hpp``?
+- ``hpx/distributed/algorithm.hpp``
+  - distributed equivalents of parallel algorithms
+
+- ``hpx/distributed/algorithm/for_loop.hpp``
   - distributed equivalents of parallel algorithms
 
 - ``hpx/distributed/latch.hpp``
   - ``hpx::distributed::latch``
+
 - ``hpx/distributed/barrier.hpp``
   - ``hpx::distributed::barrier``
+
+- ``hpx/distributed/channel.hpp``
+  - ``hpx::distributed::channel``
+
 - etc. to match local headers and namespaces
 
-- ``hpx/distributed/components.hpp``?
+- ``hpx/distributed/components.hpp``
   - ``HPX_REGISTER_COMPONENT``
   - any other classes, functions, and macros that might be required to write components?
 
-- ``hpx/distributed/actions.hpp``?
+- ``hpx/distributed/actions.hpp``
   - ``HPX_REGISTER_ACTION``
   - any other classes, functions, and macros that might be required to write actions?
 
-- ``hpx/distributed/channel.hpp``?
-  - ``hpx::distributed::channel``
-
-- ``???`` each in a separate header like channel, latch, etc.?
+- ``hpx/distributed/x.hpp`` each in a separate header like channel, latch, etc.?
   - ``hpx::distributed::all_to_all``
   - ``hpx::distributed::all_reduce``
   - ``hpx::distributed::broadcast``
@@ -306,5 +303,10 @@ TODO
 - ``HPX::hpx_local``
 - ``HPX::hpx`` (does not wrap main automatically)
 - ``HPX::wrap_main``
-- ``HPX::x_component``
-- ...
+
+- ``HPX::iostream``
+  - in header ``hpx/distributed/iostream.hpp``
+    - ``hpx::distributed::cout``
+    - ``hpx::distributed::cerr``
+- partitioned vector?
+- unordered map?

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -103,6 +103,7 @@ What's so special about |hpx|?
    :maxdepth: 2
 
    releases
+   heps
    about_hpx
 
 


### PR DESCRIPTION
Here's a very rough first draft of the public API for HPX 2.0.0 (although we can already start putting things into place for however many intermediate releases we have before that).

The header and namespace organization is 99% solved by following the standard library conventions. The rest seems to work out quite nicely with `hpx::distributed` for distributed LCOs, and just `hpx` for runtime functionality. I realized the standard libaries do ``std::experimental::abc`` for namespaces so we might actually want to go with ``hpx::experimental::abc`` as well instead of ``hpx::abc::experimental`` as I suggested in #4277. 

Things I've definitely missed:
- Various traits that go with the proposed public functionality. I need to do another pass to see which traits actually need to be public.
- Functionality required for components and actions.
- Everything related to performance counters.
- Components.
- CMake targets.

Things I've intentionally left out:
- Lots of internal functionality. The list is too long to mention.
- Many executors. Some of them could be experimental (`limiting_executor`?). Many of them could or will be removed (thread executors).
- The runtime, thread manager, partitioner classes as they can be accessed through functions like ``hpx::get_locality_id``. The partitioner could be experimental since it is required for runtime initialization. Needs cleanup though (like #4613).
- Thread pools, schedulers. These could also be experimental as I think they're close to being stable, but they would require some cleanup.
- Compute. Do we consider this stable enough?

What have I missed? Please have a look at the list and see if anything you use in your application is missing from the list and should be considered be part of the public API, or at least experimental. Users please comment about missing functionality. @aurianer, @biddisco, @hkaiser, @K-ballo, @sithhell please just push missing things directly to the branch (no force-pushing now! we can clean up the commits at the end).