### PR TITLE
Typeless communicator

### DIFF
--- a/libs/collectives/CMakeLists.txt
+++ b/libs/collectives/CMakeLists.txt
@@ -20,6 +20,7 @@ set(collectives_headers
     hpx/collectives/broadcast.hpp
     hpx/collectives/broadcast_direct.hpp
     hpx/collectives/detail/communicator.hpp
+    hpx/collectives/force_linking.hpp
     hpx/collectives/fold.hpp
     hpx/collectives/gather.hpp
     hpx/collectives/latch.hpp
@@ -42,18 +43,21 @@ set(collectives_compat_headers
 )
 
 # Default location is $HPX_ROOT/libs/collectives/src
-set(collectives_sources barrier.cpp latch.cpp detail/barrier_node.cpp)
+set(collectives_sources barrier.cpp force_linking.cpp latch.cpp
+                        detail/barrier_node.cpp detail/communicator.cpp
+)
 
 include(HPX_AddModule)
 add_hpx_module(
   collectives
   COMPATIBILITY_HEADERS ON # Added in 1.4.0
-  DEPRECATION_WARNINGS FORCE_LINKING_GEN
+  DEPRECATION_WARNINGS
   SOURCES ${collectives_sources}
   HEADERS ${collectives_headers}
   COMPAT_HEADERS ${collectives_compat_headers}
   DEPENDENCIES
     hpx_affinity
+    hpx_algorithms
     hpx_allocator_support
     hpx_assertion
     hpx_async_distributed
@@ -68,6 +72,7 @@ add_hpx_module(
     hpx_functional
     hpx_hardware
     hpx_hashing
+    hpx_init_runtime
     hpx_iterator_support
     hpx_local_lcos
     hpx_logging

--- a/libs/collectives/include/hpx/collectives/force_linking.hpp
+++ b/libs/collectives/include/hpx/collectives/force_linking.hpp
@@ -1,0 +1,16 @@
+//  Copyright (c) 2020 STE||AR Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+namespace hpx { namespace collectives {
+    struct force_linking_helper
+    {
+        void (*dummy)();
+    };
+
+    force_linking_helper& force_linking();
+}}    // namespace hpx::collectives

--- a/libs/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/collectives/include/hpx/collectives/gather.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #if defined(DOXYGEN)
+// clang-format off
 namespace hpx { namespace lcos {
 
     /// Gather a set of values from different call sites
@@ -41,7 +42,8 @@ namespace hpx { namespace lcos {
     ///
     template <typename T>
     hpx::future<std::vector<T>> gather_here(char const* basename,
-        hpx::future<T> result, std::size_t num_sites = std::size_t(-1),
+        hpx::future<T> result,
+        std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1));
 
@@ -70,13 +72,16 @@ namespace hpx { namespace lcos {
     ///             necessary internal facilities used by \a gather_here and
     ///             \a gather_there
     ///
-    /// \returns    This function returns a future which will become ready once
-    ///             the gather operation has been completed.
+    /// \returns    This function returns a future holding a vector with all
+    ///             gathered values. It will become ready once the gather
+    ///             operation has been completed.
     ///
     template <typename T>
-    hpx::future<void> gather_there(char const* basename, hpx::future<T> result,
+    hpx::future<std::vector<T>> gather_there(char const* basename,
+        hpx::future<T> result,
         std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
+        std::size_t this_site = std::size_t(-1),
+        std::size_t root_site = 0);
 
     /// Gather a set of values from different call sites
     ///
@@ -138,72 +143,37 @@ namespace hpx { namespace lcos {
     ///             necessary internal facilities used by \a gather_here and
     ///             \a gather_there
     ///
-    /// \returns    This function returns a future which will become ready once
-    ///             the gather operation has been completed.
+    /// \returns    This function returns a future holding a vector with all
+    ///             gathered values. It will become ready once the gather
+    ///             operation has been completed.
     ///
     template <typename T>
-    hpx::future<void> gather_there(char const* basename, T&& result,
+    hpx::future<std::vector<typename std::decay<T>::type>>
+    gather_there(char const* basename,
+        T&& result,
         std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
+        std::size_t this_site = std::size_t(-1),
+        std::size_t root_site = 0);
 
-/// \def HPX_REGISTER_GATHER_DECLARATION(type, name)
-///
-/// \brief Declare a gather object named \a name for a given data type \a type.
-///
-/// The macro \a HPX_REGISTER_GATHER_DECLARATION can be used to declare
-/// all facilities necessary for a (possibly remote) gather operation.
-///
-/// The parameter \a type specifies for which data type the gather
-/// operations should be enabled.
-///
-/// The (optional) parameter \a name should be a unique C-style identifier
-/// which will be internally used to identify a particular gather operation.
-/// If this defaults to \a \<type\>_gather if not specified.
-///
-/// \note The macro \a HPX_REGISTER_GATHER_DECLARATION can be used with 1
-///       or 2 arguments. The second argument is optional and defaults to
-///       \a \<type\>_gather.
-///
-#define HPX_REGISTER_GATHER_DECLARATION(type, name)
-
-/// \def HPX_REGISTER_GATHER(type, name)
-///
-/// \brief Define a gather object named \a name for a given data type \a type.
-///
-/// The macro \a HPX_REGISTER_GATHER can be used to define
-/// all facilities necessary for a (possibly remote) gather operation.
-///
-/// The parameter \a type specifies for which data type the gather
-/// operations should be enabled.
-///
-/// The (optional) parameter \a name should be a unique C-style identifier
-/// which will be internally used to identify a particular gather operation.
-/// If this defaults to \a \<type\>_gather if not specified.
-///
-/// \note The macro \a HPX_REGISTER_GATHER can be used with 1
-///       or 2 arguments. The second argument is optional and defaults to
-///       \a \<type\>_gather.
-///
-#define HPX_REGISTER_GATHER(type, name)
 }}    // namespace hpx::lcos
+
+// clang-format on
 #else
 
 #include <hpx/config.hpp>
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
-#include <hpx/async_distributed/dataflow.hpp>
+#include <hpx/async_base/launch_policy.hpp>
+#include <hpx/async_local/dataflow.hpp>
 #include <hpx/collectives/detail/communicator.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/acquire_shared_state.hpp>
 #include <hpx/modules/basic_execution.hpp>
-#include <hpx/preprocessor/cat.hpp>
-#include <hpx/preprocessor/expand.hpp>
-#include <hpx/preprocessor/nargs.hpp>
 #include <hpx/runtime/basename_registration.hpp>
-#include <hpx/runtime/components/server/simple_component_base.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime_local/get_num_localities.hpp>
+#include <hpx/thread_support/assert_owns_lock.hpp>
 #include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/unused.hpp>
 
@@ -221,7 +191,7 @@ namespace hpx { namespace traits {
     // support for gather
     namespace communication {
         struct gather_tag;
-    }
+    }    // namespace communication
 
     template <typename Communicator>
     struct communication_operation<Communicator, communication::gather_tag>
@@ -236,7 +206,7 @@ namespace hpx { namespace traits {
         template <typename Result, typename T>
         Result get(std::size_t which, T&& t)
         {
-            using arg_type = typename Communicator::arg_type;
+            using arg_type = typename std::decay<T>::type;
             using mutex_type = typename Communicator::mutex_type;
 
             auto this_ = this->shared_from_this();
@@ -248,7 +218,7 @@ namespace hpx { namespace traits {
                 auto& communicator = this_->communicator_;
 
                 std::unique_lock<mutex_type> l(communicator.mtx_);
-                return communicator.data_;
+                return communicator.template access_data<arg_type>(l);
             };
 
             std::unique_lock<mutex_type> l(communicator_.mtx_);
@@ -259,9 +229,18 @@ namespace hpx { namespace traits {
                     hpx::launch::sync, std::move(on_ready));
 
             communicator_.gate_.synchronize(1, l);
-            communicator_.data_[which] = std::forward<T>(t);
+
+            auto& data = communicator_.template access_data<arg_type>(l);
+            data[which] = std::forward<T>(t);
+
             if (communicator_.gate_.set(which, l))
             {
+                HPX_ASSERT_DOESNT_OWN_LOCK(l);
+                {
+                    std::unique_lock<mutex_type> l(communicator_.mtx_);
+                    communicator_.invalidate_data(l);
+                }
+
                 // this is a one-shot object (generations counters are not
                 // supported), unregister ourselves (but only once)
                 hpx::unregister_with_basename(
@@ -274,15 +253,24 @@ namespace hpx { namespace traits {
         template <typename Result, typename T>
         void set(std::size_t which, T&& t)
         {
+            using arg_type = typename std::decay<T>::type;
             using mutex_type = typename Communicator::mutex_type;
 
             std::unique_lock<mutex_type> l(communicator_.mtx_);
             util::ignore_while_checking<std::unique_lock<mutex_type>> il(&l);
 
             communicator_.gate_.synchronize(1, l);
-            communicator_.data_[which] = t;
+
+            communicator_.template access_data<arg_type>(l)[which] = t;
+
             if (communicator_.gate_.set(which, l))
             {
+                HPX_ASSERT_DOESNT_OWN_LOCK(l);
+                {
+                    std::unique_lock<mutex_type> l(communicator_.mtx_);
+                    communicator_.invalidate_data(l);
+                }
+
                 // this is a one-shot object (generations counters are not
                 // supported), unregister ourselves (but only once)
                 hpx::unregister_with_basename(
@@ -298,13 +286,12 @@ namespace hpx { namespace traits {
 namespace hpx { namespace lcos {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T>
-    hpx::future<hpx::id_type> create_gatherer(char const* basename,
+    inline hpx::future<hpx::id_type> create_gatherer(char const* basename,
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1))
     {
-        return detail::create_communicator<T>(
+        return detail::create_communicator(
             basename, num_sites, generation, this_site);
     }
 
@@ -320,7 +307,7 @@ namespace hpx { namespace lcos {
         auto gather_data =
             [this_site](hpx::future<hpx::id_type>&& fid,
                 hpx::future<T>&& local_result) -> hpx::future<std::vector<T>> {
-            using action_type = typename detail::communicator_server<T>::
+            using action_type = typename detail::communicator_server::
                 template communication_get_action<
                     traits::communication::gather_tag,
                     hpx::future<std::vector<T>>, T>;
@@ -355,7 +342,7 @@ namespace hpx { namespace lcos {
             this_site = static_cast<std::size_t>(hpx::get_locality_id());
 
         return gather_here(
-            create_gatherer<T>(basename, num_sites, generation, this_site),
+            create_gatherer(basename, num_sites, generation, this_site),
             std::move(result), this_site);
     }
 
@@ -375,7 +362,7 @@ namespace hpx { namespace lcos {
         auto gather_data_direct =
             [this_site](hpx::future<hpx::id_type>&& fid,
                 T&& local_result) -> hpx::future<std::vector<arg_type>> {
-            using action_type = typename detail::communicator_server<arg_type>::
+            using action_type = typename detail::communicator_server::
                 template communication_get_action<
                     traits::communication::gather_tag,
                     hpx::future<std::vector<arg_type>>, arg_type>;
@@ -413,7 +400,7 @@ namespace hpx { namespace lcos {
         }
 
         return gather_here(
-            create_gatherer<T>(basename, num_sites, generation, this_site),
+            create_gatherer(basename, num_sites, generation, this_site),
             std::forward<T>(result), this_site);
     }
 
@@ -430,7 +417,7 @@ namespace hpx { namespace lcos {
         auto gather_there_data =
             [this_site](hpx::future<hpx::id_type>&& fid,
                 hpx::future<T>&& local_result) -> hpx::future<void> {
-            using action_type = typename detail::communicator_server<T>::
+            using action_type = typename detail::communicator_server::
                 template communication_set_action<
                     traits::communication::gather_tag, void, T>;
 
@@ -483,7 +470,7 @@ namespace hpx { namespace lcos {
         auto gather_there_data_direct =
             [this_site](hpx::future<hpx::id_type>&& fid,
                 arg_type&& local_result) -> hpx::future<void> {
-            using action_type = typename detail::communicator_server<T>::
+            using action_type = typename detail::communicator_server::
                 template communication_set_action<
                     traits::communication::gather_tag, void, arg_type>;
 
@@ -521,7 +508,7 @@ namespace hpx { namespace lcos {
     }
 }}    // namespace hpx::lcos
 
-////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 namespace hpx {
     using lcos::create_gatherer;
     using lcos::gather_here;
@@ -532,25 +519,7 @@ namespace hpx {
 #define HPX_REGISTER_GATHER_DECLARATION(...) /**/
 
 ///////////////////////////////////////////////////////////////////////////////
-#define HPX_REGISTER_GATHER(...)                                               \
-    HPX_REGISTER_GATHER_(__VA_ARGS__)                                          \
-    /**/
-
-#define HPX_REGISTER_GATHER_(...)                                              \
-    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_GATHER_, HPX_PP_NARGS(__VA_ARGS__))( \
-        __VA_ARGS__))                                                          \
-    /**/
-
-#define HPX_REGISTER_GATHER_1(type)                                            \
-    HPX_REGISTER_GATHER_2(type, HPX_PP_CAT(type, _gather))                     \
-    /**/
-
-#define HPX_REGISTER_GATHER_2(type, name)                                      \
-    typedef hpx::components::component<                                        \
-        hpx::lcos::detail::communicator_server<type>>                          \
-        HPX_PP_CAT(gather_, name);                                             \
-    HPX_REGISTER_COMPONENT(HPX_PP_CAT(gather_, name))                          \
-    /**/
+#define HPX_REGISTER_GATHER(...)             /**/
 
 #endif    // COMPUTE_HOST_CODE
 #endif    // DOXYGEN

--- a/libs/collectives/src/detail/communicator.cpp
+++ b/libs/collectives/src/detail/communicator.cpp
@@ -1,0 +1,101 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+
+#include <hpx/collectives/detail/communicator.hpp>
+#include <hpx/exception.hpp>
+#include <hpx/modules/async_distributed.hpp>
+#include <hpx/modules/futures.hpp>
+#include <hpx/runtime/basename_registration.hpp>
+#include <hpx/runtime/components/component_factory.hpp>
+#include <hpx/runtime/components/new.hpp>
+#include <hpx/runtime/components/server/component.hpp>
+#include <hpx/runtime/components/server/runtime_support.hpp>
+#include <hpx/runtime/naming/id_type.hpp>
+
+#include <cstddef>
+#include <string>
+#include <utility>
+
+///////////////////////////////////////////////////////////////////////////////
+using collectives_component =
+    hpx::components::component<hpx::lcos::detail::communicator_server>;
+
+HPX_REGISTER_COMPONENT(collectives_component);
+
+namespace hpx { namespace lcos { namespace detail {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // force linking only
+    void dummy() {}
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<hpx::id_type> register_communicator_name(
+        hpx::future<hpx::id_type>&& f, std::string basename, std::size_t site)
+    {
+        hpx::id_type target = f.get();
+
+        // Register unmanaged id to avoid cyclic dependencies, unregister
+        // is done after all data has been collected in the component above.
+        hpx::future<bool> result =
+            hpx::register_with_basename(basename, target, site);
+
+        return result.then(hpx::launch::sync,
+            [target = std::move(target), basename = std::move(basename)](
+                hpx::future<bool>&& f) -> hpx::id_type {
+                bool result = f.get();
+                if (!result)
+                {
+                    HPX_THROW_EXCEPTION(bad_parameter,
+                        "hpx::lcos::detail::register_communicator_name",
+                        "the given base name for the communicator "
+                        "operation was already registered: " +
+                            basename);
+                }
+                return target;
+            });
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<hpx::id_type> create_communicator(char const* basename,
+        std::size_t num_sites, std::size_t generation, std::size_t this_site,
+        std::size_t num_values)
+    {
+        if (num_sites == std::size_t(-1))
+        {
+            num_sites = static_cast<std::size_t>(
+                hpx::get_num_localities(hpx::launch::sync));
+        }
+        if (this_site == std::size_t(-1))
+        {
+            this_site = static_cast<std::size_t>(hpx::get_locality_id());
+        }
+        if (num_values == std::size_t(-1))
+        {
+            num_values = num_sites;
+        }
+
+        std::string name(basename);
+        if (generation != std::size_t(-1))
+        {
+            name += std::to_string(generation) + "/";
+        }
+
+        // create a new communicator_server
+        hpx::future<hpx::id_type> id = hpx::new_<detail::communicator_server>(
+            hpx::find_here(), num_sites, name, this_site, num_values);
+
+        // register the communicator's id using the given basename
+        return id.then(hpx::launch::sync,
+            util::bind_back(&detail::register_communicator_name,
+                std::move(name), this_site));
+    }
+}}}    // namespace hpx::lcos::detail
+
+#endif

--- a/libs/collectives/src/force_linking.cpp
+++ b/libs/collectives/src/force_linking.cpp
@@ -1,0 +1,18 @@
+//  Copyright (c) 2020 STE||AR Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/collectives/detail/communicator.hpp>
+#include <hpx/collectives/force_linking.hpp>
+
+namespace hpx { namespace collectives {
+    // reference all symbols that have to be explicitly linked with the core
+    // library
+    force_linking_helper& force_linking()
+    {
+        static force_linking_helper helper{&hpx::lcos::detail::dummy};
+        return helper;
+    }
+}}    // namespace hpx::collectives

--- a/libs/collectives/tests/unit/all_reduce.cpp
+++ b/libs/collectives/tests/unit/all_reduce.cpp
@@ -16,10 +16,8 @@
 #include <utility>
 #include <vector>
 
-char const* all_reduce_basename = "/test/all_reduce/";
-char const* all_reduce_direct_basename = "/test/all_reduce_direct/";
-
-HPX_REGISTER_ALLREDUCE(std::uint32_t, test_all_reduce);
+constexpr char const* all_reduce_basename = "/test/all_reduce/";
+constexpr char const* all_reduce_direct_basename = "/test/all_reduce_direct/";
 
 int hpx_main(int argc, char* argv[])
 {

--- a/libs/collectives/tests/unit/all_to_all.cpp
+++ b/libs/collectives/tests/unit/all_to_all.cpp
@@ -16,10 +16,8 @@
 #include <utility>
 #include <vector>
 
-char const* all_to_all_basename = "/test/all_to_all/";
-char const* all_to_all_direct_basename = "/test/all_to_all_direct/";
-
-HPX_REGISTER_ALLTOALL(std::uint32_t, test_all_to_all);
+constexpr char const* all_to_all_basename = "/test/all_to_all/";
+constexpr char const* all_to_all_direct_basename = "/test/all_to_all_direct/";
 
 int hpx_main(int argc, char* argv[])
 {

--- a/libs/collectives/tests/unit/broadcast.cpp
+++ b/libs/collectives/tests/unit/broadcast.cpp
@@ -16,10 +16,8 @@
 #include <utility>
 #include <vector>
 
-char const* broadcast_basename = "/test/broadcast/";
-char const* broadcast_direct_basename = "/test/broadcast_direct/";
-
-HPX_REGISTER_BROADCAST(std::uint32_t, test_broadcast);
+constexpr char const* broadcast_basename = "/test/broadcast/";
+constexpr char const* broadcast_direct_basename = "/test/broadcast_direct/";
 
 int hpx_main(int argc, char* argv[])
 {

--- a/libs/collectives/tests/unit/gather.cpp
+++ b/libs/collectives/tests/unit/gather.cpp
@@ -17,10 +17,8 @@
 #include <utility>
 #include <vector>
 
-char const* gather_basename = "/test/gather/";
-char const* gather_direct_basename = "/test/gather_direct/";
-
-HPX_REGISTER_GATHER(std::uint32_t, test_gather);
+constexpr char const* gather_basename = "/test/gather/";
+constexpr char const* gather_direct_basename = "/test/gather_direct/";
 
 int hpx_main(int argc, char* argv[])
 {

--- a/libs/collectives/tests/unit/scatter.cpp
+++ b/libs/collectives/tests/unit/scatter.cpp
@@ -17,10 +17,8 @@
 #include <utility>
 #include <vector>
 
-char const* scatter_basename = "/test/scatter/";
-char const* scatter_direct_basename = "/test/scatter_direct/";
-
-HPX_REGISTER_SCATTER(std::uint32_t, test_scatter);
+constexpr char const* scatter_basename = "/test/scatter/";
+constexpr char const* scatter_direct_basename = "/test/scatter_direct/";
 
 int hpx_main(int argc, char* argv[])
 {

--- a/libs/thread_support/include/hpx/thread_support/assert_owns_lock.hpp
+++ b/libs/thread_support/include/hpx/thread_support/assert_owns_lock.hpp
@@ -21,6 +21,11 @@ namespace hpx { namespace util { namespace detail {
     {
     }
 
+    template <typename Lock>
+    void assert_doesnt_own_lock(Lock const&, int)
+    {
+    }
+
 #if !defined(HPX_DISABLE_ASSERTS) && !defined(BOOST_DISABLE_ASSERTS) &&        \
     !defined(NDEBUG)
 
@@ -31,7 +36,17 @@ namespace hpx { namespace util { namespace detail {
         HPX_ASSERT(l.owns_lock());
     }
 
+    template <typename Lock>
+    typename std::enable_if<has_owns_lock<Lock>::value>::type
+    assert_doesnt_own_lock(Lock const& l, long)
+    {
+        HPX_ASSERT(!l.owns_lock());
+    }
+
 #endif
 }}}    // namespace hpx::util::detail
 
 #define HPX_ASSERT_OWNS_LOCK(l) ::hpx::util::detail::assert_owns_lock(l, 0L)
+
+#define HPX_ASSERT_DOESNT_OWN_LOCK(l)                                          \
+    ::hpx::util::detail::assert_doesnt_own_lock(l, 0L)


### PR DESCRIPTION
- This allows to get rid of the macros for `all_reduce`, `all_to_all`, `broadcast`, `gather`, and `scatter`

Relies on #4676 (only the last commit is significant)