### PR TITLE
Fix hangs during assertion handling and distributed runtime construction

### DIFF
--- a/libs/runtime_local/src/runtime_handlers.cpp
+++ b/libs/runtime_local/src/runtime_handlers.cpp
@@ -32,6 +32,32 @@ namespace hpx { namespace detail {
         hpx::assertion::source_location const& loc, const char* expr,
         std::string const& msg)
     {
+        static thread_local bool handling_assertion = false;
+
+        if (handling_assertion)
+        {
+            std::ostringstream strm;
+            strm << "Trying to handle failed assertion while handling another "
+                    "failed assertion!"
+                 << std::endl;
+            strm << "Assertion '" << expr << "' failed";
+            if (!msg.empty())
+            {
+                strm << " (" << msg << ")";
+            }
+
+            strm << std::endl;
+            strm << "{file}: " << loc.file_name << std::endl;
+            strm << "{line}: " << loc.line_number << std::endl;
+            strm << "{function}: " << loc.function_name << std::endl;
+
+            std::cerr << strm.str();
+
+            std::abort();
+        }
+
+        handling_assertion = true;
+
         hpx::util::may_attach_debugger("exception");
 
         std::ostringstream strm;

--- a/src/runtime/agas/interface.cpp
+++ b/src/runtime/agas/interface.cpp
@@ -387,8 +387,8 @@ naming::id_type get_console_locality(
     error_code& ec
     )
 {
-    runtime* rt = get_runtime_ptr();
-    if (rt == nullptr || rt->get_state() == state_invalid)
+    runtime_distributed* rtd = get_runtime_distributed_ptr();
+    if (rtd == nullptr || rtd->get_state() == state_invalid)
         return naming::invalid_id;
 
     naming::gid_type console;
@@ -400,8 +400,8 @@ naming::id_type get_console_locality(
 
 std::uint32_t get_locality_id(error_code& ec)
 {
-    runtime* rt = get_runtime_ptr();
-    if (rt == nullptr || rt->get_state() == state_invalid)
+    runtime_distributed* rtd = get_runtime_distributed_ptr();
+    if (rtd == nullptr || rtd->get_state() == state_invalid)
         return naming::invalid_locality_id;
 
     naming::gid_type l = naming::get_agas_client().get_local_locality(ec);

--- a/src/runtime_distributed.cpp
+++ b/src/runtime_distributed.cpp
@@ -402,10 +402,6 @@ namespace hpx {
         // This needs to happen first
         runtime::init();
 
-        counters_ = std::make_shared<performance_counters::registry>();
-
-        LPROGRESS_;
-
         runtime_distributed*& runtime_distributed_ =
             get_runtime_distributed_ptr();
         if (nullptr == runtime_distributed_)
@@ -414,6 +410,10 @@ namespace hpx {
 
             runtime_distributed_ = this;
         }
+
+        LPROGRESS_;
+
+        counters_ = std::make_shared<performance_counters::registry>();
 
 #if defined(HPX_HAVE_NETWORKING)
         agas_client_.bootstrap(parcel_handler_, ini_);


### PR DESCRIPTION
This was triggered by passing `--hpx:debug-timing-log` to any application which would lead to trying to print runtime information before the distributed runtime was completely set up. There were three separate, but related bugs:

- Assertion handling didn't detect if an assertion fails while handling an assertion.
- The distributed runtime TSS pointer wasn't set up as early as possible in the distributed runtime constructor.
- `get_locality_id` was checking if the local runtime pointer was available, whereas it needs the distributed runtime pointer.

Maybe, just maybe, we'll have fewer hangs with this...