### PR TITLE
Add Jenkins configuration for running on Piz Daint

### DIFF
--- a/.jenkins/cscs/Jenkinsfile
+++ b/.jenkins/cscs/Jenkinsfile
@@ -1,0 +1,58 @@
+#!groovy
+
+// Copyright (c) 2020 ETH Zurich
+//
+// SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+pipeline {
+    agent {
+        node {
+            label 'ssl_daintvm1'
+        }
+    }
+    environment {
+        SPACK_ROOT = '/apps/daint/SSL/HPX/spack'
+        GITHUB_TOKEN = credentials('97b30156-2f6f-47fc-94eb-68044d95ec50')
+    }
+    stages {
+        stage('checkout') {
+            steps {
+                dir('hpx') {
+                    checkout scm
+                    echo "Running ${env.BUILD_ID} on ${env.JENKINS_URL}"
+                }
+            }
+        }
+        stage('build') {
+            matrix {
+                axes {
+                    axis {
+                        name 'configuration_name'
+                        values 'gcc-newest', 'gcc-oldest', 'gcc-cuda', 'clang-newest', 'clang-oldest', 'clang-cuda', 'clang-apex', 'icc'
+                    }
+                }
+                stages {
+                    stage('build') {
+                        steps {
+                            dir('hpx') {
+                                sh '''
+                                #!/bin/bash -l
+                                .jenkins/cscs/entry.sh
+                                '''
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            archiveArtifacts artifacts: 'hpx/jenkins-hpx-*', fingerprint: true
+            archiveArtifacts artifacts: 'hpx/Testing/**', fingerprint: true
+        }
+    }
+}

--- a/.jenkins/cscs/batch.sh
+++ b/.jenkins/cscs/batch.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -l
+
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set -eux
+
+orig_src_dir="$(pwd)"
+src_dir="/dev/shm/hpx/src"
+build_dir="/dev/shm/hpx/build"
+
+# Copy source directory to /dev/shm for faster builds
+mkdir -p "${build_dir}"
+cp -r "${orig_src_dir}" "${src_dir}"
+
+source ${src_dir}/.jenkins/cscs/env-${configuration_name}.sh
+
+set +e
+ctest \
+    --verbose \
+    -S ${src_dir}/.jenkins/cscs/ctest.cmake \
+    -DCTEST_CONFIGURE_EXTRA_OPTIONS="${configure_extra_options}" \
+    -DCTEST_BUILD_CONFIGURATION_NAME="${configuration_name}" \
+    -DCTEST_SOURCE_DIRECTORY="${src_dir}" \
+    -DCTEST_BINARY_DIRECTORY="${build_dir}"
+set -e
+
+# Copy the testing directory for saving as an artifact
+cp -r ${build_dir}/Testing ${orig_src_dir}/
+
+# Things went wrong by default
+ctest_exit_code=$?
+file_errors=1
+configure_errors=1
+build_errors=1
+test_errors=1
+if [[ -f ${build_dir}/Testing/TAG ]]; then
+    file_errors=0
+    tag="$(head -n 1 ${build_dir}/Testing/TAG)"
+
+    if [[ -f "${build_dir}/Testing/${tag}/Configure.xml" ]]; then
+        configure_errors=$(grep '<Error>' "${build_dir}/Testing/${tag}/Configure.xml" | wc -l)
+    fi
+
+    if [[ -f "${build_dir}/Testing/${tag}/Build.xml" ]]; then
+        build_errors=$(grep '<Error>' "${build_dir}/Testing/${tag}/Build.xml" | wc -l)
+    fi
+
+    if [[ -f "${build_dir}/Testing/${tag}/Test.xml" ]]; then
+        test_errors=$(grep '<Test Status=\"failed\">' "${build_dir}/Testing/${tag}/Test.xml" | wc -l)
+    fi
+fi
+ctest_status=$(( ctest_exit_code + file_errors + configure_errors + build_errors + test_errors ))
+
+echo "${ctest_status}" > "jenkins-hpx-${configuration_name}-ctest-status.txt"
+exit $ctest_status

--- a/.jenkins/cscs/ctest.cmake
+++ b/.jenkins/cscs/ctest.cmake
@@ -1,0 +1,41 @@
+# Copyright (c) 2020 ETH Zurich
+# Copyright (c) 2017 John Biddiscombe
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+
+set(CTEST_TEST_TIMEOUT 120)
+set(CTEST_BUILD_PARALLELISM 20)
+set(CTEST_TEST_PARALLELISM 4)
+set(CTEST_CMAKE_GENERATOR Ninja)
+set(CTEST_SITE "cscs(daint)")
+set(CTEST_BUILD_NAME "$ENV{ghprbPullId}-${CTEST_BUILD_CONFIGURATION_NAME}")
+set(CTEST_UPDATE_COMMAND "git")
+set(CTEST_UPDATE_VERSION_ONLY "ON")
+
+message("CTEST_BUILD_NAME=${CTEST_BUILD_NAME}")
+
+set(CTEST_CONFIGURE_COMMAND "${CMAKE_COMMAND} ${CTEST_SOURCE_DIRECTORY}")
+set(CTEST_CONFIGURE_COMMAND "${CTEST_CONFIGURE_COMMAND} -G${CTEST_CMAKE_GENERATOR}")
+set(CTEST_CONFIGURE_COMMAND "${CTEST_CONFIGURE_COMMAND} -B${CTEST_BINARY_DIRECTORY}")
+set(CTEST_CONFIGURE_COMMAND "${CTEST_CONFIGURE_COMMAND} -DHPX_WITH_PARALLEL_TESTS_BIND_NONE=ON")
+set(CTEST_CONFIGURE_COMMAND "${CTEST_CONFIGURE_COMMAND} ${CTEST_CONFIGURE_EXTRA_OPTIONS}")
+
+ctest_start(Experimental TRACK "Pull_Requests")
+ctest_update()
+ctest_submit(PARTS Update BUILD_ID CTEST_BUILD_ID)
+file(WRITE "jenkins-hpx-$ENV{configuration_name}-cdash-build-id.txt" "${CTEST_BUILD_ID}")
+ctest_configure()
+ctest_submit(PARTS Configure)
+ctest_build(
+  TARGET all
+  FLAGS "-k0 -j ${CTEST_BUILD_PARALLELISM}")
+ctest_build(
+  TARGET tests
+  FLAGS "-k0 -j ${CTEST_BUILD_PARALLELISM}")
+ctest_submit(PARTS Build)
+ctest_test(PARALLEL_LEVEL "${CTEST_TEST_PARALLELISM}")
+ctest_submit(PARTS Test)

--- a/.jenkins/cscs/entry.sh
+++ b/.jenkins/cscs/entry.sh
@@ -1,0 +1,73 @@
+#!/bin/bash -l
+
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# Make undefined variables errors, print each command
+set -eux
+
+# Clean up directory
+rm -f jenkins-hpx*
+
+# Start the actual build
+source .jenkins/cscs/slurm-constraint-${configuration_name}.sh
+
+set +e
+echo "${ghprbActualCommit}"
+echo "${ghprbActualCommitAuthor}"
+echo "${ghprbActualCommitAuthorEmail}"
+echo "${ghprbPullDescription}"
+echo "${ghprbPullId}"
+echo "${ghprbPullLink}"
+echo "${ghprbPullTitle}"
+echo "${ghprbSourceBranch}"
+echo "${ghprbTargetBranch}"
+echo "${ghprbCommentBody}"
+echo "${sha1}"
+sbatch \
+    --job-name="jenkins-hpx-${configuration_name}" \
+    --nodes="1" \
+    --constraint="${configuration_slurm_constraint}" \
+    --partition="cscsci" \
+    --time="01:30:00" \
+    --output="jenkins-hpx-${configuration_name}.out" \
+    --error="jenkins-hpx-${configuration_name}.err" \
+    --wait .jenkins/cscs/batch.sh
+set -e
+
+# Print slurm logs
+echo "= stdout =================================================="
+cat jenkins-hpx-${configuration_name}.out
+
+echo "= stderr =================================================="
+cat jenkins-hpx-${configuration_name}.err
+
+# Get build status
+if [[ "$(cat jenkins-hpx-${configuration_name}-ctest-status.txt)" -eq "0" ]]; then
+    github_commit_status="success"
+else
+    github_commit_status="failure"
+fi
+
+# Extract just the organization and repo names "org/repo" from the full URL
+github_commit_repo="$(echo $ghprbPullLink | sed -n 's/https:\/\/github.com\/\(.*\)\/pull\/[0-9]*/\1/p')"
+
+# Get the CDash dashboard build id
+cdash_build_id="$(cat jenkins-hpx-${configuration_name}-cdash-build-id.txt)"
+
+# Extract actual token from GITHUB_TOKEN (in the form "username:token")
+github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
+
+# Set GitHub status with CDash url
+.jenkins/cscs/set_github_status.sh \
+    "${github_token}" \
+    "${github_commit_repo}" \
+    "${ghprbActualCommit}" \
+    "${github_commit_status}" \
+    "${configuration_name}" \
+    "${cdash_build_id}"
+
+exit $(cat jenkins-hpx-${configuration_name}-ctest-status.txt)

--- a/.jenkins/cscs/env-clang-apex.sh
+++ b/.jenkins/cscs/env-clang-apex.sh
@@ -1,0 +1,40 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+source $SPACK_ROOT/share/spack/setup-env.sh
+
+export CRAYPE_LINK_TYPE=dynamic
+export APPS_ROOT="/apps/daint/SSL/HPX/packages"
+export CLANG_VER="8.0"
+export CXX_STD="17"
+export BOOST_VER="1.69.0"
+export HWLOC_VER="2.0.3"
+export CLANG_ROOT="${APPS_ROOT}/llvm-${CLANG_VER}"
+export BOOST_ROOT="${APPS_ROOT}/boost-${BOOST_VER}-clang-${CLANG_VER}-c++${CXX_STD}-debug"
+export HWLOC_ROOT="${APPS_ROOT}/hwloc-${HWLOC_VER}-clang-${CLANG_VER}"
+export PAPI_ROOT="/opt/cray/pe/papi/5.7.0.2"
+export CXXFLAGS="-Wno-unused-command-line-argument -stdlib=libc++ -nostdinc++ -I${CLANG_ROOT}/include/c++/v1 -L${CLANG_ROOT}/lib -Wl,-rpath,${CLANG_ROOT}/lib,-lsupc++"
+export LDCXXFLAGS="-stdlib=libc++ -L${CLANG_ROOT}/lib -Wl,-rpath,${CLANG_ROOT}/lib,-lsupc++"
+export CXX="${CLANG_ROOT}/bin/clang++"
+export CC="${CLANG_ROOT}/bin/clang"
+export CPP="${CLANG_ROOT}/bin/clang -E"
+
+module load daint-mc
+spack load cmake
+spack load ninja
+
+configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"
+configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT=128"
+configure_extra_options+=" -DHPX_WITH_MALLOC=system"
+configure_extra_options+=" -DHPX_WITH_CXX${CXX_STD}=ON"
+configure_extra_options+=" -DHPX_WITH_DEPRECATION_WARNINGS=OFF"
+configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS=ON"
+configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
+configure_extra_options+=" -DHPX_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
+configure_extra_options+=" -DHPX_WITH_APEX=ON"
+configure_extra_options+=" -DHPX_WITH_PAPI=ON"
+configure_extra_options+=" -DAPEX_WITH_PAPI=ON"
+configure_extra_options+=" -DPAPI_ROOT=${PAPI_ROOT}"

--- a/.jenkins/cscs/env-clang-cuda.sh
+++ b/.jenkins/cscs/env-clang-cuda.sh
@@ -1,0 +1,32 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+source $SPACK_ROOT/share/spack/setup-env.sh
+
+export CRAYPE_LINK_TYPE=dynamic
+export APPS_ROOT="/apps/daint/SSL/HPX/packages"
+export CXX_STD="17"
+export BOOST_ROOT="${APPS_ROOT}/boost-1.69.0-gcc-8.3.0-c++17-release"
+export HWLOC_ROOT="${APPS_ROOT}/hwloc-2.0.3-gcc-8.3.0"
+
+module load daint-gpu
+module load cudatoolkit
+spack load cmake
+spack load ninja
+
+export CXX=`which CC`
+export CC=`which cc`
+
+configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"
+configure_extra_options+=" -DHPX_WITH_CUDA=ON"
+configure_extra_options+=" -DHPX_WITH_CUDA_CLANG=ON"
+configure_extra_options+=" -DHPX_CUDA_CLANG_FLAGS=\"--cuda-gpu-arch=sm_60\""
+configure_extra_options+=" -DHPX_WITH_MALLOC=system"
+configure_extra_options+=" -DHPX_WITH_CXX${CXX_STD}=ON"
+configure_extra_options+=" -DHPX_WITH_DEPRECATION_WARNINGS=OFF"
+configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS=ON"
+configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
+configure_extra_options+=" -DHPX_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"

--- a/.jenkins/cscs/env-clang-newest.sh
+++ b/.jenkins/cscs/env-clang-newest.sh
@@ -1,0 +1,35 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+source $SPACK_ROOT/share/spack/setup-env.sh
+
+export CRAYPE_LINK_TYPE=dynamic
+export APPS_ROOT="/apps/daint/SSL/HPX/packages"
+export CLANG_VER="9.0"
+export CXX_STD="17"
+export BOOST_VER="1.72.0"
+export HWLOC_VER="2.1.0"
+export CLANG_ROOT="${APPS_ROOT}/llvm-${CLANG_VER}"
+export BOOST_ROOT="${APPS_ROOT}/boost-${BOOST_VER}-clang-${CLANG_VER}-c++${CXX_STD}-debug"
+export HWLOC_ROOT="${APPS_ROOT}/hwloc-${HWLOC_VER}-clang-${CLANG_VER}"
+export CXXFLAGS="-Wno-unused-command-line-argument -stdlib=libc++ -nostdinc++ -I${CLANG_ROOT}/include/c++/v1 -L${CLANG_ROOT}/lib -Wl,-rpath,${CLANG_ROOT}/lib,-lsupc++"
+export LDCXXFLAGS="-stdlib=libc++ -L${CLANG_ROOT}/lib -Wl,-rpath,${CLANG_ROOT}/lib,-lsupc++"
+export CXX="${CLANG_ROOT}/bin/clang++"
+export CC="${CLANG_ROOT}/bin/clang"
+export CPP="${CLANG_ROOT}/bin/clang -E"
+
+module load daint-mc
+spack load cmake
+spack load ninja
+
+configure_extra_options="-DCMAKE_BUILD_TYPE=Release"
+configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT=128"
+configure_extra_options+=" -DHPX_WITH_MALLOC=system"
+configure_extra_options+=" -DHPX_WITH_CXX${CXX_STD}=ON"
+configure_extra_options+=" -DHPX_WITH_DEPRECATION_WARNINGS=OFF"
+configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS=ON"
+configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
+configure_extra_options+=" -DHPX_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"

--- a/.jenkins/cscs/env-clang-oldest.sh
+++ b/.jenkins/cscs/env-clang-oldest.sh
@@ -1,0 +1,37 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+source $SPACK_ROOT/share/spack/setup-env.sh
+
+export CRAYPE_LINK_TYPE=dynamic
+export APPS_ROOT="/apps/daint/SSL/HPX/packages"
+export CLANG_VER="5.0"
+export CXX_STD="14"
+export BOOST_VER="1.61.0"
+export HWLOC_VER="1.11.11"
+export CLANG_ROOT="${APPS_ROOT}/llvm-${CLANG_VER}"
+export BOOST_ROOT="${APPS_ROOT}/boost-${BOOST_VER}-clang-${CLANG_VER}-c++${CXX_STD}-debug"
+export HWLOC_ROOT="${APPS_ROOT}/hwloc-${HWLOC_VER}-clang-${CLANG_VER}"
+export CXXFLAGS="-Wno-unused-command-line-argument -stdlib=libc++ -nostdinc++ -I${CLANG_ROOT}/include/c++/v1 -L${CLANG_ROOT}/lib -Wl,-rpath,${CLANG_ROOT}/lib,-lsupc++"
+export LDCXXFLAGS="-stdlib=libc++ -L${CLANG_ROOT}/lib -Wl,-rpath,${CLANG_ROOT}/lib,-lsupc++"
+export CXX="${CLANG_ROOT}/bin/clang++"
+export CC="${CLANG_ROOT}/bin/clang"
+export CPP="${CLANG_ROOT}/bin/clang -E"
+
+module load daint-mc
+spack load cmake
+spack load ninja
+
+configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"
+configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT="
+configure_extra_options+=" -DHPX_WITH_THREAD_SCHEDULERS=\"abp-priority;local;static-priority;static\""
+configure_extra_options+=" -DHPX_WITH_MALLOC=system"
+configure_extra_options+=" -DHPX_WITH_CXX${CXX_STD}=ON"
+configure_extra_options+=" -DHPX_WITH_NETWORKING=OFF"
+configure_extra_options+=" -DHPX_WITH_DEPRECATION_WARNINGS=OFF"
+configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS=ON"
+configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=OFF"
+configure_extra_options+=" -DHPX_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"

--- a/.jenkins/cscs/env-gcc-cuda.sh
+++ b/.jenkins/cscs/env-gcc-cuda.sh
@@ -1,0 +1,30 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+source $SPACK_ROOT/share/spack/setup-env.sh
+
+export CRAYPE_LINK_TYPE=dynamic
+export CXX_STD="14"
+
+module load daint-gpu
+module switch PrgEnv-cray PrgEnv-gnu
+module load cudatoolkit
+module load Boost
+module load hwloc/.2.0.3
+module load jemalloc/.5.1.0-CrayGNU-19.10
+spack load cmake
+spack load ninja
+
+export CXX=`which CC`
+export CC=`which cc`
+
+configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"
+configure_extra_options+=" -DHPX_WITH_MALLOC=system"
+configure_extra_options+=" -DHPX_WITH_CXX${CXX_STD}=ON"
+configure_extra_options+=" -DHPX_WITH_CUDA=ON"
+configure_extra_options+=" -DHPX_WITH_DEPRECATION_WARNINGS=OFF"
+configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS=ON"
+configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"

--- a/.jenkins/cscs/env-gcc-newest.sh
+++ b/.jenkins/cscs/env-gcc-newest.sh
@@ -1,0 +1,37 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+source $SPACK_ROOT/share/spack/setup-env.sh
+
+export CRAYPE_LINK_TYPE=dynamic
+export APPS_ROOT="/apps/daint/SSL/HPX/packages"
+export GCC_VER="10.1.0"
+export CXX_STD="17"
+export BOOST_VER="1.73.0"
+export HWLOC_VER="2.2.0"
+export GCC_ROOT="${APPS_ROOT}/gcc-${GCC_VER}"
+export BOOST_ROOT="${APPS_ROOT}/boost-${BOOST_VER}-gcc-${GCC_VER}-c++${CXX_STD}-debug"
+export HWLOC_ROOT="${APPS_ROOT}/hwloc-${HWLOC_VER}-gcc-${GCC_VER}"
+export CXXFLAGS="-nostdinc++ -I${GCC_ROOT}/include/c++/${GCC_VER} -I${GCC_ROOT}/include/c++/${GCC_VER}/x86_64-unknown-linux-gnu -I${GCC_ROOT}/include/c++/${GCC_VER}/x86_64-pc-linux-gnu -L${GCC_ROOT}/lib64 -Wl,-rpath,${GCC_ROOT}/lib64"
+export LDFLAGS="-L${GCC_ROOT}/lib64"
+export CXX=${GCC_ROOT}/bin/g++
+export CC=${GCC_ROOT}/bin/gcc
+
+module load daint-mc
+spack load cmake
+spack load ninja
+
+configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"
+configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT=128"
+configure_extra_options+=" -DHPX_WITH_MALLOC=system"
+configure_extra_options+=" -DHPX_WITH_CXX${CXX_STD}=ON"
+configure_extra_options+=" -DHPX_WITH_NETWORKING=OFF"
+configure_extra_options+=" -DHPX_WITH_DISTRIBUTED_RUNTIME=OFF"
+configure_extra_options+=" -DHPX_WITH_LOGGING=OFF"
+configure_extra_options+=" -DHPX_WITH_DEPRECATION_WARNINGS=OFF"
+configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS=ON"
+configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=OFF"
+configure_extra_options+=" -DHPX_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"

--- a/.jenkins/cscs/env-gcc-oldest.sh
+++ b/.jenkins/cscs/env-gcc-oldest.sh
@@ -1,0 +1,35 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+source $SPACK_ROOT/share/spack/setup-env.sh
+
+export CRAYPE_LINK_TYPE=dynamic
+export APPS_ROOT="/apps/daint/SSL/HPX/packages"
+export GCC_VER="7.5.0"
+export CXX_STD="14"
+export BOOST_VER="1.61.0"
+export HWLOC_VER="1.11.5"
+export GCC_ROOT="${APPS_ROOT}/gcc-${GCC_VER}"
+export BOOST_ROOT="${APPS_ROOT}/boost-${BOOST_VER}-gcc-${GCC_VER}-c++${CXX_STD}-debug"
+export HWLOC_ROOT="${APPS_ROOT}/hwloc-${HWLOC_VER}-gcc-${GCC_VER}"
+export CXXFLAGS="-nostdinc++ -I${GCC_ROOT}/include/c++/${GCC_VER} -I${GCC_ROOT}/include/c++/${GCC_VER}/x86_64-unknown-linux-gnu -I${GCC_ROOT}/include/c++/${GCC_VER}/x86_64-pc-linux-gnu -L${GCC_ROOT}/lib64 -Wl,-rpath,${GCC_ROOT}/lib64"
+export LDFLAGS="-L${GCC_ROOT}/lib64"
+export CXX=${GCC_ROOT}/bin/g++
+export CC=${GCC_ROOT}/bin/gcc
+
+module load daint-mc
+spack load cmake
+spack load ninja
+
+configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"
+configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT=128"
+configure_extra_options+=" -DHPX_WITH_MALLOC=system"
+configure_extra_options+=" -DHPX_WITH_CXX${CXX_STD}=ON"
+configure_extra_options+=" -DHPX_WITH_GENERIC_CONTEXT_COROUTINES=ON"
+configure_extra_options+=" -DHPX_WITH_DEPRECATION_WARNINGS=OFF"
+configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS=ON"
+configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
+configure_extra_options+=" -DHPX_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"

--- a/.jenkins/cscs/env-icc.sh
+++ b/.jenkins/cscs/env-icc.sh
@@ -1,0 +1,27 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+source $SPACK_ROOT/share/spack/setup-env.sh
+
+export CRAYPE_LINK_TYPE=dynamic
+
+module load daint-mc
+module switch PrgEnv-cray PrgEnv-icc
+module load CMake
+module load Boost
+module load hwloc/.2.0.3
+spack load ninja
+
+export CXX=`which CC`
+export CC=`which cc`
+
+configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"
+configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT=128"
+configure_extra_options+=" -DHPX_WITH_MALLOC=system"
+configure_extra_options+=" -DHPX_WITH_DEPRECATION_WARNINGS=OFF"
+configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS=ON"
+configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
+configure_extra_options+=" -DHPX_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"

--- a/.jenkins/cscs/set_github_status.sh
+++ b/.jenkins/cscs/set_github_status.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -l
+
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set -eux
+
+github_token=${1}
+commit_repo=${2}
+commit_sha=${3}
+commit_status=${4}
+configuration_name=${5}
+build_id=${6}
+
+curl --verbose \
+    --request POST \
+    --url "https://api.github.com/repos/${commit_repo}/statuses/${commit_sha}" \
+    --header 'Content-Type: application/json' \
+    --header "authorization: Bearer ${github_token}" \
+    --data "{ \"state\": \"${commit_status}\", \"target_url\": \"https://cdash.cscs.ch/buildSummary.php?buildid=${build_id}\", \"description\": \"Jenkins\", \"context\": \"jenkins/cscs/${configuration_name}\" }"

--- a/.jenkins/cscs/slurm-constraint-clang-apex.sh
+++ b/.jenkins/cscs/slurm-constraint-clang-apex.sh
@@ -1,0 +1,7 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+configuration_slurm_constraint="mc"

--- a/.jenkins/cscs/slurm-constraint-clang-cuda.sh
+++ b/.jenkins/cscs/slurm-constraint-clang-cuda.sh
@@ -1,0 +1,7 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+configuration_slurm_constraint="gpu"

--- a/.jenkins/cscs/slurm-constraint-clang-newest.sh
+++ b/.jenkins/cscs/slurm-constraint-clang-newest.sh
@@ -1,0 +1,7 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+configuration_slurm_constraint="mc"

--- a/.jenkins/cscs/slurm-constraint-clang-oldest.sh
+++ b/.jenkins/cscs/slurm-constraint-clang-oldest.sh
@@ -1,0 +1,7 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+configuration_slurm_constraint="mc"

--- a/.jenkins/cscs/slurm-constraint-gcc-cuda.sh
+++ b/.jenkins/cscs/slurm-constraint-gcc-cuda.sh
@@ -1,0 +1,7 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+configuration_slurm_constraint="gpu"

--- a/.jenkins/cscs/slurm-constraint-gcc-newest.sh
+++ b/.jenkins/cscs/slurm-constraint-gcc-newest.sh
@@ -1,0 +1,7 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+configuration_slurm_constraint="mc"

--- a/.jenkins/cscs/slurm-constraint-gcc-oldest.sh
+++ b/.jenkins/cscs/slurm-constraint-gcc-oldest.sh
@@ -1,0 +1,7 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+configuration_slurm_constraint="mc"

--- a/.jenkins/cscs/slurm-constraint-icc.sh
+++ b/.jenkins/cscs/slurm-constraint-icc.sh
@@ -1,0 +1,7 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+configuration_slurm_constraint="mc"

--- a/cmake/HPX_AddCompileTest.cmake
+++ b/cmake/HPX_AddCompileTest.cmake
@@ -41,6 +41,8 @@ function(add_hpx_compile_test category name)
     set_tests_properties("${category}.${name}" PROPERTIES WILL_FAIL TRUE)
   endif()
 
+  set_tests_properties("${category}.${name}" PROPERTIES RUN_SERIAL TRUE)
+
 endfunction(add_hpx_compile_test)
 
 function(add_hpx_compile_test_target_dependencies category name)

--- a/libs/algorithms/tests/unit/algorithms/includes.cpp
+++ b/libs/algorithms/tests/unit/algorithms/includes.cpp
@@ -9,6 +9,9 @@
 #include <hpx/include/parallel_set_operations.hpp>
 #include <hpx/modules/testing.hpp>
 
+#include <boost/next_prior.hpp>
+#include <boost/utility.hpp>
+
 #include <cstddef>
 #include <iostream>
 #include <iterator>

--- a/libs/async_cuda/tests/unit/CMakeLists.txt
+++ b/libs/async_cuda/tests/unit/CMakeLists.txt
@@ -39,6 +39,7 @@ foreach(test ${tests})
     FOLDER "Tests/Unit/Modules/async_cuda"
   )
 
-  add_hpx_unit_test("modules.async_cuda" ${test} ${${test}_PARAMETERS})
-
+  add_hpx_unit_test(
+    "modules.async_cuda" ${test} ${${test}_PARAMETERS} RUN_SERIAL
+  )
 endforeach()

--- a/libs/compute_cuda/examples/CMakeLists.txt
+++ b/libs/compute_cuda/examples/CMakeLists.txt
@@ -73,7 +73,7 @@ foreach(example_program ${example_programs})
   if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
     add_hpx_example_test(
       "modules.compute_cuda" ${example_program}
-      ${${example_program}_PARAMETERS}
+      ${${example_program}_PARAMETERS} RUN_SERIAL
     )
   endif()
 endforeach()

--- a/libs/compute_cuda/tests/unit/CMakeLists.txt
+++ b/libs/compute_cuda/tests/unit/CMakeLists.txt
@@ -32,5 +32,7 @@ foreach(test ${tests})
     FOLDER "Tests/Unit/Modules/Compute/CUDA"
   )
 
-  add_hpx_unit_test("modules.compute_cuda" ${test} ${${test}_PARAMETERS})
+  add_hpx_unit_test(
+    "modules.compute_cuda" ${test} ${${test}_PARAMETERS} RUN_SERIAL
+  )
 endforeach()

--- a/libs/futures/tests/unit/future.cpp
+++ b/libs/futures/tests/unit/future.cpp
@@ -457,19 +457,19 @@ void test_wait_callback_with_timed_wait()
     hpx::lcos::future<void> fv =
         fi.then(hpx::util::bind(&do_nothing_callback, std::ref(pi)));
 
-    int state = int(fv.wait_for(std::chrono::milliseconds(10)));
+    int state = int(fv.wait_for(std::chrono::milliseconds(100)));
     HPX_TEST_EQ(state, int(hpx::lcos::future_status::timeout));
     HPX_TEST_EQ(callback_called, 0U);
 
-    state = int(fv.wait_for(std::chrono::milliseconds(10)));
+    state = int(fv.wait_for(std::chrono::milliseconds(100)));
     HPX_TEST_EQ(state, int(hpx::lcos::future_status::timeout));
-    state = int(fv.wait_for(std::chrono::milliseconds(10)));
+    state = int(fv.wait_for(std::chrono::milliseconds(100)));
     HPX_TEST_EQ(state, int(hpx::lcos::future_status::timeout));
     HPX_TEST_EQ(callback_called, 0U);
 
     pi.set_value(42);
 
-    state = int(fv.wait_for(std::chrono::milliseconds(10)));
+    state = int(fv.wait_for(std::chrono::milliseconds(100)));
     HPX_TEST_EQ(state, int(hpx::lcos::future_status::ready));
 
     HPX_TEST_EQ(callback_called, 1U);

--- a/libs/futures/tests/unit/shared_future.cpp
+++ b/libs/futures/tests/unit/shared_future.cpp
@@ -521,19 +521,19 @@ void test_wait_callback_with_timed_wait()
     hpx::lcos::shared_future<void> fv =
         fi.then(hpx::util::bind(&do_nothing_callback, std::ref(pi)));
 
-    int state = int(fv.wait_for(std::chrono::milliseconds(10)));
+    int state = int(fv.wait_for(std::chrono::milliseconds(100)));
     HPX_TEST_EQ(state, int(hpx::lcos::future_status::timeout));
     HPX_TEST_EQ(callback_called, 0U);
 
-    state = int(fv.wait_for(std::chrono::milliseconds(10)));
+    state = int(fv.wait_for(std::chrono::milliseconds(100)));
     HPX_TEST_EQ(state, int(hpx::lcos::future_status::timeout));
-    state = int(fv.wait_for(std::chrono::milliseconds(10)));
+    state = int(fv.wait_for(std::chrono::milliseconds(100)));
     HPX_TEST_EQ(state, int(hpx::lcos::future_status::timeout));
     HPX_TEST_EQ(callback_called, 0U);
 
     pi.set_value(42);
 
-    state = int(fv.wait_for(std::chrono::milliseconds(10)));
+    state = int(fv.wait_for(std::chrono::milliseconds(100)));
     HPX_TEST_EQ(state, int(hpx::lcos::future_status::ready));
 
     HPX_TEST_EQ(callback_called, 1U);
@@ -1590,7 +1590,7 @@ int main(int argc, char* argv[])
     options_description cmdline("Usage: " HPX_APPLICATION_STRING " [options]");
 
     // We force this test to use several threads by default.
-    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+    std::vector<std::string> const cfg = {"hpx.os_threads=4"};
 
     // Initialize and run HPX
     return hpx::init(cmdline, argc, argv, cfg);

--- a/libs/resource_partitioner/examples/async_customization.cpp
+++ b/libs/resource_partitioner/examples/async_customization.cpp
@@ -30,6 +30,7 @@
 #include <hpx/type_support/decay.hpp>
 //
 #include <chrono>
+#include <complex>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>

--- a/libs/runtime_local/src/custom_exception_info.cpp
+++ b/libs/runtime_local/src/custom_exception_info.cpp
@@ -74,7 +74,7 @@ namespace hpx {
     std::string diagnostic_information(hpx::exception_info const& xi)
     {
         int const verbosity = util::from_string<int>(
-            get_config_entry("hpx.exception_verbosity", ""));
+            get_config_entry("hpx.exception_verbosity", "2"));
 
         std::ostringstream strm;
         strm << "\n";

--- a/libs/runtime_local/src/runtime_local.cpp
+++ b/libs/runtime_local/src/runtime_local.cpp
@@ -70,7 +70,7 @@ namespace hpx {
         if (get_config_entry("hpx.diagnostics_on_terminate", "1") == "1")
         {
             int const verbosity = util::from_string<int>(
-                get_config_entry("hpx.exception_verbosity", ""));
+                get_config_entry("hpx.exception_verbosity", "2"));
 
             if (verbosity >= 2)
             {
@@ -143,7 +143,7 @@ namespace hpx {
         if (get_config_entry("hpx.diagnostics_on_terminate", "1") == "1")
         {
             int const verbosity = util::from_string<int>(
-                get_config_entry("hpx.exception_verbosity", ""));
+                get_config_entry("hpx.exception_verbosity", "2"));
 
             char* reason = strsignal(signum);
 

--- a/libs/synchronization/tests/unit/condition_variable.cpp
+++ b/libs/synchronization/tests/unit/condition_variable.cpp
@@ -497,7 +497,7 @@ void condition_test_waits(condition_test_data* data)
 
     // Test wait_until.
     std::chrono::system_clock::time_point xt =
-        std::chrono::system_clock::now() + std::chrono::milliseconds(10);
+        std::chrono::system_clock::now() + std::chrono::milliseconds(100);
     while (data->notified != 3)
         data->condition.wait_until(lock, xt);
     HPX_TEST(lock ? true : false);
@@ -506,7 +506,7 @@ void condition_test_waits(condition_test_data* data)
     data->condition.notify_one();
 
     // Test predicate wait_until.
-    xt = std::chrono::system_clock::now() + std::chrono::milliseconds(10);
+    xt = std::chrono::system_clock::now() + std::chrono::milliseconds(100);
     cond_predicate pred(data->notified, 4);
     HPX_TEST(data->condition.wait_until(lock, xt, pred));
     HPX_TEST(lock ? true : false);
@@ -518,7 +518,7 @@ void condition_test_waits(condition_test_data* data)
     // Test predicate wait_for
     cond_predicate pred_rel(data->notified, 5);
     HPX_TEST(data->condition.wait_for(
-        lock, std::chrono::milliseconds(10), pred_rel));
+        lock, std::chrono::milliseconds(100), pred_rel));
     HPX_TEST(lock ? true : false);
     HPX_TEST(pred_rel());
     HPX_TEST_EQ(data->notified, 5);


### PR DESCRIPTION
This reproduces the configurations that we use with pycicle, but I will keep both running until I'm sure that this is working well. Some things I will try to update or fix separately:

- Some of the "oldest" configurations use somewhat outdated versions of Boost (they still build correctly though!).
- CDash may have a problem with too many builds trying to push updates at the same time (not sure if that's the real reason). In any case, when this fails the revision will not show up on CDash and the status link here on github will be wrong (it won't have a build id).
- This does *not* merge branches with master before building, unlike pycicle.

There are a couple of small code changes that popped up while setting this up, and I've included those changes here. I've also changed most tests that requested `all` threads to just use `4` (some tests specifically test that `all` works correctly and those I've left alone).

It's meant to build all pull requests from STEllAR-GROUP users automatically. For untrusted users jenkins will ask someone to verify the patch, to which an admin can reply "ok to test" to trigger one build or "add to whitelist" to permanently whitelist that user.

This now sets the github status link to point directly to the CDash build logs (modulo that potential CDash bug mentioned above). The jenkins "default" status points to the actual jenkins logs. These are unfortunately only available for CSCS users (e.g. with CSCS VPN).

Since the configurations are now in this repo, feel free to change build options if you think something is not being tested. To change dependencies you'll have to ask one of the CSCS people to install a particular version or package.