### PR TITLE
Fix compilation with HPX_WITH_NETWORKING=OFF

### DIFF
--- a/hpx/runtime/components/server/runtime_support.hpp
+++ b/hpx/runtime/components/server/runtime_support.hpp
@@ -202,7 +202,9 @@ namespace hpx { namespace components { namespace server
         HPX_DEFINE_COMPONENT_ACTION(runtime_support, create_performance_counter);
         HPX_DEFINE_COMPONENT_ACTION(runtime_support, remove_from_connection_cache);
 
+#if defined(HPX_HAVE_NETWORKING)
         HPX_DEFINE_COMPONENT_ACTION(runtime_support, dijkstra_termination);
+#endif
 
         ///////////////////////////////////////////////////////////////////////
         /// \brief Start the runtime_support component
@@ -556,8 +558,10 @@ HPX_ACTION_USES_MEDIUM_STACK(
     hpx::components::server::runtime_support::shutdown_all_action)
 HPX_ACTION_USES_MEDIUM_STACK(
     hpx::components::server::runtime_support::create_performance_counter_action)
+#if defined(HPX_HAVE_NETWORKING)
 HPX_ACTION_USES_MEDIUM_STACK(
     hpx::components::server::runtime_support::dijkstra_termination_action)
+#endif
 
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::components::server::runtime_support::load_components_action,
@@ -592,9 +596,11 @@ HPX_REGISTER_ACTION_DECLARATION(
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::components::server::runtime_support::remove_from_connection_cache_action,
     remove_from_connection_cache_action)
+#if defined(HPX_HAVE_NETWORKING)
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::components::server::runtime_support::dijkstra_termination_action,
     dijkstra_termination_action)
+#endif
 
 namespace hpx { namespace components { namespace server
 {
@@ -686,7 +692,7 @@ namespace hpx { namespace traits
 {
     ///////////////////////////////////////////////////////////////////////////
     // Termination detection does not make this locality black
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#if !defined(HPX_COMPUTE_DEVICE_CODE) && defined(HPX_HAVE_NETWORKING)
     template <>
     struct action_does_termination_detection<
         hpx::components::server::runtime_support::dijkstra_termination_action>

--- a/libs/collectives/tests/unit/CMakeLists.txt
+++ b/libs/collectives/tests/unit/CMakeLists.txt
@@ -9,31 +9,19 @@ set(tests
     all_reduce
     all_to_all
     barrier
-    broadcast
     broadcast_direct
     broadcast_apply
     broadcast_component
     fold
     gather
-    global_spmd_block
     reduce
     remote_latch
-    scatter
+    global_spmd_block
 )
 
-set(all_gather_PARAMETERS LOCALITIES 2)
-set(all_reduce_PARAMETERS LOCALITIES 2)
-set(all_to_all_PARAMETERS LOCALITIES 2)
-set(broadcast_PARAMETERS LOCALITIES 2)
-set(broadcast_direct_PARAMETERS LOCALITIES 2)
-set(broadcast_apply_PARAMETERS LOCALITIES 2)
-set(broadcast_component_PARAMETERS LOCALITIES 2)
-set(gather_PARAMETERS LOCALITIES 2)
-set(remote_latch_PARAMETERS LOCALITIES 2)
-set(reduce_PARAMETERS LOCALITIES 2)
-set(scatter_PARAMETERS LOCALITIES 2)
-
-set(global_spmd_block_PARAMETERS LOCALITIES 2)
+if(HPX_HAVE_NETWORKING)
+  set(tests ${tests} broadcast scatter)
+endif()
 
 foreach(test ${tests})
   set(sources ${test}.cpp)
@@ -49,5 +37,7 @@ foreach(test ${tests})
     FOLDER "Tests/Unit/Modules/Collectives"
   )
 
-  add_hpx_unit_test("modules.collectives" ${test} ${${test}_PARAMETERS})
+  add_hpx_unit_test(
+    "modules.collectives" ${test} ${${test}_PARAMETERS} LOCALITIES 2
+  )
 endforeach()

--- a/libs/collectives/tests/unit/all_gather.cpp
+++ b/libs/collectives/tests/unit/all_gather.cpp
@@ -22,7 +22,6 @@ constexpr char const* all_gather_direct_basename = "/test/all_gather_direct/";
 int hpx_main(int argc, char* argv[])
 {
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
-    HPX_TEST(num_localities >= 2);
 
     // test functionality based on future<> of local result
     for (int i = 0; i != 10; ++i)

--- a/libs/collectives/tests/unit/all_reduce.cpp
+++ b/libs/collectives/tests/unit/all_reduce.cpp
@@ -22,7 +22,6 @@ constexpr char const* all_reduce_direct_basename = "/test/all_reduce_direct/";
 int hpx_main(int argc, char* argv[])
 {
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
-    HPX_TEST(num_localities >= 2);
 
     // test functionality based on future<> of local result
     for (int i = 0; i != 10; ++i)

--- a/libs/collectives/tests/unit/all_to_all.cpp
+++ b/libs/collectives/tests/unit/all_to_all.cpp
@@ -24,7 +24,6 @@ int hpx_main(int argc, char* argv[])
 {
     std::uint32_t this_locality = hpx::get_locality_id();
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
-    HPX_TEST(num_localities >= 2);
 
     // test functionality based on future<> of local result
     for (int i = 0; i != 10; ++i)

--- a/libs/collectives/tests/unit/broadcast.cpp
+++ b/libs/collectives/tests/unit/broadcast.cpp
@@ -22,7 +22,7 @@ constexpr char const* broadcast_direct_basename = "/test/broadcast_direct/";
 int hpx_main(int argc, char* argv[])
 {
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
-    HPX_TEST(num_localities >= 2);
+    HPX_TEST_LTE(2, num_localities);
 
     // test functionality based on future<> of local result
     for (std::uint32_t i = 0; i != 10; ++i)

--- a/libs/collectives/tests/unit/gather.cpp
+++ b/libs/collectives/tests/unit/gather.cpp
@@ -23,7 +23,6 @@ constexpr char const* gather_direct_basename = "/test/gather_direct/";
 int hpx_main(int argc, char* argv[])
 {
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
-    HPX_TEST(num_localities >= 2);
 
     std::uint32_t this_locality = hpx::get_locality_id();
 

--- a/libs/collectives/tests/unit/scatter.cpp
+++ b/libs/collectives/tests/unit/scatter.cpp
@@ -23,7 +23,7 @@ constexpr char const* scatter_direct_basename = "/test/scatter_direct/";
 int hpx_main(int argc, char* argv[])
 {
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
-    HPX_TEST(num_localities >= 2);
+    HPX_TEST_LTE(2, num_localities);
 
     std::uint32_t this_locality = hpx::get_locality_id();
 

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -120,10 +120,12 @@ HPX_REGISTER_ACTION_ID(
     hpx::components::server::runtime_support::remove_from_connection_cache_action,
     remove_from_connection_cache_action,
     hpx::actions::remove_from_connection_cache_action_id)
+#if defined(HPX_HAVE_NETWORKING)
 HPX_REGISTER_ACTION_ID(
     hpx::components::server::runtime_support::dijkstra_termination_action,
     dijkstra_termination_action,
     hpx::actions::dijkstra_termination_action_id)
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 HPX_DEFINE_COMPONENT_NAME(hpx::components::server::runtime_support,


### PR DESCRIPTION
Fixes #4770 (at least for core, have not yet built the rest). Pycicle's `clang-oldest` now builds with `HPX_HAVE_NETWORKING=OFF` (`gcc-newest` has `HPX_WITH_DISTRIBUTED_RUNTIME=OFF` in addition, the rest are with full networking).