### PR TITLE
Unify execution parameters customization points

### DIFF
--- a/libs/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
@@ -96,7 +96,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             new buffer_type[combiner(len1, len2)]);
 
         std::size_t cores = execution::processing_units_count(
-            policy.executor(), policy.parameters());
+            policy.parameters(), policy.executor());
 
         std::size_t step = (len1 + cores - 1) / cores;
         boost::shared_array<set_chunk_data> chunks(new set_chunk_data[cores]);

--- a/libs/algorithms/include/hpx/parallel/algorithms/partition.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/partition.hpp
@@ -171,7 +171,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                         std::size_t const cores =
                             execution::processing_units_count(
-                                policy.executor(), policy.parameters());
+                                policy.parameters(), policy.executor());
 
                         std::size_t chunk_size = execution::get_chunk_size(
                             policy.parameters(), policy.executor(),
@@ -857,7 +857,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     return first;
 
                 std::size_t const cores = execution::processing_units_count(
-                    policy.executor(), policy.parameters());
+                    policy.parameters(), policy.executor());
 
                 // TODO: Find more better block size.
                 const std::size_t block_size = std::size_t(20000);

--- a/libs/algorithms/include/hpx/parallel/algorithms/sort.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/sort.hpp
@@ -180,7 +180,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             // figure out the chunk size to use
             std::size_t const cores = execution::processing_units_count(
-                policy.executor(), policy.parameters());
+                policy.parameters(), policy.executor());
 
             std::size_t max_chunks = execution::maximal_number_of_chunks(
                 policy.parameters(), policy.executor(), cores, count);

--- a/libs/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -117,7 +117,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         FwdIter& begin, std::size_t& count, Stride s)
     {
         std::size_t const cores = execution::processing_units_count(
-            policy.executor(), policy.parameters());
+            policy.parameters(), policy.executor());
 
         std::size_t max_chunks = execution::maximal_number_of_chunks(
             policy.parameters(), policy.executor(), cores, count);
@@ -177,7 +177,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         using tuple_type = hpx::util::tuple<FwdIter, std::size_t>;
 
         std::size_t const cores = execution::processing_units_count(
-            policy.executor(), policy.parameters());
+            policy.parameters(), policy.executor());
 
         std::size_t max_chunks = execution::maximal_number_of_chunks(
             policy.parameters(), policy.executor(), cores, count);
@@ -256,7 +256,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         FwdIter begin, std::size_t count, Stride s)
     {
         std::size_t const cores = execution::processing_units_count(
-            policy.executor(), policy.parameters());
+            policy.parameters(), policy.executor());
 
         std::size_t max_chunks = execution::maximal_number_of_chunks(
             policy.parameters(), policy.executor(), cores, count);
@@ -319,7 +319,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         using tuple_type = hpx::util::tuple<FwdIter, std::size_t, std::size_t>;
 
         std::size_t const cores = execution::processing_units_count(
-            policy.executor(), policy.parameters());
+            policy.parameters(), policy.executor());
 
         std::size_t max_chunks = execution::maximal_number_of_chunks(
             policy.parameters(), policy.executor(), cores, count);

