### PR TITLE
Add a pre-commit hook script to check file formatting

### DIFF
--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# simple pre commit hook script to check that *.cpp and *.hpp files 
+# are correctly clang-formatted and that CMakeLists.txt and *.cmake
+# files are cmake-formatted
+
+# to install this hook, copy this file to your git hooks as follows
+# cp tools/pre-commit .git/hooks/pre-commit
+# chmod +x .git/hooks/pre-commit
+
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+yellow=$(tput setaf 3)
+blue=$(tput setaf 4)
+normal=$(tput sgr0)
+
+cxxfiles=()
+for file in `git diff --cached --name-only --diff-filter=ACMRT | grep -E "\.(cpp|hpp)$"`; do
+    if ! cmp -s <(git show :${file}) <(git show :${file}|clang-format -style=file); then
+        cxxfiles+=("${file}")
+    fi
+done
+
+cmakefiles=()
+for file in `git diff --cached --name-only --diff-filter=ACMRT | grep -E "(CMakeLists\.txt|\.cmake)$"`; do
+    if ! cmp -s <(git show :${file}) <(git show :${file}|cmake-format); then
+        cmakefiles+=("${file}")
+    fi
+done
+
+returncode=0
+
+if [ -n "${cxxfiles}" ]; then
+    printf "# ${blue}clang-format ${red}error pre-commit${normal} : To fix run the following (use git commit ${yellow}--no-verify${normal} to bypass)\n"
+    for f in "${cxxfiles[@]}" ; do
+        printf "clang-format -style=file -i %s\n" "$f"
+    done
+    returncode=1
+fi
+
+if [ -n "${cmakefiles}" ]; then
+    printf "# ${green}cmake-format ${red}error pre-commit${normal} : To fix run the following (use git commit ${yellow}--no-verify${normal} to bypass)\n"
+    for f in "${cmakefiles[@]}" ; do
+        printf "cmake-format -i %s\n" "$f"
+    done
+    returncode=1
+fi
+
+exit $returncode

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -1,10 +1,20 @@
 #!/bin/bash
 
+# Copyright (c) 2019 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# ----------------------------------------------------------------
 # simple pre commit hook script to check that *.cpp and *.hpp files 
 # are correctly clang-formatted and that CMakeLists.txt and *.cmake
 # files are cmake-formatted
 
-# to install this hook, copy this file to your git hooks as follows
+# To use this hook, you must have clang-format and cmake-format
+# installed on your system
+
+# To install this hook, copy this file to your git hooks as follows
 # cp tools/pre-commit .git/hooks/pre-commit
 # chmod +x .git/hooks/pre-commit
 
@@ -33,7 +43,7 @@ returncode=0
 if [ -n "${cxxfiles}" ]; then
     printf "# ${blue}clang-format ${red}error pre-commit${normal} : To fix run the following (use git commit ${yellow}--no-verify${normal} to bypass)\n"
     for f in "${cxxfiles[@]}" ; do
-        printf "clang-format -style=file -i %s\n" "$f"
+        printf "clang-format -i %s\n" "$f"
     done
     returncode=1
 fi


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/941548/82331647-b36bc880-99e4-11ea-919a-ff728442e4fd.png)

The use of clang-format and cmake-format in HPX makes it
tedious to check that formatting of files is correct prior to commits;
this hook can be installed to run checks on files that are about to be
committed.

To install the hook, copy the file to your git hooks as follows
```
cp tools/pre-commit .git/hooks/pre-commit
chmod +x .git/hooks/pre-commit
```
If all files are ok, then the commit will happen as normal,
but if any file fails the clang/cmake format checks, then the commit
will be aborted and a message such as the following will be displayed
(see image above)

```
clang-format -style=file -i libs/compute_cuda/include/hpx/compute/cuda.hpp
clang-format -style=file -i libs/cuda_support/include/hpx/cuda_support/target.hpp
cmake-format -i libs/compute_cuda/CMakeLists.txt
cmake-format -i libs/cuda_support/test.cmake
```
The format of the message is intended to allow you to copy and paste it
into your terminal and execute the fixes immediately. Automatic
formatting could be done, but has not been implemented as most
developers will probably prefer to have direct control of the process.