### PR TITLE
Create coverage reports and upload them to codecov.io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,17 @@ move_debug_log: &move_debug_log
         mkdir -p ${CIRCLE_JOB}
         cp debug-log.txt ${CIRCLE_JOB} || true
 
+collect_coverage: &collect_coverage
+    name: Collecting coverage reports
+    command: |
+        mkdir -p /hpx/coverage
+        lcov -q --gcov-tool llvm-cov-wrapper --no-external --capture --base-directory /hpx/source/ --directory /hpx/build/ --output-file /hpx/coverage/${CIRCLE_JOB}.info
+
+persist_coverage: &persist_coverage
+    root: /hpx
+    paths:
+      - ./coverage
+
 gh_pages_filter: &gh_pages_filter
     filters:
       branches:
@@ -191,24 +202,25 @@ jobs:
                 /hpx/source \
                 -G "Ninja" \
                 -DCMAKE_BUILD_TYPE=Debug \
+                -DCMAKE_CXX_CLANG_TIDY=clang-tidy \
+                -DCMAKE_CXX_FLAGS="--coverage -fcolor-diagnostics" \
+                -DCMAKE_EXE_LINKER_FLAGS="--coverage" \
+                -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
                 -DHPX_WITH_MALLOC=system \
                 -DHPX_WITH_GIT_COMMIT=${CIRCLE_SHA1} \
                 -DHPX_WITH_GIT_BRANCH="${CIRCLE_BRANCH}" \
                 -DHPX_WITH_GIT_TAG="${CIRCLE_TAG}" \
                 -DHPX_WITH_TOOLS=On \
-                -DCMAKE_CXX_FLAGS="-fcolor-diagnostics" \
                 -DHPX_WITH_TESTS_HEADERS=On \
                 -DHPX_WITH_COMPILER_WARNINGS=On \
                 -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=On \
                 -DHPX_WITH_DEPRECATION_WARNINGS=On \
-                -DCMAKE_CXX_CLANG_TIDY=clang-tidy \
                 -DHPX_WITH_THREAD_LOCAL_STORAGE=On \
                 -DHPX_WITH_STACKTRACES_STATIC_SYMBOLS=On \
                 -DHPX_WITH_STACKTRACES_DEMANGLE_SYMBOLS=Off \
                 -DHPX_WITH_TESTS_DEBUG_LOG=On \
                 -DHPX_WITH_TESTS_DEBUG_LOG_DESTINATION=/hpx/build/debug-log.txt \
                 -DHPX_WITH_SPINLOCK_DEADLOCK_DETECTION=On \
-                -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
                 -DHPX_WITH_DOCUMENTATION=On \
                 -DHPX_WITH_DOCUMENTATION_OUTPUT_FORMATS="${DOCUMENTATION_OUTPUT_FORMATS}"
       - persist_to_workspace:
@@ -372,10 +384,14 @@ jobs:
           <<: *move_core_dump
       - run:
           <<: *move_debug_log
+      - run:
+          <<: *collect_coverage
       - store_test_results:
           path: tests.examples
       - store_artifacts:
           path: tests.examples
+      - persist_to_workspace:
+          <<: *persist_coverage
 
   tests.unit.actions:
     <<: *defaults
@@ -398,10 +414,14 @@ jobs:
           <<: *move_core_dump
       - run:
           <<: *move_debug_log
+      - run:
+          <<: *collect_coverage
       - store_test_results:
           path: tests.unit.actions
       - store_artifacts:
           path: tests.unit.actions
+      - persist_to_workspace:
+          <<: *persist_coverage
 
   tests.unit.agas:
     <<: *defaults
@@ -424,10 +444,14 @@ jobs:
           <<: *move_core_dump
       - run:
           <<: *move_debug_log
+      - run:
+          <<: *collect_coverage
       - store_test_results:
           path: tests.unit.agas
       - store_artifacts:
           path: tests.unit.agas
+      - persist_to_workspace:
+          <<: *persist_coverage
 
   tests.unit.build:
     <<: *defaults