--- a/libs/execution/include/hpx/execution/executors/execution_fwd.hpp
+++ b/libs/execution/include/hpx/execution/executors/execution_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2020 Hartmut Kaiser
 //  Copyright (c) 2017 Google
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -58,21 +58,27 @@ namespace hpx { namespace parallel { namespace execution {
         struct post_tag
         {
         };
+
         struct sync_execute_tag
         {
         };
+
         struct async_execute_tag
         {
         };
+
         struct then_execute_tag
         {
         };
+
         struct bulk_sync_execute_tag
         {
         };
+
         struct bulk_async_execute_tag
         {
         };
+
         struct bulk_then_execute_tag
         {
         };

--- a/libs/execution/include/hpx/execution/executors/execution_information.hpp
+++ b/libs/execution/include/hpx/execution/executors/execution_information.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2020 Hartmut Kaiser
 //  Copyright (c) 2017 Google
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -47,82 +47,6 @@ namespace hpx { namespace parallel { inline namespace v3 { namespace detail {
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace parallel { namespace execution { namespace detail {
     /// \cond NOINTERNAL
-
-    ///////////////////////////////////////////////////////////////////////
-    // customization point for interface processing_units_count()
-    template <typename Parameters_>
-    struct processing_units_count_parameter_helper
-    {
-        template <typename Parameters, typename Executor>
-        static std::size_t call(
-            hpx::traits::detail::wrap_int, Parameters&& params, Executor&& exec)
-        {
-            return hpx::get_os_thread_count();
-        }
-
-        template <typename Parameters, typename Executor>
-        static auto call(int, Parameters&& params, Executor&& exec) -> decltype(
-            params.processing_units_count(std::forward<Executor>(exec)))
-        {
-            return params.processing_units_count(std::forward<Executor>(exec));
-        }
-
-        template <typename Executor>
-        static std::size_t call(Parameters_& params, Executor&& exec)
-        {
-            return call(0, params, std::forward<Executor>(exec));
-        }
-
-        template <typename Parameters, typename Executor>
-        static std::size_t call(Parameters params, Executor&& exec)
-        {
-            return call(static_cast<Parameters_&>(params),
-                std::forward<Executor>(exec));
-        }
-    };
-
-    template <typename Parameters, typename Executor>
-    std::size_t call_processing_units_parameter_count(
-        Parameters&& params, Executor&& exec)
-    {
-        return processing_units_count_parameter_helper<
-            typename hpx::util::decay_unwrap<Parameters>::type>::
-            call(
-                std::forward<Parameters>(params), std::forward<Executor>(exec));
-    }
-
-    template <typename Executor>
-    struct processing_units_count_fn_helper<Executor,
-        typename std::enable_if<
-            hpx::traits::is_one_way_executor<Executor>::value ||
-            hpx::traits::is_two_way_executor<Executor>::value ||
-            hpx::traits::is_never_blocking_one_way_executor<Executor>::value>::
-            type>
-    {
-        template <typename AnyExecutor, typename Parameters>
-        HPX_FORCEINLINE static auto call(hpx::traits::detail::wrap_int,
-            AnyExecutor&& exec, Parameters& params)
-            -> decltype(call_processing_units_parameter_count(
-                params, std::forward<AnyExecutor>(exec)))
-        {
-            return call_processing_units_parameter_count(
-                params, std::forward<AnyExecutor>(exec));
-        }
-
-        template <typename AnyExecutor, typename Parameters>
-        HPX_FORCEINLINE static auto call(int, AnyExecutor&& exec, Parameters&)
-            -> decltype(exec.processing_units_count())
-        {
-            return exec.processing_units_count();
-        }
-
-        template <typename AnyExecutor, typename Parameters>
-        struct result
-        {
-            using type = decltype(call(
-                0, std::declval<AnyExecutor>(), std::declval<Parameters&>()));
-        };
-    };
 
     ///////////////////////////////////////////////////////////////////////
     // customization point for interface has_pending_closures()

--- a/libs/execution/include/hpx/execution/executors/execution_information_fwd.hpp
+++ b/libs/execution/include/hpx/execution/executors/execution_information_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2020 Hartmut Kaiser
 //  Copyright (c) 2017 Google
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -23,15 +23,14 @@ namespace hpx { namespace parallel { namespace execution {
     // Define infrastructure for customization points
     namespace detail {
         /// \cond NOINTERNAL
-        struct processing_units_count_tag
-        {
-        };
         struct has_pending_closures_tag
         {
         };
+
         struct get_pu_mask_tag
         {
         };
+
         struct set_scheduler_mode_tag
         {
         };
@@ -42,9 +41,6 @@ namespace hpx { namespace parallel { namespace execution {
     // Executor information customization points
     namespace detail {
         /// \cond NOINTERNAL
-        template <typename Executor, typename Enable = void>
-        struct processing_units_count_fn_helper;
-
         template <typename Executor, typename Enable = void>
         struct has_pending_closures_fn_helper;
 
@@ -58,34 +54,6 @@ namespace hpx { namespace parallel { namespace execution {
 
     namespace detail {
         /// \cond NOINTERNAL
-
-        ///////////////////////////////////////////////////////////////////////
-        // processing_units_count dispatch point
-        template <typename Executor, typename Parameters>
-        HPX_FORCEINLINE auto processing_units_count(
-            Executor&& exec, Parameters& params) ->
-            typename processing_units_count_fn_helper<typename std::decay<
-                Executor>::type>::template result<Executor, Parameters>::type
-        {
-            return processing_units_count_fn_helper<
-                typename std::decay<Executor>::type>::call(0,
-                std::forward<Executor>(exec), params);
-        }
-
-        template <>
-        struct customization_point<processing_units_count_tag>
-        {
-        public:
-            template <typename Executor, typename Parameters>
-            HPX_FORCEINLINE auto operator()(
-                Executor&& exec, Parameters& params) const
-                -> decltype(processing_units_count(
-                    std::forward<Executor>(exec), params))
-            {
-                return processing_units_count(
-                    std::forward<Executor>(exec), params);
-            }
-        };
 
         ///////////////////////////////////////////////////////////////////////
         // has_pending_closures dispatch point
@@ -169,20 +137,6 @@ namespace hpx { namespace parallel { namespace execution {
 
     // define customization points
     namespace {
-        /// Retrieve the number of (kernel-)threads used by the associated
-        /// executor.
-        ///
-        /// \param exec  [in] The executor object to use to extract the
-        ///              requested information for.
-        ///
-        /// \note This calls exec.os_thread_count() if it exists;
-        ///       otherwise it executes hpx::get_os_thread_count().
-        ///
-        constexpr detail::customization_point<
-            detail::processing_units_count_tag> const& processing_units_count =
-            detail::static_const<detail::customization_point<
-                detail::processing_units_count_tag>>::value;
-
         /// Retrieve whether this executor has operations pending or not.
         ///
         /// \param exec  [in] The executor object to use to extract the

--- a/libs/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016-2017 Hartmut Kaiser
+//  Copyright (c) 2016-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -24,21 +24,27 @@ namespace hpx { namespace parallel { namespace execution {
         struct get_chunk_size_tag
         {
         };
+
         struct maximal_number_of_chunks_tag
         {
         };
+
         struct reset_thread_distribution_tag
         {
         };
-        struct count_processing_units_tag
+
+        struct processing_units_count_tag
         {
         };
+
         struct mark_begin_execution_tag
         {
         };
+
         struct mark_end_of_scheduling_tag
         {
         };
+
         struct mark_end_execution_tag
         {
         };
@@ -63,7 +69,7 @@ namespace hpx { namespace parallel { namespace execution {
 
         template <typename Parameters, typename Executor,
             typename Enable = void>
-        struct count_processing_units_fn_helper;
+        struct processing_units_count_fn_helper;
 
         template <typename Parameters, typename Executor,
             typename Enable = void>
@@ -187,16 +193,16 @@ namespace hpx { namespace parallel { namespace execution {
         };
 
         ///////////////////////////////////////////////////////////////////////
-        // count_processing_units dispatch point
+        // processing_units_count dispatch point
         template <typename Parameters, typename Executor>
-        HPX_FORCEINLINE auto count_processing_units(
+        HPX_FORCEINLINE auto processing_units_count(
             Parameters&& params, Executor&& exec) ->
-            typename count_processing_units_fn_helper<
+            typename processing_units_count_fn_helper<
                 typename hpx::util::decay_unwrap<Parameters>::type,
                 typename hpx::util::decay<Executor>::type>::
                 template result<Parameters, Executor>::type
         {
-            return count_processing_units_fn_helper<
+            return processing_units_count_fn_helper<
                 typename hpx::util::decay_unwrap<Parameters>::type,
                 typename hpx::util::decay<Executor>::type>::
                 call(std::forward<Parameters>(params),
@@ -204,17 +210,17 @@ namespace hpx { namespace parallel { namespace execution {
         }
 
         template <>
-        struct customization_point<count_processing_units_tag>
+        struct customization_point<processing_units_count_tag>
         {
         public:
             template <typename Parameters, typename Executor>
             HPX_FORCEINLINE auto operator()(
                 Parameters&& params, Executor&& exec) const
                 -> decltype(
-                    count_processing_units(std::forward<Parameters>(params),
+                    processing_units_count(std::forward<Parameters>(params),
                         std::forward<Executor>(exec)))
             {
-                return count_processing_units(std::forward<Parameters>(params),
+                return processing_units_count(std::forward<Parameters>(params),
                     std::forward<Executor>(exec));
             }
         };
@@ -392,9 +398,9 @@ namespace hpx { namespace parallel { namespace execution {
         ///       object.
         ///
         constexpr detail::customization_point<
-            detail::count_processing_units_tag> const& count_processing_units =
+            detail::processing_units_count_tag> const& processing_units_count =
             detail::static_const<detail::customization_point<
-                detail::count_processing_units_tag>>::value;
+                detail::processing_units_count_tag>>::value;
 
         /// Mark the begin of a parallel algorithm execution
         ///

--- a/libs/execution/tests/unit/CMakeLists.txt
+++ b/libs/execution/tests/unit/CMakeLists.txt
@@ -8,6 +8,7 @@ set(tests
     bulk_async
     created_executor
     executor_parameters
+    executor_parameters_dispatching
     executor_parameters_timer_hooks
     minimal_async_executor
     minimal_sync_executor

--- a/libs/execution/tests/unit/executor_parameters_dispatching.cpp
+++ b/libs/execution/tests/unit/executor_parameters_dispatching.cpp
@@ -1,0 +1,477 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/parallel_executor_parameters.hpp>
+#include <hpx/include/parallel_executors.hpp>
+#include <hpx/testing.hpp>
+
+#include <atomic>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+// This test verifies that all parameters customization points dispatch
+// through the executor before potentially being handled by the parameters
+// object.
+
+std::atomic<std::size_t> params_count(0);
+std::atomic<std::size_t> exec_count(0);
+
+///////////////////////////////////////////////////////////////////////////////
+// get_chunks_size
+
+struct test_executor_get_chunk_size
+  : hpx::parallel::execution::parallel_executor
+{
+    test_executor_get_chunk_size()
+      : hpx::parallel::execution::parallel_executor()
+    {
+    }
+
+    template <typename Parameters, typename F>
+    std::size_t get_chunk_size(
+        Parameters&& params, F&& f, std::size_t cores, std::size_t count)
+    {
+        ++exec_count;
+        return (count + cores - 1) / cores;
+    }
+};
+
+namespace hpx { namespace parallel { namespace execution {
+    template <>
+    struct is_two_way_executor<test_executor_get_chunk_size> : std::true_type
+    {
+    };
+}}}    // namespace hpx::parallel::execution
+
+struct test_chunk_size
+{
+    template <typename Executor, typename F>
+    std::size_t get_chunk_size(
+        Executor&& exec, F&& f, std::size_t cores, std::size_t count)
+    {
+        ++params_count;
+        return (count + cores - 1) / cores;
+    }
+};
+
+namespace hpx { namespace parallel { namespace execution {
+    /// \cond NOINTERNAL
+    template <>
+    struct is_executor_parameters<test_chunk_size> : std::true_type
+    {
+    };
+    /// \endcond
+}}}    // namespace hpx::parallel::execution
+
+///////////////////////////////////////////////////////////////////////////////
+void test_get_chunk_size()
+{
+    {
+        params_count = 0;
+        exec_count = 0;
+
+        hpx::parallel::execution::get_chunk_size(
+            test_chunk_size{}, hpx::parallel::execution::par.executor(),
+            [](std::size_t) { return 0; }, 1, 1);
+
+        HPX_TEST_EQ(params_count, std::size_t(1));
+        HPX_TEST_EQ(exec_count, std::size_t(0));
+    }
+
+    {
+        params_count = 0;
+        exec_count = 0;
+
+        hpx::parallel::execution::get_chunk_size(
+            test_chunk_size{}, test_executor_get_chunk_size{},
+            [](std::size_t) { return 0; }, 1, 1);
+
+        HPX_TEST_EQ(params_count, std::size_t(0));
+        HPX_TEST_EQ(exec_count, std::size_t(1));
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// maximal_number_of_chunks
+
+struct test_executor_maximal_number_of_chunks
+  : hpx::parallel::execution::parallel_executor
+{
+    test_executor_maximal_number_of_chunks()
+      : hpx::parallel::execution::parallel_executor()
+    {
+    }
+
+    template <typename Parameters>
+    std::size_t maximal_number_of_chunks(
+        Parameters&&, std::size_t, std::size_t num_tasks)
+    {
+        ++exec_count;
+        return num_tasks;
+    }
+};
+
+namespace hpx { namespace parallel { namespace execution {
+    template <>
+    struct is_two_way_executor<test_executor_maximal_number_of_chunks>
+      : std::true_type
+    {
+    };
+}}}    // namespace hpx::parallel::execution
+
+struct test_number_of_chunks
+{
+    template <typename Executor>
+    std::size_t maximal_number_of_chunks(
+        Executor&&, std::size_t, std::size_t num_tasks)
+    {
+        ++params_count;
+        return num_tasks;
+    }
+};
+
+namespace hpx { namespace parallel { namespace execution {
+    template <>
+    struct is_executor_parameters<test_number_of_chunks> : std::true_type
+    {
+    };
+}}}    // namespace hpx::parallel::execution
+
+///////////////////////////////////////////////////////////////////////////////
+void test_maximal_number_of_chunks()
+{
+    {
+        params_count = 0;
+        exec_count = 0;
+
+        hpx::parallel::execution::maximal_number_of_chunks(
+            test_number_of_chunks{}, hpx::parallel::execution::par.executor(),
+            1, 1);
+
+        HPX_TEST_EQ(params_count, std::size_t(1));
+        HPX_TEST_EQ(exec_count, std::size_t(0));
+    }
+
+    {
+        params_count = 0;
+        exec_count = 0;
+
+        hpx::parallel::execution::maximal_number_of_chunks(
+            test_number_of_chunks{}, test_executor_maximal_number_of_chunks{},
+            1, 1);
+
+        HPX_TEST_EQ(params_count, std::size_t(0));
+        HPX_TEST_EQ(exec_count, std::size_t(1));
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// reset_thread_distribution
+
+struct test_executor_reset_thread_distribution
+  : hpx::parallel::execution::parallel_executor
+{
+    test_executor_reset_thread_distribution()
+      : hpx::parallel::execution::parallel_executor()
+    {
+    }
+
+    template <typename Parameters>
+    void reset_thread_distribution(Parameters&&)
+    {
+        ++exec_count;
+    }
+};
+
+namespace hpx { namespace parallel { namespace execution {
+    template <>
+    struct is_two_way_executor<test_executor_reset_thread_distribution>
+      : std::true_type
+    {
+    };
+}}}    // namespace hpx::parallel::execution
+
+struct test_thread_distribution
+{
+    void reset_thread_distribution()
+    {
+        ++params_count;
+    }
+};
+
+namespace hpx { namespace parallel { namespace execution {
+    template <>
+    struct is_executor_parameters<test_thread_distribution> : std::true_type
+    {
+    };
+}}}    // namespace hpx::parallel::execution
+
+///////////////////////////////////////////////////////////////////////////////
+void test_reset_thread_distribution()
+{
+    {
+        params_count = 0;
+        exec_count = 0;
+
+        hpx::parallel::execution::reset_thread_distribution(
+            test_thread_distribution{},
+            hpx::parallel::execution::par.executor());
+
+        HPX_TEST_EQ(params_count, std::size_t(1));
+        HPX_TEST_EQ(exec_count, std::size_t(0));
+    }
+
+    {
+        params_count = 0;
+        exec_count = 0;
+
+        hpx::parallel::execution::reset_thread_distribution(
+            test_thread_distribution{},
+            test_executor_reset_thread_distribution{});
+
+        HPX_TEST_EQ(params_count, std::size_t(0));
+        HPX_TEST_EQ(exec_count, std::size_t(1));
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// processing_units_count
+
+struct test_executor_processing_units_count
+  : hpx::parallel::execution::parallel_executor
+{
+    test_executor_processing_units_count()
+      : hpx::parallel::execution::parallel_executor()
+    {
+    }
+
+    std::size_t processing_units_count()
+    {
+        ++exec_count;
+        return 1;
+    }
+};
+
+namespace hpx { namespace parallel { namespace execution {
+    template <>
+    struct is_two_way_executor<test_executor_processing_units_count>
+      : std::true_type
+    {
+    };
+}}}    // namespace hpx::parallel::execution
+
+struct test_processing_units
+{
+    template <typename Executor>
+    std::size_t processing_units_count(Executor&&)
+    {
+        ++params_count;
+        return 1;
+    }
+};
+
+namespace hpx { namespace parallel { namespace execution {
+    template <>
+    struct is_executor_parameters<test_processing_units> : std::true_type
+    {
+    };
+}}}    // namespace hpx::parallel::execution
+
+///////////////////////////////////////////////////////////////////////////////
+void test_processing_units_count()
+{
+    {
+        params_count = 0;
+        exec_count = 0;
+
+        hpx::parallel::execution::processing_units_count(
+            test_processing_units{}, hpx::parallel::execution::par.executor());
+
+        HPX_TEST_EQ(params_count, std::size_t(1));
+        HPX_TEST_EQ(exec_count, std::size_t(0));
+    }
+
+    {
+        params_count = 0;
+        exec_count = 0;
+
+        hpx::parallel::execution::processing_units_count(
+            test_processing_units{}, test_executor_processing_units_count{});
+
+        HPX_TEST_EQ(params_count, std::size_t(0));
+        HPX_TEST_EQ(exec_count, std::size_t(1));
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// mark_begin_execution, mark_end_of_scheduling, mark_end_execution
+
+struct test_executor_begin_end : hpx::parallel::execution::parallel_executor
+{
+    test_executor_begin_end()
+      : hpx::parallel::execution::parallel_executor()
+    {
+    }
+
+    template <typename Parameters>
+    void mark_begin_execution(Parameters&&)
+    {
+        ++exec_count;
+    }
+
+    template <typename Parameters>
+    void mark_end_of_scheduling(Parameters&&)
+    {
+        ++exec_count;
+    }
+
+    template <typename Parameters>
+    void mark_end_execution(Parameters&&)
+    {
+        ++exec_count;
+    }
+};
+
+namespace hpx { namespace parallel { namespace execution {
+    template <>
+    struct is_two_way_executor<test_executor_begin_end> : std::true_type
+    {
+    };
+}}}    // namespace hpx::parallel::execution
+
+struct test_begin_end
+{
+    template <typename Executor>
+    void mark_begin_execution(Executor&&)
+    {
+        ++params_count;
+    }
+
+    template <typename Executor>
+    void mark_end_of_scheduling(Executor&&)
+    {
+        ++params_count;
+    }
+
+    template <typename Executor>
+    void mark_end_execution(Executor&&)
+    {
+        ++params_count;
+    }
+};
+
+namespace hpx { namespace parallel { namespace execution {
+    template <>
+    struct is_executor_parameters<test_begin_end> : std::true_type
+    {
+    };
+}}}    // namespace hpx::parallel::execution
+
+///////////////////////////////////////////////////////////////////////////////
+void test_mark_begin_execution()
+{
+    {
+        params_count = 0;
+        exec_count = 0;
+
+        hpx::parallel::execution::mark_begin_execution(
+            test_begin_end{}, hpx::parallel::execution::par.executor());
+
+        HPX_TEST_EQ(params_count, std::size_t(1));
+        HPX_TEST_EQ(exec_count, std::size_t(0));
+    }
+
+    {
+        params_count = 0;
+        exec_count = 0;
+
+        hpx::parallel::execution::mark_begin_execution(
+            test_begin_end{}, test_executor_begin_end{});
+
+        HPX_TEST_EQ(params_count, std::size_t(0));
+        HPX_TEST_EQ(exec_count, std::size_t(1));
+    }
+}
+
+void test_mark_end_of_scheduling()
+{
+    {
+        params_count = 0;
+        exec_count = 0;
+
+        hpx::parallel::execution::mark_end_of_scheduling(
+            test_begin_end{}, hpx::parallel::execution::par.executor());
+
+        HPX_TEST_EQ(params_count, std::size_t(1));
+        HPX_TEST_EQ(exec_count, std::size_t(0));
+    }
+
+    {
+        params_count = 0;
+        exec_count = 0;
+
+        hpx::parallel::execution::mark_end_of_scheduling(
+            test_begin_end{}, test_executor_begin_end{});
+
+        HPX_TEST_EQ(params_count, std::size_t(0));
+        HPX_TEST_EQ(exec_count, std::size_t(1));
+    }
+}
+
+void test_mark_end_execution()
+{
+    {
+        params_count = 0;
+        exec_count = 0;
+
+        hpx::parallel::execution::mark_end_execution(
+            test_begin_end{}, hpx::parallel::execution::par.executor());
+
+        HPX_TEST_EQ(params_count, std::size_t(1));
+        HPX_TEST_EQ(exec_count, std::size_t(0));
+    }
+
+    {
+        params_count = 0;
+        exec_count = 0;
+
+        hpx::parallel::execution::mark_end_execution(
+            test_begin_end{}, test_executor_begin_end{});
+
+        HPX_TEST_EQ(params_count, std::size_t(0));
+        HPX_TEST_EQ(exec_count, std::size_t(1));
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main()
+{
+    test_get_chunk_size();
+    test_maximal_number_of_chunks();
+    test_reset_thread_distribution();
+    test_processing_units_count();
+    test_mark_begin_execution();
+    test_mark_end_of_scheduling();
+    test_mark_end_execution();
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(
+        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/thread_executors/include/hpx/thread_executors/thread_execution_information.hpp
+++ b/libs/thread_executors/include/hpx/thread_executors/thread_execution_information.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -23,7 +23,7 @@ namespace hpx { namespace threads {
     template <typename Executor, typename Parameters>
     typename std::enable_if<hpx::traits::is_threads_executor<Executor>::value,
         std::size_t>::type
-    processing_units_count(Executor&& exec, Parameters&)
+    processing_units_count(Parameters&&, Executor&& exec)
     {
         return hpx::get_os_thread_count(exec);
     }

--- a/libs/thread_executors/tests/unit/resource_manager.cpp
+++ b/libs/thread_executors/tests/unit/resource_manager.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016-2017 Hartmut Kaiser
+//  Copyright (c) 2016-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -75,7 +75,7 @@ void test_executors(std::size_t processing_units, std::size_t num_pus)
         for (Executor& exec : execs)
         {
             HPX_TEST_EQ(hpx::parallel::execution::processing_units_count(
-                            exec, test::dummy),
+                            test::dummy, exec),
                 num_pus);
         }
 
@@ -93,7 +93,7 @@ void test_executors(std::size_t processing_units, std::size_t num_pus)
         for (Executor& exec : execs)
         {
             HPX_TEST_EQ(hpx::parallel::execution::processing_units_count(
-                            exec, test::dummy),
+                            test::dummy, exec),
                 num_pus);
         }
     }
@@ -134,7 +134,7 @@ void test_executors_shrink(std::size_t processing_units, std::size_t num_pus)
     hpx::this_thread::yield();
 
     HPX_TEST_EQ(hpx::parallel::execution::processing_units_count(
-                    shrink_exec, test::dummy),
+                    test::dummy, shrink_exec),
         processing_units);
 
     std::size_t num_execs = (processing_units - 1) / num_pus;
@@ -152,13 +152,13 @@ void test_executors_shrink(std::size_t processing_units, std::size_t num_pus)
         for (Executor& exec : execs)
         {
             HPX_TEST_EQ(hpx::parallel::execution::processing_units_count(
-                            exec, test::dummy),
+                            test::dummy, exec),
                 num_pus);
         }
 
         // the main executor should run on a reduced amount of cores
         HPX_TEST_EQ(hpx::parallel::execution::processing_units_count(
-                        shrink_exec, test::dummy),
+                        test::dummy, shrink_exec),
             processing_units - num_execs * num_pus);
 
         // schedule a couple of tasks on each of the executors
@@ -175,13 +175,13 @@ void test_executors_shrink(std::size_t processing_units, std::size_t num_pus)
         for (Executor& exec : execs)
         {
             HPX_TEST_EQ(hpx::parallel::execution::processing_units_count(
-                            exec, test::dummy),
+                            test::dummy, exec),
                 num_pus);
         }
 
         // the main executor should run on a reduced amount of cores
         HPX_TEST_EQ(hpx::parallel::execution::processing_units_count(
-                        shrink_exec, test::dummy),
+                        test::dummy, shrink_exec),
             processing_units - num_execs * num_pus);
     }
 
@@ -193,7 +193,9 @@ void test_executors_shrink(std::size_t num_pus)
     using namespace hpx::parallel::execution;
     std::size_t processing_units = hpx::get_os_thread_count();
 
-    processing_units = (processing_units / num_pus) * num_pus;
+    // we should have at least one processing unit
+    processing_units =
+        (std::max)((processing_units / num_pus) * num_pus, std::size_t(1));
 
 #if defined(HPX_HAVE_LOCAL_SCHEDULER)
     test_executors_shrink<local_queue_executor>(processing_units, num_pus);


### PR DESCRIPTION
- This unifies the processing of all execution parameters customization
  points such that all invocations are dispatched through the executor
  first before handled by the parameters object (if the executor does not
  implement the functionality)
- This also consolidates the customization points `count_processing_units`
  and `processing_units_count` by removing the former as it was never used
  anywhere. This is a slightly breaking change, which shouldn't have any
  impact on existing code.
