### PR TITLE
Add sized_sentinel_for concept and make distance dispatch according to that

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -3,6 +3,7 @@
 # Copyright (c) 2017 Denis Blank
 # Copyright (c) 2017 Google
 # Copyright (c) 2017 Taeguk Kwon
+# Copyright (c) 2020 Giannis Gonidelis
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -446,10 +447,10 @@ function(hpx_check_for_cxx20_coroutines)
 endfunction()
 
 # ##############################################################################
-function(hpx_check_for_cxx20_disable_sized_sentinel_for)
+function(hpx_check_for_cxx20_std_disable_sized_sentinel_for)
   add_hpx_config_test(
-    HPX_WITH_CXX20_DISABLE_SIZED_SENTINEL_FOR SOURCE cmake/tests/cxx20_disable_sized_sentinel_for.cpp FILE
-                                     ${ARGN}
+    HPX_WITH_CXX20_STD_DISABLE_SIZED_SENTINEL_FOR
+    SOURCE cmake/tests/cxx20_std_disable_sized_sentinel_for.cpp FILE ${ARGN}
   )
 endfunction()
 

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -446,6 +446,14 @@ function(hpx_check_for_cxx20_coroutines)
 endfunction()
 
 # ##############################################################################
+function(hpx_check_for_cxx20_disable_sized_sentinel_for)
+  add_hpx_config_test(
+    HPX_WITH_CXX20_DISABLE_SIZED_SENTINEL_FOR SOURCE cmake/tests/cxx20_disable_sized_sentinel_for.cpp FILE
+                                     ${ARGN}
+  )
+endfunction()
+
+# ##############################################################################
 function(hpx_check_for_builtin_integer_pack)
   add_hpx_config_test(
     HPX_WITH_BUILTIN_INTEGER_PACK SOURCE cmake/tests/builtin_integer_pack.cpp

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -2,6 +2,7 @@
 # Copyright (c) 2011-2014 Thomas Heller
 # Copyright (c) 2013-2016 Agustin Berge
 # Copyright (c)      2017 Taeguk Kwon
+# Copyright (c)      2020 Giannis Gonidelis
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -74,7 +75,9 @@ function(hpx_perform_cxx_feature_tests)
   # C++20 feature tests
   hpx_check_for_cxx20_coroutines(DEFINITIONS HPX_HAVE_CXX20_COROUTINES)
 
-  hpx_check_for_cxx20_disable_sized_sentinel_for(DEFINITIONS HPX_HAVE_CXX20_DISABLE_SIZED_SENTINEL_FOR)
+  hpx_check_for_cxx20_std_disable_sized_sentinel_for(
+    DEFINITIONS HPX_HAVE_CXX20_STD_DISABLE_SIZED_SENTINEL_FOR
+  )
 
   # Check the availability of certain C++ builtins
   hpx_check_for_builtin_integer_pack(DEFINITIONS HPX_HAVE_BUILTIN_INTEGER_PACK)

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -74,6 +74,8 @@ function(hpx_perform_cxx_feature_tests)
   # C++20 feature tests
   hpx_check_for_cxx20_coroutines(DEFINITIONS HPX_HAVE_CXX20_COROUTINES)
 
+  hpx_check_for_cxx20_disable_sized_sentinel_for(DEFINITIONS HPX_HAVE_CXX20_DISABLE_SIZED_SENTINEL_FOR)
+
   # Check the availability of certain C++ builtins
   hpx_check_for_builtin_integer_pack(DEFINITIONS HPX_HAVE_BUILTIN_INTEGER_PACK)
 

--- a/cmake/tests/cxx20_disable_sized_sentinel_for.cpp
+++ b/cmake/tests/cxx20_disable_sized_sentinel_for.cpp
@@ -1,0 +1,16 @@
+////////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2020 Giannis Gonidelis
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+////////////////////////////////////////////////////////////////////////////////
+
+#include <iterator>
+
+int main()
+{
+    inline constexpr bool b = std::disable_sized_sentinel_for<void, void>;
+
+    return 0;
+}

--- a/cmake/tests/cxx20_std_disable_sized_sentinel_for.cpp
+++ b/cmake/tests/cxx20_std_disable_sized_sentinel_for.cpp
@@ -10,7 +10,8 @@
 
 int main()
 {
-    inline constexpr bool b = std::disable_sized_sentinel_for<void, void>;
+    constexpr bool b = std::disable_sized_sentinel_for<void, void>;
+    (void) b;
 
     return 0;
 }

--- a/libs/algorithms/include/hpx/parallel/algorithms/detail/distance.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/detail/distance.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/iterator_support/traits/is_sentinel_for.hpp>
 
 #include <iterator>
 
@@ -14,7 +15,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     // provide implementation of std::distance supporting iterators/sentinels
     template <typename InIterB, typename InIterE>
     constexpr inline typename std::iterator_traits<InIterB>::difference_type
-    distance(InIterB first, InIterE last, std::input_iterator_tag)
+    distance(InIterB first, InIterE last, std::false_type)
     {
         typename std::iterator_traits<InIterB>::difference_type offset = 0;
         for (/**/; first != last; ++first)
@@ -26,7 +27,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
     template <typename RanIterB, typename RanIterE>
     constexpr inline typename std::iterator_traits<RanIterB>::difference_type
-    distance(RanIterB first, RanIterE last, std::random_access_iterator_tag)
+    distance(RanIterB first, RanIterE last, std::true_type)
     {
         return last - first;
     }
@@ -36,6 +37,6 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     distance(InIterB first, InIterE last)
     {
         return distance(first, last,
-            typename std::iterator_traits<InIterB>::iterator_category{});
+            typename hpx::traits::is_sized_sentinel_for<InIterE, InIterB>::type{});
     }
 }}}}    // namespace hpx::parallel::v1::detail

