### PR TITLE
Add more compatibility headers for deprecated module headers

### DIFF
--- a/libs/algorithms/include_compatibility/hpx/algorithms.hpp
+++ b/libs/algorithms/include_compatibility/hpx/algorithms.hpp
@@ -1,0 +1,21 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/algorithms/config/defines.hpp>
+#include <hpx/modules/algorithms.hpp>
+
+#if defined(HPX_ALGORITHMS_HAVE_DEPRECATION_WARNINGS)
+#if defined(HPX_MSVC)
+#pragma message("The header hpx/algorithms.hpp is deprecated, \
+    please include hpx/modules/algorithms.hpp instead")
+#else
+#warning "The header hpx/algorithms.hpp is deprecated, \
+    please include hpx/modules/algorithms.hpp instead"
+#endif
+#endif

--- a/libs/cache/include_compatibility/hpx/cache.hpp
+++ b/libs/cache/include_compatibility/hpx/cache.hpp
@@ -1,0 +1,21 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/cache/config/defines.hpp>
+#include <hpx/modules/cache.hpp>
+
+#if defined(HPX_CACHE_HAVE_DEPRECATION_WARNINGS)
+#if defined(HPX_MSVC)
+#pragma message("The header hpx/cache.hpp is deprecated, \
+    please include hpx/modules/cache.hpp instead")
+#else
+#warning "The header hpx/cache.hpp is deprecated, \
+    please include hpx/modules/cache.hpp instead"
+#endif
+#endif

--- a/libs/collectives/include_compatibility/hpx/collectives.hpp
+++ b/libs/collectives/include_compatibility/hpx/collectives.hpp
@@ -1,0 +1,21 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/collectives/config/defines.hpp>
+#include <hpx/modules/collectives.hpp>
+
+#if defined(HPX_COLLECTIVES_HAVE_DEPRECATION_WARNINGS)
+#if defined(HPX_MSVC)
+#pragma message("The header hpx/collectives.hpp is deprecated, \
+    please include hpx/modules/collectives.hpp instead")
+#else
+#warning "The header hpx/collectives.hpp is deprecated, \
+    please include hpx/modules/collectives.hpp instead"
+#endif
+#endif

--- a/libs/hardware/include_compatibility/hpx/hardware.hpp
+++ b/libs/hardware/include_compatibility/hpx/hardware.hpp
@@ -1,0 +1,21 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/hardware/config/defines.hpp>
+#include <hpx/modules/hardware.hpp>
+
+#if defined(HPX_HARDWARE_HAVE_DEPRECATION_WARNINGS)
+#if defined(HPX_MSVC)
+#pragma message("The header hpx/hardware.hpp is deprecated, \
+    please include hpx/modules/hardware.hpp instead")
+#else
+#warning "The header hpx/hardware.hpp is deprecated, \
+    please include hpx/modules/hardware.hpp instead"
+#endif
+#endif

--- a/libs/local_lcos/include_compatibility/hpx/local_lcos.hpp
+++ b/libs/local_lcos/include_compatibility/hpx/local_lcos.hpp
@@ -1,0 +1,21 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/local_lcos/config/defines.hpp>
+#include <hpx/modules/local_lcos.hpp>
+
+#if defined(HPX_LOCAL_LCOS_HAVE_DEPRECATION_WARNINGS)
+#if defined(HPX_MSVC)
+#pragma message("The header hpx/local_lcos.hpp is deprecated, \
+    please include hpx/modules/local_lcos.hpp instead")
+#else
+#warning "The header hpx/local_lcos.hpp is deprecated, \
+    please include hpx/modules/local_lcos.hpp instead"
+#endif
+#endif

--- a/libs/preprocessor/include_compatibility/hpx/preprocessor.hpp
+++ b/libs/preprocessor/include_compatibility/hpx/preprocessor.hpp
@@ -1,0 +1,20 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/preprocessor/config/defines.hpp>
+#include <hpx/modules/preprocessor.hpp>
+
+#if defined(HPX_PREPROCESSOR_HAVE_DEPRECATION_WARNINGS)
+#if defined(_MSC_VER)
+#pragma message("The header hpx/preprocessor.hpp is deprecated, \
+    please include hpx/modules/preprocessor.hpp instead")
+#else
+#warning "The header hpx/preprocessor.hpp is deprecated, \
+    please include hpx/modules/preprocessor.hpp instead"
+#endif
+#endif

--- a/libs/segmented_algorithms/include_compatibility/hpx/segmented_algorithms.hpp
+++ b/libs/segmented_algorithms/include_compatibility/hpx/segmented_algorithms.hpp
@@ -1,0 +1,21 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/segmented_algorithms/config/defines.hpp>
+#include <hpx/modules/segmented_algorithms.hpp>
+
+#if defined(HPX_SEGMENTED_ALGORITHMS_HAVE_DEPRECATION_WARNINGS)
+#if defined(HPX_MSVC)
+#pragma message("The header hpx/segmented_algorithms.hpp is deprecated, \
+    please include hpx/modules/segmented_algorithms.hpp instead")
+#else
+#warning "The header hpx/segmented_algorithms.hpp is deprecated, \
+    please include hpx/modules/segmented_algorithms.hpp instead"
+#endif
+#endif


### PR DESCRIPTION
Fixes #4720. Leaves out `hpx/execution.hpp` as that'll get a proper replacement.
