### PR TITLE
Fix init_globally example after runtime mode changes

### DIFF
--- a/examples/quickstart/init_globally.cpp
+++ b/examples/quickstart/init_globally.cpp
@@ -68,9 +68,11 @@ char** __argv = *_NSGetArgv();
 // (locality 0). In order to create an HPX instance which connects to a running
 // HPX application two changes have to be made:
 //
-//  - replace hpx::runtime_mode::console with hpx::runtime_mode::connect
+//  - replace hpx::runtime_mode::default_ with hpx::runtime_mode::connect
 //  - replace hpx::finalize() with hpx::disconnect()
 //
+// Note that the mode runtime_mode::default_ corresponds to runtime_mode::console
+// if the distributed runtime is enabled, and runtime_mode::local otherwise.
 struct manage_global_runtime
 {
     manage_global_runtime()
@@ -94,7 +96,7 @@ struct manage_global_runtime
         hpx::util::function_nonser<int(int, char**)> start_function =
             hpx::util::bind(&manage_global_runtime::hpx_main, this, _1, _2);
 
-        if (!hpx::start(start_function, __argc, __argv, cfg, hpx::runtime_mode::console))
+        if (!hpx::start(start_function, __argc, __argv, cfg, hpx::runtime_mode::default_))
         {
             // Something went wrong while initializing the runtime.
             // This early we can't generate any output, just bail out.


### PR DESCRIPTION
Or would someone prefer to explicitly use `runtime_mode::console` when `HPX_HAVE_DISTRIBUTED_RUNTIME` is defined, and `runtime_mode::local` otherwise?