--- a/libs/algorithms/include/hpx/parallel/algorithms/detail/distance.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/detail/distance.hpp
@@ -10,6 +10,7 @@
 #include <hpx/iterator_support/traits/is_sentinel_for.hpp>
 
 #include <iterator>
+#include <type_traits>
 
 namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     // provide implementation of std::distance supporting iterators/sentinels
@@ -37,6 +38,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     distance(InIterB first, InIterE last)
     {
         return distance(first, last,
-            typename hpx::traits::is_sized_sentinel_for<InIterE, InIterB>::type{});
+            typename hpx::traits::is_sized_sentinel_for<InIterE,
+                InIterB>::type{});
     }
 }}}}    // namespace hpx::parallel::v1::detail

--- a/libs/algorithms/tests/unit/algorithms/CMakeLists.txt
+++ b/libs/algorithms/tests/unit/algorithms/CMakeLists.txt
@@ -26,6 +26,7 @@ set(tests
     countif
     destroy
     destroyn
+    distance
     equal
     equal_binary
     exclusive_scan

--- a/libs/algorithms/tests/unit/algorithms/distance.cpp
+++ b/libs/algorithms/tests/unit/algorithms/distance.cpp
@@ -7,6 +7,8 @@
 #include <hpx/modules/testing.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 
+#include <cstdint>
+
 #include "iter_sent.hpp"
 
 int main(int argc, char* argv[])

--- a/libs/algorithms/tests/unit/algorithms/distance.cpp
+++ b/libs/algorithms/tests/unit/algorithms/distance.cpp
@@ -1,0 +1,19 @@
+//  Copyright (c) 2020 Giannis Gonidelis
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/algorithms/detail/distance.hpp>
+
+#include "iter_sent.hpp"
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::parallel::v1::detail::distance(
+                    Iterator<std::int64_t>{0}, Sentinel<int64_t>{100}),
+        100);
+
+    return hpx::util::report_errors();
+}

--- a/libs/algorithms/tests/unit/algorithms/iter_sent.hpp
+++ b/libs/algorithms/tests/unit/algorithms/iter_sent.hpp
@@ -1,0 +1,157 @@
+//  Copyright (c) 2019 Austin McCartney
+//  Copyright (c) 2019 Hartmut Kaiser
+//  Copyright (c) 2019 Piotr Mikolajczyk
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <cstddef>
+#include <iterator>
+
+template <typename ValueType>
+struct Sentinel
+{
+    explicit Sentinel(ValueType stop_value)
+      : stop(stop_value)
+    {
+    }
+
+    ValueType get_stop() const
+    {
+        return this->stop;
+    }
+
+private:
+    ValueType stop;
+};
+
+template <typename Value>
+struct Iterator
+{
+    using difference_type = std::ptrdiff_t;
+    using value_type = Value;
+    using iterator_category = std::forward_iterator_tag;
+    using pointer = Value const*;
+    using reference = Value const&;
+
+    explicit Iterator(Value initialState)
+      : state(initialState)
+    {
+    }
+
+    virtual Value operator*() const
+    {
+        return this->state;
+    }
+
+    virtual Value operator->() const = delete;
+
+    Iterator& operator++()
+    {
+        ++(this->state);
+        return *this;
+    }
+
+    Iterator operator++(int)
+    {
+        auto copy = *this;
+        ++(*this);
+        return copy;
+    }
+
+    Iterator& operator--()
+    {
+        --(this->state);
+        return *this;
+    }
+
+    Iterator operator--(int)
+    {
+        auto copy = *this;
+        --(*this);
+        return copy;
+    }
+
+    virtual Value operator[](difference_type n) const
+    {
+        return this->state + n;
+    }
+
+    Iterator& operator+=(difference_type n)
+    {
+        this->state += n;
+        return *this;
+    }
+
+    Iterator operator+(difference_type n) const
+    {
+        Iterator copy = *this;
+        return copy += n;
+    }
+
+    Iterator& operator-=(difference_type n)
+    {
+        this->state -= n;
+        return *this;
+    }
+
+    Iterator operator-(difference_type n) const
+    {
+        Iterator copy = *this;
+        return copy -= n;
+    }
+
+    bool operator==(const Iterator& that) const
+    {
+        return this->state == that.state;
+    }
+
+    friend bool operator==(Iterator i, Sentinel<Value> s)
+    {
+        return i.state == s.get_stop();
+    }
+    friend bool operator==(Sentinel<Value> s, Iterator i)
+    {
+        return i.state == s.get_stop();
+    }
+
+    bool operator!=(const Iterator& that) const
+    {
+        return this->state != that.state;
+    }
+
+    friend bool operator!=(Iterator i, Sentinel<Value> s)
+    {
+        return i.state != s.get_stop();
+    }
+    friend bool operator!=(Sentinel<Value> s, Iterator i)
+    {
+        return i.state != s.get_stop();
+    }
+
+    bool operator<(const Iterator& that) const
+    {
+        return this->state < that.state;
+    }
+
+    bool operator<=(const Iterator& that) const
+    {
+        return this->state <= that.state;
+    }
+
+    bool operator>(const Iterator& that) const
+    {
+        return this->state > that.state;
+    }
+
+    bool operator>=(const Iterator& that) const
+    {
+        return this->state >= that.state;
+    }
+
+protected:
+    Value state;
+};

