### PR TITLE
Add short descriptions to modules missing documentation

### DIFF
--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -427,6 +427,8 @@ rst_prolog += '''
 .. _hwloc: https://www.open-mpi.org/projects/hwloc/
 .. |tbb| replace:: Intel Threading Building Blocks (TBB)
 .. _tbb: https://www.threadingbuildingblocks.org/
+.. |vtune| replace:: Intel VTune
+.. _vtune: https://software.intel.com/content/www/us/en/develop/tools/vtune-profiler.html
 .. |ppl| replace:: Microsoft Parallel Patterns Library (PPL)
 .. _ppl: https://msdn.microsoft.com/en-us/library/dd492418.aspx
 .. |cilk_pp| replace:: Cilk++

--- a/docs/sphinx/manual/hpx_runtime_and_resources.rst
+++ b/docs/sphinx/manual/hpx_runtime_and_resources.rst
@@ -179,6 +179,8 @@ thread pool.
    It is simpler in some situations to schedule important tasks with high
    priority instead of using a separate thread pool.
 
+.. _using_resource_partitioner:
+
 Using the resource partitioner
 ------------------------------
 

--- a/libs/affinity/docs/index.rst
+++ b/libs/affinity/docs/index.rst
@@ -11,3 +11,8 @@
 affinity
 ========
 
+The affinity module contains helper functionality for mapping worker threads to
+hardware resources.
+
+See the :ref:`API reference <libs_affinity_api>` of the module for more
+details.

--- a/libs/asio/docs/index.rst
+++ b/libs/asio/docs/index.rst
@@ -11,3 +11,8 @@
 asio
 ====
 
+The asio module is a thin wrapper around the Boost.ASIO library, providing a
+few additional helper functions.
+
+See the :ref:`API reference <libs_algorithms_api>` of the module for more
+details.

--- a/libs/async_base/docs/index.rst
+++ b/libs/async_base/docs/index.rst
@@ -11,7 +11,10 @@
 async_base
 ==========
 
-TODO: High-level description of the library.
+The async_base module defines the basic functionality for spawning tasks on
+thread pools. This module does not implement any functionality on its own, but
+is extended by :ref:`libs_async_local` and :ref:`libs_async_distributed` with
+implementations for the local and distributed cases.
 
 See the :ref:`API reference <libs_async_base_api>` of this module for more
 details.

--- a/libs/command_line_handling/docs/index.rst
+++ b/libs/command_line_handling/docs/index.rst
@@ -11,3 +11,10 @@
 command_line_handling
 =====================
 
+The command_line_handling module defines and handles the command-line options
+required by the |hpx| runtime, combining them with configuration options
+defined by the :ref:`libs_runtime_configuration` module. The actual parsing of
+command line options is handled by the :ref:`libs_program_options` module.
+
+See the :ref:`API reference <libs_command_line_handling_api>` of the module for
+more details.

--- a/libs/config_registry/docs/index.rst
+++ b/libs/config_registry/docs/index.rst
@@ -11,7 +11,13 @@
 config_registry
 ===============
 
-TODO: High-level description of the library.
+The config_registry module is a low level module providing helper functionality
+for registering configuration entries to a global registry from other modules.
+The :cpp:func:`hpx::config_registry::add_module_config` function is used to add
+configuration options, and :cpp:func:`hpx::config_registry::get_module_configs`
+can be used to retrieve configuration entries registered so far.
+:cpp:class:`add_module_config_helper` can be used to register configuration
+entries through static global options.
 
 See the :ref:`API reference <libs_config_registry_api>` of this module for more
 details.

--- a/libs/distributed_executors/docs/index.rst
+++ b/libs/distributed_executors/docs/index.rst
@@ -11,7 +11,9 @@
 distributed_executors
 =====================
 
-TODO: High-level description of the library.
+This module provides the executor
+:cpp:class:`hpx::parallel::execution::disribution_policy_executor`. It allows
+one to create work that is implicitly distributed over multiple localities.
 
 See the :ref:`API reference <libs_distributed_executors_api>` of this module for more
 details.

--- a/libs/executors/docs/index.rst
+++ b/libs/executors/docs/index.rst
@@ -11,7 +11,20 @@
 executors
 =========
 
-TODO: High-level description of the library.
+The executors module exposes executors and execution policies. Most importantly,
+it exposes the following classes and constants:
+
+* :cpp:class:`hpx::parallel::execution::sequenced_executor`
+* :cpp:class:`hpx::parallel::execution::parallel_executor`
+* :cpp:class:`hpx::parallel::execution::sequenced_policy`
+* :cpp:class:`hpx::parallel::execution::parallel_policy`
+* :cpp:class:`hpx::parallel::execution::parallel_unsequenced_policy`
+* :cpp:class:`hpx::parallel::execution::sequenced_task_policy`
+* :cpp:class:`hpx::parallel::execution::parallel_task_policy`
+* :c:var:`hpx::parallel::execution::seq`
+* :c:var:`hpx::parallel::execution::par`
+* :c:var:`hpx::parallel::execution::par_unseq`
+* :c:var:`hpx::parallel::execution::task`
 
 See the :ref:`API reference <libs_executors_api>` of this module for more
 details.

--- a/libs/futures/docs/index.rst
+++ b/libs/futures/docs/index.rst
@@ -11,7 +11,11 @@
 futures
 =======
 
-TODO: High-level description of the library.
+This module defines the :cpp:class:`hpx::lcos::future` and
+:cpp:class:`hpx:lcos::shared_future` classes corresponding to the C++ standard
+library classes ``std::future`` and ``std::shared_future``. Note that the
+specializations of :cpp:func:`hpx::lcos::future::then` for executors and
+execution policies are defined in the :ref:`libs_execution` module.
 
 See the :ref:`API reference <libs_futures_api>` of this module for more
 details.

--- a/libs/io_service/docs/index.rst
+++ b/libs/io_service/docs/index.rst
@@ -11,7 +11,14 @@
 io_service
 ==========
 
-TODO: High-level description of the library.
+This module provides an abstraction over Boost.ASIO, combining multiple
+``boost::asio::io_service``\ s into a single pool.
+:cpp:class:`hpx::util::io_service_pool` provides a simple pool of
+``boost::asio::io_service``\ s with an API similar to
+``boost::asio::io_service``.
+:cpp:class:`hpx::threads::detail::io_service_thread_pool`` wraps
+:cpp:class:`hpx::util::io_service_pool` into an interface derived from
+:cpp:class:`hpx::threads::detail::thread_pool_base`.
 
 See the :ref:`API reference <libs_io_service_api>` of this module for more
 details.

--- a/libs/itt_notify/docs/index.rst
+++ b/libs/itt_notify/docs/index.rst
@@ -11,7 +11,7 @@
 itt_notify
 ==========
 
-TODO: High-level description of the library.
+This module provides support for profiling with |vtune|_.
 
 See the :ref:`API reference <libs_itt_notify_api>` of this module for more
 details.

--- a/libs/local_async/docs/index.rst
+++ b/libs/local_async/docs/index.rst
@@ -11,7 +11,9 @@
 local_async
 ===========
 
-TODO: High-level description of the library.
+This module extends :ref:`libs_async_base` to provide local implementations of
+:cpp:func:`hpx::async`, :cpp:func:`hpx::apply`, :cpp:func:`hpx::sync`, and
+:cpp:func:`hpx::dataflow`.
 
 See the :ref:`API reference <libs_local_async_api>` of this module for more
 details.

--- a/libs/mpi/docs/index.rst
+++ b/libs/mpi/docs/index.rst
@@ -15,7 +15,6 @@ The MPI library is intended to simplify the process of integrating MPI based
 codes with the HPX runtime. The library is intended to be used with the
 asynchronous API of MPI using requests.
 
-
 See the :ref:`API reference <libs_mpi_api>` of this module for more
 details.
 

--- a/libs/mpi_base/docs/index.rst
+++ b/libs/mpi_base/docs/index.rst
@@ -11,7 +11,7 @@
 mpi_base
 ========
 
-TODO: High-level description of the library.
+This module provides helper functionality for detecting MPI environments.
 
 See the :ref:`API reference <libs_mpi_base_api>` of this module for more
 details.

--- a/libs/performance_counters/docs/index.rst
+++ b/libs/performance_counters/docs/index.rst
@@ -11,7 +11,9 @@
 performance_counters
 ====================
 
-TODO: High-level description of the library.
+This module provides the basic functionality required for defining performance
+counters. See :ref:`performance_counters` for more information about
+performance counters.
 
 See the :ref:`API reference <libs_performance_counters_api>` of this module for more
 details.

--- a/libs/prefix/docs/index.rst
+++ b/libs/prefix/docs/index.rst
@@ -11,3 +11,8 @@
 prefix
 ======
 
+This module provides utilities for handling the prefix of an |hpx| application,
+i.e. the paths used for searching components and plugins.
+
+See the :ref:`API reference <libs_prefix_api>` of this module for more
+details.

--- a/libs/resource_partitioner/docs/index.rst
+++ b/libs/resource_partitioner/docs/index.rst
@@ -11,3 +11,10 @@
 resource_partitioner
 ====================
 
+The resource_partitioner module defines :cpp:class:`hpx::resource::partitioner`,
+the class used by the runtime and users to partition available hardware
+resources into thread pools. See :ref:`using_resource_partitioner` for more
+details on using the resource partitioner in applications.
+
+See the :ref:`API reference <libs_resource_partitioner_api>` of this module for
+more details.

--- a/libs/runtime_configuration/docs/index.rst
+++ b/libs/runtime_configuration/docs/index.rst
@@ -11,3 +11,7 @@
 runtime_configuration
 =====================
 
+This module handles the configuration options required by the runtime.
+
+See the :ref:`API reference <libs_runtime_configuration_api>` of this module
+for more details.

--- a/libs/schedulers/docs/index.rst
+++ b/libs/schedulers/docs/index.rst
@@ -11,7 +11,16 @@
 schedulers
 ==========
 
-TODO: High-level description of the library.
+This module provides schedulers used by thread pools in the
+:ref:`libs_thread_pools` module. There are currently three main schedulers:
+
+* :cpp:class:`hpx::threads::policies::local_priority_queue_scheduler`
+* :cpp:class:`hpx::threads::policies::static_priority_queue_scheduler`
+* :cpp:class:`hpx::threads::policies::shared_priority_queue_scheduler`
+
+Other schedulers are specializations or variations of the above schedulers. See
+the examples of the :ref:`libs_resource_partitioner` module for examples of
+specifying a custom scheduler for a thread pool.
 
 See the :ref:`API reference <libs_schedulers_api>` of this module for more
 details.

--- a/libs/static_reinit/docs/index.rst
+++ b/libs/static_reinit/docs/index.rst
@@ -11,3 +11,8 @@
 static_reinit
 =============
 
+This module provides a simple wrapper around static variables that can be
+reinitialized.
+
+See the :ref:`API reference <libs_futures_api>` of this module for more
+details.

--- a/libs/thread_executors/docs/index.rst
+++ b/libs/thread_executors/docs/index.rst
@@ -11,7 +11,8 @@
 thread_executors
 ================
 
-TODO: High-level description of the library.
+This module provides executors implementing the executor interface proposed in
+|cpp11_n3562|_. These executors are deprecated.
 
 See the :ref:`API reference <libs_thread_executors_api>` of this module for more
 details.

--- a/libs/thread_pools/docs/index.rst
+++ b/libs/thread_pools/docs/index.rst
@@ -11,7 +11,11 @@
 thread_pools
 ============
 
-TODO: High-level description of the library.
+This module defines the thread pools and utilities used by the |hpx| runtime.
+The only thread pool implementation provided by this module is
+:cpp:class:`hpx::threads::detail::scheduled_thread_pool`, which is derived from
+:cpp:class:`hpx::threads::detail::thread_pool_base` defined in the
+:ref:`libs_threading_base` module.
 
 See the :ref:`API reference <libs_thread_pools_api>` of this module for more
 details.

--- a/libs/threading/docs/index.rst
+++ b/libs/threading/docs/index.rst
@@ -11,8 +11,12 @@
 threading
 =========
 
-TODO: High-level description of the library.
+This module provides the equivalents of ``std::thread`` and ``std::jthread``
+for lightweight |hpx| threads:
 
-See the :ref:`API reference <libs_thread_api>` of this module for more
+* :cpp:class:`hpx::thread`
+* :cpp:class:`hpx::jthread`
+
+See the :ref:`API reference <libs_threading_api>` of this module for more
 details.
 

--- a/libs/threadmanager/docs/index.rst
+++ b/libs/threadmanager/docs/index.rst
@@ -11,3 +11,10 @@
 thread_manager
 ==============
 
+This module defines the :cpp:class:`hpx::threads::threadmanager` class. This is
+used by the runtime to manage the creation and destruction of thread pools. The
+:ref:`libs_resource_partitioner` module handles the partitioning of resources
+into thread pools, but not the creation of thread pools.
+
+See the :ref:`API reference <libs_thread_manager_api>` of this module for more
+details.

--- a/libs/timed_execution/docs/index.rst
+++ b/libs/timed_execution/docs/index.rst
@@ -11,7 +11,9 @@
 timed_execution
 ===============
 
-TODO: High-level description of the library.
+This module provides extensions to the executor interfaces defined in the
+:ref:`libs_execution` module that allow timed submission of tasks on thread
+pools (at or after a specified time).
 
 See the :ref:`API reference <libs_timed_execution_api>` of this module for more
 details.

--- a/libs/version/docs/index.rst
+++ b/libs/version/docs/index.rst
@@ -11,3 +11,8 @@
 version
 =======
 
+This module macros and functions for accessing version information about |hpx|
+and its dependencies.
+
+See the :ref:`API reference <libs_futures_api>` of this module for more
+details.


### PR DESCRIPTION
Fixes #4571. Apologies for the brief descriptions for some modules. However, I don't think it's worth spending a lot of time on some of these modules that are purely for internal use. Adding a one- or two-sentence description is more about having a slightly friendlier entry to modules for potential developers than `TODO: Document`... I think we'll learn over time if certain modules actually require more documentation.