### PR TITLE
Add CUDA flag to async_cuda CMakeLists

### DIFF
--- a/cmake/HPX_SetupCUDA.cmake
+++ b/cmake/HPX_SetupCUDA.cmake
@@ -20,6 +20,7 @@ if((HPX_WITH_CUDA_COMPUTE OR HPX_WITH_ASYNC_CUDA) AND NOT TARGET Cuda::cuda)
   endif()
 
   add_library(Cuda::cuda INTERFACE IMPORTED)
+  target_include_directories(Cuda::cuda INTERFACE ${CUDA_INCLUDE_DIRS})
 
   if(NOT HPX_WITH_CUDA_CLANG)
     if(NOT MSVC)

--- a/libs/async_cuda/CMakeLists.txt
+++ b/libs/async_cuda/CMakeLists.txt
@@ -40,7 +40,6 @@ set(async_cuda_sources cuda_future.cpp cuda_target.cpp get_targets.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   async_cuda
-  CUDA
   COMPATIBILITY_HEADERS ON
   DEPRECATION_WARNINGS
   GLOBAL_HEADER_GEN ON

--- a/libs/async_cuda/CMakeLists.txt
+++ b/libs/async_cuda/CMakeLists.txt
@@ -40,6 +40,7 @@ set(async_cuda_sources cuda_future.cpp cuda_target.cpp get_targets.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   async_cuda
+  CUDA
   COMPATIBILITY_HEADERS ON
   DEPRECATION_WARNINGS
   GLOBAL_HEADER_GEN ON


### PR DESCRIPTION
Since PR #4385  got merged, HPX master could not be built with g++ and HPX_WITH_CUDA=ON as g++ was not able to find the cuda_runtime.h header file during the compilation.

This PR fixes this issue by simply adding the CUDA argument to the appropriate add_hpx_module call.
