### PR TITLE
Add hpx/future.hpp header

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -654,6 +654,7 @@ jobs:
                   tests.unit.modules.futures \
                   tests.unit.modules.hardware \
                   tests.unit.modules.hashing \
+                  tests.unit.modules.include \
                   tests.unit.modules.init_runtime \
                   tests.unit.modules.iterator_support \
                   tests.unit.modules.lcos_distributed \

--- a/cmake/templates/static_parcelports.hpp.in
+++ b/cmake/templates/static_parcelports.hpp.in
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 
 #include <vector>
 

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/detail/view_element.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/detail/view_element.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/collectives/spmd_block.hpp>
 #include <hpx/components/containers/partitioned_vector/partitioned_vector_component_decl.hpp>
 #include <hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp>

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_component_impl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_component_impl.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/preprocessor/expand.hpp>
 #include <hpx/preprocessor/nargs.hpp>

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_decl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_decl.hpp
@@ -10,7 +10,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_combinators/wait_all.hpp>
 #include <hpx/async_combinators/when_all.hpp>
 #include <hpx/runtime/components/client_base.hpp>

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
@@ -12,7 +12,7 @@
 #include <hpx/async_combinators/wait_all.hpp>
 #include <hpx/async_combinators/when_all.hpp>
 #include <hpx/functional/bind_back.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution.hpp>

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_local_view_iterator.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_local_view_iterator.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/components/containers/partitioned_vector/detail/view_element.hpp>
 #include <hpx/iterator_support/iterator_adaptor.hpp>
 

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp
@@ -14,7 +14,7 @@
  // http://lafstern.org/matt/segmented.pdf.
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/algorithms/traits/is_value_proxy.hpp>

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_view.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_view.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/collectives/spmd_block.hpp>
 #include <hpx/components/containers/partitioned_vector/partitioned_vector.hpp>
 #include <hpx/components/containers/partitioned_vector/partitioned_vector_segmented_iterator.hpp>

--- a/components/containers/unordered/include/hpx/components/containers/unordered/partition_unordered_map_component.hpp
+++ b/components/containers/unordered/include/hpx/components/containers/unordered/partition_unordered_map_component.hpp
@@ -17,7 +17,7 @@
 /// classes are asynchronous API which return the futures.
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/collectives.hpp>
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/preprocessor/expand.hpp>

--- a/components/containers/unordered/include/hpx/components/containers/unordered/unordered_map.hpp
+++ b/components/containers/unordered/include/hpx/components/containers/unordered/unordered_map.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_combinators/wait_all.hpp>
 #include <hpx/runtime/components/client_base.hpp>
 #include <hpx/runtime/components/component_type.hpp>

--- a/components/containers/unordered/include/hpx/components/containers/unordered/unordered_map_segmented_iterator.hpp
+++ b/components/containers/unordered/include/hpx/components/containers/unordered/unordered_map_segmented_iterator.hpp
@@ -15,7 +15,7 @@
 
 #include <hpx/config.hpp>
 //#include <hpx/runtime/naming/id_type.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/iterator_support/iterator_adaptor.hpp>
 
 #include <hpx/components/containers/unordered/partition_unordered_map_component.hpp>

--- a/components/iostreams/include/hpx/components/iostreams/server/order_output.hpp
+++ b/components/iostreams/include/hpx/components/iostreams/server/order_output.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/thread_support/unlock_guard.hpp>
 
 #include <hpx/components/iostreams/server/buffer.hpp>

--- a/examples/accumulators/accumulator.hpp
+++ b/examples/accumulators/accumulator.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/include/components.hpp>
 
 #include "server/accumulator.hpp"

--- a/examples/accumulators/template_accumulator.hpp
+++ b/examples/accumulators/template_accumulator.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/include/components.hpp>
 
 #include "server/template_accumulator.hpp"

--- a/examples/async_io/async_io_simple.cpp
+++ b/examples/async_io/async_io_simple.cpp
@@ -9,7 +9,7 @@
 // and how to synchronize the result of this IO task with a waiting HPX thread.
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/include/iostreams.hpp>
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/runtime.hpp>

--- a/examples/cancelable_action/cancelable_action/cancelable_action.hpp
+++ b/examples/cancelable_action/cancelable_action/cancelable_action.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/include/components.hpp>
 
 #include "stubs/cancelable_action.hpp"

--- a/examples/jacobi/jacobi_component/row_range.hpp
+++ b/examples/jacobi/jacobi_component/row_range.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/thread_support/atomic_count.hpp>
 

--- a/examples/jacobi/jacobi_component/server/row.hpp
+++ b/examples/jacobi/jacobi_component/server/row.hpp
@@ -9,7 +9,7 @@
 
 #include "../row_range.hpp"
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/include/components.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>
 

--- a/examples/jacobi/jacobi_component/server/solver.hpp
+++ b/examples/jacobi/jacobi_component/server/solver.hpp
@@ -11,7 +11,7 @@
 #include "../stencil_iterator.hpp"
 #include "stencil_iterator.hpp"
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/include/components.hpp>
 #include <hpx/lcos/future_wait.hpp>
 #include <hpx/modules/timing.hpp>

--- a/examples/jacobi/jacobi_component/solver.hpp
+++ b/examples/jacobi/jacobi_component/solver.hpp
@@ -10,7 +10,7 @@
 #include "server/solver.hpp"
 #include "grid.hpp"
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/include/naming.hpp>
 
 #include <cstddef>

--- a/examples/quickstart/executor_with_thread_hooks.cpp
+++ b/examples/quickstart/executor_with_thread_hooks.cpp
@@ -13,7 +13,7 @@
 #include <hpx/hpx_main.hpp>
 
 #include <hpx/modules/algorithms.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/functional.hpp>
 

--- a/examples/quickstart/local_channel_docs.cpp
+++ b/examples/quickstart/local_channel_docs.cpp
@@ -8,7 +8,7 @@
 
 #include <hpx/hpx_main.hpp>
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/include/apply.hpp>
 #include <hpx/include/iostreams.hpp>
 #include <hpx/include/lcos.hpp>

--- a/examples/sheneos/sheneos/interpolator.cpp
+++ b/examples/sheneos/sheneos/interpolator.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/hpx.hpp>
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/include/async.hpp>
 #include <hpx/local_lcos/packaged_task.hpp>
 

--- a/examples/sheneos/sheneos/read_values.cpp
+++ b/examples/sheneos/sheneos/read_values.cpp
@@ -4,7 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/errors/exception.hpp>
 #include <hpx/hpx.hpp>
 

--- a/examples/throttle/throttle/server/throttle.cpp
+++ b/examples/throttle/throttle/server/throttle.cpp
@@ -4,7 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/bind.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/runtime.hpp>

--- a/examples/tuplespace/central_tuplespace/simple_central_tuplespace.hpp
+++ b/examples/tuplespace/central_tuplespace/simple_central_tuplespace.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/include/components.hpp>
 
 #include <string>

--- a/hpx/components/containers/container_distribution_policy.hpp
+++ b/hpx/components/containers/container_distribution_policy.hpp
@@ -11,7 +11,7 @@
 #include <hpx/runtime/components/default_distribution_policy.hpp>
 #include <hpx/traits/is_distribution_policy.hpp>
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/serialization/serialize.hpp>
 #include <hpx/serialization/shared_ptr.hpp>
 #include <hpx/serialization/vector.hpp>

--- a/hpx/lcos/base_lco_with_value.hpp
+++ b/hpx/lcos/base_lco_with_value.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/lcos/base_lco.hpp>
 #include <hpx/plugins/parcel/coalescing_message_handler_registration.hpp>
 #include <hpx/preprocessor/cat.hpp>

--- a/hpx/lcos/detail/promise_lco.hpp
+++ b/hpx/lcos/detail/promise_lco.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/lcos/base_lco_with_value.hpp>
 #include <hpx/futures/detail/future_data.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>

--- a/hpx/lcos/future_wait.hpp
+++ b/hpx/lcos/future_wait.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/futures_factory.hpp>
 #include <hpx/async_combinators/wait_all.hpp>

--- a/hpx/lcos/object_semaphore.hpp
+++ b/hpx/lcos/object_semaphore.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/lcos/server/object_semaphore.hpp>
 #include <hpx/runtime/components/client_base.hpp>

--- a/hpx/lcos/packaged_action.hpp
+++ b/hpx/lcos/packaged_action.hpp
@@ -9,7 +9,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/lcos/promise.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>

--- a/hpx/lcos/server/object_semaphore.hpp
+++ b/hpx/lcos/server/object_semaphore.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/lcos/base_lco.hpp>
 #include <hpx/synchronization/spinlock.hpp>

--- a/hpx/plugins/parcel/message_buffer.hpp
+++ b/hpx/plugins/parcel/message_buffer.hpp
@@ -10,7 +10,7 @@
 
 #if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCEL_COALESCING)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/deferred_call.hpp>
 #include <hpx/runtime/parcelset/locality.hpp>
 #include <hpx/runtime/parcelset/parcel.hpp>

--- a/hpx/plugins/parcelport/mpi/header.hpp
+++ b/hpx/plugins/parcelport/mpi/header.hpp
@@ -11,7 +11,7 @@
 
 #if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_MPI)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/mpi_base.hpp>
 #include <hpx/runtime/parcelset/parcel_buffer.hpp>
 

--- a/hpx/plugins/parcelport/mpi/receiver.hpp
+++ b/hpx/plugins/parcelport/mpi/receiver.hpp
@@ -12,7 +12,7 @@
 
 #if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_MPI)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/plugins/parcelport/mpi/header.hpp>
 #include <hpx/plugins/parcelport/mpi/receiver_connection.hpp>
 

--- a/hpx/plugins/parcelport/mpi/receiver_connection.hpp
+++ b/hpx/plugins/parcelport/mpi/receiver_connection.hpp
@@ -10,7 +10,7 @@
 
 #if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_MPI)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/plugins/parcelport/mpi/header.hpp>
 #include <hpx/runtime/parcelset/decode_parcels.hpp>
 #include <hpx/runtime/parcelset/parcel_buffer.hpp>

--- a/hpx/plugins/parcelport/mpi/sender.hpp
+++ b/hpx/plugins/parcelport/mpi/sender.hpp
@@ -11,7 +11,7 @@
 
 #if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_MPI)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 
 #include <hpx/modules/mpi_base.hpp>

--- a/hpx/plugins/parcelport/mpi/sender_connection.hpp
+++ b/hpx/plugins/parcelport/mpi/sender_connection.hpp
@@ -10,7 +10,7 @@
 
 #if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_MPI)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/performance_counters/parcels/gatherer.hpp>
 #include <hpx/plugins/parcelport/mpi/header.hpp>
 #include <hpx/plugins/parcelport/mpi/locality.hpp>

--- a/hpx/plugins/parcelport/mpi/tag_provider.hpp
+++ b/hpx/plugins/parcelport/mpi/tag_provider.hpp
@@ -10,7 +10,7 @@
 
 #if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_MPI)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 
 #include <deque>

--- a/hpx/plugins/parcelport/tcp/receiver.hpp
+++ b/hpx/plugins/parcelport/tcp/receiver.hpp
@@ -16,7 +16,7 @@
 
 #if defined(HPX_HAVE_PARCELPORT_TCP)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/config/asio.hpp>
 #include <hpx/functional/bind.hpp>
 #include <hpx/functional/protect.hpp>

--- a/hpx/plugins/parcelport/tcp/sender.hpp
+++ b/hpx/plugins/parcelport/tcp/sender.hpp
@@ -13,7 +13,7 @@
 
 #if defined(HPX_HAVE_PARCELPORT_TCP)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/asio/asio_util.hpp>
 #include <hpx/config/asio.hpp>
 #include <hpx/performance_counters/parcels/data_point.hpp>

--- a/hpx/runtime/actions/manage_object_action.hpp
+++ b/hpx/runtime/actions/manage_object_action.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/runtime/actions/action_support.hpp>
 #include <hpx/serialization/array.hpp>
 #include <hpx/serialization/base_object.hpp>

--- a/hpx/runtime/actions/plain_action.hpp
+++ b/hpx/runtime/actions/plain_action.hpp
@@ -10,7 +10,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/preprocessor/expand.hpp>
 #include <hpx/preprocessor/nargs.hpp>

--- a/hpx/runtime/actions/transfer_base_action.hpp
+++ b/hpx/runtime/actions/transfer_base_action.hpp
@@ -15,7 +15,7 @@
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/runtime/actions_fwd.hpp>
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/runtime/actions/action_support.hpp>
 #include <hpx/runtime/actions/base_action.hpp>
 #include <hpx/runtime/actions/detail/invocation_count_registry.hpp>

--- a/hpx/runtime/agas/big_boot_barrier.hpp
+++ b/hpx/runtime/agas/big_boot_barrier.hpp
@@ -12,7 +12,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/runtime_local/runtime_local.hpp>
 #include <hpx/runtime/naming/address.hpp>

--- a/hpx/runtime/components/binpacking_distribution_policy.hpp
+++ b/hpx/runtime/components/binpacking_distribution_policy.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_distributed/dataflow.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/performance_counters/performance_counter.hpp>

--- a/hpx/runtime/components/client_base.hpp
+++ b/hpx/runtime/components/client_base.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/functional/bind_back.hpp>
 #include <hpx/futures/future.hpp>

--- a/hpx/runtime/components/component_type.hpp
+++ b/hpx/runtime/components/component_type.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/unique_function.hpp>
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/preprocessor/expand.hpp>

--- a/hpx/runtime/components/default_distribution_policy.hpp
+++ b/hpx/runtime/components/default_distribution_policy.hpp
@@ -15,7 +15,7 @@
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/promise_local_result.hpp>
 #include <hpx/lcos/packaged_action.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/runtime/actions/action_support.hpp>
 #include <hpx/runtime/components/stubs/stub_base.hpp>

--- a/hpx/runtime/components/pinned_ptr.hpp
+++ b/hpx/runtime/components/pinned_ptr.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/runtime/get_lva.hpp>
 #include <hpx/traits/action_decorate_function.hpp>