@@ -457,10 +481,14 @@ jobs:
           <<: *move_core_dump
       - run:
           <<: *move_debug_log
+      - run:
+          <<: *collect_coverage
       - store_test_results:
           path: tests.unit.build
       - store_artifacts:
           path: tests.unit.build
+      - persist_to_workspace:
+          <<: *persist_coverage
 
   tests.unit.component:
     <<: *defaults
@@ -483,10 +511,14 @@ jobs:
           <<: *move_core_dump
       - run:
           <<: *move_debug_log
+      - run:
+          <<: *collect_coverage
       - store_test_results:
           path: tests.unit.component
       - store_artifacts:
           path: tests.unit.component
+      - persist_to_workspace:
+          <<: *persist_coverage
 
   tests.unit.lcos:
     <<: *defaults
@@ -509,10 +541,14 @@ jobs:
           <<: *move_core_dump
       - run:
           <<: *move_debug_log
+      - run:
+          <<: *collect_coverage
       - store_test_results:
           path: tests.unit.lcos
       - store_artifacts:
           path: tests.unit.lcos
+      - persist_to_workspace:
+          <<: *persist_coverage
 
   tests.unit.parcelset:
     <<: *defaults
@@ -535,10 +571,14 @@ jobs:
           <<: *move_core_dump
       - run:
           <<: *move_debug_log
+      - run:
+          <<: *collect_coverage
       - store_test_results:
           path: tests.unit.parcelset
       - store_artifacts:
           path: tests.unit.parcelset
+      - persist_to_workspace:
+          <<: *persist_coverage
 
   tests.unit.resource:
     <<: *defaults
@@ -561,10 +601,14 @@ jobs:
           <<: *move_core_dump
       - run:
           <<: *move_debug_log
+      - run:
+          <<: *collect_coverage
       - store_test_results:
           path: tests.unit.resource
       - store_artifacts:
           path: tests.unit.resource
+      - persist_to_workspace:
+          <<: *persist_coverage
 
   tests.unit.traits:
     <<: *defaults
@@ -587,10 +631,14 @@ jobs:
           <<: *move_core_dump
       - run:
           <<: *move_debug_log
+      - run:
+          <<: *collect_coverage
       - store_test_results:
           path: tests.unit.traits
       - store_artifacts:
           path: tests.unit.traits
+      - persist_to_workspace:
+          <<: *persist_coverage
 
   tests.unit.util:
     <<: *defaults
@@ -613,10 +661,14 @@ jobs:
           <<: *move_core_dump
       - run:
           <<: *move_debug_log
+      - run:
+          <<: *collect_coverage
       - store_test_results:
           path: tests.unit.util
       - store_artifacts:
           path: tests.unit.util
+      - persist_to_workspace:
+          <<: *persist_coverage
 
   tests.unit.modules:
     <<: *defaults
@@ -709,10 +761,14 @@ jobs:
           <<: *move_core_dump
       - run:
           <<: *move_debug_log
+      - run:
+          <<: *collect_coverage
       - store_test_results:
           path: tests.unit.modules
       - store_artifacts:
           path: tests.unit.modules
+      - persist_to_workspace:
+          <<: *persist_coverage
 
   tests.unit.modules.algorithms:
     <<: *defaults
@@ -735,10 +791,14 @@ jobs:
           <<: *move_core_dump
       - run:
           <<: *move_debug_log
+      - run:
+          <<: *collect_coverage
       - store_test_results:
           path: tests.unit.modules.algorithms
       - store_artifacts:
           path: tests.unit.modules.algorithms
+      - persist_to_workspace:
+          <<: *persist_coverage
 
   tests.unit.modules.execution:
     <<: *defaults
@@ -761,10 +821,14 @@ jobs:
           <<: *move_core_dump
       - run:
           <<: *move_debug_log
+      - run:
+          <<: *collect_coverage
       - store_test_results:
           path: tests.unit.modules.execution
       - store_artifacts:
           path: tests.unit.modules.execution
