### PR TITLE
Allow finding Boost components before finding HPX

### DIFF
--- a/cmake/HPX_SetupBoostFilesystem.cmake
+++ b/cmake/HPX_SetupBoostFilesystem.cmake
@@ -7,13 +7,19 @@
 if(HPX_FILESYSTEM_WITH_BOOST_FILESYSTEM_COMPATIBILITY)
   # In case find_package(HPX) is called multiple times
   if(NOT TARGET Boost::filesystem)
-    hpx_add_config_define_namespace(
-      DEFINE HPX_FILESYSTEM_HAVE_BOOST_FILESYSTEM_COMPATIBILITY
-      NAMESPACE FILESYSTEM
-    )
-
     find_package(Boost ${Boost_MINIMUM_VERSION} MODULE COMPONENTS filesystem)
+
+    if(NOT Boost_FILESYSTEM_FOUND)
+      hpx_error(
+        "Could not find Boost.Filesystem Provide a boost installation including the filesystem library"
+      )
+    endif()
   endif()
+
+  hpx_add_config_define_namespace(
+    DEFINE HPX_FILESYSTEM_HAVE_BOOST_FILESYSTEM_COMPATIBILITY
+    NAMESPACE FILESYSTEM
+  )
 else()
   if(NOT HPX_WITH_CXX17_FILESYSTEM)
     hpx_error(

--- a/cmake/HPX_SetupBoostProgramOptions.cmake
+++ b/cmake/HPX_SetupBoostProgramOptions.cmake
@@ -5,23 +5,22 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 if(HPX_PROGRAM_OPTIONS_WITH_BOOST_PROGRAM_OPTIONS_COMPATIBILITY)
-  set(__boost_program_options Boost::program_options)
-endif()
+  if(NOT TARGET Boost::program_options)
+    find_package(
+      Boost ${Boost_MINIMUM_VERSION} MODULE COMPONENTS program_options
+    )
 
-if(HPX_PROGRAM_OPTIONS_WITH_BOOST_PROGRAM_OPTIONS_COMPATIBILITY
-   AND NOT TARGET Boost::program_options
-)
+    if(NOT Boost_PROGRAM_OPTIONS_FOUND)
+      hpx_error(
+        "Could not find Boost.ProgramOptions. Provide a boost installation including the program_options library"
+      )
+    endif()
+  endif()
+
+  set(__boost_program_options Boost::program_options)
 
   hpx_add_config_define_namespace(
     DEFINE HPX_PROGRAM_OPTIONS_HAVE_BOOST_PROGRAM_OPTIONS_COMPATIBILITY
     NAMESPACE PROGRAM_OPTIONS
   )
-
-  find_package(Boost ${Boost_MINIMUM_VERSION} MODULE COMPONENTS program_options)
-
-  if(NOT Boost_PROGRAM_OPTIONS_FOUND)
-    hpx_error(
-      "Could not find Boost.ProgramOptions. Provide a boost installation including the program_options library"
-    )
-  endif()
 endif()

--- a/tests/unit/build/fetchcontent/CMakeLists.txt
+++ b/tests/unit/build/fetchcontent/CMakeLists.txt
@@ -11,6 +11,10 @@
 cmake_minimum_required(VERSION 3.13)
 project(HPXFetchContent LANGUAGES CXX)
 
+# Test that HPX correctly handles having Boost Filesystem and ProgramOptions
+# found before setting up HPX, if they are available (do not REQUIRE these)
+find_package(Boost COMPONENTS filesystem program_options)
+
 include(FetchContent)
 
 fetchcontent_declare(


### PR DESCRIPTION
Attempt to fix #4816. The GitHub actions fetchcontent build should test this now. Let's see what it says. I have not tested the full build locally.