### PR TITLE
Implement customization point for hpx::copy and hpx::ranges::copy

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -466,7 +466,8 @@ endfunction()
 function(hpx_check_for_cxx17_std_nontype_template_parameter_auto)
   add_hpx_config_test(
     HPX_WITH_CXX17_NONTYPE_TEMPLATE_PARAMETER_AUTO
-    SOURCE cmake/tests/cxx17_std_nontype_template_parameter_auto.cpp FILE ${ARGN}
+    SOURCE cmake/tests/cxx17_std_nontype_template_parameter_auto.cpp FILE
+           ${ARGN}
   )
 endfunction()
 

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -463,6 +463,14 @@ function(hpx_check_for_cxx17_shared_ptr_array)
 endfunction()
 
 # ##############################################################################
+function(hpx_check_for_cxx17_std_nontype_template_parameter_auto)
+  add_hpx_config_test(
+    HPX_WITH_CXX17_NONTYPE_TEMPLATE_PARAMETER_AUTO
+    SOURCE cmake/tests/cxx17_std_nontype_template_parameter_auto.cpp FILE ${ARGN}
+  )
+endfunction()
+
+# ##############################################################################
 function(hpx_check_for_cxx20_coroutines)
   add_hpx_config_test(
     HPX_WITH_CXX20_COROUTINES SOURCE cmake/tests/cxx20_coroutines.cpp FILE
@@ -475,6 +483,14 @@ function(hpx_check_for_cxx20_std_disable_sized_sentinel_for)
   add_hpx_config_test(
     HPX_WITH_CXX20_STD_DISABLE_SIZED_SENTINEL_FOR
     SOURCE cmake/tests/cxx20_std_disable_sized_sentinel_for.cpp FILE ${ARGN}
+  )
+endfunction()
+
+# ##############################################################################
+function(hpx_check_for_cxx20_no_unique_address_attribute)
+  add_hpx_config_test(
+    HPX_WITH_CXX20_NO_UNIQUE_ADDRESS_ATTRIBUTE
+    SOURCE cmake/tests/cxx20_no_unique_address_attribute.cpp FILE ${ARGN}
   )
 endfunction()
 

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -82,11 +82,19 @@ function(hpx_perform_cxx_feature_tests)
 
   hpx_check_for_cxx17_std_scan(DEFINITIONS HPX_HAVE_CXX17_STD_SCAN_ALGORITHMS)
 
+  hpx_check_for_cxx17_std_nontype_template_parameter_auto(
+    DEFINITIONS HPX_HAVE_CXX17_NONTYPE_TEMPLATE_PARAMETER_AUTO
+  )
+
   # C++20 feature tests
   hpx_check_for_cxx20_coroutines(DEFINITIONS HPX_HAVE_CXX20_COROUTINES)
 
   hpx_check_for_cxx20_std_disable_sized_sentinel_for(
     DEFINITIONS HPX_HAVE_CXX20_STD_DISABLE_SIZED_SENTINEL_FOR
+  )
+
+  hpx_check_for_cxx20_no_unique_address_attribute(
+    DEFINITIONS HPX_HAVE_CXX20_NO_UNIQUE_ADDRESS_ATTRIBUTE
   )
 
   # Check the availability of certain C++ builtins

--- a/cmake/tests/cxx17_std_nontype_template_parameter_auto.cpp
+++ b/cmake/tests/cxx17_std_nontype_template_parameter_auto.cpp
@@ -1,0 +1,14 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(__cpp_nontype_template_parameter_auto)
+#  error "__cpp_nontype_template_parameter_auto not defined, assume that non-type template auto parameters are not supported"
+#endif
+
+int main()
+{
+    return 0;
+}

--- a/cmake/tests/cxx20_no_unique_address_attribute.cpp
+++ b/cmake/tests/cxx20_no_unique_address_attribute.cpp
@@ -1,0 +1,18 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(__has_cpp_attribute)
+#  error "__has_cpp_attribute not supported, assume [[no_unique_address]] is not supported"
+#else
+#  if !__has_cpp_attribute(no_unique_address)
+#    error "__has_cpp_attribute(no_unique_address) not supported"
+#  endif
+#endif
+
+int main()
+{
+    return 0;
+}

--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -34,9 +34,9 @@ Functions
 - :cpp:func:`hpx::parallel::v1::adjacent_find`
 - :cpp:func:`hpx::parallel::v1::all_of`
 - :cpp:func:`hpx::parallel::v1::any_of`
-- :cpp:func:`hpx::parallel::v1::copy`
-- :cpp:func:`hpx::parallel::v1::copy_if`
-- :cpp:func:`hpx::parallel::v1::copy_n`
+- :cpp:func:`hpx::copy`
+- :cpp:func:`hpx::copy_if`
+- :cpp:func:`hpx::copy_n`
 - :cpp:func:`hpx::parallel::v1::count`
 - :cpp:func:`hpx::parallel::v1::count_if`
 - :cpp:func:`hpx::parallel::v1::equal`
@@ -88,6 +88,7 @@ Functions
 - :cpp:func:`hpx::parallel::v1::set_union`
 - :cpp:func:`hpx::parallel::v1::sort`
 - :cpp:func:`hpx::parallel::v1::stable_partition`
+- :cpp:func:`hpx::parallel::v1::stable_sort`
 - :cpp:func:`hpx::parallel::v1::swap_ranges`
 - :cpp:func:`hpx::parallel::v1::unique`
 - :cpp:func:`hpx::parallel::v1::unique_copy`
@@ -95,6 +96,10 @@ Functions
 - :cpp:func:`hpx::parallel::v2::for_loop_strided`
 - :cpp:func:`hpx::parallel::v2::for_loop_n`
 - :cpp:func:`hpx::parallel::v2::for_loop_n_strided`
+
+- :cpp:func:`hpx::ranges::copy`
+- :cpp:func:`hpx::ranges::copy_if`
+- :cpp:func:`hpx::ranges::copy_n`
 
 Header ``hpx/any.hpp``
 ======================

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -442,15 +442,15 @@ Parallel algorithms
      * Description
      * In header
      * Algorithm page at cppreference.com
-   * * :cpp:func:`hpx::parallel::v1::copy`
+   * * :cpp:func:`hpx::copy`
      * Copies a range of elements to a new location.
      * ``<hpx/include/parallel_copy.hpp>``
      * :cppreference-algorithm:`exclusive_scan`
-   * * :cpp:func:`hpx::parallel::v1::copy_n`
+   * * :cpp:func:`hpx::copy_n`
      * Copies a number of elements to a new location.
      * ``<hpx/include/parallel_copy.hpp>``
      * :cppreference-algorithm:`copy_n`
-   * * :cpp:func:`hpx::parallel::v1::copy_if`
+   * * :cpp:func:`hpx::copy_if`
      * Copies the elements from a range to a new location for which the given predicate is ``true``
      * ``<hpx/include/parallel_copy.hpp>``
      * :cppreference-algorithm:`copy`
@@ -649,6 +649,10 @@ Parallel algorithms
      * Sorts the elements in a range.
      * ``<hpx/include/parallel_sort.hpp>``
      * :cppreference-algorithm:`sort`
+   * * :cpp:func:`hpx::parallel::v1::stable_sort`
+     * Sorts the elements in a range, maintain sequence of equal elements.
+     * ``<hpx/include/parallel_sort.hpp>``
+     * :cppreference-algorithm:`stable_sort`
    * * :cpp:func:`hpx::parallel::v1::sort_by_key`
      * Sorts one range of data using keys supplied in another range.
      * ``<hpx/include/parallel_sort.hpp>``

--- a/libs/algorithms/CMakeLists.txt
+++ b/libs/algorithms/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2019-2020 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -134,6 +134,7 @@ set(algorithms_headers
     hpx/parallel/util/prefetching.hpp
     hpx/parallel/util/projection_identity.hpp
     hpx/parallel/util/range.hpp
+    hpx/parallel/util/result_types.hpp
     hpx/parallel/util/scan_partitioner.hpp
     hpx/parallel/util/tagged_pair.hpp
     hpx/parallel/util/tagged_tuple.hpp

--- a/libs/algorithms/include/hpx/algorithm.hpp
+++ b/libs/algorithms/include/hpx/algorithm.hpp
@@ -13,7 +13,6 @@ namespace hpx {
     using hpx::parallel::adjacent_find;
     using hpx::parallel::all_of;
     using hpx::parallel::any_of;
-    using hpx::parallel::copy;
     using hpx::parallel::copy_if;
     using hpx::parallel::copy_n;
     using hpx::parallel::count;

--- a/libs/algorithms/include/hpx/algorithm.hpp
+++ b/libs/algorithms/include/hpx/algorithm.hpp
@@ -13,7 +13,6 @@ namespace hpx {
     using hpx::parallel::adjacent_find;
     using hpx::parallel::all_of;
     using hpx::parallel::any_of;
-    using hpx::parallel::copy_n;
     using hpx::parallel::count;
     using hpx::parallel::count_if;
     using hpx::parallel::equal;

--- a/libs/algorithms/include/hpx/algorithm.hpp
+++ b/libs/algorithms/include/hpx/algorithm.hpp
@@ -13,7 +13,6 @@ namespace hpx {
     using hpx::parallel::adjacent_find;
     using hpx::parallel::all_of;
     using hpx::parallel::any_of;
-    using hpx::parallel::copy_if;
     using hpx::parallel::copy_n;
     using hpx::parallel::count;
     using hpx::parallel::count_if;

--- a/libs/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -629,18 +629,9 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::copy
-    HPX_INLINE_CONSTEXPR_VARIABLE struct copy_t
+    HPX_INLINE_CONSTEXPR_VARIABLE struct copy_t final
+      : hpx::functional::tag<copy_t>
     {
-        template <typename... Ts>
-        constexpr HPX_FORCEINLINE auto operator()(Ts&&... ts) const
-            noexcept(noexcept(hpx::functional::tag_invoke(
-                std::declval<copy_t>(), std::forward<Ts>(ts)...)))
-                -> decltype(hpx::functional::tag_invoke(
-                    std::declval<copy_t>(), std::forward<Ts>(ts)...))
-        {
-            return hpx::functional::tag_invoke(*this, std::forward<Ts>(ts)...);
-        }
-
     private:
         // clang-format off
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
@@ -677,18 +668,9 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::copy_if
-    HPX_INLINE_CONSTEXPR_VARIABLE struct copy_if_t
+    HPX_INLINE_CONSTEXPR_VARIABLE struct copy_if_t final
+      : hpx::functional::tag<copy_if_t>
     {
-        template <typename... Ts>
-        constexpr HPX_FORCEINLINE auto operator()(Ts&&... ts) const
-            noexcept(noexcept(hpx::functional::tag_invoke(
-                std::declval<copy_if_t>(), std::forward<Ts>(ts)...)))
-                -> decltype(hpx::functional::tag_invoke(
-                    std::declval<copy_if_t>(), std::forward<Ts>(ts)...))
-        {
-            return hpx::functional::tag_invoke(*this, std::forward<Ts>(ts)...);
-        }
-
     private:
         // clang-format off
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,

--- a/libs/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -19,6 +19,7 @@
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/scoped_executor_parameters.hpp>
+#include <hpx/parallel/util/result_types.hpp>
 
 #include <string>
 #include <type_traits>
@@ -42,6 +43,17 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             Result2>::local_raw_iterator type2;
 
         typedef std::pair<type1, type2> type;
+    };
+
+    template <typename Result1, typename Result2>
+    struct local_algorithm_result<util::in_out_result<Result1, Result2>>
+    {
+        typedef typename hpx::traits::segmented_local_iterator_traits<
+            Result1>::local_raw_iterator type1;
+        typedef typename hpx::traits::segmented_local_iterator_traits<
+            Result2>::local_raw_iterator type2;
+
+        typedef util::in_out_result<type1, type2> type;
     };
 
     template <typename Result1, typename Result2, typename Result3>

--- a/libs/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -246,7 +246,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a copy_n algorithm returns a \a hpx::future<FwdIter2> if
+    /// \returns  The \a exclusive_scan algorithm returns a
+    ///           \a hpx::future<FwdIter2> if
     ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
@@ -327,7 +328,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a copy_n algorithm returns a \a hpx::future<FwdIter2> if
+    /// \returns  The \a exclusive_scan algorithm returns a
+    ///           \a hpx::future<FwdIter2> if
     ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and

--- a/libs/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -305,7 +305,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a copy_n algorithm returns a \a hpx::future<FwdIter2> if
+    /// \returns  The \a inclusive_scan algorithm returns a
+    ///           \a hpx::future<FwdIter2> if
     ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
@@ -409,7 +410,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a copy_n algorithm returns a \a hpx::future<FwdIter2> if
+    /// \returns  The \a inclusive_scan algorithm returns a
+    ///           \a hpx::future<FwdIter2> if
     ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
@@ -495,7 +497,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a copy_n algorithm returns a \a hpx::future<FwdIter2> if
+    /// \returns  The \a inclusive_scan algorithm returns a
+    ///           \a hpx::future<FwdIter2> if
     ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and

--- a/libs/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
@@ -20,6 +20,7 @@
 #include <hpx/parallel/tagspec.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
+#include <hpx/parallel/util/result_types.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <algorithm>
@@ -35,8 +36,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
         // sequential remove_copy
         template <typename InIter, typename OutIter, typename T, typename Proj>
-        inline std::pair<InIter, OutIter> sequential_remove_copy(InIter first,
-            InIter last, OutIter dest, T const& value, Proj&& proj)
+        inline util::in_out_result<InIter, OutIter> sequential_remove_copy(
+            InIter first, InIter last, OutIter dest, T const& value,
+            Proj&& proj)
         {
             for (/* */; first != last; ++first)
             {
@@ -45,7 +47,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     *dest++ = *first;
                 }
             }
-            return std::make_pair(first, dest);
+            return util::in_out_result<InIter, OutIter>{first, dest};
         }
 
         template <typename IterPair>
@@ -59,8 +61,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename ExPolicy, typename InIter, typename OutIter,
                 typename T, typename Proj>
-            static std::pair<InIter, OutIter> sequential(ExPolicy, InIter first,
-                InIter last, OutIter dest, T const& val, Proj&& proj)
+            static util::in_out_result<InIter, OutIter> sequential(ExPolicy,
+                InIter first, InIter last, OutIter dest, T const& val,
+                Proj&& proj)
             {
                 return sequential_remove_copy(
                     first, last, dest, val, std::forward<Proj>(proj));
@@ -69,7 +72,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
                 typename T, typename Proj>
             static typename util::detail::algorithm_result<ExPolicy,
-                std::pair<FwdIter1, FwdIter2>>::type
+                util::in_out_result<FwdIter1, FwdIter2>>::type
             parallel(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
                 FwdIter2 dest, T const& val, Proj&& proj)
             {
@@ -158,7 +161,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             traits::projected<Proj, FwdIter1>,
                             traits::projected<Proj, T const*>>::value)>
     typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)>>::type
+        util::in_out_result<FwdIter1, FwdIter2>>::type
     remove_copy(ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest,
         T const& val, Proj&& proj = Proj())
     {
@@ -169,10 +172,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
         typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
 
-        return hpx::util::make_tagged_pair<tag::in, tag::out>(
-            detail::remove_copy<std::pair<FwdIter1, FwdIter2>>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
-                val, std::forward<Proj>(proj)));
+        return detail::remove_copy<util::in_out_result<FwdIter1, FwdIter2>>()
+            .call(std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
+                val, std::forward<Proj>(proj));
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -182,7 +184,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
         // sequential remove_copy_if
         template <typename InIter, typename OutIter, typename F, typename Proj>
-        inline std::pair<InIter, OutIter> sequential_remove_copy_if(
+        inline util::in_out_result<InIter, OutIter> sequential_remove_copy_if(
             InIter first, InIter last, OutIter dest, F p, Proj&& proj)
         {
             for (/* */; first != last; ++first)
@@ -193,7 +195,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     *dest++ = *first;
                 }
             }
-            return std::make_pair(first, dest);
+            return util::in_out_result<InIter, OutIter>{first, dest};
         }
 
         template <typename IterPair>
@@ -207,8 +209,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename ExPolicy, typename InIter, typename OutIter,
                 typename F, typename Proj>
-            static std::pair<InIter, OutIter> sequential(ExPolicy, InIter first,
-                InIter last, OutIter dest, F&& f, Proj&& proj)
+            static util::in_out_result<InIter, OutIter> sequential(ExPolicy,
+                InIter first, InIter last, OutIter dest, F&& f, Proj&& proj)
             {
                 return sequential_remove_copy_if(first, last, dest,
                     std::forward<F>(f), std::forward<Proj>(proj));
@@ -217,7 +219,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
                 typename F, typename Proj>
             static typename util::detail::algorithm_result<ExPolicy,
-                std::pair<FwdIter1, FwdIter2>>::type
+                util::in_out_result<FwdIter1, FwdIter2>>::type
             parallel(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
                 FwdIter2 dest, F&& f, Proj&& proj)
             {
@@ -326,7 +328,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             traits::projected<Proj, FwdIter1>>::value&&
                             hpx::traits::is_iterator<FwdIter2>::value)>
     typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)>>::type
+        util::in_out_result<FwdIter1, FwdIter2>>::type
     remove_copy_if(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
         FwdIter2 dest, F&& f, Proj&& proj = Proj())
     {
@@ -337,9 +339,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
         typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
 
-        return hpx::util::make_tagged_pair<tag::in, tag::out>(
-            detail::remove_copy_if<std::pair<FwdIter1, FwdIter2>>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
-                std::forward<F>(f), std::forward<Proj>(proj)));
+        return detail::remove_copy_if<util::in_out_result<FwdIter1, FwdIter2>>()
+            .call(std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
+                std::forward<F>(f), std::forward<Proj>(proj));
     }
 }}}    // namespace hpx::parallel::v1

