### PR TITLE
Fix compilation of pack_traversal_rebind_container.hpp

### DIFF
--- a/libs/pack_traversal/include/hpx/pack_traversal/traits/pack_traversal_rebind_container.hpp
+++ b/libs/pack_traversal/include/hpx/pack_traversal/traits/pack_traversal_rebind_container.hpp
@@ -19,7 +19,9 @@ namespace hpx { namespace traits {
     namespace detail {
         ////////////////////////////////////////////////////////////////////////
         template <typename NewType, typename OldType, typename Enable = void>
-        struct pack_traversal_rebind_container;
+        struct pack_traversal_rebind_container
+        {
+        };
 
         // Specialization for a container with a single type T (no allocator
         // support)
@@ -64,7 +66,7 @@ namespace hpx { namespace traits {
 
     template <typename NewType, typename OldType, typename Enable = void>
     struct pack_traversal_rebind_container
-      : pack_traversal_rebind_container<NewType, OldType>
+      : detail::pack_traversal_rebind_container<NewType, OldType>
     {
     };
 


### PR DESCRIPTION
Fixes

```
2020-05-27T14:05:31.6837782Z D:\a\hpx\hpx\libs\pack_traversal\include\hpx\pack_traversal\traits\pack_traversal_rebind_container.hpp(68,5): error C2499: 'hpx::traits::pack_traversal_rebind_container<NewType,Container,void>': a class cannot be its own base class [D:\a\hpx\hpx\build\libs\resource_partitioner\examples\guided_pool_test.vcxproj]
2020-05-27T14:05:31.6842176Z           with
2020-05-27T14:05:31.6843495Z           [
2020-05-27T14:05:31.6845687Z               NewType=char,
2020-05-27T14:05:31.6849490Z               Container=std::string
2020-05-27T14:05:31.6851492Z           ]
2020-05-27T14:05:31.6855935Z D:\a\hpx\hpx\libs\pack_traversal\include\hpx\pack_traversal\detail\pack_traversal_impl.hpp(340): message : see reference to class template instantiation 'hpx::traits::pack_traversal_rebind_container<NewType,Container,void>' being compiled [D:\a\hpx\hpx\build\libs\resource_partitioner\examples\guided_pool_test.vcxproj]
2020-05-27T14:05:31.6857163Z           with
2020-05-27T14:05:31.6868848Z           [
2020-05-27T14:05:37.0723256Z               NewType=char,
2020-05-27T14:05:37.0723667Z               Container=std::string
2020-05-27T14:05:37.0723848Z           ]
2020-05-27T14:05:37.0724009Z D:\a\hpx\hpx\libs\functional\include\hpx\functional\result_of.hpp(20): message : see reference to class template instantiation 'std::result_of<T>' being compiled [D:\a\hpx\hpx\build\libs\resource_partitioner\examples\guided_pool_test.vcxproj]
2020-05-27T14:05:37.0724140Z           with
2020-05-27T14:05:37.0724246Z           [
2020-05-27T14:05:37.0724429Z               T=hpx::util::detail::functional_unwrap_impl<hpx::parallel::execution::detail::pre_execution_async_domain_schedule<hpx::parallel::execution::guided_pool_executor<hint_type1>,hpx::parallel::execution::pool_numa_hint<hpx::parallel::execution::guided_test_tag>>,1> (void (__cdecl *&&)(size_t,bool,const std::string &),unsigned __int64 &&,bool &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&)
2020-05-27T14:05:37.0724591Z           ]
2020-05-27T14:05:37.0724706Z D:\a\hpx\hpx\libs\functional\include\hpx\functional\result_of.hpp(104): message : see reference to class template instantiation 'hpx::util::detail::result_of_function_object<T>' being compiled [D:\a\hpx\hpx\build\libs\resource_partitioner\examples\guided_pool_test.vcxproj]
2020-05-27T14:05:37.0724848Z           with
2020-05-27T14:05:37.0724949Z           [
2020-05-27T14:05:37.0725130Z               T=hpx::util::detail::functional_unwrap_impl<hpx::parallel::execution::detail::pre_execution_async_domain_schedule<hpx::parallel::execution::guided_pool_executor<hint_type1>,hpx::parallel::execution::pool_numa_hint<hpx::parallel::execution::guided_test_tag>>,1> (void (__cdecl *&&)(size_t,bool,const std::string &),unsigned __int64 &&,bool &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&)
2020-05-27T14:05:37.0725276Z           ]
2020-05-27T14:05:37.0725452Z D:\a\hpx\hpx\libs\functional\include\hpx\functional\result_of.hpp(135): message : see reference to class template instantiation 'hpx::util::detail::result_of_impl<hpx::util::detail::functional_unwrap_impl<_Ty,1>,F (void (__cdecl *&&)(size_t,bool,const std::string &),unsigned __int64 &&,bool &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&)>' being compiled [D:\a\hpx\hpx\build\libs\resource_partitioner\examples\guided_pool_test.vcxproj]
2020-05-27T14:05:37.0725818Z           with
2020-05-27T14:05:37.0725915Z           [
2020-05-27T14:05:37.0726066Z               _Ty=hpx::parallel::execution::detail::pre_execution_async_domain_schedule<hpx::parallel::execution::guided_pool_executor<hint_type1>,hpx::parallel::execution::pool_numa_hint<hpx::parallel::execution::guided_test_tag>>,
2020-05-27T14:05:37.0726249Z               F=hpx::util::detail::functional_unwrap_impl<hpx::parallel::execution::detail::pre_execution_async_domain_schedule<hpx::parallel::execution::guided_pool_executor<hint_type1>,hpx::parallel::execution::pool_numa_hint<hpx::parallel::execution::guided_test_tag>>,1>
2020-05-27T14:05:37.0726384Z           ]
2020-05-27T14:05:37.0726561Z D:\a\hpx\hpx\libs\functional\include\hpx\functional\invoke_fused.hpp(47): message : see reference to class template instantiation 'hpx::util::result_of<F (void (__cdecl *&&)(size_t,bool,const std::string &),unsigned __int64 &&,bool &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&)>' being compiled [D:\a\hpx\hpx\build\libs\resource_partitioner\examples\guided_pool_test.vcxproj]
2020-05-27T14:05:37.0726716Z           with
2020-05-27T14:05:37.0726776Z           [
2020-05-27T14:05:37.0726909Z               F=hpx::util::detail::functional_unwrap_impl<hpx::parallel::execution::detail::pre_execution_async_domain_schedule<hpx::parallel::execution::guided_pool_executor<hint_type1>,hpx::parallel::execution::pool_numa_hint<hpx::parallel::execution::guided_test_tag>>,1>
2020-05-27T14:05:37.0727041Z           ]
2020-05-27T14:05:37.0727297Z D:\a\hpx\hpx\libs\functional\include\hpx\functional\invoke_fused.hpp(64): message : see reference to class template instantiation 'hpx::util::detail::fused_result_of_impl<F,Tuple &&,hpx::util::pack_c<size_t,0,1,2,3>>' being compiled [D:\a\hpx\hpx\build\libs\resource_partitioner\examples\guided_pool_test.vcxproj]
2020-05-27T14:05:37.0727452Z           with
2020-05-27T14:05:37.0727551Z           [
2020-05-27T14:05:37.0727706Z               F=hpx::util::detail::functional_unwrap_impl<hpx::parallel::execution::detail::pre_execution_async_domain_schedule<hpx::parallel::execution::guided_pool_executor<hint_type1>,hpx::parallel::execution::pool_numa_hint<hpx::parallel::execution::guided_test_tag>>,1>,
2020-05-27T14:05:37.0727872Z               Tuple=hpx::util::tuple<void (__cdecl *)(size_t,bool,const std::string &),unsigned __int64,bool,std::basic_string<char,std::char_traits<char>,std::allocator<char>>>
2020-05-27T14:05:37.0727988Z           ]
2020-05-27T14:05:37.0728106Z D:\a\hpx\hpx\libs\executors\include\hpx\executors\dataflow.hpp(124): message : see reference to class template instantiation 'hpx::util::detail::invoke_fused_result<F,Args>' being compiled [D:\a\hpx\hpx\build\libs\resource_partitioner\examples\guided_pool_test.vcxproj]
2020-05-27T14:05:37.0728241Z           with
2020-05-27T14:05:37.0728337Z           [
2020-05-27T14:05:37.0728480Z               F=hpx::util::detail::functional_unwrap_impl<hpx::parallel::execution::detail::pre_execution_async_domain_schedule<hpx::parallel::execution::guided_pool_executor<hint_type1>,hpx::parallel::execution::pool_numa_hint<hpx::parallel::execution::guided_test_tag>>,1>,
2020-05-27T14:05:37.0728646Z               Args=hpx::util::tuple<void (__cdecl *)(size_t,bool,const std::string &),unsigned __int64,bool,std::basic_string<char,std::char_traits<char>,std::allocator<char>>>
2020-05-27T14:05:37.0728765Z           ]
2020-05-27T14:05:37.0728940Z D:\a\hpx\hpx\libs\executors\include\hpx\executors\dataflow.hpp(419): message : see reference to class template instantiation 'hpx::lcos::detail::dataflow_return<_Ty,hpx::util::tuple<T,unsigned __int64,bool,std::basic_string<char,std::char_traits<char>,std::allocator<char>>>>' being compiled [D:\a\hpx\hpx\build\libs\resource_partitioner\examples\guided_pool_test.vcxproj]
2020-05-27T14:05:37.0729157Z           with
2020-05-27T14:05:37.0729391Z           [
2020-05-27T14:05:37.0729539Z               _Ty=hpx::util::detail::functional_unwrap_impl<hpx::parallel::execution::detail::pre_execution_async_domain_schedule<hpx::parallel::execution::guided_pool_executor<hint_type1>,hpx::parallel::execution::pool_numa_hint<hpx::parallel::execution::guided_test_tag>>,1>,
2020-05-27T14:05:37.0729689Z               T=void (__cdecl *)(size_t,bool,const std::string &)
2020-05-27T14:05:37.0729799Z           ]
2020-05-27T14:05:37.0730004Z D:\a\hpx\hpx\libs\executors\include\hpx\executors\dataflow.hpp(403): message : while compiling class template member function 'std::enable_if<!hpx::traits::is_action<std::decay<F>::type,void>::value,hpx::lcos::future<detail::dataflow_return<std::decay<F>::type,hpx::util::tuple<traits::acquire_future<Ts,void>::type...>>::type>>::type hpx::lcos::detail::dataflow_dispatch_impl<false,Policy,void>::call(const Allocator &,Policy_ &&,F &&,Ts &&...)' [D:\a\hpx\hpx\build\libs\resource_partitioner\examples\guided_pool_test.vcxproj]
2020-05-27T14:05:37.0730176Z           with
2020-05-27T14:05:37.0730263Z           [
2020-05-27T14:05:37.0730335Z               Policy=hpx::detail::sync_policy
2020-05-27T14:05:37.0730441Z           ]
2020-05-27T14:05:37.0731281Z D:\a\hpx\hpx\libs\execution\include\hpx\execution\executors\execution.hpp(263): message : see reference to function template instantiation 'hpx::lcos::future<void> hpx::parallel::execution::guided_pool_executor<hint_type1>::async_execute<void(__cdecl *)(size_t,bool,const std::string &),_Ty,bool,std::basic_string<char,std::char_traits<char>,std::allocator<char>>>(F &&,_Ty &&,bool &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&)' being compiled [D:\a\hpx\hpx\build\libs\resource_partitioner\examples\guided_pool_test.vcxproj]
2020-05-27T14:05:37.0731696Z           with
2020-05-27T14:05:37.0731807Z           [
2020-05-27T14:05:37.0732125Z               _Ty=size_t,
2020-05-27T14:05:37.0732272Z               F=void (__cdecl *)(size_t,bool,const std::string &)
2020-05-27T14:05:37.0732345Z           ]
2020-05-27T14:05:37.0732556Z D:\a\hpx\hpx\libs\execution\include\hpx\execution\executors\execution.hpp(262): message : see reference to function template instantiation 'hpx::lcos::future<void> hpx::parallel::execution::guided_pool_executor<hint_type1>::async_execute<void(__cdecl *)(size_t,bool,const std::string &),_Ty,bool,std::basic_string<char,std::char_traits<char>,std::allocator<char>>>(F &&,_Ty &&,bool &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&)' being compiled [D:\a\hpx\hpx\build\libs\resource_partitioner\examples\guided_pool_test.vcxproj]
2020-05-27T14:05:37.0732742Z           with
2020-05-27T14:05:37.0732845Z           [
2020-05-27T14:05:37.0733028Z               _Ty=size_t,
2020-05-27T14:05:37.0733161Z               F=void (__cdecl *)(size_t,bool,const std::string &)
2020-05-27T14:05:37.0733278Z           ]
2020-05-27T14:05:37.0733514Z D:\a\hpx\hpx\libs\execution\include\hpx\execution\executors\execution.hpp(279): message : see reference to function template instantiation 'hpx::lcos::future<void> hpx::parallel::execution::detail::async_execute_dispatch<hpx::parallel::execution::guided_pool_executor<hint_type1>&,void(__cdecl *)(size_t,bool,const std::string &),_Ty,bool,std::basic_string<char,std::char_traits<char>,std::allocator<char>>>(int,TwoWayExecutor,F &&,_Ty &&,bool &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&)' being compiled [D:\a\hpx\hpx\build\libs\resource_partitioner\examples\guided_pool_test.vcxproj]
2020-05-27T14:05:37.0733708Z           with
2020-05-27T14:05:37.0733775Z           [
2020-05-27T14:05:37.0733933Z               _Ty=size_t,
2020-05-27T14:05:37.0734065Z               TwoWayExecutor=hpx::parallel::execution::guided_pool_executor<hint_type1> &,
2020-05-27T14:05:37.0734202Z               F=void (__cdecl *)(size_t,bool,const std::string &)
2020-05-27T14:05:37.0734442Z           ]
2020-05-27T14:05:37.0734863Z D:\a\hpx\hpx\libs\basic_execution\include\hpx\basic_execution\execution.hpp(167): message : see reference to function template instantiation 'hpx::lcos::future<void> hpx::parallel::execution::detail::async_execute_fn_helper<hpx::parallel::execution::guided_pool_executor<hint_type1>,void>::call<hpx::parallel::execution::guided_pool_executor<hint_type1>&,void(__cdecl *)(size_t,bool,const std::string &),_Ty,bool,std::basic_string<char,std::char_traits<char>,std::allocator<char>>>(TwoWayExecutor,F &&,_Ty &&,bool &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&)' being compiled [D:\a\hpx\hpx\build\libs\resource_partitioner\examples\guided_pool_test.vcxproj]
2020-05-27T14:05:37.0735040Z           with
2020-05-27T14:05:37.0735139Z           [
2020-05-27T14:05:37.0735205Z               _Ty=size_t,
2020-05-27T14:05:37.0735324Z               TwoWayExecutor=hpx::parallel::execution::guided_pool_executor<hint_type1> &,
2020-05-27T14:05:37.0735458Z               F=void (__cdecl *)(size_t,bool,const std::string &)
2020-05-27T14:05:37.0735552Z           ]
2020-05-27T14:05:37.0735954Z D:\a\hpx\hpx\libs\basic_execution\include\hpx\basic_execution\execution.hpp(165): message : see reference to function template instantiation 'hpx::lcos::future<void> hpx::parallel::execution::detail::async_execute_fn_helper<hpx::parallel::execution::guided_pool_executor<hint_type1>,void>::call<hpx::parallel::execution::guided_pool_executor<hint_type1>&,void(__cdecl *)(size_t,bool,const std::string &),_Ty,bool,std::basic_string<char,std::char_traits<char>,std::allocator<char>>>(TwoWayExecutor,F &&,_Ty &&,bool &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&)' being compiled [D:\a\hpx\hpx\build\libs\resource_partitioner\examples\guided_pool_test.vcxproj]
2020-05-27T14:05:37.0736201Z           with
2020-05-27T14:05:37.0736314Z           [
2020-05-27T14:05:37.0736372Z               _Ty=size_t,
2020-05-27T14:05:37.0736502Z               TwoWayExecutor=hpx::parallel::execution::guided_pool_executor<hint_type1> &,
2020-05-27T14:05:37.0736629Z               F=void (__cdecl *)(size_t,bool,const std::string &)
2020-05-27T14:05:37.0736734Z           ]
2020-05-27T14:05:37.0736941Z D:\a\hpx\hpx\libs\basic_execution\include\hpx\basic_execution\execution.hpp(252): message : see reference to function template instantiation 'hpx::lcos::future<void> hpx::parallel::execution::detail::async_execute<hpx::parallel::execution::guided_pool_executor<hint_type1>&,void(__cdecl *)(size_t,bool,const std::string &),_Ty,bool,std::basic_string<char,std::char_traits<char>,std::allocator<char>>>(Executor,F &&,_Ty &&,bool &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&)' being compiled [D:\a\hpx\hpx\build\libs\resource_partitioner\examples\guided_pool_test.vcxproj]
2020-05-27T14:05:37.0737101Z           with
2020-05-27T14:05:37.0737200Z           [
2020-05-27T14:05:37.0737258Z               _Ty=size_t,
2020-05-27T14:05:37.0737380Z               Executor=hpx::parallel::execution::guided_pool_executor<hint_type1> &,
2020-05-27T14:05:37.0737507Z               F=void (__cdecl *)(size_t,bool,const std::string &)
2020-05-27T14:05:37.0737612Z           ]
2020-05-27T14:05:37.0737834Z D:\a\hpx\hpx\libs\executors\include\hpx\executors\async.hpp(97): message : see reference to function template instantiation 'hpx::lcos::future<void> hpx::parallel::execution::detail::customization_point<hpx::parallel::execution::detail::async_execute_tag>::operator ()<hpx::parallel::execution::guided_pool_executor<hint_type1>&,void(__cdecl *)(size_t,bool,const std::string &),_Ty,bool,std::basic_string<char,std::char_traits<char>,std::allocator<char>>>(Executor,F &&,_Ty &&,bool &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&) const' being compiled [D:\a\hpx\hpx\build\libs\resource_partitioner\examples\guided_pool_test.vcxproj]
2020-05-27T14:05:37.0738000Z           with
2020-05-27T14:05:37.0738163Z           [
2020-05-27T14:05:37.0738261Z               _Ty=size_t,
2020-05-27T14:05:37.0738340Z               Executor=hpx::parallel::execution::guided_pool_executor<hint_type1> &,
2020-05-27T14:05:37.0738464Z               F=void (__cdecl *)(size_t,bool,const std::string &)
2020-05-27T14:05:37.0738571Z           ]
2020-05-27T14:05:37.0738784Z D:\a\hpx\hpx\libs\async_base\include\hpx\async_base\async.hpp(25): message : see reference to function template instantiation 'hpx::lcos::future<void> hpx::detail::async_dispatch<hpx::parallel::execution::guided_pool_executor<hint_type1>,void>::call<hpx::parallel::execution::guided_pool_executor<hint_type1>&,void(__cdecl *)(size_t,bool,const std::string &),_Ty,bool,std::basic_string<char,std::char_traits<char>,std::allocator<char>>>(Executor_,F &&,_Ty &&,bool &&,std::basic_string<char,std::char_traits<char>,std::allocator<char>> &&)' being compiled [D:\a\hpx\hpx\build\libs\resource_partitioner\examples\guided_pool_test.vcxproj]
2020-05-27T14:05:37.0738966Z           with
2020-05-27T14:05:37.0739068Z           [
2020-05-27T14:05:37.0739166Z               _Ty=size_t,
2020-05-27T14:05:37.0739241Z               Executor_=hpx::parallel::execution::guided_pool_executor<hint_type1> &,
2020-05-27T14:05:37.0739351Z               F=void (__cdecl *)(size_t,bool,const std::string &)
2020-05-27T14:05:37.0739461Z           ]
2020-05-27T14:05:37.0739653Z D:\a\hpx\hpx\libs\resource_partitioner\examples\guided_pool_test.cpp(146): message : see reference to function template instantiation 'hpx::lcos::future<void> hpx::async<hpx::parallel::execution::guided_pool_executor<hint_type1>&,void(__cdecl *)(size_t,bool,const std::string &),size_t,bool,std::string>(F,void (__cdecl *&&)(size_t,bool,const std::string &),size_t &&,bool &&,std::string &&)' being compiled [D:\a\hpx\hpx\build\libs\resource_partitioner\examples\guided_pool_test.vcxproj]
2020-05-27T14:05:37.0739866Z           with
2020-05-27T14:05:37.0739974Z           [
2020-05-27T14:05:37.0740087Z               F=hpx::parallel::execution::guided_pool_executor<hint_type1> &
2020-05-27T14:05:37.0740162Z           ]
```
