### PR TITLE
Include the main module header (fixes partially #4488)

### DIFF
--- a/components/iostreams/CMakeLists.txt
+++ b/components/iostreams/CMakeLists.txt
@@ -27,6 +27,7 @@ set(iostreams_headers
     hpx/components/iostreams/ostream.hpp
     hpx/components/iostreams/standard_streams.hpp
     hpx/components/iostreams/write_functions.hpp
+    hpx/distributed/iostream.hpp
     hpx/include/iostreams.hpp
 )
 

--- a/components/iostreams/include/hpx/distributed/iostream.hpp
+++ b/components/iostreams/include/hpx/distributed/iostream.hpp
@@ -9,14 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/distributed/iostream.hpp>
-
-#if defined(HPX_HAVE_DEPRECATION_WARNINGS)
-#if defined(HPX_MSVC)
-#pragma message("The header hpx/include/iostreams.hpp is deprecated, \
-    please include hpx/distributed/iostream.hpp instead")
-#else
-#warning "The header hpx/include/iostreams.hpp is deprecated, \
-    please include hpx/distributed/iostream.hpp instead"
-#endif
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/components/iostreams/standard_streams.hpp>
+#include <hpx/include/components.hpp>
 #endif

--- a/components/iostreams/tests/regressions/lost_output_2236.cpp
+++ b/components/iostreams/tests/regressions/lost_output_2236.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <sstream>

--- a/components/iostreams/tests/regressions/no_output_1173.cpp
+++ b/components/iostreams/tests/regressions/no_output_1173.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <cstdint>
@@ -58,8 +58,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
 int main(int argc, char* argv[])
 {
-    HPX_TEST_EQ_MSG(hpx::init(argc, argv), 0,
-        "HPX main exited with non-zero status");
+    HPX_TEST_EQ_MSG(
+        hpx::init(argc, argv), 0, "HPX main exited with non-zero status");
 
     HPX_TEST_NEQ(std::uint32_t(-1), locality_id);
     HPX_TEST(on_shutdown_executed || 0 != locality_id);

--- a/examples/1d_stencil/1d_stencil_4.cpp
+++ b/examples/1d_stencil/1d_stencil_4.cpp
@@ -18,7 +18,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 
-#include <hpx/include/parallel_algorithm.hpp>
+#include <hpx/algorithm.hpp>
 #include <boost/range/irange.hpp>
 
 #include <cstddef>

--- a/examples/1d_stencil/1d_stencil_4_parallel.cpp
+++ b/examples/1d_stencil/1d_stencil_4_parallel.cpp
@@ -16,7 +16,7 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/include/parallel_algorithm.hpp>
+#include <hpx/algorithm.hpp>
 #include <hpx/modules/iterator_support.hpp>
 
 #if !defined(HPX_HAVE_CXX17_SHARED_PTR_ARRAY)

--- a/examples/1d_stencil/1d_stencil_4_repart.cpp
+++ b/examples/1d_stencil/1d_stencil_4_repart.cpp
@@ -19,7 +19,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 
-#include <hpx/include/parallel_algorithm.hpp>
+#include <hpx/algorithm.hpp>
 #include <hpx/include/performance_counters.hpp>
 
 #if !defined(HPX_HAVE_CXX17_SHARED_PTR_ARRAY)

--- a/examples/1d_stencil/1d_stencil_4_throttle.cpp
+++ b/examples/1d_stencil/1d_stencil_4_throttle.cpp
@@ -17,7 +17,6 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/modules/format.hpp>
 
 #include <hpx/algorithm.hpp>
 #include <boost/range/irange.hpp>

--- a/examples/1d_stencil/1d_stencil_4_throttle.cpp
+++ b/examples/1d_stencil/1d_stencil_4_throttle.cpp
@@ -19,7 +19,7 @@
 #include <hpx/hpx.hpp>
 #include <hpx/modules/format.hpp>
 
-#include <hpx/include/parallel_algorithm.hpp>
+#include <hpx/algorithm.hpp>
 #include <boost/range/irange.hpp>
 
 #include "print_time_results.hpp"

--- a/examples/1d_stencil/1d_stencil_6.cpp
+++ b/examples/1d_stencil/1d_stencil_6.cpp
@@ -11,7 +11,7 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/serialization/serialize.hpp>
+#include <hpx/serialization.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <boost/shared_array.hpp>

--- a/examples/1d_stencil/1d_stencil_6.cpp
+++ b/examples/1d_stencil/1d_stencil_6.cpp
@@ -12,7 +12,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/serialization.hpp>
-#include <hpx/type_support/unused.hpp>
+#include <hpx/modules/type_support.hpp>
 
 #include <boost/shared_array.hpp>
 

--- a/examples/1d_stencil/1d_stencil_7.cpp
+++ b/examples/1d_stencil/1d_stencil_7.cpp
@@ -11,7 +11,7 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/serialization/serialize.hpp>
+#include <hpx/serialization.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <boost/shared_array.hpp>

--- a/examples/1d_stencil/1d_stencil_7.cpp
+++ b/examples/1d_stencil/1d_stencil_7.cpp
@@ -12,7 +12,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/serialization.hpp>
-#include <hpx/type_support/unused.hpp>
+#include <hpx/modules/type_support.hpp>
 
 #include <boost/shared_array.hpp>
 

--- a/examples/1d_stencil/1d_stencil_8.cpp
+++ b/examples/1d_stencil/1d_stencil_8.cpp
@@ -13,7 +13,7 @@
 #include <hpx/hpx.hpp>
 #include <hpx/modules/collectives.hpp>
 #include <hpx/serialization.hpp>
-#include <hpx/type_support/unused.hpp>
+#include <hpx/modules/type_support.hpp>
 
 #include <boost/shared_array.hpp>
 

--- a/examples/1d_stencil/1d_stencil_8.cpp
+++ b/examples/1d_stencil/1d_stencil_8.cpp
@@ -12,7 +12,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/modules/collectives.hpp>
-#include <hpx/serialization/serialize.hpp>
+#include <hpx/serialization.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <boost/shared_array.hpp>

--- a/examples/1d_stencil/print_time_results.hpp
+++ b/examples/1d_stencil/print_time_results.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <hpx/modules/format.hpp>
+#include <hpx/include/util.hpp>
 
 #include <cstdint>
 #include <iostream>

--- a/examples/accumulators/accumulator_client.cpp
+++ b/examples/accumulators/accumulator_client.cpp
@@ -6,6 +6,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// hpxinspect:noinclude:hpx::util::from_string
+
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/util.hpp>
 

--- a/examples/accumulators/accumulator_client.cpp
+++ b/examples/accumulators/accumulator_client.cpp
@@ -7,10 +7,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/string_util/split.hpp>
-#include <hpx/string_util/trim.hpp>
-#include <hpx/string_util/classification.hpp>
-#include <hpx/util/from_string.hpp>
+#include <hpx/include/util.hpp>
 
 #include "accumulator.hpp"
 

--- a/examples/accumulators/template_accumulator_client.cpp
+++ b/examples/accumulators/template_accumulator_client.cpp
@@ -4,6 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// hpxinspect:noinclude:hpx::util::from_string
+
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/util.hpp>
 

--- a/examples/accumulators/template_accumulator_client.cpp
+++ b/examples/accumulators/template_accumulator_client.cpp
@@ -5,10 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/string_util/split.hpp>
-#include <hpx/string_util/trim.hpp>
-#include <hpx/string_util/classification.hpp>
-#include <hpx/util/from_string.hpp>
+#include <hpx/include/util.hpp>
 
 #include "template_accumulator.hpp"
 

--- a/examples/accumulators/template_function_accumulator.cpp
+++ b/examples/accumulators/template_function_accumulator.cpp
@@ -7,7 +7,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/include/components.hpp>
-#include <hpx/include/serialization.hpp>
+#include <hpx/serialization.hpp>
 
 #include "server/template_function_accumulator.hpp"
 

--- a/examples/accumulators/template_function_accumulator_client.cpp
+++ b/examples/accumulators/template_function_accumulator_client.cpp
@@ -7,10 +7,7 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/actions.hpp>
-#include <hpx/string_util/split.hpp>
-#include <hpx/string_util/trim.hpp>
-#include <hpx/string_util/classification.hpp>
-#include <hpx/util/from_string.hpp>
+#include <hpx/include/util.hpp>
 
 #include "template_function_accumulator.hpp"
 

--- a/examples/accumulators/template_function_accumulator_client.cpp
+++ b/examples/accumulators/template_function_accumulator_client.cpp
@@ -5,6 +5,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// hpxinspect:noinclude:hpx::util::from_string
+
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/actions.hpp>
 #include <hpx/include/util.hpp>

--- a/examples/async_io/async_io_action.cpp
+++ b/examples/async_io/async_io_action.cpp
@@ -12,9 +12,9 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/actions.hpp>
-#include <hpx/include/iostreams.hpp>
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/runtime.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <iostream>
 #include <memory>

--- a/examples/async_io/async_io_external.cpp
+++ b/examples/async_io/async_io_external.cpp
@@ -10,7 +10,7 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/runtime.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <iostream>
 #include <memory>

--- a/examples/async_io/async_io_low_level.cpp
+++ b/examples/async_io/async_io_low_level.cpp
@@ -10,8 +10,8 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/runtime.hpp>
-#include <hpx/include/iostreams.hpp>
 #include <hpx/include/util.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/io_service/io_service_pool.hpp>
 
 #include <iostream>

--- a/examples/async_io/async_io_simple.cpp
+++ b/examples/async_io/async_io_simple.cpp
@@ -10,9 +10,9 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/assert.hpp>
-#include <hpx/include/iostreams.hpp>
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/runtime.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <functional>
 #include <iostream>

--- a/examples/balancing/hpx_thread_phase.cpp
+++ b/examples/balancing/hpx_thread_phase.cpp
@@ -6,10 +6,10 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/threading_base/thread_helpers.hpp>
 #include <hpx/barrier.hpp>
+#include <hpx/include/threadmanager.hpp>
+#include <hpx/include/util.hpp>
 #include <hpx/mutex.hpp>
-#include <hpx/functional/bind.hpp>
 
 #include <boost/lockfree/queue.hpp>
 

--- a/examples/balancing/hpx_thread_phase.cpp
+++ b/examples/balancing/hpx_thread_phase.cpp
@@ -7,8 +7,8 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/threading_base/thread_helpers.hpp>
-#include <hpx/synchronization/barrier.hpp>
-#include <hpx/synchronization/mutex.hpp>
+#include <hpx/barrier.hpp>
+#include <hpx/mutex.hpp>
 #include <hpx/functional/bind.hpp>
 
 #include <boost/lockfree/queue.hpp>

--- a/examples/balancing/os_thread_num.cpp
+++ b/examples/balancing/os_thread_num.cpp
@@ -6,8 +6,8 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
-#include <hpx/synchronization/barrier.hpp>
+#include <hpx/distributed/iostream.hpp>
+#include <hpx/barrier.hpp>
 #include <hpx/functional/bind.hpp>
 #include <hpx/modules/format.hpp>
 #include <boost/lockfree/queue.hpp>

--- a/examples/balancing/os_thread_num.cpp
+++ b/examples/balancing/os_thread_num.cpp
@@ -6,10 +6,11 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/distributed/iostream.hpp>
+
 #include <hpx/barrier.hpp>
-#include <hpx/functional/bind.hpp>
-#include <hpx/modules/format.hpp>
+#include <hpx/distributed/iostream.hpp>
+#include <hpx/include/util.hpp>
+
 #include <boost/lockfree/queue.hpp>
 
 #include <cstddef>

--- a/examples/cancelable_action/cancelable_action/cancelable_action.cpp
+++ b/examples/cancelable_action/cancelable_action/cancelable_action.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/include/components.hpp>
-#include <hpx/include/serialization.hpp>
+#include <hpx/serialization.hpp>
 
 #include "server/cancelable_action.hpp"
 

--- a/examples/cancelable_action/cancelable_action/server/cancelable_action.hpp
+++ b/examples/cancelable_action/cancelable_action/server/cancelable_action.hpp
@@ -11,7 +11,6 @@
 #include <hpx/include/actions.hpp>
 #include <hpx/include/threads.hpp>
 #include <hpx/include/util.hpp>
-#include <hpx/type_support/unused.hpp>
 
 #include <atomic>
 

--- a/examples/future_reduce/rnd_future_reduce.cpp
+++ b/examples/future_reduce/rnd_future_reduce.cpp
@@ -9,7 +9,9 @@
 #include <hpx/future.hpp>
 #include <hpx/include/runtime.hpp>
 #include <hpx/distributed/iostream.hpp>
+#include <hpx/include/runtime.hpp>
 #include <hpx/modules/timing.hpp>
+#include <hpx/include/util.hpp>
 //
 #include <random>
 #include <utility>

--- a/examples/future_reduce/rnd_future_reduce.cpp
+++ b/examples/future_reduce/rnd_future_reduce.cpp
@@ -5,9 +5,10 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
+
+#include <hpx/future.hpp>
 #include <hpx/include/runtime.hpp>
-#include <hpx/async_combinators/when_all.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/timing.hpp>
 //
 #include <random>

--- a/examples/heartbeat/heartbeat.cpp
+++ b/examples/heartbeat/heartbeat.cpp
@@ -8,15 +8,15 @@
 // #define HPX_USE_WINDOWS_PERFORMANCE_COUNTERS 1
 
 #include <hpx/hpx_init.hpp>
+
 #include <hpx/exception.hpp>
-#include <hpx/include/performance_counters.hpp>
-#include <hpx/include/lcos.hpp>
-#include <hpx/runtime/actions/plain_action.hpp>
-#include <hpx/threading_base/thread_helpers.hpp>
 #include <hpx/future.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/performance_counters.hpp>
+#include <hpx/include/threadmanager.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/runtime/actions/plain_action.hpp>
 #include <hpx/state.hpp>
-#include <hpx/modules/format.hpp>
-#include <hpx/modules/timing.hpp>
 
 #include <cstdint>
 #include <iostream>

--- a/examples/heartbeat/heartbeat.cpp
+++ b/examples/heartbeat/heartbeat.cpp
@@ -8,12 +8,12 @@
 // #define HPX_USE_WINDOWS_PERFORMANCE_COUNTERS 1
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/errors/exception.hpp>
+#include <hpx/exception.hpp>
 #include <hpx/include/performance_counters.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/runtime/actions/plain_action.hpp>
 #include <hpx/threading_base/thread_helpers.hpp>
-#include <hpx/futures/future.hpp>
+#include <hpx/future.hpp>
 #include <hpx/state.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/timing.hpp>

--- a/examples/heartbeat/heartbeat_console.cpp
+++ b/examples/heartbeat/heartbeat_console.cpp
@@ -5,8 +5,9 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
+
 #include <hpx/distributed/iostream.hpp>
-#include <hpx/modules/timing.hpp>
+#include <hpx/include/util.hpp>
 
 #include <string>
 #include <vector>

--- a/examples/heartbeat/heartbeat_console.cpp
+++ b/examples/heartbeat/heartbeat_console.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/timing.hpp>
 
 #include <string>

--- a/examples/hello_world_component/hello_world_component.cpp
+++ b/examples/hello_world_component/hello_world_component.cpp
@@ -6,7 +6,7 @@
 
 //[hello_world_cpp_getting_started
 #include "hello_world_component.hpp"
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <iostream>
 

--- a/examples/hello_world_component/hello_world_component.hpp
+++ b/examples/hello_world_component/hello_world_component.hpp
@@ -11,7 +11,7 @@
 #include <hpx/include/actions.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/components.hpp>
-#include <hpx/include/serialization.hpp>
+#include <hpx/serialization.hpp>
 
 #include <utility>
 

--- a/examples/interpolate1d/interpolate1d/dimension.cpp
+++ b/examples/interpolate1d/interpolate1d/dimension.cpp
@@ -4,7 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/include/serialization.hpp>
+#include <hpx/serialization.hpp>
 
 #include "dimension.hpp"
 

--- a/examples/interpolate1d/interpolate1d/dimension.hpp
+++ b/examples/interpolate1d/interpolate1d/dimension.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <hpx/include/serialization.hpp>
+#include <hpx/serialization.hpp>
 
 #include <cstddef>
 

--- a/examples/jacobi/jacobi.cpp
+++ b/examples/jacobi/jacobi.cpp
@@ -9,7 +9,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/modules/timing.hpp>
 
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include "jacobi_component/grid.hpp"
 #include "jacobi_component/solver.hpp"

--- a/examples/jacobi/jacobi_component/grid.cpp
+++ b/examples/jacobi/jacobi_component/grid.cpp
@@ -7,7 +7,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/async_combinators/wait_all.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <cstddef>
 #include <vector>

--- a/examples/jacobi/jacobi_component/grid.cpp
+++ b/examples/jacobi/jacobi_component/grid.cpp
@@ -6,8 +6,9 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx.hpp>
-#include <hpx/async_combinators/wait_all.hpp>
+
 #include <hpx/distributed/iostream.hpp>
+#include <hpx/modules/async_combinators.hpp>
 
 #include <cstddef>
 #include <vector>

--- a/examples/jacobi/jacobi_component/row_range.hpp
+++ b/examples/jacobi/jacobi_component/row_range.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/assert.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/thread_support/atomic_count.hpp>
 
 #include <boost/range/iterator.hpp>

--- a/examples/jacobi/jacobi_component/row_range.hpp
+++ b/examples/jacobi/jacobi_component/row_range.hpp
@@ -1,4 +1,3 @@
-
 //  Copyright (c) 2012 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/examples/jacobi/jacobi_component/row_range.hpp
+++ b/examples/jacobi/jacobi_component/row_range.hpp
@@ -9,7 +9,7 @@
 
 #include <hpx/assert.hpp>
 #include <hpx/modules/memory.hpp>
-#include <hpx/thread_support/atomic_count.hpp>
+#include <hpx/include/util.hpp>
 
 #include <boost/range/iterator.hpp>
 #include <boost/range/mutable_iterator.hpp>

--- a/examples/jacobi/jacobi_component/server/row.hpp
+++ b/examples/jacobi/jacobi_component/server/row.hpp
@@ -1,4 +1,3 @@
-
 //  Copyright (c) 2012 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/examples/jacobi/jacobi_component/server/row.hpp
+++ b/examples/jacobi/jacobi_component/server/row.hpp
@@ -11,7 +11,7 @@
 
 #include <hpx/assert.hpp>
 #include <hpx/include/components.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 
 #include <boost/smart_ptr/shared_array.hpp>
 

--- a/examples/jacobi/jacobi_component/server/stencil_iterator.cpp
+++ b/examples/jacobi/jacobi_component/server/stencil_iterator.cpp
@@ -7,7 +7,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/modules/async_distributed.hpp>
-#include <hpx/futures/packaged_continuation.hpp>
+#include <hpx/future.hpp>
 
 #include "stencil_iterator.hpp"
 

--- a/examples/jacobi/jacobi_component/server/stencil_iterator.hpp
+++ b/examples/jacobi/jacobi_component/server/stencil_iterator.hpp
@@ -11,7 +11,7 @@
 #include "../stencil_iterator.hpp"
 
 #include <hpx/include/components.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 
 #include <cstddef>

--- a/examples/jacobi_smp/jacobi_hpx.cpp
+++ b/examples/jacobi_smp/jacobi_hpx.cpp
@@ -9,8 +9,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/include/lcos.hpp>
-#include <hpx/async_local/dataflow.hpp>
-#include <hpx/modules/timing.hpp>
+#include <hpx/include/util.hpp>
 
 #include <cstddef>
 #include <functional>

--- a/examples/jacobi_smp/jacobi_nonuniform_hpx.cpp
+++ b/examples/jacobi_smp/jacobi_nonuniform_hpx.cpp
@@ -9,7 +9,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/include/lcos.hpp>
-#include <hpx/modules/timing.hpp>
+#include <hpx/include/util.hpp>
 
 #include <cstddef>
 #include <functional>

--- a/examples/jacobi_smp/jacobi_nonuniform_omp.hpp
+++ b/examples/jacobi_smp/jacobi_nonuniform_omp.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <hpx/modules/timing.hpp>
+#include <hpx/include/util.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/examples/jacobi_smp/jacobi_omp.hpp
+++ b/examples/jacobi_smp/jacobi_omp.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <hpx/modules/timing.hpp>
+#include <hpx/include/util.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/examples/nqueen/nqueen_client.cpp
+++ b/examples/nqueen/nqueen_client.cpp
@@ -11,7 +11,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/util/from_string.hpp>
+#include <hpx/include/util.hpp>
 
 #include <cstddef>
 #include <iostream>

--- a/examples/performance_counters/access_counter_set.cpp
+++ b/examples/performance_counters/access_counter_set.cpp
@@ -8,7 +8,7 @@
 // use a performance counter for HPX.
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/performance_counters.hpp>
 
 #include <hpx/modules/program_options.hpp>

--- a/examples/performance_counters/sine/server/sine.cpp
+++ b/examples/performance_counters/sine/server/sine.cpp
@@ -6,10 +6,9 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/include/components.hpp>
+#include <hpx/include/performance_counters.hpp>
+#include <hpx/include/util.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
-#include <hpx/performance_counters/counters.hpp>
-#include <hpx/functional/bind.hpp>
-#include <hpx/modules/timing.hpp>
 
 #include <cstdint>
 #include <mutex>

--- a/examples/performance_counters/sine/server/sine.hpp
+++ b/examples/performance_counters/sine/server/sine.hpp
@@ -7,9 +7,9 @@
 #pragma once
 
 #include <hpx/hpx.hpp>
-#include <hpx/runtime_local/interval_timer.hpp>
-#include <hpx/synchronization/spinlock.hpp>
-#include <hpx/performance_counters/base_performance_counter.hpp>
+#include <hpx/include/lcos_local.hpp>
+#include <hpx/include/performance_counters.hpp>
+#include <hpx/include/util.hpp>
 
 #include <cstdint>
 

--- a/examples/performance_counters/sine/sine.cpp
+++ b/examples/performance_counters/sine/sine.cpp
@@ -5,10 +5,9 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx.hpp>
-#include <hpx/runtime_local/startup_function.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/include/performance_counters.hpp>
-#include <hpx/functional/bind.hpp>
+#include <hpx/runtime_local/startup_function.hpp>
 
 #include <cstdint>
 

--- a/examples/performance_counters/sine/sine_client.cpp
+++ b/examples/performance_counters/sine/sine_client.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/modules/format.hpp>
+#include <hpx/include/util.hpp>
 
 #include <hpx/modules/program_options.hpp>
 

--- a/examples/qt/qt.cpp
+++ b/examples/qt/qt.cpp
@@ -7,8 +7,8 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/thread_executors.hpp>
+#include <hpx/include/util.hpp>
 #include <hpx/lcos/future_wait.hpp>
-#include <hpx/functional/bind.hpp>
 
 #include <cstddef>
 #include <vector>

--- a/examples/qt/widget.cpp
+++ b/examples/qt/widget.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/async_distributed/apply.hpp>
+#include <hpx/future.hpp>
 
 #include <cstddef>
 #include <functional>

--- a/examples/qt/widget.hpp
+++ b/examples/qt/widget.hpp
@@ -10,7 +10,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <hpx/include/threads.hpp>
-#include <hpx/synchronization/spinlock.hpp>
+#include <hpx/include/lcos_local.hpp>
 #include <cstddef>
 #include <functional>
 #endif

--- a/examples/quickstart/1d_wave_equation.cpp
+++ b/examples/quickstart/1d_wave_equation.cpp
@@ -21,13 +21,12 @@
 //
 
 // Include statements.
-#include <hpx/modules/format.hpp>
 #include <hpx/hpx_init.hpp>
+#include <hpx/include/util.hpp>
 #include <hpx/include/async.hpp>
 #include <hpx/distributed/iostream.hpp>
 #include <hpx/lcos/future_wait.hpp>
 #include <hpx/runtime/actions/plain_action.hpp>
-#include <hpx/modules/timing.hpp>
 
 #include <boost/math/constants/constants.hpp>
 

--- a/examples/quickstart/1d_wave_equation.cpp
+++ b/examples/quickstart/1d_wave_equation.cpp
@@ -24,7 +24,7 @@
 #include <hpx/modules/format.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/async.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/lcos/future_wait.hpp>
 #include <hpx/runtime/actions/plain_action.hpp>
 #include <hpx/modules/timing.hpp>

--- a/examples/quickstart/allow_unknown_options.cpp
+++ b/examples/quickstart/allow_unknown_options.cpp
@@ -9,7 +9,7 @@
 // to hpx_main.
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <string>
 #include <vector>

--- a/examples/quickstart/channel_docs.cpp
+++ b/examples/quickstart/channel_docs.cpp
@@ -9,7 +9,7 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/actions.hpp>
 #include <hpx/include/apply.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 
 #include <numeric>

--- a/examples/quickstart/command_line_handling.cpp
+++ b/examples/quickstart/command_line_handling.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <hpx/modules/program_options.hpp>
 

--- a/examples/quickstart/component_ctors.cpp
+++ b/examples/quickstart/component_ctors.cpp
@@ -9,7 +9,7 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/components.hpp>
 #include <hpx/include/actions.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <string>
 #include <utility>

--- a/examples/quickstart/component_in_executable.cpp
+++ b/examples/quickstart/component_in_executable.cpp
@@ -9,7 +9,7 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/components.hpp>
 #include <hpx/include/actions.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <utility>
 

--- a/examples/quickstart/component_inheritance.cpp
+++ b/examples/quickstart/component_inheritance.cpp
@@ -10,7 +10,7 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/components.hpp>
 #include <hpx/include/actions.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <vector>
 

--- a/examples/quickstart/component_with_custom_heap.cpp
+++ b/examples/quickstart/component_with_custom_heap.cpp
@@ -16,7 +16,7 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/actions.hpp>
 #include <hpx/include/components.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
 

--- a/examples/quickstart/component_with_executor.cpp
+++ b/examples/quickstart/component_with_executor.cpp
@@ -7,7 +7,7 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/components.hpp>
 #include <hpx/include/actions.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/parallel_executors.hpp>
 
 #include <utility>

--- a/examples/quickstart/composable_guard.cpp
+++ b/examples/quickstart/composable_guard.cpp
@@ -3,7 +3,7 @@
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-#include <hpx/lcos_local/composable_guard.hpp>
+#include <hpx/modules/lcos_local.hpp>
 #include <hpx/hpx_init.hpp>
 
 #include <atomic>

--- a/examples/quickstart/customize_async.cpp
+++ b/examples/quickstart/customize_async.cpp
@@ -11,8 +11,8 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/iostreams.hpp>
-#include <hpx/include/parallel_execution.hpp>
+#include <hpx/distributed/iostream.hpp>
+#include <hpx/execution.hpp>
 
 #include <algorithm>
 

--- a/examples/quickstart/enumerate_threads.cpp
+++ b/examples/quickstart/enumerate_threads.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/threads.hpp>
 

--- a/examples/quickstart/error_handling.cpp
+++ b/examples/quickstart/error_handling.cpp
@@ -8,8 +8,9 @@
 //  This example is documented in the Manual under the title "Error Handling"
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
+
 #include <hpx/distributed/iostream.hpp>
-#include <hpx/runtime_local/custom_exception_info.hpp>
+#include <hpx/modules/runtime_local.hpp>
 
 //[error_handling_raise_exception
 void raise_exception()

--- a/examples/quickstart/error_handling.cpp
+++ b/examples/quickstart/error_handling.cpp
@@ -8,7 +8,7 @@
 //  This example is documented in the Manual under the title "Error Handling"
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/runtime_local/custom_exception_info.hpp>
 
 //[error_handling_raise_exception

--- a/examples/quickstart/event_synchronization.cpp
+++ b/examples/quickstart/event_synchronization.cpp
@@ -8,7 +8,7 @@
 
 #include <hpx/hpx_main.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <functional>
 

--- a/examples/quickstart/executor_with_thread_hooks.cpp
+++ b/examples/quickstart/executor_with_thread_hooks.cpp
@@ -15,7 +15,6 @@
 #include <hpx/modules/algorithms.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/execution.hpp>
-#include <hpx/modules/functional.hpp>
 
 #include <algorithm>
 #include <atomic>

--- a/examples/quickstart/executor_with_thread_hooks.cpp
+++ b/examples/quickstart/executor_with_thread_hooks.cpp
@@ -14,7 +14,7 @@
 
 #include <hpx/modules/algorithms.hpp>
 #include <hpx/assert.hpp>
-#include <hpx/modules/execution.hpp>
+#include <hpx/execution.hpp>
 #include <hpx/modules/functional.hpp>
 
 #include <algorithm>

--- a/examples/quickstart/fibonacci_dataflow.cpp
+++ b/examples/quickstart/fibonacci_dataflow.cpp
@@ -15,8 +15,6 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
 
-#include <hpx/pack_traversal/unwrap.hpp>
-
 #include <cstdint>
 #include <iostream>
 #include <utility>

--- a/examples/quickstart/fibonacci_futures_distributed.cpp
+++ b/examples/quickstart/fibonacci_futures_distributed.cpp
@@ -9,7 +9,6 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/runtime.hpp>
 #include <hpx/include/util.hpp>
-#include <hpx/pack_traversal/unwrap.hpp>
 
 #include <atomic>
 #include <cstddef>

--- a/examples/quickstart/fractals.cpp
+++ b/examples/quickstart/fractals.cpp
@@ -10,7 +10,7 @@
 #include <hpx/include/actions.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/include/lcos.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <vector>
 

--- a/examples/quickstart/fractals_executor.cpp
+++ b/examples/quickstart/fractals_executor.cpp
@@ -8,9 +8,9 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/actions.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
-#include <hpx/include/parallel_execution.hpp>
+#include <hpx/execution.hpp>
 #include <hpx/include/util.hpp>
 
 #include <vector>

--- a/examples/quickstart/fractals_struct.cpp
+++ b/examples/quickstart/fractals_struct.cpp
@@ -12,7 +12,7 @@
 #include <hpx/include/actions.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/include/lcos.hpp>
-#include <hpx/include/serialization.hpp>
+#include <hpx/serialization.hpp>
 
 #include <cstddef>
 #include <memory>

--- a/examples/quickstart/hello_world_1.cpp
+++ b/examples/quickstart/hello_world_1.cpp
@@ -12,7 +12,7 @@
 // Including 'hpx/hpx_main.hpp' instead of the usual 'hpx/hpx_init.hpp' enables
 // to use the plain C-main below as the direct main HPX entry point.
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 int main()
 {

--- a/examples/quickstart/hello_world_2.cpp
+++ b/examples/quickstart/hello_world_2.cpp
@@ -10,7 +10,7 @@
 
 //[hello_world_2_getting_started
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 int hpx_main(int, char**)
 {

--- a/examples/quickstart/hello_world_distributed.cpp
+++ b/examples/quickstart/hello_world_distributed.cpp
@@ -12,7 +12,7 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/actions.hpp>
 #include <hpx/include/components.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/util.hpp>

--- a/examples/quickstart/interval_timer.cpp
+++ b/examples/quickstart/interval_timer.cpp
@@ -11,7 +11,7 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/threads.hpp>
 #include <hpx/include/util.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <chrono>
 

--- a/examples/quickstart/local_channel.cpp
+++ b/examples/quickstart/local_channel.cpp
@@ -9,7 +9,7 @@
 
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/apply.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 
 #include <numeric>

--- a/examples/quickstart/local_channel_docs.cpp
+++ b/examples/quickstart/local_channel_docs.cpp
@@ -10,7 +10,7 @@
 
 #include <hpx/assert.hpp>
 #include <hpx/include/apply.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 
 #include <numeric>

--- a/examples/quickstart/pingpong.cpp
+++ b/examples/quickstart/pingpong.cpp
@@ -9,8 +9,8 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/actions.hpp>
 #include <hpx/include/components.hpp>
-#include <hpx/include/iostreams.hpp>
-#include <hpx/include/serialization.hpp>
+#include <hpx/distributed/iostream.hpp>
+#include <hpx/serialization.hpp>
 #include <hpx/modules/timing.hpp>
 
 #include <cstddef>

--- a/examples/quickstart/pipeline1.cpp
+++ b/examples/quickstart/pipeline1.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_main.hpp>
-#include <hpx/string_util/trim.hpp>
+#include <hpx/include/util.hpp>
 
 #include <iostream>
 #include <iterator>

--- a/examples/quickstart/potpourri.cpp
+++ b/examples/quickstart/potpourri.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/parallel_generate.hpp>
 #include <hpx/include/parallel_sort.hpp>

--- a/examples/quickstart/safe_object.cpp
+++ b/examples/quickstart/safe_object.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/parallel_algorithm.hpp>
+#include <hpx/algorithm.hpp>
 
 #include <cstddef>
 #include <cstdlib>

--- a/examples/quickstart/shared_mutex.cpp
+++ b/examples/quickstart/shared_mutex.cpp
@@ -10,7 +10,7 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/threads.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <boost/thread/locks.hpp>

--- a/examples/quickstart/sierpinski.cpp
+++ b/examples/quickstart/sierpinski.cpp
@@ -20,8 +20,8 @@
 #include <hpx/include/actions.hpp>
 #include <hpx/include/async.hpp>
 #include <hpx/include/util.hpp>
-#include <hpx/include/iostreams.hpp>
-#include <hpx/include/serialization.hpp>
+#include <hpx/distributed/iostream.hpp>
+#include <hpx/serialization.hpp>
 
 #include <cstdint>
 #include <iostream>

--- a/examples/quickstart/simple_future_continuation.cpp
+++ b/examples/quickstart/simple_future_continuation.cpp
@@ -5,8 +5,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/iostreams.hpp>
-#include <hpx/include/parallel_execution.hpp>
+#include <hpx/distributed/iostream.hpp>
+#include <hpx/execution.hpp>
 #include <hpx/include/threads.hpp>
 
 #include <iostream>

--- a/examples/quickstart/sort_by_key_demo.cpp
+++ b/examples/quickstart/sort_by_key_demo.cpp
@@ -10,7 +10,7 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/parallel_sort.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <cstddef>
 #include <vector>

--- a/examples/quickstart/timed_futures.cpp
+++ b/examples/quickstart/timed_futures.cpp
@@ -9,7 +9,7 @@
 // asynchronous work.
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/timing.hpp>
 
 #include <chrono>

--- a/examples/quickstart/vector_counting_dotproduct.cpp
+++ b/examples/quickstart/vector_counting_dotproduct.cpp
@@ -6,9 +6,9 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/include/parallel_numeric.hpp>
-#include <hpx/include/parallel_algorithm.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/numeric.hpp>
+#include <hpx/algorithm.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/iterator_support.hpp>
 
 #include <algorithm>

--- a/examples/quickstart/vector_zip_dotproduct.cpp
+++ b/examples/quickstart/vector_zip_dotproduct.cpp
@@ -6,9 +6,9 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/include/parallel_numeric.hpp>
-#include <hpx/include/parallel_algorithm.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/numeric.hpp>
+#include <hpx/algorithm.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <iterator>
 #include <string>

--- a/examples/quickstart/zerocopy_rdma.cpp
+++ b/examples/quickstart/zerocopy_rdma.cpp
@@ -7,7 +7,7 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/hpx.hpp>
 
-#include <hpx/serialization/serialize.hpp>
+#include <hpx/serialization.hpp>
 
 #include <cstddef>
 #include <iostream>

--- a/examples/sheneos/sheneos/dimension.cpp
+++ b/examples/sheneos/sheneos/dimension.cpp
@@ -4,7 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/include/serialization.hpp>
+#include <hpx/serialization.hpp>
 
 #include "dimension.hpp"
 

--- a/examples/sheneos/sheneos/dimension.hpp
+++ b/examples/sheneos/sheneos/dimension.hpp
@@ -8,7 +8,7 @@
 
 #include <hpx/hpx.hpp>
 
-#include <hpx/serialization/serialize.hpp>
+#include <hpx/serialization.hpp>
 
 #include <cstddef>
 

--- a/examples/sheneos/sheneos/interpolator.cpp
+++ b/examples/sheneos/sheneos/interpolator.cpp
@@ -8,7 +8,7 @@
 
 #include <hpx/assert.hpp>
 #include <hpx/include/async.hpp>
-#include <hpx/lcos_local/packaged_task.hpp>
+#include <hpx/include/lcos_local.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/examples/sheneos/sheneos/partition3d.hpp
+++ b/examples/sheneos/sheneos/partition3d.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/hpx.hpp>
-#include <hpx/futures/future.hpp>
+#include <hpx/future.hpp>
 #include <hpx/include/client.hpp>
 
 #include <cstdint>

--- a/examples/sheneos/sheneos/read_values.cpp
+++ b/examples/sheneos/sheneos/read_values.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/assert.hpp>
-#include <hpx/errors/exception.hpp>
+#include <hpx/exception.hpp>
 #include <hpx/hpx.hpp>
 
 #include <cstddef>

--- a/examples/sheneos/sheneos/server/configuration.cpp
+++ b/examples/sheneos/sheneos/server/configuration.cpp
@@ -4,7 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/include/serialization.hpp>
+#include <hpx/serialization.hpp>
 
 #include <cstddef>
 #include <string>

--- a/examples/spell_check/spell_check_file.cpp
+++ b/examples/spell_check/spell_check_file.cpp
@@ -10,7 +10,6 @@
 #include <hpx/include/actions.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/include/lcos.hpp>
-#include <hpx/modules/string_util.hpp>
 
 #include <fstream>
 #include <iostream>

--- a/examples/spell_check/spell_check_simple.cpp
+++ b/examples/spell_check/spell_check_simple.cpp
@@ -10,7 +10,6 @@
 #include <hpx/include/actions.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/include/lcos.hpp>
-#include <hpx/modules/string_util.hpp>
 
 #include <fstream>
 #include <iostream>

--- a/examples/startup_shutdown/startup_shutdown.cpp
+++ b/examples/startup_shutdown/startup_shutdown.cpp
@@ -25,8 +25,8 @@
 // would not be executed by the runtime system.
 
 #include <hpx/hpx.hpp>
-#include <hpx/runtime_local/startup_function.hpp>
-#include <hpx/command_line_handling/parse_command_line.hpp>
+#include <hpx/modules/runtime_local.hpp>
+#include <hpx/include/util.hpp>
 
 #include <hpx/modules/program_options.hpp>
 

--- a/examples/thread_aware_timer/thread_aware_timer.cpp
+++ b/examples/thread_aware_timer/thread_aware_timer.cpp
@@ -7,7 +7,7 @@
 // Including 'hpx/hpx_main.hpp' instead of the usual 'hpx/hpx_init.hpp' enables
 // to use the plain C-main below as the direct main HPX entry point.
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/util.hpp>
 
 #define NUMTESTS 100000

--- a/examples/throttle/spin.cpp
+++ b/examples/throttle/spin.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/modules/format.hpp>
+#include <hpx/include/util.hpp>
 
 #include <iostream>
 #include <string>

--- a/examples/throttle/throttle/server/throttle.cpp
+++ b/examples/throttle/throttle/server/throttle.cpp
@@ -5,10 +5,10 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/assert.hpp>
-#include <hpx/functional/bind.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/runtime.hpp>
-#include <hpx/thread_support/unlock_guard.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/modules/thread_support.hpp>
 
 #include <thread>
 #include <chrono>

--- a/examples/throttle/throttle/server/throttle.hpp
+++ b/examples/throttle/throttle/server/throttle.hpp
@@ -8,8 +8,8 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/include/components.hpp>
-#include <hpx/futures/future.hpp>
-#include <hpx/synchronization/mutex.hpp>
+#include <hpx/future.hpp>
+#include <hpx/mutex.hpp>
 #include <hpx/runtime/actions/component_action.hpp>
 
 #include <boost/dynamic_bitset.hpp>

--- a/examples/throttle/throttle/stubs/throttle.hpp
+++ b/examples/throttle/throttle/stubs/throttle.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/hpx.hpp>
-#include <hpx/futures/future.hpp>
+#include <hpx/future.hpp>
 #include <hpx/runtime/components/stubs/stub_base.hpp>
 
 #include "../server/throttle.hpp"

--- a/examples/throttle/throttle/throttle.hpp
+++ b/examples/throttle/throttle/throttle.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/hpx.hpp>
-#include <hpx/futures/future.hpp>
+#include <hpx/future.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/include/client.hpp>
 

--- a/examples/throttle/throttle_client.cpp
+++ b/examples/throttle/throttle_client.cpp
@@ -8,9 +8,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/components.hpp>
 #include <hpx/runtime/agas/interface.hpp>
-#include <hpx/modules/format.hpp>
-#include <hpx/string_util/classification.hpp>
-#include <hpx/string_util/split.hpp>
+#include <hpx/include/util.hpp>
 
 #include "throttle/throttle.hpp"
 

--- a/examples/transpose/transpose_await.cpp
+++ b/examples/transpose/transpose_await.cpp
@@ -7,8 +7,8 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 
-#include <hpx/include/parallel_algorithm.hpp>
-#include <hpx/include/parallel_numeric.hpp>
+#include <hpx/algorithm.hpp>
+#include <hpx/numeric.hpp>
 
 #include <boost/range/irange.hpp>
 

--- a/examples/transpose/transpose_block.cpp
+++ b/examples/transpose/transpose_block.cpp
@@ -7,8 +7,8 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 
-#include <hpx/include/parallel_algorithm.hpp>
-#include <hpx/include/parallel_numeric.hpp>
+#include <hpx/algorithm.hpp>
+#include <hpx/numeric.hpp>
 
 #include <boost/range/irange.hpp>
 

--- a/examples/transpose/transpose_block_numa.cpp
+++ b/examples/transpose/transpose_block_numa.cpp
@@ -8,10 +8,10 @@
 #include <hpx/hpx.hpp>
 
 #include <hpx/modules/format.hpp>
-#include <hpx/include/parallel_algorithm.hpp>
+#include <hpx/algorithm.hpp>
 #include <hpx/include/parallel_executors.hpp>
-#include <hpx/include/parallel_numeric.hpp>
-#include <hpx/include/serialization.hpp>
+#include <hpx/numeric.hpp>
+#include <hpx/serialization.hpp>
 #include <hpx/topology/topology.hpp>
 #include <hpx/util/from_string.hpp>
 

--- a/examples/transpose/transpose_block_numa.cpp
+++ b/examples/transpose/transpose_block_numa.cpp
@@ -12,8 +12,8 @@
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/numeric.hpp>
 #include <hpx/serialization.hpp>
-#include <hpx/topology/topology.hpp>
-#include <hpx/util/from_string.hpp>
+#include <hpx/modules/topology.hpp>
+#include <hpx/include/util.hpp>
 
 #include <hpx/compute/host/numa_allocator.hpp>
 

--- a/examples/transpose/transpose_smp.cpp
+++ b/examples/transpose/transpose_smp.cpp
@@ -7,8 +7,8 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 
-#include <hpx/include/parallel_algorithm.hpp>
-#include <hpx/include/parallel_numeric.hpp>
+#include <hpx/algorithm.hpp>
+#include <hpx/numeric.hpp>
 
 #include <boost/range/irange.hpp>
 

--- a/examples/transpose/transpose_smp_block.cpp
+++ b/examples/transpose/transpose_smp_block.cpp
@@ -7,8 +7,8 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 
-#include <hpx/include/parallel_algorithm.hpp>
-#include <hpx/include/parallel_numeric.hpp>
+#include <hpx/algorithm.hpp>
+#include <hpx/numeric.hpp>
 
 #include <boost/range/irange.hpp>
 

--- a/examples/tuplespace/central_tuplespace/server/simple_central_tuplespace.hpp
+++ b/examples/tuplespace/central_tuplespace/server/simple_central_tuplespace.hpp
@@ -8,11 +8,11 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/include/components.hpp>
+#include <hpx/include/lcos_local.hpp>
+#include <hpx/include/util.hpp>
 #include <hpx/runtime/components/server/locking_hook.hpp>
 #include <hpx/runtime/actions/component_action.hpp>
 #include <hpx/util/storage/tuple.hpp>
-#include <hpx/modules/timing.hpp>
-#include <hpx/include/lcos_local.hpp>
 
 #include <mutex>
 

--- a/examples/tuplespace/central_tuplespace/server/tuples_warehouse.hpp
+++ b/examples/tuplespace/central_tuplespace/server/tuples_warehouse.hpp
@@ -8,10 +8,10 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/include/components.hpp>
+#include <hpx/include/util.hpp>
 #include <hpx/mutex.hpp>
 #include <hpx/runtime/actions/component_action.hpp>
 #include <hpx/runtime/components/server/locking_hook.hpp>
-#include <hpx/modules/timing.hpp>
 #include <hpx/util/storage/tuple.hpp>
 
 #include <algorithm>
@@ -21,8 +21,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-#include <hpx/util/storage/tuple.hpp>
 
 // #define TS_DEBUG
 

--- a/examples/tuplespace/central_tuplespace/server/tuples_warehouse.hpp
+++ b/examples/tuplespace/central_tuplespace/server/tuples_warehouse.hpp
@@ -8,7 +8,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/include/components.hpp>
-#include <hpx/synchronization/mutex.hpp>
+#include <hpx/mutex.hpp>
 #include <hpx/runtime/actions/component_action.hpp>
 #include <hpx/runtime/components/server/locking_hook.hpp>
 #include <hpx/modules/timing.hpp>

--- a/examples/tuplespace/central_tuplespace/stubs/simple_central_tuplespace.hpp
+++ b/examples/tuplespace/central_tuplespace/stubs/simple_central_tuplespace.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/runtime/components/stubs/stub_base.hpp>
-#include <hpx/async_distributed/applier/apply.hpp>
+#include <hpx/include/applier.hpp>
 #include <hpx/include/async.hpp>
 
 #include "../server/simple_central_tuplespace.hpp"

--- a/examples/tuplespace/simple_central_tuplespace_client.cpp
+++ b/examples/tuplespace/simple_central_tuplespace_client.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/actions.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/string_util/classification.hpp>
 #include <hpx/string_util/split.hpp>

--- a/examples/tuplespace/simple_central_tuplespace_client.cpp
+++ b/examples/tuplespace/simple_central_tuplespace_client.cpp
@@ -5,12 +5,11 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/actions.hpp>
+
 #include <hpx/distributed/iostream.hpp>
+#include <hpx/include/actions.hpp>
 #include <hpx/include/lcos.hpp>
-#include <hpx/string_util/classification.hpp>
-#include <hpx/string_util/split.hpp>
-#include <hpx/string_util/trim.hpp>
+#include <hpx/include/util.hpp>
 
 #include <string>
 #include <vector>

--- a/examples/tuplespace/small_big_object.hpp
+++ b/examples/tuplespace/small_big_object.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <hpx/serialization/serialize.hpp>
+#include <hpx/serialization.hpp>
 
 #include <cstdint>
 #include <iostream>

--- a/hpx/lcos/detail/promise_base.hpp
+++ b/hpx/lcos/detail/promise_base.hpp
@@ -15,7 +15,7 @@
 #include <hpx/futures/detail/future_data.hpp>
 #include <hpx/lcos/detail/promise_lco.hpp>
 #include <hpx/lcos_local/promise.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/runtime/components/server/component_heap.hpp>
 #include <hpx/runtime/components/server/managed_component_base.hpp>
 #include <hpx/runtime/naming/address.hpp>

--- a/hpx/lcos/detail/promise_lco.hpp
+++ b/hpx/lcos/detail/promise_lco.hpp
@@ -12,7 +12,7 @@
 #include <hpx/assert.hpp>
 #include <hpx/lcos/base_lco_with_value.hpp>
 #include <hpx/futures/detail/future_data.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/runtime/components/component_type.hpp>
 #include <hpx/runtime/components/server/component_heap.hpp>
 #include <hpx/runtime/components/server/managed_component_base.hpp>

--- a/hpx/lcos/packaged_action.hpp
+++ b/hpx/lcos/packaged_action.hpp
@@ -12,7 +12,7 @@
 #include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/lcos/promise.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/async_distributed/applier/apply.hpp>
 #include <hpx/async_distributed/applier/apply_callback.hpp>
 #include <hpx/runtime/components/component_type.hpp>

--- a/hpx/runtime/components/client_base.hpp
+++ b/hpx/runtime/components/client_base.hpp
@@ -11,7 +11,7 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/functional/bind_back.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/runtime/agas/interface.hpp>
 #include <hpx/runtime/components/component_type.hpp>
 #include <hpx/runtime/components/make_client.hpp>

--- a/hpx/runtime/naming/id_type.hpp
+++ b/hpx/runtime/naming/id_type.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/serialization/serialization_fwd.hpp>
 

--- a/libs/algorithms/include/hpx/numeric.hpp
+++ b/libs/algorithms/include/hpx/numeric.hpp
@@ -13,6 +13,7 @@
 #include <hpx/parallel/algorithms/transform_exclusive_scan.hpp>
 #include <hpx/parallel/algorithms/transform_inclusive_scan.hpp>
 #include <hpx/parallel/algorithms/transform_reduce.hpp>
+#include <hpx/parallel/algorithms/transform_reduce_binary.hpp>
 
 namespace hpx {
     using hpx::parallel::adjacent_difference;

--- a/libs/algorithms/tests/performance/transform_reduce_scaling.cpp
+++ b/libs/algorithms/tests/performance/transform_reduce_scaling.cpp
@@ -6,8 +6,8 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
 #include <hpx/include/parallel_numeric.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/timing/high_resolution_clock.hpp>
 #include "worker_timed.hpp"
 

--- a/libs/algorithms/tests/performance/transform_reduce_scaling.cpp
+++ b/libs/algorithms/tests/performance/transform_reduce_scaling.cpp
@@ -6,8 +6,9 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/parallel_numeric.hpp>
+
 #include <hpx/distributed/iostream.hpp>
+#include <hpx/include/parallel_numeric.hpp>
 #include <hpx/timing/high_resolution_clock.hpp>
 #include "worker_timed.hpp"
 

--- a/libs/algorithms/tests/unit/block/task_block.cpp
+++ b/libs/algorithms/tests/unit/block/task_block.cpp
@@ -6,8 +6,8 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
 #include <hpx/include/parallel_task_block.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/runtime_local/custom_exception_info.hpp>
 

--- a/libs/algorithms/tests/unit/block/task_block.cpp
+++ b/libs/algorithms/tests/unit/block/task_block.cpp
@@ -6,8 +6,9 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/parallel_task_block.hpp>
+
 #include <hpx/distributed/iostream.hpp>
+#include <hpx/include/parallel_task_block.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/runtime_local/custom_exception_info.hpp>
 

--- a/libs/algorithms/tests/unit/block/task_block_executor.cpp
+++ b/libs/algorithms/tests/unit/block/task_block_executor.cpp
@@ -6,9 +6,10 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
+
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/parallel_executor_parameters.hpp>
 #include <hpx/include/parallel_task_block.hpp>
-#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/runtime_local/custom_exception_info.hpp>
 

--- a/libs/algorithms/tests/unit/block/task_block_executor.cpp
+++ b/libs/algorithms/tests/unit/block/task_block_executor.cpp
@@ -6,9 +6,9 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
 #include <hpx/include/parallel_executor_parameters.hpp>
 #include <hpx/include/parallel_task_block.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/runtime_local/custom_exception_info.hpp>
 

--- a/libs/algorithms/tests/unit/block/task_block_par.cpp
+++ b/libs/algorithms/tests/unit/block/task_block_par.cpp
@@ -6,8 +6,8 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
 #include <hpx/include/parallel_task_block.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/runtime_local/custom_exception_info.hpp>
 

--- a/libs/algorithms/tests/unit/block/task_block_par.cpp
+++ b/libs/algorithms/tests/unit/block/task_block_par.cpp
@@ -6,8 +6,9 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/parallel_task_block.hpp>
+
 #include <hpx/distributed/iostream.hpp>
+#include <hpx/include/parallel_task_block.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/runtime_local/custom_exception_info.hpp>
 

--- a/libs/async_combinators/include/hpx/async_combinators/split_future.hpp
+++ b/libs/async_combinators/include/hpx/async_combinators/split_future.hpp
@@ -73,8 +73,8 @@ namespace hpx {
 #include <hpx/futures/traits/acquire_shared_state.hpp>
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/futures/traits/future_traits.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/type_support/pack.hpp>
 #include <hpx/type_support/unused.hpp>
 

--- a/libs/async_combinators/include/hpx/async_combinators/wait_all.hpp
+++ b/libs/async_combinators/include/hpx/async_combinators/wait_all.hpp
@@ -108,7 +108,7 @@ namespace hpx {
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/futures/traits/is_future.hpp>
 #include <hpx/iterator_support/range.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/type_support/always_void.hpp>
 #include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/unwrap_ref.hpp>

--- a/libs/async_combinators/include/hpx/async_combinators/when_each.hpp
+++ b/libs/async_combinators/include/hpx/async_combinators/when_each.hpp
@@ -139,7 +139,7 @@ namespace hpx {
 #include <hpx/futures/traits/is_future.hpp>
 #include <hpx/futures/traits/is_future_range.hpp>
 #include <hpx/iterator_support/range.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/pack.hpp>
 #include <hpx/type_support/unwrap_ref.hpp>

--- a/libs/async_combinators/tests/regressions/wait_all_hang_1946.cpp
+++ b/libs/async_combinators/tests/regressions/wait_all_hang_1946.cpp
@@ -9,8 +9,9 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/actions.hpp>
+
 #include <hpx/distributed/iostream.hpp>
+#include <hpx/include/actions.hpp>
 #include <hpx/serialization/serialize.hpp>
 
 #include <cstddef>

--- a/libs/async_combinators/tests/regressions/wait_all_hang_1946.cpp
+++ b/libs/async_combinators/tests/regressions/wait_all_hang_1946.cpp
@@ -10,7 +10,7 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/actions.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/serialization/serialize.hpp>
 
 #include <cstddef>

--- a/libs/async_cuda/src/cuda_future.cpp
+++ b/libs/async_cuda/src/cuda_future.cpp
@@ -14,8 +14,8 @@
 #include <hpx/async_cuda/target.hpp>
 #include <hpx/errors.hpp>
 #include <hpx/futures/traits/future_access.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/modules/assertion.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/runtime/find_here.hpp>
 #include <hpx/runtime/naming/id_type_impl.hpp>
 #include <hpx/runtime_fwd.hpp>

--- a/libs/async_cuda/src/cuda_target.cpp
+++ b/libs/async_cuda/src/cuda_target.cpp
@@ -10,8 +10,8 @@
 #include <hpx/assert.hpp>
 #include <hpx/async_cuda/target.hpp>
 #include <hpx/futures/traits/future_access.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/runtime/find_here.hpp>
 #include <hpx/runtime/naming/id_type_impl.hpp>
 #include <hpx/runtime_fwd.hpp>

--- a/libs/async_distributed/include/hpx/async_distributed/dataflow.hpp
+++ b/libs/async_distributed/include/hpx/async_distributed/dataflow.hpp
@@ -23,7 +23,7 @@
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/futures/traits/is_future.hpp>
 #include <hpx/futures/traits/promise_local_result.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/pack_traversal/pack_traversal_async.hpp>
 #include <hpx/runtime/actions/basic_action_fwd.hpp>
 #include <hpx/runtime/naming_fwd.hpp>

--- a/libs/async_distributed/tests/regressions/dataflow_future_swap.cpp
+++ b/libs/async_distributed/tests/regressions/dataflow_future_swap.cpp
@@ -10,7 +10,7 @@
 #include <hpx/async_local/dataflow.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/pack_traversal/unwrap.hpp>
 

--- a/libs/async_distributed/tests/regressions/dataflow_future_swap.cpp
+++ b/libs/async_distributed/tests/regressions/dataflow_future_swap.cpp
@@ -7,9 +7,10 @@
 // This test case demonstrates the issue described in #775: runtime error with
 // local dataflow (copying futures?).
 
-#include <hpx/async_local/dataflow.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_main.hpp>
+
+#include <hpx/async_local/dataflow.hpp>
 #include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/pack_traversal/unwrap.hpp>

--- a/libs/async_distributed/tests/regressions/dataflow_future_swap2.cpp
+++ b/libs/async_distributed/tests/regressions/dataflow_future_swap2.cpp
@@ -7,9 +7,10 @@
 // This test case demonstrates the issue described in #778: swapping futures
 // segfaults.
 
-#include <hpx/async_local/dataflow.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_main.hpp>
+
+#include <hpx/async_local/dataflow.hpp>
 #include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/pack_traversal/unwrap.hpp>

--- a/libs/async_distributed/tests/regressions/dataflow_future_swap2.cpp
+++ b/libs/async_distributed/tests/regressions/dataflow_future_swap2.cpp
@@ -10,7 +10,7 @@
 #include <hpx/async_local/dataflow.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/pack_traversal/unwrap.hpp>
 

--- a/libs/collectives/include/hpx/collectives/barrier.hpp
+++ b/libs/collectives/include/hpx/collectives/barrier.hpp
@@ -12,7 +12,7 @@
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/collectives/detail/barrier_node.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/runtime/components/server/managed_component_base.hpp>
 
 #include <cstddef>

--- a/libs/collectives/src/barrier.cpp
+++ b/libs/collectives/src/barrier.cpp
@@ -8,8 +8,8 @@
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_combinators/when_all.hpp>
 #include <hpx/collectives/barrier.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/modules/execution.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/runtime/basename_registration.hpp>
 #include <hpx/runtime/components/server/component_heap.hpp>
 #include <hpx/runtime_configuration/runtime_configuration.hpp>

--- a/libs/collectives/src/detail/barrier_node.cpp
+++ b/libs/collectives/src/detail/barrier_node.cpp
@@ -10,9 +10,9 @@
 #include <hpx/collectives/detail/barrier_node.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/lcos_local/promise.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/execution.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/pack_traversal/unwrap.hpp>
 #include <hpx/runtime/components/component_type.hpp>
 #include <hpx/util/from_string.hpp>

--- a/libs/collectives/tests/performance/osu/osu_bcast.cpp
+++ b/libs/collectives/tests/performance/osu/osu_bcast.cpp
@@ -8,9 +8,10 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
+
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/components.hpp>
 #include <hpx/include/serialization.hpp>
-#include <hpx/distributed/iostream.hpp>
 #include <hpx/lcos_local/and_gate.hpp>
 #include <hpx/serialization/serializable_any.hpp>
 

--- a/libs/collectives/tests/performance/osu/osu_bcast.cpp
+++ b/libs/collectives/tests/performance/osu/osu_bcast.cpp
@@ -9,8 +9,8 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/components.hpp>
-#include <hpx/include/iostreams.hpp>
 #include <hpx/include/serialization.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/lcos_local/and_gate.hpp>
 #include <hpx/serialization/serializable_any.hpp>
 

--- a/libs/collectives/tests/performance/osu/osu_scatter.cpp
+++ b/libs/collectives/tests/performance/osu/osu_scatter.cpp
@@ -8,7 +8,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/serialization/serialize_buffer.hpp>
 
 #include <cstddef>

--- a/libs/collectives/tests/performance/osu/osu_scatter.cpp
+++ b/libs/collectives/tests/performance/osu/osu_scatter.cpp
@@ -8,6 +8,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
+
 #include <hpx/distributed/iostream.hpp>
 #include <hpx/serialization/serialize_buffer.hpp>
 

--- a/libs/compute/tests/unit/numa_allocator.cpp
+++ b/libs/compute/tests/unit/numa_allocator.cpp
@@ -23,8 +23,8 @@
 #include <hpx/thread_pools/scheduled_thread_pool_impl.hpp>
 #include <hpx/topology/cpu_mask.hpp>
 //
-#include <hpx/include/runtime.hpp>
 #include <hpx/distributed/iostream.hpp>
+#include <hpx/include/runtime.hpp>
 //
 #include <hpx/modules/testing.hpp>
 //

--- a/libs/compute/tests/unit/numa_allocator.cpp
+++ b/libs/compute/tests/unit/numa_allocator.cpp
@@ -23,8 +23,8 @@
 #include <hpx/thread_pools/scheduled_thread_pool_impl.hpp>
 #include <hpx/topology/cpu_mask.hpp>
 //
-#include <hpx/include/iostreams.hpp>
 #include <hpx/include/runtime.hpp>
+#include <hpx/distributed/iostream.hpp>
 //
 #include <hpx/modules/testing.hpp>
 //

--- a/libs/execution/CMakeLists.txt
+++ b/libs/execution/CMakeLists.txt
@@ -100,6 +100,7 @@ add_hpx_module(
     hpx_errors
     hpx_functional
     hpx_iterator_support
+    hpx_memory
     hpx_preprocessor
     hpx_resource_partitioner
     hpx_synchronization

--- a/libs/execution/include/hpx/execution/detail/future_exec.hpp
+++ b/libs/execution/include/hpx/execution/detail/future_exec.hpp
@@ -22,8 +22,8 @@
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/packaged_continuation.hpp>
 #include <hpx/futures/traits/future_access.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp>
 #include <hpx/timing/steady_clock.hpp>
 #include <hpx/type_support/decay.hpp>

--- a/libs/executors/CMakeLists.txt
+++ b/libs/executors/CMakeLists.txt
@@ -77,6 +77,7 @@ add_hpx_module(
     hpx_execution
     hpx_functional
     hpx_iterator_support
+    hpx_memory
     hpx_serialization
     hpx_synchronization
     hpx_threading_base

--- a/libs/executors/include/hpx/executors/dataflow.hpp
+++ b/libs/executors/include/hpx/executors/dataflow.hpp
@@ -25,7 +25,7 @@
 #include <hpx/futures/traits/acquire_future.hpp>
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/futures/traits/is_future.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/pack_traversal/pack_traversal_async.hpp>
 #include <hpx/runtime/actions/basic_action_fwd.hpp>
 #include <hpx/runtime/naming_fwd.hpp>

--- a/libs/functional/tests/regressions/function_argument.cpp
+++ b/libs/functional/tests/regressions/function_argument.cpp
@@ -6,8 +6,8 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/distributed/iostream.hpp>
 
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/functional/function.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/modules/timing.hpp>

--- a/libs/functional/tests/regressions/function_argument.cpp
+++ b/libs/functional/tests/regressions/function_argument.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <hpx/functional/function.hpp>
 #include <hpx/modules/testing.hpp>

--- a/libs/functional/tests/regressions/function_serialization_728.cpp
+++ b/libs/functional/tests/regressions/function_serialization_728.cpp
@@ -14,8 +14,8 @@
 #ifdef HPX_HAVE_COMPRESSION_ZLIB
 #include <hpx/include/compression_zlib.hpp>
 #endif
-#include <hpx/include/iostreams.hpp>
 #include <hpx/include/parcel_coalescing.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <cstddef>

--- a/libs/functional/tests/regressions/function_serialization_728.cpp
+++ b/libs/functional/tests/regressions/function_serialization_728.cpp
@@ -7,6 +7,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <hpx/hpx_init.hpp>
+
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/actions.hpp>
 #include <hpx/include/async.hpp>
 #include <hpx/include/lcos.hpp>
@@ -15,7 +17,6 @@
 #include <hpx/include/compression_zlib.hpp>
 #endif
 #include <hpx/include/parcel_coalescing.hpp>
-#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <cstddef>

--- a/libs/futures/include/hpx/futures/detail/future_data.hpp
+++ b/libs/futures/include/hpx/futures/detail/future_data.hpp
@@ -12,9 +12,9 @@
 #include <hpx/coroutines/detail/get_stack_pointer.hpp>
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/futures/traits/get_remote_result.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/synchronization/condition_variable.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/thread_support/assert_owns_lock.hpp>

--- a/libs/futures/include/hpx/futures/future.hpp
+++ b/libs/futures/include/hpx/futures/future.hpp
@@ -22,8 +22,8 @@
 #include <hpx/futures/traits/future_then_result.hpp>
 #include <hpx/futures/traits/future_traits.hpp>
 #include <hpx/futures/traits/is_future.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp>
 #include <hpx/timing/steady_clock.hpp>
 #include <hpx/type_support/decay.hpp>

--- a/libs/futures/include/hpx/futures/futures_factory.hpp
+++ b/libs/futures/include/hpx/futures/futures_factory.hpp
@@ -16,8 +16,8 @@
 #include <hpx/futures/detail/future_data.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/future_access.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/threading_base/thread_description.hpp>
 #include <hpx/threading_base/thread_helpers.hpp>
 #include <hpx/threading_base/thread_num_tss.hpp>

--- a/libs/futures/include/hpx/futures/packaged_continuation.hpp
+++ b/libs/futures/include/hpx/futures/packaged_continuation.hpp
@@ -15,8 +15,8 @@
 #include <hpx/futures/traits/acquire_shared_state.hpp>
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/futures/traits/future_traits.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/threading_base/annotated_function.hpp>
 #include <hpx/threading_base/thread_description.hpp>
 

--- a/libs/futures/include/hpx/futures/traits/acquire_shared_state.hpp
+++ b/libs/futures/include/hpx/futures/traits/acquire_shared_state.hpp
@@ -14,7 +14,7 @@
 #include <hpx/futures/traits/is_future_range.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/util/detail/reserve.hpp>
 
 #include <algorithm>

--- a/libs/futures/include/hpx/futures/traits/detail/future_await_traits.hpp
+++ b/libs/futures/include/hpx/futures/traits/detail/future_await_traits.hpp
@@ -11,8 +11,8 @@
 #if defined(HPX_HAVE_AWAIT) || defined(HPX_HAVE_CXX20_COROUTINES)
 
 #include <hpx/futures/detail/future_data.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/modules/allocator_support.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/traits/future_access.hpp>
 
 #if defined(HPX_HAVE_CXX20_COROUTINES)

--- a/libs/futures/include/hpx/futures/traits/future_access.hpp
+++ b/libs/futures/include/hpx/futures/traits/future_access.hpp
@@ -8,7 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/futures/traits/future_traits.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 
 #include <type_traits>
 #include <utility>

--- a/libs/futures/src/future_data.cpp
+++ b/libs/futures/src/future_data.cpp
@@ -14,8 +14,8 @@
 #include <hpx/functional/deferred_call.hpp>
 #include <hpx/functional/unique_function.hpp>
 #include <hpx/futures/futures_factory.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/threading_base/annotated_function.hpp>
 
 #include <cstddef>

--- a/libs/include/CMakeLists.txt
+++ b/libs/include/CMakeLists.txt
@@ -121,6 +121,7 @@ add_hpx_module(
     hpx_pack_traversal
     hpx_resource_partitioner
     hpx_serialization
+    hpx_string_util
     hpx_synchronization
     hpx_thread_executors
     hpx_thread_pools

--- a/libs/include/include/hpx/execution.hpp
+++ b/libs/include/include/hpx/execution.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/executors.hpp>
+#include <hpx/modules/thread_executors.hpp>
 
 namespace hpx { namespace execution {
     using hpx::parallel::execution::par;

--- a/libs/include/include/hpx/include/util.hpp
+++ b/libs/include/include/hpx/include/util.hpp
@@ -31,6 +31,7 @@
 #include <hpx/timing/high_resolution_clock.hpp>
 #include <hpx/timing/high_resolution_timer.hpp>
 #include <hpx/type_support/decay.hpp>
+#include <hpx/type_support/unused.hpp>
 #include <hpx/util/from_string.hpp>
 #include <hpx/util/get_and_reset_value.hpp>
 #include <hpx/util/thread_aware_timer.hpp>
@@ -39,4 +40,8 @@
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/parallel/segmented_algorithms/traits/zip_iterator.hpp>
 #include <hpx/util/activate_counters.hpp>
+#endif
+
+#if defined(HPX_HAVE_LIB_STRING_UTIL)
+#include <hpx/modules/string_util.hpp>
 #endif

--- a/libs/iterator_support/tests/performance/stencil3_iterators.cpp
+++ b/libs/iterator_support/tests/performance/stencil3_iterators.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/modules/timing.hpp>

--- a/libs/iterator_support/tests/performance/stencil3_iterators.cpp
+++ b/libs/iterator_support/tests/performance/stencil3_iterators.cpp
@@ -6,6 +6,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
+
 #include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/testing.hpp>

--- a/libs/lcos_local/include/hpx/lcos_local/channel.hpp
+++ b/libs/lcos_local/include/hpx/lcos_local/channel.hpp
@@ -14,8 +14,8 @@
 #include <hpx/iterator_support/iterator_facade.hpp>
 #include <hpx/lcos_local/packaged_task.hpp>
 #include <hpx/lcos_local/receive_buffer.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/synchronization/no_mutex.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/thread_support/assert_owns_lock.hpp>

--- a/libs/lcos_local/include/hpx/lcos_local/promise.hpp
+++ b/libs/lcos_local/include/hpx/lcos_local/promise.hpp
@@ -10,8 +10,8 @@
 #include <hpx/allocator_support/allocator_deleter.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/future_access.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <exception>

--- a/libs/memory/include/hpx/memory/serialization/intrusive_ptr.hpp
+++ b/libs/memory/include/hpx/memory/serialization/intrusive_ptr.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/serialization/serialize.hpp>
 
 namespace hpx { namespace serialization {

--- a/libs/memory/tests/unit/intrusive_ptr.cpp
+++ b/libs/memory/tests/unit/intrusive_ptr.cpp
@@ -26,7 +26,7 @@
 
 #endif
 
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/thread_support/atomic_count.hpp>
 

--- a/libs/memory/tests/unit/intrusive_ptr_move.cpp
+++ b/libs/memory/tests/unit/intrusive_ptr_move.cpp
@@ -26,7 +26,7 @@
 
 #endif
 
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/thread_support/atomic_count.hpp>
 

--- a/libs/memory/tests/unit/intrusive_ptr_polymorphic.cpp
+++ b/libs/memory/tests/unit/intrusive_ptr_polymorphic.cpp
@@ -4,8 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/memory/serialization/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/modules/serialization.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/libs/memory/tests/unit/intrusive_ptr_polymorphic_nonintrusive.cpp
+++ b/libs/memory/tests/unit/intrusive_ptr_polymorphic_nonintrusive.cpp
@@ -4,8 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/memory/serialization/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/modules/serialization.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/libs/memory/tests/unit/ip_convertible.cpp
+++ b/libs/memory/tests/unit/ip_convertible.cpp
@@ -8,7 +8,7 @@
 //  http://www.boost.org/LICENSE_1_0.txt
 
 #include <hpx/config.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/modules/testing.hpp>
 
 //

--- a/libs/memory/tests/unit/ip_hash.cpp
+++ b/libs/memory/tests/unit/ip_hash.cpp
@@ -9,7 +9,7 @@
 // http://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <functional>

--- a/libs/memory/tests/unit/serialization_intrusive_ptr.cpp
+++ b/libs/memory/tests/unit/serialization_intrusive_ptr.cpp
@@ -4,8 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/memory/serialization/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/modules/serialization.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/libs/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
+++ b/libs/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
@@ -13,7 +13,7 @@
 #include <hpx/functional/invoke.hpp>
 #include <hpx/functional/invoke_fused.hpp>
 #include <hpx/futures/traits/future_access.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/pack_traversal/detail/container_category.hpp>
 #include <hpx/type_support/always_void.hpp>
 #include <hpx/type_support/pack.hpp>

--- a/libs/resource_partitioner/examples/guided_pool_test.cpp
+++ b/libs/resource_partitioner/examples/guided_pool_test.cpp
@@ -7,12 +7,12 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 //
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/parallel_for_loop.hpp>
 #include <hpx/include/resource_partitioner.hpp>
 #include <hpx/include/runtime.hpp>
 #include <hpx/include/threads.hpp>
-#include <hpx/distributed/iostream.hpp>
 //
 #include <cmath>
 #include <cstddef>

--- a/libs/resource_partitioner/examples/guided_pool_test.cpp
+++ b/libs/resource_partitioner/examples/guided_pool_test.cpp
@@ -7,12 +7,12 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 //
-#include <hpx/include/iostreams.hpp>
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/parallel_for_loop.hpp>
 #include <hpx/include/resource_partitioner.hpp>
 #include <hpx/include/runtime.hpp>
 #include <hpx/include/threads.hpp>
+#include <hpx/distributed/iostream.hpp>
 //
 #include <cmath>
 #include <cstddef>

--- a/libs/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
+++ b/libs/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
@@ -6,6 +6,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
+
 #include <hpx/distributed/iostream.hpp>
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/parallel_for_loop.hpp>

--- a/libs/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
+++ b/libs/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/parallel_for_loop.hpp>
 #include <hpx/include/resource_partitioner.hpp>

--- a/libs/resource_partitioner/examples/simple_resource_partitioner.cpp
+++ b/libs/resource_partitioner/examples/simple_resource_partitioner.cpp
@@ -16,8 +16,8 @@
 #include <hpx/thread_pools/scheduled_thread_pool_impl.hpp>
 #include <hpx/topology/cpu_mask.hpp>
 //
-#include <hpx/include/runtime.hpp>
 #include <hpx/distributed/iostream.hpp>
+#include <hpx/include/runtime.hpp>
 //
 #include <cmath>
 #include <cstddef>

--- a/libs/resource_partitioner/examples/simple_resource_partitioner.cpp
+++ b/libs/resource_partitioner/examples/simple_resource_partitioner.cpp
@@ -16,8 +16,8 @@
 #include <hpx/thread_pools/scheduled_thread_pool_impl.hpp>
 #include <hpx/topology/cpu_mask.hpp>
 //
-#include <hpx/include/iostreams.hpp>
 #include <hpx/include/runtime.hpp>
+#include <hpx/distributed/iostream.hpp>
 //
 #include <cmath>
 #include <cstddef>

--- a/libs/segmented_algorithms/tests/performance/minmax_element_performance.cpp
+++ b/libs/segmented_algorithms/tests/performance/minmax_element_performance.cpp
@@ -6,10 +6,11 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
+
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/parallel_generate.hpp>
 #include <hpx/include/parallel_minmax.hpp>
 #include <hpx/include/partitioned_vector.hpp>
-#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/timing.hpp>
 
 #include <hpx/modules/program_options.hpp>

--- a/libs/segmented_algorithms/tests/performance/minmax_element_performance.cpp
+++ b/libs/segmented_algorithms/tests/performance/minmax_element_performance.cpp
@@ -6,10 +6,10 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
 #include <hpx/include/parallel_generate.hpp>
 #include <hpx/include/parallel_minmax.hpp>
 #include <hpx/include/partitioned_vector.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/timing.hpp>
 
 #include <hpx/modules/program_options.hpp>

--- a/libs/serialization/tests/performance/serialization_overhead.cpp
+++ b/libs/serialization/tests/performance/serialization_overhead.cpp
@@ -6,6 +6,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
+
 #include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/testing.hpp>

--- a/libs/serialization/tests/performance/serialization_overhead.cpp
+++ b/libs/serialization/tests/performance/serialization_overhead.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/serialization/detail/preprocess_container.hpp>

--- a/libs/thread_executors/CMakeLists.txt
+++ b/libs/thread_executors/CMakeLists.txt
@@ -77,6 +77,7 @@ add_hpx_module(
     hpx_execution
     hpx_functional
     hpx_io_service
+    hpx_memory
     hpx_threading_base
     hpx_timing
     hpx_resource_partitioner

--- a/libs/thread_executors/include/hpx/thread_executors/thread_executor.hpp
+++ b/libs/thread_executors/include/hpx/thread_executors/thread_executor.hpp
@@ -11,7 +11,7 @@
 #if defined(HPX_HAVE_THREAD_EXECUTORS_COMPATIBILITY)
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/functional/unique_function.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/thread_support/atomic_count.hpp>
 #include <hpx/threading_base/scheduler_mode.hpp>
 #include <hpx/threading_base/thread_description.hpp>

--- a/libs/threading/src/thread.cpp
+++ b/libs/threading/src/thread.cpp
@@ -11,8 +11,8 @@
 #include <hpx/functional/unique_function.hpp>
 #include <hpx/futures/detail/future_data.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/modules/threading.hpp>
 #include <hpx/thread_support/unlock_guard.hpp>
 #include <hpx/threading_base/thread_helpers.hpp>

--- a/libs/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -17,9 +17,9 @@
 #include <hpx/debugging/backtrace.hpp>
 #include <hpx/execution_base/this_thread.hpp>
 #include <hpx/functional/function.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/thread_support/atomic_count.hpp>
 #include <hpx/threading_base/thread_description.hpp>

--- a/src/runtime/naming/name.cpp
+++ b/src/runtime/naming/name.cpp
@@ -14,7 +14,7 @@
 #include <hpx/modules/execution.hpp>
 #include <hpx/functional/bind.hpp>
 #include <hpx/modules/logging.hpp>
-#include <hpx/memory/intrusive_ptr.hpp>
+#include <hpx/modules/memory.hpp>
 #include <hpx/memory/serialization/intrusive_ptr.hpp>
 #include <hpx/runtime/agas/addressing_service.hpp>
 #include <hpx/runtime/components/server/destroy_component.hpp>

--- a/tests/performance/local/foreach_scaling.cpp
+++ b/tests/performance/local/foreach_scaling.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/parallel_algorithm.hpp>
 #include <hpx/include/parallel_executor_parameters.hpp>
 #include <hpx/modules/timing.hpp>

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -10,7 +10,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/apply.hpp>
 #include <hpx/include/async.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/parallel_for_loop.hpp>
 #include <hpx/include/threads.hpp>

--- a/tests/performance/local/hpx_heterogeneous_timed_task_spawn.cpp
+++ b/tests/performance/local/hpx_heterogeneous_timed_task_spawn.cpp
@@ -8,7 +8,7 @@
 #include <hpx/modules/format.hpp>
 #include <hpx/functional/bind.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/threadmanager.hpp>
 #include <hpx/modules/timing.hpp>
 

--- a/tests/performance/local/hpx_homogeneous_timed_task_spawn_executors.cpp
+++ b/tests/performance/local/hpx_homogeneous_timed_task_spawn_executors.cpp
@@ -8,7 +8,7 @@
 #include <hpx/modules/format.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <cstddef>

--- a/tests/performance/local/parent_vs_child_stealing.cpp
+++ b/tests/performance/local/parent_vs_child_stealing.cpp
@@ -7,7 +7,7 @@
 #include <hpx/modules/format.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/lcos.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/timing.hpp>
 
 #include <hpx/modules/program_options.hpp>

--- a/tests/performance/local/partitioned_vector_foreach.cpp
+++ b/tests/performance/local/partitioned_vector_foreach.cpp
@@ -8,7 +8,7 @@
 #include <hpx/hpx.hpp>
 #include <hpx/modules/timing.hpp>
 #include <hpx/include/parallel_algorithm.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/partitioned_vector_predef.hpp>
 #include <hpx/include/parallel_for_each.hpp>
 

--- a/tests/performance/local/sizeof.cpp
+++ b/tests/performance/local/sizeof.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/preprocessor/stringize.hpp>
 #include <hpx/modules/format.hpp>

--- a/tests/performance/local/skynet.cpp
+++ b/tests/performance/local/skynet.cpp
@@ -19,7 +19,7 @@
 
 #include <hpx/hpx_main.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <cstdint>
 #include <vector>

--- a/tests/performance/local/spinlock_overhead1.cpp
+++ b/tests/performance/local/spinlock_overhead1.cpp
@@ -11,7 +11,7 @@
 #include <hpx/modules/format.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/async.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/async_combinators/wait_each.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/actions/plain_action.hpp>

--- a/tests/performance/local/spinlock_overhead2.cpp
+++ b/tests/performance/local/spinlock_overhead2.cpp
@@ -11,7 +11,7 @@
 #include <hpx/modules/format.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/async.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/async_combinators/wait_each.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/actions/plain_action.hpp>

--- a/tests/performance/local/stream.cpp
+++ b/tests/performance/local/stream.cpp
@@ -20,7 +20,7 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/compute.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/parallel_copy.hpp>
 #include <hpx/include/parallel_executor_parameters.hpp>
 #include <hpx/include/parallel_executors.hpp>

--- a/tests/performance/local/transform_reduce_binary_scaling.cpp
+++ b/tests/performance/local/transform_reduce_binary_scaling.cpp
@@ -9,7 +9,7 @@
 
 #include <hpx/modules/timing.hpp>
 #include <hpx/include/parallel_transform_reduce.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/tests/performance/local/wait_all_timings.cpp
+++ b/tests/performance/local/wait_all_timings.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/modules/format.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/modules/timing.hpp>

--- a/tests/performance/network/pingpong_performance.cpp
+++ b/tests/performance/network/pingpong_performance.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/async.hpp>
 #include <hpx/include/serialization.hpp>
 

--- a/tests/regressions/actions/plain_action_1330.cpp
+++ b/tests/regressions/actions/plain_action_1330.cpp
@@ -7,7 +7,7 @@
 
 #include <hpx/hpx_start.hpp>
 #include <hpx/include/actions.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/futures/future.hpp>
 #include <utility>
 

--- a/tests/regressions/build/client_1950.cpp
+++ b/tests/regressions/build/client_1950.cpp
@@ -7,7 +7,7 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <hpx/modules/testing.hpp>
 

--- a/tests/regressions/lcos/promise_1620.cpp
+++ b/tests/regressions/lcos/promise_1620.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_start.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <atomic>

--- a/tests/unit/agas/components/server/managed_refcnt_checker.cpp
+++ b/tests/unit/agas/components/server/managed_refcnt_checker.cpp
@@ -7,7 +7,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <hpx/hpx.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/format.hpp>
 
 #include <cstdint>

--- a/tests/unit/agas/components/server/simple_refcnt_checker.cpp
+++ b/tests/unit/agas/components/server/simple_refcnt_checker.cpp
@@ -7,7 +7,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <hpx/hpx.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/format.hpp>
 
 #include <cstdint>

--- a/tests/unit/agas/credit_exhaustion.cpp
+++ b/tests/unit/agas/credit_exhaustion.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/async_distributed/applier/applier.hpp>
 #include <hpx/include/plain_actions.hpp>

--- a/tests/unit/agas/local_address_rebind.cpp
+++ b/tests/unit/agas/local_address_rebind.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <cstdint>

--- a/tests/unit/agas/local_embedded_ref_to_local_object.cpp
+++ b/tests/unit/agas/local_embedded_ref_to_local_object.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <chrono>

--- a/tests/unit/agas/local_embedded_ref_to_remote_object.cpp
+++ b/tests/unit/agas/local_embedded_ref_to_remote_object.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/async_distributed/applier/applier.hpp>
 #include <hpx/runtime/agas/interface.hpp>

--- a/tests/unit/agas/refcnted_symbol_to_local_object.cpp
+++ b/tests/unit/agas/refcnted_symbol_to_local_object.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/runtime/agas/interface.hpp>
 

--- a/tests/unit/agas/refcnted_symbol_to_remote_object.cpp
+++ b/tests/unit/agas/refcnted_symbol_to_remote_object.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/runtime/agas/interface.hpp>
 

--- a/tests/unit/agas/remote_embedded_ref_to_local_object.cpp
+++ b/tests/unit/agas/remote_embedded_ref_to_local_object.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/async_distributed/applier/applier.hpp>
 #include <hpx/runtime/agas/interface.hpp>

--- a/tests/unit/agas/remote_embedded_ref_to_remote_object.cpp
+++ b/tests/unit/agas/remote_embedded_ref_to_remote_object.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/async_distributed/applier/applier.hpp>
 #include <hpx/runtime/agas/interface.hpp>

--- a/tests/unit/agas/scoped_ref_to_local_object.cpp
+++ b/tests/unit/agas/scoped_ref_to_local_object.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <chrono>

--- a/tests/unit/agas/scoped_ref_to_remote_object.cpp
+++ b/tests/unit/agas/scoped_ref_to_remote_object.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/async_distributed/applier/applier.hpp>
 #include <hpx/runtime/agas/interface.hpp>

--- a/tests/unit/agas/split_credit.cpp
+++ b/tests/unit/agas/split_credit.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/include/plain_actions.hpp>
 #include <hpx/include/lcos.hpp>

--- a/tests/unit/agas/uncounted_symbol_to_local_object.cpp
+++ b/tests/unit/agas/uncounted_symbol_to_local_object.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/runtime/agas/interface.hpp>
 

--- a/tests/unit/agas/uncounted_symbol_to_remote_object.cpp
+++ b/tests/unit/agas/uncounted_symbol_to_remote_object.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/async_distributed/applier/applier.hpp>
 #include <hpx/runtime/agas/interface.hpp>

--- a/tests/unit/component/inheritance_2_classes_abstract.cpp
+++ b/tests/unit/component/inheritance_2_classes_abstract.cpp
@@ -9,7 +9,7 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/components.hpp>
 #include <hpx/include/actions.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <string>

--- a/tests/unit/component/inheritance_2_classes_concrete.cpp
+++ b/tests/unit/component/inheritance_2_classes_concrete.cpp
@@ -9,7 +9,7 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/components.hpp>
 #include <hpx/include/actions.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <string>

--- a/tests/unit/component/inheritance_3_classes_1_abstract.cpp
+++ b/tests/unit/component/inheritance_3_classes_1_abstract.cpp
@@ -9,7 +9,7 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/components.hpp>
 #include <hpx/include/actions.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <string>

--- a/tests/unit/component/inheritance_3_classes_2_abstract.cpp
+++ b/tests/unit/component/inheritance_3_classes_2_abstract.cpp
@@ -9,7 +9,7 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/components.hpp>
 #include <hpx/include/actions.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <string>

--- a/tests/unit/component/inheritance_3_classes_concrete.cpp
+++ b/tests/unit/component/inheritance_3_classes_concrete.cpp
@@ -9,7 +9,7 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/components.hpp>
 #include <hpx/include/actions.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <string>

--- a/tests/unit/component/migrate_component.cpp
+++ b/tests/unit/component/migrate_component.cpp
@@ -10,7 +10,7 @@
 #include <hpx/include/actions.hpp>
 #include <hpx/include/serialization.hpp>
 #include <hpx/include/lcos.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <cstdint>

--- a/tests/unit/component/migrate_polymorphic_component.cpp
+++ b/tests/unit/component/migrate_polymorphic_component.cpp
@@ -10,7 +10,7 @@
 #include <hpx/include/actions.hpp>
 #include <hpx/include/serialization.hpp>
 #include <hpx/include/lcos.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <cstdint>

--- a/tests/unit/parcelset/put_parcels.cpp
+++ b/tests/unit/parcelset/put_parcels.cpp
@@ -7,7 +7,7 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/performance_counters.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <cstddef>

--- a/tests/unit/parcelset/put_parcels_with_coalescing.cpp
+++ b/tests/unit/parcelset/put_parcels_with_coalescing.cpp
@@ -7,7 +7,7 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/actions.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/parcel_coalescing.hpp>
 #include <hpx/include/performance_counters.hpp>
 #include <hpx/modules/testing.hpp>

--- a/tests/unit/parcelset/put_parcels_with_compression.cpp
+++ b/tests/unit/parcelset/put_parcels_with_compression.cpp
@@ -8,7 +8,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/actions.hpp>
 #include <hpx/include/performance_counters.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/compression_registration.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tools/inspect/deprecated_include_check.cpp
+++ b/tools/inspect/deprecated_include_check.cpp
@@ -35,7 +35,7 @@ namespace boost
       { "boost/detail/atomic_count\\.hpp", "hpx/thread_support/atomic_count.hpp" },
       { "boost/function\\.hpp", "hpx/util/function.hpp" },
       { "boost/shared_ptr\\.hpp", "memory" },
-      { "boost/intrusive_ptr\\.hpp", "hpx/memory/intrusive_ptr.hpp" },
+      { "boost/intrusive_ptr\\.hpp", "hpx/modules/memory.hpp" },
       { "boost/make_shared\\.hpp", "memory" },
       { "boost/enable_shared_from_this\\.hpp", "memory" },
       { "boost/bind\\.hpp", "hpx/util/bind.hpp" },

--- a/tools/inspect/include_check.cpp
+++ b/tools/inspect/include_check.cpp
@@ -224,7 +224,7 @@ namespace boost
         {"(\\bstd\\s*::\\s*(memory_order_*)\\b)", "std::\\2", "atomic"},
         // boost
         {"(\\bhpx\\s*::\\s*intrusive_ptr\\b)", "hpx::intrusive_ptr",
-            "hpx/memory/intrusive_ptr.hpp"},
+            "hpx/modules/memory.hpp"},
         {"(\\bhpx\\s*::\\s*util\\s*::\\s*from_string\\b)",
             "hpx::util::from_string", "hpx/util/from_string.hpp"},
         {"(\\bhpx\\s*::\\s*util\\s*::\\s*to_string\\b)",


### PR DESCRIPTION
This replacement is made in the examples directory only (for now)

Fixes partially #4488
i.e. replace the modules headers used in the examples by the main header of the module