### PR TITLE
Update documentation on using HPX::wrap_main

### DIFF
--- a/docs/sphinx/manual/creating_hpx_projects.rst
+++ b/docs/sphinx/manual/creating_hpx_projects.rst
@@ -236,11 +236,13 @@ Additionally, if you wish to require |hpx| for your project, replace the
 
 You can check if |hpx| was successfully found with the ``HPX_FOUND`` CMake variable.
 
-Using |hpx| targets
--------------------
+.. _using_hpx_cmake_targets:
+
+Using |cmake| targets
+---------------------
 
 The recommended way of setting up your targets to use |hpx| is to link to the
-``HPX::hpx`` target:
+``HPX::hpx`` |cmake| target:
 
 .. code-block:: cmake
 
@@ -253,9 +255,15 @@ This requires that you have already created the target like this:
    add_library(hello_world_component SHARED hello_world_component.cpp)
    target_include_directories(hello_world_component PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-When you link your library to ``HPX::hpx`` you will be able use |hpx|
-functionality in your library. To create a component, however, requires setting
-two additional compile definitions:
+When you link your library to the ``HPX::hpx`` |cmake| target you will be able
+use |hpx| functionality in your library. To use ``main`` as the implicit entry
+point in your application you must additionally link your application to the
+|cmake| target ``HPX::wrap_main``. ``HPX::wrap_main`` is automatically linked to
+executables if you are using the macros described below
+(:ref:`using_hpx_cmake_macros`). See :ref:`minimal` for more information on
+implicitly using ``main`` as the entry point.
+
+Creating a component requires setting two additional compile definitions:
 
 .. code-block:: cmake
 
@@ -285,6 +293,8 @@ or output directory of your plugin you need to tell your executable where to
 find it at runtime. You can do this either by setting the environment variable
 ``HPX_COMPONENT_PATHS`` or the ini setting ``hpx.component_paths`` (see
 :option:`--hpx:ini`) to the directory containing your plugin.
+
+.. _using_hpx_cmake_macros:
 
 Using macros to create new targets
 ----------------------------------

--- a/docs/sphinx/manual/starting_the_hpx_runtime.rst
+++ b/docs/sphinx/manual/starting_the_hpx_runtime.rst
@@ -49,15 +49,19 @@ The only change to your code you have to make is to include the file
 ``hpx/hpx_main.hpp``. In this case the function ``main()`` will be invoked as
 the first |hpx| thread of the application. The runtime system will be
 initialized behind the scenes before the function ``main()`` is executed and
-will automatically stop after ``main()`` has returned. All |hpx| API functions
-can be used from within this function now.
+will automatically stop after ``main()`` has returned. For this method to work
+you must link your application to ``HPX::wrap_main``. This is done automatically
+if you are using the provided macros (:ref:`using_hpx_cmake_macros`) to set up
+your application, but must be done explicitly if you are using targets directly
+(:ref:`using_hpx_cmake_targets`). All |hpx| API functions can be used from
+within the ``main`` function now.
 
 .. note::
 
-   The function ``main()`` does not need to expect receiving ``argc`` ``argv``
-   as shown above, but could expose the signature ``int main()``. This is
-   consistent with the usually allowed prototypes for the function ``main()`` in
-   C++ applications.
+   The function ``main()`` does not need to expect receiving ``argc`` and
+   ``argv`` as shown above, but could expose the signature ``int main()``. This
+   is consistent with the usually allowed prototypes for the function ``main()``
+   in C++ applications.
 
 All command line arguments specific to |hpx| will still be processed by the
 |hpx| runtime system as usual. However, those command line options will be
@@ -90,10 +94,10 @@ to the operating system as usual.
 .. important::
 
    To achieve this seamless integration, we use different implementations for
-   different Operating Systems. In case of Linux or Mac OSX, the code present in
+   different operating systems. In case of Linux or macOS, the code present in
    ``hpx_wrap.cpp`` is put into action. We hook into the system function in case
-   of Linux and provide alternate entry point in case of Mac OSX. For other
-   Operating Systems we rely on a macro::
+   of Linux and provide alternate entry point in case of macOS. For other
+   operating systems we rely on a macro::
 
        #define main hpx_startup::user_main
 

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -179,13 +179,18 @@ build an executable using |cmake| and |hpx|:
    project(my_hpx_project CXX)
    find_package(HPX REQUIRED)
    add_executable(my_hpx_program main.cpp)
-   target_link_libraries(my_hpx_program HPX::hpx HPX::iostreams_component)
+   target_link_libraries(my_hpx_program HPX::hpx HPX::wrap_main HPX::iostreams_component)
 
 .. note::
 
    You will most likely have more than one ``main.cpp`` file in your project.
    See the section on :ref:`using_hpx_cmake` for more details on how to use
    ``add_hpx_executable``.
+
+.. note::
+
+   ``HPX::wrap_main`` is required if you are implicitly using ``main`` as the
+   runtime entry point. See :ref:`minimal` for more information.
 
 .. note::
 


### PR DESCRIPTION
Fixes #4619. I didn't mention anything about the fancier variations of linking with e.g. `gtest_main` since it's not portable. If it's going to be something more people want to do we can make it a bit more offical, and describe it in detail, but for now I'd like to not encourage more people to do so than the ones who have already tried to do so.