### PR TITLE
Add termination handler for parallel algorithms

### DIFF
--- a/hpx/runtime/parcelset/parcelport_impl.hpp
+++ b/hpx/runtime/parcelset/parcelport_impl.hpp
@@ -37,6 +37,7 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
 #include <limits>
 #include <memory>
 #include <mutex>

--- a/libs/algorithms/CMakeLists.txt
+++ b/libs/algorithms/CMakeLists.txt
@@ -108,6 +108,7 @@ set(algorithms_headers
     hpx/parallel/util/detail/algorithm_result.hpp
     hpx/parallel/util/detail/chunk_size.hpp
     hpx/parallel/util/detail/chunk_size_iterator.hpp
+    hpx/parallel/util/detail/handle_exception_termination_handler.hpp
     hpx/parallel/util/detail/handle_local_exceptions.hpp
     hpx/parallel/util/detail/handle_remote_exceptions.hpp
     hpx/parallel/util/detail/partitioner_iteration.hpp
@@ -139,6 +140,8 @@ set(algorithms_compat_headers
 )
 # cmake-format: on
 
+set(algorithms_sources handle_exception_termination_handler.cpp)
+
 include(HPX_AddModule)
 add_hpx_module(
   algorithms
@@ -146,6 +149,7 @@ add_hpx_module(
   DEPRECATION_WARNINGS FORCE_LINKING_GEN
   HEADERS ${algorithms_headers}
   COMPAT_HEADERS ${algorithms_compat_headers}
+  SOURCES ${algorithms_sources}
   DEPENDENCIES
     hpx_assertion
     hpx_concepts

--- a/libs/algorithms/include/hpx/parallel/util/detail/handle_exception_termination_handler.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/detail/handle_exception_termination_handler.hpp
@@ -1,0 +1,18 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/modules/functional.hpp>
+
+namespace hpx { namespace parallel { namespace util { namespace detail {
+    using parallel_exception_termination_handler_type =
+        hpx::util::function_nonser<void()>;
+    HPX_EXPORT void set_parallel_exception_termination_handler(
+        parallel_exception_termination_handler_type f);
+    HPX_NORETURN HPX_EXPORT void parallel_exception_termination_handler();
+}}}}    // namespace hpx::parallel::util::detail

--- a/libs/algorithms/include/hpx/parallel/util/detail/handle_local_exceptions.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/detail/handle_local_exceptions.hpp
@@ -9,10 +9,10 @@
 
 #include <hpx/config.hpp>
 #include <hpx/executors/execution_policy.hpp>
-#include <hpx/hpx_finalize.hpp>
 #include <hpx/modules/assertion.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/parallel/util/detail/handle_exception_termination_handler.hpp>
 
 #include <exception>
 #include <list>
@@ -172,7 +172,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 #else
         HPX_NORETURN static void call(std::exception_ptr const&)
         {
-            hpx::terminate();
+            parallel_exception_termination_handler();
         }
 #endif
 
@@ -186,7 +186,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         HPX_NORETURN static void call(
             std::exception_ptr const&, std::list<std::exception_ptr>&)
         {
-            hpx::terminate();
+            parallel_exception_termination_handler();
         }
 #endif
 
@@ -200,7 +200,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             for (hpx::future<T> const& f : workitems)
             {
                 if (f.has_exception())
-                    hpx::terminate();
+                    parallel_exception_termination_handler();
             }
 #endif
         }
@@ -215,7 +215,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             for (hpx::shared_future<T> const& f : workitems)
             {
                 if (f.has_exception())
-                    hpx::terminate();
+                    parallel_exception_termination_handler();
             }
 #endif
         }
@@ -230,7 +230,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             for (hpx::future<T> const& f : workitems)
             {
                 if (f.has_exception())
-                    hpx::terminate();
+                    parallel_exception_termination_handler();
             }
 #endif
         }

--- a/libs/algorithms/include/hpx/parallel/util/detail/handle_remote_exceptions.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/detail/handle_remote_exceptions.hpp
@@ -9,8 +9,8 @@
 #include <hpx/config.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/hpx_finalize.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/parallel/util/detail/handle_exception_termination_handler.hpp>
 
 #include <exception>
 #include <list>
@@ -81,7 +81,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         HPX_NORETURN static void call(
             std::exception_ptr const&, std::list<std::exception_ptr>&)
         {
-            hpx::terminate();
+            parallel_exception_termination_handler();
         }
 
         template <typename T>
