### PR TITLE
Runtime type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -654,6 +654,7 @@ jobs:
                   tests.unit.modules.futures \
                   tests.unit.modules.hardware \
                   tests.unit.modules.hashing \
+                  tests.unit.modules.init_runtime \
                   tests.unit.modules.iterator_support \
                   tests.unit.modules.lcos_distributed \
                   tests.unit.modules.async_local \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1489,6 +1489,15 @@ if(HPX_WITH_PROMISE_ALIAS_COMPATIBILITY)
   hpx_add_config_define(HPX_HAVE_PROMISE_ALIAS_COMPATIBILITY)
 endif()
 
+# HPX_WITH_UNSCOPED_ENUM_COMPATIBILITY : introduced in V1.5.0
+hpx_option(
+  HPX_WITH_UNSCOPED_ENUM_COMPATIBILITY BOOL
+  "Enable deprecated unscoped enums (default: ON)" ON ADVANCED
+)
+if(HPX_WITH_UNSCOPED_ENUM_COMPATIBILITY)
+  hpx_add_config_define(HPX_HAVE_UNSCOPED_ENUM_COMPATIBILITY)
+endif()
+
 # ##############################################################################
 # Check for compiler compatibility
 #

--- a/examples/heartbeat/heartbeat.cpp
+++ b/examples/heartbeat/heartbeat.cpp
@@ -147,6 +147,6 @@ int main(int argc, char* argv[])
 
     hpx::util::function_nonser<void()> const empty;
     return hpx::init(desc_commandline, argc, argv, cfg, empty,
-        empty, hpx::runtime_mode_connect);
+        empty, hpx::runtime_mode::connect);
 }
 

--- a/examples/quickstart/init_globally.cpp
+++ b/examples/quickstart/init_globally.cpp
@@ -68,7 +68,7 @@ char** __argv = *_NSGetArgv();
 // (locality 0). In order to create an HPX instance which connects to a running
 // HPX application two changes have to be made:
 //
-//  - replace hpx::runtime_mode_console with hpx::runtime_mode_connect
+//  - replace hpx::runtime_mode::console with hpx::runtime_mode::connect
 //  - replace hpx::finalize() with hpx::disconnect()
 //
 struct manage_global_runtime
@@ -94,7 +94,7 @@ struct manage_global_runtime
         hpx::util::function_nonser<int(int, char**)> start_function =
             hpx::util::bind(&manage_global_runtime::hpx_main, this, _1, _2);
 
-        if (!hpx::start(start_function, __argc, __argv, cfg, hpx::runtime_mode_console))
+        if (!hpx::start(start_function, __argc, __argv, cfg, hpx::runtime_mode::console))
         {
             // Something went wrong while initializing the runtime.
             // This early we can't generate any output, just bail out.

--- a/examples/throttle/throttle_client.cpp
+++ b/examples/throttle/throttle_client.cpp
@@ -101,6 +101,6 @@ int main(int argc, char* argv[])
     };
 
     hpx::util::function_nonser<void()> const empty;
-    return hpx::init(cmdline, argc, argv, cfg, empty, empty, hpx::runtime_mode_connect);
+    return hpx::init(cmdline, argc, argv, cfg, empty, empty, hpx::runtime_mode::connect);
 }
 

