### PR TITLE
Use hpx::function_nonser instead of std::function internally

### DIFF
--- a/hpx/runtime/threads/thread_pool_suspension_helpers.hpp
+++ b/hpx/runtime/threads/thread_pool_suspension_helpers.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/futures/future.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/threading_base/thread_pool_base.hpp>
 
 #include <cstddef>
@@ -42,7 +43,7 @@ namespace hpx { namespace threads {
     ///                  is pre-initialized to \a hpx#throws the function will throw
     ///                  on error instead.
     HPX_EXPORT void resume_processing_unit_cb(thread_pool_base& pool,
-        std::function<void(void)> callback, std::size_t virt_core,
+        util::function_nonser<void(void)> callback, std::size_t virt_core,
         error_code& ec = throws);
 
     /// Suspends the given processing unit. When the processing unit has been
@@ -77,7 +78,7 @@ namespace hpx { namespace threads {
     ///                  is pre-initialized to \a hpx#throws the function will throw
     ///                  on error instead.
     HPX_EXPORT void suspend_processing_unit_cb(
-        std::function<void(void)> callback, thread_pool_base& pool,
+        util::function_nonser<void(void)> callback, thread_pool_base& pool,
         std::size_t virt_core, error_code& ec = throws);
 
     /// Resumes the thread pool. When the all OS threads on the thread pool have
@@ -100,7 +101,7 @@ namespace hpx { namespace threads {
     ///                 is pre-initialized to \a hpx#throws the function will throw
     ///                 on error instead.
     HPX_EXPORT void resume_pool_cb(thread_pool_base& pool,
-        std::function<void(void)> callback, error_code& ec = throws);
+        util::function_nonser<void(void)> callback, error_code& ec = throws);
 
     /// Suspends the thread pool. When the all OS threads on the thread pool
     /// have been suspended the returned future will be ready.
@@ -129,6 +130,5 @@ namespace hpx { namespace threads {
     /// \throws hpx::exception if called from an HPX thread which is running
     ///         on the pool itself.
     HPX_EXPORT void suspend_pool_cb(thread_pool_base& pool,
-        std::function<void(void)> callback, error_code& ec = throws);
-}}
-
+        util::function_nonser<void(void)> callback, error_code& ec = throws);
+}}    // namespace hpx::threads

--- a/libs/basic_execution/CMakeLists.txt
+++ b/libs/basic_execution/CMakeLists.txt
@@ -36,6 +36,7 @@ add_hpx_module(
   SOURCES ${basic_execution_sources}
   HEADERS ${basic_execution_headers}
   COMPAT_HEADERS ${basic_execution_compat_headers}
-  DEPENDENCIES hpx_assertion hpx_config hpx_errors hpx_format hpx_timing
+  DEPENDENCIES hpx_assertion hpx_config hpx_errors hpx_format hpx_functional
+               hpx_timing
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/basic_execution/include/hpx/basic_execution/register_locks.hpp
+++ b/libs/basic_execution/include/hpx/basic_execution/register_locks.hpp
@@ -9,9 +9,9 @@
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/has_member_xxx.hpp>
+#include <hpx/modules/functional.hpp>
 
 #include <cstddef>
-#include <functional>
 #include <map>
 #include <memory>
 #ifdef HPX_HAVE_VERIFY_LOCKS_BACKTRACE
@@ -83,7 +83,7 @@ namespace hpx { namespace util {
     HPX_EXPORT void ignore_all_locks();
     HPX_EXPORT void reset_ignored_all();
 
-    using registered_locks_error_handler_type = std::function<void()>;
+    using registered_locks_error_handler_type = util::function_nonser<void()>;
 
     /// Sets a handler which gets called when verifying that no locks are held
     /// fails. Can be used to print information at the point of failure such as
@@ -91,7 +91,7 @@ namespace hpx { namespace util {
     HPX_EXPORT void set_registered_locks_error_handler(
         registered_locks_error_handler_type);
 
-    using register_locks_predicate_type = std::function<bool()>;
+    using register_locks_predicate_type = util::function_nonser<bool()>;
 
     /// Sets a predicate which gets called each time a lock is registered,
     /// unregistered, or when locks are verified. If the predicate returns

--- a/libs/errors/CMakeLists.txt
+++ b/libs/errors/CMakeLists.txt
@@ -51,6 +51,7 @@ add_hpx_module(
     hpx_config
     hpx_filesystem
     hpx_format
+    hpx_functional
     hpx_logging
     hpx_preprocessor
     hpx_thread_support

--- a/libs/errors/include/hpx/errors/exception.hpp
+++ b/libs/errors/include/hpx/errors/exception.hpp
@@ -14,6 +14,7 @@
 #include <hpx/errors/error_code.hpp>
 #include <hpx/errors/exception_fwd.hpp>
 #include <hpx/errors/exception_info.hpp>
+#include <hpx/modules/functional.hpp>
 
 #include <boost/system/error_code.hpp>
 #include <boost/system/system_error.hpp>
@@ -106,13 +107,13 @@ namespace hpx {
     };
 
     using custom_exception_info_handler_type =
-        std::function<hpx::exception_info(
+        util::function_nonser<hpx::exception_info(
             std::string const&, std::string const&, long, std::string const&)>;
 
     HPX_EXPORT void set_custom_exception_info_handler(
         custom_exception_info_handler_type f);
 
-    using pre_exception_handler_type = std::function<void()>;
+    using pre_exception_handler_type = util::function_nonser<void()>;
 
     HPX_EXPORT void set_pre_exception_handler(pre_exception_handler_type f);
 

--- a/libs/execution/include/hpx/execution/detail/execution_parameter_callbacks.hpp
+++ b/libs/execution/include/hpx/execution/detail/execution_parameter_callbacks.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/topology/topology.hpp>
 
 #include <cstddef>
@@ -14,12 +15,12 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace parallel { namespace execution { namespace detail {
     /// \cond NOINTERNAL
-    using get_os_thread_count_type = std::function<std::size_t()>;
+    using get_os_thread_count_type = hpx::util::function_nonser<std::size_t()>;
     HPX_EXPORT void set_get_os_thread_count(get_os_thread_count_type f);
     HPX_EXPORT std::size_t get_os_thread_count();
 
-    using get_pu_mask_type =
-        std::function<threads::mask_cref_type(threads::topology&, std::size_t)>;
+    using get_pu_mask_type = hpx::util::function_nonser<threads::mask_cref_type(
+        threads::topology&, std::size_t)>;
     HPX_EXPORT void set_get_pu_mask(get_pu_mask_type f);
     HPX_EXPORT threads::mask_cref_type get_pu_mask(
         threads::topology&, std::size_t);

--- a/libs/executors/include/hpx/executors/exception_list.hpp
+++ b/libs/executors/include/hpx/executors/exception_list.hpp
@@ -12,6 +12,7 @@
 #include <hpx/futures/future.hpp>
 #include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/type_support/decay.hpp>
 
 #include <exception>
@@ -177,7 +178,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         };
 #endif
 
-        using exception_list_termination_handler_type = std::function<void()>;
+        using exception_list_termination_handler_type =
+            hpx::util::function_nonser<void()>;
         HPX_EXPORT void set_exception_list_termination_handler(
             exception_list_termination_handler_type f);
         HPX_NORETURN HPX_EXPORT void exception_list_termination_handler();

--- a/libs/futures/include/hpx/futures/detail/future_data.hpp
+++ b/libs/futures/include/hpx/futures/detail/future_data.hpp
@@ -9,13 +9,12 @@
 #include <hpx/config.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/coroutines/detail/get_stack_pointer.hpp>
-#include <hpx/functional/bind.hpp>
-#include <hpx/functional/unique_function.hpp>
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/futures/traits/get_remote_result.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/synchronization/condition_variable.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/thread_support/assert_owns_lock.hpp>
@@ -54,7 +53,7 @@ namespace hpx { namespace lcos {
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace lcos { namespace detail {
     using run_on_completed_error_handler_type =
-        std::function<void(std::exception_ptr const& e)>;
+        util::function_nonser<void(std::exception_ptr const& e)>;
     void set_run_on_completed_error_handler(
         run_on_completed_error_handler_type f);
 

--- a/libs/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
@@ -475,10 +475,10 @@ namespace hpx { namespace threads { namespace policies {
                 bool steal_by_function(std::size_t domain, std::size_t q_index,
                     bool steal_numa, bool steal_core,
                     thread_holder_type* origin, T& var, const char* prefix,
-                    std::function<bool(std::size_t, std::size_t,
+                    util::function_nonser<bool(std::size_t, std::size_t,
                         thread_holder_type*, T&, bool, bool)>
                         operation_HP,
-                    std::function<bool(std::size_t, std::size_t,
+                    util::function_nonser<bool(std::size_t, std::size_t,
                         thread_holder_type*, T&, bool, bool)>
                         operation)
                 {

--- a/libs/serialization/include/hpx/serialization/exception_ptr.hpp
+++ b/libs/serialization/include/hpx/serialization/exception_ptr.hpp
@@ -7,11 +7,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
-
+#include <hpx/modules/functional.hpp>
 #include <hpx/serialization/serialization_fwd.hpp>
 
 #include <exception>
-#include <functional>
 
 namespace hpx { namespace util {
     enum exception_type
@@ -48,10 +47,10 @@ namespace hpx { namespace util {
 namespace hpx { namespace serialization {
     namespace detail {
         using save_custom_exception_handler_type =
-            std::function<void(hpx::serialization::output_archive&,
+            util::function_nonser<void(hpx::serialization::output_archive&,
                 std::exception_ptr const&, unsigned int)>;
         using load_custom_exception_handler_type =
-            std::function<void(hpx::serialization::input_archive&,
+            util::function_nonser<void(hpx::serialization::input_archive&,
                 std::exception_ptr&, unsigned int)>;
 
         HPX_EXPORT void set_save_custom_exception_handler(

--- a/libs/testing/CMakeLists.txt
+++ b/libs/testing/CMakeLists.txt
@@ -26,6 +26,6 @@ add_hpx_module(
   SOURCES ${testing_sources}
   HEADERS ${testing_headers}
   COMPAT_HEADERS ${testing_compat_headers}
-  DEPENDENCIES hpx_assertion hpx_config hpx_preprocessor hpx_util
+  DEPENDENCIES hpx_assertion hpx_config hpx_functional hpx_preprocessor hpx_util
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/testing/include/hpx/modules/testing.hpp
+++ b/libs/testing/include/hpx/modules/testing.hpp
@@ -10,6 +10,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/assertion.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/preprocessor/expand.hpp>
 #include <hpx/preprocessor/nargs.hpp>
@@ -21,14 +22,13 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
-#include <functional>
 #include <iostream>
 #include <mutex>
 #include <sstream>
 
 namespace hpx { namespace util {
 
-    using test_failure_handler_type = std::function<void()>;
+    using test_failure_handler_type = function_nonser<void()>;
     HPX_EXPORT void set_test_failure_handler(test_failure_handler_type f);
 
     enum counter_type

--- a/libs/threading/include/hpx/threading/thread.hpp
+++ b/libs/threading/include/hpx/threading/thread.hpp
@@ -7,10 +7,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/functional/deferred_call.hpp>
 #include <hpx/lcos_fwd.hpp>
 #include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/threading_base/scheduler_base.hpp>
 #include <hpx/threading_base/thread_data.hpp>
@@ -31,7 +31,7 @@
 namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     using thread_termination_handler_type =
-        std::function<void(std::exception_ptr const& e)>;
+        util::function_nonser<void(std::exception_ptr const& e)>;
     void set_thread_termination_handler(thread_termination_handler_type f);
 
     class HPX_EXPORT thread

--- a/libs/threading_base/include/hpx/threading_base/external_timer.hpp
+++ b/libs/threading_base/include/hpx/threading_base/external_timer.hpp
@@ -9,7 +9,9 @@
 #include <hpx/config.hpp>
 #include <hpx/coroutines/thread_id_type.hpp>
 #include <hpx/modules/assertion.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/threading_base/thread_description.hpp>
+
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -18,7 +20,7 @@ namespace hpx { namespace util {
 
 #ifdef HPX_HAVE_APEX
 
-    using enable_parent_task_handler_type = std::function<bool()>;
+    using enable_parent_task_handler_type = util::function_nonser<bool()>;
 
     HPX_EXPORT void set_enable_parent_task_handler(
         enable_parent_task_handler_type f);

--- a/libs/threading_base/include/hpx/threading_base/register_thread.hpp
+++ b/libs/threading_base/include/hpx/threading_base/register_thread.hpp
@@ -13,6 +13,7 @@
 #include <hpx/config/asio.hpp>
 #include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/threading_base/scheduler_base.hpp>
 #include <hpx/threading_base/thread_data.hpp>
 #include <hpx/threading_base/thread_pool_base.hpp>
@@ -107,12 +108,13 @@ namespace hpx { namespace threads {
     }
 
     namespace detail {
-        using get_default_pool_type = std::function<thread_pool_base*()>;
+        using get_default_pool_type =
+            util::function_nonser<thread_pool_base*()>;
         HPX_EXPORT void set_get_default_pool(get_default_pool_type f);
         HPX_EXPORT thread_pool_base* get_self_or_default_pool();
 
         using get_default_timer_service_type =
-            std::function<boost::asio::io_service*()>;
+            util::function_nonser<boost::asio::io_service*()>;
         HPX_EXPORT void set_get_default_timer_service(
             get_default_timer_service_type f);
         HPX_EXPORT boost::asio::io_service* get_default_timer_service();

--- a/libs/threading_base/include/hpx/threading_base/scheduler_base.hpp
+++ b/libs/threading_base/include/hpx/threading_base/scheduler_base.hpp
@@ -155,7 +155,7 @@ namespace hpx { namespace threads { namespace policies {
         // depending on the predicate
         std::vector<std::size_t> domain_threads(std::size_t local_id,
             const std::vector<std::size_t>& ts,
-            std::function<bool(std::size_t, std::size_t)> pred);
+            util::function_nonser<bool(std::size_t, std::size_t)> pred);
 
 #ifdef HPX_HAVE_THREAD_CREATION_AND_CLEANUP_RATES
         virtual std::uint64_t get_creation_time(bool reset) = 0;

--- a/plugins/parcelport/libfabric/libfabric_controller.hpp
+++ b/plugins/parcelport/libfabric/libfabric_controller.hpp
@@ -10,9 +10,10 @@
 // config
 #include <hpx/config/defines.hpp>
 //
-#include <hpx/synchronization/shared_mutex.hpp>
-#include <hpx/lcos/promise.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/futures/future.hpp>
+#include <hpx/lcos/promise.hpp>
+#include <hpx/synchronization/shared_mutex.hpp>
 //
 #include <hpx/runtime/parcelset/parcelport_impl.hpp>
 #include <hpx/runtime/agas/addressing_service.hpp>
@@ -654,9 +655,9 @@ namespace libfabric
 
         // types we need for connection and disconnection callback functions
         // into the main parcelport code.
-        typedef std::function<void(fid_ep *endpoint, uint32_t ipaddr)>
+        typedef util::function_nonser<void(fid_ep* endpoint, uint32_t ipaddr)>
             ConnectionFunction;
-        typedef std::function<void(fid_ep *endpoint, uint32_t ipaddr)>
+        typedef util::function_nonser<void(fid_ep* endpoint, uint32_t ipaddr)>
             DisconnectionFunction;
 
         // --------------------------------------------------------------------

--- a/plugins/parcelport/libfabric/pinned_memory_vector.hpp
+++ b/plugins/parcelport/libfabric/pinned_memory_vector.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/modules/functional.hpp>
 //
 #include <plugins/parcelport/parcelport_logging.hpp>
 #include <plugins/parcelport/rma_memory_pool.hpp>
@@ -42,7 +43,7 @@ namespace libfabric
 
         typedef pinned_memory_vector<T, Offset, region_type, allocator_type> vector_type;
 
-        typedef std::function<void()> deleter_callback;
+        typedef util::function_nonser<void()> deleter_callback;
 
         // internal vars
         T                   *m_array_;

--- a/plugins/parcelport/verbs/pinned_memory_vector.hpp
+++ b/plugins/parcelport/verbs/pinned_memory_vector.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/modules/functional.hpp>
 //
 #include <plugins/parcelport/parcelport_logging.hpp>
 #include <plugins/parcelport/verbs/rdma/rdma_memory_pool.hpp>
@@ -38,8 +39,8 @@ namespace verbs
         typedef typename std::vector<T>::size_type size_type;
         typedef Allocator allocator_type;
 
-        typedef std::function<void()> deleter_callback;
-        T *m_array_;
+        typedef util::function_nonser<void()> deleter_callback;
+        T* m_array_;
         int m_size_;
         deleter_callback m_cb_;
         allocator_type *m_alloc_;

--- a/plugins/parcelport/verbs/rdma/rdma_controller.hpp
+++ b/plugins/parcelport/verbs/rdma/rdma_controller.hpp
@@ -9,9 +9,10 @@
 // config
 #include <hpx/config/defines.hpp>
 //
-#include <hpx/synchronization/shared_mutex.hpp>
-#include <hpx/lcos/promise.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/futures/future.hpp>
+#include <hpx/lcos/promise.hpp>
+#include <hpx/synchronization/shared_mutex.hpp>
 //
 #include <plugins/parcelport/parcelport_logging.hpp>
 #include <plugins/parcelport/verbs/rdma/rdma_error.hpp>
@@ -65,8 +66,10 @@ namespace verbs
 
         // types we need for connection and disconnection callback functions
         // into the main parcelport code.
-        typedef std::function<void(verbs_endpoint_ptr)>       ConnectionFunction;
-        typedef std::function<int(verbs_endpoint_ptr client)> DisconnectionFunction;
+        typedef util::function_nonser<void(verbs_endpoint_ptr)>
+            ConnectionFunction;
+        typedef util::function_nonser<int(verbs_endpoint_ptr client)>
+            DisconnectionFunction;
 
         // Set a callback which will be called immediately after
         // RDMA_CM_EVENT_ESTABLISHED has been received.
@@ -109,7 +112,8 @@ namespace verbs
             return memory_pool_;
         }
 
-        typedef std::function<int(struct ibv_wc completion, verbs_endpoint *client)>
+        typedef util::function_nonser<int(
+            struct ibv_wc completion, verbs_endpoint* client)>
             CompletionFunction;
 
         void setCompletionFunction(CompletionFunction f) {

--- a/src/runtime/threads/thread_pool_suspension_helpers.cpp
+++ b/src/runtime/threads/thread_pool_suspension_helpers.cpp
@@ -7,10 +7,11 @@
 #include <hpx/async_local/apply.hpp>
 #include <hpx/async_local/async.hpp>
 #include <hpx/futures/future.hpp>
+#include <hpx/modules/functional.hpp>
+#include <hpx/runtime/threads/thread_pool_suspension_helpers.hpp>
 #include <hpx/threading_base/scheduler_base.hpp>
 #include <hpx/threading_base/thread_data.hpp>
 #include <hpx/threading_base/thread_pool_base.hpp>
-#include <hpx/runtime/threads/thread_pool_suspension_helpers.hpp>
 
 #include <cstddef>
 #include <utility>
@@ -26,7 +27,7 @@ namespace hpx { namespace threads {
                 "resume_processing_unit_cb instead");
         }
         else if (!pool.get_scheduler()->has_scheduler_mode(
-                  policies::enable_elasticity))
+                     policies::enable_elasticity))
         {
             return hpx::make_exceptional_future<void>(
                 HPX_GET_EXCEPTION(invalid_status, "resume_processing_unit",
@@ -40,10 +41,11 @@ namespace hpx { namespace threads {
     }
 
     void resume_processing_unit_cb(thread_pool_base& pool,
-        std::function<void(void)> callback, std::size_t virt_core,
+        util::function_nonser<void(void)> callback, std::size_t virt_core,
         error_code& ec)
     {
-        if (!pool.get_scheduler()->has_scheduler_mode(policies::enable_elasticity))
+        if (!pool.get_scheduler()->has_scheduler_mode(
+                policies::enable_elasticity))
         {
             HPX_THROWS_IF(ec, invalid_status, "resume_processing_unit_cb",
                 "this thread pool does not support suspending "
@@ -76,14 +78,16 @@ namespace hpx { namespace threads {
                 "cannot call suspend_processing_unit from outside HPX, use"
                 "suspend_processing_unit_cb instead");
         }
-        else if (!pool.get_scheduler()->has_scheduler_mode(policies::enable_elasticity))
+        else if (!pool.get_scheduler()->has_scheduler_mode(
+                     policies::enable_elasticity))
         {
             return hpx::make_exceptional_future<void>(
                 HPX_GET_EXCEPTION(invalid_status, "suspend_processing_unit",
                     "this thread pool does not support suspending "
                     "processing units"));
         }
-        else if (!pool.get_scheduler()->has_scheduler_mode(policies::enable_stealing) &&
+        else if (!pool.get_scheduler()->has_scheduler_mode(
+                     policies::enable_stealing) &&
             hpx::this_thread::get_pool() == &pool)
         {
             return hpx::make_exceptional_future<void>(
@@ -98,10 +102,11 @@ namespace hpx { namespace threads {
     }
 
     void suspend_processing_unit_cb(thread_pool_base& pool,
-        std::function<void(void)> callback, std::size_t virt_core,
+        util::function_nonser<void(void)> callback, std::size_t virt_core,
         error_code& ec)
     {
-        if (!pool.get_scheduler()->has_scheduler_mode(policies::enable_elasticity))
+        if (!pool.get_scheduler()->has_scheduler_mode(
+                policies::enable_elasticity))
         {
             HPX_THROWS_IF(ec, invalid_status, "suspend_processing_unit_cb",
                 "this thread pool does not support suspending processing "
@@ -117,7 +122,8 @@ namespace hpx { namespace threads {
 
         if (threads::get_self_ptr())
         {
-            if (!pool.get_scheduler()->has_scheduler_mode(policies::enable_stealing) &&
+            if (!pool.get_scheduler()->has_scheduler_mode(
+                    policies::enable_stealing) &&
                 hpx::this_thread::get_pool() == &pool)
             {
                 HPX_THROW_EXCEPTION(invalid_status,
@@ -150,10 +156,10 @@ namespace hpx { namespace threads {
     }
 
     void resume_pool_cb(thread_pool_base& pool,
-        std::function<void(void)> callback, error_code& ec)
+        util::function_nonser<void(void)> callback, error_code& ec)
     {
-        auto resume_direct_wrapper = [&pool,
-                                         callback = std::move(callback)]() -> void {
+        auto resume_direct_wrapper =
+            [&pool, callback = std::move(callback)]() -> void {
             pool.resume_direct(throws);
             callback();
         };
@@ -191,7 +197,7 @@ namespace hpx { namespace threads {
     }
 
     void suspend_pool_cb(thread_pool_base& pool,
-        std::function<void(void)> callback, error_code& ec)
+        util::function_nonser<void(void)> callback, error_code& ec)
     {
         if (threads::get_self_ptr() && hpx::this_thread::get_pool() == &pool)
         {
@@ -200,7 +206,8 @@ namespace hpx { namespace threads {
             return;
         }
 
-        auto suspend_direct_wrapper = [&pool, callback = std::move(callback)]() {
+        auto suspend_direct_wrapper = [&pool,
+                                          callback = std::move(callback)]() {
             pool.suspend_direct(throws);
             callback();
         };


### PR DESCRIPTION
Fixes #4672. I've only replaced uses of `std::function` in the main library. I've left `std::function` in tests, examples, and the `program_options` module.