### PR TITLE
Move deprecation warnings from base template to template specializations for result_of etc. structs

### DIFF
--- a/libs/functional/include/hpx/functional/deferred_call.hpp
+++ b/libs/functional/include/hpx/functional/deferred_call.hpp
@@ -26,12 +26,19 @@ namespace hpx { namespace traits { namespace detail {
     struct HPX_DEPRECATED(HPX_DEPRECATED_MSG
         " Use is_deferred_invocable instead.") is_deferred_callable;
 
+#if defined(HPX_GCC_VERSION)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
     template <typename F, typename... Ts>
     struct is_deferred_callable<F(Ts...)>
       : is_invocable<typename util::decay_unwrap<F>::type,
             typename util::decay_unwrap<Ts>::type...>
     {
     };
+#if defined(HPX_GCC_VERSION)
+#pragma GCC diagnostic pop
+#endif
 
     template <typename F, typename... Ts>
     struct is_deferred_invocable
@@ -49,12 +56,19 @@ namespace hpx { namespace util {
         struct HPX_DEPRECATED(HPX_DEPRECATED_MSG
             " Use invoke_deferred_result instead.") deferred_result_of;
 
+#if defined(HPX_GCC_VERSION)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
         template <typename F, typename... Ts>
         struct deferred_result_of<F(Ts...)>
           : util::invoke_result<typename util::decay_unwrap<F>::type,
                 typename util::decay_unwrap<Ts>::type...>
         {
         };
+#if defined(HPX_GCC_VERSION)
+#pragma GCC diagnostic pop
+#endif
 
         template <typename F, typename... Ts>
         struct invoke_deferred_result

--- a/libs/functional/include/hpx/functional/invoke_fused.hpp
+++ b/libs/functional/include/hpx/functional/invoke_fused.hpp
@@ -49,12 +49,19 @@ namespace hpx { namespace util {
         struct HPX_DEPRECATED(HPX_DEPRECATED_MSG
             " Use invoke_fused_result instead.") fused_result_of;
 
+#if defined(HPX_GCC_VERSION)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
         template <typename F, typename Tuple>
         struct fused_result_of<F(Tuple)>
           : invoke_fused_result_impl<F, Tuple&&,
                 typename fused_index_pack<Tuple>::type>
         {
         };
+#if defined(HPX_GCC_VERSION)
+#pragma GCC diagnostic pop
+#endif
 
         template <typename F, typename Tuple>
         struct invoke_fused_result

--- a/libs/functional/include/hpx/functional/invoke_result.hpp
+++ b/libs/functional/include/hpx/functional/invoke_result.hpp
@@ -130,11 +130,18 @@ namespace hpx { namespace util {
     struct HPX_DEPRECATED(
         HPX_DEPRECATED_MSG " Use invoke_result instead.") result_of;
 
+#if defined(HPX_GCC_VERSION)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
     template <typename F, typename... Ts>
     struct result_of<F(Ts...)>
       : detail::invoke_result_impl<typename std::decay<F>::type, F(Ts...)>
     {
     };
+#if defined(HPX_GCC_VERSION)
+#pragma GCC diagnostic pop
+#endif
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename F, typename... Ts>

--- a/libs/functional/include/hpx/functional/traits/is_invocable.hpp
+++ b/libs/functional/include/hpx/functional/traits/is_invocable.hpp
@@ -47,10 +47,17 @@ namespace hpx { namespace traits {
     struct HPX_DEPRECATED(
         HPX_DEPRECATED_MSG " Use is_invocable instead.") is_callable;
 
+#if defined(HPX_GCC_VERSION)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
     template <typename F, typename... Ts, typename R>
     struct is_callable<F(Ts...), R> : detail::is_invocable_impl<F(Ts...), R>
     {
     };
+#if defined(HPX_GCC_VERSION)
+#pragma GCC diagnostic pop
+#endif
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename F, typename... Ts>


### PR DESCRIPTION
Having the deprecation attribute on the base template lead to warnings when specializing the template, even though the specializations were not used anywhere. It seems like clang was fine with the old behaviour, but gcc does not want the deprecation attribute on the base template.