### PR TITLE
Miscellaneous compilation fixes

### DIFF
--- a/libs/functional/tests/unit/tag_invoke.cpp
+++ b/libs/functional/tests/unit/tag_invoke.cpp
@@ -13,10 +13,14 @@
 namespace mylib {
     HPX_INLINE_CONSTEXPR_VARIABLE struct foo_fn
     {
+        // We use std::declval<foo_fn> in the function signature instead of
+        // *this to work around a bug in GCC <= 8.
         template <typename T>
-        constexpr auto operator()(T&& x) const noexcept(
-            noexcept(hpx::functional::tag_invoke(*this, std::forward<T>(x))))
-            -> decltype(hpx::functional::tag_invoke(*this, std::forward<T>(x)))
+        constexpr auto operator()(T&& x) const
+            noexcept(noexcept(hpx::functional::tag_invoke(
+                std::declval<foo_fn>(), std::forward<T>(x))))
+                -> decltype(hpx::functional::tag_invoke(
+                    std::declval<foo_fn>(), std::forward<T>(x)))
         {
             return hpx::functional::tag_invoke(*this, std::forward<T>(x));
         }
@@ -24,12 +28,13 @@ namespace mylib {
 
     HPX_INLINE_CONSTEXPR_VARIABLE struct bar_fn
     {
+        // See above for an explanation of std::declval<bar_fn>().
         template <typename T, typename U>
-        constexpr auto operator()(T&& x, U&& u) const
-            noexcept(noexcept(hpx::functional::tag_invoke(
-                *this, std::forward<T>(x), std::forward<U>(u))))
-                -> decltype(hpx::functional::tag_invoke(
-                    *this, std::forward<T>(x), std::forward<U>(u)))
+        constexpr auto operator()(T&& x, U&& u) const noexcept(
+            noexcept(hpx::functional::tag_invoke(std::declval<bar_fn>(),
+                std::forward<T>(x), std::forward<U>(u))))
+            -> decltype(hpx::functional::tag_invoke(
+                std::declval<bar_fn>(), std::forward<T>(x), std::forward<U>(u)))
         {
             return hpx::functional::tag_invoke(
                 *this, std::forward<T>(x), std::forward<U>(u));

--- a/libs/futures/tests/regressions/CMakeLists.txt
+++ b/libs/futures/tests/regressions/CMakeLists.txt
@@ -5,19 +5,21 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests
-    future_2667
-    future_790
+set(tests future_2667 future_790 future_unwrap_878 future_unwrap_1182
+          shared_future_continuation_order shared_future_then_2166
+)
+
+if(HPX_WITH_DISTRIBUTED_RUNTIME)
+  list(
+    APPEND
+    tests
     future_hang_on_get_629
     future_hang_on_then_629
     future_hang_on_wait_with_callback_629
-    future_timed_wait_1025
     future_serialization_1898
-    future_unwrap_878
-    future_unwrap_1182
-    shared_future_continuation_order
-    shared_future_then_2166
-)
+    future_timed_wait_1025
+  )
+endif()
 
 set(future_hang_on_get_629_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 2)
 set(future_hang_on_wait_with_callback_629_PARAMETERS THREADS_PER_LOCALITY 4)

--- a/libs/futures/tests/regressions/future_hang_on_get_629.cpp
+++ b/libs/futures/tests/regressions/future_hang_on_get_629.cpp
@@ -168,21 +168,27 @@ int main(int argc, char* argv[])
     // Configure application-specific options.
     options_description cmdline("usage: " HPX_APPLICATION_STRING " [options]");
 
-    cmdline.add_options()("test-runs",
-        value<std::uint64_t>()->default_value(10),
-        "number of times to repeat the test (0 == infinite)")
+    // clang-format off
+    cmdline.add_options()
+        ("test-runs"
+        , value<std::uint64_t>()->default_value(10)
+        , "number of times to repeat the test (0 == infinite)")
 
-        ("verbose", "print state every iteration")
+        ("verbose"
+        , "print state every iteration")
 
-            ("children", value<std::uint64_t>()->default_value(8),
-                "number of children each node has")
+        ("children"
+        , value<std::uint64_t>()->default_value(8)
+        , "number of children each node has")
 
-                ("depth", value<std::uint64_t>()->default_value(3),
-                    "depth of the tree structure")
+        ("depth"
+        , value<std::uint64_t>()->default_value(3)
+        , "depth of the tree structure")
 
-                    ("delay-iterations",
-                        value<std::uint64_t>()->default_value(1000),
-                        "number of iterations in the delay loop");
+        ("delay-iterations"
+        , value<std::uint64_t>()->default_value(1000)
+        , "number of iterations in the delay loop");
+    // clang-format on
 
     // Initialize and run HPX.
     return hpx::init(cmdline, argc, argv);

--- a/libs/futures/tests/regressions/future_hang_on_then_629.cpp
+++ b/libs/futures/tests/regressions/future_hang_on_then_629.cpp
@@ -184,21 +184,27 @@ int main(int argc, char* argv[])
     // Configure application-specific options.
     options_description cmdline("usage: " HPX_APPLICATION_STRING " [options]");
 
-    cmdline.add_options()("test-runs",
-        value<std::uint64_t>()->default_value(10),
-        "number of times to repeat the test (0 == infinite)")
+    // clang-format off
+    cmdline.add_options()
+        ("test-runs"
+        , value<std::uint64_t>()->default_value(10)
+        , "number of times to repeat the test (0 == infinite)")
 
-        ("verbose", "print state every iteration")
+        ("verbose"
+        , "print state every iteration")
 
-            ("children", value<std::uint64_t>()->default_value(8),
-                "number of children each node has")
+        ("children"
+        , value<std::uint64_t>()->default_value(8)
+        , "number of children each node has")
 
-                ("depth", value<std::uint64_t>()->default_value(3),
-                    "depth of the tree structure")
+        ("depth"
+        , value<std::uint64_t>()->default_value(3)
+        , "depth of the tree structure")
 
-                    ("delay-iterations",
-                        value<std::uint64_t>()->default_value(1000),
-                        "number of iterations in the delay loop");
+        ("delay-iterations"
+        , value<std::uint64_t>()->default_value(1000)
+        , "number of iterations in the delay loop");
+    // clang-format on
 
     // Initialize and run HPX.
     return hpx::init(cmdline, argc, argv);

--- a/libs/futures/tests/regressions/future_hang_on_wait_with_callback_629.cpp
+++ b/libs/futures/tests/regressions/future_hang_on_wait_with_callback_629.cpp
@@ -155,21 +155,27 @@ int main(int argc, char* argv[])
     // Configure application-specific options.
     options_description cmdline("usage: " HPX_APPLICATION_STRING " [options]");
 
-    cmdline.add_options()("test-runs",
-        value<std::uint64_t>()->default_value(1000),
-        "number of times to repeat the test (0 == infinite)")
+    // clang-format off
+    cmdline.add_options()
+        ("test-runs"
+        , value<std::uint64_t>()->default_value(1000)
+        , "number of times to repeat the test (0 == infinite)")
 
-        ("verbose", "print state every iteration")
+        ("verbose"
+        , "print state every iteration")
 
-            ("children", value<std::uint64_t>()->default_value(8),
-                "number of children each node has")
+        ("children"
+        , value<std::uint64_t>()->default_value(8)
+        , "number of children each node has")
 
-                ("depth", value<std::uint64_t>()->default_value(2),
-                    "depth of the tree structure")
+        ("depth"
+        , value<std::uint64_t>()->default_value(2)
+        , "depth of the tree structure")
 
-                    ("delay-iterations",
-                        value<std::uint64_t>()->default_value(1000),
-                        "number of iterations in the delay loop");
+        ("delay-iterations"
+        , value<std::uint64_t>()->default_value(1000)
+        , "number of iterations in the delay loop");
+    // clang-format on
 
     // Initialize and run HPX.
     return hpx::init(cmdline, argc, argv);

--- a/libs/synchronization/tests/unit/barrier_cpp20.cpp
+++ b/libs/synchronization/tests/unit/barrier_cpp20.cpp
@@ -6,8 +6,8 @@
 
 #include <hpx/hpx_main.hpp>
 
-#include <hpx/async.hpp>
 #include <hpx/barrier.hpp>
+#include <hpx/local_async.hpp>
 #include <hpx/testing.hpp>
 
 #include <atomic>

--- a/libs/synchronization/tests/unit/latch_cpp20.cpp
+++ b/libs/synchronization/tests/unit/latch_cpp20.cpp
@@ -6,8 +6,8 @@
 
 #include <hpx/hpx_init.hpp>
 
-#include <hpx/async.hpp>
 #include <hpx/latch.hpp>
+#include <hpx/local_async.hpp>
 #include <hpx/testing.hpp>
 
 #include <atomic>

--- a/libs/threading_base/include/hpx/threading_base/print.hpp
+++ b/libs/threading_base/include/hpx/threading_base/print.hpp
@@ -126,12 +126,13 @@ namespace hpx { namespace debug {
         inline std::ostream& operator<<(
             std::ostream& os, const current_time_print_helper&)
         {
-            using namespace std::chrono;
-            static high_resolution_clock::time_point log_t_start =
-                high_resolution_clock::now();
+            static std::chrono::high_resolution_clock::time_point log_t_start =
+                std::chrono::high_resolution_clock::now();
             //
-            auto now = high_resolution_clock::now();
-            auto nowt = duration_cast<microseconds>(now - log_t_start).count();
+            auto now = std::chrono::high_resolution_clock::now();
+            auto nowt = std::chrono::duration_cast<std::chrono::microseconds>(
+                now - log_t_start)
+                            .count();
             //
             os << debug::dec<10>(nowt) << " ";
             return os;

--- a/libs/threading_base/src/execution_agent.cpp
+++ b/libs/threading_base/src/execution_agent.cpp
@@ -164,6 +164,7 @@ namespace hpx { namespace threads {
             threads::detail::reset_backtrace bt(id);
 #endif
             on_exit_reset_held_lock_data held_locks;
+            HPX_UNUSED(held_locks);
 
             HPX_ASSERT(thrd_data->get_state().state() == active);
             HPX_ASSERT(state != active);


### PR DESCRIPTION
Fixes small things that broke while pycicle was down. I think I fixed all that were reported directly by pycicle but I may have missed other things that were broken but didn't show up in the logs. I'm enabling pycicle for all PRs now to see what's missing.

Flyby: reformat some command line options in the futures module.