--- a/hpx/runtime/components/server/component.hpp
+++ b/hpx/runtime/components/server/component.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
 #include <hpx/traits/component_heap_type.hpp>
 

--- a/hpx/runtime/components/server/component_base.hpp
+++ b/hpx/runtime/components/server/component_base.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/runtime/components/component_type.hpp>
 #include <hpx/runtime/components/server/create_component_fwd.hpp>
 #include <hpx/runtime/components_fwd.hpp>

--- a/hpx/runtime/components/server/distributed_metadata_base.hpp
+++ b/hpx/runtime/components/server/distributed_metadata_base.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/lcos/base_lco_with_value.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/preprocessor/cat.hpp>

--- a/hpx/runtime/components/server/fixed_component_base.hpp
+++ b/hpx/runtime/components/server/fixed_component_base.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_distributed/applier/applier.hpp>
 #include <hpx/async_distributed/applier/bind_naming_wrappers.hpp>
 #include <hpx/runtime/components/component_type.hpp>

--- a/hpx/runtime/components/server/managed_component_base.hpp
+++ b/hpx/runtime/components/server/managed_component_base.hpp
@@ -9,7 +9,7 @@
 
 #include <hpx/config.hpp>
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/runtime/components/component_type.hpp>
 #include <hpx/runtime/components/server/component_heap.hpp>
 #include <hpx/runtime/components/server/create_component_fwd.hpp>

--- a/hpx/runtime/components/server/migration_support.hpp
+++ b/hpx/runtime/components/server/migration_support.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/local_lcos/promise.hpp>

--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/synchronization/condition_variable.hpp>
 #include <hpx/synchronization/mutex.hpp>

--- a/hpx/runtime/components/server/wrapper_heap.hpp
+++ b/hpx/runtime/components/server/wrapper_heap.hpp
@@ -9,7 +9,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/itt_notify.hpp>
 #include <hpx/runtime/naming/name.hpp>
 #include <hpx/runtime_fwd.hpp>

--- a/hpx/runtime/get_ptr.hpp
+++ b/hpx/runtime/get_ptr.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/runtime/agas/gva.hpp>
 #include <hpx/runtime/components/client_base.hpp>
 #include <hpx/runtime/components/component_type.hpp>

--- a/hpx/runtime/naming/name.hpp
+++ b/hpx/runtime/naming/name.hpp
@@ -10,7 +10,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/register_locks.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
 #include <hpx/concurrency/spinlock_pool.hpp>

--- a/hpx/runtime/parcelset/decode_parcels.hpp
+++ b/hpx/runtime/parcelset/decode_parcels.hpp
@@ -10,7 +10,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/performance_counters/parcels/data_point.hpp>

--- a/hpx/runtime/parcelset/detail/call_for_each.hpp
+++ b/hpx/runtime/parcelset/detail/call_for_each.hpp
@@ -10,7 +10,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/runtime/parcelset/parcelport.hpp>
 
 #include <cstddef>

--- a/hpx/runtime/parcelset/encode_parcels.hpp
+++ b/hpx/runtime/parcelset/encode_parcels.hpp
@@ -13,7 +13,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/runtime/actions/basic_action.hpp>

--- a/hpx/runtime/parcelset/locality.hpp
+++ b/hpx/runtime/parcelset/locality.hpp
@@ -10,7 +10,7 @@
 
 #include <hpx/config.hpp>
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/runtime/parcelset_fwd.hpp>
 #include <hpx/serialization/map.hpp>

--- a/hpx/runtime/parcelset/parcelhandler.hpp
+++ b/hpx/runtime/parcelset/parcelhandler.hpp
@@ -11,7 +11,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/synchronization/spinlock.hpp>

--- a/hpx/runtime/parcelset/parcelport_connection.hpp
+++ b/hpx/runtime/parcelset/parcelport_connection.hpp
@@ -10,7 +10,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/runtime/parcelset/parcel_buffer.hpp>
 
 #include <cstdint>

--- a/hpx/runtime/parcelset/parcelport_impl.hpp
+++ b/hpx/runtime/parcelset/parcelport_impl.hpp
@@ -13,7 +13,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/functional/deferred_call.hpp>

--- a/hpx/runtime/parcelset/put_parcel.hpp
+++ b/hpx/runtime/parcelset/put_parcel.hpp
@@ -10,7 +10,7 @@
 
 #if defined(HPX_HAVE_NETWORKING)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/runtime_local/runtime_local.hpp>

--- a/hpx/runtime/serialization/detail/preprocess_futures.hpp
+++ b/hpx/runtime/serialization/detail/preprocess_futures.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/local_lcos/promise.hpp>

--- a/hpx/runtime/serialization/detail/preprocess_gid_types.hpp
+++ b/hpx/runtime/serialization/detail/preprocess_gid_types.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/runtime/naming/name.hpp>

--- a/hpx/runtime/trigger_lco.hpp
+++ b/hpx/runtime/trigger_lco.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/lcos_fwd.hpp>
 #include <hpx/runtime/actions/action_priority.hpp>
 #include <hpx/runtime/actions/continuation_fwd.hpp>

--- a/hpx/util/connection_cache.hpp
+++ b/hpx/util/connection_cache.hpp
@@ -16,7 +16,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/synchronization/spinlock.hpp>

--- a/hpx/util/one_size_heap_list.hpp
+++ b/hpx/util/one_size_heap_list.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/util/wrapper_heap_base.hpp>
 

--- a/hpx/util/remove_local_destinations.hpp
+++ b/hpx/util/remove_local_destinations.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/runtime/naming/address.hpp>
 #include <hpx/runtime/naming/name.hpp>
 

--- a/libs/affinity/include/hpx/affinity/affinity_data.hpp
+++ b/libs/affinity/include/hpx/affinity/affinity_data.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/topology/topology.hpp>
 
 #include <atomic>

--- a/libs/affinity/include/hpx/affinity/parse_affinity_options.hpp
+++ b/libs/affinity/include/hpx/affinity/parse_affinity_options.hpp
@@ -11,7 +11,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/topology/cpu_mask.hpp>
 

--- a/libs/affinity/src/affinity_data.cpp
+++ b/libs/affinity/src/affinity_data.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/affinity/affinity_data.hpp>
 #include <hpx/affinity/parse_affinity_options.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/topology/cpu_mask.hpp>

--- a/libs/affinity/src/parse_affinity_options.cpp
+++ b/libs/affinity/src/parse_affinity_options.cpp
@@ -5,8 +5,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/affinity/parse_affinity_options.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/datastructures/tuple.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/topology/topology.hpp>

--- a/libs/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -11,10 +11,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/parallel/util/tagged_pair.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>

--- a/libs/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 
 #include <hpx/execution/executors/execution_information.hpp>
 #include <hpx/executors/execution_policy.hpp>

--- a/libs/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -15,10 +15,10 @@
 #include <hpx/functional/traits/get_function_address.hpp>
 #include <hpx/functional/traits/get_function_annotation.hpp>
 #endif
+#include <hpx/assert.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/threading_base/annotated_function.hpp>
 #include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/pack.hpp>

--- a/libs/algorithms/include/hpx/parallel/algorithms/for_loop_reduction.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/for_loop_reduction.hpp
@@ -9,8 +9,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/concurrency/cache_line_data.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/runtime_local/get_os_thread_count.hpp>
 #include <hpx/runtime_local/get_worker_thread_num.hpp>
 #include <hpx/type_support/decay.hpp>

--- a/libs/algorithms/include/hpx/parallel/algorithms/merge.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/merge.hpp
@@ -7,10 +7,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/parallel/util/tagged_tuple.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>

--- a/libs/algorithms/include/hpx/parallel/algorithms/minmax.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/minmax.hpp
@@ -12,10 +12,10 @@
 
 #include <hpx/config.hpp>
 #include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/parallel/util/tagged_pair.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>

--- a/libs/algorithms/include/hpx/parallel/algorithms/partition.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/partition.hpp
@@ -8,12 +8,12 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/functional/traits/is_callable.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/parallel/util/tagged_tuple.hpp>
 #include <hpx/synchronization/spinlock.hpp>

--- a/libs/algorithms/include/hpx/parallel/algorithms/sort.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/sort.hpp
@@ -10,11 +10,11 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_local/dataflow.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/type_support/decay.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>

--- a/libs/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -7,10 +7,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/iterator_support/iterator_range.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/type_support/decay.hpp>
 
 #include <hpx/execution/algorithms/detail/is_negative.hpp>

--- a/libs/algorithms/include/hpx/parallel/util/detail/handle_local_exceptions.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/detail/handle_local_exceptions.hpp
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/executors/execution_policy.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/parallel/util/detail/handle_exception_termination_handler.hpp>

--- a/libs/algorithms/include/hpx/parallel/util/foreach_partitioner.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/foreach_partitioner.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_combinators/wait_all.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/async_local/dataflow.hpp>

--- a/libs/algorithms/include/hpx/parallel/util/loop.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/loop.hpp
@@ -10,11 +10,11 @@
 #if defined(HPX_HAVE_DATAPAR)
 #include <hpx/parallel/datapar/loop.hpp>
 #endif
+#include <hpx/assert.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/execution/traits/is_execution_policy.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/functional/result_of.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 

--- a/libs/algorithms/include/hpx/parallel/util/partitioner.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/partitioner.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/async_local/dataflow.hpp>
 #endif

--- a/libs/algorithms/include/hpx/parallel/util/partitioner_with_cleanup.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/partitioner_with_cleanup.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_combinators/wait_all.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/async_local/dataflow.hpp>

--- a/libs/algorithms/include/hpx/parallel/util/scan_partitioner.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/scan_partitioner.hpp
@@ -9,8 +9,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_combinators/wait_all.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/async_local/dataflow.hpp>

--- a/libs/algorithms/include/hpx/parallel/util/tagged_pair.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/tagged_pair.hpp
@@ -10,10 +10,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/datastructures/tagged_pair.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/type_support/decay.hpp>
 
 #include <cstddef>

--- a/libs/asio/src/asio_util.cpp
+++ b/libs/asio/src/asio_util.cpp
@@ -14,7 +14,7 @@
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/config/asio.hpp>
 #include <hpx/asio/asio_util.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 
 #include <boost/asio/io_service.hpp>

--- a/libs/assertion/include_compatibility/hpx/util/assert.hpp
+++ b/libs/assertion/include_compatibility/hpx/util/assert.hpp
@@ -14,16 +14,16 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assertion/config/defines.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 
 #if defined(HPX_ASSERTION_HAVE_DEPRECATION_WARNINGS)
 #if defined(HPX_MSVC)
 #pragma message(                                                               \
     "The header hpx/util/assert.hpp is deprecated,                             \
-    please include hpx/modules/assertion.hpp instead")
+    please include hpx/assert.hpp instead")
 #else
 #warning                                                                       \
     "The header hpx/util/assert.hpp is deprecated,                        \
-    please include hpx/modules/assertion.hpp instead"
+    please include hpx/assert.hpp instead"
 #endif
 #endif

--- a/libs/assertion/src/assertion.cpp
+++ b/libs/assertion/src/assertion.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 
 #include <iostream>
 #include <string>