--- a/libs/iterator_support/include/hpx/iterator_support/traits/is_sentinel_for.hpp
+++ b/libs/iterator_support/include/hpx/iterator_support/traits/is_sentinel_for.hpp
@@ -36,28 +36,27 @@ namespace hpx { namespace traits {
     {
     };
 
-#if defined(HPX_HAVE_CXX20_DISABLE_SIZED_SENTINEL_FOR)
+#if defined(HPX_HAVE_CXX20_STD_DISABLE_SIZED_SENTINEL_FOR)
     template <typename Sent, typename Iter>
-    constexpr bool disable_sized_sentinel_for =
+    inline constexpr bool disable_sized_sentinel_for =
         std::disable_sized_sentinel_for<Sent, Iter>;
 #else
     template <typename Sent, typename Iter>
-    constexpr bool disable_sized_sentinel_for = false;
+    HPX_INLINE_CONSTEXPR_VARIABLE bool disable_sized_sentinel_for = false;
 #endif
 
     template <typename Sent, typename Iter, typename Enable = void>
-    struct sized_sentinel_for : std::false_type
+    struct is_sized_sentinel_for : std::false_type
     {
     };
 
     template <typename Sent, typename Iter>
-    struct sized_sentinel_for<Sent, Iter,
+    struct is_sized_sentinel_for<Sent, Iter,
         typename util::always_void<
-            typename hpx::traits::is_sentinel_for<Sent, Iter>::type,
-
-            // add remove_cv_t<> constraint
-            typename std::enable_if<!disable_sized_sentinel_for<Sent, Iter>>::type,
-
+            typename std::enable_if<
+                hpx::traits::is_sentinel_for<Sent, Iter>::value &&
+                !disable_sized_sentinel_for<typename remove_cv<Sent>::type,
+                    typename remove_cv<Iter>::type>>::type,
             typename detail::subtraction_result<Iter, Sent>::type,
             typename detail::subtraction_result<Sent, Iter>::type>::type>
       : std::true_type

--- a/libs/iterator_support/include/hpx/iterator_support/traits/is_sentinel_for.hpp
+++ b/libs/iterator_support/include/hpx/iterator_support/traits/is_sentinel_for.hpp
@@ -36,6 +36,15 @@ namespace hpx { namespace traits {
     {
     };
 
+#if defined(HPX_HAVE_CXX20_DISABLE_SIZED_SENTINEL_FOR)
+    template <typename Sent, typename Iter>
+    constexpr bool disable_sized_sentinel_for =
+        std::disable_sized_sentinel_for<Sent, Iter>;
+#else
+    template <typename Sent, typename Iter>
+    constexpr bool disable_sized_sentinel_for = false;
+#endif
+
     template <typename Sent, typename Iter, typename Enable = void>
     struct sized_sentinel_for : std::false_type
     {
@@ -45,9 +54,13 @@ namespace hpx { namespace traits {
     struct sized_sentinel_for<Sent, Iter,
         typename util::always_void<
             typename hpx::traits::is_sentinel_for<Sent, Iter>::type,
-            //disable_sized_sentinel_for goes here,
+
+            // add remove_cv_t<> constraint
+            typename std::enable_if<!disable_sized_sentinel_for<Sent, Iter>>::type,
+
             typename detail::subtraction_result<Iter, Sent>::type,
-            typename detail::subtraction_result<Sent, Iter>::type>::type> : std::true_type
+            typename detail::subtraction_result<Sent, Iter>::type>::type>
+      : std::true_type
     {
     };
 

--- a/libs/iterator_support/include/hpx/iterator_support/traits/is_sentinel_for.hpp
+++ b/libs/iterator_support/include/hpx/iterator_support/traits/is_sentinel_for.hpp
@@ -35,4 +35,20 @@ namespace hpx { namespace traits {
       : std::true_type
     {
     };
+
+    template <typename Sent, typename Iter, typename Enable = void>
+    struct sized_sentinel_for : std::false_type
+    {
+    };
+
+    template <typename Sent, typename Iter>
+    struct sized_sentinel_for<Sent, Iter,
+        typename util::always_void<
+            typename hpx::traits::is_sentinel_for<Sent, Iter>::type,
+            //disable_sized_sentinel_for goes here,
+            typename detail::subtraction_result<Iter, Sent>::type,
+            typename detail::subtraction_result<Sent, Iter>::type>::type> : std::true_type
+    {
+    };
+
 }}    // namespace hpx::traits

--- a/libs/iterator_support/include/hpx/iterator_support/traits/is_sentinel_for.hpp
+++ b/libs/iterator_support/include/hpx/iterator_support/traits/is_sentinel_for.hpp
@@ -55,8 +55,8 @@ namespace hpx { namespace traits {
         typename util::always_void<
             typename std::enable_if<
                 hpx::traits::is_sentinel_for<Sent, Iter>::value &&
-                !disable_sized_sentinel_for<typename remove_cv<Sent>::type,
-                    typename remove_cv<Iter>::type>>::type,
+                !disable_sized_sentinel_for<typename std::remove_cv<Sent>::type,
+                    typename std::remove_cv<Iter>::type>>::type,
             typename detail::subtraction_result<Iter, Sent>::type,
             typename detail::subtraction_result<Sent, Iter>::type>::type>
       : std::true_type

--- a/libs/iterator_support/tests/unit/CMakeLists.txt
+++ b/libs/iterator_support/tests/unit/CMakeLists.txt
@@ -16,6 +16,7 @@ set(tests
     transform_iterator2
     zip_iterator
     is_sentinel_for
+    is_sized_sentinel_for
 )
 
 # Set the dependencies of each test

--- a/libs/iterator_support/tests/unit/is_sized_sentinel_for.cpp
+++ b/libs/iterator_support/tests/unit/is_sized_sentinel_for.cpp
@@ -1,0 +1,43 @@
+//  Copyright (c) 2020 Giannis Gonidelis
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/iterator_support/traits/is_sentinel_for.hpp>
+#include <hpx/modules/testing.hpp>
+#include "iter_sent.hpp"
+
+#include <cstdint>
+#include <iterator>
+#include <string>
+#include <vector>
+
+void is_sized_sentinel_for()
+{
+    HPX_TEST_MSG((hpx::traits::is_sized_sentinel_for<Sentinel<int64_t>,
+                      Iterator<std::int64_t>>::value == false),
+        "Sentinel falsely marked as sized for particular iterator");
+
+    HPX_TEST_MSG((hpx::traits::is_sized_sentinel_for<std::vector<int>::iterator,
+                      std::vector<int>::iterator>::value == true),
+        "Begin end iterator (vector) pair should be sized");
+
+    HPX_TEST_MSG((hpx::traits::is_sized_sentinel_for<std::string::iterator,
+                      std::string::iterator>::value == true),
+        "Begin end iterator (string) pair should be sized");
+
+    HPX_TEST_MSG((hpx::traits::is_sized_sentinel_for<std::int64_t,
+                      std::vector<int>::iterator>::value == false),
+        "Integer is not a sized sentinel for a vector iterator");
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    {
+        is_sized_sentinel_for();
+    }
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
# Fixes 

- Added `sized_sentinel_for` on `is_sentinel_for.hpp`
- Added the `disable_sized_sentinel_for` feature check
- Adjusted `hpx::parallel::v1::detail::distance()` in order to decide for the type dispatching according to `sized_sentinel_for`
- Added test for the adapted `distance` implementation

## To do

  - [x] Add unit tests for `sized_sentinel_for`
  - [x] Add `remove_cv_t` trait on `disable_sized_sentinel_for` inside the `sized_sentinel_for` implementation (for some reason it would not compile when I add it)
  - [ ] Please inform me if there needs to be a test for `disable_sized_sentinel_for`
  - [x] Please inform me whether the test for `distance` is under the correct directory (`distance.hpp` lies on `algorithms/detail`)