--- a/libs/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
@@ -18,6 +18,7 @@
 #include <hpx/parallel/algorithms/detail/set_operation.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/loop.hpp>
+#include <hpx/parallel/util/result_types.hpp>
 
 #include <algorithm>
 #include <iterator>
@@ -69,12 +70,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 if (first2 == last2)
                 {
                     return util::detail::convert_to_result(
-                        detail::copy<std::pair<RanIter1, FwdIter>>().call(
-                            std::forward<ExPolicy>(policy), std::false_type(),
-                            first1, last1, dest),
-                        [](std::pair<RanIter1, FwdIter> const& p) -> FwdIter {
-                            return p.second;
-                        });
+                        detail::copy<util::in_out_result<RanIter1, FwdIter>>()
+                            .call(std::forward<ExPolicy>(policy),
+                                std::false_type(), first1, last1, dest),
+                        [](util::in_out_result<RanIter1, FwdIter> const& p)
+                            -> FwdIter { return p.out; });
                 }
 
                 typedef

--- a/libs/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
@@ -18,6 +18,7 @@
 #include <hpx/parallel/algorithms/detail/set_operation.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/loop.hpp>
+#include <hpx/parallel/util/result_types.hpp>
 
 #include <algorithm>
 #include <iterator>
@@ -62,23 +63,21 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 if (first1 == last1)
                 {
                     return util::detail::convert_to_result(
-                        detail::copy<std::pair<RanIter2, FwdIter>>().call(
-                            std::forward<ExPolicy>(policy), std::false_type(),
-                            first2, last2, dest),
-                        [](std::pair<RanIter2, FwdIter> const& p) -> FwdIter {
-                            return p.second;
-                        });
+                        detail::copy<util::in_out_result<RanIter2, FwdIter>>()
+                            .call(std::forward<ExPolicy>(policy),
+                                std::false_type(), first2, last2, dest),
+                        [](util::in_out_result<RanIter2, FwdIter> const& p)
+                            -> FwdIter { return p.out; });
                 }
 
                 if (first2 == last2)
                 {
                     return util::detail::convert_to_result(
-                        detail::copy<std::pair<RanIter1, FwdIter>>().call(
-                            std::forward<ExPolicy>(policy), std::false_type(),
-                            first1, last1, dest),
-                        [](std::pair<RanIter1, FwdIter> const& p) -> FwdIter {
-                            return p.second;
-                        });
+                        detail::copy<util::in_out_result<RanIter1, FwdIter>>()
+                            .call(std::forward<ExPolicy>(policy),
+                                std::false_type(), first1, last1, dest),
+                        [](util::in_out_result<RanIter1, FwdIter> const& p)
+                            -> FwdIter { return p.out; });
                 }
 
                 typedef

--- a/libs/algorithms/include/hpx/parallel/algorithms/set_union.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/set_union.hpp
@@ -18,6 +18,7 @@
 #include <hpx/parallel/algorithms/detail/set_operation.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/loop.hpp>
+#include <hpx/parallel/util/result_types.hpp>
 
 #include <algorithm>
 #include <iterator>
@@ -61,23 +62,21 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 if (first1 == last1)
                 {
                     return util::detail::convert_to_result(
-                        detail::copy<std::pair<RanIter2, FwdIter>>().call(
-                            std::forward<ExPolicy>(policy), std::false_type(),
-                            first2, last2, dest),
-                        [](std::pair<RanIter2, FwdIter> const& p) -> FwdIter {
-                            return p.second;
-                        });
+                        detail::copy<util::in_out_result<RanIter2, FwdIter>>()
+                            .call(std::forward<ExPolicy>(policy),
+                                std::false_type(), first2, last2, dest),
+                        [](util::in_out_result<RanIter2, FwdIter> const& p)
+                            -> FwdIter { return p.out; });
                 }
 
                 if (first2 == last2)
                 {
                     return util::detail::convert_to_result(
-                        detail::copy<std::pair<RanIter1, FwdIter>>().call(
-                            std::forward<ExPolicy>(policy), std::false_type(),
-                            first1, last1, dest),
-                        [](std::pair<RanIter1, FwdIter> const& p) -> FwdIter {
-                            return p.second;
-                        });
+                        detail::copy<util::in_out_result<RanIter1, FwdIter>>()
+                            .call(std::forward<ExPolicy>(policy),
+                                std::false_type(), first1, last1, dest),
+                        [](util::in_out_result<RanIter1, FwdIter> const& p)
+                            -> FwdIter { return p.out; });
                 }
 
                 typedef

--- a/libs/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -269,7 +269,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a copy_n algorithm returns a \a hpx::future<FwdIter2> if
+    /// \returns  The \a transform_exclusive_scan algorithm returns a
+    ///           \a hpx::future<FwdIter2> if
     ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and

--- a/libs/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -339,7 +339,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a copy_n algorithm returns a \a hpx::future<FwdIter2> if
+    /// \returns  The \a transform_inclusive_scan algorithm returns a
+    ///           \a hpx::future<FwdIter2> if
     ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
@@ -466,7 +467,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a copy_n algorithm returns a \a hpx::future<FwdIter2> if
+    /// \returns  The \a transform_inclusive_scan algorithm returns a
+    ///           \a hpx::future<FwdIter2> if
     ///           the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/copy.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/copy.hpp