--- a/hpx/runtime/agas/addressing_service.hpp
+++ b/hpx/runtime/agas/addressing_service.hpp
@@ -179,14 +179,14 @@ public:
     ///        locality.
     bool is_console() const
     {
-        return runtime_type == runtime_mode_console;
+        return runtime_type == runtime_mode::console;
     }
 
     /// \brief Returns whether this addressing_service is connecting to a
     ///        running application
     bool is_connecting() const
     {
-        return runtime_type == runtime_mode_connect;
+        return runtime_type == runtime_mode::connect;
     }
 
     bool resolve_locally_known_addresses(

--- a/libs/command_line_handling/include/hpx/command_line_handling/command_line_handling.hpp
+++ b/libs/command_line_handling/include/hpx/command_line_handling/command_line_handling.hpp
@@ -42,7 +42,7 @@ namespace hpx { namespace util {
     struct command_line_handling
     {
         command_line_handling()
-          : rtcfg_(nullptr, runtime_mode_default)
+          : rtcfg_(nullptr, runtime_mode::default_)
           , node_(std::size_t(-1))
           , num_threads_(1)
           , num_cores_(1)

--- a/libs/command_line_handling/include/hpx/command_line_handling/parse_command_line.hpp
+++ b/libs/command_line_handling/include/hpx/command_line_handling/parse_command_line.hpp
@@ -32,7 +32,7 @@ namespace hpx { namespace util {
         hpx::program_options::options_description const& app_options,
         std::string const& cmdline, hpx::program_options::variables_map& vm,
         std::size_t node, int error_mode = return_on_error,
-        hpx::runtime_mode mode = runtime_mode_default,
+        hpx::runtime_mode mode = runtime_mode::default_,
         hpx::program_options::options_description* visible = nullptr,
         std::vector<std::string>* unregistered_options = nullptr);
 
@@ -41,7 +41,7 @@ namespace hpx { namespace util {
         std::string const& arg0, std::vector<std::string> const& args,
         hpx::program_options::variables_map& vm, std::size_t node,
         int error_mode = return_on_error,
-        hpx::runtime_mode mode = runtime_mode_default,
+        hpx::runtime_mode mode = runtime_mode::default_,
         hpx::program_options::options_description* visible = nullptr,
         std::vector<std::string>* unregistered_options = nullptr);
 

--- a/libs/command_line_handling/src/command_line_handling.cpp
+++ b/libs/command_line_handling/src/command_line_handling.cpp
@@ -867,14 +867,14 @@ namespace hpx { namespace util {
             // The default mode is console, i.e. all workers need to be
             // started with --worker/-w.
             rtcfg_.mode_ = hpx::runtime_mode_console;
-            if (vm.count("hpx:console") + vm.count("hpx:worker") +
-                    vm.count("hpx:connect") >
+            if (vm.count("hpx:local") + vm.count("hpx:console") +
+                    vm.count("hpx:worker") + vm.count("hpx:connect") >
                 1)
             {
                 throw hpx::detail::command_line_error(
                     "Ambiguous command line options. "
-                    "Do not specify more than one of --hpx:console, "
-                    "--hpx:worker, or --hpx:connect");
+                    "Do not specify more than one of --hpx:local, "
+                    "--hpx:console, --hpx:worker, or --hpx:connect");
             }
 
             // In these cases we default to executing with an empty
@@ -897,103 +897,113 @@ namespace hpx { namespace util {
             {
                 rtcfg_.mode_ = hpx::runtime_mode_connect;
             }
-#else
+            else if (vm.count("hpx:local"))
+            {
+                rtcfg_.mode_ = hpx::runtime_mode_local;
+            }
+#elif defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
             rtcfg_.mode_ = hpx::runtime_mode_console;
+#else
+            rtcfg_.mode_ = hpx::runtime_mode_local;
 #endif
         }
 
 #if defined(HPX_HAVE_NETWORKING)
-        // we initialize certain settings if --node is specified (or data
-        // has been retrieved from the environment)
-        if (rtcfg_.mode_ == hpx::runtime_mode_connect)
+        if (rtcfg_.mode_ != hpx::runtime_mode_local)
         {
-            // when connecting we need to select a unique port
-            hpx_port = cfgmap.get_value<std::uint16_t>("hpx.parcel.port",
-                hpx::util::from_string<std::uint16_t>(rtcfg_.get_entry(
-                    "hpx.parcel.port", HPX_CONNECTING_IP_PORT)));
+            // we initialize certain settings if --node is specified (or data
+            // has been retrieved from the environment)
+            if (rtcfg_.mode_ == hpx::runtime_mode_connect)
+            {
+                // when connecting we need to select a unique port
+                hpx_port = cfgmap.get_value<std::uint16_t>("hpx.parcel.port",
+                    hpx::util::from_string<std::uint16_t>(rtcfg_.get_entry(
+                        "hpx.parcel.port", HPX_CONNECTING_IP_PORT)));
 
 #if !defined(HPX_HAVE_RUN_MAIN_EVERYWHERE)
-            // do not execute any explicit hpx_main except if asked
-            // otherwise
-            if (!vm.count("hpx:run-hpx-main") &&
-                !cfgmap.get_value<int>("hpx.run_hpx_main", 0))
-            {
-                util::detail::reset_function(hpx_main_f_);
-            }
+                // do not execute any explicit hpx_main except if asked
+                // otherwise
+                if (!vm.count("hpx:run-hpx-main") &&
+                    !cfgmap.get_value<int>("hpx.run_hpx_main", 0))
+                {
+                    util::detail::reset_function(hpx_main_f_);
+                }
 #endif
-        }
-        else if (node != std::size_t(-1) || vm.count("hpx:node"))
-        {
-            // command line overwrites the environment
-            if (vm.count("hpx:node"))
-            {
-                if (vm.count("hpx:agas"))
-                {
-                    throw hpx::detail::command_line_error(
-                        "Command line option --hpx:node "
-                        "is not compatible with --hpx:agas");
-                }
-                node = vm["hpx:node"].as<std::size_t>();
             }
-
-            if (!vm.count("hpx:worker"))
+            else if (node != std::size_t(-1) || vm.count("hpx:node"))
             {
-                if (env.agas_node() == node)
+                // command line overwrites the environment
+                if (vm.count("hpx:node"))
                 {
-                    // console node, by default runs AGAS
-                    run_agas_server = true;
-                    rtcfg_.mode_ = hpx::runtime_mode_console;
-                }
-                else
-                {
-                    // don't use port zero for non-console localities
-                    if (hpx_port == 0 && node != 0)
-                        hpx_port = HPX_INITIAL_IP_PORT;
-
-                    // each node gets an unique port
-                    hpx_port = static_cast<std::uint16_t>(hpx_port + node);
-                    rtcfg_.mode_ = hpx::runtime_mode_worker;
-
-#if !defined(HPX_HAVE_RUN_MAIN_EVERYWHERE)
-                    // do not execute any explicit hpx_main except if asked
-                    // otherwise
-                    if (!vm.count("hpx:run-hpx-main") &&
-                        !cfgmap.get_value<int>("hpx.run_hpx_main", 0))
+                    if (vm.count("hpx:agas"))
                     {
-                        util::detail::reset_function(hpx_main_f_);
+                        throw hpx::detail::command_line_error(
+                            "Command line option --hpx:node "
+                            "is not compatible with --hpx:agas");
                     }
+                    node = vm["hpx:node"].as<std::size_t>();
+                }
+
+                if (!vm.count("hpx:worker"))
+                {
+                    if (env.agas_node() == node)
+                    {
+                        // console node, by default runs AGAS
+                        run_agas_server = true;
+                        rtcfg_.mode_ = hpx::runtime_mode_console;
+                    }
+                    else
+                    {
+                        // don't use port zero for non-console localities
+                        if (hpx_port == 0 && node != 0)
+                            hpx_port = HPX_INITIAL_IP_PORT;
+
+                        // each node gets an unique port
+                        hpx_port = static_cast<std::uint16_t>(hpx_port + node);
+                        rtcfg_.mode_ = hpx::runtime_mode_worker;
+
+#if !defined(HPX_HAVE_RUN_MAIN_EVERYWHERE)
+                        // do not execute any explicit hpx_main except if asked
+                        // otherwise
+                        if (!vm.count("hpx:run-hpx-main") &&
+                            !cfgmap.get_value<int>("hpx.run_hpx_main", 0))
+                        {
+                            util::detail::reset_function(hpx_main_f_);
+                        }
 #endif
+                    }
+                }
+
+                // store node number in configuration, don't do that if we're on a
+                // worker and the node number is zero
+                if (!vm.count("hpx:worker") || node != 0)
+                {
+                    ini_config.emplace_back(
+                        "hpx.locality!=" + std::to_string(node));
                 }
             }
 
-            // store node number in configuration, don't do that if we're on a
-            // worker and the node number is zero
-            if (!vm.count("hpx:worker") || node != 0)
+            if (vm.count("hpx:hpx"))
             {
-                ini_config.emplace_back(
-                    "hpx.locality!=" + std::to_string(node));
+                if (!util::split_ip_address(
+                        vm["hpx:hpx"].as<std::string>(), hpx_host, hpx_port))
+                {
+                    std::cerr
+                        << "hpx::init: command line warning: illegal port "
+                           "number given, using default value instead."
+                        << std::endl;
+                }
             }
-        }
 
-        if (vm.count("hpx:hpx"))
-        {
-            if (!util::split_ip_address(
-                    vm["hpx:hpx"].as<std::string>(), hpx_host, hpx_port))
+            if ((vm.count("hpx:connect") ||
+                    rtcfg_.mode_ == hpx::runtime_mode_connect) &&
+                hpx_host == "127.0.0.1")
             {
-                std::cerr << "hpx::init: command line warning: illegal port "
-                             "number given, using default value instead."
-                          << std::endl;
+                hpx_host = hpx::util::resolve_public_ip_address();
             }
-        }
 
-        if ((vm.count("hpx:connect") ||
-                rtcfg_.mode_ == hpx::runtime_mode_connect) &&
-            hpx_host == "127.0.0.1")
-        {
-            hpx_host = hpx::util::resolve_public_ip_address();
+            ini_config.emplace_back("hpx.node!=" + std::to_string(node));
         }
-
-        ini_config.emplace_back("hpx.node!=" + std::to_string(node));
 #endif
 
         // handle setting related to schedulers
@@ -1086,8 +1096,8 @@ namespace hpx { namespace util {
         agas_host = mapnames.map(agas_host, agas_port);
 
         // sanity checks
-        if (num_localities_ == 1 && !vm.count("hpx:agas") &&
-            !vm.count("hpx:node"))
+        if (rtcfg_.mode_ != hpx::runtime_mode_local && num_localities_ == 1 &&
+            !vm.count("hpx:agas") && !vm.count("hpx:node"))
         {
             // We assume we have to run the AGAS server if the number of
             // localities to run on is not specified (or is '1')
@@ -1097,118 +1107,129 @@ namespace hpx { namespace util {
             run_agas_server = rtcfg_.mode_ != runtime_mode_connect;
         }
 
+        if (rtcfg_.mode_ != hpx::runtime_mode_local)
+        {
 #if defined(HPX_HAVE_NETWORKING)
-        if (hpx_host == agas_host && hpx_port == agas_port)
-        {
-            // we assume that we need to run the agas server if the user
-            // asked for the same network addresses for HPX and AGAS
-            run_agas_server = rtcfg_.mode_ != runtime_mode_connect;
-        }
-        else if (run_agas_server)
-        {
-            // otherwise, if the user instructed us to run the AGAS server,
-            // we set the AGAS network address to the same value as the HPX
-            // network address
-            if (agas_host == HPX_INITIAL_IP_ADDRESS)
+            if (hpx_host == agas_host && hpx_port == agas_port)
             {
-                agas_host = hpx_host;
-                agas_port = hpx_port;
+                // we assume that we need to run the agas server if the user
+                // asked for the same network addresses for HPX and AGAS
+                run_agas_server = rtcfg_.mode_ != runtime_mode_connect;
             }
-        }
-        else if (env.found_batch_environment())
-        {
-            // in batch mode, if the network addresses are different and we
-            // should not run the AGAS server we assume to be in worker mode
-            rtcfg_.mode_ = hpx::runtime_mode_worker;
+            else if (run_agas_server)
+            {
+                // otherwise, if the user instructed us to run the AGAS server,
+                // we set the AGAS network address to the same value as the HPX
+                // network address
+                if (agas_host == HPX_INITIAL_IP_ADDRESS)
+                {
+                    agas_host = hpx_host;
+                    agas_port = hpx_port;
+                }
+            }
+            else if (env.found_batch_environment())
+            {
+                // in batch mode, if the network addresses are different and we
+                // should not run the AGAS server we assume to be in worker mode
+                rtcfg_.mode_ = hpx::runtime_mode_worker;
 
 #if !defined(HPX_HAVE_RUN_MAIN_EVERYWHERE)
-            // do not execute any explicit hpx_main except if asked
-            // otherwise
-            if (!vm.count("hpx:run-hpx-main") &&
-                !cfgmap.get_value<int>("hpx.run_hpx_main", 0))
-            {
-                util::detail::reset_function(hpx_main_f_);
-            }
+                // do not execute any explicit hpx_main except if asked
+                // otherwise
+                if (!vm.count("hpx:run-hpx-main") &&
+                    !cfgmap.get_value<int>("hpx.run_hpx_main", 0))
+                {
+                    util::detail::reset_function(hpx_main_f_);
+                }
 #endif
-        }
+            }
 
-        // write HPX and AGAS network parameters to the proper ini-file entries
-        ini_config.emplace_back("hpx.parcel.address=" + hpx_host);
-        ini_config.emplace_back("hpx.parcel.port=" + std::to_string(hpx_port));
-        ini_config.emplace_back("hpx.agas.address=" + agas_host);
-        ini_config.emplace_back("hpx.agas.port=" + std::to_string(agas_port));
+            // write HPX and AGAS network parameters to the proper ini-file entries
+            ini_config.emplace_back("hpx.parcel.address=" + hpx_host);
+            ini_config.emplace_back(
+                "hpx.parcel.port=" + std::to_string(hpx_port));
+            ini_config.emplace_back("hpx.agas.address=" + agas_host);
+            ini_config.emplace_back(
+                "hpx.agas.port=" + std::to_string(agas_port));
 
-        if (run_agas_server)
-        {
-            ini_config.emplace_back("hpx.agas.service_mode=bootstrap");
-        }
+            if (run_agas_server)
+            {
+                ini_config.emplace_back("hpx.agas.service_mode=bootstrap");
+            }
 
-        // we can't run the AGAS server while connecting
-        if (run_agas_server && rtcfg_.mode_ == runtime_mode_connect)
-        {
-            throw hpx::detail::command_line_error(
-                "Command line option error: can't run AGAS server"
-                "while connecting to a running application.");
-        }
+            // we can't run the AGAS server while connecting
+            if (run_agas_server && rtcfg_.mode_ == runtime_mode_connect)
+            {
+                throw hpx::detail::command_line_error(
+                    "Command line option error: can't run AGAS server"
+                    "while connecting to a running application.");
+            }
 
 #else
-        ini_config.emplace_back("hpx.agas.service_mode=bootstrap");
+            ini_config.emplace_back("hpx.agas.service_mode=bootstrap");
 #endif
+        }
 
         enable_logging_settings(vm, ini_config);
 
-        // Set number of localities in configuration (do it everywhere,
-        // even if this information is only used by the AGAS server).
-        ini_config.emplace_back(
-            "hpx.localities!=" + std::to_string(num_localities_));
-
-        // FIXME: AGAS V2: if a locality is supposed to run the AGAS
-        //        service only and requests to use 'priority_local' as the
-        //        scheduler, switch to the 'local' scheduler instead.
-        ini_config.emplace_back(std::string("hpx.runtime_mode=") +
-            get_runtime_mode_name(rtcfg_.mode_));
-
-        bool noshutdown_evaluate = false;
-        if (vm.count("hpx:print-counter-at"))
+        if (rtcfg_.mode_ != hpx::runtime_mode_local)
         {
-            std::vector<std::string> print_counters_at =
-                vm["hpx:print-counter-at"].as<std::vector<std::string>>();
+            // Set number of localities in configuration (do it everywhere,
+            // even if this information is only used by the AGAS server).
+            ini_config.emplace_back(
+                "hpx.localities!=" + std::to_string(num_localities_));
 
-            for (std::string const& s : print_counters_at)
+            // FIXME: AGAS V2: if a locality is supposed to run the AGAS
+            //        service only and requests to use 'priority_local' as the
+            //        scheduler, switch to the 'local' scheduler instead.
+            ini_config.emplace_back(std::string("hpx.runtime_mode=") +
+                get_runtime_mode_name(rtcfg_.mode_));
+
+            bool noshutdown_evaluate = false;
+            if (vm.count("hpx:print-counter-at"))
             {
-                if (0 == std::string("startup").find(s))
-                {
-                    ini_config.emplace_back("hpx.print_counter.startup!=1");
-                    continue;
-                }
-                if (0 == std::string("shutdown").find(s))
-                {
-                    ini_config.emplace_back("hpx.print_counter.shutdown!=1");
-                    continue;
-                }
-                if (0 == std::string("noshutdown").find(s))
-                {
-                    ini_config.emplace_back("hpx.print_counter.shutdown!=0");
-                    noshutdown_evaluate = true;
-                    continue;
-                }
+                std::vector<std::string> print_counters_at =
+                    vm["hpx:print-counter-at"].as<std::vector<std::string>>();
 
-                throw hpx::detail::command_line_error(hpx::util::format(
-                    "Invalid argument for option --hpx:print-counter-at: "
-                    "'{1}', allowed values: 'startup', 'shutdown' (default), "
-                    "'noshutdown'",
-                    s));
+                for (std::string const& s : print_counters_at)
+                {
+                    if (0 == std::string("startup").find(s))
+                    {
+                        ini_config.emplace_back("hpx.print_counter.startup!=1");
+                        continue;
+                    }
+                    if (0 == std::string("shutdown").find(s))
+                    {
+                        ini_config.emplace_back(
+                            "hpx.print_counter.shutdown!=1");
+                        continue;
+                    }
+                    if (0 == std::string("noshutdown").find(s))
+                    {
+                        ini_config.emplace_back(
+                            "hpx.print_counter.shutdown!=0");
+                        noshutdown_evaluate = true;
+                        continue;
+                    }
+
+                    throw hpx::detail::command_line_error(hpx::util::format(
+                        "Invalid argument for option --hpx:print-counter-at: "
+                        "'{1}', allowed values: 'startup', 'shutdown' "
+                        "(default), "
+                        "'noshutdown'",
+                        s));
+                }
             }
-        }
 
-        // if any counters have to be evaluated, always print at the end
-        if (vm.count("hpx:print-counter") ||
-            vm.count("hpx:print-counter-reset"))
-        {
-            if (!noshutdown_evaluate)
-                ini_config.emplace_back("hpx.print_counter.shutdown!=1");
-            if (vm.count("hpx:reset-counters"))
-                ini_config.emplace_back("hpx.print_counter.reset!=1");
+            // if any counters have to be evaluated, always print at the end
+            if (vm.count("hpx:print-counter") ||
+                vm.count("hpx:print-counter-reset"))
+            {
+                if (!noshutdown_evaluate)
+                    ini_config.emplace_back("hpx.print_counter.shutdown!=1");
+                if (vm.count("hpx:reset-counters"))
+                    ini_config.emplace_back("hpx.print_counter.reset!=1");
+            }
         }
 
         if (debug_clp)

--- a/libs/command_line_handling/src/command_line_handling.cpp
+++ b/libs/command_line_handling/src/command_line_handling.cpp
@@ -861,12 +861,12 @@ namespace hpx { namespace util {
 
         // If the user has not specified an explicit runtime mode we
         // retrieve it from the command line.
-        if (hpx::runtime_mode_default == rtcfg_.mode_)
+        if (hpx::runtime_mode::default_ == rtcfg_.mode_)
         {
 #if defined(HPX_HAVE_NETWORKING)
             // The default mode is console, i.e. all workers need to be
             // started with --worker/-w.
-            rtcfg_.mode_ = hpx::runtime_mode_console;
+            rtcfg_.mode_ = hpx::runtime_mode::console;
             if (vm.count("hpx:local") + vm.count("hpx:console") +
                     vm.count("hpx:worker") + vm.count("hpx:connect") >
                 1)
@@ -881,7 +881,7 @@ namespace hpx { namespace util {
             // hpx_main, except if specified otherwise.
             if (vm.count("hpx:worker"))
             {
-                rtcfg_.mode_ = hpx::runtime_mode_worker;
+                rtcfg_.mode_ = hpx::runtime_mode::worker;
 
 #if !defined(HPX_HAVE_RUN_MAIN_EVERYWHERE)
                 // do not execute any explicit hpx_main except if asked
@@ -895,25 +895,25 @@ namespace hpx { namespace util {
             }
             else if (vm.count("hpx:connect"))
             {
-                rtcfg_.mode_ = hpx::runtime_mode_connect;
+                rtcfg_.mode_ = hpx::runtime_mode::connect;
             }
             else if (vm.count("hpx:local"))
             {
-                rtcfg_.mode_ = hpx::runtime_mode_local;
+                rtcfg_.mode_ = hpx::runtime_mode::local;
             }
 #elif defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
-            rtcfg_.mode_ = hpx::runtime_mode_console;
+            rtcfg_.mode_ = hpx::runtime_mode::console;
 #else
-            rtcfg_.mode_ = hpx::runtime_mode_local;
+            rtcfg_.mode_ = hpx::runtime_mode::local;
 #endif
         }
 
 #if defined(HPX_HAVE_NETWORKING)
-        if (rtcfg_.mode_ != hpx::runtime_mode_local)
+        if (rtcfg_.mode_ != hpx::runtime_mode::local)
         {
             // we initialize certain settings if --node is specified (or data
             // has been retrieved from the environment)
-            if (rtcfg_.mode_ == hpx::runtime_mode_connect)
+            if (rtcfg_.mode_ == hpx::runtime_mode::connect)
             {
                 // when connecting we need to select a unique port
                 hpx_port = cfgmap.get_value<std::uint16_t>("hpx.parcel.port",
@@ -950,7 +950,7 @@ namespace hpx { namespace util {
                     {
                         // console node, by default runs AGAS
                         run_agas_server = true;
-                        rtcfg_.mode_ = hpx::runtime_mode_console;
+                        rtcfg_.mode_ = hpx::runtime_mode::console;
                     }
                     else
                     {
@@ -960,7 +960,7 @@ namespace hpx { namespace util {
 
                         // each node gets an unique port
                         hpx_port = static_cast<std::uint16_t>(hpx_port + node);
-                        rtcfg_.mode_ = hpx::runtime_mode_worker;
+                        rtcfg_.mode_ = hpx::runtime_mode::worker;
 
 #if !defined(HPX_HAVE_RUN_MAIN_EVERYWHERE)
                         // do not execute any explicit hpx_main except if asked
@@ -996,7 +996,7 @@ namespace hpx { namespace util {
             }
 
             if ((vm.count("hpx:connect") ||
-                    rtcfg_.mode_ == hpx::runtime_mode_connect) &&
+                    rtcfg_.mode_ == hpx::runtime_mode::connect) &&
                 hpx_host == "127.0.0.1")
             {
                 hpx_host = hpx::util::resolve_public_ip_address();
@@ -1096,7 +1096,7 @@ namespace hpx { namespace util {
         agas_host = mapnames.map(agas_host, agas_port);
 
         // sanity checks
-        if (rtcfg_.mode_ != hpx::runtime_mode_local && num_localities_ == 1 &&
+        if (rtcfg_.mode_ != hpx::runtime_mode::local && num_localities_ == 1 &&
             !vm.count("hpx:agas") && !vm.count("hpx:node"))
         {
             // We assume we have to run the AGAS server if the number of
@@ -1104,17 +1104,17 @@ namespace hpx { namespace util {
             // and no additional option (--hpx:agas or --hpx:node) has been
             // specified. That simplifies running small standalone
             // applications on one locality.
-            run_agas_server = rtcfg_.mode_ != runtime_mode_connect;
+            run_agas_server = rtcfg_.mode_ != runtime_mode::connect;
         }
 
-        if (rtcfg_.mode_ != hpx::runtime_mode_local)
+        if (rtcfg_.mode_ != hpx::runtime_mode::local)
         {
 #if defined(HPX_HAVE_NETWORKING)
             if (hpx_host == agas_host && hpx_port == agas_port)
             {
                 // we assume that we need to run the agas server if the user
                 // asked for the same network addresses for HPX and AGAS
-                run_agas_server = rtcfg_.mode_ != runtime_mode_connect;
+                run_agas_server = rtcfg_.mode_ != runtime_mode::connect;
             }
             else if (run_agas_server)
             {
@@ -1131,7 +1131,7 @@ namespace hpx { namespace util {
             {
                 // in batch mode, if the network addresses are different and we
                 // should not run the AGAS server we assume to be in worker mode
-                rtcfg_.mode_ = hpx::runtime_mode_worker;
+                rtcfg_.mode_ = hpx::runtime_mode::worker;
 
 #if !defined(HPX_HAVE_RUN_MAIN_EVERYWHERE)
                 // do not execute any explicit hpx_main except if asked
@@ -1158,7 +1158,7 @@ namespace hpx { namespace util {
             }
 
             // we can't run the AGAS server while connecting
-            if (run_agas_server && rtcfg_.mode_ == runtime_mode_connect)
+            if (run_agas_server && rtcfg_.mode_ == runtime_mode::connect)
             {
                 throw hpx::detail::command_line_error(
                     "Command line option error: can't run AGAS server"
@@ -1172,7 +1172,7 @@ namespace hpx { namespace util {
 
         enable_logging_settings(vm, ini_config);
 
-        if (rtcfg_.mode_ != hpx::runtime_mode_local)
+        if (rtcfg_.mode_ != hpx::runtime_mode::local)
         {
             // Set number of localities in configuration (do it everywhere,
             // even if this information is only used by the AGAS server).

--- a/libs/command_line_handling/src/parse_command_line.cpp
+++ b/libs/command_line_handling/src/parse_command_line.cpp
@@ -382,7 +382,7 @@ namespace hpx { namespace util {
 
             switch (mode)
             {
-            case runtime_mode_default:
+            case runtime_mode::default_:
 #if defined(HPX_HAVE_NETWORKING)
                 // clang-format off
                 hpx_options.add_options()
@@ -400,9 +400,9 @@ namespace hpx { namespace util {
                 break;
 
 #if defined(HPX_HAVE_NETWORKING)
-            case runtime_mode_worker:
-            case runtime_mode_console:
-            case runtime_mode_connect:
+            case runtime_mode::worker:
+            case runtime_mode::console:
+            case runtime_mode::connect:
                 // If the runtime for this application is always run in
                 // worker mode, silently ignore the worker option for
                 // hpx_pbs compatibility.
@@ -416,7 +416,7 @@ namespace hpx { namespace util {
                 // clang-format on
                 break;
 #else
-            case runtime_mode_console:
+            case runtime_mode::console:
                 // clang-format off
                 hidden_options.add_options()
                     ("hpx:console", "run this instance in console mode")
@@ -424,10 +424,10 @@ namespace hpx { namespace util {
                 // clang-format on
                 break;
 #endif
-            case runtime_mode_local:
+            case runtime_mode::local:
                 break;
 
-            case runtime_mode_invalid:
+            case runtime_mode::invalid:
             default:
                 throw hpx::detail::command_line_error(
                     "Invalid runtime mode specified");

--- a/libs/command_line_handling/src/parse_command_line.cpp
+++ b/libs/command_line_handling/src/parse_command_line.cpp
@@ -424,12 +424,19 @@ namespace hpx { namespace util {
                 // clang-format on
                 break;
 #endif
+            case runtime_mode_local:
+                break;
 
             case runtime_mode_invalid:
             default:
                 throw hpx::detail::command_line_error(
                     "Invalid runtime mode specified");
             }
+
+            // Always add the option to start the local runtime
+            hpx_options.add_options()("hpx:local",
+                "run this instance in local mode (experimental; certain "
+                "functionality not available at runt-time)");
 
             // general options definitions
             // clang-format off

--- a/libs/init_runtime/include/hpx/hpx_init.hpp
+++ b/libs/init_runtime/include/hpx/hpx_init.hpp
@@ -238,9 +238,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -259,7 +259,7 @@ namespace hpx {
         char** argv, std::vector<std::string> const& cfg,
         startup_function_type startup = startup_function_type(),
         shutdown_function_type shutdown = shutdown_function_type(),
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main entry point for launching the HPX runtime system.
     ///
@@ -295,9 +295,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -314,7 +314,7 @@ namespace hpx {
         hpx::program_options::options_description const& desc_cmdline, int argc,
         char** argv, startup_function_type startup = startup_function_type(),
         shutdown_function_type shutdown = shutdown_function_type(),
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main entry point for launching the HPX runtime system.
     ///
@@ -346,9 +346,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -366,7 +366,7 @@ namespace hpx {
         hpx::program_options::options_description const& desc_cmdline, int argc,
         char** argv, startup_function_type startup = startup_function_type(),
         shutdown_function_type shutdown = shutdown_function_type(),
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main entry point for launching the HPX runtime system.
     ///
@@ -404,9 +404,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -425,7 +425,7 @@ namespace hpx {
         char** argv, std::vector<std::string> const& cfg,
         startup_function_type startup = startup_function_type(),
         shutdown_function_type shutdown = shutdown_function_type(),
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main entry point for launching the HPX runtime system.
     ///
@@ -451,9 +451,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -465,7 +465,7 @@ namespace hpx {
     ///                     executed in console or worker mode depending on the
     ///                     command line arguments passed in `argc`/`argv`.
     inline int init(int argc, char** argv, std::vector<std::string> const& cfg,
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main entry point for launching the HPX runtime system.
     ///
@@ -490,9 +490,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -500,7 +500,7 @@ namespace hpx {
     ///                     returned from `hpx_main` (or 0 when executed in
     ///                     worker mode).
     ///
-    /// \note               If the parameter \p mode is runtime_mode_default,
+    /// \note               If the parameter \p mode is runtime_mode::default_,
     ///                     the created runtime system instance will be
     ///                     executed in console or worker mode depending on the
     ///                     command line arguments passed in `argc`/`argv`.
@@ -539,9 +539,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -549,7 +549,7 @@ namespace hpx {
     ///                     returned from `hpx_main` (or 0 when executed in
     ///                     worker mode).
     ///
-    /// \note               If the parameter \p mode is runtime_mode_default,
+    /// \note               If the parameter \p mode is runtime_mode::default_,
     ///                     the created runtime system instance will be
     ///                     executed in console or worker mode depending on the
     ///                     command line arguments passed in `argc`/`argv`.
@@ -576,9 +576,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -591,7 +591,7 @@ namespace hpx {
     ///                     command line arguments passed in `argc`/`argv`.
     inline int init(std::string const& app_name, int argc = 0,
         char** argv = nullptr,
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main entry point for launching the HPX runtime system.
     ///
@@ -608,9 +608,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -629,7 +629,7 @@ namespace hpx {
     ///                     command line options as described in the section
     ///                     'HPX Command Line Options'.
     inline int init(std::vector<std::string> const& cfg,
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main entry point for launching the HPX runtime system.
     ///
@@ -654,9 +654,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -668,7 +668,7 @@ namespace hpx {
     ///                     command line arguments passed in `argc`/`argv`.
     inline int init(int (*f)(hpx::program_options::variables_map& vm),
         std::string const& app_name, int argc, char** argv,
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main entry point for launching the HPX runtime system.
     ///
@@ -692,9 +692,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -705,7 +705,7 @@ namespace hpx {
     ///                     executed in console or worker mode depending on the
     ///                     command line arguments passed in `argc`/`argv`.
     inline int init(int (*f)(hpx::program_options::variables_map& vm), int argc,
-        char** argv, hpx::runtime_mode mode = hpx::runtime_mode_default);
+        char** argv, hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main entry point for launching the HPX runtime system.
     ///
@@ -730,9 +730,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -744,7 +744,7 @@ namespace hpx {
     ///                     command line arguments passed in `argc`/`argv`.
     inline int init(util::function_nonser<int(int, char**)> const& f,
         std::string const& app_name, int argc, char** argv,
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main entry point for launching the HPX runtime system.
     ///
@@ -774,9 +774,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -788,7 +788,7 @@ namespace hpx {
     ///                     command line arguments passed in `argc`/`argv`.
     inline int init(util::function_nonser<int(int, char**)> const& f, int argc,
         char** argv, std::vector<std::string> const& cfg,
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main entry point for launching the HPX runtime system.
     ///
@@ -812,9 +812,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -826,21 +826,21 @@ namespace hpx {
     ///                     configuration passed in `cfg`.
     inline int init(util::function_nonser<int(int, char**)> const& f,
         std::vector<std::string> const& cfg,
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \cond NOINTERNAL
     inline int init(std::nullptr_t f, std::string const& app_name, int argc,
-        char** argv, hpx::runtime_mode mode = hpx::runtime_mode_default);
+        char** argv, hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     inline int init(std::nullptr_t f, int argc, char** argv,
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     inline int init(std::nullptr_t f, int argc, char** argv,
         std::vector<std::string> const& cfg,
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     inline int init(std::nullptr_t f, std::vector<std::string> const& cfg,
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 /// \endcond
 #endif
 

--- a/libs/init_runtime/include/hpx/hpx_init_params.hpp
+++ b/libs/init_runtime/include/hpx/hpx_init_params.hpp
@@ -94,9 +94,9 @@ namespace hpx {
     /// \var mode           The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     /// \var rp_mode        The mode the resource partitioner should be created
@@ -114,7 +114,7 @@ namespace hpx {
         std::vector<std::string> cfg;
         mutable startup_function_type startup;
         mutable shutdown_function_type shutdown;
-        hpx::runtime_mode mode = ::hpx::runtime_mode_default;
+        hpx::runtime_mode mode = ::hpx::runtime_mode::default_;
         hpx::resource::partitioner_mode rp_mode = ::hpx::resource::mode_default;
         hpx::resource::rp_callback_type rp_callback;
     };

--- a/libs/init_runtime/include/hpx/hpx_start.hpp
+++ b/libs/init_runtime/include/hpx/hpx_start.hpp
@@ -240,9 +240,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -262,7 +262,7 @@ namespace hpx {
         char** argv, std::vector<std::string> const& cfg,
         startup_function_type startup = startup_function_type(),
         shutdown_function_type shutdown = shutdown_function_type(),
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main non-blocking entry point for launching the HPX runtime system.
     ///
@@ -300,9 +300,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -320,7 +320,7 @@ namespace hpx {
         hpx::program_options::options_description const& desc_cmdline, int argc,
         char** argv, startup_function_type startup = startup_function_type(),
         shutdown_function_type shutdown = shutdown_function_type(),
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main non-blocking entry point for launching the HPX runtime system.
     ///
@@ -354,9 +354,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -374,7 +374,7 @@ namespace hpx {
         hpx::program_options::options_description const& desc_cmdline, int argc,
         char** argv, startup_function_type startup = startup_function_type(),
         shutdown_function_type shutdown = shutdown_function_type(),
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main non-blocking entry point for launching the HPX runtime system.
     ///
@@ -414,9 +414,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -435,7 +435,7 @@ namespace hpx {
         char** argv, std::vector<std::string> const& cfg,
         startup_function_type startup = startup_function_type(),
         shutdown_function_type shutdown = shutdown_function_type(),
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main non-blocking entry point for launching the HPX runtime system.
     ///
@@ -463,9 +463,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -473,7 +473,7 @@ namespace hpx {
     ///                     succeeded and the runtime system was started successfully.
     ///                     It will return \a false otherwise.
     ///
-    /// \note               If the parameter \p mode is runtime_mode_default,
+    /// \note               If the parameter \p mode is runtime_mode::default_,
     ///                     the created runtime system instance will be
     ///                     executed in console or worker mode depending on the
     ///                     command line arguments passed in `argc`/`argv`.
@@ -481,7 +481,7 @@ namespace hpx {
     ///                     parameter\p mode.
     inline bool start(int argc, char** argv,
         std::vector<std::string> const& cfg,
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main non-blocking entry point for launching the HPX runtime system.
     ///
@@ -508,9 +508,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -518,7 +518,7 @@ namespace hpx {
     ///                     succeeded and the runtime system was started successfully.
     ///                     It will return \a false otherwise.
     ///
-    /// \note               If the parameter \p mode is runtime_mode_default,
+    /// \note               If the parameter \p mode is runtime_mode::default_,
     ///                     the created runtime system instance will be
     ///                     executed in console or worker mode depending on the
     ///                     command line arguments passed in `argc`/`argv`.
@@ -559,9 +559,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -569,7 +569,7 @@ namespace hpx {
     ///                     succeeded and the runtime system was started successfully.
     ///                     It will return \a false otherwise.
     ///
-    /// \note               If the parameter \p mode is runtime_mode_default,
+    /// \note               If the parameter \p mode is runtime_mode::default_,
     ///                     the created runtime system instance will be
     ///                     executed in console or worker mode depending on the
     ///                     command line arguments passed in `argc`/`argv`.
@@ -598,9 +598,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -613,7 +613,7 @@ namespace hpx {
     ///                     command line arguments passed in `argc`/`argv`.
     inline bool start(std::string const& app_name, int argc = 0,
         char** argv = nullptr,
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main non-blocking entry point for launching the HPX runtime system.
     ///
@@ -632,9 +632,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -653,7 +653,7 @@ namespace hpx {
     ///                     command line options as described in the section
     ///                     'HPX Command Line Options'.
     inline bool start(std::vector<std::string> const& cfg,
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main non-blocking entry point for launching the HPX runtime system.
     ///
@@ -678,9 +678,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -693,7 +693,7 @@ namespace hpx {
     ///                     command line arguments passed in `argc`/`argv`.
     inline bool start(int (*f)(hpx::program_options::variables_map& vm),
         std::string const& app_name, int argc, char** argv,
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main non-blocking entry point for launching the HPX runtime system.
     ///
@@ -720,9 +720,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -735,7 +735,7 @@ namespace hpx {
     ///                     command line arguments passed in `argc`/`argv`.
     inline bool start(util::function_nonser<int(int, char**)> const& f,
         std::string const& app_name, int argc, char** argv,
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main non-blocking entry point for launching the HPX runtime system.
     ///
@@ -767,9 +767,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -782,7 +782,7 @@ namespace hpx {
     ///                     command line arguments passed in `argc`/`argv`.
     inline bool start(util::function_nonser<int(int, char**)> const& f,
         int argc, char** argv, std::vector<std::string> const& cfg,
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main non-blocking entry point for launching the HPX runtime system.
     ///
@@ -808,9 +808,9 @@ namespace hpx {
     /// \param mode         [in] The mode the created runtime environment
     ///                     should be initialized in. There has to be exactly
     ///                     one locality in each HPX application which is
-    ///                     executed in console mode (\a hpx::runtime_mode_console),
+    ///                     executed in console mode (\a hpx::runtime_mode::console),
     ///                     all other localities have to be run in worker mode
-    ///                     (\a hpx::runtime_mode_worker). Normally this is
+    ///                     (\a hpx::runtime_mode::worker). Normally this is
     ///                     set up automatically, but sometimes it is necessary
     ///                     to explicitly specify the mode.
     ///
@@ -823,18 +823,18 @@ namespace hpx {
     ///                     configuration passed in `cfg`.
     inline bool start(util::function_nonser<int(int, char**)> const& f,
         std::vector<std::string> const& cfg,
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \cond NOINTERNAL
     inline bool start(std::nullptr_t f, std::string const& app_name, int argc,
-        char** argv, hpx::runtime_mode mode = hpx::runtime_mode_default);
+        char** argv, hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     inline bool start(std::nullptr_t f, int argc, char** argv,
         std::vector<std::string> const& cfg,
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     inline bool start(std::nullptr_t f, std::vector<std::string> const& cfg,
-        hpx::runtime_mode mode = hpx::runtime_mode_default);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 /// \endcond
 #endif
 }    // namespace hpx

--- a/libs/init_runtime/src/hpx_init.cpp
+++ b/libs/init_runtime/src/hpx_init.cpp
@@ -393,7 +393,7 @@ namespace hpx {
             // initialize logging
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
             util::detail::init_logging(
-                cms.rtcfg_, cms.rtcfg_.mode_ == runtime_mode_console);
+                cms.rtcfg_, cms.rtcfg_.mode_ == runtime_mode::console);
 #endif
 
 #if defined(HPX_HAVE_NETWORKING)
@@ -610,7 +610,7 @@ namespace hpx {
             // infos (on console only).
             bool print_counters_locally =
                 vm.count("hpx:print-counters-locally") != 0;
-            if (mode == runtime_mode_console || print_counters_locally)
+            if (mode == runtime_mode::console || print_counters_locally)
                 handle_list_and_print_options(rt, vm, print_counters_locally);
 #endif
 
@@ -860,10 +860,10 @@ namespace hpx {
                 std::unique_ptr<hpx::runtime> rt;
 
                 // Command line handling should have updated this by now.
-                HPX_ASSERT(cms.rtcfg_.mode_ != runtime_mode_default);
+                HPX_ASSERT(cms.rtcfg_.mode_ != runtime_mode::default_);
                 switch (cms.rtcfg_.mode_)
                 {
-                case runtime_mode_local:
+                case runtime_mode::local:
                 {
                     LPROGRESS_ << "creating local runtime";
                     rt.reset(new hpx::runtime(cms.rtcfg_));

--- a/libs/init_runtime/tests/unit/CMakeLists.txt
+++ b/libs/init_runtime/tests/unit/CMakeLists.txt
@@ -3,3 +3,25 @@
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests runtime_type)
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  set(${test}_PARAMETERS THREADS_PER_LOCALITY 4)
+
+  source_group("Source Files" FILES ${sources})
+
+  set(folder_name "Tests/Unit/Modules/InitRuntime")
+
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER ${folder_name}
+  )
+
+  add_hpx_unit_test("modules.init_runtime" ${test} ${${test}_PARAMETERS})
+endforeach()

--- a/libs/init_runtime/tests/unit/runtime_type.cpp
+++ b/libs/init_runtime/tests/unit/runtime_type.cpp
@@ -38,17 +38,17 @@ int main(int argc, char* argv[])
     // all functionality may work)
     {
         hpx::init_params iparams;
-        iparams.mode = hpx::runtime_mode_local;
+        iparams.mode = hpx::runtime_mode::local;
         ran_hpx_main = false;
         hpx::init(argc, argv, iparams);
         HPX_TEST(ran_hpx_main);
     }
 
-    // The distributed runtime (i.e. any non-runtime_mode_local mode) can only
+    // The distributed runtime (i.e. any non-runtime_mode::local mode) can only
     // be started when the distributed runtime has been enabled
     {
         hpx::init_params iparams;
-        iparams.mode = hpx::runtime_mode_console;
+        iparams.mode = hpx::runtime_mode::console;
 
         ran_hpx_main = false;
         bool caught_exception = false;

--- a/libs/init_runtime/tests/unit/runtime_type.cpp
+++ b/libs/init_runtime/tests/unit/runtime_type.cpp
@@ -1,0 +1,75 @@
+//  Copyright (c) 2018 Mikael Simberg
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/runtime.hpp>
+#include <hpx/modules/testing.hpp>
+
+static bool ran_hpx_main;
+
+int hpx_main()
+{
+    ran_hpx_main = true;
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // The default should always start the runtime in whatever mode is
+    // available
+    {
+        ran_hpx_main = false;
+        hpx::init(argc, argv);
+        HPX_TEST(ran_hpx_main);
+    }
+
+    // Also when the init parameters struct is explicitly passed.
+    {
+        hpx::init_params iparams;
+        ran_hpx_main = false;
+        hpx::init(argc, argv, iparams);
+        HPX_TEST(ran_hpx_main);
+    }
+
+    // The local runtime should always be possible to start (even though not
+    // all functionality may work)
+    {
+        hpx::init_params iparams;
+        iparams.mode = hpx::runtime_mode_local;
+        ran_hpx_main = false;
+        hpx::init(argc, argv, iparams);
+        HPX_TEST(ran_hpx_main);
+    }
+
+    // The distributed runtime (i.e. any non-runtime_mode_local mode) can only
+    // be started when the distributed runtime has been enabled
+    {
+        hpx::init_params iparams;
+        iparams.mode = hpx::runtime_mode_console;
+
+        ran_hpx_main = false;
+        bool caught_exception = false;
+
+        try
+        {
+            hpx::init(argc, argv, iparams);
+        }
+        catch (...)
+        {
+            caught_exception = true;
+        }
+
+#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
+        HPX_TEST(ran_hpx_main);
+        HPX_TEST(!caught_exception);
+#else
+        HPX_TEST(!ran_hpx_main);
+        HPX_TEST(caught_exception);
+#endif
+    }
+
+    return hpx::util::report_errors();
+}

--- a/libs/mpi_base/src/mpi_environment.cpp
+++ b/libs/mpi_base/src/mpi_environment.cpp
@@ -189,11 +189,11 @@ namespace hpx { namespace util {
 
         if (this_rank == 0)
         {
-            rtcfg.mode_ = hpx::runtime_mode_console;
+            rtcfg.mode_ = hpx::runtime_mode::console;
         }
         else
         {
-            rtcfg.mode_ = hpx::runtime_mode_worker;
+            rtcfg.mode_ = hpx::runtime_mode::worker;
         }
 
         rtcfg.add_entry("hpx.parcel.mpi.rank", std::to_string(this_rank));

--- a/libs/runtime_configuration/include/hpx/runtime_configuration/runtime_mode.hpp
+++ b/libs/runtime_configuration/include/hpx/runtime_configuration/runtime_mode.hpp
@@ -23,7 +23,8 @@ namespace hpx {
         runtime_mode_worker = 1,     ///< The runtime is a worker locality
         runtime_mode_connect = 2,    ///< The runtime is a worker locality
                                      ///< connecting late
-        runtime_mode_default = 3,    ///< The runtime mode will be determined
+        runtime_mode_local = 3,      ///< The runtime is fully local
+        runtime_mode_default = 4,    ///< The runtime mode will be determined
                                      ///< based on the command line arguments
         runtime_mode_last
     };

--- a/libs/runtime_configuration/include/hpx/runtime_configuration/runtime_mode.hpp
+++ b/libs/runtime_configuration/include/hpx/runtime_configuration/runtime_mode.hpp
@@ -16,18 +16,40 @@
 namespace hpx {
     /// A HPX runtime can be executed in two different modes: console mode
     /// and worker mode.
-    enum runtime_mode
+    enum class runtime_mode
     {
-        runtime_mode_invalid = -1,
-        runtime_mode_console = 0,    ///< The runtime is the console locality
-        runtime_mode_worker = 1,     ///< The runtime is a worker locality
-        runtime_mode_connect = 2,    ///< The runtime is a worker locality
-                                     ///< connecting late
-        runtime_mode_local = 3,      ///< The runtime is fully local
-        runtime_mode_default = 4,    ///< The runtime mode will be determined
-                                     ///< based on the command line arguments
-        runtime_mode_last
+        invalid = -1,
+        console = 0,     ///< The runtime is the console locality
+        worker = 1,      ///< The runtime is a worker locality
+        connect = 2,     ///< The runtime is a worker locality
+                         ///< connecting late
+        local = 3,       ///< The runtime is fully local
+        default_ = 4,    ///< The runtime mode will be determined
+                         ///< based on the command line arguments
+        last
     };
+
+#if defined(HPX_HAVE_UNSCOPED_ENUM_COMPATIBILITY)
+#define HPX_RUNTIME_MODE_UNSCOPED_ENUM_DEPRECATION_MSG                         \
+    "The unscoped runtime_mode names are deprecated. Please use "              \
+    "runtime_mode::mode instead."
+
+    HPX_DEPRECATED(HPX_RUNTIME_MODE_UNSCOPED_ENUM_DEPRECATION_MSG)
+    static constexpr runtime_mode runtime_mode_invalid = runtime_mode::invalid;
+    HPX_DEPRECATED(HPX_RUNTIME_MODE_UNSCOPED_ENUM_DEPRECATION_MSG)
+    static constexpr runtime_mode runtime_mode_console = runtime_mode::console;
+    HPX_DEPRECATED(HPX_RUNTIME_MODE_UNSCOPED_ENUM_DEPRECATION_MSG)
+    static constexpr runtime_mode runtime_mode_worker = runtime_mode::worker;
+    HPX_DEPRECATED(HPX_RUNTIME_MODE_UNSCOPED_ENUM_DEPRECATION_MSG)
+    static constexpr runtime_mode runtime_mode_connect = runtime_mode::connect;
+    HPX_DEPRECATED(HPX_RUNTIME_MODE_UNSCOPED_ENUM_DEPRECATION_MSG)
+    static constexpr runtime_mode runtime_mode_local = runtime_mode::local;
+    HPX_DEPRECATED(HPX_RUNTIME_MODE_UNSCOPED_ENUM_DEPRECATION_MSG)
+    static constexpr runtime_mode runtime_mode_default = runtime_mode::default_;
+    HPX_DEPRECATED(HPX_RUNTIME_MODE_UNSCOPED_ENUM_DEPRECATION_MSG)
+    static constexpr runtime_mode runtime_mode_last = runtime_mode::last;
+#undef HPX_RUNTIME_MODE_UNSCOPED_ENUM_DEPRECATION_MSG
+#endif
 
     /// Get the readable string representing the name of the given runtime_mode
     /// constant.

--- a/libs/runtime_configuration/src/runtime_mode.cpp
+++ b/libs/runtime_configuration/src/runtime_mode.cpp
@@ -20,24 +20,26 @@ namespace hpx {
             "console",    // 0
             "worker",     // 1
             "connect",    // 2
-            "default",    // 3
+            "local",      // 3
+            "default",    // 4
         };
     }
 
     char const* get_runtime_mode_name(runtime_mode state)
     {
-        if (state < runtime_mode_invalid || state >= runtime_mode_last)
+        if (state < runtime_mode::invalid || state >= runtime_mode::last)
             return "invalid (value out of bounds)";
-        return strings::runtime_mode_names[state + 1];
+        return strings::runtime_mode_names[static_cast<int>(state) + 1];
     }
 
     runtime_mode get_runtime_mode_from_name(std::string const& mode)
     {
-        for (std::size_t i = 0; i < runtime_mode_last; ++i)
+        for (std::size_t i = 0;
+             static_cast<runtime_mode>(i) < runtime_mode::last; ++i)
         {
             if (mode == strings::runtime_mode_names[i])
                 return static_cast<runtime_mode>(i - 1);
         }
-        return runtime_mode_invalid;
+        return runtime_mode::invalid;
     }
 }    // namespace hpx

--- a/src/runtime_distributed.cpp
+++ b/src/runtime_distributed.cpp
@@ -160,7 +160,7 @@ namespace hpx {
         runtime& rt = get_runtime();
 
         int exit_code = 0;
-        if (runtime_mode_connect == mode)
+        if (runtime_mode::connect == mode)
         {
             lbt_ << "(2nd stage) pre_main: locality is in connect mode, "
                     "skipping 2nd and 3rd stage startup synchronization";

--- a/tests/unit/component/launched_process.cpp
+++ b/tests/unit/component/launched_process.cpp
@@ -81,8 +81,8 @@ int main(int argc, char* argv[])
         "hpx.expect_connecting_localities!=1"
     };
 
-    // Note: this uses runtime_mode_connect to instruct this locality to
+    // Note: this uses runtime_mode::connect to instruct this locality to
     // connect to the existing HPX applications
-    return hpx::init(desc_commandline, argc, argv, cfg, hpx::runtime_mode_connect);
+    return hpx::init(desc_commandline, argc, argv, cfg, hpx::runtime_mode::connect);
 }
 

--- a/wrap/src/hpx_wrap.cpp
+++ b/wrap/src/hpx_wrap.cpp
@@ -107,7 +107,6 @@ extern "C" int initialize_main(int argc, char** argv)
         hpx::init_params iparams;
         iparams.desc_cmdline = desc;
         iparams.cfg = cfg;
-        iparams.mode = hpx::runtime_mode_console;
 
         // Initialize the HPX runtime system
         return hpx::init(start_function, argc, argv, iparams);


### PR DESCRIPTION
Note: this builds on #4606. Only the last commit belongs to this PR.

This adds a `runtime_type` enum that can be passed in the `init_params` struct, to choose which runtime to start. If the distributed runtime isn't enabled and it's requested an exception will be thrown during init. The default is to use the distributed runtime if available and otherwise the local one.