@@ -91,7 +91,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             for (hpx::future<T> const& f : workitems)
             {
                 if (f.has_exception())
-                    hpx::terminate();
+                    parallel_exception_termination_handler();
             }
         }
 
@@ -102,7 +102,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             for (hpx::shared_future<T> const& f : workitems)
             {
                 if (f.has_exception())
-                    hpx::terminate();
+                    parallel_exception_termination_handler();
             }
         }
     };

--- a/libs/algorithms/src/handle_exception_termination_handler.cpp
+++ b/libs/algorithms/src/handle_exception_termination_handler.cpp
@@ -1,0 +1,33 @@
+//  Copyright (c) 2020      ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/parallel/util/detail/handle_exception_termination_handler.hpp>
+
+namespace hpx { namespace parallel { namespace util { namespace detail {
+    parallel_exception_termination_handler_type&
+    get_parallel_exception_termination_handler()
+    {
+        static parallel_exception_termination_handler_type f;
+        return f;
+    }
+
+    void set_parallel_exception_termination_handler(
+        parallel_exception_termination_handler_type f)
+    {
+        get_parallel_exception_termination_handler() = f;
+    }
+
+    HPX_NORETURN void parallel_exception_termination_handler()
+    {
+        if (get_parallel_exception_termination_handler())
+        {
+            get_parallel_exception_termination_handler()();
+        }
+
+        std::terminate();
+    }
+}}}}    // namespace hpx::parallel::util::detail

--- a/libs/algorithms/src/handle_exception_termination_handler.cpp
+++ b/libs/algorithms/src/handle_exception_termination_handler.cpp
@@ -7,6 +7,8 @@
 #include <hpx/config.hpp>
 #include <hpx/parallel/util/detail/handle_exception_termination_handler.hpp>
 
