### PR TITLE
Move all CUDA functionality to hpx::cuda::experimental namespace

### DIFF
--- a/libs/async_cuda/docs/index.rst
+++ b/libs/async_cuda/docs/index.rst
@@ -24,9 +24,9 @@ The usage is best illustrated by looking at an example
 .. code-block:: C++
 
     // create a cuda target using device number 0,1,2...
-    hpx::cuda::target target(device);
+    hpx::cuda::experimental::target target(device);
     // create a stream helper object
-    hpx::cuda::cuda_future_helper helper(device);
+    hpx::cuda::experimental::cuda_future_helper helper(device);
 
     // launch a kernel and return a future
     auto fn = &cuda_trivial_kernel<double>;
@@ -57,8 +57,7 @@ only the presence of CUDA on the system and only exposes cuda+fuures support
 (``HPX_WITH_ASYNC_CUDA`` may be used when ``HPX_WITH_CUDA_COMPUTE=OFF``).
 
 ``HPX_WITH_CUDA_COMPUTE=ON`` enables building HPX compute features that allow parallel
-algorithms to be passed through to the GPU/CUDA backend by using algorithms
-in the ``hpx::compute::cuda`` namespace.
+algorithms to be passed through to the GPU/CUDA backend.
 
 See the :ref:`API reference <libs_async_cuda_api>` of this module for more
 details.

