### PR TITLE
Allow thread function destructors to yield

### DIFF
--- a/libs/coroutines/include/hpx/coroutines/detail/coroutine_impl.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/coroutine_impl.hpp
@@ -86,6 +86,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
     public:
         void bind_result(result_type res)
         {
+            HPX_ASSERT(m_result.first != terminated);
             m_result = res;
         }
 
@@ -122,6 +123,8 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
 
         void rebind(functor_type&& f, thread_id_type id)
         {
+            HPX_ASSERT(
+                m_result.first == unknown || m_result.first == terminated);
             this->rebind_stack();    // count how often a coroutines object was reused
             m_result = result_type(unknown, invalid_thread_id);
             m_arg = nullptr;

--- a/libs/coroutines/include/hpx/coroutines/detail/coroutine_impl.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/coroutine_impl.hpp
@@ -114,11 +114,14 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
 
         void reset()
         {
-            this->reset_stack();
-            m_result = result_type(terminated, invalid_thread_id);
+            // First reset the function and arguments
             m_arg = nullptr;
-            m_fun.reset();    // just reset the bound function
+            m_fun.reset();
+
+            // Then reset the id and stack as they may be used by the
+            // destructors of the thread function above
             this->super_type::reset();
+            this->reset_stack();
         }
 
         void rebind(functor_type&& f, thread_id_type id)

--- a/libs/coroutines/src/detail/coroutine_impl.cpp
+++ b/libs/coroutines/src/detail/coroutine_impl.cpp
@@ -74,6 +74,9 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
                     result_last = m_fun(*this->args());
                     HPX_ASSERT(
                         result_last.first == thread_state_enum::terminated);
+
+                    // Reset early as the destructors may still yield.
+                    this->reset();
                 }
                 catch (...)
                 {
@@ -87,7 +90,6 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
                 this->bind_result(result_last);
             }
 
-            this->reset();
             this->do_return(status, std::move(tinfo));
         } while (this->m_state == super_type::ctx_running);
 

--- a/libs/coroutines/tests/regressions/CMakeLists.txt
+++ b/libs/coroutines/tests/regressions/CMakeLists.txt
@@ -1,5 +1,24 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2020 ETH Zurich
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests coroutine_function_destructor_yield_4800)
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+  set(${test}_PARAMETERS THREADS_PER_LOCALITY 4)
+
+  source_group("Source Files" FILES ${sources})
+
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/Modules/Coroutines"
+  )
+
+  add_hpx_regression_test("modules.coroutines" ${test} ${${test}_PARAMETERS})
+endforeach()

--- a/libs/coroutines/tests/regressions/coroutine_function_destructor_yield_4800.cpp
+++ b/libs/coroutines/tests/regressions/coroutine_function_destructor_yield_4800.cpp
@@ -1,0 +1,75 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This test verifies that the destructor of a thread function may yield.
+
+#include <hpx/future.hpp>
+#include <hpx/modules/threading.hpp>
+#include <hpx/thread.hpp>
+#include <hpx/wrap_main.hpp>
+
+#include <utility>
+
+struct thread_function_yield_destructor
+{
+    hpx::threads::thread_result_type operator()(hpx::threads::thread_arg_type)
+    {
+        return {hpx::threads::terminated, hpx::threads::invalid_thread_id};
+    }
+
+    ~thread_function_yield_destructor()
+    {
+        hpx::this_thread::yield();
+    }
+};
+
+struct yielder
+{
+    ~yielder()
+    {
+        hpx::this_thread::yield();
+    }
+};
+
+int main()
+{
+    // We supply the thread function ourselves which means that the destructor
+    // will be called late in the coroutine call operator.
+    {
+        hpx::threads::thread_init_data data{thread_function_yield_destructor{},
+            "thread_function_yield_destructor"};
+        hpx::threads::register_thread(data);
+    }
+
+    // This is a more complicated example which sometimes leads to the yielder
+    // destructor being called late in the coroutine call operator.
+    for (int i = 0; i < 1000; ++i)
+    {
+        hpx::lcos::local::promise<yielder> p;
+        hpx::future<yielder> f = p.get_future();
+        hpx::dataflow([](auto&&) {}, f);
+        p.set_value(yielder{});
+    }
+
+    // In the following two cases the yielder instance gets destructed earlier
+    // in the coroutine call operator (before the thread function returns), so
+    // these cases should never fail, even when the above two cases may fail.
+    for (int i = 0; i < 1000; ++i)
+    {
+        hpx::lcos::local::promise<yielder> p;
+        hpx::future<yielder> f = p.get_future();
+        f.then([](auto&&) {});
+        p.set_value(yielder{});
+    }
+
+    for (int i = 0; i < 1000; ++i)
+    {
+        yielder y;
+        hpx::apply([y = std::move(y)]() {});
+    }
+
+    return 0;
+}

