### PR TITLE
Fix 4723

### DIFF
--- a/libs/mpi_base/include/hpx/mpi_base/mpi.hpp
+++ b/libs/mpi_base/include/hpx/mpi_base/mpi.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #if (defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_MPI)) ||      \
-    defined(HPX_HAVE_LIB_MPI)
+    defined(HPX_HAVE_LIB_MPI_BASE)
 
 #if defined(__clang__)
 #pragma clang diagnostic push

--- a/libs/mpi_base/include/hpx/mpi_base/mpi_environment.hpp
+++ b/libs/mpi_base/include/hpx/mpi_base/mpi_environment.hpp
@@ -9,7 +9,7 @@
 #include <hpx/config.hpp>
 
 #if (defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_MPI)) ||      \
-    defined(HPX_HAVE_LIB_MPI)
+    defined(HPX_HAVE_LIB_MPI_BASE)
 
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/mpi_base/mpi.hpp>

--- a/libs/mpi_base/src/mpi_environment.cpp
+++ b/libs/mpi_base/src/mpi_environment.cpp
@@ -66,7 +66,7 @@ namespace hpx { namespace util {
             return false;
         }
         return true;
-#elif defined(HPX_HAVE_LIB_MPI)
+#elif defined(HPX_HAVE_LIB_MPI_BASE)
         // if MPI futures are enabled while networking is off we need to
         // check whether we were run using mpirun
         return detail::detect_mpi_environment(cfg, HPX_HAVE_PARCELPORT_MPI_ENV);
@@ -77,7 +77,7 @@ namespace hpx { namespace util {
 }}    // namespace hpx::util
 
 #if (defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_MPI)) ||      \
-    defined(HPX_HAVE_LIB_MPI)
+    defined(HPX_HAVE_LIB_MPI_BASE)
 
 namespace hpx { namespace util {
 

--- a/libs/resource_partitioner/src/detail_partitioner.cpp
+++ b/libs/resource_partitioner/src/detail_partitioner.cpp
@@ -894,7 +894,7 @@ namespace hpx { namespace resource { namespace detail {
         cfg_.hpx_main_f_ = f;
 
 #if (defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_MPI)) ||      \
-    defined(HPX_HAVE_LIB_MPI)
+    defined(HPX_HAVE_LIB_MPI_BASE)
         // getting localities from MPI environment (support mpirun)
         if (util::mpi_environment::check_mpi_environment(cfg_.rtcfg_))
         {

--- a/libs/version/src/version.cpp
+++ b/libs/version/src/version.cpp
@@ -20,7 +20,7 @@
 #include <boost/version.hpp>
 
 #if (defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_MPI)) ||      \
-    defined(HPX_HAVE_LIB_MPI)
+    defined(HPX_HAVE_LIB_MPI_BASE)
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-qual"
@@ -86,7 +86,7 @@ namespace hpx {
     }
 
 #if (defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_MPI)) ||      \
-    defined(HPX_HAVE_LIB_MPI)
+    defined(HPX_HAVE_LIB_MPI_BASE)
     std::string mpi_version()
     {
         std::ostringstream strm;
@@ -266,7 +266,7 @@ namespace hpx {
                                                 "  Boost: {}\n"
                                                 "  Hwloc: {}\n"
 #if (defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_MPI)) ||      \
-    defined(HPX_HAVE_LIB_MPI)
+    defined(HPX_HAVE_LIB_MPI_BASE)
                                                 "  MPI: {}\n"
 #endif
                                                 "\n"
@@ -278,7 +278,7 @@ namespace hpx {
                                                 "  Standard Library: {}\n",
             build_string(), boost_version(), hwloc_version(),
 #if (defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_MPI)) ||      \
-    defined(HPX_HAVE_LIB_MPI)
+    defined(HPX_HAVE_LIB_MPI_BASE)
             mpi_version(),
 #endif
             build_type(), build_date_time(), boost_platform(), boost_compiler(),


### PR DESCRIPTION
Fixes #4723 

Fix 1 - the module name is `MPI_BASE`, but various `#ifdef` checks in some files are using module `MPI` - this is not related to 4723, but needs to be addressed. Change `XXX_LIB_MPI` to `XXX_LIB_MPI_BASE` in several places

Fix 2 - when the user sets `HPX_WITH_XXX` it may be asked for, but it might not be possible if other contradicting options have been set. The code should set `HPX_HAVE_XXX` if and only if that option's requirements are fulfilled. A clear distinction between `WITH` and `HAVE` exists between features requested, and features delivered.

`HPX_WITH_DISTRIBUTED_RUNTIME` cannot be met if `HPX_WITH_NETWORKING=OFF` so the cmake code should not use `HPX_WITH_DISTRIBUTED_RUNTIME` directly in checks (in other modules etc), but rather a new variable `HPX_HAVE_DISTRIBUTED_RUNTIME` that is only set if all conditions are met. 