--- a/libs/async_cuda/include/hpx/async_cuda/cublas_executor.hpp
+++ b/libs/async_cuda/include/hpx/async_cuda/cublas_executor.hpp
@@ -27,7 +27,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace cuda {
+namespace hpx { namespace cuda { namespace experimental {
 
     namespace detail {
         using print_on = debug::enable_print<false>;
@@ -138,7 +138,7 @@ namespace hpx { namespace cuda {
         cublas_executor(std::size_t device,
             cublasPointerMode_t pointer_mode = CUBLAS_POINTER_MODE_HOST,
             bool event_mode = false)
-          : hpx::cuda::cuda_executor(device, event_mode)
+          : hpx::cuda::experimental::cuda_executor(device, event_mode)
           , pointer_mode_(pointer_mode)
         {
             detail::cub_debug.debug(
@@ -254,18 +254,20 @@ namespace hpx { namespace cuda {
         cublasPointerMode_t pointer_mode_;
     };
 
-}}    // namespace hpx::cuda
+}}}    // namespace hpx::cuda::experimental
 
 namespace hpx { namespace parallel { namespace execution {
     /// \cond NOINTERNAL
     template <>
-    struct is_one_way_executor<hpx::cuda::cublas_executor> : std::true_type
+    struct is_one_way_executor<hpx::cuda::experimental::cublas_executor>
+      : std::true_type
     {
         // we support fire and forget without returning a waitable/future
     };
 
     template <>
-    struct is_two_way_executor<hpx::cuda::cublas_executor> : std::true_type
+    struct is_two_way_executor<hpx::cuda::experimental::cublas_executor>
+      : std::true_type
     {
         // we support returning a waitable/future
     };

--- a/libs/async_cuda/include/hpx/async_cuda/cuda_event.hpp
+++ b/libs/async_cuda/include/hpx/async_cuda/cuda_event.hpp
@@ -13,7 +13,7 @@
 //
 #include <cuda_runtime.h>
 
-namespace hpx { namespace cuda {
+namespace hpx { namespace cuda { namespace experimental {
 
     // a pool of cudaEvent_t objects.
     // Since allocation of a cuda event passes into the cuda runtime
@@ -74,4 +74,4 @@ namespace hpx { namespace cuda {
             boost::lockfree::capacity<max_events_in_pool>>
             free_list_;
     };
-}}    // namespace hpx::cuda
+}}}    // namespace hpx::cuda::experimental

--- a/libs/async_cuda/include/hpx/async_cuda/cuda_exception.hpp
+++ b/libs/async_cuda/include/hpx/async_cuda/cuda_exception.hpp
@@ -14,7 +14,7 @@
 //
 #include <string>
 
-namespace hpx { namespace cuda {
+namespace hpx { namespace cuda { namespace experimental {
 
     // -------------------------------------------------------------------------
     // exception type for failed launch of cuda functions
@@ -46,4 +46,4 @@ namespace hpx { namespace cuda {
         }
         return err;
     }
-}}    // namespace hpx::cuda
+}}}    // namespace hpx::cuda::experimental

--- a/libs/async_cuda/include/hpx/async_cuda/cuda_executor.hpp
+++ b/libs/async_cuda/include/hpx/async_cuda/cuda_executor.hpp
@@ -25,7 +25,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace cuda {
+namespace hpx { namespace cuda { namespace experimental {
 
     namespace detail {
         // -------------------------------------------------------------------------
@@ -84,7 +84,7 @@ namespace hpx { namespace cuda {
           : device_(device)
           , event_mode_(event_mode)
         {
-            target_ = std::make_shared<hpx::cuda::target>(device);
+            target_ = std::make_shared<hpx::cuda::experimental::target>(device);
             stream_ = target_->native_handle().get_stream();
         }
 
@@ -101,7 +101,7 @@ namespace hpx { namespace cuda {
         int device_;
         bool event_mode_;
         cudaStream_t stream_;
-        std::shared_ptr<hpx::cuda::target> target_;
+        std::shared_ptr<hpx::cuda::experimental::target> target_;
     };
 
     // -------------------------------------------------------------------------
@@ -181,19 +181,21 @@ namespace hpx { namespace cuda {
         }
     };
 
-}}    // namespace hpx::cuda
+}}}    // namespace hpx::cuda::experimental
 
 namespace hpx { namespace parallel { namespace execution {
 
     /// \cond NOINTERNAL
     template <>
-    struct is_one_way_executor<hpx::cuda::cuda_executor> : std::true_type
+    struct is_one_way_executor<hpx::cuda::experimental::cuda_executor>
+      : std::true_type
     {
         // we support fire and forget without returning a waitable/future
     };
 
     template <>
-    struct is_two_way_executor<hpx::cuda::cuda_executor> : std::true_type
+    struct is_two_way_executor<hpx::cuda::experimental::cuda_executor>
+      : std::true_type
     {
         // we support returning a waitable/future
     };

--- a/libs/async_cuda/include/hpx/async_cuda/cuda_future.hpp
+++ b/libs/async_cuda/include/hpx/async_cuda/cuda_future.hpp
@@ -30,7 +30,7 @@
 #include <utility>
 #include <vector>
 
-namespace hpx { namespace cuda {
+namespace hpx { namespace cuda { namespace experimental {
 
     using print_on = debug::enable_print<false>;
     static constexpr print_on cud_debug("CUDAFUT");
@@ -343,4 +343,4 @@ namespace hpx { namespace cuda {
         std::string pool_name_;
     };
 
-}}    // namespace hpx::cuda
+}}}    // namespace hpx::cuda::experimental

--- a/libs/async_cuda/include/hpx/async_cuda/get_targets.hpp
+++ b/libs/async_cuda/include/hpx/async_cuda/get_targets.hpp
@@ -14,7 +14,7 @@
 
 #include <vector>
 
-namespace hpx { namespace cuda {
+namespace hpx { namespace cuda { namespace experimental {
     struct HPX_EXPORT target;
 
     HPX_EXPORT std::vector<target> get_local_targets();
@@ -22,4 +22,4 @@ namespace hpx { namespace cuda {
         hpx::id_type const& locality);
     HPX_EXPORT void print_local_targets();
 
-}}    // namespace hpx::cuda
+}}}    // namespace hpx::cuda::experimental

--- a/libs/async_cuda/include/hpx/async_cuda/target.hpp
+++ b/libs/async_cuda/include/hpx/async_cuda/target.hpp
@@ -34,7 +34,7 @@
 
 #include <hpx/config/warnings_prefix.hpp>
 
-namespace hpx { namespace cuda {
+namespace hpx { namespace cuda { namespace experimental {
 
     ///////////////////////////////////////////////////////////////////////////
     struct target
@@ -196,12 +196,12 @@ namespace hpx { namespace cuda {
 
         static std::vector<target> get_local_targets()
         {
-            return cuda::get_local_targets();
+            return cuda::experimental::get_local_targets();
         }
         static hpx::future<std::vector<target>> get_targets(
             hpx::id_type const& locality)
         {
-            return cuda::get_targets(locality);
+            return cuda::experimental::get_targets(locality);
         }
 
         friend bool operator==(target const& lhs, target const& rhs)
@@ -224,6 +224,6 @@ namespace hpx { namespace cuda {
 
     using detail::get_future_with_callback;
     HPX_EXPORT target& get_default_target();
-}}    // namespace hpx::cuda
+}}}    // namespace hpx::cuda::experimental
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/async_cuda/include_compatibility/hpx/compute/cuda/get_targets.hpp
+++ b/libs/async_cuda/include_compatibility/hpx/compute/cuda/get_targets.hpp
@@ -21,5 +21,5 @@
 #endif
 
 namespace hpx { namespace compute { namespace cuda {
-    using hpx::cuda::target;
+    using hpx::cuda::experimental::target;
 }}}    // namespace hpx::compute::cuda

--- a/libs/async_cuda/include_compatibility/hpx/compute/cuda/target.hpp
+++ b/libs/async_cuda/include_compatibility/hpx/compute/cuda/target.hpp
@@ -21,5 +21,5 @@
 #endif
 
 namespace hpx { namespace compute { namespace cuda {
-    using target = hpx::cuda::target;
+    using target = hpx::cuda::experimental::target;
 }}}    // namespace hpx::compute::cuda

--- a/libs/async_cuda/src/cuda_future.cpp
+++ b/libs/async_cuda/src/cuda_future.cpp
@@ -29,7 +29,7 @@
 
 #include <cuda_runtime.h>
 
-namespace hpx { namespace cuda { namespace detail {
+namespace hpx { namespace cuda { namespace experimental { namespace detail {
 
     HPX_EXPORT void register_polling(hpx::threads::thread_pool_base&);
     HPX_EXPORT void unregister_polling(hpx::threads::thread_pool_base&);
@@ -130,7 +130,7 @@ namespace hpx { namespace cuda { namespace detail {
     void poll()
     {
         // don't poll if another thread is already polling
-        std::unique_lock<hpx::cuda::detail::mutex_type> lk(
+        std::unique_lock<hpx::cuda::experimental::detail::mutex_type> lk(
             detail::get_list_mtx(), std::try_to_lock);
         if (!lk.owns_lock())
         {
@@ -161,7 +161,8 @@ namespace hpx { namespace cuda { namespace detail {
         }
 
         // grab the handle to the event pool so we can return completed events
-        cuda_event_pool& pool = hpx::cuda::cuda_event_pool::get_event_pool();
+        cuda_event_pool& pool =
+            hpx::cuda::experimental::cuda_event_pool::get_event_pool();
 
         // iterate over our list of events and see if any have completed
         detail::future_data_ptr fdp;
@@ -248,7 +249,8 @@ namespace hpx { namespace cuda { namespace detail {
         cud_debug.debug(debug::str<>("Setting mode"), "enable_user_polling");
 
         // always set polling function before enabling polling
-        sched->set_user_polling_function(&hpx::cuda::detail::poll);
+        sched->set_user_polling_function(
+            &hpx::cuda::experimental::detail::poll);
         sched->add_remove_scheduler_mode(threads::policies::enable_user_polling,
             threads::policies::do_background_work);
     }
@@ -261,4 +263,4 @@ namespace hpx { namespace cuda { namespace detail {
         sched->remove_scheduler_mode(threads::policies::enable_user_polling);
     }
 
-}}}    // namespace hpx::cuda::detail
+}}}}    // namespace hpx::cuda::experimental::detail

--- a/libs/async_cuda/src/cuda_target.cpp
+++ b/libs/async_cuda/src/cuda_target.cpp
@@ -35,7 +35,7 @@
 
 #include <cuda_runtime.h>
 
-namespace hpx { namespace cuda {
+namespace hpx { namespace cuda { namespace experimental {
     void target::native_handle_type::init_processing_units()
     {
         cudaDeviceProp props;
@@ -158,7 +158,7 @@ namespace hpx { namespace cuda {
             if (error != cudaSuccess)
             {
                 HPX_THROW_EXCEPTION(kernel_error,
-                    "cuda::target::native_handle::get_stream()",
+                    "cuda::experimental::target::native_handle::get_stream()",
                     std::string("cudaSetDevice failed: ") +
                         cudaGetErrorString(error));
             }
@@ -166,7 +166,7 @@ namespace hpx { namespace cuda {
             if (error != cudaSuccess)
             {
                 HPX_THROW_EXCEPTION(kernel_error,
-                    "cuda::target::native_handle::get_stream()",
+                    "cuda::experimental::target::native_handle::get_stream()",
                     std::string("cudaStreamCreate failed: ") +
                         cudaGetErrorString(error));
             }
@@ -184,14 +184,16 @@ namespace hpx { namespace cuda {
 
         if (stream == 0)
         {
-            HPX_THROW_EXCEPTION(invalid_status, "cuda::target::synchronize",
+            HPX_THROW_EXCEPTION(invalid_status,
+                "cuda::experimental::target::synchronize",
                 "no stream available");
         }
 
         cudaError_t error = cudaStreamSynchronize(stream);
         if (error != cudaSuccess)
         {
-            HPX_THROW_EXCEPTION(kernel_error, "cuda::target::synchronize",
+            HPX_THROW_EXCEPTION(kernel_error,
+                "cuda::experimental::target::synchronize",
                 std::string("cudaStreamSynchronize failed: ") +
                     cudaGetErrorString(error));
         }
@@ -227,4 +229,4 @@ namespace hpx { namespace cuda {
         ar << handle_.device_ << locality_;
     }
 #endif
-}}    // namespace hpx::cuda
+}}}    // namespace hpx::cuda::experimental

--- a/libs/async_cuda/src/get_targets.cpp
+++ b/libs/async_cuda/src/get_targets.cpp
@@ -30,14 +30,15 @@
 
 #include <cuda_runtime.h>
 
-namespace hpx { namespace cuda {
+namespace hpx { namespace cuda { namespace experimental {
     std::vector<target> get_local_targets()
     {
         int device_count = 0;
         cudaError_t error = cudaGetDeviceCount(&device_count);
         if (error != cudaSuccess)
         {
-            HPX_THROW_EXCEPTION(kernel_error, "cuda::get_local_targets()",
+            HPX_THROW_EXCEPTION(kernel_error,
+                "cuda::experimental::get_local_targets()",
                 std::string("cudaGetDeviceCount failed: ") +
                     cudaGetErrorString(error));
         }
@@ -66,12 +67,13 @@ namespace hpx { namespace cuda {
         }
     }
 
-}}    // namespace hpx::cuda
+}}}    // namespace hpx::cuda::experimental
 
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
-HPX_PLAIN_ACTION(hpx::cuda::get_local_targets, cuda_get_targets_action);
+HPX_PLAIN_ACTION(
+    hpx::cuda::experimental::get_local_targets, cuda_get_targets_action);
 
-namespace hpx { namespace cuda {
+namespace hpx { namespace cuda { namespace experimental {
     hpx::future<std::vector<target>> get_targets(hpx::id_type const& locality)
     {
         if (locality == hpx::find_here())
@@ -79,5 +81,5 @@ namespace hpx { namespace cuda {
 
         return hpx::async(cuda_get_targets_action(), locality);
     }
-}}    // namespace hpx::cuda
+}}}    // namespace hpx::cuda::experimental
 #endif

--- a/libs/async_cuda/tests/unit/cuda_future.cpp
+++ b/libs/async_cuda/tests/unit/cuda_future.cpp
@@ -38,7 +38,7 @@ extern void cuda_trivial_kernel(T, cudaStream_t stream);
 
 extern __global__ void saxpy(int n, float a, float* x, float* y);
 // -------------------------------------------------------------------------
-int test_saxpy(hpx::cuda::cuda_executor& cudaexec)
+int test_saxpy(hpx::cuda::experimental::cuda_executor& cudaexec)
 {
     int N = 1 << 20;
 
@@ -47,9 +47,11 @@ int test_saxpy(hpx::cuda::cuda_executor& cudaexec)
     std::vector<float> h_B(N);
 
     float *d_A, *d_B;
-    hpx::cuda::check_cuda_error(cudaMalloc((void**) &d_A, N * sizeof(float)));
+    hpx::cuda::experimental::check_cuda_error(
+        cudaMalloc((void**) &d_A, N * sizeof(float)));
 
-    hpx::cuda::check_cuda_error(cudaMalloc((void**) &d_B, N * sizeof(float)));
+    hpx::cuda::experimental::check_cuda_error(
+        cudaMalloc((void**) &d_B, N * sizeof(float)));
 
     // init host data
     for (int idx = 0; idx < N; idx++)
@@ -107,7 +109,7 @@ int test_saxpy(hpx::cuda::cuda_executor& cudaexec)
 int hpx_main(hpx::program_options::variables_map& vm)
 {
     // install cuda future polling handler
-    hpx::cuda::enable_user_polling poll("default");
+    hpx::cuda::experimental::enable_user_polling poll("default");
     //
     std::size_t device = vm["device"].as<std::size_t>();
     //
@@ -119,13 +121,14 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::srand(seed);
 
     // create a cuda target using device number 0,1,2...
-    hpx::cuda::target target(device);
+    hpx::cuda::experimental::target target(device);
 
     // for debug purposes, print out available targets
-    hpx::cuda::print_local_targets();
+    hpx::cuda::experimental::print_local_targets();
 
     // create a stream helper object
-    hpx::cuda::cuda_executor cudaexec(device, hpx::cuda::event_mode{});
+    hpx::cuda::experimental::cuda_executor cudaexec(
+        device, hpx::cuda::experimental::event_mode{});
 
     // --------------------
     // test kernel launch<float> using apply and async

--- a/libs/compute_cuda/examples/data_copy.cu
+++ b/libs/compute_cuda/examples/data_copy.cu
@@ -31,10 +31,10 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::vector<int> h_B(N);
     std::iota(h_A.begin(), h_A.end(), dis(gen));
 
-    hpx::cuda::target target;
+    hpx::cuda::experimental::target target;
 
     // create data vector on device
-    typedef hpx::compute::cuda::allocator<int> allocator_type;
+    typedef hpx::cuda::experimental::allocator<int> allocator_type;
     allocator_type alloc(target);
 
     hpx::compute::vector<int, allocator_type> d_A(N, alloc);

--- a/libs/compute_cuda/examples/hello_compute.cu
+++ b/libs/compute_cuda/examples/hello_compute.cu
@@ -39,9 +39,9 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::transform(h_A.begin(), h_A.end(), h_B.begin(), h_C_ref.begin(),
         [](int a, int b) { return a + b; });
 
-    typedef hpx::compute::cuda::allocator<int> allocator_type;
+    typedef hpx::cuda::experimental::allocator<int> allocator_type;
 
-    hpx::cuda::target target;
+    hpx::cuda::experimental::target target;
     allocator_type alloc(target);
     hpx::compute::vector<int, allocator_type> d_A(N, alloc);
     hpx::compute::vector<int, allocator_type> d_B(N, alloc);
@@ -57,7 +57,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     int threadsPerBlock = 256;
     int blocksPerGrid = (N + threadsPerBlock - 1) / threadsPerBlock;
 
-    hpx::compute::cuda::detail::launch(target, blocksPerGrid, threadsPerBlock,
+    hpx::cuda::experimental::detail::launch(target, blocksPerGrid, threadsPerBlock,
         [=] __device__ (int* A, int* B, int* C) mutable
         {
             int i = blockDim.x * blockIdx.x + threadIdx.x;

--- a/libs/compute_cuda/examples/partitioned_vector.cu
+++ b/libs/compute_cuda/examples/partitioned_vector.cu
@@ -16,7 +16,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 // Define the partitioned vector types to be used.
-typedef hpx::compute::cuda::allocator<int> target_allocator;
+typedef hpx::cuda::experimental::allocator<int> target_allocator;
 typedef hpx::compute::vector<int, target_allocator> target_vector;
 
 HPX_REGISTER_PARTITIONED_VECTOR(int, target_vector);
@@ -35,8 +35,8 @@ struct pfo
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(hpx::program_options::variables_map& vm)
 {
-    hpx::compute::cuda::target_distribution_policy policy =
-        hpx::compute::cuda::target_layout(hpx::compute::cuda::get_local_targets());
+    hpx::cuda::experimental::target_distribution_policy policy =
+        hpx::cuda::experimental::target_layout(hpx::cuda::experimental::get_local_targets());
 
     {
         using namespace hpx::parallel;

--- a/libs/compute_cuda/include/hpx/compute/cuda/allocator.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/allocator.hpp
@@ -31,7 +31,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace compute { namespace cuda {
+namespace hpx { namespace cuda { namespace experimental {
     template <typename T>
     class allocator
     {
@@ -58,10 +58,10 @@ namespace hpx { namespace compute { namespace cuda {
         typedef std::true_type is_always_equal;
         typedef std::true_type propagate_on_container_move_assignment;
 
-        typedef hpx::cuda::target target_type;
+        typedef hpx::cuda::experimental::target target_type;
 
         allocator()
-          : target_(hpx::cuda::get_default_target())
+          : target_(hpx::cuda::experimental::get_default_target())
         {
         }
 
@@ -121,7 +121,7 @@ namespace hpx { namespace compute { namespace cuda {
             if (error != cudaSuccess)
             {
                 HPX_THROW_EXCEPTION(out_of_memory,
-                    "cuda::allocator<T>::allocate()",
+                    "cuda::experimental::allocator<T>::allocate()",
                     std::string("cudaMalloc failed: ") +
                         cudaGetErrorString(error));
             }
@@ -142,7 +142,7 @@ namespace hpx { namespace compute { namespace cuda {
             if (error != cudaSuccess)
             {
                 HPX_THROW_EXCEPTION(kernel_error,
-                    "cuda::allocator<T>::deallocate()",
+                    "cuda::experimental::allocator<T>::deallocate()",
                     std::string("cudaFree failed: ") +
                         cudaGetErrorString(error));
             }
@@ -161,7 +161,7 @@ namespace hpx { namespace compute { namespace cuda {
             if (error != cudaSuccess)
             {
                 HPX_THROW_EXCEPTION(kernel_error,
-                    "cuda::allocator<T>::max_size()",
+                    "cuda::experimental::allocator<T>::max_size()",
                     std::string("cudaMemGetInfo failed: ") +
                         cudaGetErrorString(error));
             }
@@ -252,6 +252,6 @@ namespace hpx { namespace compute { namespace cuda {
     private:
         target_type target_;
     };
-}}}    // namespace hpx::compute::cuda
+}}}    // namespace hpx::cuda::experimental
 
 #endif

--- a/libs/compute_cuda/include/hpx/compute/cuda/concurrent_executor.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/concurrent_executor.hpp
@@ -24,14 +24,14 @@
 #include <utility>
 #include <vector>
 
-namespace hpx { namespace compute { namespace cuda {
+namespace hpx { namespace cuda { namespace experimental {
     template <typename Executor =
                   hpx::parallel::execution::restricted_thread_pool_executor>
     struct concurrent_executor
     {
     private:
-        typedef host::block_executor<Executor> host_executor_type;
-        typedef cuda::default_executor cuda_executor_type;
+        typedef hpx::compute::host::block_executor<Executor> host_executor_type;
+        typedef cuda::experimental::default_executor cuda_executor_type;
 
     public:
         // By default, this executor relies on a special executor parameters
@@ -39,8 +39,8 @@ namespace hpx { namespace compute { namespace cuda {
         // bulk-shape ranges for the accelerator.
         typedef concurrent_executor_parameters executor_parameters_type;
 
-        concurrent_executor(hpx::cuda::target const& cuda_target,
-            std::vector<host::target> const& host_targets)
+        concurrent_executor(hpx::cuda::experimental::target const& cuda_target,
+            std::vector<hpx::compute::host::target> const& host_targets)
           : host_executor_(host_targets)
           , current_(0)
         {
@@ -48,7 +48,8 @@ namespace hpx { namespace compute { namespace cuda {
             cuda_executors_.reserve(num_targets);
             for (std::size_t i = 0; i != num_targets; ++i)
             {
-                hpx::cuda::target t(cuda_target.native_handle().get_device());
+                hpx::cuda::experimental::target t(
+                    cuda_target.native_handle().get_device());
                 t.native_handle().get_stream();
                 cuda_executors_.emplace_back(std::move(t));
             }
@@ -105,7 +106,7 @@ namespace hpx { namespace compute { namespace cuda {
             return !(*this == rhs);
         }
 
-        host::target const& context() const noexcept
+        hpx::compute::host::target const& context() const noexcept
         {
             return host_executor_.context();
         }
@@ -187,37 +188,37 @@ namespace hpx { namespace compute { namespace cuda {
         std::vector<cuda_executor_type> cuda_executors_;
         std::atomic<std::size_t> current_;
     };
-}}}    // namespace hpx::compute::cuda
+}}}    // namespace hpx::cuda::experimental
 
 namespace hpx { namespace parallel { namespace execution {
     template <typename Executor>
     struct executor_execution_category<
-        compute::cuda::concurrent_executor<Executor>>
+        cuda::experimental::concurrent_executor<Executor>>
     {
         typedef parallel::execution::parallel_execution_tag type;
     };
 
     template <typename Executor>
-    struct is_one_way_executor<compute::cuda::concurrent_executor<Executor>>
-      : std::true_type
+    struct is_one_way_executor<
+        cuda::experimental::concurrent_executor<Executor>> : std::true_type
     {
     };
 
     template <typename Executor>
-    struct is_two_way_executor<compute::cuda::concurrent_executor<Executor>>
-      : std::true_type
+    struct is_two_way_executor<
+        cuda::experimental::concurrent_executor<Executor>> : std::true_type
     {
     };
 
     template <typename Executor>
     struct is_bulk_one_way_executor<
-        compute::cuda::concurrent_executor<Executor>> : std::true_type
+        cuda::experimental::concurrent_executor<Executor>> : std::true_type
     {
     };
 
     template <typename Executor>
     struct is_bulk_two_way_executor<
-        compute::cuda::concurrent_executor<Executor>> : std::true_type
+        cuda::experimental::concurrent_executor<Executor>> : std::true_type
     {
     };
 }}}    // namespace hpx::parallel::execution

--- a/libs/compute_cuda/include/hpx/compute/cuda/concurrent_executor_parameters.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/concurrent_executor_parameters.hpp
@@ -14,7 +14,7 @@
 #include <cstddef>
 #include <type_traits>
 
-namespace hpx { namespace compute { namespace cuda {
+namespace hpx { namespace cuda { namespace experimental {
     struct concurrent_executor_parameters
     {
         template <typename Executor, typename F>
@@ -24,12 +24,12 @@ namespace hpx { namespace compute { namespace cuda {
             return (num_tasks + cores - 1) / cores;
         }
     };
-}}}    // namespace hpx::compute::cuda
+}}}    // namespace hpx::cuda::experimental
 
 namespace hpx { namespace parallel { namespace execution {
     template <>
-    struct is_executor_parameters<compute::cuda::concurrent_executor_parameters>
-      : std::true_type
+    struct is_executor_parameters<
+        cuda::experimental::concurrent_executor_parameters> : std::true_type
     {
     };
 }}}    // namespace hpx::parallel::execution

--- a/libs/compute_cuda/include/hpx/compute/cuda/default_executor.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/default_executor.hpp
@@ -34,15 +34,15 @@
 #include <utility>
 #include <vector>
 
-namespace hpx { namespace compute { namespace cuda {
+namespace hpx { namespace cuda { namespace experimental {
     namespace detail {
         // generic implementation which simply passes through the shape elements
         template <typename Shape, typename Enable = void>
         struct bulk_launch_helper
         {
             template <typename F, typename... Ts>
-            static void call(hpx::cuda::target const& target, F&& f,
-                Shape const& shape, Ts&&... ts)
+            static void call(hpx::cuda::experimental::target const& target,
+                F&& f, Shape const& shape, Ts&&... ts)
             {
 #if defined(HPX_COMPUTE_DEVICE_CODE) || defined(HPX_COMPUTE_HOST_CODE)
                 std::size_t count = util::size(shape);
@@ -54,7 +54,7 @@ namespace hpx { namespace compute { namespace cuda {
 
                 typedef typename hpx::traits::range_traits<Shape>::value_type
                     value_type;
-                typedef cuda::allocator<value_type> alloc_type;
+                typedef cuda::experimental::allocator<value_type> alloc_type;
 
                 // transfer shape to the GPU
                 compute::vector<value_type, alloc_type> shape_container(
@@ -74,7 +74,7 @@ namespace hpx { namespace compute { namespace cuda {
                     std::forward<Ts>(ts)...);
 #else
                 HPX_THROW_EXCEPTION(hpx::not_implemented,
-                    "hpx::compute::cuda::detail::bulk_launch_helper",
+                    "hpx::cuda::experimental::detail::bulk_launch_helper",
                     "Trying to launch a CUDA kernel, but did not compile in "
                     "CUDA mode");
 #endif
@@ -89,8 +89,8 @@ namespace hpx { namespace compute { namespace cuda {
                 hpx::traits::is_iterator<Iterator>::value>::type>
         {
             template <typename F, typename Shape, typename... Ts>
-            static void call(hpx::cuda::target const& target, F&& f,
-                Shape const& shape, Ts&&... ts)
+            static void call(hpx::cuda::experimental::target const& target,
+                F&& f, Shape const& shape, Ts&&... ts)
             {
 #if defined(HPX_COMPUTE_DEVICE_CODE) || defined(HPX_COMPUTE_HOST_CODE)
                 typedef typename hpx::traits::range_traits<Shape>::value_type
@@ -123,7 +123,7 @@ namespace hpx { namespace compute { namespace cuda {
                 }
 #else
                 HPX_THROW_EXCEPTION(hpx::not_implemented,
-                    "hpx::compute::cuda::detail::bulk_launch_helper",
+                    "hpx::cuda::experimental::detail::bulk_launch_helper",
                     "Trying to launch a CUDA kernel, but did not compile in "
                     "CUDA mode");
 #endif
@@ -138,7 +138,7 @@ namespace hpx { namespace compute { namespace cuda {
         // bulk-shape ranges for the accelerator.
         typedef default_executor_parameters executor_parameters_type;
 
-        default_executor(hpx::cuda::target const& target)
+        default_executor(hpx::cuda::experimental::target const& target)
           : target_(target)
         {
         }
@@ -154,7 +154,7 @@ namespace hpx { namespace compute { namespace cuda {
             return !(*this == rhs);
         }
 
-        hpx::cuda::target const& context() const noexcept
+        hpx::cuda::experimental::target const& context() const noexcept
         {
             return target_;
         }
@@ -211,46 +211,48 @@ namespace hpx { namespace compute { namespace cuda {
             target_.synchronize();
         }
 
-        hpx::cuda::target& target()
+        hpx::cuda::experimental::target& target()
         {
             return target_;
         }
 
-        hpx::cuda::target const& target() const
+        hpx::cuda::experimental::target const& target() const
         {
             return target_;
         }
 
     private:
-        hpx::cuda::target target_;
+        hpx::cuda::experimental::target target_;
     };
-}}}    // namespace hpx::compute::cuda
+}}}    // namespace hpx::cuda::experimental
 
 namespace hpx { namespace parallel { namespace execution {
     template <>
-    struct executor_execution_category<compute::cuda::default_executor>
+    struct executor_execution_category<cuda::experimental::default_executor>
     {
         typedef parallel::execution::parallel_execution_tag type;
     };
 
     template <>
-    struct is_one_way_executor<compute::cuda::default_executor> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_two_way_executor<compute::cuda::default_executor> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_bulk_one_way_executor<compute::cuda::default_executor>
+    struct is_one_way_executor<cuda::experimental::default_executor>
       : std::true_type
     {
     };
 
     template <>
-    struct is_bulk_two_way_executor<compute::cuda::default_executor>
+    struct is_two_way_executor<cuda::experimental::default_executor>
+      : std::true_type
+    {
+    };
+
+    template <>
+    struct is_bulk_one_way_executor<cuda::experimental::default_executor>
+      : std::true_type
+    {
+    };
+
+    template <>
+    struct is_bulk_two_way_executor<cuda::experimental::default_executor>
       : std::true_type
     {
     };

--- a/libs/compute_cuda/include/hpx/compute/cuda/default_executor_parameters.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/default_executor_parameters.hpp
@@ -15,7 +15,7 @@
 #include <cstddef>
 #include <type_traits>
 
-namespace hpx { namespace compute { namespace cuda {
+namespace hpx { namespace cuda { namespace experimental {
     struct default_executor_parameters
     {
         template <typename Executor, typename F>
@@ -25,12 +25,12 @@ namespace hpx { namespace compute { namespace cuda {
             return std::size_t(-1);
         }
     };
-}}}    // namespace hpx::compute::cuda
+}}}    // namespace hpx::cuda::experimental
 
 namespace hpx { namespace parallel { namespace execution {
     template <>
-    struct is_executor_parameters<compute::cuda::default_executor_parameters>
-      : std::true_type
+    struct is_executor_parameters<
+        cuda::experimental::default_executor_parameters> : std::true_type
     {
     };
 }}}    // namespace hpx::parallel::execution

--- a/libs/compute_cuda/include/hpx/compute/cuda/detail/launch.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/detail/launch.hpp
@@ -27,7 +27,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace compute { namespace cuda { namespace detail {
+namespace hpx { namespace cuda { namespace experimental { namespace detail {
     template <typename Closure>
     __global__ void launch_function(Closure closure)
     {
@@ -84,8 +84,9 @@ namespace hpx { namespace compute { namespace cuda { namespace detail {
         }
 
         template <typename DimType>
-        HPX_HOST_DEVICE static void call(hpx::cuda::target const& tgt,
-            DimType grid_dim, DimType block_dim, fun_type f, args_type args)
+        HPX_HOST_DEVICE static void call(
+            hpx::cuda::experimental::target const& tgt, DimType grid_dim,
+            DimType block_dim, fun_type f, args_type args)
         {
             // This is needed for the device code to make sure the kernel
             // is instantiated correctly.
@@ -126,14 +127,14 @@ namespace hpx { namespace compute { namespace cuda { namespace detail {
     // Launch any given function F with the given parameters. This function
     // does not involve any device synchronization.
     template <typename DimType, typename F, typename... Ts>
-    HPX_HOST_DEVICE void launch(hpx::cuda::target const& t, DimType grid_dim,
-        DimType block_dim, F&& f, Ts&&... vs)
+    HPX_HOST_DEVICE void launch(hpx::cuda::experimental::target const& t,
+        DimType grid_dim, DimType block_dim, F&& f, Ts&&... vs)
     {
         typedef closure<F, Ts...> closure_type;
         launch_helper<closure_type>::call(t, grid_dim, block_dim,
             std::forward<F>(f),
             util::forward_as_tuple(std::forward<Ts>(vs)...));
     }
-}}}}    // namespace hpx::compute::cuda::detail
+}}}}    // namespace hpx::cuda::experimental::detail
 
 #endif

--- a/libs/compute_cuda/include/hpx/compute/cuda/detail/scoped_active_target.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/detail/scoped_active_target.hpp
@@ -19,10 +19,10 @@
 
 #include <string>
 
-namespace hpx { namespace compute { namespace cuda { namespace detail {
+namespace hpx { namespace cuda { namespace experimental { namespace detail {
     struct scoped_active_target
     {
-        scoped_active_target(hpx::cuda::target const& t)
+        scoped_active_target(hpx::cuda::experimental::target const& t)
           : previous_device_(-1)
           , target_(t)
         {
@@ -85,8 +85,8 @@ namespace hpx { namespace compute { namespace cuda { namespace detail {
 
     private:
         int previous_device_;
-        hpx::cuda::target const& target_;
+        hpx::cuda::experimental::target const& target_;
     };
-}}}}    // namespace hpx::compute::cuda::detail
+}}}}    // namespace hpx::cuda::experimental::detail
 
 #endif

--- a/libs/compute_cuda/include/hpx/compute/cuda/serialization/value_proxy.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/serialization/value_proxy.hpp
@@ -16,7 +16,7 @@
 namespace hpx { namespace serialization {
     template <typename T>
     void serialize(
-        input_archive& ar, compute::cuda::value_proxy<T>& v, unsigned)
+        input_archive& ar, cuda::experimental::value_proxy<T>& v, unsigned)
     {
         T t;
         ar >> t;
@@ -24,8 +24,8 @@ namespace hpx { namespace serialization {
     }
 
     template <typename T>
-    void serialize(
-        output_archive& ar, compute::cuda::value_proxy<T> const& v, unsigned)
+    void serialize(output_archive& ar,
+        cuda::experimental::value_proxy<T> const& v, unsigned)
     {
         ar << T(v);
     }

--- a/libs/compute_cuda/include/hpx/compute/cuda/target_distribution_policy.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/target_distribution_policy.hpp
@@ -31,12 +31,14 @@
 #include <utility>
 #include <vector>
 
-namespace hpx { namespace compute { namespace cuda {
+namespace hpx { namespace cuda { namespace experimental {
     /// A target_distribution_policy used for CPU bound localities.
     struct target_distribution_policy
-      : compute::detail::target_distribution_policy<hpx::cuda::target>
+      : compute::detail::target_distribution_policy<
+            hpx::cuda::experimental::target>
     {
-        typedef compute::detail::target_distribution_policy<hpx::cuda::target>
+        typedef compute::detail::target_distribution_policy<
+            hpx::cuda::experimental::target>
             base_type;
 
         /// Default-construct a new instance of a \a target_distribution_policy.
@@ -219,21 +221,22 @@ namespace hpx { namespace compute { namespace cuda {
     /// It will represent all local CUDA devices and will place all items to
     /// create here.
     static target_distribution_policy const target_layout;
-}}}    // namespace hpx::compute::cuda
+}}}    // namespace hpx::cuda::experimental
 
 /// \cond NOINTERNAL
 namespace hpx { namespace traits {
     template <>
-    struct is_distribution_policy<compute::cuda::target_distribution_policy>
-      : std::true_type
+    struct is_distribution_policy<
+        cuda::experimental::target_distribution_policy> : std::true_type
     {
     };
 
     template <>
-    struct num_container_partitions<compute::cuda::target_distribution_policy>
+    struct num_container_partitions<
+        cuda::experimental::target_distribution_policy>
     {
         static std::size_t call(
-            compute::cuda::target_distribution_policy const& policy)
+            cuda::experimental::target_distribution_policy const& policy)
         {
             return policy.get_num_partitions();
         }

--- a/libs/compute_cuda/include/hpx/compute/cuda/target_ptr.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/target_ptr.hpp
@@ -21,7 +21,7 @@
 
 #include <cstddef>
 
-namespace hpx { namespace compute { namespace cuda {
+namespace hpx { namespace cuda { namespace experimental {
     template <typename T>
     class target_ptr
       : public hpx::util::iterator_adaptor<target_ptr<T>, T*,
@@ -44,7 +44,8 @@ namespace hpx { namespace compute { namespace cuda {
             base_type;
 
     public:
-        typedef typename compute::detail::get_proxy_type<T>::type* proxy_type;
+        typedef
+            typename hpx::compute::detail::get_proxy_type<T>::type* proxy_type;
 
         HPX_HOST_DEVICE HPX_FORCEINLINE target_ptr()
           : base_type(nullptr)
@@ -58,7 +59,7 @@ namespace hpx { namespace compute { namespace cuda {
         {
         }
 
-        target_ptr(T* p, hpx::cuda::target& tgt)
+        target_ptr(T* p, hpx::cuda::experimental::target& tgt)
           : base_type(p)
           , tgt_(&tgt)
         {
@@ -139,8 +140,8 @@ namespace hpx { namespace compute { namespace cuda {
         }
 
     private:
-        hpx::cuda::target* tgt_;
+        hpx::cuda::experimental::target* tgt_;
     };
-}}}    // namespace hpx::compute::cuda
+}}}    // namespace hpx::cuda::experimental
 
 #endif

--- a/libs/compute_cuda/include/hpx/compute/cuda/traits/access_target.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/traits/access_target.hpp
@@ -18,12 +18,13 @@
 
 namespace hpx { namespace compute { namespace traits {
     template <>
-    struct access_target<hpx::cuda::target>
+    struct access_target<hpx::cuda::experimental::target>
     {
-        typedef hpx::cuda::target target_type;
+        typedef hpx::cuda::experimental::target target_type;
 
         template <typename T>
-        HPX_HOST_DEVICE static T read(hpx::cuda::target const& tgt, T const* t)
+        HPX_HOST_DEVICE static T read(
+            hpx::cuda::experimental::target const& tgt, T const* t)
         {
 #if defined(__CUDA_ARCH__)
             return *t;
@@ -38,7 +39,7 @@ namespace hpx { namespace compute { namespace traits {
 
         template <typename T>
         HPX_HOST_DEVICE static void write(
-            hpx::cuda::target const& tgt, T* dst, T const* src)
+            hpx::cuda::experimental::target const& tgt, T* dst, T const* src)
         {
 #if defined(__CUDA_ARCH__)
             *dst = *src;

--- a/libs/compute_cuda/include/hpx/compute/cuda/transfer.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/transfer.hpp
@@ -26,9 +26,10 @@ namespace hpx { namespace traits {
     // pointer category.
     template <typename T>
     struct remove_const_iterator_value_type<
-        compute::detail::iterator<T const, compute::cuda::allocator<T>>>
+        compute::detail::iterator<T const, cuda::experimental::allocator<T>>>
     {
-        typedef compute::detail::iterator<T, compute::cuda::allocator<T>> type;
+        typedef compute::detail::iterator<T, cuda::experimental::allocator<T>>
+            type;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -49,8 +50,8 @@ namespace hpx { namespace traits {
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
     struct pointer_category<
-        compute::detail::iterator<T, compute::cuda::allocator<T>>,
-        compute::detail::iterator<T, compute::cuda::allocator<T>>,
+        compute::detail::iterator<T, cuda::experimental::allocator<T>>,
+        compute::detail::iterator<T, cuda::experimental::allocator<T>>,
         typename std::enable_if<!std::is_trivially_copyable<
             typename hpx::util::decay<T>::type>::value>::type>
     {
@@ -59,12 +60,12 @@ namespace hpx { namespace traits {
 
     template <typename Source, typename T>
     struct pointer_category<Source,
-        compute::detail::iterator<T, compute::cuda::allocator<T>>,
+        compute::detail::iterator<T, cuda::experimental::allocator<T>>,
         typename std::enable_if<!std::is_trivially_copyable<typename hpx::util::
                                         decay<T>::type>::value &&
             !std::is_same<Source,
                 compute::detail::iterator<T,
-                    compute::cuda::allocator<T>>>::value>::type>
+                    cuda::experimental::allocator<T>>>::value>::type>
     {
         // FIXME: turn into proper pointer category
         static_assert(
@@ -77,12 +78,12 @@ namespace hpx { namespace traits {
 
     template <typename T, typename U, typename Dest>
     struct pointer_category<
-        compute::detail::iterator<T, compute::cuda::allocator<U>>, Dest,
+        compute::detail::iterator<T, cuda::experimental::allocator<U>>, Dest,
         typename std::enable_if<!std::is_trivially_copyable<typename hpx::util::
                                         decay<T>::type>::value &&
             !std::is_same<Dest,
                 compute::detail::iterator<T,
-                    compute::cuda::allocator<U>>>::value>::type>
+                    cuda::experimental::allocator<U>>>::value>::type>
     {
         // FIXME: turn into proper pointer category
         static_assert(
@@ -107,8 +108,8 @@ namespace hpx { namespace traits {
 
     template <typename T>
     struct pointer_category<
-        compute::detail::iterator<T, compute::cuda::allocator<T>>,
-        compute::detail::iterator<T, compute::cuda::allocator<T>>,
+        compute::detail::iterator<T, cuda::experimental::allocator<T>>,
+        compute::detail::iterator<T, cuda::experimental::allocator<T>>,
         typename std::enable_if<std::is_trivially_copyable<
             typename hpx::util::decay<T>::type>::value>::type>
     {
@@ -117,12 +118,12 @@ namespace hpx { namespace traits {
 
     template <typename Source, typename T>
     struct pointer_category<Source,
-        compute::detail::iterator<T, compute::cuda::allocator<T>>,
+        compute::detail::iterator<T, cuda::experimental::allocator<T>>,
         typename std::enable_if<std::is_trivially_copyable<typename hpx::util::
                                         decay<T>::type>::value &&
             !std::is_same<Source,
                 compute::detail::iterator<T,
-                    compute::cuda::allocator<T>>>::value>::type>
+                    cuda::experimental::allocator<T>>>::value>::type>
     {
         // FIXME: turn into proper pointer category
         static_assert(
@@ -135,12 +136,12 @@ namespace hpx { namespace traits {
 
     template <typename T, typename U, typename Dest>
     struct pointer_category<
-        compute::detail::iterator<T, compute::cuda::allocator<U>>, Dest,
+        compute::detail::iterator<T, cuda::experimental::allocator<U>>, Dest,
         typename std::enable_if<std::is_trivially_copyable<typename hpx::util::
                                         decay<T>::type>::value &&
             !std::is_same<Dest,
                 compute::detail::iterator<T,
-                    compute::cuda::allocator<U>>>::value>::type>
+                    cuda::experimental::allocator<U>>>::value>::type>
     {
         // FIXME: turn into proper pointer category
         static_assert(

--- a/libs/compute_cuda/include/hpx/compute/cuda/value_proxy.hpp
+++ b/libs/compute_cuda/include/hpx/compute/cuda/value_proxy.hpp
@@ -18,14 +18,16 @@
 
 #include <type_traits>
 
-namespace hpx { namespace compute { namespace cuda {
+namespace hpx { namespace cuda { namespace experimental {
     template <typename T>
     class value_proxy
     {
-        typedef traits::access_target<hpx::cuda::target> access_target;
+        typedef hpx::compute::traits::access_target<
+            hpx::cuda::experimental::target>
+            access_target;
 
     public:
-        value_proxy(T* p, hpx::cuda::target& tgt) noexcept
+        value_proxy(T* p, hpx::cuda::experimental::target& tgt) noexcept
           : p_(p)
           , target_(&tgt)
         {
@@ -73,25 +75,27 @@ namespace hpx { namespace compute { namespace cuda {
             return p_;
         }
 
-        hpx::cuda::target& target() const noexcept
+        hpx::cuda::experimental::target& target() const noexcept
         {
             return *target_;
         }
 
     private:
         T* p_;
-        hpx::cuda::target* target_;
+        hpx::cuda::experimental::target* target_;
     };
 
     template <typename T>
     class value_proxy<T const>
     {
-        typedef traits::access_target<hpx::cuda::target> access_target;
+        typedef hpx::compute::traits::access_target<
+            hpx::cuda::experimental::target>
+            access_target;
 
     public:
         typedef T const proxy_type;
 
-        value_proxy(T* p, hpx::cuda::target& tgt) noexcept
+        value_proxy(T* p, hpx::cuda::experimental::target& tgt) noexcept
           : p_(p)
           , target_(tgt)
         {
@@ -113,20 +117,21 @@ namespace hpx { namespace compute { namespace cuda {
             return p_;
         }
 
-        hpx::cuda::target& target() const noexcept
+        hpx::cuda::experimental::target& target() const noexcept
         {
             return target_;
         }
 
     private:
         T* p_;
-        hpx::cuda::target& target_;
+        hpx::cuda::experimental::target& target_;
     };
-}}}    // namespace hpx::compute::cuda
+}}}    // namespace hpx::cuda::experimental
 
 namespace hpx { namespace traits {
     template <typename T>
-    struct is_value_proxy<hpx::compute::cuda::value_proxy<T>> : std::true_type
+    struct is_value_proxy<hpx::cuda::experimental::value_proxy<T>>
+      : std::true_type
     {
     };
 }}    // namespace hpx::traits

--- a/libs/compute_cuda/tests/performance/synchronize.cu
+++ b/libs/compute_cuda/tests/performance/synchronize.cu
@@ -18,10 +18,10 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::size_t iterations = vm["iterations"].as<std::size_t>();
 
     // Get the cuda targets we want to run on
-    hpx::cuda::target target;
+    hpx::cuda::experimental::target target;
 
     // Create the executor
-    hpx::compute::cuda::default_executor executor(target);
+    hpx::cuda::experimental::default_executor executor(target);
 
     {
         auto cuda_stream = target.native_handle().get_stream();

--- a/libs/compute_cuda/tests/unit/default_executor.cu
+++ b/libs/compute_cuda/tests/unit/default_executor.cu
@@ -28,18 +28,18 @@ struct test
 
 void test_sync()
 {
-    typedef hpx::compute::cuda::default_executor executor;
+    typedef hpx::cuda::experimental::default_executor executor;
 
-    hpx::cuda::target target;
+    hpx::cuda::experimental::target target;
     executor exec(target);
     hpx::parallel::execution::sync_execute(exec, test());
 }
 
 void test_async()
 {
-    typedef hpx::compute::cuda::default_executor executor;
+    typedef hpx::cuda::experimental::default_executor executor;
 
-    hpx::cuda::target target;
+    hpx::cuda::experimental::target target;
     executor exec(target);
     hpx::parallel::execution::async_execute(exec, test()).get();
 }
@@ -57,7 +57,7 @@ struct bulk_test
 
 void test_bulk_sync()
 {
-    typedef hpx::compute::cuda::default_executor executor;
+    typedef hpx::cuda::experimental::default_executor executor;
 
     std::vector<int> v(107);
     std::iota(boost::begin(v), boost::end(v), gen());
@@ -65,7 +65,7 @@ void test_bulk_sync()
     using hpx::util::placeholders::_1;
     using hpx::util::placeholders::_2;
 
-    hpx::cuda::target target;
+    hpx::cuda::experimental::target target;
     executor exec(target);
 //    traits::bulk_execute(exec, hpx::util::bind(&bulk_test, _1), v);
     hpx::parallel::execution::bulk_sync_execute(exec, bulk_test(), v);
@@ -73,7 +73,7 @@ void test_bulk_sync()
 
 void test_bulk_async()
 {
-    typedef hpx::compute::cuda::default_executor executor;
+    typedef hpx::cuda::experimental::default_executor executor;
 
     std::vector<int> v(107);
     std::iota(boost::begin(v), boost::end(v), gen());
@@ -81,7 +81,7 @@ void test_bulk_async()
     using hpx::util::placeholders::_1;
     using hpx::util::placeholders::_2;
 
-    hpx::cuda::target target;
+    hpx::cuda::experimental::target target;
     executor exec(target);
 //    hpx::when_all(traits::bulk_async_execute(
 //        exec, hpx::util::bind(&bulk_test, _1), v)

--- a/libs/compute_cuda/tests/unit/for_each_compute.cu
+++ b/libs/compute_cuda/tests/unit/for_each_compute.cu
@@ -22,8 +22,8 @@
 
 #include <boost/program_options.hpp>
 
-typedef hpx::compute::cuda::default_executor executor_type;
-typedef hpx::compute::cuda::allocator<int> target_allocator;
+typedef hpx::cuda::experimental::default_executor executor_type;
+typedef hpx::cuda::experimental::allocator<int> target_allocator;
 typedef hpx::compute::vector<int, target_allocator> target_vector;
 
 void test_for_each(executor_type& exec, target_vector& d_A)
@@ -68,7 +68,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::iota(h_A.begin(), h_A.end(), dis(gen));
 
     // define execution target (here device 0)
-    hpx::cuda::target target;
+    hpx::cuda::experimental::target target;
 
     // allocate data on the device
     target_allocator alloc(target);

--- a/libs/compute_cuda/tests/unit/for_loop_compute.cu
+++ b/libs/compute_cuda/tests/unit/for_loop_compute.cu
@@ -22,8 +22,8 @@
 
 #include <boost/program_options.hpp>
 
-typedef hpx::compute::cuda::default_executor executor_type;
-typedef hpx::compute::cuda::allocator<int> target_allocator;
+typedef hpx::cuda::experimental::default_executor executor_type;
+typedef hpx::cuda::experimental::allocator<int> target_allocator;
 typedef hpx::compute::vector<int, target_allocator> target_vector;
 
 void test_for_loop(executor_type& exec,
@@ -82,7 +82,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         [](int a, int b) { return a + 3.0 * b; });
 
     // define execution targets (here device 0), allows overlapping operations
-    hpx::cuda::target targetA, targetB;
+    hpx::cuda::experimental::target targetA, targetB;
 
     // allocate data on the device
     target_allocator allocA(targetA);

--- a/libs/compute_cuda/tests/unit/transform_compute.cu
+++ b/libs/compute_cuda/tests/unit/transform_compute.cu
@@ -21,8 +21,8 @@
 
 #include <boost/program_options.hpp>
 
-typedef hpx::compute::cuda::default_executor executor_type;
-typedef hpx::compute::cuda::allocator<int> target_allocator;
+typedef hpx::cuda::experimental::default_executor executor_type;
+typedef hpx::cuda::experimental::allocator<int> target_allocator;
 typedef hpx::compute::vector<int, target_allocator> target_vector;
 
 struct transform_test
@@ -86,7 +86,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         [](int a, int b) { return a + 3.0 * b; });
 
     // define execution targets (here device 0), allows overlapping operations
-    hpx::cuda::target targetA, targetB;
+    hpx::cuda::experimental::target targetA, targetB;
 
     // allocate data on the device
     target_allocator allocA(targetA);

--- a/tests/performance/local/stream.cpp
+++ b/tests/performance/local/stream.cpp
@@ -445,11 +445,11 @@ int hpx_main(hpx::program_options::variables_map& vm)
     if (use_accel)
     {
 #if defined(HPX_HAVE_CUDA)
-        using executor_type = hpx::compute::cuda::concurrent_executor<>;
-        using allocator_type = hpx::compute::cuda::allocator<STREAM_TYPE>;
+        using executor_type = hpx::cuda::experimental::concurrent_executor<>;
+        using allocator_type = hpx::cuda::experimental::allocator<STREAM_TYPE>;
 
         // Get the cuda targets we want to run on
-        hpx::cuda::target target;
+        hpx::cuda::experimental::target target;
 
         // Get the host targets we want to run on
         auto host_targets = hpx::compute::host::get_local_targets();


### PR DESCRIPTION
Fixes #4766. This moves *all* CUDA functionality to `hpx::cuda::experimental`, including the compute functionality. I have not added any new compatibility layers except the one that already existed for `target` (and maybe a few other things).

I suppose the host compute functionality could eventually either be removed or be moved to `hpx::(experimental::)` (e.g. `hpx::compute::vector` should just be `hpx::vector` if it's going to stay).