### PR TITLE
Alternative INVOKE implementation

### DIFF
--- a/libs/core/functional/CMakeLists.txt
+++ b/libs/core/functional/CMakeLists.txt
@@ -14,6 +14,7 @@ set(functional_headers
     hpx/functional/detail/basic_function.hpp
     hpx/functional/detail/empty_function.hpp
     hpx/functional/detail/function_registration.hpp
+    hpx/functional/detail/invoke.hpp
     hpx/functional/detail/reset_function.hpp
     hpx/functional/detail/vtable/callable_vtable.hpp
     hpx/functional/detail/vtable/copyable_vtable.hpp

--- a/libs/core/functional/include/hpx/functional/detail/invoke.hpp
+++ b/libs/core/functional/include/hpx/functional/detail/invoke.hpp
@@ -1,0 +1,111 @@
+//  Copyright (c) 2017-2020 Agustin Berge
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace util { namespace detail {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // when `pm` is a pointer to member of a class `C` and
+    // `is_base_of_v<C, remove_reference_t<T>>` is `true`;
+    template <typename C, typename T,
+        typename = typename std::enable_if<std::is_base_of<C,
+            typename std::remove_reference<T>::type>::value>::type>
+    static constexpr T&& mem_ptr_target(T&& v) noexcept
+    {
+        return std::forward<T>(v);
+    }
+
+    // when `pm` is a pointer to member of a class `C` and
+    // `remove_cvref_t<T>` is a specialization of `reference_wrapper`;
+    template <typename C, typename T>
+    static constexpr T& mem_ptr_target(std::reference_wrapper<T> v) noexcept
+    {
+        return v.get();
+    }
+
+    // when `pm` is a pointer to member of a class `C` and `T` does not
+    // satisfy the previous two items;
+    template <typename C, typename T>
+    static constexpr auto mem_ptr_target(T&& v) noexcept(
+        noexcept(*std::forward<T>(v))) -> decltype(*std::forward<T>(v))
+    {
+        return *std::forward<T>(v);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T, typename C>
+    struct invoke_mem_obj
+    {
+        T C::*pm;
+
+    public:
+        constexpr invoke_mem_obj(T C::*pm) noexcept
+          : pm(pm)
+        {
+        }
+
+        template <typename T1>
+        constexpr auto operator()(T1&& t1) const noexcept(
+            noexcept(detail::mem_ptr_target<C>(std::forward<T1>(t1)).*pm))
+            -> decltype(detail::mem_ptr_target<C>(std::forward<T1>(t1)).*pm)
+        {
+            return detail::mem_ptr_target<C>(std::forward<T1>(t1)).*pm;
+        }
+    };
+
+    template <typename T, typename C>
+    struct invoke_mem_fun
+    {
+        T C::*pm;
+
+    public:
+        constexpr invoke_mem_fun(T C::*pm) noexcept
+          : pm(pm)
+        {
+        }
+
+        template <typename T1, typename... Tn>
+        constexpr auto operator()(T1&& t1, Tn&&... tn) const
+            noexcept(noexcept((detail::mem_ptr_target<C>(std::forward<T1>(t1)).*
+                pm)(std::forward<Tn>(tn)...)))
+                -> decltype((detail::mem_ptr_target<C>(std::forward<T1>(t1)).*
+                    pm)(std::forward<Tn>(tn)...))
+        {
+            return (detail::mem_ptr_target<C>(std::forward<T1>(t1)).*pm)(
+                std::forward<Tn>(tn)...);
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename F,
+        typename FD = typename std::remove_cv<
+            typename std::remove_reference<F>::type>::type>
+    struct dispatch_invoke
+    {
+        using type = F&&;
+    };
+
+    template <typename F, typename T, typename C>
+    struct dispatch_invoke<F, T C::*>
+    {
+        using type = typename std::conditional<std::is_function<T>::value,
+            invoke_mem_fun<T, C>, invoke_mem_obj<T, C>>::type;
+    };
+
+    template <typename F>
+    using invoke = typename dispatch_invoke<F>::type;
+
+#define HPX_INVOKE(F, ...)                                                     \
+    (::hpx::util::detail::invoke<decltype((F))>(F)(__VA_ARGS__))
+
+}}}    // namespace hpx::util::detail

--- a/libs/core/functional/include/hpx/functional/invoke.hpp
+++ b/libs/core/functional/include/hpx/functional/invoke.hpp
@@ -7,110 +7,16 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/functional/invoke_result.hpp>
 #include <hpx/type_support/void_guard.hpp>
 
-#include <functional>
-#include <type_traits>
 #include <utility>
 
 namespace hpx { namespace util {
-    ///////////////////////////////////////////////////////////////////////////
-    namespace detail {
-        template <typename T, typename C>
-        struct invoke_mem_obj
-        {
-            T C::*f;
-
-            constexpr HPX_HOST_DEVICE invoke_mem_obj(T C::*mem_obj) noexcept
-              : f(mem_obj)
-            {
-            }
-
-            // t0.*f
-            template <typename T0>
-            constexpr HPX_HOST_DEVICE typename std::enable_if<
-                std::is_base_of<C, typename std::decay<T0>::type>::value,
-                util::invoke_result<T C::*, T0>>::type::type
-            operator()(T0&& v0) const noexcept
-            {
-                return std::forward<T0>(v0).*f;
-            }
-
-            // (*t0).*f
-            template <typename T0>
-            constexpr HPX_HOST_DEVICE typename std::enable_if<
-                !std::is_base_of<C, typename std::decay<T0>::type>::value,
-                util::invoke_result<T C::*, T0>>::type::type
-            operator()(T0&& v0) const noexcept(noexcept(*std::forward<T0>(v0)))
-            {
-                return (*std::forward<T0>(v0)).*f;
-            }
-        };
-
-        template <typename T, typename C>
-        struct invoke_mem_fun
-        {
-            T C::*f;
-
-            constexpr HPX_HOST_DEVICE invoke_mem_fun(T C::*mem_fun) noexcept
-              : f(mem_fun)
-            {
-            }
-
-            // (t0.*f)(t1, ..., tN)
-            template <typename T0, typename... Ts>
-            constexpr HPX_HOST_DEVICE typename std::enable_if<
-                std::is_base_of<C, typename std::decay<T0>::type>::value,
-                util::invoke_result<T C::*, T0, Ts...>>::type::type
-            operator()(T0&& v0, Ts&&... vs) const
-            {
-                return (std::forward<T0>(v0).*f)(std::forward<Ts>(vs)...);
-            }
-
-            // ((*t0).*f)(t1, ..., tN)
-            template <typename T0, typename... Ts>
-            constexpr HPX_HOST_DEVICE typename std::enable_if<
-                !std::is_base_of<C, typename std::decay<T0>::type>::value,
-                util::invoke_result<T C::*, T0, Ts...>>::type::type
-            operator()(T0&& v0, Ts&&... vs) const
-            {
-                return ((*std::forward<T0>(v0)).*f)(std::forward<Ts>(vs)...);
-            }
-        };
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename F, typename FD = typename std::decay<F>::type>
-        struct dispatch_invoke
-        {
-            using type = F&&;
-        };
-
-        template <typename F, typename T, typename C>
-        struct dispatch_invoke<F, T C::*>
-        {
-            using type = typename std::conditional<std::is_function<T>::value,
-                invoke_mem_fun<T, C>, invoke_mem_obj<T, C>>::type;
-        };
-
-        // flatten std::[c]ref
-        template <typename F, typename X>
-        struct dispatch_invoke<F, ::std::reference_wrapper<X>>
-        {
-            using type = X&;
-        };
-
-        template <typename F>
-        using dispatch_invoke_t =
-            typename ::hpx::util::detail::dispatch_invoke<F>::type;
-
-        ///////////////////////////////////////////////////////////////////////
-#define HPX_INVOKE(F, ...)                                                     \
-    (::hpx::util::detail::dispatch_invoke_t<decltype((F))>(F)(__VA_ARGS__))
 
 #define HPX_INVOKE_R(R, F, ...)                                                \
     (::hpx::util::void_guard<R>(), HPX_INVOKE(F, __VA_ARGS__))
-    }    // namespace detail
 
     /// Invokes the given callable object f with the content of
     /// the argument pack vs

--- a/libs/core/functional/include/hpx/functional/tag_invoke.hpp
+++ b/libs/core/functional/include/hpx/functional/tag_invoke.hpp
@@ -193,7 +193,7 @@ namespace hpx { namespace functional {
         template <typename... Args>
         constexpr HPX_FORCEINLINE auto operator()(Args&&... args) const
             noexcept(is_nothrow_tag_invocable_v<Tag, Args...>)
-                -> tag_invoke_result_t<Tag, decltype(args)...>
+                -> tag_invoke_result_t<Tag, Args...>
         {
             return hpx::functional::tag_invoke(
                 static_cast<Tag const&>(*this), std::forward<Args>(args)...);


### PR DESCRIPTION
This alternative INVOKE implementation takes full advantage of C++11 features. The old implementation is very conservative, carefully designed to work with compilers lacking full expression SFINAE support (specifically anything mem-ptr related). Now that those compilers are no longer targeted we can have a more straightforward implementation, and one that fully supports member pointers (the old implementation lacks support for ref-qualified mem-funs, noexcept mem-funs, C-style variadics mem-funs, ...).

As a bonus, this straightforward implementation compiles in about half the time for msvc.