### PR TITLE
Fixing compilation problems with unordered map

### DIFF
--- a/components/containers/partitioned_vector/tests/regressions/CMakeLists.txt
+++ b/components/containers/partitioned_vector/tests/regressions/CMakeLists.txt
@@ -19,7 +19,7 @@ foreach(test ${tests})
     SOURCES ${sources} ${${test}_FLAGS}
     EXCLUDE_FROM_ALL
     HPX_PREFIX ${HPX_BUILD_PREFIX}
-    FOLDER "Tests/Regressions/Components/Containers"
+    FOLDER "Tests/Regressions/Components/Containers/PartitionedVector"
   )
 
   add_hpx_regression_test(

--- a/components/containers/partitioned_vector/tests/unit/CMakeLists.txt
+++ b/components/containers/partitioned_vector/tests/unit/CMakeLists.txt
@@ -38,7 +38,7 @@ foreach(test ${tests})
 
   source_group("Source Files" FILES ${sources})
 
-  set(folder_name "Tests/Unit/Components/Containers")
+  set(folder_name "Tests/Unit/Components/Containers/PartitionedVector")
 
   # add example executable
   add_hpx_executable(

--- a/components/containers/unordered/tests/regressions/CMakeLists.txt
+++ b/components/containers/unordered/tests/regressions/CMakeLists.txt
@@ -1,5 +1,27 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2020 Hartmut Kaiser
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests unordered_compilation_4685)
+
+set(unordered_compilation_4685_FLAGS COMPONENT_DEPENDENCIES unordered)
+set(unordered_compilation_4685_PARAMETERS THREADS_PER_LOCALITY 2)
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  # add example executable
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/Components/Containers/Unordered"
+  )
+
+  add_hpx_regression_test("components.unordered" ${test} ${${test}_PARAMETERS})
+endforeach()

--- a/components/containers/unordered/tests/regressions/unordered_compilation_4685.cpp
+++ b/components/containers/unordered/tests/regressions/unordered_compilation_4685.cpp
@@ -1,0 +1,46 @@
+//  Copyright (c) 2020 Nick Robison
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_finalize.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/serialization.hpp>
+#include <hpx/include/unordered_map.hpp>
+
+#include <string>
+#include <vector>
+
+HPX_REGISTER_UNORDERED_MAP(std::string, double);
+
+const char* const map_name = "mobility_visit_map";
+
+int hpx_main()
+{
+    hpx::unordered_map<std::string, double> m;
+
+    if (0 == hpx::get_locality_id())
+    {
+        auto localities = hpx::find_all_localities();
+
+        m = hpx::unordered_map<std::string, double>(
+            hpx::container_layout(10, localities));
+        auto f1 = m.register_as(map_name);
+        f1.get();
+    }
+    else
+    {
+        auto f1 = m.connect_to(map_name);
+        f1.get();
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char** argv)
+{
+    std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
+
+    return hpx::init(argc, argv, cfg);
+}

--- a/components/containers/unordered/tests/unit/CMakeLists.txt
+++ b/components/containers/unordered/tests/unit/CMakeLists.txt
@@ -16,7 +16,7 @@ foreach(test ${tests})
 
   source_group("Source Files" FILES ${sources})
 
-  set(folder_name "Tests/Unit/Components/Containers")
+  set(folder_name "Tests/Unit/Components/Containers/Unordered")
 
   # add example executable
   add_hpx_executable(


### PR DESCRIPTION
- flyby: fixing cmake FOLDERs for container component tests

Fixes #4685

@nickrobison-usds please check whether this solves your issue