--- a/libs/functional/include_compatibility/hpx/functional/traits/is_callable.hpp
+++ b/libs/functional/include_compatibility/hpx/functional/traits/is_callable.hpp
@@ -8,14 +8,15 @@
 
 #include <hpx/config.hpp>
 #include <hpx/functional/config/defines.hpp>
-#include <hpx/functional/is_invocable.hpp>
+#include <hpx/functional/traits/is_invocable.hpp>
 
 #if defined(HPX_FUNCTIONAL_HAVE_DEPRECATION_WARNINGS)
 #if defined(HPX_MSVC)
-#pragma message("The header hpx/functional/is_callable.hpp is deprecated, \
-    please include hpx/functional/is_invocable.hpp instead")
+#pragma message(                                                               \
+    "The header hpx/functional/traits/is_callable.hpp is deprecated, \
+    please include hpx/functional/traits/is_invocable.hpp instead")
 #else
-#warning "The header hpx/functional/is_callable.hpp is deprecated, \
-    please include hpx/functional/is_invocable.hpp instead"
+#warning "The header hpx/functional/traits/is_callable.hpp is deprecated, \
+    please include hpx/functional/traits/is_invocable.hpp instead"
 #endif
 #endif


### PR DESCRIPTION
Fixes #4800.

The problem was the coroutine thread function destructor yielding (because of user code). Since the thread function was reset after the thread id, stack, local self reference etc. the bookkeeping got somewhat messed up (the thread result was set to `pending` by the yield after the thread result had been set to `terminated`). I think this is a reasonable thing to allow, but it's not 100% clear to me if this can be avoided in dataflow or in user code.

I've added a test that reproduces the problem. The first variant always fails before the fixes here. The second uses dataflow and fails occasionally. This is the closest I could get to the original code while still triggering the assertion. I've also added `hpx::future::then` and `hpx::apply` tests that do not trigger the assertion because the user-supplied function is destructed early enough. @hkaiser I'd appreciate your eyes on the dataflow test to see if we should or could fix this elsewhere.

