### PR TITLE
Explicitly instantiate get_exception

### DIFF
--- a/libs/errors/src/exception.cpp
+++ b/libs/errors/src/exception.cpp
@@ -276,6 +276,50 @@ namespace hpx { namespace detail {
     template HPX_EXPORT std::exception_ptr get_exception(hpx::exception const&,
         std::string const&, std::string const&, long, std::string const&);
 
+    template HPX_EXPORT std::exception_ptr get_exception(
+        boost::system::system_error const&, std::string const&,
+        std::string const&, long, std::string const&);
+
+    template HPX_EXPORT std::exception_ptr get_exception(std::exception const&,
+        std::string const&, std::string const&, long, std::string const&);
+    template HPX_EXPORT std::exception_ptr get_exception(
+        hpx::detail::std_exception const&, std::string const&,
+        std::string const&, long, std::string const&);
+    template HPX_EXPORT std::exception_ptr get_exception(
+        std::bad_exception const&, std::string const&, std::string const&, long,
+        std::string const&);
+    template HPX_EXPORT std::exception_ptr get_exception(
+        hpx::detail::bad_exception const&, std::string const&,
+        std::string const&, long, std::string const&);
+    template HPX_EXPORT std::exception_ptr get_exception(std::bad_typeid const&,
+        std::string const&, std::string const&, long, std::string const&);
+    template HPX_EXPORT std::exception_ptr get_exception(
+        hpx::detail::bad_typeid const&, std::string const&, std::string const&,
+        long, std::string const&);
+    template HPX_EXPORT std::exception_ptr get_exception(std::bad_cast const&,
+        std::string const&, std::string const&, long, std::string const&);
+    template HPX_EXPORT std::exception_ptr get_exception(
+        hpx::detail::bad_cast const&, std::string const&, std::string const&,
+        long, std::string const&);
+    template HPX_EXPORT std::exception_ptr get_exception(std::bad_alloc const&,
+        std::string const&, std::string const&, long, std::string const&);
+    template HPX_EXPORT std::exception_ptr get_exception(
+        hpx::detail::bad_alloc const&, std::string const&, std::string const&,
+        long, std::string const&);
+    template HPX_EXPORT std::exception_ptr get_exception(
+        std::logic_error const&, std::string const&, std::string const&, long,
+        std::string const&);
+    template HPX_EXPORT std::exception_ptr get_exception(
+        std::runtime_error const&, std::string const&, std::string const&, long,
+        std::string const&);
+    template HPX_EXPORT std::exception_ptr get_exception(
+        std::out_of_range const&, std::string const&, std::string const&, long,
+        std::string const&);
+    template HPX_EXPORT std::exception_ptr get_exception(
+        std::invalid_argument const&, std::string const&, std::string const&,
+        long, std::string const&);
+
+    ///////////////////////////////////////////////////////////////////////////
     template HPX_EXPORT void throw_exception(
         hpx::exception const&, std::string const&, std::string const&, long);
 


### PR DESCRIPTION
Probably fixes #4669. The builder to look out for is the GH actions "Linux (Release, FetchContent)" (because of the relase build, not the fetchcontent part...).