### PR TITLE
Display relative paths in hook to make cut'n'paste easier

### DIFF
--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -49,7 +49,8 @@ returncode=0
 if [ -n "${cxxfiles}" ]; then
     printf "# ${blue}clang-format ${red}error pre-commit${normal} : To fix run the following (use git commit ${yellow}--no-verify${normal} to bypass)\n"
     for f in "${cxxfiles[@]}" ; do
-        printf "clang-format -i %s\n" "$f"
+        rel=$(realpath --relative-to $GIT_PREFIX $f)
+        printf "clang-format -i %s\n" "$rel"
     done
     returncode=1
 fi
@@ -57,7 +58,8 @@ fi
 if [ -n "${cmakefiles}" ]; then
     printf "# ${green}cmake-format ${red}error pre-commit${normal} : To fix run the following (use git commit ${yellow}--no-verify${normal} to bypass)\n"
     for f in "${cmakefiles[@]}" ; do
-        printf "cmake-format -i %s\n" "$f"
+        rel=$(realpath --relative-to $GIT_PREFIX $f)
+        printf "cmake-format -i %s\n" "$rel"
     done
     returncode=1
 fi


### PR DESCRIPTION
Just for ease of use - if you commit from a subdir instead of the root dir of the git repo ...