The stacktrace for the original test (with an added assert that fails when the coroutine result is set from `terminated` to `pending`, meaning a bit earlier than the assertion posted in #4800; the line numbers also don't 100% match current master because of added print statements) is below. The stacktrace starts from the coroutine reset function, and the user code starts in frame 18.

```
#0  0x00002aaabffca160 in raise () from /lib64/libc.so.6
#1  0x00002aaabffcb741 in abort () from /lib64/libc.so.6
#2  0x00002aaaac8e9728 in hpx::detail::assertion_handler (loc=..., expr=0x2aaaacb9168b "m_result.first != terminated", msg=...) at ../../libs/runtime_local/src/runtime_handlers.cpp:74
#3  0x00002aaaac62d229 in hpx::assertion::detail::handle_assert (loc=..., expr=0x2aaaacb9168b "m_result.first != terminated", msg=...) at ../../libs/assertion/src/assertion.cpp:47
#4  0x00002aaaac70e3f0 in hpx::threads::coroutines::detail::coroutine_impl::bind_result (this=0x2aab8c4d8e10, res=...) at ../../libs/coroutines/include/hpx/coroutines/detail/coroutine_impl.hpp:94
#5  0x00002aaaac70e8bc in hpx::threads::coroutines::detail::coroutine_stackful_self::yield_impl (this=0x2aab8c4d8f60, arg=...) at ../../libs/coroutines/include/hpx/coroutines/detail/coroutine_stackful_self.hpp:41
#6  0x00002aaaac942cfd in hpx::threads::coroutines::detail::coroutine_self::yield (this=0x2aab8c4d8f60, arg=...) at ../../libs/coroutines/include/hpx/coroutines/detail/coroutine_self.hpp:89
#7  0x00002aaaaca3d62f in hpx::threads::execution_agent::do_yield (this=0x2aab8c4d8f58, desc=0x2aaaacbe6f86 "hpx::threads::execution_agent::resume", state=hpx::threads::pending) at ../../libs/threading_base/src/execution_agent.cpp:175
#8  0x00002aaaaca3d1bb in hpx::threads::execution_agent::yield (this=0x2aab8c4d8f58, desc=0x2aaaacbe6f86 "hpx::threads::execution_agent::resume") at ../../libs/threading_base/src/execution_agent.cpp:59
#9  0x00002aaaac720487 in hpx::execution_base::agent_ref::yield_k (this=0x2aaba16ae578, k=0, desc=0x2aaaacbe6f86 "hpx::threads::execution_agent::resume") at ../../libs/execution_base/src/agent_ref.cpp:37
#10 0x00002aaaac723dba in hpx::execution_base::this_thread::yield_k (k=0, desc=0x2aaaacbe6f86 "hpx::threads::execution_agent::resume") at ../../libs/execution_base/src/this_thread.cpp:269
#11 0x00002aaaaca3dcd3 in hpx::threads::execution_agent::do_resume (this=0x2aab38007798, desc=0x2aaaacbb9a23 "hpx::execution_base::agent_ref::resume", statex=hpx::threads::wait_signaled) at ../../libs/threading_base/src/execution_agent.cpp:223
#12 0x00002aaaaca3da72 in hpx::threads::execution_agent::resume (this=0x2aab38007798, desc=0x2aaaacbb9a23 "hpx::execution_base::agent_ref::resume") at ../../libs/threading_base/src/execution_agent.cpp:87
#13 0x00002aaaac7205fe in hpx::execution_base::agent_ref::resume (this=0x2aaba16af4f8, desc=0x2aaaacbb9a23 "hpx::execution_base::agent_ref::resume") at ../../libs/execution_base/src/agent_ref.cpp:53
#14 0x00002aaaac91a4e0 in hpx::lcos::local::detail::condition_variable::notify_one (this=0x2aab58016158, lock=..., priority=hpx::threads::thread_priority_boost, ec=...) at ../../libs/synchronization/src/detail/condition_variable.cpp:87
#15 0x000000000058325e in hpx::lcos::detail::future_data_base<dlaf::Tile<float, (dlaf::Device)0> >::set_value<dlaf::Tile<float, (dlaf::Device)0> > (this=0x2aab58016100, ts=...) at /apps/daint/UES/simbergm/tmp/hpx-dla-future-debugging/include/hpx/futures/detail/future_data.hpp:454
#16 0x00000000005b4953 in hpx::lcos::local::detail::promise_base<dlaf::Tile<float, (dlaf::Device)0>, hpx::lcos::detail::future_data<dlaf::Tile<float, (dlaf::Device)0> > >::set_value<dlaf::Tile<float, (dlaf::Device)0> > (this=0x2aab54009f80, ts=...) at /apps/daint/UES/simbergm/tmp/hpx-dla-future-debugging/include/hpx/lcos_local/promise.hpp:184
#17 0x00000000005b12ad in hpx::lcos::local::promise<dlaf::Tile<float, (dlaf::Device)0> >::set_value (this=0x2aab54009f80, r=...) at /apps/daint/UES/simbergm/tmp/hpx-dla-future-debugging/include/hpx/lcos_local/promise.hpp:335
#18 0x00000000005b10e4 in dlaf::Tile<float const, (dlaf::Device)0>::~Tile (this=0x2aab744e3f70) at ../../include/dlaf/tile.tpp:40
#19 0x0000000000491b3e in hpx::lcos::detail::future_data_base<dlaf::Tile<float const, (dlaf::Device)0> >::reset (this=0x2aab744e3f00) at /apps/daint/UES/simbergm/tmp/hpx-dla-future-debugging/include/hpx/futures/detail/future_data.hpp:594
#20 0x0000000000491a65 in hpx::lcos::detail::future_data_base<dlaf::Tile<float const, (dlaf::Device)0> >::~future_data_base (this=0x2aab744e3f00) at /apps/daint/UES/simbergm/tmp/hpx-dla-future-debugging/include/hpx/futures/detail/future_data.hpp:378
#21 0x0000000000491a05 in hpx::lcos::detail::future_data<dlaf::Tile<float const, (dlaf::Device)0> >::~future_data (this=0x2aab744e3f00) at /apps/daint/UES/simbergm/tmp/hpx-dla-future-debugging/include/hpx/futures/detail/future_data.hpp:661
#22 0x0000000000585eb4 in hpx::lcos::detail::continuation<hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> >, dlaf::Matrix<float const, (dlaf::Device)0>::read(dlaf::common::Index2D<int, dlaf::matrix::LocalTile_TAG> const&)::{lambda(hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> >&&)#1}, dlaf::Tile<float const, (dlaf::Device)0> >::~continuation() (this=0x2aab744e3f00) at
/apps/daint/UES/simbergm/tmp/hpx-dla-future-debugging/include/hpx/futures/packaged_continuation.hpp:172
#23 0x0000000000585a01 in hpx::lcos::detail::continuation_allocator<std::allocator<int>, hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> >, dlaf::Matrix<float const, (dlaf::Device)0>::read(dlaf::common::Index2D<int, dlaf::matrix::LocalTile_TAG> const&)::{lambda(hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> >&&)#1}, dlaf::Tile<float const, (dlaf::Device)0> >::~continuat
ion_allocator() (this=0x2aab744e3f00) at /apps/daint/UES/simbergm/tmp/hpx-dla-future-debugging/include/hpx/futures/packaged_continuation.hpp:581
#24 0x0000000000585f84 in __gnu_cxx::new_allocator<hpx::lcos::detail::continuation_allocator<std::allocator<int>, hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> >, dlaf::Matrix<float const, (dlaf::Device)0>::read(dlaf::common::Index2D<int, dlaf::matrix::LocalTile_TAG> const&)::{lambda(hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> >&&)#1}, dlaf::Tile<float const, (dlaf
::Device)0> > >::destroy<dlaf::Tile<float const, (dlaf::Device)0> >(dlaf::Tile<float const, (dlaf::Device)0>*) (this=0x2aaba16afa70, __p=0x2aab744e3f00) at /opt/gcc/8.1.0/snos/lib/gcc/x86_64-suse-linux/8.1.0/../../../../include/g++/ext/new_allocator.h:140
#25 0x0000000000585f18 in std::allocator_traits<std::allocator<hpx::lcos::detail::continuation_allocator<std::allocator<int>, hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> >, dlaf::Matrix<float const, (dlaf::Device)0>::read(dlaf::common::Index2D<int, dlaf::matrix::LocalTile_TAG> const&)::{lambda(hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> >&&)#1}, dlaf::Tile<float
const, (dlaf::Device)0> > > >::destroy<dlaf::Tile<float const, (dlaf::Device)0> >(hpx::lcos::detail::continuation_allocator<std::allocator<int>, hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> >, dlaf::Matrix<float const, (dlaf::Device)0>::read(dlaf::common::Index2D<int, dlaf::matrix::LocalTile_TAG> const&)::{lambda(hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> >&&)#1}, dlaf::Tile<float const, (dlaf::Device)0> >&, dlaf::Tile<float const, (dlaf::Device)0>*) (__a=..., __p=0x2aab744e3f00) at /opt/gcc/8.1.0/snos/lib/gcc/x86_64-suse-linux/8.1.0/../../../../include/g++/bits/alloc_traits.h:487
#26 0x0000000000585a7d in hpx::lcos::detail::continuation_allocator<std::allocator<int>, hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> >, dlaf::Matrix<float const, (dlaf::Device)0>::read(dlaf::common::Index2D<int, dlaf::matrix::LocalTile_TAG> const&)::{lambda(hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> >&&)#1}, dlaf::Tile<float const, (dlaf::Device)0> >::destroy() (this=0x2aab744e3f00) at /apps/daint/UES/simbergm/tmp/hpx-dla-future-debugging/include/hpx/futures/packaged_continuation.hpp:613
#27 0x000000000047e0a0 in hpx::lcos::detail::intrusive_ptr_release (p=0x2aab744e3f00) at /apps/daint/UES/simbergm/tmp/hpx-dla-future-debugging/include/hpx/futures/detail/future_data.hpp:125
#28 0x000000000048061a in hpx::memory::intrusive_ptr<hpx::lcos::detail::future_data_base<dlaf::Tile<float const, (dlaf::Device)0> > >::~intrusive_ptr (this=0x2aab744e4d70) at /apps/daint/UES/simbergm/tmp/hpx-dla-future-debugging/include/hpx/memory/intrusive_ptr.hpp:81
#29 0x000000000048fc05 in hpx::lcos::detail::future_base<hpx::lcos::shared_future<dlaf::Tile<float const, (dlaf::Device)0> >, dlaf::Tile<float const, (dlaf::Device)0> >::~future_base (this=0x2aab744e4d70) at /apps/daint/UES/simbergm/tmp/hpx-dla-future-debugging/include/hpx/futures/future.hpp:476
#30 0x0000000000477e35 in hpx::lcos::shared_future<dlaf::Tile<float const, (dlaf::Device)0> >::~shared_future (this=0x2aab744e4d70) at /apps/daint/UES/simbergm/tmp/hpx-dla-future-debugging/include/hpx/futures/future.hpp:1157
#31 0x000000000049ae75 in hpx::util::detail::member_leaf<5ul, hpx::lcos::shared_future<dlaf::Tile<float const, (dlaf::Device)0> >, false>::~member_leaf (this=0x2aab744e4d70) at /apps/daint/UES/simbergm/tmp/hpx-dla-future-debugging/include/hpx/datastructures/member_pack.hpp:22
#32 0x000000000049aed7 in hpx::util::member_pack<hpx::util::pack_c<unsigned long, 0ul, 1ul, 2ul, 3ul, 4ul, 5ul, 6ul>, blas::Side, blas::Uplo, blas::Op, blas::Diag, float, hpx::lcos::shared_future<dlaf::Tile<float const, (dlaf::Device)0> >, hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> > >::~member_pack (this=0x2aab744e4d68) at /apps/daint/UES/simbergm/tmp/hpx-dla-future-deb
ugging/include/hpx/datastructures/member_pack.hpp:80
#33 0x000000000049ae95 in hpx::util::tuple<blas::Side, blas::Uplo, blas::Op, blas::Diag, float, hpx::lcos::shared_future<dlaf::Tile<float const, (dlaf::Device)0> >, hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> > >::~tuple (this=0x2aab744e4d68) at /apps/daint/UES/simbergm/tmp/hpx-dla-future-debugging/include/hpx/datastructures/tuple.hpp:226
#34 0x00000000004a2365 in hpx::util::detail::member_leaf<0ul, hpx::util::tuple<blas::Side, blas::Uplo, blas::Op, blas::Diag, float, hpx::lcos::shared_future<dlaf::Tile<float const, (dlaf::Device)0> >, hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> > >, false>::~member_leaf (this=0x2aab744e4d68) at /apps/daint/UES/simbergm/tmp/hpx-dla-future-debugging/include/hpx/datastructur
es/member_pack.hpp:22
#35 0x00000000004a2345 in hpx::util::member_pack<hpx::util::pack_c<unsigned long, 0ul>, hpx::util::tuple<blas::Side, blas::Uplo, blas::Op, blas::Diag, float, hpx::lcos::shared_future<dlaf::Tile<float const, (dlaf::Device)0> >, hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> > > >::~member_pack (this=0x2aab744e4d68) at /apps/daint/UES/simbergm/tmp/hpx-dla-future-debugging/include/hpx/datastructures/member_pack.hpp:80
#36 0x000000000049f775 in hpx::util::detail::deferred<hpx::lcos::detail::dataflow_finalization<hpx::lcos::detail::dataflow_frame<hpx::parallel::execution::parallel_policy_executor<hpx::launch>, hpx::util::detail::functional_unwrap_impl<void (*)(blas::Side, blas::Uplo, blas::Op, blas::Diag, float, dlaf::Tile<float const, (dlaf::Device)0> const&, dlaf::Tile<float, (dlaf::Device)0> c
onst&), 1ul>, hpx::util::tuple<blas::Side, blas::Uplo, blas::Op, blas::Diag, float, hpx::lcos::shared_future<dlaf::Tile<float const, (dlaf::Device)0> >, hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> > > > >, hpx::util::pack_c<unsigned long, 0ul>, hpx::util::tuple<blas::Side, blas::Uplo, blas::Op, blas::Diag, float, hpx::lcos::shared_future<dlaf::Tile<float const, (dlaf::Dev
ice)0> >, hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> > > >::~deferred (this=0x2aab744e4d60) at /apps/daint/UES/simbergm/tmp/hpx-dla-future-debugging/include/hpx/functional/deferred_call.hpp:85
#37 0x000000000049f875 in hpx::threads::detail::thread_function_nullary<hpx::util::detail::deferred<hpx::lcos::detail::dataflow_finalization<hpx::lcos::detail::dataflow_frame<hpx::parallel::execution::parallel_policy_executor<hpx::launch>, hpx::util::detail::functional_unwrap_impl<void (*)(blas::Side, blas::Uplo, blas::Op, blas::Diag, float, dlaf::Tile<float const, (dlaf::Device)0
> const&, dlaf::Tile<float, (dlaf::Device)0> const&), 1ul>, hpx::util::tuple<blas::Side, blas::Uplo, blas::Op, blas::Diag, float, hpx::lcos::shared_future<dlaf::Tile<float const, (dlaf::Device)0> >, hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> > > > >, hpx::util::pack_c<unsigned long, 0ul>, hpx::util::tuple<blas::Side, blas::Uplo, blas::Op, blas::Diag, float, hpx::lcos::sh
ared_future<dlaf::Tile<float const, (dlaf::Device)0> >, hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> > > > >::~thread_function_nullary (this=0x2aab744e4d60) at /apps/daint/UES/simbergm/tmp/hpx-dla-future-debugging/include/hpx/threading_base/register_thread.hpp:70
#38 0x000000000049fbe2 in hpx::util::detail::vtable::_deallocate<hpx::threads::detail::thread_function_nullary<hpx::util::detail::deferred<hpx::lcos::detail::dataflow_finalization<hpx::lcos::detail::dataflow_frame<hpx::parallel::execution::parallel_policy_executor<hpx::launch>, hpx::util::detail::functional_unwrap_impl<void (*)(blas::Side, blas::Uplo, blas::Op, blas::Diag, float,
dlaf::Tile<float const, (dlaf::Device)0> const&, dlaf::Tile<float, (dlaf::Device)0> const&), 1ul>, hpx::util::tuple<blas::Side, blas::Uplo, blas::Op, blas::Diag, float, hpx::lcos::shared_future<dlaf::Tile<float const, (dlaf::Device)0> >, hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> > > > >, hpx::util::pack_c<unsigned long, 0ul>, hpx::util::tuple<blas::Side, blas::Uplo, bla
s::Op, blas::Diag, float, hpx::lcos::shared_future<dlaf::Tile<float const, (dlaf::Device)0> >, hpx::lcos::future<dlaf::Tile<float, (dlaf::Device)0> > > > > > (obj=0x2aab744e4d60, storage_size=24, destroy=true) at /apps/daint/UES/simbergm/tmp/hpx-dla-future-debugging/include/hpx/functional/detail/vtable/vtable.hpp:78
#39 0x00002aaaac727309 in hpx::util::detail::function_base::destroy (this=0x2aab8c4d8f30) at ../../libs/functional/src/basic_function.cpp:102
#40 0x00002aaaac727600 in hpx::util::detail::function_base::reset (this=0x2aab8c4d8f30, empty_vptr=0x668fa8 <hpx::util::detail::vtables<hpx::util::detail::function_vtable<std::pair<hpx::threads::thread_state_enum, hpx::threads::thread_id> (hpx::threads::thread_state_ex_enum), true>, hpx::util::detail::empty_function>::instance>) at ../../libs/functional/src/basic_function.cpp:109
#41 0x00002aaaac70f275 in hpx::util::detail::basic_function<std::pair<hpx::threads::thread_state_enum, hpx::threads::thread_id> (hpx::threads::thread_state_ex_enum), false, false>::reset() (this=0x2aab8c4d8f30) at ../../libs/functional/include/hpx/functional/detail/basic_function.hpp:190
#42 0x00002aaaac70e6ba in hpx::threads::coroutines::detail::coroutine_impl::reset (this=0x2aab8c4d8e10) at ../../libs/coroutines/include/hpx/coroutines/detail/coroutine_impl.hpp:128
#43 0x00002aaaac70dd83 in hpx::threads::coroutines::detail::coroutine_impl::operator() (this=0x2aab8c4d8e10) at ../../libs/coroutines/src/detail/coroutine_impl.cpp:95
#44 0x00002aaaac70d545 in hpx::threads::coroutines::detail::lx::trampoline<hpx::threads::coroutines::detail::coroutine_impl> (fun=0x2aab8c4d8e10) at ../../libs/coroutines/include/hpx/coroutines/detail/context_linux_x86.hpp:92
#45 0x0000000000000000 in ?? ()
```

Flyby: fix a compatibility header.