### PR TITLE
Make internal algorithms functions const

### DIFF
--- a/libs/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -46,8 +46,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename F, typename Proj>
         struct invoke_projected
         {
-            typename hpx::util::decay<F>::type& f_;
-            typename hpx::util::decay<Proj>::type& proj_;
+            typename hpx::util::decay<F>::type const& f_;
+            typename hpx::util::decay<Proj>::type const& proj_;
 
             template <typename T>
             HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
@@ -78,18 +78,18 @@ namespace hpx { namespace parallel { inline namespace v1 {
         struct invoke_projected<F, util::projection_identity>
         {
             HPX_HOST_DEVICE invoke_projected(
-                typename hpx::util::decay<F>::type& f,
+                typename hpx::util::decay<F>::type const& f,
                 util::projection_identity)
               : f_(f)
             {
             }
 
-            typename hpx::util::decay<F>::type& f_;
+            typename hpx::util::decay<F>::type const& f_;
 
             template <typename T>
             HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
                 !hpx::traits::is_value_proxy<T>::value>::type
-            call(T&& t)
+            call(T&& t) const
             {
                 T&& tmp = std::forward<T>(t);
                 hpx::util::invoke(f_, tmp);
@@ -98,7 +98,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             template <typename T>
             HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
                 hpx::traits::is_value_proxy<T>::value>::type
-            call(T&& t)
+            call(T&& t) const
             {
                 auto tmp = std::forward<T>(t);
                 hpx::util::invoke_r<void>(f_, tmp);
@@ -120,12 +120,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef typename hpx::util::decay<F>::type fun_type;
             typedef typename hpx::util::decay<Proj>::type proj_type;
 
-            fun_type f_;
-            proj_type proj_;
+            const fun_type f_;
+            const proj_type proj_;
 
             template <typename Iter>
             HPX_HOST_DEVICE HPX_FORCEINLINE void execute(
-                Iter part_begin, std::size_t part_size)
+                Iter part_begin, std::size_t part_size) const
             {
                 util::loop_n<execution_policy_type>(part_begin, part_size,
                     invoke_projected<fun_type, proj_type>{f_, proj_});
@@ -160,7 +160,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename Iter>
             HPX_HOST_DEVICE HPX_FORCEINLINE void operator()(Iter part_begin,
-                std::size_t part_size, std::size_t /*part_index*/)
+                std::size_t part_size, std::size_t /*part_index*/) const
             {
                 hpx::util::annotate_function annotate(f_);
                 execute(part_begin, part_size);

--- a/libs/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -95,9 +95,9 @@ namespace hpx { namespace parallel { inline namespace v2 {
         {
             typedef typename hpx::util::decay<F>::type fun_type;
 
-            fun_type f_;
-            S stride_;
-            hpx::util::tuple<Ts...> args_;
+            const fun_type f_;
+            const S stride_;
+            mutable hpx::util::tuple<Ts...> args_;
 
             template <typename F_, typename S_, typename Args>
             part_iterations(F_&& f, S_&& stride, Args&& args)
@@ -109,7 +109,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
 
             template <typename B>
             HPX_HOST_DEVICE void execute(
-                B part_begin, std::size_t part_steps, std::size_t part_index)
+                B part_begin, std::size_t part_steps, std::size_t part_index) const
             {
                 auto pack =
                     typename hpx::util::make_index_pack<sizeof...(Ts)>::type();
@@ -135,7 +135,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
 
             template <typename B>
             HPX_HOST_DEVICE void operator()(
-                B part_begin, std::size_t part_steps, std::size_t part_index)
+                B part_begin, std::size_t part_steps, std::size_t part_index) const
             {
                 hpx::util::annotate_function annotate(f_);
                 execute(part_begin, part_steps, part_index);

--- a/libs/algorithms/include/hpx/parallel/algorithms/transform.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/transform.hpp
@@ -48,13 +48,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename F, typename Proj>
         struct transform_projected
         {
-            typename hpx::util::decay<F>::type& f_;
-            typename hpx::util::decay<Proj>::type& proj_;
+            typename hpx::util::decay<F>::type const& f_;
+            typename hpx::util::decay<Proj>::type const& proj_;
 
             template <typename Iter>
             HPX_HOST_DEVICE HPX_FORCEINLINE auto operator()(Iter curr)
                 -> decltype(
-                    hpx::util::invoke(f_, hpx::util::invoke(proj_, *curr)))
+                    hpx::util::invoke(f_, hpx::util::invoke(proj_, *curr))) const
             {
                 return hpx::util::invoke(f_, hpx::util::invoke(proj_, *curr));
             }
@@ -68,8 +68,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef typename hpx::util::decay<F>::type fun_type;
             typedef typename hpx::util::decay<Proj>::type proj_type;
 
-            fun_type f_;
-            proj_type proj_;
+            const fun_type f_;
+            const proj_type proj_;
 
             template <typename F_, typename Proj_>
             HPX_HOST_DEVICE transform_iteration(F_&& f, Proj_&& proj)
@@ -105,7 +105,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               typename Iter::iterator_tuple_type>::type,
                     typename hpx::util::tuple_element<1,
                         typename Iter::iterator_tuple_type>::type>
-                execute(Iter part_begin, std::size_t part_size)
+                execute(Iter part_begin, std::size_t part_size) const
             {
                 auto iters = part_begin.get_iterator_tuple();
                 return util::transform_loop_n<execution_policy_type>(
@@ -121,7 +121,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     typename hpx::util::tuple_element<1,
                         typename Iter::iterator_tuple_type>::type>
                 operator()(Iter part_begin, std::size_t part_size,
-                    std::size_t /*part_index*/)
+                    std::size_t /*part_index*/) const
             {
                 hpx::util::annotate_function annotate(f_);
                 return execute(part_begin, part_size);

--- a/libs/algorithms/include/hpx/parallel/util/detail/partitioner_iteration.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/detail/partitioner_iteration.hpp
@@ -20,10 +20,10 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     template <typename Result, typename F>
     struct partitioner_iteration
     {
-        typename std::decay<F>::type f_;
+        mutable typename std::decay<F>::type f_;
 
         template <typename T>
-        HPX_HOST_DEVICE HPX_FORCEINLINE Result operator()(T&& t)
+        HPX_HOST_DEVICE HPX_FORCEINLINE Result operator()(T&& t) const
         {
             return hpx::util::invoke_fused_r<Result>(f_, std::forward<T>(t));
         }

--- a/libs/iterator_support/include/hpx/iterator_support/zip_iterator.hpp
+++ b/libs/iterator_support/include/hpx/iterator_support/zip_iterator.hpp
@@ -237,7 +237,7 @@ namespace hpx { namespace util {
 
         struct advance_iterator
         {
-            explicit advance_iterator(std::ptrdiff_t n)
+            HPX_HOST_DEVICE explicit advance_iterator(std::ptrdiff_t n)
               : n_(n)
             {
             }


### PR DESCRIPTION
HPX parallel algorithms wrap element-wise functions into bigger functions that operate on chunks. These functions are non-const. In the Kokkos executors I invoke those wrapping functions inside a Kokkos parallel region, and Kokkos expects element-wise functions to be const. This is a workaround that marks HPX functions like `operator()` for `for_loop_iteration` as const, and its members as mutable. As far as I can tell we can't make them properly const because of requirements in HPX itself, but I may be wrong here. Also as far as I can tell we don't really violate anything fundamental in Kokkos by doing this. Kokkos mostly requires functions to be const to discourage modifying e.g. members in a parallel region since that can be difficult to get right. Of course, this does feel very wrong, so I'm opening this up to see if someone would have suggestions on how to avoid this.

Note: I've only done this for `for_loop`, `for_each`, and `transform` as those are the only parallel algorithms that currently work with the Kokkos executors. Others will need specialization instead of going through our parallel algorithm machinery.