### PR TITLE
Change cmake targets

### DIFF
--- a/.github/workflows/windows_debug.yml
+++ b/.github/workflows/windows_debug.yml
@@ -23,11 +23,15 @@ jobs:
     - name: Configure
       shell: bash
       run: |
-          cmake . -Bbuild -G'Visual Studio 16 2019' -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE='C:/projects/vcpkg/scripts/buildsystems/vcpkg.cmake' -DHPX_WITH_PSEUDO_DEPENDENCIES=OFF -DHPX_WITH_EXAMPLES=ON -DHPX_WITH_TESTS=ON -DHPX_WITH_DEPRECATION_WARNINGS=OFF -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=2
+          cmake . -Bbuild -G'Visual Studio 16 2019' -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE='C:/projects/vcpkg/scripts/buildsystems/vcpkg.cmake' -DHPX_WITH_PSEUDO_DEPENDENCIES=OFF -DHPX_WITH_EXAMPLES=ON -DHPX_WITH_TESTS=ON -DHPX_WITH_TESTS_UNIT=ON -DHPX_WITH_DEPRECATION_WARNINGS=OFF -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=2
     - name: Build
       shell: bash
       run: |
-          cmake --build build --config Debug --target ALL_BUILD -- -maxcpucount -verbosity:minimal -nologo
+          cmake --build build --config Debug \
+          --target ALL_BUILD \
+            cmake_build_dir_targets_test.make_compile \
+            cmake_build_dir_macros_test.make_compile \
+          -- -maxcpucount -verbosity:minimal -nologo
     - name: Test
       shell: bash
       run: |

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -23,11 +23,26 @@ jobs:
     - name: Configure
       shell: bash
       run: |
-          cmake . -Bbuild -G'Visual Studio 16 2019' -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE='C:/projects/vcpkg/scripts/buildsystems/vcpkg.cmake' -DHPX_WITH_PSEUDO_DEPENDENCIES=OFF -DHPX_WITH_EXAMPLES=ON -DHPX_WITH_TESTS=ON -DHPX_WITH_DEPRECATION_WARNINGS=OFF -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=2
+          cmake . -Bbuild -G'Visual Studio 16 2019' -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE='C:/projects/vcpkg/scripts/buildsystems/vcpkg.cmake' -DHPX_WITH_PSEUDO_DEPENDENCIES=OFF -DHPX_WITH_EXAMPLES=ON -DHPX_WITH_TESTS=ON -DHPX_WITH_TESTS_UNIT=ON -DHPX_WITH_DEPRECATION_WARNINGS=OFF -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=2
     - name: Build
       shell: bash
       run: |
-          cmake --build build --config Release --target ALL_BUILD -- -maxcpucount -verbosity:minimal -nologo
+          cmake --build build --config Release \
+          --target ALL_BUILD \
+            cmake_build_dir_targets_test.make_compile \
+            cmake_build_dir_macros_test.make_compile \
+          -- -maxcpucount -verbosity:minimal -nologo
+    - name: Install
+      shell: bash
+      run: |
+          cmake --install build
+    - name: Build External
+      shell: bash
+      run: |
+          cmake --build build --config Release \
+            --target cmake_install_dir_targets_test.make_compile \
+              cmake_install_dir_macros_test.make_compile \
+            -- -maxcpucount -verbosity:minimal -nologo
     - name: Test
       shell: bash
       run: |

--- a/cmake/HPX_SetupTarget.cmake
+++ b/cmake/HPX_SetupTarget.cmake
@@ -172,9 +172,15 @@ function(hpx_setup_target target)
   endif()
 
   if(NOT target_NOLIBS)
