### PR TITLE
Make header tests parallel again

### DIFF
--- a/cmake/HPX_AddCompileTest.cmake
+++ b/cmake/HPX_AddCompileTest.cmake
@@ -41,8 +41,6 @@ function(add_hpx_compile_test category name)
     set_tests_properties("${category}.${name}" PROPERTIES WILL_FAIL TRUE)
   endif()
 
-  set_tests_properties("${category}.${name}" PROPERTIES RUN_SERIAL TRUE)
-
 endfunction(add_hpx_compile_test)
 
 function(add_hpx_compile_test_target_dependencies category name)


### PR DESCRIPTION
I did not see any test failures from running those tests in parallel