### PR TITLE
Making sure APEX is linked into every application, if needed

### DIFF
--- a/hpx/hpx_init_impl.hpp
+++ b/hpx/hpx_init_impl.hpp
@@ -34,6 +34,14 @@ extern HPX_EXPORT char** freebsd_environ;
 extern char** environ;
 #endif
 
+#if defined(HPX_WINDOWS) && defined(HPX_HAVE_APEX)
+namespace apex {
+
+    // force linking of the application with APEX
+    HPX_SYMBOL_IMPORT std::string& version();
+}
+#endif
+
 namespace hpx
 {
     /// \cond NOINTERNAL
@@ -63,6 +71,11 @@ namespace hpx
     {
 #if defined(HPX_WINDOWS)
         detail::init_winsocket();
+#if defined(HPX_HAVE_APEX)
+        // artificially force the apex shared library to be loaded by the
+        // application
+        apex::version();
+#endif
 #endif
         util::set_hpx_prefix(HPX_PREFIX);
 #if defined(__FreeBSD__)

--- a/hpx/hpx_start_impl.hpp
+++ b/hpx/hpx_start_impl.hpp
@@ -32,6 +32,14 @@ extern HPX_EXPORT char** freebsd_environ;
 extern char** environ;
 #endif
 
+#if defined(HPX_WINDOWS) && defined(HPX_HAVE_APEX)
+namespace apex {
+
+    // force linking of the application with APEX
+    HPX_SYMBOL_IMPORT std::string& version();
+}
+#endif
+
 namespace hpx
 {
     /// \cond NOINTERNAL
@@ -63,6 +71,11 @@ namespace hpx
     {
 #if defined(HPX_WINDOWS)
         detail::init_winsocket();
+#if defined(HPX_HAVE_APEX)
+        // artificially force the apex shared library to be loaded by the
+        // application
+        apex::version();
+#endif
 #endif
         util::set_hpx_prefix(HPX_PREFIX);
 #if defined(__FreeBSD__)


### PR DESCRIPTION
- this is a Windows specific change

This makes APEX usable on windows (to some minimal extend), relies on https://github.com/khuck/xpress-apex/pull/122 being merged.