### PR TITLE
Force some tests to run serially

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1356,6 +1356,14 @@ hpx_option(
   CATEGORY "Debugging" ADVANCED
 )
 
+hpx_option(
+  HPX_WITH_PARALLEL_TESTS_BIND_NONE
+  BOOL
+  "Pass --hpx:bind=none to tests that may run in parallel (cmake -j flag) (default: OFF)"
+  OFF
+  CATEGORY "Debugging" ADVANCED
+)
+
 # If APEX is defined, the action timers need thread debug info.
 if(HPX_WITH_APEX)
   hpx_add_config_define(HPX_HAVE_THREAD_DESCRIPTION)

--- a/cmake/HPX_AddCompileTest.cmake
+++ b/cmake/HPX_AddCompileTest.cmake
@@ -41,6 +41,8 @@ function(add_hpx_compile_test category name)
     set_tests_properties("${category}.${name}" PROPERTIES WILL_FAIL TRUE)
   endif()
 
+  set_tests_properties("${category}.${name}" PROPERTIES RUN_SERIAL TRUE)
+
 endfunction(add_hpx_compile_test)
 
 function(add_hpx_compile_test_target_dependencies category name)

--- a/cmake/HPX_AddTest.cmake
+++ b/cmake/HPX_AddTest.cmake
@@ -5,7 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 function(add_hpx_test category name)
-  set(options FAILURE_EXPECTED)
+  set(options FAILURE_EXPECTED RUN_SERIAL)
   set(one_value_args EXECUTABLE LOCALITIES THREADS_PER_LOCALITY)
   set(multi_value_args ARGS PARCELPORTS)
   cmake_parse_arguments(
@@ -43,6 +43,15 @@ function(add_hpx_test category name)
     set(expected "1")
   endif()
 
+  if(${name}_RUN_SERIAL)
+    set(run_serial TRUE)
+  endif()
+
+  # If --hpx:threads=cores or all
+  if(${name}_THREADS_PER_LOCALITY LESS_EQUAL 0)
+    set(run_serial TRUE)
+  endif()
+
   set(args)
 
   foreach(arg ${${name}_UNPARSED_ARGUMENTS})
@@ -53,6 +62,13 @@ function(add_hpx_test category name)
     set(args ${args}
              "--hpx:debug-hpx-log=${HPX_WITH_TESTS_DEBUG_LOG_DESTINATION}"
     )
+  endif()
+
+  if(${HPX_WITH_PARALLEL_TESTS_BIND_NONE}
+     AND NOT run_serial
+     AND ${name}_LOCALITIES STREQUAL "1"
+  )
+    set(args ${args} "--hpx:bind=none")
   endif()
 
   if(HPX_WITH_INSTALLED_VERSION)
@@ -78,7 +94,11 @@ function(add_hpx_test category name)
   endif()
 
   if(${name}_LOCALITIES STREQUAL "1")
+    set(_full_name "${category}.${name}")
     add_test(NAME "${category}.${name}" COMMAND ${cmd} ${args})
+    if(${run_serial})
+      set_tests_properties("${_full_name}" PROPERTIES RUN_SERIAL TRUE)
+    endif()
   else()
     if(HPX_WITH_PARCELPORT_VERBS)
       set(_add_test FALSE)
@@ -92,26 +112,12 @@ function(add_hpx_test category name)
         set(_add_test TRUE)
       endif()
       if(_add_test)
-        add_test(NAME "${category}.distributed.verbs.${name}"
-                 COMMAND ${cmd} "-p" "verbs" ${args}
+        set(_full_name "${category}.distributed.verbs.${name}")
+        add_test(NAME "${_full_name}"
+                 COMMAND ${cmd} "-p" "verbs" ${args} set_tests_properties
+                         ("${_full_name}" PROPERTIES RUN_SERIAL TRUE)
         )
-      endif()
-    endif()
-    if(HPX_WITH_PARCELPORT_IPC)
-      set(_add_test FALSE)
-      if(DEFINED ${name}_PARCELPORTS)
-        set(PP_FOUND -1)
-        list(FIND ${name}_PARCELPORTS "ipc" PP_FOUND)
-        if(NOT PP_FOUND EQUAL -1)
-          set(_add_test TRUE)
-        endif()
-      else()
-        set(_add_test TRUE)
-      endif()
-      if(_add_test)
-        add_test(NAME "${category}.distributed.ipc.${name}"
-                 COMMAND ${cmd} "-p" "ipc" ${args}
-        )
+        set_tests_properties("${_full_name}" PROPERTIES RUN_SERIAL TRUE)
       endif()
     endif()
     if(HPX_WITH_PARCELPORT_MPI)
@@ -126,9 +132,11 @@ function(add_hpx_test category name)
         set(_add_test TRUE)
       endif()
       if(_add_test)
-        add_test(NAME "${category}.distributed.mpi.${name}"
-                 COMMAND ${cmd} "-p" "mpi" "-r" "mpi" ${args}
+        set(_full_name "${category}.distributed.mpi.${name}")
+        add_test(NAME "${_full_name}" COMMAND ${cmd} "-p" "mpi" "-r" "mpi"
+                                              ${args}
         )
+        set_tests_properties("${_full_name}" PROPERTIES RUN_SERIAL TRUE)
       endif()
     endif()
     if(HPX_WITH_PARCELPORT_TCP)
@@ -143,9 +151,9 @@ function(add_hpx_test category name)
         set(_add_test TRUE)
       endif()
       if(_add_test)
-        add_test(NAME "${category}.distributed.tcp.${name}"
-                 COMMAND ${cmd} "-p" "tcp" ${args}
-        )
+        set(_full_name "${category}.distributed.tcp.${name}")
+        add_test(NAME "${_full_name}" COMMAND ${cmd} "-p" "tcp" ${args})
+        set_tests_properties("${_full_name}" PROPERTIES RUN_SERIAL TRUE)
       endif()
     endif()
   endif()
@@ -199,7 +207,9 @@ function(add_hpx_regression_test subcategory name)
 endfunction(add_hpx_regression_test)
 
 function(add_hpx_performance_test subcategory name)
-  add_test_and_deps_test("performance" "${subcategory}" ${name} ${ARGN})
+  add_test_and_deps_test(
+    "performance" "${subcategory}" ${name} ${ARGN} RUN_SERIAL
+  )
 endfunction(add_hpx_performance_test)
 
 function(add_hpx_example_test subcategory name)

--- a/examples/transpose/CMakeLists.txt
+++ b/examples/transpose/CMakeLists.txt
@@ -26,6 +26,7 @@ set(transpose_smp_block_PARAMETERS THREADS_PER_LOCALITY 4)
 set(transpose_block_PARAMETERS THREADS_PER_LOCALITY 4)
 set(transpose_block_numa_PARAMETERS
     THREADS_PER_LOCALITY 4 "--transpose-threads=4" "--transpose-numa-domains=1"
+    RUN_SERIAL
 )
 
 foreach(example_program ${example_programs})

--- a/libs/compute/tests/regressions/CMakeLists.txt
+++ b/libs/compute/tests/regressions/CMakeLists.txt
@@ -7,7 +7,7 @@
 set(tests for_each_value_proxy parallel_fill_4132)
 
 set(for_each_value_proxy_PARAMETERS THREADS_PER_LOCALITY 4)
-set(parallel_fill_4132_PARAMETERS THREADS_PER_LOCALITY 4)
+set(parallel_fill_4132_PARAMETERS THREADS_PER_LOCALITY 4 RUN_SERIAL)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/futures/tests/regressions/future_timed_wait_1025.cpp
+++ b/libs/futures/tests/regressions/future_timed_wait_1025.cpp
@@ -54,9 +54,9 @@ void test_wait_for()
 
     HPX_TEST(thread.joinable());
 
-    hpx::this_thread::sleep_for(std::chrono::seconds(10));
+    hpx::this_thread::sleep_for(std::chrono::seconds(5));
     promise.set_value(42);
-    hpx::this_thread::sleep_for(std::chrono::seconds(10));
+    hpx::this_thread::sleep_for(std::chrono::seconds(5));
 
     hpx::threads::thread_state thread_state =
         hpx::threads::get_thread_state(thread.native_handle());
@@ -78,9 +78,9 @@ void test_wait_until()
 
     HPX_TEST(thread.joinable());
 
-    hpx::this_thread::sleep_for(std::chrono::seconds(10));
+    hpx::this_thread::sleep_for(std::chrono::seconds(5));
     promise.set_value(42);
-    hpx::this_thread::sleep_for(std::chrono::seconds(10));
+    hpx::this_thread::sleep_for(std::chrono::seconds(5));
 
     hpx::threads::thread_state thread_state =
         hpx::threads::get_thread_state(thread.native_handle());

--- a/libs/synchronization/tests/performance/channel_mpmc_throughput.cpp
+++ b/libs/synchronization/tests/performance/channel_mpmc_throughput.cpp
@@ -28,7 +28,11 @@ struct data
     int data_[8];
 };
 
+#if HPX_DEBUG
+constexpr int NUM_TESTS = 1000000;
+#else
 constexpr int NUM_TESTS = 100000000;
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 inline data channel_get(hpx::lcos::local::channel_mpmc<data> const& c)

--- a/libs/synchronization/tests/performance/channel_mpsc_throughput.cpp
+++ b/libs/synchronization/tests/performance/channel_mpsc_throughput.cpp
@@ -28,7 +28,11 @@ struct data
     int data_[8];
 };
 
+#if HPX_DEBUG
+constexpr int NUM_TESTS = 1000000;
+#else
 constexpr int NUM_TESTS = 100000000;
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 inline data channel_get(hpx::lcos::local::channel_mpsc<data> const& c)

--- a/libs/synchronization/tests/performance/channel_spsc_throughput.cpp
+++ b/libs/synchronization/tests/performance/channel_spsc_throughput.cpp
@@ -28,7 +28,11 @@ struct data
     int data_[8];
 };
 