--- a/libs/assertion/tests/unit/assert_fail.cpp
+++ b/libs/assertion/tests/unit/assert_fail.cpp
@@ -4,7 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 
 int main()
 {

--- a/libs/assertion/tests/unit/assert_succeed.cpp
+++ b/libs/assertion/tests/unit/assert_succeed.cpp
@@ -4,7 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 
 int main()
 {

--- a/libs/async_combinators/include/hpx/async_combinators/wait_some.hpp
+++ b/libs/async_combinators/include/hpx/async_combinators/wait_some.hpp
@@ -175,6 +175,7 @@ namespace hpx {
 #else
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/functional/deferred_call.hpp>
 #include <hpx/futures/future.hpp>
@@ -182,7 +183,6 @@ namespace hpx {
 #include <hpx/futures/traits/detail/future_traits.hpp>
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/futures/traits/is_future.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/threading.hpp>
 #include <hpx/preprocessor/strip_parens.hpp>

--- a/libs/async_combinators/include/hpx/async_combinators/when_any.hpp
+++ b/libs/async_combinators/include/hpx/async_combinators/when_any.hpp
@@ -121,6 +121,7 @@ namespace hpx {
 #else    // DOXYGEN
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_combinators/when_any.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
 #include <hpx/datastructures/tuple.hpp>
@@ -132,7 +133,6 @@ namespace hpx {
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/futures/traits/is_future.hpp>
 #include <hpx/futures/traits/is_future_range.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/threading.hpp>
 #include <hpx/type_support/pack.hpp>
 #include <hpx/util/detail/reserve.hpp>

--- a/libs/async_combinators/include/hpx/async_combinators/when_some.hpp
+++ b/libs/async_combinators/include/hpx/async_combinators/when_some.hpp
@@ -224,6 +224,7 @@ namespace hpx {
 #else    // DOXYGEN
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/functional/deferred_call.hpp>
 #include <hpx/futures/future.hpp>
@@ -234,7 +235,6 @@ namespace hpx {
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/futures/traits/is_future.hpp>
 #include <hpx/futures/traits/is_future_range.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/threading.hpp>
 #include <hpx/type_support/pack.hpp>

--- a/libs/async_distributed/include/hpx/async_distributed/applier/applier.hpp
+++ b/libs/async_distributed/include/hpx/async_distributed/applier/applier.hpp
@@ -11,8 +11,8 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
+#include <hpx/assert.hpp>
 #include <hpx/async_distributed/applier_fwd.hpp>    // this needs to go first
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/threadmanager.hpp>
 #include <hpx/runtime/agas_fwd.hpp>
 #include <hpx/runtime/components/component_type.hpp>

--- a/libs/async_distributed/include/hpx/async_distributed/applier/apply.hpp
+++ b/libs/async_distributed/include/hpx/async_distributed/applier/apply.hpp
@@ -8,11 +8,11 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_distributed/applier/apply_helper.hpp>
 #include <hpx/async_distributed/applier/detail/apply_implementations.hpp>
 #include <hpx/async_local/apply.hpp>
 #include <hpx/functional/traits/is_action.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/threading_base.hpp>
 #include <hpx/runtime/actions/action_priority.hpp>
 #include <hpx/runtime/actions/action_support.hpp>

--- a/libs/async_distributed/include/hpx/async_distributed/async.hpp
+++ b/libs/async_distributed/include/hpx/async_distributed/async.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_base/traits/is_launch_policy.hpp>
 #include <hpx/async_distributed/async.hpp>
@@ -22,7 +23,6 @@
 #include <hpx/functional/traits/is_action.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/promise_local_result.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/runtime/components/client_base.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/traits/extract_action.hpp>

--- a/libs/async_distributed/include/hpx/async_distributed/detail/async_colocated.hpp
+++ b/libs/async_distributed/include/hpx/async_distributed/detail/async_colocated.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_distributed/async_continue_fwd.hpp>
 #include <hpx/async_distributed/async_fwd.hpp>
 #include <hpx/async_distributed/detail/async_colocated_fwd.hpp>
@@ -15,7 +16,6 @@
 #include <hpx/functional/unique_function.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/promise_local_result.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/runtime/actions/action_support.hpp>
 #include <hpx/runtime/agas/primary_namespace.hpp>
 #include <hpx/runtime/agas/server/primary_namespace.hpp>

--- a/libs/async_distributed/include/hpx/async_distributed/detail/async_colocated_callback.hpp
+++ b/libs/async_distributed/include/hpx/async_distributed/detail/async_colocated_callback.hpp
@@ -6,11 +6,11 @@
 
 #pragma once
 
+#include <hpx/assert.hpp>
 #include <hpx/async_distributed/async_continue_callback.hpp>
 #include <hpx/async_distributed/detail/async_colocated.hpp>
 #include <hpx/async_distributed/detail/async_colocated_callback_fwd.hpp>
 #include <hpx/futures/traits/promise_local_result.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/runtime/agas/primary_namespace.hpp>
 #include <hpx/runtime/agas/server/primary_namespace.hpp>
 #include <hpx/traits/extract_action.hpp>

--- a/libs/async_distributed/include/hpx/async_distributed/detail/async_implementations.hpp
+++ b/libs/async_distributed/include/hpx/async_distributed/detail/async_implementations.hpp
@@ -7,12 +7,12 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_distributed/detail/async_implementations_fwd.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/lcos/packaged_action.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/threading.hpp>
 #include <hpx/runtime/naming/address.hpp>

--- a/libs/async_distributed/include/hpx/async_distributed/detail/async_unwrap_result_implementations.hpp
+++ b/libs/async_distributed/include/hpx/async_distributed/detail/async_unwrap_result_implementations.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_distributed/detail/async_implementations.hpp>
 #include <hpx/async_distributed/detail/async_unwrap_result_implementations_fwd.hpp>
@@ -14,7 +15,6 @@
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/lcos/packaged_action.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/threading.hpp>
 #include <hpx/runtime/naming/address.hpp>

--- a/libs/async_distributed/include/hpx/async_distributed/sync.hpp
+++ b/libs/async_distributed/include/hpx/async_distributed/sync.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_base/traits/is_launch_policy.hpp>
 #include <hpx/async_distributed/detail/sync_implementations.hpp>
@@ -18,7 +19,6 @@
 #include <hpx/functional/bind_back.hpp>
 #include <hpx/functional/traits/is_action.hpp>
 #include <hpx/futures/traits/promise_local_result.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/runtime/components/client_base.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/traits/extract_action.hpp>

--- a/libs/async_mpi/src/mpi_future.cpp
+++ b/libs/async_mpi/src/mpi_future.cpp
@@ -5,8 +5,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_mpi/mpi_future.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/threading_base.hpp>
 

--- a/libs/basic_execution/src/agent_ref.cpp
+++ b/libs/basic_execution/src/agent_ref.cpp
@@ -4,8 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/agent_ref.hpp>
-#include <hpx/modules/assertion.hpp>
 #ifdef HPX_HAVE_VERIFY_LOCKS
 #include <hpx/basic_execution/register_locks.hpp>
 #endif

--- a/libs/basic_execution/src/register_locks.cpp
+++ b/libs/basic_execution/src/register_locks.cpp
@@ -6,8 +6,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/register_locks.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 
 #include <cstddef>

--- a/libs/basic_execution/src/this_thread.cpp
+++ b/libs/basic_execution/src/this_thread.cpp
@@ -7,11 +7,11 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/agent_base.hpp>
 #include <hpx/basic_execution/context_base.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
 #include <hpx/errors/throw_exception.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/timing/steady_clock.hpp>
 

--- a/libs/batch_environments/src/slurm_environment.cpp
+++ b/libs/batch_environments/src/slurm_environment.cpp
@@ -6,8 +6,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/batch_environments/slurm_environment.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/string_util/classification.hpp>
 #include <hpx/string_util/split.hpp>
 #include <hpx/util/from_string.hpp>

--- a/libs/collectives/include/hpx/collectives/broadcast_direct.hpp
+++ b/libs/collectives/include/hpx/collectives/broadcast_direct.hpp
@@ -127,6 +127,7 @@ namespace hpx { namespace lcos {
 #else
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_combinators/when_all.hpp>
 #include <hpx/async_distributed/applier/detail/apply_colocated.hpp>
 #include <hpx/async_distributed/apply.hpp>
@@ -134,7 +135,6 @@ namespace hpx { namespace lcos {
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/promise_local_result.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/preprocessor/cat.hpp>

--- a/libs/collectives/include/hpx/collectives/detail/barrier_node.hpp
+++ b/libs/collectives/include/hpx/collectives/detail/barrier_node.hpp
@@ -7,10 +7,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/lcos/base_lco.hpp>
 #include <hpx/local_lcos/promise.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/runtime/components/server/managed_component_base.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/synchronization/barrier.hpp>

--- a/libs/collectives/include/hpx/collectives/detail/communicator.hpp
+++ b/libs/collectives/include/hpx/collectives/detail/communicator.hpp
@@ -10,12 +10,12 @@
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/datastructures/any.hpp>
 #include <hpx/functional/bind_back.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/local_lcos/and_gate.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/basic_execution.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/parallel/algorithms/reduce.hpp>

--- a/libs/collectives/include/hpx/collectives/fold.hpp
+++ b/libs/collectives/include/hpx/collectives/fold.hpp
@@ -158,12 +158,12 @@ namespace hpx { namespace lcos {
 #else
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_combinators/when_all.hpp>
 #include <hpx/async_distributed/detail/async_colocated.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/promise_local_result.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/preprocessor/expand.hpp>
 #include <hpx/preprocessor/nargs.hpp>

--- a/libs/collectives/include/hpx/collectives/reduce.hpp
+++ b/libs/collectives/include/hpx/collectives/reduce.hpp
@@ -74,12 +74,12 @@ namespace hpx { namespace lcos {
 #else
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_combinators/when_all.hpp>
 #include <hpx/async_distributed/detail/async_colocated.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/promise_local_result.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/preprocessor/expand.hpp>
 #include <hpx/preprocessor/nargs.hpp>

--- a/libs/collectives/src/barrier.cpp
+++ b/libs/collectives/src/barrier.cpp
@@ -4,11 +4,11 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_combinators/when_all.hpp>
 #include <hpx/collectives/barrier.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/runtime/basename_registration.hpp>
 #include <hpx/runtime/components/server/component_heap.hpp>

--- a/libs/collectives/src/detail/barrier_node.cpp
+++ b/libs/collectives/src/detail/barrier_node.cpp
@@ -4,13 +4,13 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_combinators/when_all.hpp>
 #include <hpx/collectives/detail/barrier_node.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/local_lcos/promise.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/pack_traversal/unwrap.hpp>

--- a/libs/collectives/src/latch.cpp
+++ b/libs/collectives/src/latch.cpp
@@ -4,9 +4,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/assert.hpp>
 #include <hpx/collectives/latch.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/runtime/actions/continuation.hpp>

--- a/libs/command_line_handling/src/command_line_handling.cpp
+++ b/libs/command_line_handling/src/command_line_handling.cpp
@@ -5,9 +5,9 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/detail/reset_function.hpp>
 #include <hpx/modules/asio.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/batch_environments.hpp>
 #include <hpx/modules/command_line_handling.hpp>
 #include <hpx/modules/debugging.hpp>

--- a/libs/compute/include/hpx/compute/detail/iterator.hpp
+++ b/libs/compute/include/hpx/compute/detail/iterator.hpp
@@ -9,8 +9,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/iterator_support/iterator_adaptor.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <hpx/compute/detail/get_proxy_type.hpp>
 #include <hpx/compute/traits/allocator_traits.hpp>

--- a/libs/compute/include/hpx/compute/host/numa_allocator.hpp
+++ b/libs/compute/include/hpx/compute/host/numa_allocator.hpp
@@ -8,12 +8,12 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_combinators/wait_all.hpp>
 #include <hpx/execution/executors/execution_information.hpp>
 #include <hpx/execution/executors/static_chunk_size.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/parallel/algorithms/for_each.hpp>
 #include <hpx/runtime_local/get_worker_thread_num.hpp>
 #include <hpx/topology/topology.hpp>

--- a/libs/compute/include/hpx/compute/host/numa_binding_allocator.hpp
+++ b/libs/compute/include/hpx/compute/host/numa_binding_allocator.hpp
@@ -8,10 +8,10 @@
 
 #include <hpx/config.hpp>
 
+#include <hpx/assert.hpp>
 #include <hpx/async_local/async.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/executors/guided_pool_executor.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/threadmanager.hpp>
 #include <hpx/runtime_fwd.hpp>
 #include <hpx/runtime_local/thread_pool_helpers.hpp>

--- a/libs/compute/include/hpx/compute/host/target_distribution_policy.hpp
+++ b/libs/compute/include/hpx/compute/host/target_distribution_policy.hpp
@@ -11,7 +11,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/async_local/dataflow.hpp>
 #endif

--- a/libs/compute/include/hpx/compute/vector.hpp
+++ b/libs/compute/include/hpx/compute/vector.hpp
@@ -9,11 +9,11 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/compute/detail/iterator.hpp>
 #include <hpx/compute/traits/access_target.hpp>
 #include <hpx/compute/traits/allocator_traits.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/parallel/util/transfer.hpp>
 #include <hpx/runtime_local/report_error.hpp>
 

--- a/libs/compute_cuda/include/hpx/compute/cuda/allocator.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/allocator.hpp
@@ -10,12 +10,12 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_CUDA)
+#include <hpx/assert.hpp>
 #include <hpx/compute/cuda/detail/launch.hpp>
 #include <hpx/compute/cuda/detail/scoped_active_target.hpp>
 #include <hpx/compute/cuda/target.hpp>
 #include <hpx/compute/cuda/target_ptr.hpp>
 #include <hpx/compute/cuda/value_proxy.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/statistics/min.hpp>
 #include <hpx/type_support/unused.hpp>

--- a/libs/compute_cuda/include/hpx/compute/cuda/detail/scoped_active_target.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/detail/scoped_active_target.hpp
@@ -11,8 +11,8 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_CUDA)
+#include <hpx/assert.hpp>
 #include <hpx/compute/cuda/target.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 
 #include <cuda_runtime.h>

--- a/libs/compute_cuda/include/hpx/compute/cuda/target.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/target.hpp
@@ -13,10 +13,10 @@
 
 #if defined(HPX_HAVE_CUDA)
 #include <hpx/allocator_support/allocator_deleter.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/compute/cuda/get_targets.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/future_access.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/runtime/find_here.hpp>
 #include <hpx/runtime_fwd.hpp>
 #include <hpx/synchronization/spinlock.hpp>

--- a/libs/compute_cuda/include/hpx/compute/cuda/target_distribution_policy.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/target_distribution_policy.hpp
@@ -12,7 +12,7 @@
 
 #if defined(HPX_HAVE_CUDA)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/async_distributed/dataflow.hpp>
 #endif

--- a/libs/compute_cuda/include/hpx/compute/cuda/target_ptr.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/target_ptr.hpp
@@ -12,8 +12,8 @@
 
 #if defined(HPX_HAVE_CUDA)
 
+#include <hpx/assert.hpp>
 #include <hpx/iterator_support/iterator_adaptor.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <hpx/compute/cuda/target.hpp>
 #include <hpx/compute/cuda/value_proxy.hpp>

--- a/libs/compute_cuda/include/hpx/compute/detail/iterator.hpp
+++ b/libs/compute_cuda/include/hpx/compute/detail/iterator.hpp
@@ -9,8 +9,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/iterator_support/iterator_adaptor.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <hpx/compute/detail/get_proxy_type.hpp>
 #include <hpx/compute/traits/allocator_traits.hpp>

--- a/libs/compute_cuda/src/cuda_target.cpp
+++ b/libs/compute_cuda/src/cuda_target.cpp
@@ -9,10 +9,10 @@
 #if defined(HPX_HAVE_CUDA)
 
 #include <hpx/allocator_support/internal_allocator.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/compute/cuda/target.hpp>
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/runtime/find_here.hpp>
 #include <hpx/runtime/naming/id_type_impl.hpp>

--- a/libs/coroutines/include/hpx/coroutines/coroutine.hpp
+++ b/libs/coroutines/include/hpx/coroutines/coroutine.hpp
@@ -32,13 +32,13 @@
 
 #include <hpx/config.hpp>
 
+#include <hpx/assert.hpp>
 #include <hpx/coroutines/coroutine_fwd.hpp>
 #include <hpx/coroutines/detail/coroutine_accessor.hpp>
 #include <hpx/coroutines/detail/coroutine_impl.hpp>
 #include <hpx/coroutines/detail/coroutine_self.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/coroutines/thread_id_type.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/libs/coroutines/include/hpx/coroutines/detail/combined_tagged_state.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/combined_tagged_state.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/libs/coroutines/include/hpx/coroutines/detail/context_base.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/context_base.hpp
@@ -43,10 +43,10 @@
 // This needs to be first for building on Macs
 #include <hpx/coroutines/detail/context_impl.hpp>
 
+#include <hpx/assert.hpp>
 #include <hpx/coroutines/detail/swap_context.hpp>    //for swap hints
 #include <hpx/coroutines/detail/tss.hpp>
 #include <hpx/coroutines/thread_id_type.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <atomic>
 #include <cstddef>

--- a/libs/coroutines/include/hpx/coroutines/detail/context_generic_context.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/context_generic_context.hpp
@@ -10,9 +10,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/coroutines/detail/get_stack_pointer.hpp>
 #include <hpx/coroutines/detail/swap_context.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/util/get_and_reset_value.hpp>
 
 // include unist.d conditionally to check for POSIX version. Not all OSs have the

--- a/libs/coroutines/include/hpx/coroutines/detail/context_linux_x86.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/context_linux_x86.hpp
@@ -15,10 +15,10 @@
 #if defined(__linux) || defined(linux) || defined(__linux__)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/coroutines/detail/get_stack_pointer.hpp>
 #include <hpx/coroutines/detail/posix_utility.hpp>
 #include <hpx/coroutines/detail/swap_context.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/util/get_and_reset_value.hpp>
 

--- a/libs/coroutines/include/hpx/coroutines/detail/context_posix.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/context_posix.hpp
@@ -43,7 +43,7 @@
 #endif
 #endif
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/type_support/unused.hpp>
 #include <hpx/util/get_and_reset_value.hpp>
 

--- a/libs/coroutines/include/hpx/coroutines/detail/context_windows_fibers.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/context_windows_fibers.hpp
@@ -33,9 +33,9 @@
 #include <winnt.h>
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/coroutines/detail/get_stack_pointer.hpp>
 #include <hpx/coroutines/detail/swap_context.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/type_support/unused.hpp>
 #include <hpx/util/get_and_reset_value.hpp>
 

--- a/libs/coroutines/include/hpx/coroutines/detail/coroutine_impl.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/coroutine_impl.hpp
@@ -36,13 +36,13 @@
 #endif
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/coroutines/coroutine_fwd.hpp>
 #include <hpx/coroutines/detail/context_base.hpp>
 #include <hpx/coroutines/detail/coroutine_accessor.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/coroutines/thread_id_type.hpp>
 #include <hpx/functional/unique_function.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <cstddef>
 #include <utility>

--- a/libs/coroutines/include/hpx/coroutines/detail/coroutine_self.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/coroutine_self.hpp
@@ -30,12 +30,12 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/coroutines/detail/coroutine_accessor.hpp>
 #include <hpx/coroutines/detail/coroutine_impl.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/coroutines/thread_id_type.hpp>
 #include <hpx/functional/function.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <cstddef>
 #include <exception>

--- a/libs/coroutines/include/hpx/coroutines/detail/coroutine_stackful_self.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/coroutine_stackful_self.hpp
@@ -7,12 +7,12 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/coroutines/detail/coroutine_impl.hpp>
 #include <hpx/coroutines/detail/coroutine_self.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/coroutines/thread_id_type.hpp>
 #include <hpx/functional/function.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <cstddef>
 #include <exception>

--- a/libs/coroutines/include/hpx/coroutines/detail/coroutine_stackless_self.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/coroutine_stackless_self.hpp
@@ -7,11 +7,11 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/coroutines/detail/coroutine_self.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/coroutines/thread_id_type.hpp>
 #include <hpx/functional/function.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <cstddef>
 #include <exception>

--- a/libs/coroutines/include/hpx/coroutines/detail/posix_utility.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/posix_utility.hpp
@@ -31,7 +31,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 
 // include unist.d conditionally to check for POSIX version. Not all OSs have the
 // unistd header...

--- a/libs/coroutines/include/hpx/coroutines/detail/tss.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/tss.hpp
@@ -12,7 +12,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 
 #include <cstddef>
 #include <map>

--- a/libs/coroutines/include/hpx/coroutines/stackless_coroutine.hpp
+++ b/libs/coroutines/include/hpx/coroutines/stackless_coroutine.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/coroutines/coroutine.hpp>
 #include <hpx/coroutines/detail/coroutine_self.hpp>
 #include <hpx/coroutines/detail/tss.hpp>
@@ -15,7 +16,6 @@
 #include <hpx/coroutines/thread_id_type.hpp>
 #include <hpx/functional/detail/reset_function.hpp>
 #include <hpx/functional/unique_function.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <cstddef>

--- a/libs/coroutines/src/detail/coroutine_impl.cpp
+++ b/libs/coroutines/src/detail/coroutine_impl.cpp
@@ -30,10 +30,10 @@
 
 #include <hpx/config.hpp>
 
+#include <hpx/assert.hpp>
 #include <hpx/coroutines/coroutine.hpp>
 #include <hpx/coroutines/detail/coroutine_impl.hpp>
 #include <hpx/coroutines/detail/coroutine_stackful_self.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <cstddef>
 #include <exception>

--- a/libs/coroutines/src/detail/coroutine_self.cpp
+++ b/libs/coroutines/src/detail/coroutine_self.cpp
@@ -6,8 +6,8 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/coroutines/detail/coroutine_self.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <cstddef>
 

--- a/libs/coroutines/src/detail/tss.cpp
+++ b/libs/coroutines/src/detail/tss.cpp
@@ -10,10 +10,10 @@
 // (C) Copyright 2011-2012 Vicente J. Botet Escriba
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/coroutines/coroutine.hpp>
 #include <hpx/coroutines/detail/coroutine_self.hpp>
 #include <hpx/coroutines/detail/tss.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 
 #include <cstddef>

--- a/libs/datastructures/include/hpx/datastructures/any.hpp
+++ b/libs/datastructures/include/hpx/datastructures/any.hpp
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/datastructures/traits/supports_streaming_with_any.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/libs/datastructures/include/hpx/datastructures/tagged_pair.hpp
+++ b/libs/datastructures/include/hpx/datastructures/tagged_pair.hpp
@@ -10,9 +10,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/datastructures/tagged.hpp>
 #include <hpx/datastructures/tuple.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/type_support/decay.hpp>
 
 #include <cstddef>

--- a/libs/errors/src/exception.cpp
+++ b/libs/errors/src/exception.cpp
@@ -6,11 +6,11 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/errors/error.hpp>
 #include <hpx/errors/error_code.hpp>
 #include <hpx/errors/exception.hpp>
 #include <hpx/errors/exception_info.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/logging.hpp>
 

--- a/libs/execution/include/hpx/execution/algorithms/detail/predicates.hpp
+++ b/libs/execution/include/hpx/execution/algorithms/detail/predicates.hpp
@@ -7,9 +7,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <hpx/execution/algorithms/detail/is_negative.hpp>
 

--- a/libs/execution/include/hpx/execution/detail/async_launch_policy_dispatch.hpp
+++ b/libs/execution/include/hpx/execution/detail/async_launch_policy_dispatch.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/functional/deferred_call.hpp>
@@ -14,7 +15,6 @@
 #include <hpx/functional/traits/is_action.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/futures_factory.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/threading_base/thread_helpers.hpp>
 #include <hpx/threading_base/thread_pool_base.hpp>
 

--- a/libs/execution/include/hpx/execution/detail/future_exec.hpp
+++ b/libs/execution/include/hpx/execution/detail/future_exec.hpp
@@ -9,6 +9,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_base/traits/is_launch_policy.hpp>
 #include <hpx/execution/detail/post_policy_dispatch.hpp>
@@ -22,7 +23,6 @@
 #include <hpx/futures/packaged_continuation.hpp>
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp>
 #include <hpx/timing/steady_clock.hpp>

--- a/libs/execution/include/hpx/execution/executors/execution.hpp
+++ b/libs/execution/include/hpx/execution/executors/execution.hpp
@@ -13,6 +13,7 @@
 // Necessary to avoid circular include
 #include <hpx/basic_execution/execution.hpp>
 
+#include <hpx/assert.hpp>
 #include <hpx/async_combinators/wait_all.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/execution/executors/fused_bulk_execute.hpp>
@@ -26,7 +27,6 @@
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/futures/traits/future_traits.hpp>
 #include <hpx/iterator_support/range.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/pack_traversal/unwrap.hpp>
 #include <hpx/type_support/detail/wrap_int.hpp>

--- a/libs/execution/include/hpx/execution/executors/polymorphic_executor.hpp
+++ b/libs/execution/include/hpx/execution/executors/polymorphic_executor.hpp
@@ -9,10 +9,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/execution.hpp>
 #include <hpx/execution/traits/is_executor.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/thread_support.hpp>
 

--- a/libs/execution/include/hpx/execution/executors/thread_pool_executor.hpp
+++ b/libs/execution/include/hpx/execution/executors/thread_pool_executor.hpp
@@ -11,6 +11,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>
@@ -27,7 +28,6 @@
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/future_traits.hpp>
 #include <hpx/iterator_support/range.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/pack_traversal/unwrap.hpp>
 #include <hpx/serialization/serialize.hpp>
 #include <hpx/synchronization/latch.hpp>

--- a/libs/execution/src/polymorphic_executor.cpp
+++ b/libs/execution/src/polymorphic_executor.cpp
@@ -5,8 +5,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/execution/executors/polymorphic_executor.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 
 #include <cstddef>

--- a/libs/executors/include/hpx/executors/exception_list.hpp
+++ b/libs/executors/include/hpx/executors/exception_list.hpp
@@ -8,9 +8,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/executors/execution_policy_fwd.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/type_support/decay.hpp>

--- a/libs/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/executors/include/hpx/executors/parallel_executor.hpp
@@ -11,6 +11,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/execution/detail/async_launch_policy_dispatch.hpp>
@@ -26,7 +27,6 @@
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/future_traits.hpp>
 #include <hpx/iterator_support/range.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/pack_traversal/unwrap.hpp>
 #include <hpx/serialization/serialize.hpp>
 #include <hpx/synchronization/latch.hpp>

--- a/libs/executors/include/hpx/executors/parallel_executor_aggregated.hpp
+++ b/libs/executors/include/hpx/executors/parallel_executor_aggregated.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/execution/detail/async_launch_policy_dispatch.hpp>
@@ -21,7 +22,6 @@
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/future_traits.hpp>
 #include <hpx/iterator_support/range.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/serialization/serialize.hpp>
 #include <hpx/synchronization/latch.hpp>
 #include <hpx/threading_base/thread_helpers.hpp>

--- a/libs/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
+++ b/libs/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
@@ -10,9 +10,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/execution/executors/execution_parameters.hpp>
 #include <hpx/execution/executors/thread_pool_executor.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <atomic>
 #include <cstddef>

--- a/libs/executors/include/hpx/executors/service_executors.hpp
+++ b/libs/executors/include/hpx/executors/service_executors.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/execution.hpp>
 #include <hpx/execution/executors/execution.hpp>
 #include <hpx/execution/executors/fused_bulk_execute.hpp>
@@ -20,7 +21,6 @@
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/future_traits.hpp>
 #include <hpx/io_service/io_service_pool.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/pack_traversal/unwrap.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
 #include <hpx/runtime_fwd.hpp>

--- a/libs/format/src/format.cpp
+++ b/libs/format/src/format.cpp
@@ -5,7 +5,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/format.hpp>
 
 #include <boost/utility/string_ref.hpp>

--- a/libs/functional/include/hpx/functional/bind.hpp
+++ b/libs/functional/include/hpx/functional/bind.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/datastructures/member_pack.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/functional/one_shot.hpp>
@@ -17,7 +18,6 @@
 #include <hpx/functional/traits/is_action.hpp>
 #include <hpx/functional/traits/is_bind_expression.hpp>
 #include <hpx/functional/traits/is_placeholder.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/pack.hpp>
 

--- a/libs/functional/include/hpx/functional/detail/basic_function.hpp
+++ b/libs/functional/include/hpx/functional/detail/basic_function.hpp
@@ -10,13 +10,13 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/detail/empty_function.hpp>
 #include <hpx/functional/detail/vtable/function_vtable.hpp>
 #include <hpx/functional/detail/vtable/vtable.hpp>
 #include <hpx/functional/traits/get_function_address.hpp>
 #include <hpx/functional/traits/get_function_annotation.hpp>
 #include <hpx/functional/traits/is_callable.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <cstddef>
 #include <cstring>

--- a/libs/functional/include/hpx/functional/function_ref.hpp
+++ b/libs/functional/include/hpx/functional/function_ref.hpp
@@ -7,13 +7,13 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/detail/empty_function.hpp>
 #include <hpx/functional/detail/vtable/callable_vtable.hpp>
 #include <hpx/functional/detail/vtable/vtable.hpp>
 #include <hpx/functional/traits/get_function_address.hpp>
 #include <hpx/functional/traits/get_function_annotation.hpp>
 #include <hpx/functional/traits/is_callable.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <cstddef>
 #include <cstring>

--- a/libs/functional/include/hpx/functional/one_shot.hpp
+++ b/libs/functional/include/hpx/functional/one_shot.hpp
@@ -8,11 +8,11 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/functional/result_of.hpp>
 #include <hpx/functional/traits/get_function_address.hpp>
 #include <hpx/functional/traits/get_function_annotation.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <cstddef>
 #include <type_traits>

--- a/libs/functional/include/hpx/functional/serialization/detail/serializable_basic_function.hpp
+++ b/libs/functional/include/hpx/functional/serialization/detail/serializable_basic_function.hpp
@@ -10,12 +10,12 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/detail/basic_function.hpp>
 #include <hpx/functional/detail/vtable/function_vtable.hpp>
 #include <hpx/functional/detail/vtable/vtable.hpp>
 #include <hpx/functional/serialization/detail/vtable/serializable_function_vtable.hpp>
 #include <hpx/functional/serialization/detail/vtable/serializable_vtable.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/serialization/serialization_fwd.hpp>
 
 #include <string>

--- a/libs/functional/src/basic_function.cpp
+++ b/libs/functional/src/basic_function.cpp
@@ -7,6 +7,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/assert.hpp>
 #include <hpx/functional/detail/basic_function.hpp>
 #include <hpx/functional/detail/empty_function.hpp>
 #include <hpx/functional/detail/vtable/function_vtable.hpp>
@@ -14,7 +15,6 @@
 #include <hpx/functional/traits/get_function_address.hpp>
 #include <hpx/functional/traits/get_function_annotation.hpp>
 #include <hpx/functional/traits/is_callable.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/itt_notify.hpp>
 
 #include <cstddef>

--- a/libs/futures/include/hpx/futures/detail/future_data.hpp
+++ b/libs/futures/include/hpx/futures/detail/future_data.hpp
@@ -7,12 +7,12 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/coroutines/detail/get_stack_pointer.hpp>
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/futures/traits/get_remote_result.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/synchronization/condition_variable.hpp>

--- a/libs/futures/include/hpx/futures/future.hpp
+++ b/libs/futures/include/hpx/futures/future.hpp
@@ -10,6 +10,7 @@
 #include <hpx/config.hpp>
 #include <hpx/allocator_support/allocator_deleter.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
@@ -22,7 +23,6 @@
 #include <hpx/futures/traits/future_traits.hpp>
 #include <hpx/futures/traits/is_future.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp>
 #include <hpx/timing/steady_clock.hpp>

--- a/libs/futures/src/future_data.cpp
+++ b/libs/futures/src/future_data.cpp
@@ -8,13 +8,13 @@
 #include <hpx/futures/future.hpp>
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
 #include <hpx/functional/deferred_call.hpp>
 #include <hpx/functional/unique_function.hpp>
 #include <hpx/futures/futures_factory.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/threading_base/annotated_function.hpp>
 

--- a/libs/include/CMakeLists.txt
+++ b/libs/include/CMakeLists.txt
@@ -10,6 +10,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(include_headers
     hpx/hpx.hpp
+    hpx/future.hpp
     hpx/include/actions.hpp
     hpx/include/agas.hpp
     hpx/include/applier.hpp

--- a/libs/include/include/hpx/future.hpp
+++ b/libs/include/include/hpx/future.hpp
@@ -1,0 +1,18 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/modules/async_base.hpp>
+#include <hpx/modules/async_combinators.hpp>
+#include <hpx/modules/async_local.hpp>
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/futures.hpp>
+#include <hpx/modules/local_lcos.hpp>
+
+namespace hpx {
+    using hpx::lcos::local::packaged_task;
+}

--- a/libs/include/include/hpx/include/util.hpp
+++ b/libs/include/include/hpx/include/util.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
 #include <hpx/command_line_handling/parse_command_line.hpp>
 #include <hpx/functional/bind.hpp>
@@ -17,7 +18,6 @@
 #include <hpx/functional/unique_function.hpp>
 #include <hpx/iterator_support/iterator_adaptor.hpp>
 #include <hpx/iterator_support/iterator_facade.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/pack_traversal/unwrap.hpp>
 #include <hpx/preprocessor/cat.hpp>

--- a/libs/include/tests/unit/CMakeLists.txt
+++ b/libs/include/tests/unit/CMakeLists.txt
@@ -3,3 +3,22 @@
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests api_future)
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  set(folder_name "Tests/Unit/Modules/Include")
+
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    FOLDER ${folder_name}
+  )
+
+  add_hpx_unit_test("modules.include" ${test} ${${test}_PARAMETERS})
+endforeach()

--- a/libs/include/tests/unit/api_future.cpp
+++ b/libs/include/tests/unit/api_future.cpp
@@ -1,0 +1,82 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/assert.hpp>
+#include <hpx/future.hpp>
+#include <hpx/hpx_main.hpp>
+#include <hpx/tuple.hpp>
+
+#include <iostream>
+#include <utility>
+
+int main()
+{
+    // Asynchronous execution with futures
+    hpx::future<void> f1 = hpx::async(hpx::launch::async, []() {});
+    hpx::shared_future<int> f2 =
+        hpx::async(hpx::launch::async, []() { return 42; });
+    hpx::future<int> f3 =
+        f2.then([](hpx::shared_future<int>&& f) { return f.get() * 3; });
+
+    hpx::lcos::local::promise<double> p;
+    auto f4 = p.get_future();
+    HPX_ASSERT(!f4.is_ready());
+    p.set_value(123.45);
+    HPX_ASSERT(f4.is_ready());
+
+    hpx::packaged_task<int()> t([]() { return 43; });
+    hpx::future<int> f5 = t.get_future();
+    HPX_ASSERT(!f5.is_ready());
+    t();
+    HPX_ASSERT(f5.is_ready());
+
+    // Fire-and-forget
+    hpx::apply([]() {
+        std::cout << "This will be printed later\n" << std::flush;
+    });
+
+    // Synchronous execution
+    hpx::sync([]() {
+        std::cout << "This will be printed immediately\n" << std::flush;
+    });
+
+    // Combinators
+    hpx::future<double> f6 = hpx::async([]() { return 3.14; });
+    hpx::future<double> f7 = hpx::async([]() { return 42.0; });
+    std::cout
+        << hpx::when_all(f6, f7)
+               .then([](hpx::future<
+                         hpx::tuple<hpx::future<double>, hpx::future<double>>>
+                             f) {
+                   hpx::tuple<hpx::future<double>, hpx::future<double>> t =
+                       f.get();
+                   double pi = hpx::get<0>(t).get();
+                   double r = hpx::get<1>(t).get();
+                   return pi * r * r;
+               })
+               .get()
+        << std::endl;
+
+    // Easier continuations with dataflow; it waits for all future or
+    // shared_future arguments before executing the continuation, and also
+    // accepts non-future arguments
+    hpx::future<double> f8 = hpx::async([]() { return 3.14; });
+    hpx::future<double> f9 = hpx::make_ready_future(42.0);
+    hpx::shared_future<double> f10 = hpx::async([]() { return 123.45; });
+    hpx::future<hpx::tuple<double, double>> f11 = hpx::dataflow(
+        [](hpx::future<double> a, hpx::future<double> b,
+            hpx::shared_future<double> c, double d) {
+            return hpx::make_tuple<>(a.get() + b.get(), c.get() / d);
+        },
+        f8, f9, f10, -3.9);
+
+    // split_future gives a tuple of futures from a future of tuple
+    hpx::tuple<hpx::future<double>, hpx::future<double>> f12 =
+        hpx::split_future(std::move(f11));
+    std::cout << hpx::get<1>(f12).get() << std::endl;
+
+    return 0;
+}

--- a/libs/init_runtime/include/hpx/hpx_init_impl.hpp
+++ b/libs/init_runtime/include/hpx/hpx_init_impl.hpp
@@ -8,13 +8,13 @@
 
 #pragma once
 
+#include <hpx/assert.hpp>
 #include <hpx/functional/bind_back.hpp>
 #include <hpx/functional/function.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx_main_winsocket.hpp>
 #include <hpx/hpx_user_main_config.hpp>
 #include <hpx/init_runtime/detail/run_or_start.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/program_options.hpp>
 #include <hpx/prefix/find_prefix.hpp>
 #include <hpx/runtime_configuration/runtime_mode.hpp>

--- a/libs/init_runtime/include/hpx/hpx_start_impl.hpp
+++ b/libs/init_runtime/include/hpx/hpx_start_impl.hpp
@@ -7,13 +7,13 @@
 
 #pragma once
 
+#include <hpx/assert.hpp>
 #include <hpx/functional/bind_back.hpp>
 #include <hpx/functional/function.hpp>
 #include <hpx/hpx_main_winsocket.hpp>
 #include <hpx/hpx_start.hpp>
 #include <hpx/hpx_user_main_config.hpp>
 #include <hpx/init_runtime/detail/run_or_start.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/program_options.hpp>
 #include <hpx/prefix/find_prefix.hpp>
 #include <hpx/runtime_configuration/runtime_mode.hpp>

--- a/libs/init_runtime/src/hpx_init.cpp
+++ b/libs/init_runtime/src/hpx_init.cpp
@@ -9,6 +9,7 @@
 
 #include <hpx/hpx_init.hpp>
 
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/register_locks.hpp>
 #include <hpx/command_line_handling/command_line_handling.hpp>
 #include <hpx/coroutines/detail/context_impl.hpp>
@@ -21,7 +22,6 @@
 #include <hpx/hpx_suspend.hpp>
 #include <hpx/hpx_user_main_config.hpp>
 #include <hpx/init_runtime/detail/run_or_start.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/filesystem.hpp>
 #include <hpx/modules/format.hpp>

--- a/libs/io_service/src/io_service_pool.cpp
+++ b/libs/io_service/src/io_service_pool.cpp
@@ -10,9 +10,9 @@
 
 #include <hpx/config.hpp>
 #include <hpx/config/asio.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/concurrency/barrier.hpp>
 #include <hpx/io_service/io_service_pool.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
 

--- a/libs/io_service/src/io_service_thread_pool.cpp
+++ b/libs/io_service/src/io_service_thread_pool.cpp
@@ -6,10 +6,10 @@
 
 #include <hpx/config.hpp>
 #include <hpx/affinity/affinity_data.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/concurrency/barrier.hpp>
 #include <hpx/io_service/io_service_pool.hpp>
 #include <hpx/io_service/io_service_thread_pool.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/threading_base/callback_notifier.hpp>
 #include <hpx/threading_base/scheduler_mode.hpp>
 

--- a/libs/lcos_distributed/include/hpx/lcos_distributed/channel.hpp
+++ b/libs/lcos_distributed/include/hpx/lcos_distributed/channel.hpp
@@ -7,11 +7,11 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_distributed/apply.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/lcos_distributed/server/channel.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/runtime/components/client_base.hpp>
 #include <hpx/runtime/components/new.hpp>
 #include <hpx/runtime/naming_fwd.hpp>

--- a/libs/local_lcos/include/hpx/local_lcos/and_gate.hpp
+++ b/libs/local_lcos/include/hpx/local_lcos/and_gate.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/local_lcos/conditional_trigger.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/synchronization/no_mutex.hpp>
 #include <hpx/synchronization/spinlock.hpp>

--- a/libs/local_lcos/include/hpx/local_lcos/channel.hpp
+++ b/libs/local_lcos/include/hpx/local_lcos/channel.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/basic_execution/register_locks.hpp>
 #include <hpx/futures/future.hpp>
@@ -14,7 +15,6 @@
 #include <hpx/local_lcos/packaged_task.hpp>
 #include <hpx/local_lcos/receive_buffer.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/synchronization/no_mutex.hpp>
 #include <hpx/synchronization/spinlock.hpp>

--- a/libs/local_lcos/include/hpx/local_lcos/composable_guard.hpp
+++ b/libs/local_lcos/include/hpx/local_lcos/composable_guard.hpp
@@ -81,10 +81,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/deferred_call.hpp>
 #include <hpx/functional/unique_function.hpp>
 #include <hpx/local_lcos/packaged_task.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <atomic>
 #include <cstddef>

--- a/libs/local_lcos/include/hpx/local_lcos/conditional_trigger.hpp
+++ b/libs/local_lcos/include/hpx/local_lcos/conditional_trigger.hpp
@@ -7,10 +7,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/function.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/local_lcos/promise.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 
 #include <utility>

--- a/libs/local_lcos/include/hpx/local_lcos/receive_buffer.hpp
+++ b/libs/local_lcos/include/hpx/local_lcos/receive_buffer.hpp
@@ -8,9 +8,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/local_lcos/promise.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/synchronization/no_mutex.hpp>
 #include <hpx/synchronization/spinlock.hpp>

--- a/libs/local_lcos/include/hpx/local_lcos/trigger.hpp
+++ b/libs/local_lcos/include/hpx/local_lcos/trigger.hpp
@@ -7,9 +7,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/local_lcos/conditional_trigger.hpp>
 #include <hpx/local_lcos/promise.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/synchronization/no_mutex.hpp>
 #include <hpx/synchronization/spinlock.hpp>

--- a/libs/local_lcos/src/composable_guard.cpp
+++ b/libs/local_lcos/src/composable_guard.cpp
@@ -5,9 +5,9 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/functional/function.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <hpx/local_lcos/composable_guard.hpp>
 

--- a/libs/logging/src/format/named_write.cpp
+++ b/libs/logging/src/format/named_write.cpp
@@ -17,9 +17,9 @@
 #include <hpx/logging/format/named_write.hpp>
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/logging/format/destinations.hpp>
 #include <hpx/logging/format/formatters.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <cstddef>
 #include <memory>

--- a/libs/memory/include/hpx/memory/intrusive_ptr.hpp
+++ b/libs/memory/include/hpx/memory/intrusive_ptr.hpp
@@ -13,8 +13,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/memory/config/defines.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/memory/detail/sp_convertible.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <cstddef>
 #include <functional>

--- a/libs/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
+++ b/libs/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
@@ -8,12 +8,12 @@
 
 #include <hpx/config.hpp>
 #include <hpx/allocator_support/allocator_deleter.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/functional/invoke_fused.hpp>
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/pack_traversal/detail/container_category.hpp>
 #include <hpx/type_support/always_void.hpp>
 #include <hpx/type_support/pack.hpp>

--- a/libs/performance_counters/include/hpx/performance_counters/parcels/gatherer.hpp
+++ b/libs/performance_counters/include/hpx/performance_counters/parcels/gatherer.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/performance_counters/parcels/data_point.hpp>
 #include <hpx/synchronization/no_mutex.hpp>
 #include <hpx/synchronization/spinlock.hpp>

--- a/libs/performance_counters/src/counters.cpp
+++ b/libs/performance_counters/src/counters.cpp
@@ -6,11 +6,11 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_distributed/applier/apply.hpp>
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/functional/function.hpp>
 #include <hpx/futures/packaged_continuation.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/performance_counters/base_performance_counter.hpp>

--- a/libs/performance_counters/src/manage_counter.cpp
+++ b/libs/performance_counters/src/manage_counter.cpp
@@ -5,8 +5,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/bind_front.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>

--- a/libs/performance_counters/src/performance_counter.cpp
+++ b/libs/performance_counters/src/performance_counter.cpp
@@ -5,9 +5,9 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_distributed/apply.hpp>
 #include <hpx/functional/bind.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/errors.hpp>
 

--- a/libs/performance_counters/src/performance_counter_set.cpp
+++ b/libs/performance_counters/src/performance_counter_set.cpp
@@ -5,10 +5,10 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/functional/bind.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/pack_traversal/unwrap.hpp>

--- a/libs/plugin/include/hpx/plugin/detail/dll_dlopen.hpp
+++ b/libs/plugin/include/hpx/plugin/detail/dll_dlopen.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/plugin/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/filesystem.hpp>
 

--- a/libs/plugin/include/hpx/plugin/detail/dll_windows.hpp
+++ b/libs/plugin/include/hpx/plugin/detail/dll_windows.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/plugin/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/filesystem.hpp>
 

--- a/libs/prefix/src/find_prefix.cpp
+++ b/libs/prefix/src/find_prefix.cpp
@@ -8,7 +8,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/filesystem.hpp>
 #include <hpx/modules/plugin.hpp>

--- a/libs/program_options/include/hpx/program_options/detail/value_semantic.hpp
+++ b/libs/program_options/include/hpx/program_options/detail/value_semantic.hpp
@@ -34,9 +34,9 @@ namespace hpx { namespace program_options {
 
 #else
 
+#include <hpx/assert.hpp>
 #include <hpx/datastructures/any.hpp>
 #include <hpx/datastructures/optional.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/program_options/errors.hpp>
 #include <hpx/util/from_string.hpp>
 

--- a/libs/program_options/include/hpx/program_options/environment_iterator.hpp
+++ b/libs/program_options/include/hpx/program_options/environment_iterator.hpp
@@ -21,7 +21,7 @@ namespace hpx { namespace program_options {
 
 #else
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/program_options/eof_iterator.hpp>
 
 #include <string>

--- a/libs/program_options/src/cmdline.cpp
+++ b/libs/program_options/src/cmdline.cpp
@@ -7,7 +7,7 @@
 #include <hpx/program_options/config.hpp>
 
 #if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY)
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/program_options/detail/cmdline.hpp>
 #include <hpx/program_options/errors.hpp>
 #include <hpx/program_options/options_description.hpp>

--- a/libs/program_options/src/config_file.cpp
+++ b/libs/program_options/src/config_file.cpp
@@ -7,7 +7,7 @@
 #include <hpx/program_options/config.hpp>
 
 #if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY)
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/program_options/detail/config_file.hpp>
 #include <hpx/program_options/detail/convert.hpp>
 #include <hpx/program_options/errors.hpp>

--- a/libs/program_options/src/options_description.cpp
+++ b/libs/program_options/src/options_description.cpp
@@ -8,7 +8,7 @@
 #include <hpx/program_options/config.hpp>
 
 #if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY)
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/program_options/options_description.hpp>
 // FIXME: this is only to get multiple_occurrences class
 // should move that to a separate headers.

--- a/libs/program_options/src/positional_options.cpp
+++ b/libs/program_options/src/positional_options.cpp
@@ -7,7 +7,7 @@
 #include <hpx/program_options/config.hpp>
 
 #if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY)
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/program_options/positional_options.hpp>
 
 #include <cstddef>

--- a/libs/program_options/src/variables_map.cpp
+++ b/libs/program_options/src/variables_map.cpp
@@ -8,8 +8,8 @@
 #include <hpx/program_options/config.hpp>
 
 #if !defined(HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY)
+#include <hpx/assert.hpp>
 #include <hpx/datastructures/any.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/program_options/options_description.hpp>
 #include <hpx/program_options/parsers.hpp>
 #include <hpx/program_options/value_semantic.hpp>

--- a/libs/program_options/tests/unit/cmdline.cpp
+++ b/libs/program_options/tests/unit/cmdline.cpp
@@ -5,8 +5,8 @@
 //  (See accompanying file LICENSE_1_0.txt
 //  or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/assert.hpp>
 #include <hpx/hpx_main.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <hpx/program_options/cmdline.hpp>

--- a/libs/resource_partitioner/include/hpx/resource_partitioner/detail/partitioner.hpp
+++ b/libs/resource_partitioner/include/hpx/resource_partitioner/detail/partitioner.hpp
@@ -8,9 +8,9 @@
 
 #include <hpx/config.hpp>
 #include <hpx/affinity/affinity_data.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/command_line_handling/command_line_handling.hpp>
 #include <hpx/datastructures/tuple.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/program_options.hpp>
 #include <hpx/resource_partitioner/partitioner.hpp>
 #include <hpx/runtime_configuration/runtime_mode.hpp>

--- a/libs/resource_partitioner/src/detail_partitioner.cpp
+++ b/libs/resource_partitioner/src/detail_partitioner.cpp
@@ -5,9 +5,9 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/command_line_handling/command_line_handling.hpp>
 #include <hpx/functional/function.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/mpi_base.hpp>

--- a/libs/runtime_configuration/src/ini.cpp
+++ b/libs/runtime_configuration/src/ini.cpp
@@ -23,7 +23,7 @@
 #include <utility>
 #include <vector>
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/runtime_configuration/ini.hpp>
 #include <hpx/serialization/map.hpp>

--- a/libs/runtime_configuration/src/init_ini_data.cpp
+++ b/libs/runtime_configuration/src/init_ini_data.cpp
@@ -6,7 +6,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/filesystem.hpp>
 #include <hpx/modules/logging.hpp>

--- a/libs/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/runtime_configuration/src/runtime_configuration.cpp
@@ -5,7 +5,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/filesystem.hpp>
 #include <hpx/modules/itt_notify.hpp>
 #include <hpx/prefix/find_prefix.hpp>

--- a/libs/runtime_local/include/hpx/runtime_local/custom_exception_info.hpp
+++ b/libs/runtime_local/include/hpx/runtime_local/custom_exception_info.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/naming_base.hpp>
 

--- a/libs/runtime_local/include/hpx/runtime_local/run_as_hpx_thread.hpp
+++ b/libs/runtime_local/include/hpx/runtime_local/run_as_hpx_thread.hpp
@@ -7,11 +7,11 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/datastructures/optional.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/functional/result_of.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/threading_base/thread_helpers.hpp>
 

--- a/libs/runtime_local/include/hpx/runtime_local/run_as_os_thread.hpp
+++ b/libs/runtime_local/include/hpx/runtime_local/run_as_os_thread.hpp
@@ -7,10 +7,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/execution/executors/execution.hpp>
 #include <hpx/functional/deferred_call.hpp>
 #include <hpx/functional/result_of.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/runtime_local/service_executors.hpp>
 
 #include <type_traits>

--- a/libs/runtime_local/include/hpx/runtime_local/runtime_handlers.hpp
+++ b/libs/runtime_local/include/hpx/runtime_local/runtime_handlers.hpp
@@ -11,7 +11,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/config/asio.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/threading_base/thread_pool_base.hpp>
 
 #include <boost/asio/io_service.hpp>

--- a/libs/runtime_local/include/hpx/runtime_local/runtime_local.hpp
+++ b/libs/runtime_local/include/hpx/runtime_local/runtime_local.hpp
@@ -8,9 +8,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/io_service/io_service_pool.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/program_options.hpp>
 #include <hpx/modules/threadmanager.hpp>
 #include <hpx/modules/topology.hpp>

--- a/libs/runtime_local/src/custom_exception_info.cpp
+++ b/libs/runtime_local/src/custom_exception_info.cpp
@@ -6,11 +6,11 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/register_locks.hpp>
 #include <hpx/command_line_handling/command_line_handling.hpp>
 #include <hpx/debugging/backtrace.hpp>
 #include <hpx/futures/futures_factory.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/logging.hpp>

--- a/libs/runtime_local/src/interval_timer.cpp
+++ b/libs/runtime_local/src/interval_timer.cpp
@@ -5,9 +5,9 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/functional/deferred_call.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/runtime_local/interval_timer.hpp>
 #include <hpx/runtime_local/shutdown_function.hpp>

--- a/libs/runtime_local/src/runtime_handlers.cpp
+++ b/libs/runtime_local/src/runtime_handlers.cpp
@@ -8,8 +8,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/debugging/backtrace.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/threadmanager.hpp>

--- a/libs/runtime_local/src/runtime_local.cpp
+++ b/libs/runtime_local/src/runtime_local.cpp
@@ -6,11 +6,11 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
 #include <hpx/coroutines/coroutine.hpp>
 #include <hpx/debugging/backtrace.hpp>
 #include <hpx/itt_notify/thread_name.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/command_line_handling.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>

--- a/libs/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
@@ -9,8 +9,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/affinity/affinity_data.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/concurrency/cache_line_data.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/logging.hpp>

--- a/libs/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
+++ b/libs/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
@@ -11,7 +11,7 @@
 
 #if defined(HPX_HAVE_LOCAL_SCHEDULER)
 #include <hpx/affinity/affinity_data.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/logging.hpp>

--- a/libs/schedulers/include/hpx/schedulers/queue_holder_thread.hpp
+++ b/libs/schedulers/include/hpx/schedulers/queue_holder_thread.hpp
@@ -7,9 +7,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/debugging/print.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/schedulers/lockfree_queue_backends.hpp>
 #include <hpx/threading_base/print.hpp>
 #include <hpx/threading_base/scheduler_base.hpp>

--- a/libs/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
@@ -11,9 +11,9 @@
 #endif
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
 #include <hpx/debugging/print.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/schedulers/lockfree_queue_backends.hpp>

--- a/libs/schedulers/include/hpx/schedulers/static_priority_queue_scheduler.hpp
+++ b/libs/schedulers/include/hpx/schedulers/static_priority_queue_scheduler.hpp
@@ -11,7 +11,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/schedulers/local_priority_queue_scheduler.hpp>
 #include <hpx/schedulers/lockfree_queue_backends.hpp>
 

--- a/libs/schedulers/include/hpx/schedulers/static_queue_scheduler.hpp
+++ b/libs/schedulers/include/hpx/schedulers/static_queue_scheduler.hpp
@@ -10,7 +10,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_STATIC_SCHEDULER)
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/schedulers/deadlock_detection.hpp>
 #include <hpx/schedulers/local_queue_scheduler.hpp>

--- a/libs/schedulers/include/hpx/schedulers/thread_queue.hpp
+++ b/libs/schedulers/include/hpx/schedulers/thread_queue.hpp
@@ -9,10 +9,10 @@
 
 #include <hpx/config.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/concurrency/cache_line_data.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/functional/function.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/schedulers/deadlock_detection.hpp>

--- a/libs/schedulers/include/hpx/schedulers/thread_queue_mc.hpp
+++ b/libs/schedulers/include/hpx/schedulers/thread_queue_mc.hpp
@@ -9,10 +9,10 @@
 
 #include <hpx/config.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/concurrency/cache_line_data.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/functional/function.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/schedulers/deadlock_detection.hpp>
 #include <hpx/schedulers/lockfree_queue_backends.hpp>

--- a/libs/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
+++ b/libs/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
@@ -8,9 +8,9 @@
 
 #include <hpx/config.hpp>
 #include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/datastructures/tuple.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/runtime/actions/plain_action.hpp>
 #include <hpx/runtime/components/colocating_distribution_policy.hpp>
 #include <hpx/runtime/naming/id_type.hpp>

--- a/libs/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/transfer.hpp
+++ b/libs/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/transfer.hpp
@@ -8,8 +8,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_distributed/dataflow.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>

--- a/libs/serialization/include/hpx/serialization/basic_archive.hpp
+++ b/libs/serialization/include/hpx/serialization/basic_archive.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/serialization/detail/extra_archive_data.hpp>
 

--- a/libs/serialization/include/hpx/serialization/detail/extra_archive_data.hpp
+++ b/libs/serialization/include/hpx/serialization/detail/extra_archive_data.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 
 #include <memory>
 #include <type_traits>

--- a/libs/serialization/include/hpx/serialization/detail/polymorphic_id_factory.hpp
+++ b/libs/serialization/include/hpx/serialization/detail/polymorphic_id_factory.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/preprocessor/stringize.hpp>
 #include <hpx/serialization/detail/polymorphic_intrusive_factory.hpp>

--- a/libs/serialization/include/hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp
+++ b/libs/serialization/include/hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp
@@ -10,7 +10,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/debugging.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/hashing.hpp>

--- a/libs/serialization/include/hpx/serialization/input_archive.hpp
+++ b/libs/serialization/include/hpx/serialization/input_archive.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/serialization/basic_archive.hpp>
 #include <hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp>
 #include <hpx/serialization/detail/raw_ptr.hpp>

--- a/libs/serialization/include/hpx/serialization/input_container.hpp
+++ b/libs/serialization/include/hpx/serialization/input_container.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/serialization/binary_filter.hpp>
 #include <hpx/serialization/container.hpp>

--- a/libs/serialization/include/hpx/serialization/output_archive.hpp
+++ b/libs/serialization/include/hpx/serialization/output_archive.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/serialization/basic_archive.hpp>
 #include <hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp>
 #include <hpx/serialization/detail/raw_ptr.hpp>

--- a/libs/serialization/include/hpx/serialization/output_container.hpp
+++ b/libs/serialization/include/hpx/serialization/output_container.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/serialization/binary_filter.hpp>
 #include <hpx/serialization/container.hpp>
 #include <hpx/serialization/serialization_chunk.hpp>

--- a/libs/serialization/include/hpx/serialization/serializable_any.hpp
+++ b/libs/serialization/include/hpx/serialization/serializable_any.hpp
@@ -16,9 +16,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/datastructures/any.hpp>
 #include <hpx/datastructures/traits/supports_streaming_with_any.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/serialization/base_object.hpp>
 #include <hpx/serialization/detail/raw_ptr.hpp>
 #include <hpx/serialization/serialize.hpp>

--- a/libs/serialization/src/detail/pointer.cpp
+++ b/libs/serialization/src/detail/pointer.cpp
@@ -6,7 +6,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/serialization/detail/pointer.hpp>
 #include <hpx/serialization/input_archive.hpp>
 #include <hpx/serialization/output_archive.hpp>

--- a/libs/serialization/src/detail/polymorphic_id_factory.cpp
+++ b/libs/serialization/src/detail/polymorphic_id_factory.cpp
@@ -7,7 +7,7 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/serialization/detail/polymorphic_id_factory.hpp>
 
 #include <cstdint>

--- a/libs/serialization/src/exception_ptr.cpp
+++ b/libs/serialization/src/exception_ptr.cpp
@@ -5,7 +5,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/serialization/exception_ptr.hpp>
 #include <hpx/serialization/serialize.hpp>

--- a/libs/static_reinit/include/hpx/static_reinit/reinitializable_static.hpp
+++ b/libs/static_reinit/include/hpx/static_reinit/reinitializable_static.hpp
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/bind_front.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/static_reinit/static_reinit.hpp>
 
 #include <cstddef>

--- a/libs/synchronization/include/hpx/synchronization/barrier.hpp
+++ b/libs/synchronization/include/hpx/synchronization/barrier.hpp
@@ -10,7 +10,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/synchronization/condition_variable.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 

--- a/libs/synchronization/include/hpx/synchronization/channel_mpmc.hpp
+++ b/libs/synchronization/include/hpx/synchronization/channel_mpmc.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/concurrency.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/thread_support.hpp>

--- a/libs/synchronization/include/hpx/synchronization/channel_mpsc.hpp
+++ b/libs/synchronization/include/hpx/synchronization/channel_mpsc.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/concurrency.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/thread_support.hpp>

--- a/libs/synchronization/include/hpx/synchronization/channel_spsc.hpp
+++ b/libs/synchronization/include/hpx/synchronization/channel_spsc.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/concurrency.hpp>
 #include <hpx/modules/errors.hpp>
 

--- a/libs/synchronization/include/hpx/synchronization/detail/counting_semaphore.hpp
+++ b/libs/synchronization/include/hpx/synchronization/detail/counting_semaphore.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/synchronization/condition_variable.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/thread_support/assert_owns_lock.hpp>

--- a/libs/synchronization/include/hpx/synchronization/detail/sliding_semaphore.hpp
+++ b/libs/synchronization/include/hpx/synchronization/detail/sliding_semaphore.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/synchronization/condition_variable.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/thread_support/assert_owns_lock.hpp>

--- a/libs/synchronization/include/hpx/synchronization/event.hpp
+++ b/libs/synchronization/include/hpx/synchronization/event.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/synchronization/condition_variable.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 

--- a/libs/synchronization/include/hpx/synchronization/latch.hpp
+++ b/libs/synchronization/include/hpx/synchronization/latch.hpp
@@ -8,8 +8,8 @@
 
 #pragma once
 
+#include <hpx/assert.hpp>
 #include <hpx/concurrency/cache_line_data.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/synchronization/condition_variable.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/type_support/unused.hpp>

--- a/libs/synchronization/include/hpx/synchronization/recursive_mutex.hpp
+++ b/libs/synchronization/include/hpx/synchronization/recursive_mutex.hpp
@@ -11,9 +11,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/agent_ref.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 
 #include <atomic>

--- a/libs/synchronization/src/detail/condition_variable.cpp
+++ b/libs/synchronization/src/detail/condition_variable.cpp
@@ -7,8 +7,8 @@
 
 #include <hpx/synchronization/condition_variable.hpp>
 
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/memory.hpp>

--- a/libs/synchronization/src/mutex.cpp
+++ b/libs/synchronization/src/mutex.cpp
@@ -7,9 +7,9 @@
 
 #include <hpx/synchronization/mutex.hpp>
 
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/register_locks.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/itt_notify.hpp>
 #include <hpx/runtime/threads/thread_data.hpp>

--- a/libs/synchronization/src/stop_token.cpp
+++ b/libs/synchronization/src/stop_token.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/basic_execution.hpp>
 #include <hpx/modules/thread_support.hpp>
 #include <hpx/synchronization/mutex.hpp>

--- a/libs/testing/include/hpx/modules/testing.hpp
+++ b/libs/testing/include/hpx/modules/testing.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/preprocessor/expand.hpp>

--- a/libs/testing/src/testing.cpp
+++ b/libs/testing/src/testing.cpp
@@ -7,7 +7,7 @@
 
 #define HPX_NO_VERSION_CHECK
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/modules/util.hpp>
 

--- a/libs/thread_executors/include/hpx/thread_executors/thread_execution.hpp
+++ b/libs/thread_executors/include/hpx/thread_executors/thread_execution.hpp
@@ -11,6 +11,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_THREAD_EXECUTORS_COMPATIBILITY)
+#include <hpx/assert.hpp>
 #include <hpx/async_base/traits/is_launch_policy.hpp>
 #include <hpx/basic_execution/execution.hpp>
 #include <hpx/datastructures/tuple.hpp>
@@ -24,7 +25,6 @@
 #include <hpx/futures/futures_factory.hpp>
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/iterator_support/range.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/pack_traversal/unwrap.hpp>
 #include <hpx/threading_base/thread_helpers.hpp>
 #include <hpx/type_support/pack.hpp>

--- a/libs/thread_executors/src/embedded_thread_pool_executors.cpp
+++ b/libs/thread_executors/src/embedded_thread_pool_executors.cpp
@@ -19,12 +19,12 @@
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
 #include <hpx/schedulers/static_priority_queue_scheduler.hpp>
 #endif
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/execution/detail/execution_parameter_callbacks.hpp>
 #include <hpx/functional/deferred_call.hpp>
 #include <hpx/functional/unique_function.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
 #include <hpx/thread_executors/detail/on_self_reset.hpp>
 #include <hpx/thread_executors/manage_thread_executor.hpp>

--- a/libs/thread_executors/src/resource_manager.cpp
+++ b/libs/thread_executors/src/resource_manager.cpp
@@ -8,8 +8,8 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_THREAD_EXECUTORS_COMPATIBILITY)
+#include <hpx/assert.hpp>
 #include <hpx/execution/detail/execution_parameter_callbacks.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/topology.hpp>
 #include <hpx/static_reinit/reinitializable_static.hpp>

--- a/libs/thread_executors/src/this_thread_executors.cpp
+++ b/libs/thread_executors/src/this_thread_executors.cpp
@@ -19,10 +19,10 @@
 #endif
 
 #include <hpx/affinity/affinity_data.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/functional/deferred_call.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
 #include <hpx/thread_executors/detail/on_self_reset.hpp>
 #include <hpx/thread_executors/manage_thread_executor.hpp>

--- a/libs/thread_executors/src/thread_pool_os_executors.cpp
+++ b/libs/thread_executors/src/thread_pool_os_executors.cpp
@@ -20,12 +20,12 @@
 #if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
 #include <hpx/schedulers/static_priority_queue_scheduler.hpp>
 #endif
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/datastructures/optional.hpp>
 #include <hpx/functional/bind.hpp>
 #include <hpx/functional/unique_function.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/threading_base/thread_description.hpp>
 #include <hpx/timing/steady_clock.hpp>
 

--- a/libs/thread_pools/include/hpx/thread_pools/scheduled_thread_pool.hpp
+++ b/libs/thread_pools/include/hpx/thread_pools/scheduled_thread_pool.hpp
@@ -9,9 +9,9 @@
 
 #include <hpx/config.hpp>
 #include <hpx/affinity/affinity_data.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/concurrency/barrier.hpp>
 #include <hpx/functional/function.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/thread_pools/scheduling_loop.hpp>
 #include <hpx/threading_base/callback_notifier.hpp>

--- a/libs/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
+++ b/libs/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
@@ -8,11 +8,11 @@
 #pragma once
 
 #include <hpx/affinity/affinity_data.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
 #include <hpx/concurrency/barrier.hpp>
 #include <hpx/functional/deferred_call.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/schedulers.hpp>
 #include <hpx/thread_pools/scheduled_thread_pool.hpp>

--- a/libs/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
+++ b/libs/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
@@ -7,10 +7,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
 #include <hpx/functional/unique_function.hpp>
 #include <hpx/hardware/timestamp.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/itt_notify.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/threading_base/scheduler_base.hpp>

--- a/libs/thread_support/include/hpx/thread_support/assert_owns_lock.hpp
+++ b/libs/thread_support/include/hpx/thread_support/assert_owns_lock.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/concepts/has_member_xxx.hpp>
-#include <hpx/modules/assertion.hpp>
 
 #include <type_traits>
 

--- a/libs/thread_support/include/hpx/thread_support/thread_specific_ptr.hpp
+++ b/libs/thread_support/include/hpx/thread_support/thread_specific_ptr.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 
 // Needed to get potentially get _GLIBCXX_HAVE_TLS
 #include <cstdlib>

--- a/libs/threading/include/hpx/threading/thread.hpp
+++ b/libs/threading/include/hpx/threading/thread.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/lcos_fwd.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/synchronization/spinlock.hpp>

--- a/libs/threading/src/thread.cpp
+++ b/libs/threading/src/thread.cpp
@@ -4,6 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/register_locks.hpp>
 #include <hpx/functional/bind.hpp>
 #include <hpx/functional/bind_front.hpp>
@@ -11,7 +12,6 @@
 #include <hpx/futures/detail/future_data.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/threading.hpp>
 #include <hpx/thread_support/unlock_guard.hpp>

--- a/libs/threading_base/include/hpx/threading_base/external_timer.hpp
+++ b/libs/threading_base/include/hpx/threading_base/external_timer.hpp
@@ -7,8 +7,8 @@
 #pragma once    // prevent multiple inclusions of this header file.
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/coroutines/thread_id_type.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/threading_base/thread_description.hpp>
 

--- a/libs/threading_base/include/hpx/threading_base/register_thread.hpp
+++ b/libs/threading_base/include/hpx/threading_base/register_thread.hpp
@@ -11,7 +11,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/config/asio.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/threading_base/scheduler_base.hpp>

--- a/libs/threading_base/include/hpx/threading_base/scheduler_base.hpp
+++ b/libs/threading_base/include/hpx/threading_base/scheduler_base.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/concurrency/cache_line_data.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/functional.hpp>

--- a/libs/threading_base/include/hpx/threading_base/set_thread_state.hpp
+++ b/libs/threading_base/include/hpx/threading_base/set_thread_state.hpp
@@ -8,10 +8,10 @@
 
 #include <hpx/config.hpp>
 #include <hpx/config/asio.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/coroutines/coroutine.hpp>
 #include <hpx/functional/bind.hpp>
 #include <hpx/functional/bind_front.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/threading_base/create_thread.hpp>

--- a/libs/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
 #include <hpx/concurrency/spinlock_pool.hpp>
 #include <hpx/coroutines/coroutine.hpp>
@@ -17,7 +18,6 @@
 #include <hpx/debugging/backtrace.hpp>
 #include <hpx/functional/function.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/naming_base.hpp>

--- a/libs/threading_base/include/hpx/threading_base/thread_data_stackful.hpp
+++ b/libs/threading_base/include/hpx/threading_base/thread_data_stackful.hpp
@@ -10,9 +10,9 @@
 
 #include <hpx/config.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/coroutines/thread_id_type.hpp>
 #include <hpx/functional/function.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/threading_base/execution_agent.hpp>
 #include <hpx/threading_base/thread_data.hpp>

--- a/libs/threading_base/include/hpx/threading_base/thread_data_stackless.hpp
+++ b/libs/threading_base/include/hpx/threading_base/thread_data_stackless.hpp
@@ -10,10 +10,10 @@
 
 #include <hpx/config.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/coroutines/stackless_coroutine.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/functional/function.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/threading_base/thread_data.hpp>
 #include <hpx/threading_base/thread_init_data.hpp>

--- a/libs/threading_base/include/hpx/threading_base/thread_description.hpp
+++ b/libs/threading_base/include/hpx/threading_base/thread_description.hpp
@@ -7,11 +7,11 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/traits/get_action_name.hpp>
 #include <hpx/functional/traits/get_function_address.hpp>
 #include <hpx/functional/traits/get_function_annotation.hpp>
 #include <hpx/functional/traits/is_action.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/threading_base/threading_base_fwd.hpp>
 #if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
 #include <hpx/modules/itt_notify.hpp>

--- a/libs/threading_base/src/execution_agent.cpp
+++ b/libs/threading_base/src/execution_agent.cpp
@@ -5,10 +5,10 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/register_locks.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/errors/throw_exception.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/threading_base/thread_data.hpp>

--- a/libs/threading_base/src/external_timer.cpp
+++ b/libs/threading_base/src/external_timer.cpp
@@ -6,7 +6,7 @@
 //
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/threading_base/external_timer.hpp>
 #include <hpx/threading_base/thread_data.hpp>
 

--- a/libs/threading_base/src/register_thread.cpp
+++ b/libs/threading_base/src/register_thread.cpp
@@ -5,7 +5,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/threading_base/register_thread.hpp>
 #include <hpx/threading_base/scheduler_base.hpp>
 #include <hpx/threading_base/thread_description.hpp>

--- a/libs/threading_base/src/scheduler_base.cpp
+++ b/libs/threading_base/src/scheduler_base.cpp
@@ -5,8 +5,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/threading_base/scheduler_base.hpp>
 #include <hpx/threading_base/scheduler_mode.hpp>
 #include <hpx/threading_base/scheduler_state.hpp>

--- a/libs/threading_base/src/thread_data.cpp
+++ b/libs/threading_base/src/thread_data.cpp
@@ -6,10 +6,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/register_locks.hpp>
 #include <hpx/coroutines/detail/coroutine_accessor.hpp>
 #include <hpx/functional/function.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/naming_base.hpp>

--- a/libs/threading_base/src/thread_description.cpp
+++ b/libs/threading_base/src/thread_description.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/threading_base/thread_data.hpp>
 #include <hpx/threading_base/thread_description.hpp>
 #include <hpx/util/to_string.hpp>

--- a/libs/threading_base/src/thread_helpers.cpp
+++ b/libs/threading_base/src/thread_helpers.cpp
@@ -7,8 +7,8 @@
 
 #include <hpx/threading_base/thread_helpers.hpp>
 
+#include <hpx/assert.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #ifdef HPX_HAVE_VERIFY_LOCKS
 #include <hpx/basic_execution/register_locks.hpp>

--- a/libs/threading_base/src/thread_pool_base.cpp
+++ b/libs/threading_base/src/thread_pool_base.cpp
@@ -5,9 +5,9 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/affinity/affinity_data.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/bind.hpp>
 #include <hpx/hardware/timestamp.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/threading_base/callback_notifier.hpp>
 #include <hpx/threading_base/scheduler_base.hpp>

--- a/libs/threadmanager/src/threadmanager.cpp
+++ b/libs/threadmanager/src/threadmanager.cpp
@@ -9,12 +9,12 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_combinators/wait_all.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
 #include <hpx/command_line_handling/command_line_handling.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/hardware/timestamp.hpp>
-#include <hpx/modules/assertion.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/schedulers.hpp>

--- a/libs/topology/include/hpx/topology/cpu_mask.hpp
+++ b/libs/topology/include/hpx/topology/cpu_mask.hpp
@@ -11,7 +11,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 
 #include <climits>
 #include <cstddef>

--- a/libs/topology/src/topology.cpp
+++ b/libs/topology/src/topology.cpp
@@ -6,7 +6,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/logging.hpp>

--- a/plugins/parcel/coalescing/coalescing_message_handler.cpp
+++ b/plugins/parcel/coalescing/coalescing_message_handler.cpp
@@ -7,7 +7,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCEL_COALESCING)
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/bind.hpp>
 #include <hpx/functional/bind_back.hpp>
 #include <hpx/functional/bind_front.hpp>

--- a/plugins/parcelport/libfabric/header.hpp
+++ b/plugins/parcelport/libfabric/header.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/runtime/parcelset/parcel_buffer.hpp>
 #include <plugins/parcelport/parcelport_logging.hpp>
 //

--- a/plugins/parcelport/libfabric/parcelport_libfabric.cpp
+++ b/plugins/parcelport/libfabric/parcelport_libfabric.cpp
@@ -26,7 +26,7 @@
 #include <hpx/runtime/parcelset/parcelport.hpp>
 #include <hpx/runtime/parcelset/parcelport_impl.hpp>
 //
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/runtime_local/thread_stacktrace.hpp>
 //
 #include <boost/asio/ip/host_name.hpp>

--- a/plugins/parcelport/libfabric/receiver.cpp
+++ b/plugins/parcelport/libfabric/receiver.cpp
@@ -16,7 +16,7 @@
 #include <hpx/runtime/parcelset/decode_parcels.hpp>
 #include <hpx/runtime/parcelset/parcel_buffer.hpp>
 //
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
 //
 #include <cstddef>

--- a/plugins/parcelport/libfabric/rma_receiver.cpp
+++ b/plugins/parcelport/libfabric/rma_receiver.cpp
@@ -11,7 +11,7 @@
 #include <hpx/runtime/parcelset/decode_parcels.hpp>
 #include <hpx/runtime/parcelset/parcel_buffer.hpp>
 //
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
 //
 #include <cstddef>

--- a/plugins/parcelport/libfabric/sender.cpp
+++ b/plugins/parcelport/libfabric/sender.cpp
@@ -11,7 +11,7 @@
 #include <plugins/parcelport/libfabric/sender.hpp>
 #include <plugins/parcelport/rma_memory_pool.hpp>
 //
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/unique_function.hpp>
 #include <hpx/thread_support/atomic_count.hpp>
 #include <hpx/timing/high_resolution_timer.hpp>

--- a/plugins/parcelport/libfabric/sender.hpp
+++ b/plugins/parcelport/libfabric/sender.hpp
@@ -16,7 +16,7 @@
 
 #include <hpx/runtime/parcelset/locality.hpp>
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/unique_function.hpp>
 #include <hpx/thread_support/atomic_count.hpp>
 

--- a/plugins/parcelport/tcp/connection_handler_tcp.cpp
+++ b/plugins/parcelport/tcp/connection_handler_tcp.cpp
@@ -12,7 +12,7 @@
 
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/asio/asio_util.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/functional/bind.hpp>
 #include <hpx/futures/future.hpp>

--- a/plugins/parcelport/verbs/header.hpp
+++ b/plugins/parcelport/verbs/header.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/runtime/parcelset/parcel_buffer.hpp>
 //
 #include <array>

--- a/plugins/parcelport/verbs/parcelport_verbs.cpp
+++ b/plugins/parcelport/verbs/parcelport_verbs.cpp
@@ -9,7 +9,7 @@
 
 #if defined(HPX_HAVE_NETWORKING)
 // util
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/functional/deferred_call.hpp>

--- a/plugins/parcelport/verbs/rdma/rdma_chunk_pool.hpp
+++ b/plugins/parcelport/verbs/rdma/rdma_chunk_pool.hpp
@@ -16,7 +16,7 @@
 #undef BOOST_POOL_INSTRUMENT
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 //
 #include <plugins/parcelport/verbs/rdma/verbs_memory_region.hpp>
 

--- a/src/runtime/actions/detail/action_factory.cpp
+++ b/src/runtime/actions/detail/action_factory.cpp
@@ -7,7 +7,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/runtime/actions/detail/action_factory.hpp>
 #include <hpx/modules/errors.hpp>
 

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -11,7 +11,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/async_distributed/apply.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/basic_execution/register_locks.hpp>
 #include <hpx/modules/errors.hpp>

--- a/src/runtime/agas/big_boot_barrier.cpp
+++ b/src/runtime/agas/big_boot_barrier.cpp
@@ -11,7 +11,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/runtime_local/runtime_local.hpp>

--- a/src/runtime/agas/detail/bootstrap_component_namespace.cpp
+++ b/src/runtime/agas/detail/bootstrap_component_namespace.cpp
@@ -6,7 +6,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/runtime/agas/detail/bootstrap_component_namespace.hpp>
 
 #include <cstdint>

--- a/src/runtime/agas/detail/bootstrap_locality_namespace.cpp
+++ b/src/runtime/agas/detail/bootstrap_locality_namespace.cpp
@@ -10,7 +10,7 @@
 
 #include <hpx/config.hpp>
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/runtime/agas/detail/bootstrap_locality_namespace.hpp>
 #include <hpx/runtime/agas/server/locality_namespace.hpp>
 #include <hpx/runtime/naming/name.hpp>

--- a/src/runtime/agas/detail/hosted_locality_namespace.cpp
+++ b/src/runtime/agas/detail/hosted_locality_namespace.cpp
@@ -11,7 +11,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/runtime/agas/detail/hosted_locality_namespace.hpp>
 #include <hpx/runtime/agas/server/locality_namespace.hpp>

--- a/src/runtime/agas/interface.cpp
+++ b/src/runtime/agas/interface.cpp
@@ -7,7 +7,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/runtime_distributed.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/agas/interface.hpp>

--- a/src/runtime/agas/primary_namespace.cpp
+++ b/src/runtime/agas/primary_namespace.cpp
@@ -8,7 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/async_distributed/apply.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/lcos/base_lco_with_value.hpp>
 #include <hpx/runtime/actions/continuation.hpp>

--- a/src/runtime/agas/server/component_namespace_server.cpp
+++ b/src/runtime/agas/server/component_namespace_server.cpp
@@ -8,7 +8,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/functional/bind_back.hpp>
 #include <hpx/functional/bind_front.hpp>

--- a/src/runtime/agas/server/locality_namespace_server.cpp
+++ b/src/runtime/agas/server/locality_namespace_server.cpp
@@ -9,7 +9,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/functional/bind_back.hpp>
 #include <hpx/functional/bind_front.hpp>

--- a/src/runtime/agas/server/primary_namespace_server.cpp
+++ b/src/runtime/agas/server/primary_namespace_server.cpp
@@ -9,7 +9,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/basic_execution/register_locks.hpp>
 #include <hpx/modules/errors.hpp>

--- a/src/runtime/agas/server/route.cpp
+++ b/src/runtime/agas/server/route.cpp
@@ -8,7 +8,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/runtime_local/runtime_local.hpp>
 #include <hpx/runtime_distributed.hpp>

--- a/src/runtime/agas/server/symbol_namespace_server.cpp
+++ b/src/runtime/agas/server/symbol_namespace_server.cpp
@@ -9,7 +9,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/functional/bind_back.hpp>

--- a/src/runtime/applier/applier.cpp
+++ b/src/runtime/applier/applier.cpp
@@ -8,7 +8,7 @@
 
 #include <hpx/config.hpp>
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/register_locks.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/runtime_local/runtime_local.hpp>

--- a/src/runtime/components/console_logging.cpp
+++ b/src/runtime/components/console_logging.cpp
@@ -6,7 +6,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/runtime_local/runtime_local.hpp>
 #include <hpx/runtime/actions/continuation.hpp>

--- a/src/runtime/components/server/component_base.cpp
+++ b/src/runtime/components/server/component_base.cpp
@@ -6,7 +6,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/runtime/agas/interface.hpp>
 #include <hpx/async_distributed/applier/applier.hpp>

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -47,7 +47,7 @@
 #include <hpx/modules/collectives.hpp>
 #include <hpx/local_lcos/packaged_task.hpp>
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/basic_execution/this_thread.hpp>
 #include <hpx/command_line_handling/command_line_handling.hpp>
 #include <hpx/command_line_handling/parse_command_line.hpp>

--- a/src/runtime/components/server/wrapper_heap.cpp
+++ b/src/runtime/components/server/wrapper_heap.cpp
@@ -6,7 +6,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_distributed/applier/applier.hpp>
 #include <hpx/async_distributed/applier/bind_naming_wrappers.hpp>
 #include <hpx/modules/itt_notify.hpp>

--- a/src/runtime/naming/name.cpp
+++ b/src/runtime/naming/name.cpp
@@ -8,7 +8,7 @@
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime/naming/name.hpp>
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/functional/bind.hpp>

--- a/src/runtime/parcelset/locality.cpp
+++ b/src/runtime/parcelset/locality.cpp
@@ -6,7 +6,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/runtime_distributed.hpp>
 #include <hpx/runtime/parcelset/locality.hpp>

--- a/src/runtime/parcelset/parcel.cpp
+++ b/src/runtime/parcelset/parcel.cpp
@@ -8,7 +8,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_distributed/applier/applier.hpp>
 #include <hpx/modules/itt_notify.hpp>
 #include <hpx/runtime_local/runtime_local.hpp>

--- a/src/runtime/parcelset/parcelhandler.cpp
+++ b/src/runtime/parcelset/parcelhandler.cpp
@@ -11,7 +11,7 @@
 
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/config/asio.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_distributed/applier/applier.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>

--- a/src/runtime/parcelset/parcelport.cpp
+++ b/src/runtime/parcelset/parcelport.cpp
@@ -21,7 +21,7 @@
 #if defined(HPX_HAVE_APEX)
 #include <hpx/threading_base/external_timer.hpp>
 #endif
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/src/runtime/threads/threadmanager_counters.cpp
+++ b/src/runtime/threads/threadmanager_counters.cpp
@@ -9,7 +9,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/functional/bind_back.hpp>
 #include <hpx/functional/bind_front.hpp>

--- a/src/runtime_distributed.cpp
+++ b/src/runtime_distributed.cpp
@@ -7,7 +7,7 @@
 
 #include <hpx/config.hpp>
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_distributed/applier/applier.hpp>
 #include <hpx/async_distributed/apply.hpp>

--- a/src/util/activate_counters.cpp
+++ b/src/util/activate_counters.cpp
@@ -6,7 +6,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/async_combinators/wait_all.hpp>

--- a/src/util/one_size_heap_list.cpp
+++ b/src/util/one_size_heap_list.cpp
@@ -6,7 +6,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/state.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/functional/bind_front.hpp>

--- a/src/util/pool_timer.cpp
+++ b/src/util/pool_timer.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/functional/function.hpp>

--- a/src/util/query_counters.cpp
+++ b/src/util/query_counters.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/async_combinators/wait_all.hpp>

--- a/src/util/serialize_exception.cpp
+++ b/src/util/serialize_exception.cpp
@@ -4,7 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/runtime_local/custom_exception_info.hpp>
 #include <hpx/serialization/serialize.hpp>

--- a/tests/performance/local/htts_v2/htts2.hpp
+++ b/tests/performance/local/htts_v2/htts2.hpp
@@ -10,7 +10,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 
 #include <chrono>
 #include <cmath>

--- a/tests/performance/local/openmp_homogeneous_timed_task_spawn.cpp
+++ b/tests/performance/local/openmp_homogeneous_timed_task_spawn.cpp
@@ -32,7 +32,7 @@
 
 #include <hpx/config.hpp>
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/timing.hpp>
 

--- a/tests/performance/local/qthreads_heterogeneous_timed_task_spawn.cpp
+++ b/tests/performance/local/qthreads_heterogeneous_timed_task_spawn.cpp
@@ -30,7 +30,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 // EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/functional/bind.hpp>
 #include <hpx/modules/timing.hpp>

--- a/tests/performance/local/tbb_homogeneous_timed_task_spawn.cpp
+++ b/tests/performance/local/tbb_homogeneous_timed_task_spawn.cpp
@@ -34,7 +34,7 @@
 
 #include "worker_timed.hpp"
 
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/timing.hpp>
 

--- a/tests/unit/component/action_invoke_no_more_than.hpp
+++ b/tests/unit/component/action_invoke_no_more_than.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/assertion.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/functional/bind_back.hpp>
 #include <hpx/synchronization/counting_semaphore.hpp>
 #include <hpx/synchronization/spinlock.hpp>

--- a/tools/inspect/include_check.cpp
+++ b/tools/inspect/include_check.cpp
@@ -239,8 +239,8 @@ namespace boost
         {"(\\bHPX_PP_STRIP_PARENS\\b)", "HPX_PP_STRIP_PARENS",
             "hpx/preprocessor/strip_parens.hpp"},
         //
-        {"(\\HPX_ASSERT\\b)", "HPX_ASSERT", "hpx/modules/assertion.hpp"},
-        {"(\\HPX_ASSERT_MSG\\b)", "HPX_ASSERT_MSG", "hpx/modules/assertion.hpp"},
+        {"(\\HPX_ASSERT\\b)", "HPX_ASSERT", "hpx/assert.hpp"},
+        {"(\\HPX_ASSERT_MSG\\b)", "HPX_ASSERT_MSG", "hpx/assert.hpp"},
         {nullptr, nullptr, nullptr}};
 
     //  include_check constructor  -------------------------------------------//


### PR DESCRIPTION
This is in the `include` module because it requires pulling in headers from quite a few different modules.

I've also added a little unit test/example that is roughly what I was thinking we could include alongside the public API listings in #4695.