+    set(_wrap_main_deps)
+    if("${_type}" STREQUAL "EXECUTABLE")
+      set(_wrap_main_deps $<TARGET_NAME_IF_EXISTS:wrap_main>
+                          $<TARGET_NAME_IF_EXISTS:HPX::wrap_main>
+      )
+    endif()
     target_link_libraries(
       ${target} ${__tll_public} $<TARGET_NAME_IF_EXISTS:hpx>
-      $<TARGET_NAME_IF_EXISTS:HPX::hpx>
+      $<TARGET_NAME_IF_EXISTS:HPX::hpx> ${_wrap_main_deps}
     )
     hpx_handle_component_dependencies(target_COMPONENT_DEPENDENCIES)
     target_link_libraries(

--- a/examples/gtest_emulation/CMakeLists.txt
+++ b/examples/gtest_emulation/CMakeLists.txt
@@ -28,6 +28,8 @@ if(EXISTS "${HPX_DIR}")
 else()
   message(
     WARNING
-      "HPX_DIR=${HPX_DIR} does not exist. Did you forget to run the install rule?"
+      "Skipping build test because HPX_DIR=${HPX_DIR} does not exist. This \
+      last test requires HPX to be installed.  Did you forget to run the \
+      install rule?"
   )
 endif()

--- a/examples/gtest_emulation/CMakeLists.txt
+++ b/examples/gtest_emulation/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright (c) 2020  ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+cmake_minimum_required(VERSION 3.13)
+
+project(gtest CXX)
+
+if(EXISTS "${HPX_DIR}")
+
+  find_package(HPX REQUIRED)
+
+  # Add a static library which contains a main to emulate gtest_main
+  add_library(static_main_lib STATIC static_main.cpp)
+
+  # /!\ This helper interface is needed to keep the right linking order
+  add_library(hpx_helper_interface INTERFACE)
+  target_link_libraries(
+    hpx_helper_interface INTERFACE HPX::hpx HPX::wrap_main static_main_lib
+  )
+
+  # Test with the main function in a separate static library
+  add_executable(hpx_main_ext_main hpx_main_ext_main.cpp)
+  target_link_libraries(hpx_main_ext_main PRIVATE hpx_helper_interface)
+
+else()
+  message(
+    WARNING
+      "HPX_DIR=${HPX_DIR} does not exist. Did you forget to run the install rule?"
+  )
+endif()

--- a/examples/gtest_emulation/hpx_main_ext_main.cpp
+++ b/examples/gtest_emulation/hpx_main_ext_main.cpp
@@ -1,0 +1,15 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/modules/testing.hpp>
+
+int report_errors_hpx()
+{
+    // Check that HPX runtime is started
+    HPX_TEST(hpx::threads::get_self_ptr() != nullptr);
+    return hpx::util::report_errors();
+}

--- a/examples/gtest_emulation/static_main.cpp
+++ b/examples/gtest_emulation/static_main.cpp
@@ -1,0 +1,12 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+int report_errors_hpx();
+
+int main(int argc, char** argv)
+{
+    return report_errors_hpx();
+}

--- a/examples/hello_world_component/CMakeLists.txt
+++ b/examples/hello_world_component/CMakeLists.txt
@@ -19,7 +19,8 @@ if(EXISTS "${HPX_DIR}")
 
   if("${SETUP_TYPE}" STREQUAL "TARGETS")
     target_link_libraries(
-      hello_world_component PUBLIC HPX::hpx HPX::iostreams_component
+      hello_world_component PUBLIC HPX::hpx HPX::wrap_main
+                                   HPX::iostreams_component
     )
     target_link_libraries(hello_world_component PRIVATE HPX::component)
 
@@ -28,6 +29,7 @@ if(EXISTS "${HPX_DIR}")
     hpx_setup_target(
       hello_world_component
       COMPONENT_DEPENDENCIES iostreams
+      DEPENDENCIES HPX::wrap_main
       TYPE COMPONENT
     )
 

--- a/examples/hello_world_component/CMakeLists.txt
+++ b/examples/hello_world_component/CMakeLists.txt
@@ -40,6 +40,8 @@ if(EXISTS "${HPX_DIR}")
 else()
   message(
     WARNING
-      "HPX_DIR=${HPX_DIR} does not exist. Did you forget to run the install rule?"
+      "Skipping build test because HPX_DIR=${HPX_DIR} does not exist. This \
+      last test requires HPX to be installed.  Did you forget to run the \
+      install rule?"
   )
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -536,54 +536,51 @@ set(_library_types
 set(_is_executable "$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>")
 set(_is_library "$<IN_LIST:$<TARGET_PROPERTY:TYPE>,${_library_types}>")
 
-add_library(hpx_no_wrap_main INTERFACE)
 add_library(hpx INTERFACE)
+add_library(wrap_main INTERFACE)
 
-target_link_libraries(hpx_no_wrap_main INTERFACE hpx_core)
 target_link_libraries(hpx INTERFACE hpx_core)
 
-# hpx_interface and hpx_interface_no_wrap_main contain additional interface
-# options to be passed to dependent targets. We create these as separate targets
-# to easily filter out the generator expressions that can't be handled by the
+# hpx_interface and hpx_interface_wrap_main contain additional interface options
+# to be passed to dependent targets. We create these as separate targets to
+# easily filter out the generator expressions that can't be handled by the
 # pkgconfig file generation.
-add_library(hpx_interface_no_wrap_main INTERFACE)
+add_library(hpx_interface INTERFACE)
 target_link_libraries(
-  hpx_interface_no_wrap_main
+  hpx_interface
   INTERFACE $<${_is_executable}:$<TARGET_NAME_IF_EXISTS:hpx_init>>
 )
 target_link_libraries(
-  hpx_interface_no_wrap_main
+  hpx_interface
   INTERFACE $<${_is_executable}:$<TARGET_NAME_IF_EXISTS:HPXInternal::hpx_init>>
 )
 target_compile_definitions(
-  hpx_interface_no_wrap_main
+  hpx_interface
   INTERFACE
     "$<${_is_executable}:HPX_APPLICATION_NAME_DEFAULT=$<TARGET_PROPERTY:NAME>>"
 )
 target_compile_definitions(
-  hpx_interface_no_wrap_main
+  hpx_interface
   INTERFACE "$<${_is_executable}:HPX_PREFIX_DEFAULT=\"${HPX_PREFIX}\">"
 )
 target_compile_definitions(
-  hpx_interface_no_wrap_main
-  INTERFACE "$<${_is_executable}:HPX_APPLICATION_EXPORTS>"
+  hpx_interface INTERFACE "$<${_is_executable}:HPX_APPLICATION_EXPORTS>"
 )
 target_compile_definitions(
-  hpx_interface_no_wrap_main INTERFACE "$<${_is_library}:HPX_LIBRARY_EXPORTS>"
+  hpx_interface INTERFACE "$<${_is_library}:HPX_LIBRARY_EXPORTS>"
 )
 
-add_library(hpx_interface INTERFACE)
-target_link_libraries(hpx_interface INTERFACE hpx_interface_no_wrap_main)
+add_library(hpx_interface_wrap_main INTERFACE)
 target_link_libraries(
-  hpx_interface
+  hpx_interface_wrap_main
   INTERFACE $<${_is_executable}:$<TARGET_NAME_IF_EXISTS:hpx_wrap>>
 )
 target_link_libraries(
-  hpx_interface
+  hpx_interface_wrap_main
   INTERFACE $<${_is_executable}:$<TARGET_NAME_IF_EXISTS:HPXInternal::hpx_wrap>>
 )
 
-target_link_libraries(hpx_no_wrap_main INTERFACE hpx_interface_no_wrap_main)
+target_link_libraries(wrap_main INTERFACE hpx_interface_wrap_main)
 target_link_libraries(hpx INTERFACE hpx_interface)
 
 # HPX::component is to be linked privately to all HPX components NOTE: The
@@ -610,8 +607,13 @@ target_compile_definitions(
     "$<${_is_library}:HPX_PLUGIN_NAME_DEFAULT=hpx_$<TARGET_PROPERTY:NAME>>"
 )
 
-set(hpx_targets hpx hpx_no_wrap_main plugin component)
-set(hpx_internal_targets hpx_core hpx_interface hpx_interface_no_wrap_main)
+set(hpx_targets hpx wrap_main plugin component)
+set(hpx_internal_targets hpx_core hpx_interface hpx_interface_wrap_main)
+
+# Temporary for compatibility with projects like gridtools
+add_library(hpx_no_wrap_main INTERFACE)
+target_link_libraries(hpx_no_wrap_main INTERFACE hpx)
+list(APPEND hpx_targets hpx_no_wrap_main)
 
 install(
   TARGETS ${hpx_targets}

--- a/tests/unit/build/CMakeLists.txt
+++ b/tests/unit/build/CMakeLists.txt
@@ -22,12 +22,11 @@ function(create_cmake_test name hpx_dir setup_type test_dir)
     COMMAND "${CMAKE_COMMAND}" -E make_directory "${build_dir}"
     VERBATIM
   )
-  set(ADDITIONAL_CMAKE_OPTIONS)
-  set(ADDITIONAL_CMAKE_OPTIONS ${ADDITIONAL_CMAKE_OPTIONS}
-                               -DSETUP_TYPE=${setup_type}
-  )
+  set(ADDITIONAL_CMAKE_OPTIONS -DSETUP_TYPE=${setup_type})
   if(CMAKE_TOOLCHAIN_FILE)
-    set(ADDITIONAL_CMAKE_OPTIONS -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE})
+    set(ADDITIONAL_CMAKE_OPTIONS ${ADDITIONAL_CMAKE_OPTIONS}
+                                 -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+    )
   endif()
   if(CMAKE_MAKE_COMMAND)
     set(ADDITIONAL_CMAKE_OPTIONS ${ADDITIONAL_CMAKE_OPTIONS}
@@ -52,13 +51,13 @@ function(create_cmake_test name hpx_dir setup_type test_dir)
                                  -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
     )
   endif()
+  set(test_dir "${PROJECT_SOURCE_DIR}/${test_dir}")
   add_custom_target(
     ${name}.make_configure
     COMMAND
-      "${CMAKE_COMMAND}" -E chdir "${build_dir}" "${CMAKE_COMMAND}"
-      "${PROJECT_SOURCE_DIR}/${test_dir}" -DHPX_DIR=${hpx_dir}
-      -DBOOST_ROOT=${BOOST_ROOT} ${ADDITIONAL_CMAKE_OPTIONS}
-      -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS_SAFE}
+      "${CMAKE_COMMAND}" -E chdir "${build_dir}" "${CMAKE_COMMAND}" ${test_dir}
+      -DHPX_DIR=${hpx_dir} -DBOOST_ROOT=${BOOST_ROOT}
+      ${ADDITIONAL_CMAKE_OPTIONS} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS_SAFE}
       -DCMAKE_BUILD_TYPE=$<CONFIGURATION>
     VERBATIM
   )

