### PR TITLE
Adding C++20 latch API

### DIFF
--- a/libs/synchronization/CMakeLists.txt
+++ b/libs/synchronization/CMakeLists.txt
@@ -10,6 +10,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # Default location is $HPX_ROOT/libs/synchronization/include
 set(synchronization_headers
+    hpx/latch.hpp
     hpx/synchronization/barrier.hpp
     hpx/synchronization/condition_variable.hpp
     hpx/synchronization/counting_semaphore.hpp

--- a/libs/synchronization/include/hpx/latch.hpp
+++ b/libs/synchronization/include/hpx/latch.hpp
@@ -1,0 +1,14 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/synchronization/latch.hpp>
+
+namespace hpx {
+
+    using latch = hpx::lcos::local::cpp20_latch;
+}

--- a/libs/synchronization/include/hpx/synchronization/latch.hpp
+++ b/libs/synchronization/include/hpx/synchronization/latch.hpp
@@ -16,6 +16,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <mutex>
 #include <utility>
 
@@ -25,26 +26,12 @@ namespace hpx { namespace lcos { namespace local {
     /// threads to block until an operation is completed. An individual latch
     /// is a singleuse object; once the operation has been completed, the latch
     /// cannot be reused.
-    ///
-    /// A latch maintains an internal counter_ that is initialized when the
-    /// latch is created. Threads may block at a synchronization point waiting
-    /// for counter_ to be decremented to 0. When counter_ reaches 0, all such
-    /// blocked threads are released.
-    ///
-    /// Calls to countdown_and_wait() , count_down() , wait() , is_ready(),
-    /// count_up() , and reset() behave as atomic operations.
-    ///
-    /// \note   A \a local::latch is not a LCO in the sense that it has no
-    ///         global id and it can't be triggered using the action (parcel)
-    ///         mechanism. Use lcos::latch instead if this is required.
-    ///         It is just a low level synchronization primitive allowing to
-    ///         synchronize a given number of \a threads.
-    class latch
+    class cpp20_latch
     {
     public:
-        HPX_NON_COPYABLE(latch);
+        HPX_NON_COPYABLE(cpp20_latch);
 
-    private:
+    protected:
         typedef lcos::local::spinlock mutex_type;
 
     public:
@@ -54,7 +41,7 @@ namespace hpx { namespace lcos { namespace local {
         /// Synchronization: None
         /// Postconditions: counter_ == count.
         ///
-        explicit latch(std::ptrdiff_t count)
+        explicit cpp20_latch(std::ptrdiff_t count)
           : mtx_()
           , cond_()
           , counter_(count)
@@ -72,32 +59,20 @@ namespace hpx { namespace lcos { namespace local {
         /// \note It is the caller's responsibility to ensure that no other
         ///       thread enters wait() after one thread has called the
         ///       destructor. This may require additional coordination.
-        ~latch()
+#if defined(HPX_DEBUG)
+        ~cpp20_latch()
         {
             HPX_ASSERT(counter_ == 0);
         }
+#else
+        ~cpp20_latch() = default;
+#endif
 
-        /// Decrements counter_ by 1 . Blocks at the synchronization point
-        /// until counter_ reaches 0.
-        ///
-        /// Requires: counter_ > 0.
-        ///
-        /// Synchronization: Synchronizes with all calls that block on this
-        /// latch and with all is_ready calls on this latch that return true.
-        ///
-        /// \throws Nothing.
-        ///
-        void count_down_and_wait()
+        /// Returns:        The maximum value of counter that the implementation
+        ///                 supports.
+        static constexpr std::ptrdiff_t(max)() noexcept
         {
-            std::unique_lock<mutex_type> l(mtx_.data_);
-            HPX_ASSERT(counter_ > 0);
-            if (--counter_ == 0)
-            {
-                notified_ = true;
-                cond_.data_.notify_all(std::move(l));    // release the threads
-            }
-            else
-                cond_.data_.wait(l, "hpx::local::latch::count_down_and_wait");
+            return PTRDIFF_MAX;
         }
 
         /// Decrements counter_ by n. Does not block.
@@ -105,30 +80,29 @@ namespace hpx { namespace lcos { namespace local {
         /// Requires: counter_ >= n and n >= 0.
         ///
         /// Synchronization: Synchronizes with all calls that block on this
-        /// latch and with all is_ready calls on this latch that return true .
+        /// latch and with all try_wait calls on this latch that return true .
         ///
         /// \throws Nothing.
         ///
-        void count_down(std::ptrdiff_t n)
+        void count_down(std::ptrdiff_t update)
         {
-            HPX_ASSERT(n >= 0);
+            HPX_ASSERT(update >= 0);
 
-            std::ptrdiff_t new_count = (counter_ -= n);
+            std::unique_lock<mutex_type> l(mtx_.data_);
+
+            std::ptrdiff_t new_count = (counter_ -= update);
             HPX_ASSERT(new_count >= 0);
 
             if (new_count == 0)
             {
-                std::unique_lock<mutex_type> l(mtx_.data_);
                 notified_ = true;
                 cond_.data_.notify_all(std::move(l));    // release the threads
             }
         }
 
-        /// Returns: counter_ == 0. Does not block.
-        ///
-        /// \throws Nothing.
-        ///
-        bool is_ready() const noexcept
+        /// Returns:        With very low probability false. Otherwise
+        ///                 counter == 0.
+        bool try_wait() const noexcept
         {
             return counter_.load(std::memory_order_acquire) == 0;
         }
@@ -143,7 +117,107 @@ namespace hpx { namespace lcos { namespace local {
         {
             std::unique_lock<mutex_type> l(mtx_.data_);
             if (counter_.load(std::memory_order_relaxed) > 0 || !notified_)
-                cond_.data_.wait(l, "hpx::local::latch::wait");
+            {
+                cond_.data_.wait(l, "hpx::local::cpp20_latch::wait");
+            }
+        }
+
+        /// Effects: Equivalent to:
+        ///             count_down(update);
+        ///             wait();
+        void arrive_and_wait(std::ptrdiff_t update = 1)
+        {
+            HPX_ASSERT(update >= 0);
+
+            std::unique_lock<mutex_type> l(mtx_.data_);
+
+            std::ptrdiff_t new_count = (counter_ -= update);
+            HPX_ASSERT(new_count >= 0);
+
+            if (new_count == 0)
+            {
+                notified_ = true;
+                cond_.data_.notify_all(std::move(l));    // release the threads
+            }
+            else
+            {
+                cond_.data_.wait(
+                    l, "hpx::local::cpp20_latch::count_down_and_wait");
+            }
+        }
+
+    protected:
+        mutable util::cache_line_data<mutex_type> mtx_;
+        mutable util::cache_line_data<local::detail::condition_variable> cond_;
+        std::atomic<std::ptrdiff_t> counter_;
+        bool notified_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// A latch maintains an internal counter_ that is initialized when the
+    /// latch is created. Threads may block at a synchronization point waiting
+    /// for counter_ to be decremented to 0. When counter_ reaches 0, all such
+    /// blocked threads are released.
+    ///
+    /// Calls to countdown_and_wait() , count_down() , wait() , is_ready(),
+    /// count_up() , and reset() behave as atomic operations.
+    ///
+    /// \note   A \a local::latch is not an LCO in the sense that it has no
+    ///         global id and it can't be triggered using the action (parcel)
+    ///         mechanism. Use lcos::latch instead if this is required.
+    ///         It is just a low level synchronization primitive allowing to
+    ///         synchronize a given number of \a threads.
+    class latch : public cpp20_latch
+    {
+    public:
+        HPX_NON_COPYABLE(latch);
+
+    public:
+        /// Initialize the latch
+        ///
+        /// Requires: count >= 0.
+        /// Synchronization: None
+        /// Postconditions: counter_ == count.
+        ///
+        explicit latch(std::ptrdiff_t count)
+          : cpp20_latch(count)
+        {
+        }
+
+        /// Requires: No threads are blocked at the synchronization point.
+        ///
+        /// \note May be called even if some threads have not yet returned
+        ///       from wait() or count_down_and_wait(), provided that counter_
+        ///       is 0.
+        /// \note The destructor might not return until all threads have exited
+        ///       wait() or count_down_and_wait().
+        /// \note It is the caller's responsibility to ensure that no other
+        ///       thread enters wait() after one thread has called the
+        ///       destructor. This may require additional coordination.
+        ~latch() = default;
+
+        /// Decrements counter_ by 1 . Blocks at the synchronization point
+        /// until counter_ reaches 0.
+        ///
+        /// Requires: counter_ > 0.
+        ///
+        /// Synchronization: Synchronizes with all calls that block on this
+        /// latch and with all is_ready calls on this latch that return true.
+        ///
+        /// \throws Nothing.
+        ///
+        void count_down_and_wait()
+        {
+            cpp20_latch::arrive_and_wait();
+        }
+
+        /// Returns: counter_ == 0. Does not block.
+        ///
+        /// \throws Nothing.
+        ///
+        bool is_ready() const noexcept
+        {
+            return cpp20_latch::try_wait();
         }
 
         void abort_all()
@@ -188,11 +262,5 @@ namespace hpx { namespace lcos { namespace local {
             HPX_ASSERT(notified_);
             notified_ = false;
         }
-
-    protected:
-        mutable util::cache_line_data<mutex_type> mtx_;
-        mutable util::cache_line_data<local::detail::condition_variable> cond_;
-        std::atomic<std::ptrdiff_t> counter_;
-        bool notified_;
     };
 }}}    // namespace hpx::lcos::local

--- a/libs/synchronization/tests/unit/CMakeLists.txt
+++ b/libs/synchronization/tests/unit/CMakeLists.txt
@@ -13,6 +13,7 @@ set(tests
     channel_spsc_shift
     condition_variable
     counting_semaphore
+    latch_cpp20
     local_latch
     local_barrier
     local_barrier_count_up
@@ -33,6 +34,7 @@ set(channel_spsc_shift_PARAMETERS THREADS_PER_LOCALITY 4)
 
 set(counting_semaphore_PARAMETERS THREADS_PER_LOCALITY 4)
 
+set(latch_cpp20_PARAMETERS THREADS_PER_LOCALITY 4)
 set(local_barrier_PARAMETERS THREADS_PER_LOCALITY 4)
 set(local_latch_PARAMETERS THREADS_PER_LOCALITY 4)
 set(local_event_PARAMETERS THREADS_PER_LOCALITY 4)

--- a/libs/synchronization/tests/unit/latch_cpp20.cpp
+++ b/libs/synchronization/tests/unit/latch_cpp20.cpp
@@ -1,0 +1,115 @@
+//  Copyright (c) 2015-2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+
+#include <hpx/async.hpp>
+#include <hpx/latch.hpp>
+#include <hpx/testing.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <functional>
+#include <vector>
+
+#define NUM_THREADS std::size_t(100)
+
+///////////////////////////////////////////////////////////////////////////////
+std::atomic<std::size_t> num_threads(0);
+
+///////////////////////////////////////////////////////////////////////////////
+void test_arrive_and_wait(hpx::latch& l)
+{
+    ++num_threads;
+
+    HPX_TEST(!l.try_wait());
+    l.arrive_and_wait();
+}
+
+void test_count_down(hpx::latch& l)
+{
+    ++num_threads;
+
+    HPX_TEST(!l.try_wait());
+    l.count_down(NUM_THREADS);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main()
+{
+    // arraive_and_wait
+    {
+        hpx::latch l(NUM_THREADS + 1);
+        HPX_TEST(!l.try_wait());
+
+        std::vector<hpx::future<void>> results;
+        for (std::ptrdiff_t i = 0; i != NUM_THREADS; ++i)
+        {
+            results.push_back(hpx::async(&test_arrive_and_wait, std::ref(l)));
+        }
+
+        HPX_TEST(!l.try_wait());
+
+        // Wait for all threads to reach this point.
+        l.arrive_and_wait();
+
+        hpx::wait_all(results);
+
+        HPX_TEST(l.try_wait());
+        HPX_TEST_EQ(num_threads.load(), NUM_THREADS);
+    }
+
+    // count_down
+    {
+        num_threads.store(0);
+
+        hpx::latch l(NUM_THREADS + 1);
+        HPX_TEST(!l.try_wait());
+
+        hpx::future<void> f = hpx::async(&test_count_down, std::ref(l));
+
+        HPX_TEST(!l.try_wait());
+        l.arrive_and_wait();
+
+        f.get();
+
+        HPX_TEST(l.try_wait());
+        HPX_TEST_EQ(num_threads.load(), std::size_t(1));
+    }
+
+    // wait
+    {
+        num_threads.store(0);
+
+        hpx::latch l(NUM_THREADS);
+        HPX_TEST(!l.try_wait());
+
+        std::vector<hpx::future<void>> results;
+        for (std::ptrdiff_t i = 0; i != NUM_THREADS; ++i)
+        {
+            results.push_back(hpx::async(&test_arrive_and_wait, std::ref(l)));
+        }
+
+        hpx::wait_all(results);
+
+        l.wait();
+
+        HPX_TEST(l.try_wait());
+        HPX_TEST_EQ(num_threads.load(), NUM_THREADS);
+    }
+
+    HPX_TEST_EQ(hpx::finalize(), 0);
+    return 0;
+}
+
+int main(int argc, char* argv[])
+{
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(
+        hpx::init(argc, argv), 0, "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/threading/CMakeLists.txt
+++ b/libs/threading/CMakeLists.txt
@@ -8,7 +8,9 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-set(threading_headers hpx/threading/jthread.hpp hpx/threading/thread.hpp)
+set(threading_headers hpx/thread.hpp hpx/threading/jthread.hpp
+                      hpx/threading/thread.hpp
+)
 
 set(threading_compat_headers hpx/runtime/threads/thread.hpp)
 

--- a/libs/threading/include/hpx/thread.hpp
+++ b/libs/threading/include/hpx/thread.hpp
@@ -1,0 +1,10 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/threading/jthread.hpp>
+#include <hpx/threading/thread.hpp>


### PR DESCRIPTION
- adding `hpx/latch.hpp` that imports `hpx::lcos::local::latch` into namespace hpx
- flyby: adding `hpx/thread.hpp` for compatibility