+      - persist_to_workspace:
+          <<: *persist_coverage
 
   tests.unit.modules.segmented_algorithms:
     <<: *defaults
@@ -789,10 +853,14 @@ jobs:
           <<: *move_core_dump
       - run:
           <<: *move_debug_log
+      - run:
+          <<: *collect_coverage
       - store_test_results:
           path: tests.unit.modules.segmented_algorithms
       - store_artifacts:
           path: tests.unit.modules.segmented_algorithms
+      - persist_to_workspace:
+          <<: *persist_coverage
 
   tests.regressions:
     <<: *defaults
@@ -814,10 +882,14 @@ jobs:
           <<: *move_core_dump
       - run:
           <<: *move_debug_log
+      - run:
+          <<: *collect_coverage
       - store_test_results:
           path: tests.regressions
       - store_artifacts:
           path: tests.regressions
+      - persist_to_workspace:
+          <<: *persist_coverage
 
   tests.headers:
     <<: *defaults
@@ -830,10 +902,14 @@ jobs:
               ctest --timeout 60 -j1 -T test --no-compress-output --output-on-failure -R tests.headers -E tests.headers.modules
       - run:
           <<: *convert_xml
+      - run:
+          <<: *collect_coverage
       - store_test_results:
           path: tests.headers
       - store_artifacts:
           path: tests.headers
+      - persist_to_workspace:
+          <<: *persist_coverage
 
   tests.headers.modules:
     <<: *defaults
@@ -846,10 +922,14 @@ jobs:
               ctest --timeout 60 -j2 -T test --no-compress-output --output-on-failure -R tests.headers.modules
       - run:
           <<: *convert_xml
+      - run:
+          <<: *collect_coverage
       - store_test_results:
           path: tests.headers.modules
       - store_artifacts:
           path: tests.headers.modules
+      - persist_to_workspace:
+          <<: *persist_coverage
 
   tests.performance:
     <<: *defaults
@@ -874,6 +954,20 @@ jobs:
           root: /hpx
           paths:
             - ./build
+
+  coverage:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /hpx
+      - run:
+          name: Generating Coverage Reports
+          command: |
+              lcov --gcov-tool llvm-cov-wrapper --no-external --capture --initial --base-directory /hpx/source/ --directory /hpx/build/ --output-file /hpx/coverage/baseline.info
+              TRACE_FILES_ARGS=`find /hpx/coverage -type f -iname '*.info' -exec sh -c "echo --add-tracefile {}" \;`
+              lcov ${TRACE_FILES_ARGS} --output-file "/hpx/coverage/combined.info"
+              lcov --remove combined.info '*CMakeCXXCompilerId.cpp*' '*static_parcelports.hpp*' '*modules.cpp*' '*config_entries.cpp*' '*force_linking.cpp' -o coverage.info
+              bash <(curl -s https://codecov.io/bash) -f coverage.info
 
   install:
     docker:
@@ -1084,6 +1178,28 @@ workflows:
             - tests.regressions
             - examples
           <<: *gh_pages_filter
+      - coverage:
+          requires:
+            - core
+            - tests.examples
+            - tests.unit.actions
+            - tests.unit.agas
+            - tests.unit.build
+            - tests.unit.component
+            - tests.unit.lcos
+            - tests.unit.parcelset
+            - tests.unit.resource
+            - tests.unit.traits
+            - tests.unit.util
+            - tests.unit.modules
+            - tests.unit.modules.algorithms
+            - tests.unit.modules.execution
+            - tests.unit.modules.segmented_algorithms
+            - tests.headers
+            - tests.headers.modules
+            - tests.performance
+            - tests.regressions
+            - examples
       - push_stable_tag:
           requires:
             - install


### PR DESCRIPTION
Now that https://github.com/STEllAR-GROUP/docker_build_env/pull/25 is merged, this PR generates coverage reports and uploads them to codecov.io. I believe codecov will magically accept reports without any other config. 

On my fork of hpx circle ci timed out, so we have to see here if it works.