### PR TITLE
Fixing assertion in split_gids and memory leaks in 1d_stencil_7

### DIFF
--- a/examples/1d_stencil/1d_stencil_7.cpp
+++ b/examples/1d_stencil/1d_stencil_7.cpp
@@ -301,7 +301,7 @@ struct stepper
 
                     // The new partition_data will be allocated on the same locality
                     // as 'middle'.
-                    return partition(middle.get_id(), next);
+                    return partition(middle.get_id(), std::move(next));
                 }
             ),
             std::move(next_middle),
@@ -342,6 +342,10 @@ stepper::space stepper::do_work(std::size_t np, std::size_t nx, std::size_t nt)
     for (std::size_t i = 0; i != np; ++i)
         U[0][i] = partition(localities[locidx(i, np, nl)], nx, double(i));
 
+    // limit depth of dependency tree
+    std::size_t nd = 3;
+    hpx::lcos::local::sliding_semaphore sem(nd);
+
     heat_part_action act;
     for (std::size_t t = 0; t != nt; ++t)
     {
@@ -357,6 +361,20 @@ stepper::space stepper::do_work(std::size_t np, std::size_t nx, std::size_t nt)
                     current[idx(i, -1, np)], current[i], current[idx(i, +1, np)]
                 );
         }
+
+        if ((t % nd) == 0)
+        {
+            next[0].then(
+                [&sem, t](partition&&)
+                {
+                    // inform semaphore about new lower limit
+                    sem.signal(t);
+                });
+        }
+
+        // suspend if the tree has become too deep, the continuation above
+        // will resume this thread once the computation has caught up
+        sem.wait(t);
     }
 
     // Return the solution at time-step 'nt'.

--- a/hpx/runtime/naming/name.hpp
+++ b/hpx/runtime/naming/name.hpp
@@ -415,6 +415,8 @@ namespace hpx { namespace naming
         std::uint64_t id_msb_;
         std::uint64_t id_lsb_;
     };
+
+    HPX_EXPORT void decrement_refcnt(gid_type const& gid);
 }}
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/runtime/naming/name.cpp
+++ b/src/runtime/naming/name.cpp
@@ -246,20 +246,27 @@ namespace hpx { namespace naming
             auto& handle_futures =
                 ar.get_extra_data<serialization::detail::preprocess_futures>();
 
+            // avoid races between the split-handling and the future
+            // preprocessing
+            handle_futures.increment_future_count();
+
             auto f = split_gid_if_needed(gid).then(hpx::launch::sync,
-                [&split_gids, &gid](hpx::future<gid_type>&& gid_future) {
+                [&split_gids, &handle_futures, &gid](
+                    hpx::future<gid_type>&& gid_future) {
+                    HPX_ASSERT(handle_futures.has_futures());
                     split_gids.add_gid(gid, gid_future.get());
                 });
 
             handle_futures.await_future(
-                *traits::future_access<decltype(f)>::get_shared_state(f));
+                *traits::future_access<decltype(f)>::get_shared_state(f),
+                false);
         }
 
         void id_type_impl::preprocess_gid(serialization::output_archive& ar) const
         {
             // unmanaged gids do not require any special handling
             // check-pointing does not require any special handling here neither
-            if (unmanaged == type_)
+            if (unmanaged == type_ || managed_move_credit == type_)
             {
                 return;
             }
@@ -288,11 +295,10 @@ namespace hpx { namespace naming
 
             // Request new credits from AGAS if needed (i.e. the remainder
             // of the credit splitting is equal to one).
-            if (managed == type_)
-            {
-                handle_credit_splitting(
-                    ar, const_cast<id_type_impl&>(*this), split_gids);
-            }
+            HPX_ASSERT(managed == type_);
+
+            handle_credit_splitting(
+                ar, const_cast<id_type_impl&>(*this), split_gids);
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -332,6 +338,7 @@ namespace hpx { namespace naming
             std::int64_t new_credit = src_credit + split_credit;
             std::int64_t overflow_credit = new_credit -
                 static_cast<std::int64_t>(HPX_GLOBALCREDIT_INITIAL);
+            HPX_ASSERT(overflow_credit >= 0);
 
             new_credit
                 = (std::min)(
@@ -582,6 +589,12 @@ namespace hpx { namespace naming
                 HPX_ASSERT(new_gid != invalid_gid);
             }
 
+#if defined(HPX_DEBUG)
+            auto* split_gids = ar.try_get_extra_data<
+                serialization::detail::preprocess_gid_types>();
+            HPX_ASSERT(!split_gids || !split_gids->has_gid(*this));
+#endif
+
             gid_serialization_data data{new_gid, type};
             ar << data;
         }
@@ -681,6 +694,20 @@ namespace hpx { namespace naming
             << std::right << std::setfill('0') << std::setw(16) << id_msb_
             << std::right << std::setfill('0') << std::setw(16) << id_lsb_;
         return out.str();
+    }
+
+    void decrement_refcnt(gid_type const& gid)
+    {
+        // We assume that the gid was split in the past
+        HPX_ASSERT(detail::gid_was_split(gid));
+
+        // decrement global reference count for the given gid,
+        std::int64_t credits = detail::get_credit_from_gid(gid);
+        HPX_ASSERT(0 != credits);
+
+        // Fire-and-forget semantics.
+        error_code ec(lightweight);
+        agas::decref(gid, credits, ec);
     }
 
     std::ostream& operator<<(std::ostream& os, gid_type const& id)

--- a/src/runtime/naming/name.cpp
+++ b/src/runtime/naming/name.cpp
@@ -253,6 +253,7 @@ namespace hpx { namespace naming
             auto f = split_gid_if_needed(gid).then(hpx::launch::sync,
                 [&split_gids, &handle_futures, &gid](
                     hpx::future<gid_type>&& gid_future) {
+                    HPX_UNUSED(handle_futures);
                     HPX_ASSERT(handle_futures.has_futures());
                     split_gids.add_gid(gid, gid_future.get());
                 });

--- a/src/runtime/parcelset/detail/parcel_await.cpp
+++ b/src/runtime/parcelset/detail/parcel_await.cpp
@@ -79,7 +79,7 @@ namespace hpx { namespace parcelset { namespace detail {
                 serialization::detail::preprocess_gid_types>();
             if (split_gids)
             {
-                p.set_split_gids(std::move(split_gids->move_split_gids()));
+                p.set_split_gids(split_gids->move_split_gids());
             }
 
             return true;

--- a/src/runtime/parcelset/parcel.cpp
+++ b/src/runtime/parcelset/parcel.cpp
@@ -330,6 +330,7 @@ namespace hpx { namespace parcelset
 
     void parcel::set_split_gids(parcel::split_gids_type&& split_gids)
     {
+        HPX_ASSERT(split_gids_.empty());
         split_gids_ = std::move(split_gids);
     }
 


### PR DESCRIPTION
Fixes #4732
Fixes #4746

The two mentioned issues were connected. The cause for the memory leak (and as a side effect for the assertions) was that parcel preprocessing is done on a parcel-by-parcel basis, while the actual serialization may store several parcels using the same serialization archive. This caused (managed) `id_types` that were part of two or more parcels to have their credits split two or more times but subsequently they were serialized only once (because of pointer tracking). As a result the credits were leaked that were supposed to be sent over the wire by the second (or subsequent) instance of the same `id_type`.

This patch fixes this by giving back to AGAS all credits that end up not being sent. 

This patch also fixes a possible race condition between handling the credit splitting and the corresponding future during parcel preprocessing.

@kordejong please verify that the memory leaks are gone for you as well (for me their appear to be fixed).