+#include <exception>
+
 namespace hpx { namespace parallel { namespace util { namespace detail {
     parallel_exception_termination_handler_type&
     get_parallel_exception_termination_handler()

--- a/libs/coroutines/include/hpx/coroutines/detail/context_posix.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/context_posix.hpp
@@ -63,6 +63,7 @@
 #include <cerrno>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
 #include <limits>
 #include "pth/pth.h"
 

--- a/libs/executors/src/exception_list_callbacks.cpp
+++ b/libs/executors/src/exception_list_callbacks.cpp
@@ -9,6 +9,8 @@
 #include <hpx/config.hpp>
 #include <hpx/executors/exception_list.hpp>
 
+#include <exception>
+
 namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     exception_list_termination_handler_type&
     get_exception_list_termination_handler()

--- a/libs/init_runtime/CMakeLists.txt
+++ b/libs/init_runtime/CMakeLists.txt
@@ -28,7 +28,7 @@ add_hpx_module(
   GLOBAL_HEADER_GEN OFF
   SOURCES ${init_runtime_sources}
   HEADERS ${init_runtime_headers}
-  DEPENDENCIES hpx_runtime_local hpx_testing
+  DEPENDENCIES hpx_algorithms hpx_runtime_local hpx_testing
   CMAKE_SUBDIRS examples tests
 )
 

--- a/libs/init_runtime/src/hpx_init.cpp
+++ b/libs/init_runtime/src/hpx_init.cpp
@@ -30,6 +30,7 @@
 #include <hpx/modules/schedulers.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/modules/timing.hpp>
+#include <hpx/parallel/util/detail/handle_exception_termination_handler.hpp>
 #include <hpx/program_options/options_description.hpp>
 #include <hpx/program_options/parsers.hpp>
 #include <hpx/program_options/variables_map.hpp>
@@ -734,6 +735,8 @@ namespace hpx {
                 []() { return hpx::get_os_thread_count(); });
             hpx::parallel::v1::detail::set_exception_list_termination_handler(
                 &hpx::terminate);
+            hpx::parallel::util::detail::
+                set_parallel_exception_termination_handler(&hpx::terminate);
 
 #if defined(HPX_NATIVE_MIC) || defined(__bgq__) || defined(__bgqion__)
             unsetenv("LANG");

--- a/plugins/parcelport/libfabric/fabric_error.hpp
+++ b/plugins/parcelport/libfabric/fabric_error.hpp
@@ -8,9 +8,10 @@
 
 #include <plugins/parcelport/parcelport_logging.hpp>
 //
+#include <exception>
 #include <stdexcept>
-#include <string>
 #include <string.h>
+#include <string>
 //
 #include <rdma/fi_errno.h>
 //

--- a/plugins/parcelport/libfabric/libfabric_controller.hpp
+++ b/plugins/parcelport/libfabric/libfabric_controller.hpp
@@ -26,22 +26,23 @@
 //
 #include <plugins/parcelport/unordered_map.hpp>
 //
-#include <memory>
-#include <deque>
-#include <chrono>
-#include <iostream>
-#include <functional>
-#include <map>
-#include <atomic>
-#include <string>
-#include <utility>
 #include <array>
-#include <vector>
-#include <unordered_map>
-#include <sstream>
-#include <cstdint>
+#include <atomic>
+#include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
+#include <deque>
+#include <exception>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 //
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>

--- a/plugins/parcelport/libfabric/receiver.cpp
+++ b/plugins/parcelport/libfabric/receiver.cpp
@@ -19,9 +19,10 @@
 #include <hpx/modules/assertion.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
 //
-#include <utility>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
+#include <utility>
 
 namespace hpx {
 namespace parcelset {

--- a/plugins/parcelport/verbs/parcelport_verbs.cpp
+++ b/plugins/parcelport/verbs/parcelport_verbs.cpp
@@ -96,6 +96,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <exception>
 #include <iostream>
 #include <list>
 #include <memory>

--- a/plugins/parcelport/verbs/rdma/rdma_controller.cpp
+++ b/plugins/parcelport/verbs/rdma/rdma_controller.cpp
@@ -21,18 +21,19 @@
 #include <plugins/parcelport/verbs/rdma/verbs_completion_queue.hpp>
 #include <plugins/parcelport/verbs/rdma/verbs_device.hpp>
 //
-#include <poll.h>
-#include <errno.h>
-#include <iomanip>
-#include <sstream>
-#include <queue>
-#include <stdio.h>
-#include <thread>
-#include <fstream>
-#include <memory>
-#include <utility>
 #include <cstdint>
 #include <cstring>
+#include <errno.h>
+#include <exception>
+#include <fstream>
+#include <iomanip>
+#include <memory>
+#include <poll.h>
+#include <queue>
+#include <sstream>
+#include <stdio.h>
+#include <thread>
+#include <utility>
 //
 #include <netinet/in.h>
 

--- a/plugins/parcelport/verbs/rdma/verbs_completion_queue.hpp
+++ b/plugins/parcelport/verbs/rdma/verbs_completion_queue.hpp
@@ -11,11 +11,12 @@
 //
 #include <hpx/util/to_string.hpp>
 //
-#include <inttypes.h>
+#include <exception>
 #include <infiniband/verbs.h>
-#include <string>
+#include <inttypes.h>
 #include <memory>
 #include <mutex>
+#include <string>
 
 namespace hpx {
 namespace parcelset {

--- a/plugins/parcelport/verbs/rdma/verbs_endpoint.hpp
+++ b/plugins/parcelport/verbs/rdma/verbs_endpoint.hpp
@@ -20,8 +20,9 @@
 #include <plugins/parcelport/verbs/rdma/verbs_memory_region.hpp>
 #include <plugins/parcelport/verbs/rdma/verbs_protection_domain.hpp>
 //
-#include <inttypes.h>
 #include <atomic>
+#include <exception>
+#include <inttypes.h>
 #include <iomanip>
 #include <iostream>
 #include <memory>

--- a/tools/inspect/include_check.cpp
+++ b/tools/inspect/include_check.cpp
@@ -212,8 +212,10 @@ namespace boost
         {"(\\bstd\\s*::\\s*declval\\b)", "std::declval", "utility"},
         {"(\\bstd\\s*::\\s*pair\\b)", "std::pair", "utility"},
         {"(\\bstd\\s*::\\s*make_pair\\b)", "std::make_pair", "utility"},
+        // exception
         {"(\\bstd\\s*::\\s*exception_ptr\\b)", "std::exception_ptr",
             "exception"},
+        {"(\\bstd\\s*::\\s*terminate\\b)", "std::terminate", "exception"},
         // algorithm
         {"(\\bstd\\s*::\\s*swap_ranges\\b)", "std::swap_ranges", "algorithm"},
         {"(\\bstd\\s*::\\s*iter_swap\\b)", "std::iter_swap", "algorithm"},


### PR DESCRIPTION
I thought this was a circular dependency that `cpp-dependencies` did not see. It turns out it was fine, since the `init_runtime` module did not depend on algorithms. In any case, this gets rid of the dependency from `algorithms` to `init_runtime` and allows us to have `algorithms` in a separate library that does not depend on the runtime.