### PR TITLE
Adding all_gather and fixing all_to_all 

### DIFF
--- a/libs/collectives/CMakeLists.txt
+++ b/libs/collectives/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2019-2020 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -14,6 +14,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # Default location is $HPX_ROOT/libs/collectives/include
 set(collectives_headers
+    hpx/collectives/all_gather.hpp
     hpx/collectives/all_reduce.hpp
     hpx/collectives/all_to_all.hpp
     hpx/collectives/barrier.hpp

--- a/libs/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/collectives/include/hpx/collectives/all_gather.hpp
@@ -1,10 +1,10 @@
-//  Copyright (c) 2019-2020 Hartmut Kaiser
+//  Copyright (c) 2019 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file all_to_all.hpp
+/// \file all_gather.hpp
 
 #pragma once
 
@@ -17,34 +17,34 @@ namespace hpx { namespace lcos {
     /// This function receives a set of values from all call sites operating on
     /// the given base name.
     ///
-    /// \param  basename    The base name identifying the all_to_all operation
+    /// \param  basename    The base name identifying the all_gather operation
     /// \param  local_result A future referring to the value to transmit to all
     ///                     participating sites from this call site.
     /// \param  num_sites   The number of participating sites (default: all
     ///                     localities).
     /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the all_to_all operation performed on the
+    ///                     number of the all_gather operation performed on the
     ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the all_to_all operation on the
+    ///                     supplied only if the all_gather operation on the
     ///                     given base name has to be performed more than once.
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     /// \params root_site   The site that is responsible for creating the
-    ///                     all_to_all support object. This value is optional
+    ///                     all_gather support object. This value is optional
     ///                     and defaults to '0' (zero).
     ///
-    /// \note       Each all_to_all operation has to be accompanied with a unique
+    /// \note       Each all_gather operation has to be accompanied with a unique
     ///             usage of the \a HPX_REGISTER_ALLTOALL macro to define the
-    ///             necessary internal facilities used by \a all_to_all.
+    ///             necessary internal facilities used by \a all_gather.
     ///
     /// \returns    This function returns a future holding a vector with all
     ///             values send by all participating sites. It will become
-    ///             ready once the all_to_all operation has been completed.
+    ///             ready once the all_gather operation has been completed.
     ///
     template <typename T>
-    hpx::future<std::vector<T>> all_to_all(char const* basename,
-        hpx::future<std::vector<T>>&& result,
+    hpx::future<std::vector<T>> all_gather(char const* basename,
+        hpx::future<T>&& result,
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1),
@@ -55,37 +55,39 @@ namespace hpx { namespace lcos {
     /// This function receives a set of values from all call sites operating on
     /// the given base name.
     ///
-    /// \param  basename    The base name identifying the all_to_all operation
+    /// \param  basename    The base name identifying the all_gather operation
     /// \param  local_result The value to transmit to all
     ///                     participating sites from this call site.
     /// \param  num_sites   The number of participating sites (default: all
     ///                     localities).
     /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the all_to_all operation performed on the
+    ///                     number of the all_gather operation performed on the
     ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the all_to_all operation on the
+    ///                     supplied only if the all_gather operation on the
     ///                     given base name has to be performed more than once.
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     /// \params root_site   The site that is responsible for creating the
-    ///                     all_to_all support object. This value is optional
+    ///                     all_gather support object. This value is optional
     ///                     and defaults to '0' (zero).
     ///
-    /// \note       Each all_to_all operation has to be accompanied with a unique
+    /// \note       Each all_gather operation has to be accompanied with a unique
     ///             usage of the \a HPX_REGISTER_ALLTOALL macro to define the
-    ///             necessary internal facilities used by \a all_to_all.
+    ///             necessary internal facilities used by \a all_gather.
     ///
     /// \returns    This function returns a future holding a vector with all
     ///             values send by all participating sites. It will become
-    ///             ready once the all_to_all operation has been completed.
+    ///             ready once the all_gather operation has been completed.
     ///
     template <typename T>
-    hpx::future<std::vector<typename std::decay<T>::type>> all_to_all(
-        char const* basename, T&& result,
+    hpx::future<std::vector<typename std::decay<T>::type>>
+    all_gather(char const* basename,
+        T&& result,
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
+        std::size_t this_site = std::size_t(-1),
+        std::size_t root_site = 0);
 }}    // namespace hpx::lcos
 
 // clang-format on
@@ -95,15 +97,15 @@ namespace hpx { namespace lcos {
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
+#include <hpx/async/dataflow.hpp>
 #include <hpx/async_base/launch_policy.hpp>
-#include <hpx/async_local/dataflow.hpp>
+#include <hpx/basic_execution.hpp>
 #include <hpx/collectives/detail/communicator.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/acquire_shared_state.hpp>
-#include <hpx/modules/basic_execution.hpp>
 #include <hpx/runtime/basename_registration.hpp>
+#include <hpx/runtime/get_num_localities.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
-#include <hpx/runtime_local/get_num_localities.hpp>
 #include <hpx/thread_support/assert_owns_lock.hpp>
 #include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/unused.hpp>
@@ -119,15 +121,15 @@ namespace hpx { namespace lcos {
 namespace hpx { namespace traits {
 
     namespace communication {
-        struct all_to_all_tag;
+        struct all_gather_tag;
     }    // namespace communication
 
     ///////////////////////////////////////////////////////////////////////////
-    // support for all_to_all
+    // support for all_gather
     template <typename Communicator>
-    struct communication_operation<Communicator, communication::all_to_all_tag>
+    struct communication_operation<Communicator, communication::all_gather_tag>
       : std::enable_shared_from_this<communication_operation<Communicator,
-            communication::all_to_all_tag>>
+            communication::all_gather_tag>>
     {
         communication_operation(Communicator& comm)
           : communicator_(comm)
@@ -135,34 +137,21 @@ namespace hpx { namespace traits {
         }
 
         template <typename Result, typename T>
-        Result get(std::size_t which, std::vector<T>&& t)
+        Result get(std::size_t which, T&& t)
         {
             using arg_type = typename std::decay<T>::type;
             using mutex_type = typename Communicator::mutex_type;
 
             auto this_ = this->shared_from_this();
             auto on_ready =
-                [this_ = std::move(this_), which](
+                [this_ = std::move(this_)](
                     shared_future<void>&& f) -> std::vector<arg_type> {
                 f.get();    // propagate any exceptions
 
                 auto& communicator = this_->communicator_;
 
                 std::unique_lock<mutex_type> l(communicator.mtx_);
-                auto& data =
-                    communicator.template access_data<std::vector<arg_type>>(l);
-
-                // slice the overall data based on the locality id of the
-                // requesting site
-                std::vector<T> result;
-                result.reserve(data.size());
-
-                for (auto const& v : data)
-                {
-                    result.push_back(v[which]);
-                }
-
-                return result;
+                return communicator.template access_data<arg_type>(l);
             };
 
             std::unique_lock<mutex_type> l(communicator_.mtx_);
@@ -174,9 +163,8 @@ namespace hpx { namespace traits {
 
             communicator_.gate_.synchronize(1, l);
 
-            auto& data =
-                communicator_.template access_data<std::vector<arg_type>>(l);
-            data[which] = std::move(t);
+            auto& data = communicator_.template access_data<arg_type>(l);
+            data[which] = std::forward<T>(t);
 
             if (communicator_.gate_.set(which, l))
             {
@@ -202,7 +190,7 @@ namespace hpx { namespace traits {
 namespace hpx { namespace lcos {
 
     ///////////////////////////////////////////////////////////////////////////
-    inline hpx::future<hpx::id_type> create_all_to_all(char const* basename,
+    inline hpx::future<hpx::id_type> create_all_gather(char const* basename,
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1))
@@ -213,22 +201,19 @@ namespace hpx { namespace lcos {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    hpx::future<std::vector<T>> all_to_all(hpx::future<hpx::id_type>&& fid,
-        hpx::future<std::vector<T>>&& local_result,
-        std::size_t this_site = std::size_t(-1))
+    hpx::future<std::vector<T>> all_gather(hpx::future<hpx::id_type>&& fid,
+        hpx::future<T>&& local_result, std::size_t this_site = std::size_t(-1))
     {
         if (this_site == std::size_t(-1))
-        {
             this_site = static_cast<std::size_t>(hpx::get_locality_id());
-        }
 
-        auto all_to_all_data = [this_site](hpx::future<hpx::id_type>&& f,
-                                   hpx::future<std::vector<T>>&& local_result)
-            -> hpx::future<std::vector<T>> {
+        auto all_gather_data =
+            [this_site](hpx::future<hpx::id_type>&& f,
+                hpx::future<T>&& local_result) -> hpx::future<std::vector<T>> {
             using action_type = typename detail::communicator_server::
                 template communication_get_action<
-                    traits::communication::all_to_all_tag,
-                    hpx::future<std::vector<T>>, std::vector<T>>;
+                    traits::communication::all_gather_tag,
+                    hpx::future<std::vector<T>>, T>;
 
             // make sure id is kept alive as long as the returned future
             hpx::id_type id = f.get();
@@ -241,14 +226,13 @@ namespace hpx { namespace lcos {
             return result;
         };
 
-        return dataflow(hpx::launch::sync, std::move(all_to_all_data),
+        return dataflow(hpx::launch::sync, std::move(all_gather_data),
             std::move(fid), std::move(local_result));
     }
 
     template <typename T>
-    hpx::future<std::vector<T>> all_to_all(char const* basename,
-        hpx::future<std::vector<T>>&& local_result,
-        std::size_t num_sites = std::size_t(-1),
+    hpx::future<std::vector<T>> all_gather(char const* basename,
+        hpx::future<T>&& local_result, std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {
@@ -264,8 +248,8 @@ namespace hpx { namespace lcos {
 
         if (this_site == root_site)
         {
-            return all_to_all(
-                create_all_to_all(basename, num_sites, generation, root_site),
+            return all_gather(
+                create_all_gather(basename, num_sites, generation, root_site),
                 std::move(local_result), this_site);
         }
 
@@ -275,28 +259,32 @@ namespace hpx { namespace lcos {
             name += std::to_string(generation) + "/";
         }
 
-        return all_to_all(hpx::find_from_basename(std::move(name), root_site),
+        return all_gather(hpx::find_from_basename(std::move(name), root_site),
             std::move(local_result), this_site);
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    // all_to_all plain values
+    // all_gather plain values
     template <typename T>
-    hpx::future<std::vector<T>> all_to_all(hpx::future<hpx::id_type>&& fid,
-        std::vector<T>&& local_result, std::size_t this_site = std::size_t(-1))
+    hpx::future<std::vector<typename util::decay<T>::type>> all_gather(
+        hpx::future<hpx::id_type>&& fid, T&& local_result,
+        std::size_t this_site = std::size_t(-1))
     {
         if (this_site == std::size_t(-1))
         {
             this_site = static_cast<std::size_t>(hpx::get_locality_id());
         }
 
-        auto all_to_all_data_direct =
-            [local_result = std::move(local_result), this_site](
-                hpx::future<hpx::id_type>&& f) -> hpx::future<std::vector<T>> {
+        using arg_type = typename util::decay<T>::type;
+
+        auto all_gather_data_direct =
+            [local_result = std::forward<T>(local_result), this_site](
+                hpx::future<hpx::id_type>&& f)
+            -> hpx::future<std::vector<arg_type>> {
             using action_type = typename detail::communicator_server::
                 template communication_get_action<
-                    traits::communication::all_to_all_tag,
-                    hpx::future<std::vector<T>>, std::vector<T>>;
+                    traits::communication::all_gather_tag,
+                    hpx::future<std::vector<arg_type>>, arg_type>;
 
             // make sure id is kept alive as long as the returned future
             hpx::id_type id = f.get();
@@ -309,12 +297,12 @@ namespace hpx { namespace lcos {
             return result;
         };
 
-        return fid.then(hpx::launch::sync, std::move(all_to_all_data_direct));
+        return fid.then(hpx::launch::sync, std::move(all_gather_data_direct));
     }
 
     template <typename T>
-    hpx::future<std::vector<T>> all_to_all(
-        char const* basename, std::vector<T>&& local_result,
+    hpx::future<std::vector<typename util::decay<T>::type>> all_gather(
+        char const* basename, T&& local_result,
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
@@ -331,9 +319,9 @@ namespace hpx { namespace lcos {
 
         if (this_site == root_site)
         {
-            return all_to_all(
-                create_all_to_all(basename, num_sites, generation, root_site),
-                std::move(local_result), this_site);
+            return all_gather(
+                create_all_gather(basename, num_sites, generation, root_site),
+                std::forward<T>(local_result), this_site);
         }
 
         std::string name(basename);
@@ -342,22 +330,22 @@ namespace hpx { namespace lcos {
             name += std::to_string(generation) + "/";
         }
 
-        return all_to_all(hpx::find_from_basename(std::move(name), root_site),
-            std::move(local_result), this_site);
+        return all_gather(hpx::find_from_basename(std::move(name), root_site),
+            std::forward<T>(local_result), this_site);
     }
 }}    // namespace hpx::lcos
 
 ////////////////////////////////////////////////////////////////////////////////
 namespace hpx {
-    using lcos::all_to_all;
-    using lcos::create_all_to_all;
+    using lcos::all_gather;
+    using lcos::create_all_gather;
 }    // namespace hpx
 
 ////////////////////////////////////////////////////////////////////////////////
-#define HPX_REGISTER_ALLTOALL_DECLARATION(...) /**/
+#define HPX_REGISTER_ALLGATHER_DECLARATION(...) /**/
 
 ////////////////////////////////////////////////////////////////////////////////
-#define HPX_REGISTER_ALLTOALL(...)             /**/
+#define HPX_REGISTER_ALLGATHER(...)             /**/
 
 #endif    // COMPUTE_HOST_CODE
 #endif    // DOXYGEN

--- a/libs/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/collectives/include/hpx/collectives/all_gather.hpp
@@ -97,15 +97,15 @@ namespace hpx { namespace lcos {
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
-#include <hpx/async/dataflow.hpp>
 #include <hpx/async_base/launch_policy.hpp>
-#include <hpx/basic_execution.hpp>
+#include <hpx/async_local/dataflow.hpp>
 #include <hpx/collectives/detail/communicator.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/acquire_shared_state.hpp>
+#include <hpx/modules/basic_execution.hpp>
 #include <hpx/runtime/basename_registration.hpp>
-#include <hpx/runtime/get_num_localities.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
+#include <hpx/runtime_local/get_num_localities.hpp>
 #include <hpx/thread_support/assert_owns_lock.hpp>
 #include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/unused.hpp>

--- a/libs/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/collectives/include/hpx/collectives/all_to_all.hpp
@@ -313,9 +313,8 @@ namespace hpx { namespace lcos {
     }
 
     template <typename T>
-    hpx::future<std::vector<T>> all_to_all(
-        char const* basename, std::vector<T>&& local_result,
-        std::size_t num_sites = std::size_t(-1),
+    hpx::future<std::vector<T>> all_to_all(char const* basename,
+        std::vector<T>&& local_result, std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {

--- a/libs/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/collectives/include/hpx/collectives/gather.hpp
@@ -143,19 +143,13 @@ namespace hpx { namespace lcos {
     ///             necessary internal facilities used by \a gather_here and
     ///             \a gather_there
     ///
-    /// \returns    This function returns a future holding a vector with all
-    ///             gathered values. It will become ready once the gather
-    ///             operation has been completed.
+    /// \returns    This function returns a future which will become ready once
+    ///             the gather operation has been completed.
     ///
     template <typename T>
-    hpx::future<std::vector<typename std::decay<T>::type>>
-    gather_there(char const* basename,
-        T&& result,
+    hpx::future<void> gather_there(char const* basename, T&& result,
         std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1),
-        std::size_t root_site = 0);
-
-}}    // namespace hpx::lcos
+        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
 
 // clang-format on
 #else

--- a/libs/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/collectives/include/hpx/collectives/gather.hpp
@@ -154,9 +154,6 @@ namespace hpx { namespace lcos {
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1),
         std::size_t root_site = 0);
-
-}}    // namespace hpx::lcos
-
 }}    // namespace hpx::lcos
 
 // clang-format on
@@ -304,7 +301,9 @@ namespace hpx { namespace lcos {
         hpx::future<T>&& result, std::size_t this_site = std::size_t(-1))
     {
         if (this_site == std::size_t(-1))
+        {
             this_site = static_cast<std::size_t>(hpx::get_locality_id());
+        }
 
         auto gather_data =
             [this_site](hpx::future<hpx::id_type>&& fid,
@@ -341,7 +340,9 @@ namespace hpx { namespace lcos {
                 hpx::get_num_localities(hpx::launch::sync));
         }
         if (this_site == std::size_t(-1))
+        {
             this_site = static_cast<std::size_t>(hpx::get_locality_id());
+        }
 
         return gather_here(
             create_gatherer(basename, num_sites, generation, this_site),
@@ -359,6 +360,7 @@ namespace hpx { namespace lcos {
         {
             this_site = static_cast<std::size_t>(hpx::get_locality_id());
         }
+
         typedef typename std::decay<T>::type arg_type;
 
         auto gather_data_direct =
@@ -443,14 +445,11 @@ namespace hpx { namespace lcos {
         hpx::future<T>&& result, std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {
-        if (this_site == std::size_t(-1))
-        {
-            this_site = static_cast<std::size_t>(hpx::get_locality_id());
-        }
-
         std::string name(basename);
         if (generation != std::size_t(-1))
+        {
             name += std::to_string(generation) + "/";
+        }
 
         return gather_there(hpx::find_from_basename(std::move(name), root_site),
             std::move(result), this_site);
@@ -496,14 +495,11 @@ namespace hpx { namespace lcos {
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {
-        if (this_site == std::size_t(-1))
-        {
-            this_site = static_cast<std::size_t>(hpx::get_locality_id());
-        }
-
         std::string name(basename);
         if (generation != std::size_t(-1))
+        {
             name += std::to_string(generation) + "/";
+        }
 
         return gather_there(hpx::find_from_basename(std::move(name), root_site),
             std::forward<T>(local_result), this_site);

--- a/libs/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/collectives/include/hpx/collectives/gather.hpp
@@ -143,13 +143,21 @@ namespace hpx { namespace lcos {
     ///             necessary internal facilities used by \a gather_here and
     ///             \a gather_there
     ///
-    /// \returns    This function returns a future which will become ready once
-    ///             the gather operation has been completed.
+    /// \returns    This function returns a future holding a vector with all
+    ///             gathered values. It will become ready once the gather
+    ///             operation has been completed.
     ///
     template <typename T>
-    hpx::future<void> gather_there(char const* basename, T&& result,
+    hpx::future<std::vector<typename std::decay<T>::type>>
+    gather_there(char const* basename,
+        T&& result,
         std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
+        std::size_t this_site = std::size_t(-1),
+        std::size_t root_site = 0);
+
+}}    // namespace hpx::lcos
+
+}}    // namespace hpx::lcos
 
 // clang-format on
 #else

--- a/libs/collectives/tests/unit/CMakeLists.txt
+++ b/libs/collectives/tests/unit/CMakeLists.txt
@@ -5,6 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    all_gather
     all_reduce
     all_to_all
     barrier
@@ -20,6 +21,7 @@ set(tests
     scatter
 )
 
+set(all_gather_PARAMETERS LOCALITIES 2)
 set(all_reduce_PARAMETERS LOCALITIES 2)
 set(all_to_all_PARAMETERS LOCALITIES 2)
 set(broadcast_PARAMETERS LOCALITIES 2)

--- a/libs/collectives/tests/unit/all_gather.cpp
+++ b/libs/collectives/tests/unit/all_gather.cpp
@@ -4,10 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/collectives.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/modules/collectives.hpp>
-#include <hpx/modules/testing.hpp>
+#include <hpx/testing.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -16,8 +16,8 @@
 #include <utility>
 #include <vector>
 
-constexpr char const* all_reduce_basename = "/test/all_reduce/";
-constexpr char const* all_reduce_direct_basename = "/test/all_reduce_direct/";
+constexpr char const* all_gather_basename = "/test/all_gather/";
+constexpr char const* all_gather_direct_basename = "/test/all_gather_direct/";
 
 int hpx_main(int argc, char* argv[])
 {
@@ -30,16 +30,17 @@ int hpx_main(int argc, char* argv[])
         hpx::future<std::uint32_t> value =
             hpx::make_ready_future(hpx::get_locality_id());
 
-        hpx::future<std::uint32_t> overall_result =
-            hpx::all_reduce(all_reduce_basename, std::move(value),
-                std::plus<std::uint32_t>{}, num_localities, i);
+        hpx::future<std::vector<std::uint32_t>> overall_result =
+            hpx::all_gather(
+                all_gather_basename, std::move(value), num_localities, i);
 
-        std::uint32_t sum = 0;
-        for (std::uint32_t j = 0; j != num_localities; ++j)
+        std::vector<std::uint32_t> r = overall_result.get();
+        HPX_TEST_EQ(r.size(), num_localities);
+
+        for (std::size_t j = 0; j != r.size(); ++j)
         {
-            sum += j;
+            HPX_TEST_EQ(r[j], j);
         }
-        HPX_TEST_EQ(sum, overall_result.get());
     }
 
     // test functionality based on immediate local result value
@@ -47,16 +48,17 @@ int hpx_main(int argc, char* argv[])
     {
         std::uint32_t value = hpx::get_locality_id();
 
-        hpx::future<std::uint32_t> overall_result =
-            hpx::all_reduce(all_reduce_direct_basename, value,
-                std::plus<std::uint32_t>{}, num_localities, i);
+        hpx::future<std::vector<std::uint32_t>> overall_result =
+            hpx::all_gather(
+                all_gather_direct_basename, value, num_localities, i);
 
-        std::uint32_t sum = 0;
-        for (std::uint32_t j = 0; j != num_localities; ++j)
+        std::vector<std::uint32_t> r = overall_result.get();
+        HPX_TEST_EQ(r.size(), num_localities);
+
+        for (std::size_t j = 0; j != r.size(); ++j)
         {
-            sum += j;
+            HPX_TEST_EQ(r[j], j);
         }
-        HPX_TEST_EQ(sum, overall_result.get());
     }
 
     return hpx::finalize();

--- a/libs/collectives/tests/unit/all_gather.cpp
+++ b/libs/collectives/tests/unit/all_gather.cpp
@@ -4,10 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/collectives.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/testing.hpp>
+#include <hpx/modules/collectives.hpp>
+#include <hpx/modules/testing.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/libs/collectives/tests/unit/all_to_all.cpp
+++ b/libs/collectives/tests/unit/all_to_all.cpp
@@ -9,6 +9,7 @@
 #include <hpx/modules/collectives.hpp>
 #include <hpx/modules/testing.hpp>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
@@ -21,13 +22,18 @@ constexpr char const* all_to_all_direct_basename = "/test/all_to_all_direct/";
 
 int hpx_main(int argc, char* argv[])
 {
+    std::uint32_t this_locality = hpx::get_locality_id();
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
+    HPX_TEST(num_localities >= 2);
 
     // test functionality based on future<> of local result
     for (int i = 0; i != 10; ++i)
     {
-        hpx::future<std::uint32_t> value =
-            hpx::make_ready_future(hpx::get_locality_id());
+        std::vector<std::uint32_t> values(num_localities);
+        std::fill(values.begin(), values.end(), this_locality);
+
+        hpx::future<std::vector<std::uint32_t>> value =
+            hpx::make_ready_future(std::move(values));
 
         hpx::future<std::vector<std::uint32_t>> overall_result =
             hpx::all_to_all(
@@ -45,11 +51,12 @@ int hpx_main(int argc, char* argv[])
     // test functionality based on immediate local result value
     for (int i = 0; i != 10; ++i)
     {
-        std::uint32_t value = hpx::get_locality_id();
+        std::vector<std::uint32_t> values(num_localities);
+        std::fill(values.begin(), values.end(), this_locality);
 
         hpx::future<std::vector<std::uint32_t>> overall_result =
-            hpx::all_to_all(
-                all_to_all_direct_basename, value, num_localities, i);
+            hpx::all_to_all(all_to_all_direct_basename, std::move(values),
+                num_localities, i);
 
         std::vector<std::uint32_t> r = overall_result.get();
         HPX_TEST_EQ(r.size(), num_localities);


### PR DESCRIPTION
 This essentially renames the existing `all_to_all` to `all_gather` and adds a proper implementation of `all_to_all`.

This relies on #4678 (only the last commit is significant).

