### PR TITLE
Changes to apply needed for cuda/cublas executor

### DIFF
--- a/libs/execution/include/hpx/execution/executors/execution.hpp
+++ b/libs/execution/include/hpx/execution/executors/execution.hpp
@@ -463,7 +463,7 @@ namespace hpx { namespace parallel { namespace execution {
                 std::forward<Ts>(ts)...))
             {
                 // use post, if exposed
-                exec.post(std::forward<F>(f), std::forward<Ts>(ts)...);
+                return exec.post(std::forward<F>(f), std::forward<Ts>(ts)...);
             }
 
             template <typename TwoWayExecutor, typename F, typename... Ts>

--- a/libs/executors/include/hpx/executors/apply.hpp
+++ b/libs/executors/include/hpx/executors/apply.hpp
@@ -49,9 +49,8 @@ namespace hpx { namespace detail {
             traits::is_threads_executor<Executor>::value>::type>
     {
         template <typename Executor_, typename F, typename... Ts>
-        HPX_FORCEINLINE static typename std::enable_if<
-            traits::detail::is_deferred_invocable<F, Ts...>::value, bool>::type
-        call(Executor_&& exec, F&& f, Ts&&... ts)
+        HPX_FORCEINLINE static decltype(auto) call(
+            Executor_&& exec, F&& f, Ts&&... ts)
         {
             parallel::execution::post(std::forward<Executor_>(exec),
                 std::forward<F>(f), std::forward<Ts>(ts)...);


### PR DESCRIPTION
Two patches:
#p1
    Use decltype(auto) for apply return type to fix cuda executor issue:
makes the `hpx::apply` dispatch match the `hpx::async` dispatch and allows the return type to be deduced by return from the executor instead of the function - which breaks when functions have things like cuda streams added by the executor

#p2 Allow apply to return a value:
Certain executors such as cuda, cublas, or networking, are able to
create asynchronous work without spawning a task and will usually return
a future, however the use of `apply` instead of `async` might be preferred
in certain cases to allow multiple kernels (for example) to be launched
on a stream (execution order guaranteed by the 3rd party library).

In these cases, the return value of the function invocation should
be passed back to the user so that a call to apply can be checked
before proceeding if an error code is returned from a function.

This allows constructions such as
    ```cudaError_t err = hpx::apply(cuda_exec, cudaMemcpyAsync,
        d_A, h_A.data(), size_A * sizeof(T), cudaMemcpyHostToDevice);```
to be used and the return checked directly.