@@ -51,9 +51,9 @@ namespace hpx { namespace ranges {
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
+    /// \param iter         Refers to the beginning of the sequence of elements
     ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
+    /// \param sent         Refers to the end of the sequence of elements the
     ///                     algorithm will be applied to.
     /// \param dest         Refers to the beginning of the destination range.
     ///
@@ -77,9 +77,9 @@ namespace hpx { namespace ranges {
     ///           destination range, one past the last element copied.
     template <typename ExPolicy, typename FwdIter1, typename Sent1,
         typename FwdIter>
-        typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+    typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
         hpx::ranges::copy_result<FwdIter1, FwdIter>>::type
-        copy(ExPolicy&& policy, FwdIter1 iter, Sent1 sent, FwdIter dest);
+    copy(ExPolicy&& policy, FwdIter1 iter, Sent1 sent, FwdIter dest);
 
     /// Copies the elements in the range \a rng to another
     /// range beginning at \a dest.
@@ -127,10 +127,97 @@ namespace hpx { namespace ranges {
     template <typename ExPolicy, typename Rng, typename FwdIter>
     typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
         hpx::ranges::copy_result<
-        typename hpx::traits::range_traits<Rng>::iterator_type,
-        FwdIter>
-    >::type
-        copy(ExPolicy&& policy, Rng&& rng, FwdIter dest);
+            typename hpx::traits::range_traits<Rng>::iterator_type,
+            FwdIter>
+        >::type
+    copy(ExPolicy&& policy, Rng&& rng, FwdIter dest);
+
+    /// Copies the elements in the range, defined by [first, last) to another
+    /// range beginning at \a dest. Copies only the elements for which the
+    /// predicate \a f returns true. The order of the elements that are not
+    /// removed is preserved.
+    ///
+    /// \note   Complexity: Performs not more than
+    ///         std::distance(begin(rng), end(rng)) assignments,
+    ///         exactly std::distance(begin(rng), end(rng)) applications
+    ///         of the predicate \a f.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the begin source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent1       The type of the end source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     sentinel for FwdIter1.
+    /// \tparam FwdIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a copy_if requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param iter         Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param sent         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a InIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a copy_if algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a copy_if algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a copy_if algorithm returns a
+    ///           \a hpx::future<ranges::copy_if_result<iterator_t<Rng>, FwdIter2>>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or \a parallel_task_policy and
+    ///           returns \a ranges::copy_if_result<iterator_t<Rng>, FwdIter2>
+    ///           otherwise.
+    ///           The \a copy_if algorithm returns the pair of the input iterator
+    ///           \a last and the output iterator to the element in the
+    ///           destination range, one past the last element copied.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename Sent1,
+        typename FwdIter, typename F,
+        typename Proj = hpx::parallel::util::projection_identity>
+    typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+        hpx::ranges::copy_if_result<
+            typename hpx::traits::range_traits<Rng>::iterator_type,
+            OutIter>>::type
+    copy_if(ExPolicy&& policy, FwdIter1 iter, Sent1 sent, FwdIter dest, F&& f,
+        Proj&& proj = Proj());
 
     /// Copies the elements in the range \a rng to another
     /// range beginning at \a dest. Copies only the elements for which the
@@ -195,21 +282,21 @@ namespace hpx { namespace ranges {
     /// within each thread.
     ///
     /// \returns  The \a copy_if algorithm returns a
-    ///           \a hpx::future<tagged_pair<tag::in(iterator_t<Rng>),
-    ///           tag::out(FwdIter2)> > if the execution policy is of type
+    ///           \a hpx::future<ranges::copy_if_result<iterator_t<Rng>, FwdIter2>>
+    ///           if the execution policy is of type
     ///           \a sequenced_task_policy or \a parallel_task_policy and
-    ///           returns \a tagged_pair<tag::in(iterator_t<Rng>),
-    ///           tag::out(FwdIter2)> otherwise.
+    ///           returns \a ranges::copy_if_result<iterator_t<Rng>, FwdIter2>
+    ///           otherwise.
     ///           The \a copy_if algorithm returns the pair of the input iterator
     ///           \a last and the output iterator to the element in the
     ///           destination range, one past the last element copied.
     ///
     template <typename ExPolicy, typename Rng, typename OutIter, typename F,
-        typename Proj = util::projection_identity>
-    typename util::detail::algorithm_result<ExPolicy,
-        ranges::copy_if_result<
-            typename hpx::traits::range_traits<Rng>::iterator_type,
-            OutIter>>::type
+        typename Proj = hpx::parallel::util::projection_identity>
+    typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+        hpx::ranges::copy_if_result<
+            typename hpx::traits::range_traits<Rng>::iterator_type, OutIter>
+    >::type
     copy_if(
         ExPolicy&& policy, Rng&& rng, OutIter dest, F&& f, Proj&& proj = Proj());
 
@@ -245,7 +332,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename FwdIter1, typename Sent1,
             typename FwdIter,
             HPX_CONCEPT_REQUIRES_(
-                parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
@@ -257,16 +344,16 @@ namespace hpx { namespace ranges {
             Sent1 sent, FwdIter dest)
         {
             using copy_iter_t =
-                parallel::v1::detail::copy_iter<FwdIter1, FwdIter>;
+                hpx::parallel::v1::detail::copy_iter<FwdIter1, FwdIter>;
 
-            return parallel::v1::detail::transfer<copy_iter_t>(
+            return hpx::parallel::v1::detail::transfer<copy_iter_t>(
                 std::forward<ExPolicy>(policy), iter, sent, dest);
         }
 
         // clang-format off
         template <typename ExPolicy, typename Rng, typename FwdIter,
             HPX_CONCEPT_REQUIRES_(
-                parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
@@ -278,11 +365,11 @@ namespace hpx { namespace ranges {
         tag_invoke(
             hpx::ranges::copy_t, ExPolicy&& policy, Rng&& rng, FwdIter dest)
         {
-            using copy_iter_t = parallel::v1::detail::copy_iter<
+            using copy_iter_t = hpx::parallel::v1::detail::copy_iter<
                 typename hpx::traits::range_traits<Rng>::iterator_type,
                 FwdIter>;
 
-            return parallel::v1::detail::transfer<copy_iter_t>(
+            return hpx::parallel::v1::detail::transfer<copy_iter_t>(
                 std::forward<ExPolicy>(policy), hpx::util::begin(rng),
                 hpx::util::end(rng), dest);
         }
@@ -299,10 +386,10 @@ namespace hpx { namespace ranges {
             hpx::ranges::copy_t, FwdIter1 iter, Sent1 sent, FwdIter dest)
         {
             using copy_iter_t =
-                parallel::v1::detail::copy_iter<FwdIter1, FwdIter>;
+                hpx::parallel::v1::detail::copy_iter<FwdIter1, FwdIter>;
 
-            return parallel::v1::detail::transfer<copy_iter_t>(
-                parallel::execution::seq, iter, sent, dest);
+            return hpx::parallel::v1::detail::transfer<copy_iter_t>(
+                hpx::parallel::execution::seq, iter, sent, dest);
         }
 
         // clang-format off
@@ -316,22 +403,172 @@ namespace hpx { namespace ranges {
             typename hpx::traits::range_traits<Rng>::iterator_type, FwdIter>
         tag_invoke(hpx::ranges::copy_t, Rng&& rng, FwdIter dest)
         {
-            using copy_iter_t = parallel::v1::detail::copy_iter<
+            using copy_iter_t = hpx::parallel::v1::detail::copy_iter<
                 typename hpx::traits::range_traits<Rng>::iterator_type,
                 FwdIter>;
 
-            return parallel::v1::detail::transfer<copy_iter_t>(
-                parallel::execution::seq, hpx::util::begin(rng),
+            return hpx::parallel::v1::detail::transfer<copy_iter_t>(
+                hpx::parallel::execution::seq, hpx::util::begin(rng),
                 hpx::util::end(rng), dest);
         }
     } copy{};
-    /// \endcond
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::copy_if
+    HPX_INLINE_CONSTEXPR_VARIABLE struct copy_if_t
+    {
+        template <typename... Ts>
+        constexpr HPX_FORCEINLINE auto operator()(Ts&&... ts) const
+            noexcept(noexcept(hpx::functional::tag_invoke(
+                std::declval<copy_if_t>(), std::forward<Ts>(ts)...)))
+                -> decltype(hpx::functional::tag_invoke(
+                    std::declval<copy_if_t>(), std::forward<Ts>(ts)...))
+        {
+            return hpx::functional::tag_invoke(*this, std::forward<Ts>(ts)...);
+        }
+
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename Sent1,
+            typename FwdIter, typename Pred,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
+                hpx::parallel::traits::is_projected<Proj, FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
+                    hpx::parallel::traits::projected<Proj, FwdIter1>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            ranges::copy_if_result<FwdIter1, FwdIter>>::type
+        tag_invoke(hpx::ranges::copy_if_t, ExPolicy&& policy, FwdIter1 iter,
+            Sent1 sent, FwdIter dest, Pred&& pred, Proj&& proj = Proj())
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Required at least forward iterator.");
+
+            static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
+                "Required at least forward iterator.");
+
+            using is_seq =
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>;
+
+            return hpx::parallel::v1::detail::copy_if<
+                hpx::parallel::util::in_out_result<FwdIter1, FwdIter>>()
+                .call(std::forward<ExPolicy>(policy), is_seq{}, iter, sent,
+                    dest, std::forward<Pred>(pred), std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng, typename FwdIter,
+            typename Pred,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
+                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
+                    hpx::parallel::traits::projected_range<Proj, Rng>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            ranges::copy_if_result<
+                typename hpx::traits::range_traits<Rng>::iterator_type,
+                FwdIter>>::type
+        tag_invoke(hpx::ranges::copy_if_t, ExPolicy&& policy, Rng&& rng,
+            FwdIter dest, Pred&& pred, Proj&& proj = Proj())
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
+                "Required at least forward iterator.");
+
+            using is_seq =
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>;
+
+            return hpx::parallel::v1::detail::copy_if<
+                hpx::parallel::util::in_out_result<
+                    typename hpx::traits::range_traits<Rng>::iterator_type,
+                    FwdIter>>()
+                .call(std::forward<ExPolicy>(policy), is_seq(),
+                    hpx::util::begin(rng), hpx::util::end(rng), dest,
+                    std::forward<Pred>(pred), std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename FwdIter1, typename Sent1, typename FwdIter,
+            typename Pred,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
+                hpx::parallel::traits::is_projected<Proj, FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::parallel::execution::sequenced_policy, Pred,
+                    hpx::parallel::traits::projected<Proj, FwdIter1>
+                >::value
+            )>
+        // clang-format on
+        friend ranges::copy_if_result<FwdIter1, FwdIter> tag_invoke(
+            hpx::ranges::copy_if_t, FwdIter1 iter, Sent1 sent, FwdIter dest,
+            Pred&& pred, Proj&& proj = Proj())
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Required at least forward iterator.");
+
+            static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
+                "Required at least forward iterator.");
+
+            return hpx::parallel::v1::detail::copy_if<
+                hpx::parallel::util::in_out_result<FwdIter1, FwdIter>>()
+                .call(hpx::parallel::execution::seq, std::true_type{}, iter,
+                    sent, dest, std::forward<Pred>(pred),
+                    std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename Rng, typename FwdIter, typename Pred,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
+                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::parallel::execution::sequenced_policy, Pred,
+                    hpx::parallel::traits::projected_range<Proj, Rng>
+                >::value
+            )>
+        // clang-format on
+        friend ranges::copy_if_result<
+            typename hpx::traits::range_traits<Rng>::iterator_type, FwdIter>
+        tag_invoke(hpx::ranges::copy_if_t, Rng&& rng, FwdIter dest, Pred&& pred,
+            Proj&& proj = Proj())
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
+                "Required at least forward iterator.");
+
+            return hpx::parallel::v1::detail::copy_if<
+                hpx::parallel::util::in_out_result<
+                    typename hpx::traits::range_traits<Rng>::iterator_type,
+                    FwdIter>>()
+                .call(hpx::parallel::execution::seq, std::true_type{},
+                    hpx::util::begin(rng), hpx::util::end(rng), dest,
+                    std::forward<Pred>(pred), std::forward<Proj>(proj));
+        }
+
+    } copy_if{};
 
 }}    // namespace hpx::ranges
 
 namespace hpx { namespace parallel { inline namespace v1 {
 
-    /// \cond NOINTERNAL
     // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename Sent1,
         typename FwdIter,
@@ -342,9 +579,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
             hpx::traits::is_iterator<FwdIter>::value
         )>
     // clang-format on
-    typename util::detail::algorithm_result<ExPolicy,
-        ranges::copy_result<FwdIter1, FwdIter>>::type
-    copy(ExPolicy&& policy, FwdIter1 iter, Sent1 sent, FwdIter dest)
+    HPX_DEPRECATED(
+        "hpx::parallel::copy is deprecated, use hpx::ranges::copy instead")
+        typename util::detail::algorithm_result<ExPolicy,
+            hpx::ranges::copy_result<FwdIter1, FwdIter>>::type
+        copy(ExPolicy&& policy, FwdIter1 iter, Sent1 sent, FwdIter dest)
     {
         using copy_iter_t = detail::copy_iter<FwdIter1, FwdIter>;
         return detail::transfer<copy_iter_t>(
@@ -359,11 +598,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
             hpx::traits::is_iterator<FwdIter>::value
         )>
     // clang-format on
-    typename util::detail::algorithm_result<ExPolicy,
-        ranges::copy_result<
-            typename hpx::traits::range_traits<Rng>::iterator_type,
-            FwdIter>>::type
-    copy(ExPolicy&& policy, Rng&& rng, FwdIter dest)
+    HPX_DEPRECATED(
+        "hpx::parallel::copy is deprecated, use hpx::ranges::copy instead")
+        typename util::detail::algorithm_result<ExPolicy,
+            ranges::copy_result<
+                typename hpx::traits::range_traits<Rng>::iterator_type,
+                FwdIter>>::type copy(ExPolicy&& policy, Rng&& rng, FwdIter dest)
     {
         using copy_iter_t = detail::copy_iter<
             typename hpx::traits::range_traits<Rng>::iterator_type, FwdIter>;
@@ -376,27 +616,27 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename Rng, typename OutIter, typename F,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_range<Rng>::value &&
-            traits::is_projected_range<Proj, Rng>::value &&
-            hpx::traits::is_iterator<OutIter>::value &&
+            execution::is_execution_policy<ExPolicy>::value&&
+            hpx::traits::is_range<Rng>::value&&
+            traits::is_projected_range<Proj, Rng>::value&&
+            hpx::traits::is_iterator<OutIter>::value&&
             traits::is_indirect_callable<ExPolicy, F,
                 traits::projected_range<Proj, Rng>
             >::value
         )>
     // clang-format on
-    typename util::detail::algorithm_result<ExPolicy,
-        ranges::copy_if_result<
-            typename hpx::traits::range_traits<Rng>::iterator_type,
-            OutIter>>::type
-    copy_if(
-        ExPolicy&& policy, Rng&& rng, OutIter dest, F&& f, Proj&& proj = Proj())
+    HPX_DEPRECATED("hpx::parallel::copy_if is deprecated, use "
+                   "hpx::ranges::copy_if instead")
+        typename util::detail::algorithm_result<ExPolicy,
+            ranges::copy_if_result<
+                typename hpx::traits::range_traits<Rng>::iterator_type,
+                OutIter>>::type copy_if(ExPolicy&& policy, Rng&& rng,
+            OutIter dest, F&& f, Proj&& proj = Proj())
     {
         return copy_if(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
             hpx::util::end(rng), dest, std::forward<F>(f),
             std::forward<Proj>(proj));
     }
-    /// \endcond
 }}}    // namespace hpx::parallel::v1
 
 #endif    // DOXYGEN

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/copy.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/copy.hpp
@@ -315,18 +315,9 @@ namespace hpx { namespace ranges {
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::copy
-    HPX_INLINE_CONSTEXPR_VARIABLE struct copy_t
+    HPX_INLINE_CONSTEXPR_VARIABLE struct copy_t final
+      : hpx::functional::tag<copy_t>
     {
-        template <typename... Ts>
-        constexpr HPX_FORCEINLINE auto operator()(Ts&&... ts) const
-            noexcept(noexcept(hpx::functional::tag_invoke(
-                std::declval<copy_t>(), std::forward<Ts>(ts)...)))
-                -> decltype(hpx::functional::tag_invoke(
-                    std::declval<copy_t>(), std::forward<Ts>(ts)...))
-        {
-            return hpx::functional::tag_invoke(*this, std::forward<Ts>(ts)...);
-        }
-
     private:
         // clang-format off
         template <typename ExPolicy, typename FwdIter1, typename Sent1,
@@ -415,18 +406,9 @@ namespace hpx { namespace ranges {
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::copy_if
-    HPX_INLINE_CONSTEXPR_VARIABLE struct copy_if_t
+    HPX_INLINE_CONSTEXPR_VARIABLE struct copy_if_t final
+      : hpx::functional::tag<copy_if_t>
     {
-        template <typename... Ts>
-        constexpr HPX_FORCEINLINE auto operator()(Ts&&... ts) const
-            noexcept(noexcept(hpx::functional::tag_invoke(
-                std::declval<copy_if_t>(), std::forward<Ts>(ts)...)))
-                -> decltype(hpx::functional::tag_invoke(
-                    std::declval<copy_if_t>(), std::forward<Ts>(ts)...))
-        {
-            return hpx::functional::tag_invoke(*this, std::forward<Ts>(ts)...);
-        }
-
     private:
         // clang-format off
         template <typename ExPolicy, typename FwdIter1, typename Sent1,

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/move.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/move.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2017 Bruno Pitrus
+//  Copyright (c) 2017-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -13,14 +14,90 @@
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
-#include <hpx/parallel/util/tagged_pair.hpp>
+#include <hpx/parallel/util/result_types.hpp>
 
 #include <hpx/parallel/algorithms/move.hpp>
 
 #include <type_traits>
 #include <utility>
 
+namespace hpx { namespace ranges {
+
+    template <typename I, typename O>
+    using move_result = parallel::util::in_out_result<I, O>;
+}}    // namespace hpx::ranges
+
 namespace hpx { namespace parallel { inline namespace v1 {
+
+    /// Moves the elements in the range \a rng to another range beginning
+    /// at \a dest. After this operation the elements in the moved-from
+    /// range will still contain valid values of the appropriate type,
+    /// but not necessarily the same values as before the move.
+    ///
+    /// \note   Complexity: Performs exactly
+    ///         std::distance(begin(rng), end(rng)) assignments.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the begin source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent1       The type of the end source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     sentinel for FwdIter1.
+    /// \tparam FwdIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    ///
+    /// The assignments in the parallel \a copy algorithm invoked with an
+    /// execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a copy algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a move algorithm returns a
+    ///           \a hpx::future<ranges::move_result<iterator_t<Rng>, FwdIter2>>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or \a parallel_task_policy and
+    ///           returns \a ranges::move_result<iterator_t<Rng>, FwdIter2>
+    ///           otherwise.
+    ///           The \a move algorithm returns the pair of the input iterator
+    ///           \a last and the output iterator to the element in the
+    ///           destination range, one past the last element moved.
+    ///
+    // clang-format off
+    template <typename ExPolicy, typename FwdIter1, typename Sent1,
+        typename FwdIter,
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<FwdIter1>::value&&
+            hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value&&
+            hpx::traits::is_iterator<FwdIter>::value)>
+    // clang-format on
+    typename util::detail::algorithm_result<ExPolicy,
+        ranges::move_result<FwdIter1, FwdIter>>::type
+    move(ExPolicy&& policy, FwdIter1 iter, Sent1 sent, FwdIter dest)
+    {
+        using move_iter_t = detail::move<FwdIter1, FwdIter>;
+        return detail::transfer<move_iter_t>(
+            std::forward<ExPolicy>(policy), iter, sent, dest);
+    }
+
     /// Moves the elements in the range \a rng to another range beginning
     /// at \a dest. After this operation the elements in the moved-from
     /// range will still contain valid values of the appropriate type,
@@ -36,10 +113,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// \tparam Rng         The type of the source range used (deduced).
     ///                     The iterators extracted from this range type must
     ///                     meet the requirements of an input iterator.
-    /// \tparam OutIter     The type of the iterator representing the
+    /// \tparam FwdIter     The type of the iterator representing the
     ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
-    ///                     output iterator.
+    ///                     forward iterator.
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
@@ -58,26 +135,33 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// within each thread.
     ///
     /// \returns  The \a move algorithm returns a
-    ///           \a hpx::future<tagged_pair<tag::in(iterator_t<Rng>),
-    ///           tag::out(FwdIter2)> > if the execution policy is of type
+    ///           \a hpx::future<ranges::move_result<iterator_t<Rng>, FwdIter2>>
+    ///           if the execution policy is of type
     ///           \a sequenced_task_policy or \a parallel_task_policy and
-    ///           returns \a tagged_pair<tag::in(iterator_t<Rng>),
-    ///           tag::out(FwdIter2)> otherwise.
+    ///           returns \a ranges::move_result<iterator_t<Rng>, FwdIter2>
+    ///           otherwise.
     ///           The \a move algorithm returns the pair of the input iterator
     ///           \a last and the output iterator to the element in the
     ///           destination range, one past the last element moved.
     ///
-    template <typename ExPolicy, typename Rng, typename OutIter,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&&
-                    hpx::traits::is_iterator<OutIter>::value)>
+    // clang-format off
+    template <typename ExPolicy, typename Rng, typename FwdIter,
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value &&
+            hpx::traits::is_iterator<FwdIter>::value)>
+    // clang-format on
     typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_pair<
-            tag::in(typename hpx::traits::range_traits<Rng>::iterator_type),
-            tag::out(OutIter)>>::type
-    move(ExPolicy&& policy, Rng&& rng, OutIter dest)
+        ranges::move_result<
+            typename hpx::traits::range_traits<Rng>::iterator_type,
+            FwdIter>>::type
+    move(ExPolicy&& policy, Rng&& rng, FwdIter dest)
     {
-        return move(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
-            hpx::util::end(rng), dest);
+        using move_iter_t =
+            detail::move<typename hpx::traits::range_traits<Rng>::iterator_type,
+                FwdIter>;
+
+        return detail::transfer<move_iter_t>(std::forward<ExPolicy>(policy),
+            hpx::util::begin(rng), hpx::util::end(rng), dest);
     }
 }}}    // namespace hpx::parallel::v1

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/remove.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/remove.hpp
@@ -13,12 +13,10 @@
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
-#include <hpx/parallel/util/tagged_pair.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/parallel/algorithms/remove.hpp>
-#include <hpx/parallel/tagspec.hpp>
 
 #include <type_traits>
 #include <utility>

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/remove_copy.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/remove_copy.hpp
@@ -20,6 +20,7 @@
 #include <hpx/parallel/algorithms/remove_copy.hpp>
 #include <hpx/parallel/tagspec.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
+#include <hpx/parallel/util/result_types.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -97,9 +98,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::equal_to<T>, traits::projected_range<Proj, Rng>,
                     traits::projected<Proj, T const*>>::value)>
     typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_pair<
-            tag::in(typename hpx::traits::range_traits<Rng>::iterator_type),
-            tag::out(OutIter)>>::type
+        util::in_out_result<
+            typename hpx::traits::range_traits<Rng>::iterator_type,
+            OutIter>>::type
     remove_copy(ExPolicy&& policy, Rng&& rng, OutIter dest, T const& val,
         Proj&& proj = Proj())
     {
@@ -196,9 +197,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     Rng>::value&& traits::is_indirect_callable<ExPolicy, F,
                     traits::projected_range<Proj, Rng>>::value)>
     typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_pair<
-            tag::in(typename hpx::traits::range_traits<Rng>::iterator_type),
-            tag::out(OutIter)>>::type
+        util::in_out_result<
+            typename hpx::traits::range_traits<Rng>::iterator_type,
+            OutIter>>::type
     remove_copy_if(
         ExPolicy&& policy, Rng&& rng, OutIter dest, F&& f, Proj&& proj = Proj())
     {

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/reverse.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/reverse.hpp
@@ -13,7 +13,7 @@
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
-#include <hpx/parallel/util/tagged_pair.hpp>
+#include <hpx/parallel/util/result_types.hpp>
 
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/parallel/algorithms/reverse.hpp>
@@ -113,11 +113,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// within each thread.
     ///
     /// \returns  The \a reverse_copy algorithm returns a
-    ///           \a hpx::future<tagged_pair<tag::in(BidirIter), tag::out(OutIter)> >
+    ///           \a hpx::future<in_out_result<BidirIter, OutIter> >
     ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a tagged_pair<tag::in(BidirIter), tag::out(OutIter)>
+    ///           returns \a in_out_result<BidirIter, OutIter>
     ///           otherwise.
     ///           The \a copy algorithm returns the pair of the input iterator
     ///           forwarded to the first element after the last in the input
@@ -130,9 +130,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 hpx::traits::is_range<Rng>::value&&
                     hpx::traits::is_iterator<OutIter>::value)>
     typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_pair<
-            tag::in(typename hpx::traits::range_iterator<Rng>::type),
-            tag::out(OutIter)>>::type
+        util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
+            OutIter>>::type
     reverse_copy(ExPolicy&& policy, Rng&& rng, OutIter dest_first)
     {
         return reverse_copy(std::forward<ExPolicy>(policy),

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/rotate.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/rotate.hpp
@@ -19,6 +19,7 @@
 #include <hpx/parallel/algorithms/rotate.hpp>
 #include <hpx/parallel/tagspec.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
+#include <hpx/parallel/util/result_types.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -73,9 +74,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value)>
     typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_pair<
-            tag::begin(typename hpx::traits::range_iterator<Rng>::type),
-            tag::end(typename hpx::traits::range_iterator<Rng>::type)>>::type
+        util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
+            typename hpx::traits::range_iterator<Rng>::type>>::type
     rotate(ExPolicy&& policy, Rng&& rng,
         typename hpx::traits::range_iterator<Rng>::type middle)
     {
@@ -135,9 +135,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 hpx::traits::is_range<Rng>::value&&
                     hpx::traits::is_iterator<OutIter>::value)>
     typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_pair<
-            tag::in(typename hpx::traits::range_iterator<Rng>::type),
-            tag::out(OutIter)>>::type
+        util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
+            OutIter>>::type
     rotate_copy(ExPolicy&& policy, Rng&& rng,
         typename hpx::traits::range_iterator<Rng>::type middle,
         OutIter dest_first)

--- a/libs/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/future.hpp>
+#include <hpx/futures/future.hpp>
 #include <hpx/tuple.hpp>
 
 #include <type_traits>

--- a/libs/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -1,0 +1,91 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/container_algorithms/copy.hpp
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/future.hpp>
+#include <hpx/tuple.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { namespace util {
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename I, typename O>
+    struct in_out_result
+    {
+        HPX_NO_UNIQUE_ADDRESS I in;
+        HPX_NO_UNIQUE_ADDRESS O out;
+
+        template <typename I2, typename O2,
+            typename Enable = typename std::enable_if<
+                std::is_convertible<I const&, I2&>::value &&
+                std::is_convertible<O const&, O2&>::value>::type>
+        constexpr operator in_out_result<I2, O2>() const&
+        {
+            return {in, out};
+        }
+
+        template <typename I2, typename O2,
+            typename Enable =
+                typename std::enable_if<std::is_convertible<I, I2>::value &&
+                    std::is_convertible<O, O2>::value>::type>
+        constexpr operator in_out_result<I2, O2>() &&
+        {
+            return {std::move(in), std::move(out)};
+        }
+
+        template <typename Archive>
+        void serialize(Archive& ar, unsigned)
+        {
+            // clang-format off
+            ar & in & out;
+            // clang-format on
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename ZipIter>
+    in_out_result<typename hpx::util::tuple_element<0,
+                      typename ZipIter::iterator_tuple_type>::type,
+        typename hpx::util::tuple_element<1,
+            typename ZipIter::iterator_tuple_type>::type>
+    get_in_out_result(ZipIter&& zipiter)
+    {
+        using iterator_tuple_type = typename ZipIter::iterator_tuple_type;
+
+        using result_type = in_out_result<
+            typename hpx::util::tuple_element<0, iterator_tuple_type>::type,
+            typename hpx::util::tuple_element<1, iterator_tuple_type>::type>;
+
+        iterator_tuple_type t = zipiter.get_iterator_tuple();
+        return result_type{hpx::util::get<0>(t), hpx::util::get<1>(t)};
+    }
+
+    template <typename ZipIter>
+    hpx::future<in_out_result<typename hpx::util::tuple_element<0,
+                                  typename ZipIter::iterator_tuple_type>::type,
+        typename hpx::util::tuple_element<1,
+            typename ZipIter::iterator_tuple_type>::type>>
+    get_in_out_result(hpx::future<ZipIter>&& zipiter)
+    {
+        using iterator_tuple_type = typename ZipIter::iterator_tuple_type;
+
+        using result_type = in_out_result<
+            typename hpx::util::tuple_element<0, iterator_tuple_type>::type,
+            typename hpx::util::tuple_element<1, iterator_tuple_type>::type>;
+
+        return lcos::make_future<result_type>(
+            std::move(zipiter), [](ZipIter zipiter) {
+                return get_in_out_result(std::move(zipiter));
+            });
+    }
+
+}}}    // namespace hpx::parallel::util

--- a/libs/algorithms/include/hpx/parallel/util/transfer.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/transfer.hpp
@@ -56,7 +56,8 @@ namespace hpx { namespace parallel { namespace util {
 
             std::advance(first, count);
             std::advance(dest, count);
-            return in_out_result<InIter, OutIter>{first, dest};
+            return in_out_result<InIter, OutIter>{
+                std::move(first), std::move(dest)};
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -71,7 +72,8 @@ namespace hpx { namespace parallel { namespace util {
             {
                 while (first != last)
                     *dest++ = *first++;
-                return in_out_result<InIter, OutIter>{first, dest};
+                return in_out_result<InIter, OutIter>{
+                    std::move(first), std::move(dest)};
             }
         };
 
@@ -112,7 +114,8 @@ namespace hpx { namespace parallel { namespace util {
             {
                 for (std::size_t i = 0; i != count; ++i)
                     *dest++ = *first++;
-                return in_out_result<InIter, OutIter>{first, dest};
+                return in_out_result<InIter, OutIter>{
+                    std::move(first), std::move(dest)};
             }
         };
 
@@ -175,7 +178,8 @@ namespace hpx { namespace parallel { namespace util {
             {
                 while (first != last)
                     *dest++ = std::move(*first++);
-                return in_out_result<InIter, OutIter>{first, dest};
+                return in_out_result<InIter, OutIter>{
+                    std::move(first), std::move(dest)};
             }
         };
 
@@ -214,7 +218,8 @@ namespace hpx { namespace parallel { namespace util {
             {
                 for (std::size_t i = 0; i != count; ++i)
                     *dest++ = std::move(*first++);
-                return in_out_result<InIter, OutIter>{first, dest};
+                return in_out_result<InIter, OutIter>{
+                    std::move(first), std::move(dest)};
             }
         };
 

--- a/libs/algorithms/tests/performance/benchmark_inplace_merge.cpp
+++ b/libs/algorithms/tests/performance/benchmark_inplace_merge.cpp
@@ -60,8 +60,7 @@ double run_inplace_merge_benchmark_std(int test_count, OrgIter org_first,
     for (int i = 0; i < test_count; ++i)
     {
         // Restore [first, last) with original data.
-        hpx::parallel::copy(
-            hpx::parallel::execution::par, org_first, org_last, first);
+        hpx::copy(hpx::parallel::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
         std::inplace_merge(first, middle, last);
@@ -82,8 +81,7 @@ double run_inplace_merge_benchmark_hpx(int test_count, ExPolicy policy,
     for (int i = 0; i < test_count; ++i)
     {
         // Restore [first, last) with original data.
-        hpx::parallel::copy(
-            hpx::parallel::execution::par, org_first, org_last, first);
+        hpx::copy(hpx::parallel::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
         hpx::parallel::inplace_merge(policy, first, middle, last);

--- a/libs/algorithms/tests/performance/benchmark_partition.cpp
+++ b/libs/algorithms/tests/performance/benchmark_partition.cpp
@@ -60,8 +60,7 @@ double run_partition_benchmark_std(int test_count, OrgIter org_first,
     for (int i = 0; i < test_count; ++i)
     {
         // Restore [first, last) with original data.
-        hpx::parallel::copy(
-            hpx::parallel::execution::par, org_first, org_last, first);
+        hpx::copy(hpx::parallel::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
         std::partition(first, last, pred);
@@ -81,8 +80,7 @@ double run_partition_benchmark_hpx(int test_count, ExPolicy policy,
     for (int i = 0; i < test_count; ++i)
     {
         // Restore [first, last) with original data.
-        hpx::parallel::copy(
-            hpx::parallel::execution::par, org_first, org_last, first);
+        hpx::copy(hpx::parallel::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
         hpx::parallel::partition(policy, first, last, pred);

--- a/libs/algorithms/tests/performance/benchmark_remove.cpp
+++ b/libs/algorithms/tests/performance/benchmark_remove.cpp
@@ -96,8 +96,7 @@ double run_remove_benchmark_std(int test_count, OrgIter org_first,
     for (int i = 0; i < test_count; ++i)
     {
         // Restore [first, last) with original data.
-        hpx::parallel::copy(
-            hpx::parallel::execution::par, org_first, org_last, first);
+        hpx::copy(hpx::parallel::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
         (void) std::remove(first, last, value);
@@ -119,8 +118,7 @@ double run_remove_benchmark_hpx(int test_count, ExPolicy policy,
     for (int i = 0; i < test_count; ++i)
     {
         // Restore [first, last) with original data.
-        hpx::parallel::copy(
-            hpx::parallel::execution::par, org_first, org_last, first);
+        hpx::copy(hpx::parallel::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
         hpx::parallel::remove(policy, first, last, value);

--- a/libs/algorithms/tests/performance/benchmark_remove_if.cpp
+++ b/libs/algorithms/tests/performance/benchmark_remove_if.cpp
@@ -96,8 +96,7 @@ double run_remove_if_benchmark_std(int test_count, OrgIter org_first,
     for (int i = 0; i < test_count; ++i)
     {
         // Restore [first, last) with original data.
-        hpx::parallel::copy(
-            hpx::parallel::execution::par, org_first, org_last, first);
+        hpx::copy(hpx::parallel::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
         (void) std::remove_if(first, last, pred);
@@ -117,8 +116,7 @@ double run_remove_if_benchmark_hpx(int test_count, ExPolicy policy,
     for (int i = 0; i < test_count; ++i)
     {
         // Restore [first, last) with original data.
-        hpx::parallel::copy(
-            hpx::parallel::execution::par, org_first, org_last, first);
+        hpx::copy(hpx::parallel::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
         hpx::parallel::remove_if(policy, first, last, pred);

--- a/libs/algorithms/tests/performance/benchmark_unique.cpp
+++ b/libs/algorithms/tests/performance/benchmark_unique.cpp
@@ -96,8 +96,7 @@ double run_unique_benchmark_std(int test_count, OrgIter org_first,
     for (int i = 0; i < test_count; ++i)
     {
         // Restore [first, last) with original data.
-        hpx::parallel::copy(
-            hpx::parallel::execution::par, org_first, org_last, first);
+        hpx::copy(hpx::parallel::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
         (void) std::unique(first, last);
@@ -117,8 +116,7 @@ double run_unique_benchmark_hpx(int test_count, ExPolicy policy,
     for (int i = 0; i < test_count; ++i)
     {
         // Restore [first, last) with original data.
-        hpx::parallel::copy(
-            hpx::parallel::execution::par, org_first, org_last, first);
+        hpx::copy(hpx::parallel::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
         hpx::parallel::unique(policy, first, last);

--- a/libs/algorithms/tests/regressions/scan_shortlength.cpp
+++ b/libs/algorithms/tests/regressions/scan_shortlength.cpp
@@ -25,8 +25,8 @@ void test_zero()
     std::vector<int> a;
     std::vector<int> b, c, d;
 
-    auto p_copy_if = copy_if(execution::par, a.begin(), a.end(), b.begin(),
-        [](int bar) { return bar % 2 == 1; });
+    auto p_copy_if = hpx::ranges::copy_if(execution::par, a.begin(), a.end(),
+        b.begin(), [](int bar) { return bar % 2 == 1; });
     auto p_remove_copy_if = remove_copy_if(execution::par, a.begin(), a.end(),
         c.begin(), [](int bar) { return bar % 2 != 1; });
     auto p_remove_copy =
@@ -38,9 +38,9 @@ void test_zero()
         a.begin(), a.end(), c.begin(), [](int bar) { return bar % 2 != 1; });
     Iter ans_remove_copy = std::remove_copy(a.begin(), a.end(), d.begin(), 0);
 
-    HPX_TEST(p_copy_if.out() == ans_copy_if);
-    HPX_TEST(p_remove_copy_if.out() == ans_remove_copy_if);
-    HPX_TEST(p_remove_copy.out() == ans_remove_copy);
+    HPX_TEST(p_copy_if.out == ans_copy_if);
+    HPX_TEST(p_remove_copy_if.out == ans_remove_copy_if);
+    HPX_TEST(p_remove_copy.out == ans_remove_copy);
 }
 
 void test_async_zero()
@@ -51,8 +51,8 @@ void test_async_zero()
     std::vector<int> a;
     std::vector<int> b, c, d;
 
-    auto f_copy_if = copy_if(execution::par(execution::task), a.begin(),
-        a.end(), b.begin(), [](int bar) { return bar % 2 == 1; });
+    auto f_copy_if = hpx::ranges::copy_if(execution::par(execution::task),
+        a.begin(), a.end(), b.begin(), [](int bar) { return bar % 2 == 1; });
     auto f_remove_copy_if = remove_copy_if(execution::par(execution::task),
         a.begin(), a.end(), c.begin(), [](int bar) { return bar % 2 != 1; });
     auto f_remove_copy = remove_copy(
@@ -64,9 +64,9 @@ void test_async_zero()
         a.begin(), a.end(), c.begin(), [](int bar) { return bar % 2 != 1; });
     Iter ans_remove_copy = std::remove_copy(a.begin(), a.end(), d.begin(), 0);
 
-    HPX_TEST(f_copy_if.get().out() == ans_copy_if);
-    HPX_TEST(f_remove_copy_if.get().out() == ans_remove_copy_if);
-    HPX_TEST(f_remove_copy.get().out() == ans_remove_copy);
+    HPX_TEST(f_copy_if.get().out == ans_copy_if);
+    HPX_TEST(f_remove_copy_if.get().out == ans_remove_copy_if);
+    HPX_TEST(f_remove_copy.get().out == ans_remove_copy);
 }
 
 void test_one(std::vector<int> a)
@@ -77,8 +77,8 @@ void test_one(std::vector<int> a)
     std::vector<int> b(n), c(n), d(n);
     std::vector<int> b_ans(n), c_ans(n), d_ans(n);
 
-    auto p_copy_if = copy_if(execution::par, a.begin(), a.end(), b.begin(),
-        [](int bar) { return bar % 2 == 1; });
+    auto p_copy_if = hpx::ranges::copy_if(execution::par, a.begin(), a.end(),
+        b.begin(), [](int bar) { return bar % 2 == 1; });
     auto p_remove_copy_if = remove_copy_if(execution::par, a.begin(), a.end(),
         c.begin(), [](int bar) { return bar % 2 != 1; });
     auto p_remove_copy =
@@ -116,8 +116,8 @@ void test_async_one(std::vector<int> a)
     std::vector<int> b(n), c(n), d(n);
     std::vector<int> b_ans(n), c_ans(n), d_ans(n);
 
-    auto f_copy_if = copy_if(execution::par(execution::task), a.begin(),
-        a.end(), b.begin(), [](int bar) { return bar % 2 == 1; });
+    auto f_copy_if = hpx::ranges::copy_if(execution::par(execution::task),
+        a.begin(), a.end(), b.begin(), [](int bar) { return bar % 2 == 1; });
     auto f_remove_copy_if = remove_copy_if(execution::par(execution::task),
         a.begin(), a.end(), c.begin(), [](int bar) { return bar % 2 != 1; });
     auto f_remove_copy = remove_copy(

--- a/libs/algorithms/tests/unit/algorithms/copy.cpp
+++ b/libs/algorithms/tests/unit/algorithms/copy.cpp
@@ -36,7 +36,7 @@ void test_copy(ExPolicy policy, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), gen());
-    hpx::parallel::copy(
+    hpx::copy(
         policy, iterator(std::begin(c)), iterator(std::end(c)), std::begin(d));
 
     std::size_t count = 0;
@@ -59,7 +59,7 @@ void test_copy_async(ExPolicy p, IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f = hpx::parallel::copy(
+    auto f = hpx::copy(
         p, iterator(std::begin(c)), iterator(std::end(c)), std::begin(d));
     f.wait();
 
@@ -110,7 +110,7 @@ void test_copy_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::copy(policy,
+        hpx::copy(policy,
             decorated_iterator(
                 std::begin(c), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c)), std::begin(d));
@@ -144,7 +144,7 @@ void test_copy_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::copy(p,
+        auto f = hpx::copy(p,
             decorated_iterator(
                 std::begin(c), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c)), std::begin(d));
@@ -207,7 +207,7 @@ void test_copy_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::copy(policy,
+        hpx::copy(policy,
             decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c)), std::begin(d));
         HPX_TEST(false);
@@ -239,7 +239,7 @@ void test_copy_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::copy(p,
+        auto f = hpx::copy(p,
             decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c)), std::begin(d));
         returned_from_algorithm = true;

--- a/libs/algorithms/tests/unit/algorithms/copyif_bad_alloc.cpp
+++ b/libs/algorithms/tests/unit/algorithms/copyif_bad_alloc.cpp
@@ -40,8 +40,8 @@ void test_copy_if_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::copy_if(policy, iterator(std::begin(c)),
-            iterator(std::end(c)), std::begin(d),
+        hpx::copy_if(policy, iterator(std::begin(c)), iterator(std::end(c)),
+            std::begin(d),
             [](std::size_t v) { return throw std::bad_alloc(), v != 0; });
 
         HPX_TEST(false);
@@ -72,8 +72,8 @@ void test_copy_if_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::copy_if(p, iterator(std::begin(c)),
-            iterator(std::end(c)), std::begin(d),
+        auto f = hpx::copy_if(p, iterator(std::begin(c)), iterator(std::end(c)),
+            std::begin(d),
             [](std::size_t v) { return throw std::bad_alloc(), v != 0; });
 
         returned_from_algorithm = true;

--- a/libs/algorithms/tests/unit/algorithms/copyif_exception.cpp
+++ b/libs/algorithms/tests/unit/algorithms/copyif_exception.cpp
@@ -40,8 +40,8 @@ void test_copy_if_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::copy_if(policy, iterator(std::begin(c)),
-            iterator(std::end(c)), std::begin(d), [](std::size_t v) {
+        hpx::copy_if(policy, iterator(std::begin(c)), iterator(std::end(c)),
+            std::begin(d), [](std::size_t v) {
                 return throw std::runtime_error("test"), v != 0;
             });
         HPX_TEST(false);
@@ -73,8 +73,8 @@ void test_copy_if_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::copy_if(p, iterator(std::begin(c)),
-            iterator(std::end(c)), std::begin(d), [](std::size_t v) {
+        auto f = hpx::copy_if(p, iterator(std::begin(c)), iterator(std::end(c)),
+            std::begin(d), [](std::size_t v) {
                 return throw std::runtime_error("test"), v != 0;
             });
 

--- a/libs/algorithms/tests/unit/algorithms/copyif_forward.cpp
+++ b/libs/algorithms/tests/unit/algorithms/copyif_forward.cpp
@@ -40,8 +40,8 @@ void test_copy_if(ExPolicy policy)
     std::iota(std::begin(c), middle, dis(gen));
     std::fill(middle, std::end(c), -1);
 
-    hpx::parallel::copy_if(policy, iterator(std::begin(c)),
-        iterator(std::end(c)), std::begin(d), [](int i) { return !(i < 0); });
+    hpx::copy_if(policy, iterator(std::begin(c)), iterator(std::end(c)),
+        std::begin(d), [](int i) { return !(i < 0); });
 
     std::size_t count = 0;
     HPX_TEST(std::equal(
@@ -74,8 +74,8 @@ void test_copy_if_async(ExPolicy p)
     std::iota(std::begin(c), middle, dis(gen));
     std::fill(middle, std::end(c), -1);
 
-    auto f = hpx::parallel::copy_if(p, iterator(std::begin(c)),
-        iterator(std::end(c)), std::begin(d), [](int i) { return !(i < 0); });
+    auto f = hpx::copy_if(p, iterator(std::begin(c)), iterator(std::end(c)),
+        std::begin(d), [](int i) { return !(i < 0); });
     f.wait();
 
     std::size_t count = 0;

--- a/libs/algorithms/tests/unit/algorithms/copyif_random.cpp
+++ b/libs/algorithms/tests/unit/algorithms/copyif_random.cpp
@@ -41,8 +41,8 @@ void test_copy_if(ExPolicy policy)
     std::iota(std::begin(c), middle, dis(gen));
     std::fill(middle, std::end(c), -1);
 
-    hpx::parallel::copy_if(policy, iterator(std::begin(c)),
-        iterator(std::end(c)), std::begin(d), [](int i) { return !(i < 0); });
+    hpx::copy_if(policy, iterator(std::begin(c)), iterator(std::end(c)),
+        std::begin(d), [](int i) { return !(i < 0); });
 
     std::size_t count = 0;
     HPX_TEST(std::equal(
@@ -75,8 +75,8 @@ void test_copy_if_async(ExPolicy p)
     std::iota(std::begin(c), middle, dis(gen));
     std::fill(middle, std::end(c), -1);
 
-    auto f = hpx::parallel::copy_if(p, iterator(std::begin(c)),
-        iterator(std::end(c)), std::begin(d), [](int i) { return !(i < 0); });
+    auto f = hpx::copy_if(p, iterator(std::begin(c)), iterator(std::end(c)),
+        std::begin(d), [](int i) { return !(i < 0); });
     f.wait();
 
     std::size_t count = 0;

--- a/libs/algorithms/tests/unit/algorithms/reduce_by_key.cpp
+++ b/libs/algorithms/tests/unit/algorithms/reduce_by_key.cpp
@@ -171,7 +171,7 @@ void test_reduce_by_key1(ExPolicy&& policy, Tkey, Tval, bool benchmark,
     double elapsed = t.elapsed();
 
     bool is_equal = std::equal(
-        values.begin(), result.second, check_values.begin(), almost_equal());
+        values.begin(), result.out, check_values.begin(), almost_equal());
     HPX_TEST(is_equal);
     if (is_equal)
     {
@@ -185,8 +185,8 @@ void test_reduce_by_key1(ExPolicy&& policy, Tkey, Tval, bool benchmark,
     {
 //         debug::output("keys     ", o_keys);
 //         debug::output("values   ", o_values);
-//         debug::output("key range", keys.begin(), result.first);
-//         debug::output("val range", values.begin(), result.second);
+//         debug::output("key range", keys.begin(), result.in);
+//         debug::output("val range", values.begin(), result.out);
 //         debug::output("expected ", check_values);
 //         throw std::string("Problem");
 #if defined(EXTRA_DEBUG)
@@ -273,7 +273,7 @@ void test_reduce_by_key_const(ExPolicy&& policy, Tkey, Tval, bool benchmark,
     double elapsed = t.elapsed();
 
     bool is_equal = std::equal(
-        values.begin(), result.second, check_values.begin(), almost_equal());
+        values.begin(), result.out, check_values.begin(), almost_equal());
     HPX_TEST(is_equal);
     if (is_equal)
     {
@@ -287,8 +287,8 @@ void test_reduce_by_key_const(ExPolicy&& policy, Tkey, Tval, bool benchmark,
     {
 //         debug::output("keys     ", o_keys);
 //         debug::output("values   ", o_values);
-//         debug::output("key range", keys.begin(), result.first);
-//         debug::output("val range", values.begin(), result.second);
+//         debug::output("key range", keys.begin(), result.in);
+//         debug::output("val range", values.begin(), result.out);
 //         debug::output("expected ", check_values);
 //         throw std::string("Problem");
 #if defined(EXTRA_DEBUG)
@@ -376,7 +376,7 @@ void test_reduce_by_key_async(
     std::cout << "Async time " << async_seconds << " Sync time " << sync_seconds
               << "\n";
     bool is_equal = std::equal(
-        values.begin(), result.second, check_values.begin(), almost_equal());
+        values.begin(), result.out, check_values.begin(), almost_equal());
     HPX_TEST(is_equal);
     if (is_equal)
     {
@@ -386,8 +386,8 @@ void test_reduce_by_key_async(
     {
 //         debug::output("keys     ", o_keys);
 //         debug::output("values   ", o_values);
-//         debug::output("key range", keys.begin(), result.first);
-//         debug::output("val range", values.begin(), result.second);
+//         debug::output("key range", keys.begin(), result.in);
+//         debug::output("val range", values.begin(), result.out);
 //         debug::output("expected ", check_values);
 //         throw std::string("Problem");
 #if defined(EXTRA_DEBUG)

--- a/libs/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -8,6 +8,7 @@ set(tests
     all_of_range
     any_of_range
     copy_range
+    copyn_range
     copyif_range
     count_range
     countif_range

--- a/libs/algorithms/tests/unit/container_algorithms/copy_range.cpp
+++ b/libs/algorithms/tests/unit/container_algorithms/copy_range.cpp
@@ -36,7 +36,7 @@ void test_copy(ExPolicy policy, IteratorTag)
     test_vector c(10007);
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
-    hpx::parallel::copy(policy, c, std::begin(d));
+    hpx::ranges::copy(policy, c, std::begin(d));
 
     std::size_t count = 0;
     HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d),
@@ -60,7 +60,7 @@ void test_copy_async(ExPolicy p, IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
 
-    auto f = hpx::parallel::copy(p, c, std::begin(d));
+    auto f = hpx::ranges::copy(p, c, std::begin(d));
     f.wait();
 
     std::size_t count = 0;
@@ -110,7 +110,7 @@ void test_copy_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::copy(policy,
+        hpx::ranges::copy(policy,
             hpx::util::make_iterator_range(
                 decorated_iterator(
                     std::begin(c), []() { throw std::runtime_error("test"); }),
@@ -146,7 +146,7 @@ void test_copy_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::copy(p,
+        auto f = hpx::ranges::copy(p,
             hpx::util::make_iterator_range(
                 decorated_iterator(
                     std::begin(c), []() { throw std::runtime_error("test"); }),
@@ -211,7 +211,7 @@ void test_copy_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::copy(policy,
+        hpx::ranges::copy(policy,
             hpx::util::make_iterator_range(
                 decorated_iterator(
                     std::begin(c), []() { throw std::bad_alloc(); }),
@@ -246,7 +246,7 @@ void test_copy_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::copy(p,
+        auto f = hpx::ranges::copy(p,
             hpx::util::make_iterator_range(
                 decorated_iterator(
                     std::begin(c), []() { throw std::bad_alloc(); }),

--- a/libs/algorithms/tests/unit/container_algorithms/copyif_range.cpp
+++ b/libs/algorithms/tests/unit/container_algorithms/copyif_range.cpp
@@ -37,7 +37,7 @@ void test_copy_if(ExPolicy policy)
     std::iota(std::begin(c), middle, std::rand());
     std::fill(middle, std::end(c), -1);
 
-    hpx::parallel::copy_if(
+    hpx::ranges::copy_if(
         policy, c, std::begin(d), [](int i) { return !(i < 0); });
 
     std::size_t count = 0;
@@ -71,7 +71,7 @@ void test_copy_if_async(ExPolicy p)
     std::iota(std::begin(c), middle, std::rand());
     std::fill(middle, std::end(c), -1);
 
-    auto f = hpx::parallel::copy_if(
+    auto f = hpx::ranges::copy_if(
         p, c, std::begin(d), [](int i) { return !(i < 0); });
     f.wait();
 

--- a/libs/algorithms/tests/unit/container_algorithms/copyn_range.cpp
+++ b/libs/algorithms/tests/unit/container_algorithms/copyn_range.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014 Grant Mercer
+//  Copyright (c) 2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -37,7 +38,8 @@ void test_copy_n(ExPolicy policy, IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::copy_n(policy, iterator(std::begin(c)), c.size(), std::begin(d));
+    hpx::ranges::copy_n(
+        policy, iterator(std::begin(c)), c.size(), std::begin(d));
 
     std::size_t count = 0;
     HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d),
@@ -59,7 +61,8 @@ void test_copy_n_async(ExPolicy p, IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f = hpx::copy_n(p, iterator(std::begin(c)), c.size(), std::begin(d));
+    auto f = hpx::ranges::copy_n(
+        p, iterator(std::begin(c)), c.size(), std::begin(d));
     f.wait();
 
     std::size_t count = 0;
@@ -110,7 +113,7 @@ void test_copy_n_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::copy_n(policy,
+        hpx::ranges::copy_n(policy,
             decorated_iterator(
                 std::begin(c), []() { throw std::runtime_error("test"); }),
             c.size(), std::begin(d));
@@ -144,7 +147,7 @@ void test_copy_n_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::copy_n(p,
+        auto f = hpx::ranges::copy_n(p,
             decorated_iterator(
                 std::begin(c), []() { throw std::runtime_error("test"); }),
             c.size(), std::begin(d));
@@ -208,7 +211,7 @@ void test_copy_n_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::copy_n(policy,
+        hpx::ranges::copy_n(policy,
             decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
             c.size(), std::begin(d));
 
@@ -241,7 +244,7 @@ void test_copy_n_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::copy_n(p,
+        auto f = hpx::ranges::copy_n(p,
             decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
             c.size(), std::begin(d));
 

--- a/libs/algorithms/tests/unit/container_algorithms/move_range.cpp
+++ b/libs/algorithms/tests/unit/container_algorithms/move_range.cpp
@@ -32,7 +32,8 @@ void test_move(ExPolicy policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
+    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
+        test_vector;
 
     test_vector c(10007);
     std::vector<std::size_t> d(c.size());
@@ -58,7 +59,8 @@ void test_move_async(ExPolicy p, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
+    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
+        test_vector;
 
     test_vector c(10007);
     std::vector<std::size_t> d(c.size());

--- a/libs/compute_cuda/include/hpx/compute/cuda/transfer.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/transfer.hpp
@@ -11,8 +11,10 @@
 
 #if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
 
-#include <hpx/parallel/util/transfer.hpp>
 #include <hpx/traits/pointer_category.hpp>
+
+#include <hpx/parallel/util/result_types.hpp>
+#include <hpx/parallel/util/transfer.hpp>
 
 #include <hpx/compute/cuda/allocator.hpp>
 #include <hpx/compute/detail/iterator.hpp>
@@ -157,8 +159,9 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     struct copy_helper<hpx::traits::trivially_cuda_copyable_pointer_tag, Dummy>
     {
         template <typename InIter, typename OutIter>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static std::pair<InIter, OutIter> call(
-            InIter first, InIter last, OutIter dest)
+        HPX_HOST_DEVICE
+            HPX_FORCEINLINE static util::in_out_result<InIter, OutIter>
+            call(InIter first, InIter last, OutIter dest)
         {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             return copy_helper<hpx::traits::general_pointer_tag>::call(
@@ -173,7 +176,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
                 dest.target().native_handle().get_stream());
 
             std::advance(dest, count);
-            return std::make_pair(last, dest);
+            return util::in_out_result<InIter, OutIter>{last, dest};
 #endif
         }
     };
@@ -183,8 +186,9 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         Dummy>
     {
         template <typename InIter, typename OutIter>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static std::pair<InIter, OutIter> call(
-            InIter first, InIter last, OutIter dest)
+        HPX_HOST_DEVICE
+            HPX_FORCEINLINE static util::in_out_result<InIter, OutIter>
+            call(InIter first, InIter last, OutIter dest)
         {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             return copy_helper<hpx::traits::general_pointer_tag>::call(
@@ -199,7 +203,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
                 first.target().native_handle().get_stream());
 
             std::advance(dest, count);
-            return std::make_pair(last, dest);
+            return util::in_out_result<InIter, OutIter>{last, dest};
 #endif
         }
     };
@@ -209,8 +213,9 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         hpx::traits::trivially_cuda_copyable_pointer_tag_to_device, Dummy>
     {
         template <typename InIter, typename OutIter>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static std::pair<InIter, OutIter> call(
-            InIter first, InIter last, OutIter dest)
+        HPX_HOST_DEVICE
+            HPX_FORCEINLINE static util::in_out_result<InIter, OutIter>
+            call(InIter first, InIter last, OutIter dest)
         {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             return copy_helper<hpx::traits::general_pointer_tag>::call(
@@ -225,7 +230,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
                 dest.target().native_handle().get_stream());
 
             std::advance(dest, count);
-            return std::make_pair(last, dest);
+            return util::in_out_result<InIter, OutIter>{last, dest};
 #endif
         }
     };
@@ -236,8 +241,9 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         Dummy>
     {
         template <typename InIter, typename OutIter>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static std::pair<InIter, OutIter> call(
-            InIter first, std::size_t count, OutIter dest)
+        HPX_HOST_DEVICE
+            HPX_FORCEINLINE static util::in_out_result<InIter, OutIter>
+            call(InIter first, std::size_t count, OutIter dest)
         {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             return copy_n_helper<hpx::traits::general_pointer_tag>::call(
@@ -252,7 +258,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
             std::advance(first, count);
             std::advance(dest, count);
-            return std::make_pair(first, dest);
+            return util::in_out_result<InIter, OutIter>{first, dest};
 #endif
         }
     };
@@ -262,8 +268,9 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         hpx::traits::trivially_cuda_copyable_pointer_tag_to_host, Dummy>
     {
         template <typename InIter, typename OutIter>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static std::pair<InIter, OutIter> call(
-            InIter first, std::size_t count, OutIter dest)
+        HPX_HOST_DEVICE
+            HPX_FORCEINLINE static util::in_out_result<InIter, OutIter>
+            call(InIter first, std::size_t count, OutIter dest)
         {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             return copy_n_helper<hpx::traits::general_pointer_tag>::call(
@@ -278,7 +285,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
             std::advance(first, count);
             std::advance(dest, count);
-            return std::make_pair(first, dest);
+            return util::in_out_result<InIter, OutIter>{first, dest};
 #endif
         }
     };
@@ -288,8 +295,9 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         hpx::traits::trivially_cuda_copyable_pointer_tag_to_device, Dummy>
     {
         template <typename InIter, typename OutIter>
-        HPX_HOST_DEVICE HPX_FORCEINLINE static std::pair<InIter, OutIter> call(
-            InIter first, std::size_t count, OutIter dest)
+        HPX_HOST_DEVICE
+            HPX_FORCEINLINE static util::in_out_result<InIter, OutIter>
+            call(InIter first, std::size_t count, OutIter dest)
         {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             return copy_n_helper<hpx::traits::general_pointer_tag>::call(
@@ -304,7 +312,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
             std::advance(first, count);
             std::advance(dest, count);
-            return std::make_pair(first, dest);
+            return util::in_out_result<InIter, OutIter>{first, dest};
 #endif
         }
     };

--- a/libs/compute_cuda/tests/unit/CMakeLists.txt
+++ b/libs/compute_cuda/tests/unit/CMakeLists.txt
@@ -6,13 +6,15 @@
 
 set(tests)
 
-set(tests ${tests} default_executor for_each_compute for_loop_compute
-          transform_compute
-)
+set(tests ${tests} default_executor for_each_compute)
 set(default_executor_CUDA On)
 set(for_each_compute_CUDA On)
-set(for_loop_compute_CUDA On)
-set(transform_compute_CUDA On)
+
+if(HPX_WITH_CUDA_CLANG)
+  set(tests ${tests} for_loop_compute transform_compute)
+  set(for_loop_compute_CUDA On)
+  set(transform_compute_CUDA On)
+endif()
 
 foreach(test ${tests})
   if(${${test}_CUDA})

--- a/libs/config/include/hpx/config/attributes.hpp
+++ b/libs/config/include/hpx/config/attributes.hpp
@@ -34,6 +34,12 @@
 /// For more details see
 /// `https://en.cppreference.com/w/cpp/language/attributes/nodiscard`__.
 #define HPX_NODISCARD
+
+/// Indicates that this data member need not have an address distinct from all
+/// other non-static data members of its class.
+/// For more details see
+/// `https://en.cppreference.com/w/cpp/language/attributes/no_unique_address`__.
+#define HPX_NO_UNIQUE_ADDRESS
 #else
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -106,6 +112,14 @@
 #else
 #   define HPX_NODISCARD
 #   define HPX_NODISCARD_MSG(x)
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+// handle [[no_unique_address]]
+#if defined(HPX_HAVE_CXX20_NO_UNIQUE_ADDRESS_ATTRIBUTE)
+#   define HPX_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#else
+#   define HPX_NO_UNIQUE_ADDRESS
 #endif
 
 // clang-format on

--- a/libs/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
+++ b/libs/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
@@ -20,6 +20,7 @@
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/handle_remote_exceptions.hpp>
+#include <hpx/parallel/util/result_types.hpp>
 
 #include <exception>
 #include <list>
@@ -77,6 +78,27 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         {
             return std::make_pair(traits1::remote(std::move(p.first)),
                 traits2::remote(std::move(p.second)));
+        }
+    };
+
+    template <typename Iterator1, typename Iterator2>
+    struct algorithm_result_helper<util::in_out_result<Iterator1, Iterator2>,
+        typename std::enable_if<
+            hpx::traits::is_segmented_local_iterator<Iterator1>::value ||
+            hpx::traits::is_segmented_local_iterator<Iterator2>::value>::type>
+    {
+        typedef hpx::traits::segmented_local_iterator_traits<Iterator1> traits1;
+        typedef hpx::traits::segmented_local_iterator_traits<Iterator2> traits2;
+
+        static HPX_FORCEINLINE util::in_out_result<
+            typename traits1::local_iterator, typename traits2::local_iterator>
+        call(util::in_out_result<typename traits1::local_raw_iterator,
+            typename traits2::local_raw_iterator>&& p)
+        {
+            return util::in_out_result<typename traits1::local_iterator,
+                typename traits2::local_iterator>{
+                traits1::remote(std::move(p.in)),
+                traits2::remote(std::move(p.out))};
         }
     };
 
@@ -140,15 +162,50 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             typename traits1::local_iterator, typename traits2::local_iterator>>
         call(future<arg_type>&& f)
         {
-            return f.then(
-                hpx::launch::sync,
-                [](future<arg_type> &&
-                    f) -> std::pair<typename traits1::local_iterator,
-                           typename traits2::local_iterator> {
+            // different versions of clang-format produce different results
+            // clang-format off
+            return f.then(hpx::launch::sync,
+                [](future<arg_type>&& f)
+                    -> std::pair<typename traits1::local_iterator,
+                        typename traits2::local_iterator> {
                     auto&& p = f.get();
                     return std::make_pair(
                         traits1::remote(p.first), traits2::remote(p.second));
                 });
+            // clang-format on
+        }
+    };
+
+    template <typename Iterator1, typename Iterator2>
+    struct algorithm_result_helper<
+        future<util::in_out_result<Iterator1, Iterator2>>,
+        typename std::enable_if<
+            hpx::traits::is_segmented_local_iterator<Iterator1>::value ||
+            hpx::traits::is_segmented_local_iterator<Iterator2>::value>::type>
+    {
+        typedef hpx::traits::segmented_local_iterator_traits<Iterator1> traits1;
+        typedef hpx::traits::segmented_local_iterator_traits<Iterator2> traits2;
+
+        typedef util::in_out_result<typename traits1::local_raw_iterator,
+            typename traits2::local_raw_iterator>
+            arg_type;
+
+        static HPX_FORCEINLINE future<util::in_out_result<
+            typename traits1::local_iterator, typename traits2::local_iterator>>
+        call(future<arg_type>&& f)
+        {
+            // different versions of clang-format produce different results
+            // clang-format off
+            return f.then(hpx::launch::sync,
+                [](future<arg_type>&& f)
+                    -> util::in_out_result<typename traits1::local_iterator,
+                        typename traits2::local_iterator> {
+                    auto&& p = f.get();
+                    return util::in_out_result<typename traits1::local_iterator,
+                        typename traits2::local_iterator>{traits1::remote(p.in),
+                            traits2::remote(p.out)};
+                });
+            // clang-format on
         }
     };
 
@@ -174,18 +231,20 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             typename traits3::local_iterator>>
         call(future<arg_type>&& f)
         {
-            return f.then(
-                hpx::launch::sync,
-                [](future<arg_type> &&
-                    f) -> hpx::util::tuple<typename traits1::local_iterator,
-                           typename traits2::local_iterator,
-                           typename traits3::local_iterator> {
+            // different versions of clang-format produce different results
+            // clang-format off
+            return f.then(hpx::launch::sync,
+                [](future<arg_type>&& f)
+                    -> hpx::util::tuple<typename traits1::local_iterator,
+                        typename traits2::local_iterator,
+                        typename traits3::local_iterator> {
                     auto&& p = f.get();
                     return hpx::util::make_tuple(
                         traits1::remote(std::move(hpx::util::get<0>(p))),
                         traits2::remote(std::move(hpx::util::get<1>(p))),
                         traits3::remote(std::move(hpx::util::get<2>(p))));
                 });
+            // clang-format on
         }
     };
 

--- a/libs/segmented_algorithms/tests/unit/partitioned_vector_copy.cpp
+++ b/libs/segmented_algorithms/tests/unit/partitioned_vector_copy.cpp
@@ -78,8 +78,8 @@ void copy_algo_tests_with_policy(std::size_t size, std::size_t localities,
     fill_vector(v1, T(43));
 
     hpx::partitioned_vector<T> v2(size, policy);
-    auto p = hpx::parallel::copy(copy_policy, v1.begin(), v1.end(), v2.begin());
-    HPX_TEST(p.out() == v2.end());
+    auto p = hpx::ranges::copy(copy_policy, v1.begin(), v1.end(), v2.begin());
+    HPX_TEST(p.out == v2.end());
     compare_vectors(v1, v2);
 }
 
@@ -93,10 +93,10 @@ void copy_algo_tests_with_policy_async(std::size_t size, std::size_t localities,
     using hpx::parallel::execution::task;
 
     hpx::partitioned_vector<T> v2(size, policy);
-    auto f = hpx::parallel::copy(
-        copy_policy(task), v1.begin(), v1.end(), v2.begin());
+    auto f =
+        hpx::ranges::copy(copy_policy(task), v1.begin(), v1.end(), v2.begin());
 
-    HPX_TEST(f.get().out() == v2.end());
+    HPX_TEST(f.get().out == v2.end());
     compare_vectors(v1, v2);
 }
 

--- a/libs/segmented_algorithms/tests/unit/partitioned_vector_move.cpp
+++ b/libs/segmented_algorithms/tests/unit/partitioned_vector_move.cpp
@@ -95,7 +95,7 @@ void move_algo_tests_with_policy(std::size_t size, std::size_t localities,
 
     hpx::partitioned_vector<T> v3(size, policy);
     auto p = hpx::parallel::move(move_policy, v2.begin(), v2.end(), v3.begin());
-    HPX_TEST(p.out() == v3.end());
+    HPX_TEST(p.out == v3.end());
     compare_vectors(v1, v3);
 }
 
@@ -115,7 +115,7 @@ void move_algo_tests_with_policy_async(std::size_t size, std::size_t localities,
     auto f = hpx::parallel::move(
         move_policy(task), v2.begin(), v2.end(), v3.begin());
 
-    HPX_TEST(f.get().out() == v3.end());
+    HPX_TEST(f.get().out == v3.end());
     compare_vectors(v1, v3);
 }
 

--- a/libs/topology/include/hpx/topology/topology.hpp
+++ b/libs/topology/include/hpx/topology/topology.hpp
@@ -418,7 +418,7 @@ namespace hpx { namespace threads {
         return topo.get();
     }
 
-    HPX_EXPORT HPX_NODISCARD unsigned int hardware_concurrency();
+    HPX_NODISCARD HPX_EXPORT unsigned int hardware_concurrency();
 
     ///////////////////////////////////////////////////////////////////////////
     // abstract away memory page size, calls to system functions are

--- a/tests/performance/local/stream.cpp
+++ b/tests/performance/local/stream.cpp
@@ -94,11 +94,11 @@ void check_results(std::size_t iterations, Vector const& a_res,
     std::vector<STREAM_TYPE> b(b_res.size());
     std::vector<STREAM_TYPE> c(c_res.size());
 
-    hpx::parallel::copy(
+    hpx::copy(
         hpx::parallel::execution::par, a_res.begin(), a_res.end(), a.begin());
-    hpx::parallel::copy(
+    hpx::copy(
         hpx::parallel::execution::par, b_res.begin(), b_res.end(), b.begin());
-    hpx::parallel::copy(
+    hpx::copy(
         hpx::parallel::execution::par, c_res.begin(), c_res.end(), c.begin());
 
     STREAM_TYPE aj, bj, cj, scalar;
@@ -362,7 +362,7 @@ std::vector<std::vector<double>> run_benchmark(std::size_t iterations,
     {
         // Copy
         timing[0][iteration] = mysecond();
-        hpx::parallel::copy(policy, a.begin(), a.end(), c.begin());
+        hpx::copy(policy, a.begin(), a.end(), c.begin());
         timing[0][iteration] = mysecond() - timing[0][iteration];
 
         // Scale


### PR DESCRIPTION
- This creates two customization points for the copy algorithm. This
  also makes `hpx::copy` and `hpx::ranges::copy` fully conforming to C++20
  by adding support for sentinels and algorithms that do not expect
  an execution policy as their first argument
- Replace all uses of `hpx::parallel::copy` with the appropriate new
  versions of the algorithms, deprecate `hpx::parallel::copy`
- Same for `copy_if` and `copy_n`
- flyby: add `HPX_NO_UNIQUE_ADDRESS` expanding to `[[no_unique_address]]`
  on systems that support it
- flyby: add check for support of non-type template parameter auto arguments (`HPX_HAVE_NONTYPE_TEMPLATE_PARAMATER_AUTO`)
- flyby: fixing `hpx::functional::tag_invoke` for MSVC and adding
  `hpx::functional::tag_t<>` helper template

This also adds a `hpx::functional::tag<>` template that implements the necessary `tag_invoke` functionality for customization point objects as a CRTP base class (@sithhell please review).