### PR TITLE
Add missing hpx/execution.hpp includes for future::then

### DIFF
--- a/libs/collectives/include/hpx/collectives/detail/communicator.hpp
+++ b/libs/collectives/include/hpx/collectives/detail/communicator.hpp
@@ -13,6 +13,7 @@
 #include <hpx/assertion.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/basic_execution/register_locks.hpp>
+#include <hpx/execution.hpp>
 #include <hpx/functional/bind_back.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/local_lcos/and_gate.hpp>

--- a/libs/collectives/src/detail/barrier_node.cpp
+++ b/libs/collectives/src/detail/barrier_node.cpp
@@ -9,6 +9,7 @@
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_combinators/when_all.hpp>
 #include <hpx/collectives/detail/barrier_node.hpp>
+#include <hpx/execution.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/local_lcos/promise.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>

--- a/libs/performance_counters/src/counters.cpp
+++ b/libs/performance_counters/src/counters.cpp
@@ -8,6 +8,7 @@
 #include <hpx/config.hpp>
 #include <hpx/assertion.hpp>
 #include <hpx/async/applier/apply.hpp>
+#include <hpx/execution.hpp>
 #include <hpx/format.hpp>
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/functional/function.hpp>

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -15,6 +15,7 @@
 #include <hpx/async.hpp>
 #include <hpx/basic_execution/register_locks.hpp>
 #include <hpx/errors.hpp>
+#include <hpx/execution.hpp>
 #include <hpx/format.hpp>
 #include <hpx/functional/bind.hpp>
 #include <hpx/functional/bind_back.hpp>


### PR DESCRIPTION
Fixes #4675 and probably fixes #4620 (I could not reproduce the error but I've added the header that should fix it).

@biddisco would you mind giving this a try to verify that things are ok for you too?