### PR TITLE
Fixing support for mpirun (and similar)

### DIFF
--- a/libs/resource_partitioner/CMakeLists.txt
+++ b/libs/resource_partitioner/CMakeLists.txt
@@ -48,6 +48,7 @@ add_hpx_module(
     hpx_functional
     hpx_hardware
     hpx_memory
+    hpx_mpi_base
     hpx_pack_traversal
     hpx_plugin
     hpx_program_options

--- a/libs/threading_base/include/hpx/threading_base/scheduler_base.hpp
+++ b/libs/threading_base/include/hpx/threading_base/scheduler_base.hpp
@@ -251,8 +251,9 @@ namespace hpx { namespace threads { namespace policies {
             switch (stacksize)
             {
             case thread_stacksize_small:
+                HPX_FALLTHROUGH;
+            case thread_stacksize_current:
                 return thread_queue_init_.small_stacksize_;
-                break;
 
             case thread_stacksize_medium:
                 return thread_queue_init_.medium_stacksize_;

--- a/src/hpx_init.cpp
+++ b/src/hpx_init.cpp
@@ -19,7 +19,6 @@
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/functional/function.hpp>
 #include <hpx/hpx_user_main_config.hpp>
-#include <hpx/mpi_base.hpp>
 #include <hpx/logging.hpp>
 #include <hpx/program_options/options_description.hpp>
 #include <hpx/program_options/parsers.hpp>
@@ -397,19 +396,6 @@ namespace hpx
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
             util::detail::init_logging(
                 cms.rtcfg_, cms.rtcfg_.mode_ == runtime_mode_console);
-#endif
-
-#if (defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_MPI)) ||      \
-    defined(HPX_HAVE_LIB_MPI)
-            // getting localities from MPI environment (support mpirun)
-            if (util::mpi_environment::check_mpi_environment(cms.rtcfg_))
-            {
-                util::mpi_environment::init(&argc, &argv, cms.rtcfg_);
-                cms.num_localities_ =
-                    static_cast<std::size_t>(util::mpi_environment::size());
-                cms.node_ =
-                    static_cast<std::size_t>(util::mpi_environment::rank());
-            }
 #endif
 
 #if defined(HPX_HAVE_NETWORKING)


### PR DESCRIPTION
- Checking MPI environment before initializing the runtime
- flyby: handling stack size problem for newly created threads
