### PR TITLE
Add experimental unity build option to CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,17 @@ else()
   )
 endif()
 
+hpx_option(
+  HPX_WITH_UNITY_BUILD
+  BOOL
+  "Enable unity build for certain build targets (experimental, requires CMake 3.16 or newer) (default OFF)"
+  OFF
+  ADVANCED
+)
+if(HPX_WITH_UNITY_BUILD AND (CMAKE_VERSION VERSION_LESS "3.16"))
+  hpx_error("HPX_WITH_UNITY_BUILD=ON but this requires CMake 3.16 or newer.")
+endif()
+
 # ##############################################################################
 # Some platforms do not support dynamic linking. Enable this to link all
 # libraries statically. This also changes some of the internals of HPX related

--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -318,6 +318,10 @@ function(add_hpx_module name)
     hpx_${name} PROPERTIES FOLDER "Core/Modules" POSITION_INDEPENDENT_CODE ON
   )
 
+  if(HPX_WITH_UNITY_BUILD)
+    set_target_properties(hpx_${name} PROPERTIES UNITY_BUILD ON)
+  endif()
+
   if(MSVC)
     set_target_properties(
       hpx_${name}

--- a/libs/thread_executors/CMakeLists.txt
+++ b/libs/thread_executors/CMakeLists.txt
@@ -15,6 +15,7 @@ set(thread_executors_headers
     hpx/execution/executors/thread_pool_os_executors.hpp
     hpx/thread_executors/current_executor.hpp
     hpx/thread_executors/default_executor.hpp
+    hpx/thread_executors/detail/on_self_reset.hpp
     hpx/thread_executors/embedded_thread_pool_executors.hpp
     hpx/thread_executors/executors.hpp
     hpx/thread_executors/force_linking.hpp

--- a/libs/thread_executors/include/hpx/thread_executors/detail/on_self_reset.hpp
+++ b/libs/thread_executors/include/hpx/thread_executors/detail/on_self_reset.hpp
@@ -1,0 +1,23 @@
+//  Copyright (c) 2007-2019 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/modules/threading_base.hpp>
+
+namespace hpx { namespace threads { namespace executors { namespace detail {
+    struct on_self_reset
+    {
+        on_self_reset(threads::thread_self* self)
+        {
+            threads::detail::set_self_ptr(self);
+        }
+        ~on_self_reset()
+        {
+            threads::detail::set_self_ptr(nullptr);
+        }
+    };
+}}}}    // namespace hpx::threads::executors::detail

--- a/libs/thread_executors/src/embedded_thread_pool_executors.cpp
+++ b/libs/thread_executors/src/embedded_thread_pool_executors.cpp
@@ -26,6 +26,7 @@
 #include <hpx/functional/unique_function.hpp>
 #include <hpx/modules/assertion.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
+#include <hpx/thread_executors/detail/on_self_reset.hpp>
 #include <hpx/thread_executors/manage_thread_executor.hpp>
 #include <hpx/thread_executors/resource_manager.hpp>
 #include <hpx/thread_pools/scheduling_loop.hpp>
@@ -264,18 +265,6 @@ namespace hpx { namespace threads { namespace executors { namespace detail {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    struct on_self_reset
-    {
-        on_self_reset(threads::thread_self* self)
-        {
-            threads::detail::set_self_ptr(self);
-        }
-        ~on_self_reset()
-        {
-            threads::detail::set_self_ptr(nullptr);
-        }
-    };
-
     template <typename Scheduler>
     void
     embedded_thread_pool_executor<Scheduler>::suspend_back_into_calling_context(

--- a/libs/thread_executors/src/this_thread_executors.cpp
+++ b/libs/thread_executors/src/this_thread_executors.cpp
@@ -24,6 +24,7 @@
 #include <hpx/functional/deferred_call.hpp>
 #include <hpx/modules/assertion.hpp>
 #include <hpx/runtime/threads/thread_helpers.hpp>
+#include <hpx/thread_executors/detail/on_self_reset.hpp>
 #include <hpx/thread_executors/manage_thread_executor.hpp>
 #include <hpx/thread_executors/resource_manager.hpp>
 #include <hpx/thread_pools/scheduling_loop.hpp>
@@ -258,18 +259,6 @@ namespace hpx { namespace threads { namespace executors { namespace detail {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    struct on_self_reset
-    {
-        on_self_reset(threads::thread_self* self)
-        {
-            threads::detail::set_self_ptr(self);
-        }
-        ~on_self_reset()
-        {
-            threads::detail::set_self_ptr(nullptr);
-        }
-    };
-
     template <typename Scheduler>
     void this_thread_executor<Scheduler>::suspend_back_into_calling_context()
     {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -541,6 +541,10 @@ endif()
 
 target_compile_definitions(hpx_core PRIVATE HPX_COMPONENT_NAME=hpx HPX_EXPORTS)
 
+if(HPX_WITH_UNITY_BUILD)
+  set_target_properties(hpx_core PROPERTIES UNITY_BUILD ON)
+endif()
+
 # ##############################################################################
 # Emulation of SwapContext on Windows
 # ##############################################################################

--- a/src/runtime/agas/server/route.cpp
+++ b/src/runtime/agas/server/route.cpp
@@ -27,17 +27,17 @@
 #include <utility>
 #include <vector>
 
-
-namespace {
+namespace hpx { namespace detail {
     void update_agas_cache(hpx::naming::gid_type const& gid,
         hpx::naming::address const& addr, std::uint64_t count,
         std::uint64_t offset)
     {
-        hpx::naming::get_agas_client().update_cache_entry(gid, addr, count, offset);
+        hpx::naming::get_agas_client().update_cache_entry(
+            gid, addr, count, offset);
     }
-}
+}}    // namespace hpx::detail
 
-HPX_PLAIN_ACTION_ID(update_agas_cache, update_agas_cache_action,
+HPX_PLAIN_ACTION_ID(hpx::detail::update_agas_cache, update_agas_cache_action,
     hpx::actions::update_agas_cache_action_id)
 
 namespace hpx { namespace agas { namespace server

--- a/src/runtime/parcelset/detail/parcel_route_handler.cpp
+++ b/src/runtime/parcelset/detail/parcel_route_handler.cpp
@@ -9,10 +9,11 @@
 
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/modules/errors.hpp>
-#include <hpx/runtime_distributed.hpp>
+#include <hpx/runtime/parcelset/detail/parcel_route_handler.hpp>
 #include <hpx/runtime/parcelset/parcel.hpp>
 #include <hpx/runtime/parcelset/parcelhandler.hpp>
 #include <hpx/runtime/runtime_fwd.hpp>
+#include <hpx/runtime_distributed.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace detail


### PR DESCRIPTION
This adds a CMake option to use CMake's unity build functionality from 3.16 onwards (https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html). Essentially this batches compilation of source files to save a bit (or a lot) of header parsing. Internally CMake batches up to 8 (default) source files into one file that looks roughly like this:
```
#include "/path/to/source1.cpp"
#include "/path/to/source2.cpp"
#include "/path/to/source3.cpp"
...
```
and compiles that instead. The downside of this is that files that are batched together can't have duplicate static definitions. For `on_self_reset` in the `thread_executors` module I just lifted the definitions out into a separate header file. If needed the batching can be turned off for specific source files as well. This can also lead to slightly increased build times when only a few files need to be recompiled since the whole batch needs to be recompiled rather than just one or two files.

When `HPX_WITH_UNITY_BUILD=ON` the modules and main HPX library have the `UNITY_BUILD` property set to on. With the fixes here it works fine, and most importantly a single job build of the main library went from about 34 minutes to 16 minutes on my laptop.

Please give it a try. If this works well for a longer time we can consider always building with `UNITY_BUILD`.