### PR TITLE
Fix a wrong #ifdef for IO/TIMER pools causing build errors

### DIFF
--- a/libs/runtime_local/include/hpx/runtime_local/runtime_local.hpp
+++ b/libs/runtime_local/include/hpx/runtime_local/runtime_local.hpp
@@ -85,7 +85,7 @@ namespace hpx {
             ,
             notification_policy_type&& io_pool_notifier
 #endif
-#ifdef HPX_HAVE_IO_POOL
+#ifdef HPX_HAVE_TIMER_POOL
             ,
             notification_policy_type&& timer_pool_notifier
 #endif

--- a/libs/runtime_local/src/runtime_local.cpp
+++ b/libs/runtime_local/src/runtime_local.cpp
@@ -313,7 +313,7 @@ namespace hpx {
         ,
         notification_policy_type&& io_pool_notifier
 #endif
-#ifdef HPX_HAVE_IO_POOL
+#ifdef HPX_HAVE_TIMER_POOL
         ,
         notification_policy_type&& timer_pool_notifier
 #endif


### PR DESCRIPTION
Jut a flyby fix that was causing build errors for me