### PR TITLE
Fix compilation issues

### DIFF
--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_component_decl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_component_decl.hpp
@@ -333,7 +333,11 @@ namespace hpx
             > base_type;
 
     public:
+#if defined(HPX_CLANG_VERSION) && HPX_CLANG_VERSION < 60000
+        partitioned_vector_partition() {};
+#else
         partitioned_vector_partition() = default;
+#endif
 
         explicit partitioned_vector_partition(id_type const& gid);
 

--- a/components/performance_counters/papi/src/papi_startup.cpp
+++ b/components/performance_counters/papi/src/papi_startup.cpp
@@ -12,14 +12,13 @@
 #include <hpx/components/performance_counters/papi/server/papi.hpp>
 #include <hpx/components/performance_counters/papi/util/papi.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/runtime_local.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/manage_counter_type.hpp>
-#include <hpx/runtime.hpp>
 #include <hpx/runtime/components/component_commandline.hpp>
 #include <hpx/runtime/components/component_factory_base.hpp>
 #include <hpx/runtime/components/component_startup_shutdown.hpp>
 #include <hpx/runtime/components/server/create_component.hpp>
-#include <hpx/runtime_local/startup_function.hpp>
 #include <hpx/functional/bind_back.hpp>
 #include <hpx/runtime_local/thread_mapper.hpp>
 

--- a/components/performance_counters/papi/src/server/papi.cpp
+++ b/components/performance_counters/papi/src/server/papi.cpp
@@ -12,11 +12,11 @@
 #include <hpx/components/performance_counters/papi/server/papi.hpp>
 #include <hpx/components/performance_counters/papi/util/papi.hpp>
 #include <hpx/modules/errors.hpp>
-#include <hpx/runtime.hpp>
+#include <hpx/modules/runtime_local.hpp>
+#include <hpx/modules/timing.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/components/derived_component_factory.hpp>
 #include <hpx/runtime/components/server/component.hpp>
-#include <hpx/modules/timing.hpp>
 #include <hpx/runtime_local/thread_mapper.hpp>
 
 #include <boost/version.hpp>

--- a/components/performance_counters/papi/src/util/papi.cpp
+++ b/components/performance_counters/papi/src/util/papi.cpp
@@ -9,11 +9,10 @@
 #if defined(HPX_HAVE_PAPI)
 
 #include <hpx/config/asio.hpp>
+#include <hpx/modules/command_line_handling.hpp>
 #include <hpx/modules/errors.hpp>
-#include <hpx/runtime.hpp>
 #include <hpx/modules/format.hpp>
-#include <hpx/command_line_handling/parse_command_line.hpp>
-#include <hpx/runtime_local/thread_mapper.hpp>
+#include <hpx/modules/runtime_local.hpp>
 #include <hpx/components/performance_counters/papi/util/papi.hpp>
 
 #include <boost/asio/ip/host_name.hpp>


### PR DESCRIPTION
Fixes #4755 and the `clang-oldest` build. The clang fix is for what seems to be this, or a related bug: https://bugs.llvm.org/show_bug.cgi?id=39649, with the difference it's not a defaulted move constructor that I had to change, just the default constructor. I've not verified if the bug is there still in clang 6. It's not a problem on gcc 7, gcc 10, or clang 9.