### PR TITLE
Adding C++20 counting semaphore API

### DIFF
--- a/libs/synchronization/CMakeLists.txt
+++ b/libs/synchronization/CMakeLists.txt
@@ -11,7 +11,10 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 # Default location is $HPX_ROOT/libs/synchronization/include
 set(synchronization_headers
     hpx/barrier.hpp
+    hpx/condition_variable.hpp
     hpx/latch.hpp
+    hpx/semaphore.hpp
+    hpx/stop_token.hpp
     hpx/synchronization/barrier.hpp
     hpx/synchronization/condition_variable.hpp
     hpx/synchronization/counting_semaphore.hpp

--- a/libs/synchronization/include/hpx/condition_variable.hpp
+++ b/libs/synchronization/include/hpx/condition_variable.hpp
@@ -1,0 +1,21 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/synchronization/condition_variable.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+// C++20 condition_variable
+
+namespace hpx {
+
+    using hpx::lcos::local::condition_variable;
+    using hpx::lcos::local::condition_variable_any;
+
+    using hpx::lcos::local::cv_status;
+}    // namespace hpx

--- a/libs/synchronization/include/hpx/semaphore.hpp
+++ b/libs/synchronization/include/hpx/semaphore.hpp
@@ -1,0 +1,42 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/synchronization/counting_semaphore.hpp>
+
+#include <cstddef>
+
+///////////////////////////////////////////////////////////////////////////////
+// C++20 counting semaphores
+
+namespace hpx {
+
+    // Semaphores are lightweight synchronization primitives used to constrain
+    // concurrent access to a shared resource. They are widely used to
+    // implement other synchronization primitives and, whenever both are
+    // applicable, can be more efficient than condition variables.
+
+    // A counting semaphore is a semaphore object that models a non - negative
+    // resource count. A binary semaphore is a semaphore object that has only
+    // two states.
+    //
+    // Class template counting_semaphore maintains an internal counter that is
+    // initialized when the semaphore is created. The counter is decremented
+    // when a thread acquires the semaphore, and is incremented when a thread
+    // releases the semaphore. If a thread tries to acquire the semaphore when
+    // the counter is zero, the thread will block until another thread
+    // increments the counter by releasing the semaphore.
+    template <std::ptrdiff_t LeastMaxValue = PTRDIFF_MAX>
+    using counting_semaphore =
+        hpx::lcos::local::cpp20_counting_semaphore<LeastMaxValue>;
+
+    // A binary semaphore should be more efficient than the default
+    // implementation of a counting semaphore with a unit resource count.
+    using binary_semaphore = hpx::lcos::local::cpp20_binary_semaphore<>;
+
+}    // namespace hpx

--- a/libs/synchronization/include/hpx/stop_token.hpp
+++ b/libs/synchronization/include/hpx/stop_token.hpp
@@ -1,0 +1,12 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/synchronization/stop_token.hpp>
+
+// C++20 stop_token

--- a/libs/synchronization/include/hpx/synchronization/counting_semaphore.hpp
+++ b/libs/synchronization/include/hpx/synchronization/counting_semaphore.hpp
@@ -10,7 +10,9 @@
 #include <hpx/config.hpp>
 #include <hpx/synchronization/detail/counting_semaphore.hpp>
 #include <hpx/synchronization/spinlock.hpp>
+#include <hpx/timing/steady_clock.hpp>
 
+#include <cstddef>
 #include <cstdint>
 #include <mutex>
 #include <utility>
@@ -22,87 +24,227 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace lcos { namespace local {
-    /// A semaphore is a protected variable (an entity storing a value) or
-    /// abstract data type (an entity grouping several variables that may or
-    /// may not be numerical) which constitutes the classic method for
-    /// restricting access to shared resources, such as shared memory, in a
-    /// multiprogramming environment. Semaphores exist in many variants, though
-    /// usually the term refers to a counting semaphore, since a binary
-    /// semaphore is better known as a mutex. A counting semaphore is a counter
-    /// for a set of available resources, rather than a locked/unlocked flag of
-    /// a single resource. It was invented by Edsger Dijkstra. Semaphores are
-    /// the classic solution to preventing race conditions in the dining
-    /// philosophers problem, although they do not prevent resource deadlocks.
-    ///
-    /// Counting semaphores can be used for synchronizing multiple threads as
-    /// well: one thread waiting for several other threads to touch (signal)
-    /// the semaphore, or several threads waiting for one other thread to touch
-    /// this semaphore.
-    template <typename Mutex = hpx::lcos::local::spinlock, int N = 0>
-    class counting_semaphore_var
+    // A semaphore is a protected variable (an entity storing a value) or
+    // abstract data type (an entity grouping several variables that may or
+    // may not be numerical) which constitutes the classic method for
+    // restricting access to shared resources, such as shared memory, in a
+    // multiprogramming environment. Semaphores exist in many variants, though
+    // usually the term refers to a counting semaphore, since a binary
+    // semaphore is better known as a mutex. A counting semaphore is a counter
+    // for a set of available resources, rather than a locked/unlocked flag of
+    // a single resource. It was invented by Edsger Dijkstra. Semaphores are
+    // the classic solution to preventing race conditions in the dining
+    // philosophers problem, although they do not prevent resource deadlocks.
+    //
+    // Counting semaphores can be used for synchronizing multiple threads as
+    // well: one thread waiting for several other threads to touch (signal)
+    // the semaphore, or several threads waiting for one other thread to touch
+    // this semaphore.
+    template <std::ptrdiff_t LeastMaxValue = PTRDIFF_MAX,
+        typename Mutex = hpx::lcos::local::spinlock>
+    class cpp20_counting_semaphore
     {
-    private:
-        typedef Mutex mutex_type;
+    public:
+        HPX_NON_COPYABLE(cpp20_counting_semaphore);
+
+    protected:
+        using mutex_type = Mutex;
 
     public:
-        /// \brief Construct a new counting semaphore
-        ///
-        /// \param value    [in] The initial value of the internal semaphore
-        ///                 lock count. Normally this value should be zero
-        ///                 (which is the default), values greater than zero
-        ///                 are equivalent to the same number of signals pre-
-        ///                 set, and negative values are equivalent to the
-        ///                 same number of waits pre-set.
-        counting_semaphore_var(std::int64_t value = N)
+        // Returns The maximum value of counter. This value is greater than or
+        // equal to LeastMaxValue.
+        static constexpr std::ptrdiff_t(max)() noexcept
+        {
+            return LeastMaxValue;
+        }
+
+        // \brief Construct a new counting semaphore
+        //
+        // \param value    [in] The initial value of the internal semaphore
+        //                 lock count. Normally this value should be zero
+        //                 (which is the default), values greater than zero
+        //                 are equivalent to the same number of signals pre-
+        //                 set, and negative values are equivalent to the
+        //                 same number of waits pre-set.
+        //
+        //  Preconditions   value >= 0 is true, and value <= max() is true.
+        //  Effects         Initializes counter with desired.
+        //  Throws          Nothing.
+        explicit cpp20_counting_semaphore(std::ptrdiff_t value)
           : sem_(value)
         {
         }
 
-        /// \brief Wait for the semaphore to be signaled
-        ///
-        /// \param count    [in] The value by which the internal lock count will
-        ///                 be decremented. At the same time this is the minimum
-        ///                 value of the lock count at which the thread is not
-        ///                 yielded.
-        void wait(std::int64_t count = 1)
+        ~cpp20_counting_semaphore() = default;
+
+        // Preconditions:   update >= 0 is true, and update <= max() - counter
+        //                  is true.
+        // Effects:         Atomically execute counter += update. Then, unblocks
+        //                  any threads that are waiting for counter to be
+        //                  greater than zero.
+        // Synchronization: Strongly happens before invocations of try_acquire
+        //                  that observe the result of the effects.
+        // Throws:          system_error when an exception is required
+        //                  ([thread.req.exception]).
+        // Error conditions: Any of the error conditions allowed for mutex
+        //                  types ([thread.mutex.requirements.mutex]).
+        void release(std::ptrdiff_t update = 1)
         {
             std::unique_lock<mutex_type> l(mtx_);
-            sem_.wait(l, count);
+            sem_.signal(std::move(l), update);
         }
 
-        /// \brief Try to wait for the semaphore to be signaled
-        ///
-        /// \param count    [in] The value by which the internal lock count will
-        ///                 be decremented. At the same time this is the minimum
-        ///                 value of the lock count at which the thread is not
-        ///                 yielded.
-        ///
-        /// \returns        The function returns true if the calling thread was
-        ///                 able to acquire the requested amount of credits.
-        ///                 The function returns false if not sufficient credits
-        ///                 are available at this point in time.
-        bool try_wait(std::int64_t count = 1)
+        // Effects:         Attempts to atomically decrement counter if it is
+        //                  positive, without blocking. If counter is not
+        //                  decremented, there is no effect and try_acquire
+        //                  immediately returns. An implementation may fail to
+        //                  decrement counter even if it is positive. [ Note:
+        //                  This spurious failure is normally uncommon, but
+        //                  allows interesting implementations based on a simple
+        //                  compare and exchange ([atomics]). - end note ]
+        //                  An implementation should ensure that try_acquire
+        //                  does not consistently return false in the absence
+        //                  of contending semaphore operations.
+        // Returns:         true if counter was decremented, otherwise false.
+        bool try_acquire() noexcept
         {
             std::unique_lock<mutex_type> l(mtx_);
-            return sem_.try_wait(l, count);
+            return sem_.try_acquire(l);
+        }
+
+        // Effects:         Repeatedly performs the following steps, in order:
+        //                    - Evaluates try_acquire. If the result is true,
+        //                      returns.
+        //                    - Blocks on *this until counter is greater than
+        //                      zero.
+        // Throws:          system_error when an exception is required
+        //                  ([thread.req.exception]).
+        // Error conditions: Any of the error conditions allowed for mutex
+        //                  types ([thread.mutex.requirements.mutex]).
+        void acquire()
+        {
+            std::unique_lock<mutex_type> l(mtx_);
+            sem_.wait(l, 1);
+        }
+
+        // Effects:         Repeatedly performs the following steps, in order:
+        //                    - Evaluates try_acquire(). If the result is true,
+        //                      returns true.
+        //                    - Blocks on *this until counter is greater than
+        //                      zero or until the timeout expires. If it is
+        //                      unblocked by the timeout expiring, returns false.
+        //                  The timeout expires ([thread.req.timing]) when the
+        //                  current time is after abs_time (for
+        //                  try_acquire_until) or when at least rel_time has
+        //                  passed from the start of the function (for
+        //                  try_acquire_for).
+        // Throws:          Timeout - related exceptions ([thread.req.timing]),
+        //                  or system_error when a non - timeout - related
+        //                  exception is required ([thread.req.exception]).
+        // Error conditions: Any of the error conditions allowed for mutex types
+        //                  ([thread.mutex.requirements.mutex]).
+        bool try_acquire_until(util::steady_time_point const& abs_time)
+        {
+            std::unique_lock<mutex_type> l(mtx_);
+            return sem_.wait_until(l, abs_time, 1);
+        }
+
+        bool try_acquire_for(util::steady_duration const& rel_time)
+        {
+            return try_acquire_until(rel_time.from_now());
+        }
+
+    protected:
+        mutable mutex_type mtx_;
+        detail::counting_semaphore sem_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Mutex = hpx::lcos::local::spinlock>
+    class cpp20_binary_semaphore : public cpp20_counting_semaphore<1, Mutex>
+    {
+    public:
+        HPX_NON_COPYABLE(cpp20_binary_semaphore);
+
+    public:
+        cpp20_binary_semaphore(std::ptrdiff_t value = 1)
+          : cpp20_counting_semaphore<1, Mutex>(value)
+        {
+        }
+
+        ~cpp20_binary_semaphore() = default;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Mutex = hpx::lcos::local::spinlock, int N = 0>
+    class counting_semaphore_var : cpp20_counting_semaphore<PTRDIFF_MAX, Mutex>
+    {
+    private:
+        using mutex_type = Mutex;
+
+    public:
+        // \brief Construct a new counting semaphore
+        //
+        // \param value    [in] The initial value of the internal semaphore
+        //                 lock count. Normally this value should be zero
+        //                 (which is the default), values greater than zero
+        //                 are equivalent to the same number of signals pre-
+        //                 set, and negative values are equivalent to the
+        //                 same number of waits pre-set.
+        //
+        //  Preconditions   value >= 0 is true, and value <= max() is true.
+        //  Effects         Initializes counter with desired.
+        //  Throws          Nothing.
+        explicit counting_semaphore_var(std::ptrdiff_t value = N)
+          : cpp20_counting_semaphore<PTRDIFF_MAX, Mutex>(value)
+        {
+        }
+
+        counting_semaphore_var(counting_semaphore_var const&) = delete;
+        counting_semaphore_var& operator=(
+            counting_semaphore_var const&) = delete;
+
+        // \brief Wait for the semaphore to be signaled
+        //
+        // \param count    [in] The value by which the internal lock count will
+        //                 be decremented. At the same time this is the minimum
+        //                 value of the lock count at which the thread is not
+        //                 yielded.
+        void wait(std::ptrdiff_t count = 1)
+        {
+            std::unique_lock<mutex_type> l(this->mtx_);
+            this->sem_.wait(l, count);
+        }
+
+        // \brief Try to wait for the semaphore to be signaled
+        //
+        // \param count    [in] The value by which the internal lock count will
+        //                 be decremented. At the same time this is the minimum
+        //                 value of the lock count at which the thread is not
+        //                 yielded.
+        //
+        // \returns        The function returns true if the calling thread was
+        //                 able to acquire the requested amount of credits.
+        //                 The function returns false if not sufficient credits
+        //                 are available at this point in time.
+        bool try_wait(std::ptrdiff_t count = 1)
+        {
+            std::unique_lock<mutex_type> l(this->mtx_);
+            return this->sem_.try_wait(l, count);
         }
 
         /// \brief Signal the semaphore
-        void signal(std::int64_t count = 1)
+        void signal(std::ptrdiff_t count = 1)
         {
-            std::unique_lock<mutex_type> l(mtx_);
-            sem_.signal(std::move(l), count);
+            std::unique_lock<mutex_type> l(this->mtx_);
+            this->sem_.signal(std::move(l), count);
         }
 
-        std::int64_t signal_all()
+        std::ptrdiff_t signal_all()
         {
-            std::unique_lock<mutex_type> l(mtx_);
-            return sem_.signal_all(std::move(l));
+            std::unique_lock<mutex_type> l(this->mtx_);
+            return this->sem_.signal_all(std::move(l));
         }
-
-    private:
-        mutable mutex_type mtx_;
-        detail::counting_semaphore sem_;
     };
 
     typedef counting_semaphore_var<> counting_semaphore;

--- a/libs/synchronization/tests/unit/CMakeLists.txt
+++ b/libs/synchronization/tests/unit/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 set(tests
     barrier_cpp20
+    binary_semaphore_cpp20
     channel_mpmc_fib
     channel_mpmc_shift
     channel_mpsc_fib
@@ -14,6 +15,7 @@ set(tests
     channel_spsc_shift
     condition_variable
     counting_semaphore
+    counting_semaphore_cpp20
     latch_cpp20
     local_latch
     local_barrier
@@ -27,6 +29,7 @@ set(tests
 )
 
 set(barrier_cpp20_PARAMETERS THREADS_PER_LOCALITY 4)
+set(binary_semaphore_cpp20_PARAMETERS THREADS_PER_LOCALITY 4)
 set(channel_mpmc_fib_PARAMETERS THREADS_PER_LOCALITY 4)
 set(channel_mpmc_shift_PARAMETERS THREADS_PER_LOCALITY 4)
 set(channel_mpsc_fib_PARAMETERS THREADS_PER_LOCALITY 4)
@@ -35,6 +38,7 @@ set(channel_spsc_fib_PARAMETERS THREADS_PER_LOCALITY 4)
 set(channel_spsc_shift_PARAMETERS THREADS_PER_LOCALITY 4)
 
 set(counting_semaphore_PARAMETERS THREADS_PER_LOCALITY 4)
+set(counting_semaphore_cpp20_PARAMETERS THREADS_PER_LOCALITY 4)
 
 set(latch_cpp20_PARAMETERS THREADS_PER_LOCALITY 4)
 set(local_barrier_PARAMETERS THREADS_PER_LOCALITY 4)

--- a/libs/synchronization/tests/unit/binary_semaphore_cpp20.cpp
+++ b/libs/synchronization/tests/unit/binary_semaphore_cpp20.cpp
@@ -1,0 +1,189 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (C) 2013 Tim Blechmann
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_main.hpp>
+
+#include <hpx/synchronization.hpp>
+#include <hpx/testing.hpp>
+#include <hpx/threading.hpp>
+
+#include <chrono>
+
+void test_semaphore_release_acquire()
+{
+    hpx::binary_semaphore sem;
+
+    sem.release();
+    sem.acquire();
+}
+
+void test_semaphore_try_acquire()
+{
+    hpx::binary_semaphore sem(0);
+
+    HPX_TEST(!sem.try_acquire());
+    sem.release();
+    HPX_TEST(sem.try_acquire());
+}
+
+struct semaphore_acquire_and_release_test
+{
+    void run()
+    {
+        hpx::thread release_thread(
+            &semaphore_acquire_and_release_test::acquire_and_release, this);
+        sem_.acquire();
+        release_thread.join();
+    }
+
+    void acquire_and_release()
+    {
+        hpx::this_thread::sleep_for(std::chrono::seconds(1));
+        sem_.release();
+    }
+
+    hpx::binary_semaphore sem_;
+};
+
+void test_semaphore_acquire_and_release()
+{
+    semaphore_acquire_and_release_test test;
+    test.run();
+}
+
+void test_semaphore_try_acquire_for()
+{
+    hpx::binary_semaphore sem(0);
+
+    auto start = std::chrono::system_clock::now();
+
+    HPX_TEST(!sem.try_acquire_for(std::chrono::milliseconds(500)));
+
+    auto end = std::chrono::system_clock::now();
+    auto acquire_time = end - start;
+
+    // guessing!
+    HPX_TEST(acquire_time > std::chrono::milliseconds(450));
+    HPX_TEST(acquire_time < std::chrono::milliseconds(1000));
+
+    sem.release();
+
+    HPX_TEST(sem.try_acquire_for(std::chrono::milliseconds(500)));
+}
+
+void test_semaphore_try_acquire_until()
+{
+    hpx::binary_semaphore sem(0);
+
+    {
+        auto now = std::chrono::system_clock::now();
+        auto timeout = now + std::chrono::milliseconds(500);
+
+        HPX_TEST(!sem.try_acquire_until(timeout));
+
+        auto end = std::chrono::system_clock::now();
+        auto timeout_delta = end - timeout;
+
+        // guessing!
+        HPX_TEST(timeout_delta > std::chrono::milliseconds(-400));
+        HPX_TEST(timeout_delta < std::chrono::milliseconds(400));
+    }
+
+    sem.release();
+
+    {
+        auto start = std::chrono::system_clock::now();
+        auto timeout = start + std::chrono::milliseconds(500);
+
+        HPX_TEST(sem.try_acquire_until(timeout));
+
+        auto end = std::chrono::system_clock::now();
+
+        // guessing!
+        HPX_TEST((end - start) < std::chrono::milliseconds(100));
+    }
+}
+
+void test_semaphore_try_acquire_for_until()
+{
+    hpx::binary_semaphore sem(0);
+
+    // Relative timeouts
+    {
+        auto start = std::chrono::system_clock::now();
+
+        HPX_TEST(!sem.try_acquire_for(std::chrono::milliseconds(500)));
+
+        auto end = std::chrono::system_clock::now();
+        auto acquire_time = end - start;
+
+        // guessing!
+        HPX_TEST(acquire_time > std::chrono::milliseconds(450));
+        HPX_TEST(acquire_time < std::chrono::milliseconds(1000));
+
+        sem.release();
+
+        HPX_TEST(sem.try_acquire_for(std::chrono::milliseconds(500)));
+    }
+
+    // Absolute timeouts
+    {
+        auto now = std::chrono::system_clock::now();
+        auto timeout = now + std::chrono::milliseconds(500);
+
+        HPX_TEST(!sem.try_acquire_until(timeout));
+
+        auto end = std::chrono::system_clock::now();
+        auto timeout_delta = end - timeout;
+
+        // guessing!
+        HPX_TEST(timeout_delta > std::chrono::milliseconds(-400));
+        HPX_TEST(timeout_delta < std::chrono::milliseconds(400));
+    }
+
+    sem.release();
+
+    {
+        auto start = std::chrono::system_clock::now();
+        auto timeout = start + std::chrono::milliseconds(500);
+
+        HPX_TEST(sem.try_acquire_until(timeout));
+
+        auto end = std::chrono::system_clock::now();
+
+        // guessing!
+        HPX_TEST((end - start) < std::chrono::milliseconds(100));
+    }
+
+    sem.release();
+
+    {
+        // timed acquire after timeout
+        hpx::binary_semaphore sema;
+
+        auto start = std::chrono::steady_clock::now();
+        auto timeout = start + std::chrono::milliseconds(100);
+
+        hpx::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+        sema.release();
+
+        HPX_TEST(sema.try_acquire_until(timeout));
+    }
+}
+
+int main()
+{
+    test_semaphore_release_acquire();
+    test_semaphore_try_acquire();
+    test_semaphore_acquire_and_release();
+    test_semaphore_try_acquire_for();
+    test_semaphore_try_acquire_until();
+    test_semaphore_try_acquire_for_until();
+
+    return hpx::util::report_errors();
+}

--- a/libs/synchronization/tests/unit/counting_semaphore_cpp20.cpp
+++ b/libs/synchronization/tests/unit/counting_semaphore_cpp20.cpp
@@ -1,0 +1,204 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (C) 2013 Tim Blechmann
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_main.hpp>
+
+#include <hpx/synchronization.hpp>
+#include <hpx/testing.hpp>
+#include <hpx/threading.hpp>
+
+#include <chrono>
+
+void test_semaphore_release_acquire()
+{
+    hpx::counting_semaphore<> sem(1);
+
+    sem.release();
+    sem.acquire();
+}
+
+void test_semaphore_try_acquire()
+{
+    hpx::counting_semaphore<> sem(0);
+
+    HPX_TEST(!sem.try_acquire());
+    sem.release();
+    HPX_TEST(sem.try_acquire());
+}
+
+void test_semaphore_initial_count()
+{
+    hpx::counting_semaphore<> sem(2);
+
+    HPX_TEST(sem.try_acquire());
+    HPX_TEST(sem.try_acquire());
+    HPX_TEST(!sem.try_acquire());
+}
+
+struct semaphore_acquire_and_release_test
+{
+    semaphore_acquire_and_release_test()
+      : sem_(1)
+    {
+    }
+
+    void run()
+    {
+        hpx::thread release_thread(
+            &semaphore_acquire_and_release_test::acquire_and_release, this);
+        sem_.acquire();
+        release_thread.join();
+    }
+
+    void acquire_and_release()
+    {
+        hpx::this_thread::sleep_for(std::chrono::seconds(1));
+        sem_.release();
+    }
+
+    hpx::counting_semaphore<> sem_;
+};
+
+void test_semaphore_acquire_and_release()
+{
+    semaphore_acquire_and_release_test test;
+    test.run();
+}
+
+void test_semaphore_try_acquire_for()
+{
+    hpx::counting_semaphore<> sem(0);
+
+    auto start = std::chrono::system_clock::now();
+
+    HPX_TEST(!sem.try_acquire_for(std::chrono::milliseconds(500)));
+
+    auto end = std::chrono::system_clock::now();
+    auto acquire_time = end - start;
+
+    // guessing!
+    HPX_TEST(acquire_time > std::chrono::milliseconds(450));
+    HPX_TEST(acquire_time < std::chrono::milliseconds(1000));
+
+    sem.release();
+
+    HPX_TEST(sem.try_acquire_for(std::chrono::milliseconds(500)));
+}
+
+void test_semaphore_try_acquire_until()
+{
+    hpx::counting_semaphore<> sem(0);
+
+    {
+        auto now = std::chrono::system_clock::now();
+        auto timeout = now + std::chrono::milliseconds(500);
+
+        HPX_TEST(!sem.try_acquire_until(timeout));
+
+        auto end = std::chrono::system_clock::now();
+        auto timeout_delta = end - timeout;
+
+        // guessing!
+        HPX_TEST(timeout_delta > std::chrono::milliseconds(-400));
+        HPX_TEST(timeout_delta < std::chrono::milliseconds(400));
+    }
+
+    sem.release();
+
+    {
+        auto start = std::chrono::system_clock::now();
+        auto timeout = start + std::chrono::milliseconds(500);
+
+        HPX_TEST(sem.try_acquire_until(timeout));
+
+        auto end = std::chrono::system_clock::now();
+
+        // guessing!
+        HPX_TEST((end - start) < std::chrono::milliseconds(100));
+    }
+}
+
+void test_semaphore_try_acquire_for_until()
+{
+    hpx::counting_semaphore<> sem(0);
+
+    // Relative timeouts
+    {
+        auto start = std::chrono::system_clock::now();
+
+        HPX_TEST(!sem.try_acquire_for(std::chrono::milliseconds(500)));
+
+        auto end = std::chrono::system_clock::now();
+        auto acquire_time = end - start;
+
+        // guessing!
+        HPX_TEST(acquire_time > std::chrono::milliseconds(450));
+        HPX_TEST(acquire_time < std::chrono::milliseconds(1000));
+
+        sem.release();
+
+        HPX_TEST(sem.try_acquire_for(std::chrono::milliseconds(500)));
+    }
+
+    // Absolute timeouts
+    {
+        auto now = std::chrono::system_clock::now();
+        auto timeout = now + std::chrono::milliseconds(500);
+
+        HPX_TEST(!sem.try_acquire_until(timeout));
+
+        auto end = std::chrono::system_clock::now();
+        auto timeout_delta = end - timeout;
+
+        // guessing!
+        HPX_TEST(timeout_delta > std::chrono::milliseconds(-400));
+        HPX_TEST(timeout_delta < std::chrono::milliseconds(400));
+    }
+
+    sem.release();
+
+    {
+        auto start = std::chrono::system_clock::now();
+        auto timeout = start + std::chrono::milliseconds(500);
+
+        HPX_TEST(sem.try_acquire_until(timeout));
+
+        auto end = std::chrono::system_clock::now();
+
+        // guessing!
+        HPX_TEST((end - start) < std::chrono::milliseconds(100));
+    }
+
+    sem.release();
+
+    {
+        // timed acquire after timeout
+        hpx::counting_semaphore<> sema(1);
+
+        auto start = std::chrono::steady_clock::now();
+        auto timeout = start + std::chrono::milliseconds(100);
+
+        hpx::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+        sema.release();
+
+        HPX_TEST(sema.try_acquire_until(timeout));
+    }
+}
+
+int main()
+{
+    test_semaphore_release_acquire();
+    test_semaphore_try_acquire();
+    test_semaphore_initial_count();
+    test_semaphore_acquire_and_release();
+    test_semaphore_try_acquire_for();
+    test_semaphore_try_acquire_until();
+    test_semaphore_try_acquire_for_until();
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/component/action_invoke_no_more_than.hpp
+++ b/tests/unit/component/action_invoke_no_more_than.hpp
@@ -18,6 +18,7 @@
 #include <hpx/traits/is_future.hpp>
 #include <hpx/type_support/static.hpp>
 
+#include <cstddef>
 #include <memory>
 #include <type_traits>
 #include <utility>
@@ -48,8 +49,8 @@ namespace hpx { namespace actions { namespace detail
     struct action_decorate_function_semaphore
     {
         typedef lcos::local::counting_semaphore_var<
-                hpx::lcos::local::spinlock, N
-            > semaphore_type;
+                hpx::lcos::local::spinlock, N>
+            semaphore_type;
 
         struct tag {};
 


### PR DESCRIPTION
- adding `hpx::binary_semaphore`
- adding `hpx/counting_semaphore.hpp` that imports it into namespace hpx
- flyby: adding `hpx/condition_variable.hpp` and `hpx/stop_token.hpp` headers for
         conformance. This also imports `lcos::local::conditional_variable`
         into namespace hpx