--- a/tests/unit/build/CMakeLists.txt
+++ b/tests/unit/build/CMakeLists.txt
@@ -141,18 +141,20 @@ create_cmake_test(
   "examples/hello_world_component"
 )
 
-# Google test emulation
-create_cmake_test(
-  cmake_build_dir_gtest_emulation_test
-  "${PROJECT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}" TARGETS
-  "examples/gtest_emulation"
-)
+if(HPX_WITH_DYNAMIC_HPX_MAIN)
+  # Google test emulation
+  create_cmake_test(
+    cmake_build_dir_gtest_emulation_test
+    "${PROJECT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}" TARGETS
+    "examples/gtest_emulation"
+  )
 
-create_cmake_test(
-  cmake_install_dir_gtest_emulation_test
-  "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}" TARGETS
-  "examples/gtest_emulation"
-)
+  create_cmake_test(
+    cmake_install_dir_gtest_emulation_test
+    "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}" TARGETS
+    "examples/gtest_emulation"
+  )
+endif()
 
 # PkgConfig
 if(NOT MSVC)

--- a/tests/unit/build/CMakeLists.txt
+++ b/tests/unit/build/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT HPX_WITH_DISTRIBUTED_RUNTIME)
 endif()
 
 # Try building an external cmake based project ...
-function(create_cmake_test name hpx_dir setup_type)
+function(create_cmake_test name hpx_dir setup_type test_dir)
   set(build_dir "${CMAKE_CURRENT_BINARY_DIR}/${name}")
   add_custom_target(
     ${name}.make_build_dir
@@ -56,9 +56,9 @@ function(create_cmake_test name hpx_dir setup_type)
     ${name}.make_configure
     COMMAND
       "${CMAKE_COMMAND}" -E chdir "${build_dir}" "${CMAKE_COMMAND}"
-      "${PROJECT_SOURCE_DIR}/examples/hello_world_component"
-      -DHPX_DIR=${hpx_dir} -DBOOST_ROOT=${BOOST_ROOT}
-      ${ADDITIONAL_CMAKE_OPTIONS} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS_SAFE}
+      "${PROJECT_SOURCE_DIR}/${test_dir}" -DHPX_DIR=${hpx_dir}
+      -DBOOST_ROOT=${BOOST_ROOT} ${ADDITIONAL_CMAKE_OPTIONS}
+      -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS_SAFE}
       -DCMAKE_BUILD_TYPE=$<CONFIGURATION>
     VERBATIM
   )
