### PR TITLE
Making sure MPI_CXX_COMPILE_FLAGS is interpreted as a sequence  of options

### DIFF
--- a/cmake/HPX_SetupMPI.cmake
+++ b/cmake/HPX_SetupMPI.cmake
@@ -35,14 +35,11 @@ macro(setup_mpi)
     if(MPI_EXTRA_LIBRARY)
       target_link_libraries(Mpi::mpi INTERFACE ${MPI_EXTRA_LIBRARY})
     endif()
+    separate_arguments(MPI_CXX_COMPILE_FLAGS)
     target_compile_options(Mpi::mpi INTERFACE ${MPI_CXX_COMPILE_FLAGS})
     target_compile_definitions(
       Mpi::mpi INTERFACE ${MPI_CXX_COMPILE_DEFINITIONS}
     )
-
-    if(MPI_CXX_LINK_FLAGS)
-      # hpx_add_link_flag_if_available(${MPI_CXX_LINK_FLAGS})
-    endif()
 
     hpx_info("MPI version: " ${MPI_C_VERSION})
   endif()


### PR DESCRIPTION

Fixes #4286

`MPI_CXX_COMPILE_FLAGS` is a string and needs to be separated in order to be interpreted as a list of options.