### PR TITLE
Adding scatter_to/scatter_from collective operations

### DIFF
--- a/libs/collectives/CMakeLists.txt
+++ b/libs/collectives/CMakeLists.txt
@@ -24,6 +24,7 @@ set(collectives_headers
     hpx/collectives/gather.hpp
     hpx/collectives/latch.hpp
     hpx/collectives/reduce.hpp
+    hpx/collectives/scatter.hpp
     hpx/collectives/spmd_block.hpp
     hpx/collectives/detail/barrier_node.hpp
     hpx/collectives/detail/latch.hpp

--- a/libs/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/collectives/include/hpx/collectives/all_reduce.hpp
@@ -302,7 +302,9 @@ namespace hpx { namespace lcos {
 
         std::string name(basename);
         if (generation != std::size_t(-1))
+        {
             name += std::to_string(generation) + "/";
+        }
 
         return all_reduce(hpx::find_from_basename(std::move(name), root_site),
             std::move(local_result), std::forward<F>(op), this_site);

--- a/libs/collectives/include/hpx/collectives/detail/communicator.hpp
+++ b/libs/collectives/include/hpx/collectives/detail/communicator.hpp
@@ -95,20 +95,21 @@ namespace hpx { namespace lcos { namespace detail {
         {
         };
 
-        template <typename Operation, typename... Args>
-        void set_result(std::size_t which, Args... args)
+        template <typename Operation, typename Result, typename... Args>
+        Result set_result(std::size_t which, Args... args)
         {
             return std::make_shared<traits::communication_operation<
                 communicator_server, Operation>>(*this)
-                ->set(which, std::move(args)...);
+                ->template set<Result>(which, std::move(args)...);
         }
 
-        template <typename Operation, typename... Args>
+        template <typename Operation, typename Result, typename... Args>
         struct communication_set_action
-          : hpx::actions::make_action<void (communicator_server::*)(
+          : hpx::actions::make_action<Result (communicator_server::*)(
                                           std::size_t, Args...),
-                &communicator_server::template set_result<Operation, Args...>,
-                communication_set_action<Operation, Args...>>::type
+                &communicator_server::template set_result<Operation, Result,
+                    Args...>,
+                communication_set_action<Operation, Result, Args...>>::type
         {
         };
 

--- a/libs/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/collectives/include/hpx/collectives/gather.hpp
@@ -146,6 +146,81 @@ namespace hpx { namespace lcos {
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
 
+    /// Gather a set of values from different call sites
+    ///
+    /// This function receives a set of values from all call sites operating on
+    /// the given base name.
+    ///
+    /// \param  basename    The base name identifying the gather operation
+    /// \param  result      The value to transmit to the central gather point
+    ///                     from this call site.
+    /// \param  num_sites   The number of participating sites (default: all
+    ///                     localities).
+    /// \param  generation  The generational counter identifying the sequence
+    ///                     number of the gather operation performed on the
+    ///                     given base name. This is optional and needs to be
+    ///                     supplied only if the gather operation on the given
+    ///                     base name has to be performed more than once.
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
+    /// \param root_site    The sequence number of the central gather point
+    ///                     (usually the locality id). This value is optional
+    ///                     and defaults to 0.
+    ///
+    /// \note       Each gather operation has to be accompanied with a unique
+    ///             usage of the \a HPX_REGISTER_GATHER macro to define the
+    ///             necessary internal facilities used by \a gather_here and
+    ///             \a gather_there
+    ///
+    /// \returns    This function returns a future holding a vector with all
+    ///             gathered values. It will become ready once the gather
+    ///             operation has been completed.
+    ///
+    template <typename T>
+    hpx::future<std::vector<typename std::decay<T>::type>> gather(
+        char const* basename, T&& result,
+        std::size_t num_sites = std::size_t(-1),
+        std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
+
+    /// Gather a set of values from different call sites
+    ///
+    /// This function receives a set of values from all call sites operating on
+    /// the given base name.
+    ///
+    /// \param  basename    The base name identifying the gather operation
+    /// \param  result      The value to transmit to the central gather point
+    ///                     from this call site.
+    /// \param  num_sites   The number of participating sites (default: all
+    ///                     localities).
+    /// \param  generation  The generational counter identifying the sequence
+    ///                     number of the gather operation performed on the
+    ///                     given base name. This is optional and needs to be
+    ///                     supplied only if the gather operation on the given
+    ///                     base name has to be performed more than once.
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
+    /// \param root_site    The sequence number of the central gather point
+    ///                     (usually the locality id). This value is optional
+    ///                     and defaults to 0.
+    ///
+    /// \note       Each gather operation has to be accompanied with a unique
+    ///             usage of the \a HPX_REGISTER_GATHER macro to define the
+    ///             necessary internal facilities used by \a gather_here and
+    ///             \a gather_there
+    ///
+    /// \returns    This function returns a future holding a vector with all
+    ///             gathered values. It will become ready once the gather
+    ///             operation has been completed.
+    ///
+    template <typename T>
+    hpx::future<std::vector<T>> gather(char const* basename,
+        hpx::future<T>&& result, std::size_t num_sites = std::size_t(-1),
+        std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
+
 /// \def HPX_REGISTER_GATHER_DECLARATION(type, name)
 ///
 /// \brief Declare a gather object named \a name for a given data type \a type.
@@ -247,12 +322,8 @@ namespace hpx { namespace traits {
 
                 auto& communicator = this_->communicator_;
 
-                std::vector<T> data(communicator.num_sites_);
-                {
-                    std::unique_lock<mutex_type> l(communicator.mtx_);
-                    std::swap(data, communicator.data_);
-                }
-                return data;
+                std::unique_lock<mutex_type> l(communicator.mtx_);
+                return communicator.data_;
             };
 
             std::unique_lock<mutex_type> l(communicator_.mtx_);
@@ -273,26 +344,6 @@ namespace hpx { namespace traits {
                     .get();
             }
             return f;
-        }
-
-        template <typename T>
-        void set(std::size_t which, T&& t)
-        {
-            using mutex_type = typename Communicator::mutex_type;
-
-            std::unique_lock<mutex_type> l(communicator_.mtx_);
-            util::ignore_while_checking<std::unique_lock<mutex_type>> il(&l);
-
-            communicator_.gate_.synchronize(1, l);
-            communicator_.data_[which] = std::forward<T>(t);
-            if (communicator_.gate_.set(which, l))
-            {
-                // this is a one-shot object (generations counters are not
-                // supported), unregister ourselves (but only once)
-                hpx::unregister_with_basename(
-                    std::move(communicator_.name_), communicator_.site_)
-                    .get();
-            }
         }
 
         Communicator& communicator_;
@@ -382,7 +433,7 @@ namespace hpx { namespace lcos {
             using action_type = typename detail::communicator_server<arg_type>::
                 template communication_get_action<
                     traits::communication::gather_tag,
-                    hpx::future<std::vector<arg_type>>>;
+                    hpx::future<std::vector<arg_type>>, arg_type>;
 
             // make sure id is kept alive as long as the returned future
             hpx::id_type id = fid.get();
@@ -423,7 +474,7 @@ namespace hpx { namespace lcos {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    hpx::future<void> gather_there(hpx::future<hpx::id_type>&& fid,
+    hpx::future<std::vector<T>> gather_there(hpx::future<hpx::id_type>&& fid,
         hpx::future<T>&& local_result, std::size_t this_site = std::size_t(-1))
     {
         if (this_site == std::size_t(-1))
@@ -433,10 +484,11 @@ namespace hpx { namespace lcos {
 
         auto gather_there_data =
             [this_site](hpx::future<hpx::id_type>&& fid,
-                hpx::future<T>&& local_result) -> hpx::future<void> {
+                hpx::future<T>&& local_result) -> hpx::future<std::vector<T>> {
             using action_type = typename detail::communicator_server<T>::
-                template communication_set_action<
-                    traits::communication::gather_tag, T>;
+                template communication_get_action<
+                    traits::communication::gather_tag,
+                    hpx::future<std::vector<T>>, T>;
 
             // make sure id is kept alive as long as the returned future
             hpx::id_type id = fid.get();
@@ -454,7 +506,7 @@ namespace hpx { namespace lcos {
     }
 
     template <typename T>
-    hpx::future<void> gather_there(char const* basename,
+    hpx::future<std::vector<T>> gather_there(char const* basename,
         hpx::future<T>&& result, std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {
@@ -474,8 +526,9 @@ namespace hpx { namespace lcos {
     ///////////////////////////////////////////////////////////////////////////
     // gather plain values
     template <typename T>
-    hpx::future<void> gather_there(hpx::future<hpx::id_type>&& fid,
-        T&& local_result, std::size_t this_site = std::size_t(-1))
+    hpx::future<std::vector<typename util::decay<T>::type>> gather_there(
+        hpx::future<hpx::id_type>&& fid, T&& local_result,
+        std::size_t this_site = std::size_t(-1))
     {
         if (this_site == std::size_t(-1))
         {
@@ -486,10 +539,11 @@ namespace hpx { namespace lcos {
 
         auto gather_there_data_direct =
             [this_site](hpx::future<hpx::id_type>&& fid,
-                arg_type&& local_result) -> hpx::future<void> {
+                arg_type&& local_result) -> hpx::future<std::vector<arg_type>> {
             using action_type = typename detail::communicator_server<T>::
                 template communication_get_action<
-                    traits::communication::gather_tag, hpx::future<T>>;
+                    traits::communication::gather_tag,
+                    hpx::future<std::vector<arg_type>>, arg_type>;
 
             // make sure id is kept alive as long as the returned future
             hpx::id_type id = fid.get();
@@ -507,7 +561,8 @@ namespace hpx { namespace lcos {
     }
 
     template <typename T>
-    hpx::future<void> gather_there(char const* basename, T&& local_result,
+    hpx::future<std::vector<typename util::decay<T>::type>> gather_there(
+        char const* basename, T&& local_result,
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {
@@ -523,7 +578,59 @@ namespace hpx { namespace lcos {
         return gather_there(hpx::find_from_basename(std::move(name), root_site),
             std::forward<T>(local_result), this_site);
     }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    hpx::future<std::vector<T>> gather(char const* basename,
+        hpx::future<T>&& local_result, std::size_t num_sites = std::size_t(-1),
+        std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
+    {
+        if (this_site == std::size_t(-1))
+        {
+            this_site = static_cast<std::size_t>(hpx::get_locality_id());
+        }
+
+        if (this_site == root_site)
+        {
+            return gather_here(basename, std::move(local_result), num_sites,
+                generation, this_site);
+        }
+
+        return gather_there(basename, std::move(local_result), generation,
+            this_site, root_site);
+    }
+
+    template <typename T>
+    hpx::future<std::vector<typename util::decay<T>::type>> gather(
+        char const* basename, T&& local_result,
+        std::size_t num_sites = std::size_t(-1),
+        std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
+    {
+        if (this_site == std::size_t(-1))
+        {
+            this_site = static_cast<std::size_t>(hpx::get_locality_id());
+        }
+
+        if (this_site == root_site)
+        {
+            return gather_here(basename, std::forward<T>(local_result),
+                num_sites, generation, this_site);
+        }
+
+        return gather_there(basename, std::forward<T>(local_result), generation,
+            this_site, root_site);
+    }
 }}    // namespace hpx::lcos
+
+////////////////////////////////////////////////////////////////////////////////
+namespace hpx {
+    using lcos::create_gatherer;
+    using lcos::gather;
+    using lcos::gather_here;
+    using lcos::gather_there;
+}    // namespace hpx
 
 ///////////////////////////////////////////////////////////////////////////////
 #define HPX_REGISTER_GATHER_DECLARATION(...) /**/

--- a/libs/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/collectives/include/hpx/collectives/scatter.hpp
@@ -1,0 +1,516 @@
+//  Copyright (c) 2014-2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file scatter.hpp
+
+#pragma once
+
+#if defined(DOXYGEN)
+namespace hpx { namespace lcos {
+
+    /// Scatter (receive) a set of values to different call sites
+    ///
+    /// This function receives an element of a set of values operating on
+    /// the given base name.
+    ///
+    /// \param  basename    The base name identifying the scatter operation
+    /// \param  result      A future referring to the value to transmit to the
+    ///                     central scatter point from this call site.
+    /// \param  generation  The generational counter identifying the sequence
+    ///                     number of the scatter operation performed on the
+    ///                     given base name. This is optional and needs to be
+    ///                     supplied only if the scatter operation on the given
+    ///                     base name has to be performed more than once.
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
+    /// \param root_site    The sequence number of the central scatter point
+    ///                     (usually the locality id). This value is optional
+    ///                     and defaults to 0.
+    ///
+    /// \note       Each scatter operation has to be accompanied with a unique
+    ///             usage of the \a HPX_REGISTER_SCATTER macro to define the
+    ///             necessary internal facilities used by \a scatter_from and
+    ///             \a scatter_to
+    ///
+    /// \returns    This function returns a future holding a the
+    ///             scattered value. It will become ready once the scatter
+    ///             operation has been completed.
+    ///
+    template <typename T>
+    hpx::future<T> scatter_from(char const* basename,
+        std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
+
+    /// Scatter (send) a part of the value set at the given call site
+    ///
+    /// This function transmits the value given by \a result to a central scatter
+    /// site (where the corresponding \a scatter_from is executed)
+    ///
+    /// \param  basename    The base name identifying the scatter operation
+    /// \param  result      A future referring to the value to transmit to the
+    ///                     central scatter point from this call site.
+    /// \param  num_sites   The number of participating sites (default: all
+    ///                     localities).
+    /// \param  generation  The generational counter identifying the sequence
+    ///                     number of the scatter operation performed on the
+    ///                     given base name. This is optional and needs to be
+    ///                     supplied only if the scatter operation on the given
+    ///                     base name has to be performed more than once.
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
+    ///
+    /// \note       Each scatter operation has to be accompanied with a unique
+    ///             usage of the \a HPX_REGISTER_SCATTER macro to define the
+    ///             necessary internal facilities used by \a scatter_from and
+    ///             \a scatter_to
+    ///
+    /// \returns    This function returns a future holding a the
+    ///             scattered value. It will become ready once the scatter
+    ///             operation has been completed.
+    ///
+    template <typename T>
+    hpx::future<T> scatter_to(char const* basename,
+        hpx::future<std::vector<T>> result,
+        std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
+
+    /// Scatter (receive) a set of values to different call sites
+    ///
+    /// This function receives an element of a set of values operating on
+    /// the given base name.
+    ///
+    /// \param  basename    The base name identifying the scatter operation
+    /// \param  result      The value to transmit to the central scatter point
+    ///                     from this call site.
+    /// \param  generation  The generational counter identifying the sequence
+    ///                     number of the scatter operation performed on the
+    ///                     given base name. This is optional and needs to be
+    ///                     supplied only if the scatter operation on the given
+    ///                     base name has to be performed more than once.
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
+    /// \param root_site    The sequence number of the central scatter point
+    ///                     (usually the locality id). This value is optional
+    ///                     and defaults to 0.
+    ///
+    /// \note       Each scatter operation has to be accompanied with a unique
+    ///             usage of the \a HPX_REGISTER_SCATTER macro to define the
+    ///             necessary internal facilities used by \a scatter_from and
+    ///             \a scatter_to
+    ///
+    /// \returns    This function returns a future holding a the
+    ///             scattered value. It will become ready once the scatter
+    ///             operation has been completed.
+    ///
+    template <typename T>
+    hpx::future<T> scatter_from(char const* basename,
+        std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
+
+    /// Scatter (send) a part of the value set at the given call site
+    ///
+    /// This function transmits the value given by \a result to a central scatter
+    /// site (where the corresponding \a scatter_from is executed)
+    ///
+    /// \param  basename    The base name identifying the scatter operation
+    /// \param  result      The value to transmit to the central scatter point
+    ///                     from this call site.
+    /// \param  num_sites   The number of participating sites (default: all
+    ///                     localities).
+    /// \param  generation  The generational counter identifying the sequence
+    ///                     number of the scatter operation performed on the
+    ///                     given base name. This is optional and needs to be
+    ///                     supplied only if the scatter operation on the given
+    ///                     base name has to be performed more than once.
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
+    ///
+    /// \note       Each scatter operation has to be accompanied with a unique
+    ///             usage of the \a HPX_REGISTER_SCATTER macro to define the
+    ///             necessary internal facilities used by \a scatter_from and
+    ///             \a scatter_to
+    ///
+    /// \returns    This function returns a future holding a the
+    ///             scattered value. It will become ready once the scatter
+    ///             operation has been completed.
+    ///
+    template <typename T>
+    hpx::future<T> scatter_to(char const* basename,
+        std::vector<T> const& result, std::size_t num_sites = std::size_t(-1),
+        std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1));
+
+    template <typename T>
+    hpx::future<T> scatter_to(char const* basename, std::vector<T>&& result,
+        std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
+
+/// \def HPX_REGISTER_SCATTER_DECLARATION(type, name)
+///
+/// \brief Declare a scatter object named \a name for a given data type \a type.
+///
+/// The macro \a HPX_REGISTER_SCATTER_DECLARATION can be used to declare
+/// all facilities necessary for a (possibly remote) scatter operation.
+///
+/// The parameter \a type specifies for which data type the scatter
+/// operations should be enabled.
+///
+/// The (optional) parameter \a name should be a unique C-style identifier
+/// which will be internally used to identify a particular scatter operation.
+/// If this defaults to \a \<type\>_scatter if not specified.
+///
+/// \note The macro \a HPX_REGISTER_SCATTER_DECLARATION can be used with 1
+///       or 2 arguments. The second argument is optional and defaults to
+///       \a \<type\>_scatter.
+///
+#define HPX_REGISTER_SCATTER_DECLARATION(type, name)
+
+/// \def HPX_REGISTER_SCATTER(type, name)
+///
+/// \brief Define a scatter object named \a name for a given data type \a type.
+///
+/// The macro \a HPX_REGISTER_SCATTER can be used to define
+/// all facilities necessary for a (possibly remote) scatter operation.
+///
+/// The parameter \a type specifies for which data type the scatter
+/// operations should be enabled.
+///
+/// The (optional) parameter \a name should be a unique C-style identifier
+/// which will be internally used to identify a particular scatter operation.
+/// If this defaults to \a \<type\>_scatter if not specified.
+///
+/// \note The macro \a HPX_REGISTER_SCATTER can be used with 1
+///       or 2 arguments. The second argument is optional and defaults to
+///       \a \<type\>_scatter.
+///
+#define HPX_REGISTER_SCATTER(type, name)
+}}    // namespace hpx::lcos
+#else
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+
+#include <hpx/async/dataflow.hpp>
+#include <hpx/basic_execution.hpp>
+#include <hpx/collectives/detail/communicator.hpp>
+#include <hpx/futures/future.hpp>
+#include <hpx/futures/traits/acquire_shared_state.hpp>
+#include <hpx/preprocessor/cat.hpp>
+#include <hpx/preprocessor/expand.hpp>
+#include <hpx/preprocessor/nargs.hpp>
+#include <hpx/runtime/basename_registration.hpp>
+#include <hpx/runtime/components/server/simple_component_base.hpp>
+#include <hpx/runtime/get_num_localities.hpp>
+#include <hpx/runtime/naming/id_type.hpp>
+#include <hpx/type_support/decay.hpp>
+#include <hpx/type_support/unused.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace traits {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // support for scatter
+    namespace communication {
+        struct scatter_tag;
+    }
+
+    template <typename Communicator>
+    struct communication_operation<Communicator, communication::scatter_tag>
+      : std::enable_shared_from_this<
+            communication_operation<Communicator, communication::scatter_tag>>
+    {
+        communication_operation(Communicator& comm)
+          : communicator_(comm)
+        {
+        }
+
+        template <typename Result>
+        Result get(std::size_t which)
+        {
+            using arg_type = typename Communicator::arg_type;
+            using mutex_type = typename Communicator::mutex_type;
+
+            auto this_ = this->shared_from_this();
+            auto on_ready = [this_ = std::move(this_), which](
+                                shared_future<void>&& f) -> arg_type {
+                f.get();    // propagate any exceptions
+
+                auto& communicator = this_->communicator_;
+
+                std::unique_lock<mutex_type> l(communicator.mtx_);
+                return std::move(communicator.data_[which]);
+            };
+
+            std::unique_lock<mutex_type> l(communicator_.mtx_);
+            util::ignore_while_checking<std::unique_lock<mutex_type>> il(&l);
+
+            hpx::future<arg_type> f =
+                communicator_.gate_.get_shared_future(l).then(
+                    hpx::launch::sync, std::move(on_ready));
+
+            communicator_.gate_.synchronize(1, l);
+            if (communicator_.gate_.set(which, l))
+            {
+                // this is a one-shot object (generations counters are not
+                // supported), unregister ourselves (but only once)
+                hpx::unregister_with_basename(
+                    std::move(communicator_.name_), communicator_.site_)
+                    .get();
+            }
+            return f;
+        }
+
+        template <typename Result, typename T>
+        Result set(std::size_t which, std::vector<T> t)
+        {
+            using mutex_type = typename Communicator::mutex_type;
+
+            std::unique_lock<mutex_type> l(communicator_.mtx_);
+            util::ignore_while_checking<std::unique_lock<mutex_type>> il(&l);
+
+            communicator_.gate_.synchronize(1, l);
+            communicator_.data_ = std::move(t);
+            auto result = std::move(communicator_.data_[which]);
+
+            if (communicator_.gate_.set(which, l))
+            {
+                // this is a one-shot object (generations counters are not
+                // supported), unregister ourselves (but only once)
+                hpx::unregister_with_basename(
+                    std::move(communicator_.name_), communicator_.site_)
+                    .get();
+            }
+            return result;
+        }
+
+        Communicator& communicator_;
+    };
+}}    // namespace hpx::traits
+
+namespace hpx { namespace lcos {
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    hpx::future<hpx::id_type> create_scatterer(char const* basename,
+        std::size_t num_sites = std::size_t(-1),
+        std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1))
+    {
+        return detail::create_communicator<T>(
+            basename, num_sites, generation, this_site, num_sites);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // destination site needs to be handled differently
+    template <typename T>
+    hpx::future<T> scatter_from(hpx::future<hpx::id_type>&& fid,
+        std::size_t this_site = std::size_t(-1))
+    {
+        if (this_site == std::size_t(-1))
+        {
+            this_site = static_cast<std::size_t>(hpx::get_locality_id());
+        }
+
+        auto scatter_data =
+            [this_site](hpx::future<hpx::id_type>&& fid) -> hpx::future<T> {
+            using action_type = typename detail::communicator_server<T>::
+                template communication_get_action<
+                    traits::communication::scatter_tag, hpx::future<T>>;
+
+            // make sure id is kept alive as long as the returned future
+            hpx::id_type id = fid.get();
+            auto result = async(action_type(), id, this_site);
+
+            traits::detail::get_shared_state(result)->set_on_completed(
+                [id = std::move(id)]() { HPX_UNUSED(id); });
+
+            return result;
+        };
+
+        return fid.then(hpx::launch::sync, std::move(scatter_data));
+    }
+
+    template <typename T>
+    hpx::future<T> scatter_from(char const* basename,
+        std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
+    {
+        if (this_site == std::size_t(-1))
+        {
+            this_site = static_cast<std::size_t>(hpx::get_locality_id());
+        }
+
+        std::string name(basename);
+        if (generation != std::size_t(-1))
+        {
+            name += std::to_string(generation) + "/";
+        }
+
+        return scatter_from<T>(
+            hpx::find_from_basename(std::move(name), root_site), this_site);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // scatter_to
+    template <typename T>
+    hpx::future<T> scatter_to(hpx::future<hpx::id_type>&& fid,
+        hpx::future<std::vector<T>>&& result,
+        std::size_t this_site = std::size_t(-1))
+    {
+        if (this_site == std::size_t(-1))
+        {
+            this_site = static_cast<std::size_t>(hpx::get_locality_id());
+        }
+
+        auto scatter_to_data =
+            [this_site](hpx::future<hpx::id_type>&& fid,
+                hpx::future<std::vector<T>>&& local_result) -> hpx::future<T> {
+            using action_type = typename detail::communicator_server<T>::
+                template communication_set_action<
+                    traits::communication::scatter_tag, T, std::vector<T>>;
+
+            // make sure id is kept alive as long as the returned future
+            hpx::id_type id = fid.get();
+            auto result =
+                async(action_type(), id, this_site, local_result.get());
+
+            traits::detail::get_shared_state(result)->set_on_completed(
+                [id = std::move(id)]() { HPX_UNUSED(id); });
+
+            return result;
+        };
+
+        return dataflow(hpx::launch::sync, std::move(scatter_to_data),
+            std::move(fid), std::move(result));
+    }
+
+    template <typename T>
+    hpx::future<T> scatter_to(char const* basename,
+        hpx::future<std::vector<T>>&& result,
+        std::size_t num_sites = std::size_t(-1),
+        std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1))
+    {
+        if (num_sites == std::size_t(-1))
+        {
+            num_sites = static_cast<std::size_t>(
+                hpx::get_num_localities(hpx::launch::sync));
+        }
+        if (this_site == std::size_t(-1))
+        {
+            this_site = static_cast<std::size_t>(hpx::get_locality_id());
+        }
+
+        return scatter_to(
+            create_scatterer<T>(basename, num_sites, generation, this_site),
+            std::move(result), this_site);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // scatter plain values
+    template <typename T>
+    hpx::future<T> scatter_to(hpx::future<hpx::id_type>&& fid,
+        std::vector<T>&& local_result, std::size_t this_site = std::size_t(-1))
+    {
+        if (this_site == std::size_t(-1))
+        {
+            this_site = static_cast<std::size_t>(hpx::get_locality_id());
+        }
+
+        auto scatter_to_data_direct =
+            [this_site](hpx::future<hpx::id_type>&& fid,
+                std::vector<T>&& local_result) -> hpx::future<T> {
+            using action_type = typename detail::communicator_server<T>::
+                template communication_set_action<
+                    traits::communication::scatter_tag, T, std::vector<T>>;
+
+            // make sure id is kept alive as long as the returned future
+            hpx::id_type id = fid.get();
+            auto result =
+                async(action_type(), id, this_site, std::move(local_result));
+
+            traits::detail::get_shared_state(result)->set_on_completed(
+                [id = std::move(id)]() { HPX_UNUSED(id); });
+
+            return result;
+        };
+
+        return dataflow(std::move(scatter_to_data_direct), std::move(fid),
+            std::move(local_result));
+    }
+
+    template <typename T>
+    hpx::future<T> scatter_to(char const* basename,
+        std::vector<T>&& local_result, std::size_t num_sites = std::size_t(-1),
+        std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1))
+    {
+        if (num_sites == std::size_t(-1))
+        {
+            num_sites = static_cast<std::size_t>(
+                hpx::get_num_localities(hpx::launch::sync));
+        }
+        if (this_site == std::size_t(-1))
+        {
+            this_site = static_cast<std::size_t>(hpx::get_locality_id());
+        }
+
+        std::string name(basename);
+        if (generation != std::size_t(-1))
+        {
+            name += std::to_string(generation) + "/";
+        }
+
+        return scatter_to(
+            create_scatterer<T>(basename, num_sites, generation, this_site),
+            std::move(local_result), this_site);
+    }
+}}    // namespace hpx::lcos
+
+////////////////////////////////////////////////////////////////////////////////
+namespace hpx {
+    using lcos::scatter_from;
+    using lcos::scatter_to;
+}    // namespace hpx
+
+///////////////////////////////////////////////////////////////////////////////
+#define HPX_REGISTER_SCATTER_DECLARATION(...) /**/
+
+///////////////////////////////////////////////////////////////////////////////
+#define HPX_REGISTER_SCATTER(...)                                              \
+    HPX_REGISTER_SCATTER_(__VA_ARGS__)                                         \
+    /**/
+
+#define HPX_REGISTER_SCATTER_(...)                                             \
+    HPX_PP_EXPAND(HPX_PP_CAT(                                                  \
+        HPX_REGISTER_SCATTER_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))        \
+    /**/
+
+#define HPX_REGISTER_SCATTER_1(type)                                           \
+    HPX_REGISTER_SCATTER_2(type, HPX_PP_CAT(type, _scatter))                   \
+    /**/
+
+#define HPX_REGISTER_SCATTER_2(type, name)                                     \
+    typedef hpx::components::component<                                        \
+        hpx::lcos::detail::communicator_server<type>>                          \
+        HPX_PP_CAT(scatter_, name);                                            \
+    HPX_REGISTER_COMPONENT(HPX_PP_CAT(scatter_, name))                         \
+    /**/
+
+#endif    // COMPUTE_HOST_CODE
+#endif    // DOXYGEN

--- a/libs/collectives/tests/regressions/multiple_gather_ops_2001.cpp
+++ b/libs/collectives/tests/regressions/multiple_gather_ops_2001.cpp
@@ -9,6 +9,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
+#include <hpx/testing.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -38,15 +39,20 @@ int hpx_main(int argc, char* argv[])
 
             for (std::size_t j = 0; j < sol.size(); ++j)
             {
-                std::cout << "got residual " << sol[j] << " from " << j
-                          << std::endl;
+                HPX_TEST(j == sol[j]);
             }
         }
         else
         {
-            hpx::future<void> f =
+            hpx::future<std::vector<std::uint32_t>> overall_result =
                 hpx::lcos::gather_there(gather_basename, std::move(value), i);
-            f.get();
+
+            std::vector<std::uint32_t> sol = overall_result.get();
+
+            for (std::size_t j = 0; j < sol.size(); ++j)
+            {
+                HPX_TEST(j == sol[j]);
+            }
         }
     }
 

--- a/libs/collectives/tests/regressions/multiple_gather_ops_2001.cpp
+++ b/libs/collectives/tests/regressions/multiple_gather_ops_2001.cpp
@@ -44,15 +44,10 @@ int hpx_main(int argc, char* argv[])
         }
         else
         {
-            hpx::future<std::vector<std::uint32_t>> overall_result =
+            hpx::future<void> overall_result =
                 hpx::lcos::gather_there(gather_basename, std::move(value), i);
 
-            std::vector<std::uint32_t> sol = overall_result.get();
-
-            for (std::size_t j = 0; j < sol.size(); ++j)
-            {
-                HPX_TEST(j == sol[j]);
-            }
+            overall_result.get();
         }
     }
 

--- a/libs/collectives/tests/unit/CMakeLists.txt
+++ b/libs/collectives/tests/unit/CMakeLists.txt
@@ -13,9 +13,11 @@ set(tests
     broadcast_apply
     broadcast_component
     fold
+    gather
     global_spmd_block
     reduce
     remote_latch
+    scatter
 )
 
 set(all_reduce_PARAMETERS LOCALITIES 2)
@@ -24,8 +26,11 @@ set(broadcast_PARAMETERS LOCALITIES 2)
 set(broadcast_direct_PARAMETERS LOCALITIES 2)
 set(broadcast_apply_PARAMETERS LOCALITIES 2)
 set(broadcast_component_PARAMETERS LOCALITIES 2)
+set(gather_PARAMETERS LOCALITIES 2)
 set(remote_latch_PARAMETERS LOCALITIES 2)
 set(reduce_PARAMETERS LOCALITIES 2)
+set(scatter_PARAMETERS LOCALITIES 2)
+
 set(global_spmd_block_PARAMETERS LOCALITIES 2)
 
 foreach(test ${tests})

--- a/libs/collectives/tests/unit/gather.cpp
+++ b/libs/collectives/tests/unit/gather.cpp
@@ -22,7 +22,7 @@ char const* gather_direct_basename = "/test/gather_direct/";
 
 HPX_REGISTER_GATHER(std::uint32_t, test_gather);
 
-void test_gather_here_there()
+int hpx_main(int argc, char* argv[])
 {
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
     HPX_TEST(num_localities >= 2);
@@ -47,15 +47,9 @@ void test_gather_here_there()
         }
         else
         {
-            hpx::future<std::vector<std::uint32_t>> overall_result =
-                hpx::lcos::gather_there(gather_basename,
-                    hpx::make_ready_future(this_locality + 42), i);
-
-            std::vector<std::uint32_t> sol = overall_result.get();
-            for (std::size_t j = 0; j != sol.size(); ++j)
-            {
-                HPX_TEST(j + 42 == sol[j]);
-            }
+            hpx::future<void> overall_result = hpx::lcos::gather_there(
+                gather_basename, hpx::make_ready_future(this_locality + 42), i);
+            overall_result.get();
         }
     }
 
@@ -76,58 +70,11 @@ void test_gather_here_there()
         }
         else
         {
-            hpx::future<std::vector<std::uint32_t>> overall_result =
-                hpx::lcos::gather_there(
-                    gather_direct_basename, this_locality + 42, i);
-
-            std::vector<std::uint32_t> sol = overall_result.get();
-            for (std::size_t j = 0; j != sol.size(); ++j)
-            {
-                HPX_TEST(j + 42 == sol[j]);
-            }
+            hpx::future<void> overall_result = hpx::lcos::gather_there(
+                gather_direct_basename, this_locality + 42, i);
+            overall_result.get();
         }
     }
-}
-
-void test_gather()
-{
-    std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
-    HPX_TEST(num_localities >= 2);
-
-    std::uint32_t this_locality = hpx::get_locality_id();
-
-    // test functionality based on future<> of local result
-    for (std::uint32_t i = 0; i != 10; ++i)
-    {
-        hpx::future<std::vector<std::uint32_t>> overall_result =
-            hpx::gather(gather_basename,
-                hpx::make_ready_future(this_locality + 42), num_localities, i);
-
-        std::vector<std::uint32_t> sol = overall_result.get();
-        for (std::size_t j = 0; j != sol.size(); ++j)
-        {
-            HPX_TEST(j + 42 == sol[j]);
-        }
-    }
-
-    // test functionality based on immediate local result value
-    for (std::uint32_t i = 0; i != 10; ++i)
-    {
-        hpx::future<std::vector<std::uint32_t>> overall_result =
-            hpx::gather(gather_basename, this_locality + 42, num_localities, i);
-
-        std::vector<std::uint32_t> sol = overall_result.get();
-        for (std::size_t j = 0; j != sol.size(); ++j)
-        {
-            HPX_TEST(j + 42 == sol[j]);
-        }
-    }
-}
-
-int hpx_main(int argc, char* argv[])
-{
-    test_gather_here_there();
-    test_gather();
 
     return hpx::finalize();
 }

--- a/libs/local_lcos/include/hpx/local_lcos/and_gate.hpp
+++ b/libs/local_lcos/include/hpx/local_lcos/and_gate.hpp
@@ -228,6 +228,7 @@ namespace hpx { namespace lcos { namespace local {
                 return true;
             }
 
+            outer_lock.unlock();
             return false;
         }
 


### PR DESCRIPTION
- ~~adding hpx::gather API combining gather_here/gather_there~~ (adding this was a mistake as it did turn gather into an equivalent for all_gather)
- adding missing gather test
- fixing various problems and inconsistencies with broadcast
