### PR TITLE
Remove `using util::result_of` from namespace hpx

### DIFF
--- a/libs/functional/include/hpx/type_traits.hpp
+++ b/libs/functional/include/hpx/type_traits.hpp
@@ -12,5 +12,4 @@
 
 namespace hpx {
     using hpx::util::invoke_result;
-    using hpx::util::result_of;
 }    // namespace hpx


### PR DESCRIPTION
Fixes a ton of warnings for MSVC. 

This shouldn't be imported as an API into namespace hpx to begin with as it is deprecated anyways.