+#if HPX_DEBUG
+constexpr int NUM_TESTS = 1000000;
+#else
 constexpr int NUM_TESTS = 100000000;
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 inline data channel_get(hpx::lcos::local::channel_spsc<data> const& c)

--- a/tests/unit/component/CMakeLists.txt
+++ b/tests/unit/component/CMakeLists.txt
@@ -104,7 +104,7 @@ foreach(test ${tests})
     FOLDER ${folder_name}
   )
 
-  add_hpx_unit_test("component" ${test} ${${test}_PARAMETERS})
+  add_hpx_unit_test("component" ${test} ${${test}_PARAMETERS} RUN_SERIAL)
 
 endforeach()
 

--- a/tests/unit/resource/suspend_pool.cpp
+++ b/tests/unit/resource/suspend_pool.cpp
@@ -53,7 +53,7 @@ int hpx_main(int argc, char* argv[])
         // Suspend and resume pool with future
         hpx::util::high_resolution_timer t;
 
-        while (t.elapsed() < 2)
+        while (t.elapsed() < 1)
         {
             std::vector<hpx::future<void>> fs;
 
@@ -76,7 +76,7 @@ int hpx_main(int argc, char* argv[])
         hpx::lcos::local::counting_semaphore sem;
         hpx::util::high_resolution_timer t;
 
-        while (t.elapsed() < 2)
+        while (t.elapsed() < 1)
         {
             std::vector<hpx::future<void>> fs;
 
@@ -104,7 +104,7 @@ int hpx_main(int argc, char* argv[])
         // Suspend pool with some threads already suspended
         hpx::util::high_resolution_timer t;
 
-        while (t.elapsed() < 2)
+        while (t.elapsed() < 1)
         {
             for (std::size_t thread_num = 0;
                  thread_num < worker_pool_threads - 1; ++thread_num)


### PR DESCRIPTION
Forces some tests to run serially if `ctest` is given the `-j` option.

I've set all distributed tests, benchmarks, and tests that request `all` or `cores` threads. I've been a bit conservative and set the compile tests to run serially as well as I've seen problems before trying to build multiple header tests concurrently.

This would allow us to run tests much more quickly on hardware that has spare resources (most tests run with 1 or 4 threads).

@haampie I'm currently running the tests to see if there are any unexpected results. The option does work as advertised, I just have to make sure I haven't missed any other tests that require running serially.