@@ -120,23 +120,41 @@ endfunction()
 create_cmake_test(
   cmake_build_dir_targets_test
   "${PROJECT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}" TARGETS
+  "examples/hello_world_component"
 )
 
 create_cmake_test(
   cmake_build_dir_macros_test
   "${PROJECT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}" MACROS
+  "examples/hello_world_component"
 )
 
 create_cmake_test(
   cmake_install_dir_targets_test
   "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}" TARGETS
+  "examples/hello_world_component"
 )
 
 create_cmake_test(
   cmake_install_dir_macros_test
   "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}" MACROS
+  "examples/hello_world_component"
 )
 
+# Google test emulation
+create_cmake_test(
+  cmake_build_dir_gtest_emulation_test
+  "${PROJECT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}" TARGETS
+  "examples/gtest_emulation"
+)
+
+create_cmake_test(
+  cmake_install_dir_gtest_emulation_test
+  "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}" TARGETS
+  "examples/gtest_emulation"
+)
+
+# PkgConfig
 if(NOT MSVC)
   find_package(PkgConfig)
   if(PKGCONFIG_FOUND)
@@ -151,8 +169,9 @@ if(NOT MSVC)
 endif()
 
 set(build_systems cmake)
-set(cmake_tests build_dir_targets build_dir_macros install_dir_targets
-                install_dir_macros
+set(cmake_tests
+    build_dir_targets install_dir_targets build_dir_macros install_dir_macros
+    build_dir_gtest_emulation install_dir_gtest_emulation
 )
 if(NOT CMAKE_TOOLCHAIN_FILE
    AND PKGCONFIG_FOUND


### PR DESCRIPTION
- Change the default hpx target not to include `wrap_main` as discussed in the last PMC meeting, the `HPX::wrap_main` target is exposed to the user in case it's needed
- Add a gtest unit test to check we don't break anything during our changes to the cmake targets
