### PR TITLE
Fix thread stack size handling

### DIFF
--- a/libs/schedulers/include/hpx/schedulers/thread_queue.hpp
+++ b/libs/schedulers/include/hpx/schedulers/thread_queue.hpp
@@ -643,6 +643,13 @@ namespace hpx { namespace threads { namespace policies {
             if (id)
                 *id = invalid_thread_id;
 
+            if (data.stacksize == threads::thread_stacksize_current)
+            {
+                data.stacksize = get_self_stacksize_enum();
+            }
+
+            HPX_ASSERT(data.stacksize != threads::thread_stacksize_current);
+
             if (data.run_now)
             {
                 threads::thread_id_type thrd;

--- a/libs/schedulers/include/hpx/schedulers/thread_queue_mc.hpp
+++ b/libs/schedulers/include/hpx/schedulers/thread_queue_mc.hpp
@@ -9,6 +9,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/concurrency/cache_line_data.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/errors.hpp>
@@ -200,6 +201,13 @@ namespace hpx { namespace threads { namespace policies {
             // thread has not been created yet
             if (id)
                 *id = invalid_thread_id;
+
+            if (data.stacksize == threads::thread_stacksize_current)
+            {
+                data.stacksize = get_self_stacksize_enum();
+            }
+
+            HPX_ASSERT(data.stacksize != threads::thread_stacksize_current);
 
             if (data.run_now)
             {

--- a/libs/threading_base/include/hpx/threading_base/scheduler_base.hpp
+++ b/libs/threading_base/include/hpx/threading_base/scheduler_base.hpp
@@ -248,11 +248,11 @@ namespace hpx { namespace threads { namespace policies {
                 stacksize = get_self_stacksize_enum();
             }
 
+            HPX_ASSERT(stacksize != thread_stacksize_current);
+
             switch (stacksize)
             {
             case thread_stacksize_small:
-                HPX_FALLTHROUGH;
-            case thread_stacksize_current:
                 return thread_queue_init_.small_stacksize_;
 
             case thread_stacksize_medium:

--- a/libs/threading_base/src/thread_data.cpp
+++ b/libs/threading_base/src/thread_data.cpp
@@ -76,6 +76,8 @@ namespace hpx { namespace threads {
         LTM_(debug) << "thread::thread(" << this << "), description("
                     << get_description() << ")";
 
+        HPX_ASSERT(stacksize_enum_ != threads::thread_stacksize_current);
+
 #ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
         // store the thread id of the parent thread, mainly for debugging
         // purposes
@@ -303,8 +305,11 @@ namespace hpx { namespace threads {
     thread_stacksize get_self_stacksize_enum()
     {
         thread_data* thrd_data = get_self_id_data();
-        return thrd_data ? thrd_data->get_stack_size_enum() :
-                           thread_stacksize_default;
+        thread_stacksize stacksize = thrd_data ?
+            thrd_data->get_stack_size_enum() :
+            thread_stacksize_default;
+        HPX_ASSERT(stacksize != thread_stacksize_current);
+        return stacksize;
     }
 
 #ifndef HPX_HAVE_THREAD_PARENT_REFERENCE

--- a/libs/threading_base/tests/regressions/CMakeLists.txt
+++ b/libs/threading_base/tests/regressions/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests thread_local_data)
+set(tests thread_local_data thread_stacksize_current)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/threading_base/tests/regressions/thread_stacksize_current.cpp
+++ b/libs/threading_base/tests/regressions/thread_stacksize_current.cpp
@@ -1,0 +1,76 @@
+//  Copyright (c) 2020 Mikael Simberg
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This test checks that no thread has thread_stacksize_current as its actual
+// stacksize. thread_stacksize_current can be used as input when creating a
+// thread, but it should always be converted to something between
+// thread_stacksize_minimal and thread_stacksize_maximal when a thread has been
+// created.
+
+#include <hpx/hpx_init.hpp>
+
+#include <hpx/local_async.hpp>
+#include <hpx/testing.hpp>
+#include <hpx/threading_base.hpp>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+void test(hpx::threads::thread_stacksize stacksize)
+{
+    hpx::parallel::execution::parallel_executor exec(stacksize);
+    hpx::parallel::execution::parallel_executor exec_current(
+        hpx::threads::thread_stacksize_current);
+
+    hpx::async(exec, [&exec_current, stacksize]() {
+        // This thread should have the stack size stacksize; it has been
+        // explicitly set in the executor.
+        hpx::threads::thread_stacksize self_stacksize =
+            hpx::threads::get_self_stacksize_enum();
+        HPX_TEST_EQ(self_stacksize, stacksize);
+        HPX_TEST_NEQ(self_stacksize, hpx::threads::thread_stacksize_current);
+
+        hpx::async(exec_current, [stacksize]() {
+            // This thread should also have the stack size stacksize; it has
+            // been inherited size from the parent thread.
+            hpx::threads::thread_stacksize self_stacksize =
+                hpx::threads::get_self_stacksize_enum();
+            HPX_TEST_EQ(self_stacksize, stacksize);
+            HPX_TEST_NEQ(
+                self_stacksize, hpx::threads::thread_stacksize_current);
+        }).get();
+    }).get();
+}
+
+int hpx_main()
+{
+    for (hpx::threads::thread_stacksize stacksize =
+             hpx::threads::thread_stacksize_minimal;
+         stacksize < hpx::threads::thread_stacksize_maximal;
+         stacksize = static_cast<hpx::threads::thread_stacksize>(stacksize + 1))
+    {
+        test(stacksize);
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char** argv)
+{
+    std::vector<std::string> schedulers = {"local", "local-priority-fifo",
+        "local-priority-lifo", "static", "static-priority", "abp-priority-fifo",
+        "abp-priority-lifo", "shared-priority"};
+    for (auto const& scheduler : schedulers)
+    {
+        hpx::init_params iparams;
+        iparams.cfg = {"--hpx:queuing=" + std::string(scheduler)};
+        std::cout << iparams.cfg[0] << std::endl;
+        hpx::init(argc, argv, iparams);
+    }
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Fixes #4648. The stack size enum is now updated from `thread_stacksize_current` to an actual stack size when a thread is added.