### PR TITLE
Fix missing includes for future::then specializations

### DIFF
--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
@@ -8,19 +8,20 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
-#include <hpx/modules/async_distributed.hpp>
+#include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_combinators/wait_all.hpp>
 #include <hpx/async_combinators/when_all.hpp>
+#include <hpx/functional/bind_back.hpp>
+#include <hpx/modules/assertion.hpp>
+#include <hpx/modules/async_distributed.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/execution.hpp>
 #include <hpx/runtime/components/client_base.hpp>
 #include <hpx/runtime/components/copy_component.hpp>
 #include <hpx/runtime/components/new.hpp>
 #include <hpx/runtime/components/server/distributed_metadata_base.hpp>
 #include <hpx/runtime/get_ptr.hpp>
-#include <hpx/async_base/launch_policy.hpp>
-#include <hpx/modules/errors.hpp>
 #include <hpx/traits/is_distribution_policy.hpp>
-#include <hpx/functional/bind_back.hpp>
 
 #include <hpx/components/containers/container_distribution_policy.hpp>
 #include <hpx/components/containers/partitioned_vector/partitioned_vector_decl.hpp>

--- a/components/iostreams/src/standard_streams.cpp
+++ b/components/iostreams/src/standard_streams.cpp
@@ -6,13 +6,14 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/functional/bind_back.hpp>
 #include <hpx/lcos/base_lco_with_value.hpp>
+#include <hpx/modules/execution.hpp>
 #include <hpx/runtime/actions/plain_action.hpp>
 #include <hpx/runtime/agas/interface.hpp>
 #include <hpx/runtime/components/server/component.hpp>
 #include <hpx/runtime/components/server/create_component.hpp>
 #include <hpx/runtime/runtime_fwd.hpp>
-#include <hpx/functional/bind_back.hpp>
 
 #include <hpx/components/iostreams/ostream.hpp>
 #include <hpx/components/iostreams/standard_streams.hpp>

--- a/hpx/runtime/components/default_distribution_policy.hpp
+++ b/hpx/runtime/components/default_distribution_policy.hpp
@@ -9,15 +9,17 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/async_base/launch_policy.hpp>
+#include <hpx/async_distributed/applier/apply.hpp>
 #include <hpx/async_distributed/dataflow.hpp>
 #include <hpx/futures/future.hpp>
+#include <hpx/futures/traits/promise_local_result.hpp>
 #include <hpx/lcos/packaged_action.hpp>
+#include <hpx/modules/assertion.hpp>
+#include <hpx/modules/execution.hpp>
 #include <hpx/runtime/actions/action_support.hpp>
-#include <hpx/async_distributed/applier/apply.hpp>
 #include <hpx/runtime/components/stubs/stub_base.hpp>
 #include <hpx/runtime/find_here.hpp>
-#include <hpx/async_base/launch_policy.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime/naming/name.hpp>
 #include <hpx/serialization/serialization_fwd.hpp>
@@ -25,7 +27,6 @@
 #include <hpx/serialization/vector.hpp>
 #include <hpx/traits/extract_action.hpp>
 #include <hpx/traits/is_distribution_policy.hpp>
-#include <hpx/futures/traits/promise_local_result.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/libs/collectives/include/hpx/collectives/broadcast_direct.hpp
+++ b/libs/collectives/include/hpx/collectives/broadcast_direct.hpp
@@ -136,6 +136,7 @@ namespace hpx { namespace lcos {
 #include <hpx/futures/traits/promise_local_result.hpp>
 #include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/execution.hpp>
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/preprocessor/expand.hpp>
 #include <hpx/preprocessor/nargs.hpp>


### PR DESCRIPTION
Fixes #4679. @weilewei would you mind trying again?

I'd like to prioritize getting #4696 first in though (it will otherwise keep conflicting or have a few headers missing). I'll update this one to use `hpx/modules/execution.hpp` after that.