### PR TITLE
Storing hpx_options in global property to speed up summary report

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -493,7 +493,7 @@ with section("parse"):
     'hpx_include': {'pargs': {'nargs': 0}},
     'hpx_info': {'pargs': {'nargs': 0}},
     'hpx_message': {'pargs': {'nargs': 1}},
-    'hpx_option': { 'kwargs': {'CATEGORY': 1, 'STRINGS': '+'},
+    'hpx_option': { 'kwargs': {'CATEGORY': 1, 'MODULE': 1, 'STRINGS': '+'},
                     'pargs': {'flags': ['ADVANCED'], 'nargs': '4+'}},
     'hpx_perform_cxx_feature_tests': {'pargs': {'nargs': 0}},
     'hpx_print_list': {'pargs': {'nargs': 3}},

--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -41,7 +41,9 @@ function(add_hpx_module name)
   hpx_option(
     HPX_${name_upper}_WITH_TESTS BOOL
     "Build HPX ${name} module tests. (default: ${HPX_WITH_TESTS})"
-    ${HPX_WITH_TESTS} ADVANCED CATEGORY "Modules"
+    ${HPX_WITH_TESTS} ADVANCED
+    CATEGORY "Modules"
+    MODULE ${name_upper}
   )
 
   set(_deprecation_warnings_default OFF)
@@ -55,6 +57,7 @@ function(add_hpx_module name)
     ${_deprecation_warnings_default}
     ADVANCED
     CATEGORY "Modules"
+    MODULE ${name_upper}
   )
   if(${HPX_${name_upper}_WITH_DEPRECATION_WARNINGS})
     hpx_add_config_cond_define_namespace(
@@ -75,6 +78,7 @@ function(add_hpx_module name)
       ${_compatibility_headers_default}
       ADVANCED
       CATEGORY "Modules"
+      MODULE ${name_upper}
     )
   endif()
 

--- a/cmake/HPX_Option.cmake
+++ b/cmake/HPX_Option.cmake
@@ -20,7 +20,7 @@ set(HPX_OPTION_CATEGORIES
 
 function(hpx_option option type description default)
   set(options ADVANCED)
-  set(one_value_args CATEGORY)
+  set(one_value_args CATEGORY MODULE)
   set(multi_value_args STRINGS)
   cmake_parse_arguments(
     HPX_OPTION "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN}
@@ -66,6 +66,13 @@ function(hpx_option option type description default)
         FATAL_ERROR "hpx_option(): STRINGS can only be used if type is STRING !"
       )
     endif()
+  endif()
+
+  if(HPX_OPTION_MODULE)
+    string(TOUPPER HPX_MODULE_CONFIG_${HPX_OPTION_MODULE} varname_uc)
+    set_property(GLOBAL APPEND PROPERTY ${varname_uc} ${option})
+  else()
+    set_property(GLOBAL APPEND PROPERTY HPX_MODULE_CONFIG_HPX ${option})
   endif()
 
   set(_category "Generic")

--- a/cmake/HPX_PrintSummary.cmake
+++ b/cmake/HPX_PrintSummary.cmake
@@ -28,7 +28,9 @@ function(create_configuration_summary message module_name)
     list(REMOVE_DUPLICATES DEFINITIONS_VARS)
   endif()
 
-  get_cmake_property(_variableNames CACHE_VARIABLES)
+  get_property(
+    _variableNames GLOBAL PROPERTY HPX_MODULE_CONFIG_${module_name_uc}
+  )
   foreach(_variableName ${_variableNames})
     if(${_variableName}Category)
 

--- a/cmake/installed_hpx.cmake
+++ b/cmake/installed_hpx.cmake
@@ -121,7 +121,9 @@ if(HPX_WITH_TESTS)
       hpx_option(
         HPX_${lib_upper}_WITH_TESTS BOOL
         "Build HPX ${name} module tests. (default: ${HPX_WITH_TESTS})"
-        ${HPX_WITH_TESTS} ADVANCED CATEGORY "Modules"
+        ${HPX_WITH_TESTS} ADVANCED
+        CATEGORY "Modules"
+        MODULE ${lib_upper}
       )
       add_subdirectory(libs/${lib}/tests)
     endif()

--- a/libs/datastructures/CMakeLists.txt
+++ b/libs/datastructures/CMakeLists.txt
@@ -10,7 +10,9 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 hpx_option(
   HPX_DATASTRUCTURES_WITH_ADAPT_STD_TUPLE BOOL
   "Enable compatibility of hpx::util::tuple with std::tuple. (default: ON)" ON
-  ADVANCED CATEGORY "Modules"
+  ADVANCED
+  CATEGORY "Modules"
+  MODULE DATASTRUCTURES
 )
 
 if(HPX_DATASTRUCTURES_WITH_ADAPT_STD_TUPLE)

--- a/libs/serialization/CMakeLists.txt
+++ b/libs/serialization/CMakeLists.txt
@@ -13,6 +13,7 @@ hpx_option(
   HPX_SERIALIZATION_WITH_BOOST_TYPES BOOL
   "Enable serialization of certain Boost types. (default: ON)" ON ADVANCED
   CATEGORY "Modules"
+  MODULE SERIALIZATION
 )
 
 if(HPX_SERIALIZATION_WITH_BOOST_TYPES)


### PR DESCRIPTION
Fixes #4758 

As it turns out, CMake profiling reports only data for the configure step (not for the generation step). For this reason, the change proposed here improves only the configure step by reducing the amount of time required to create the configuration summary for each module. See here for the new trace:

![image](https://user-images.githubusercontent.com/568063/84822516-69293780-afe2-11ea-91da-34350db8a69b.png)

which demonstrates the reduction nicely (if compared to #4758).

Overall timing: the configure step went down from 49s to 28s for me.