### PR TITLE
Adding CPOs for hpx::reduce

### DIFF
--- a/libs/algorithms/CMakeLists.txt
+++ b/libs/algorithms/CMakeLists.txt
@@ -91,6 +91,7 @@ set(algorithms_headers
     hpx/parallel/container_algorithms/minmax.hpp
     hpx/parallel/container_algorithms/move.hpp
     hpx/parallel/container_algorithms/partition.hpp
+    hpx/parallel/container_algorithms/reduce.hpp
     hpx/parallel/container_algorithms/remove_copy.hpp
     hpx/parallel/container_algorithms/remove.hpp
     hpx/parallel/container_algorithms/replace.hpp
@@ -101,6 +102,7 @@ set(algorithms_headers
     hpx/parallel/container_algorithms/stable_sort.hpp
     hpx/parallel/container_algorithms/transform.hpp
     hpx/parallel/container_algorithms/unique.hpp
+    hpx/parallel/container_numeric.hpp
     hpx/parallel/datapar.hpp
     hpx/parallel/datapar/iterator_helpers.hpp
     hpx/parallel/datapar/loop.hpp

--- a/libs/algorithms/include/hpx/numeric.hpp
+++ b/libs/algorithms/include/hpx/numeric.hpp
@@ -6,20 +6,13 @@
 
 #pragma once
 
-#include <hpx/parallel/algorithms/adjacent_difference.hpp>
-#include <hpx/parallel/algorithms/exclusive_scan.hpp>
-#include <hpx/parallel/algorithms/inclusive_scan.hpp>
-#include <hpx/parallel/algorithms/reduce.hpp>
-#include <hpx/parallel/algorithms/transform_exclusive_scan.hpp>
-#include <hpx/parallel/algorithms/transform_inclusive_scan.hpp>
-#include <hpx/parallel/algorithms/transform_reduce.hpp>
-#include <hpx/parallel/algorithms/transform_reduce_binary.hpp>
+#include <hpx/parallel/numeric.hpp>
+#include <hpx/parallel/container_numeric.hpp>
 
 namespace hpx {
     using hpx::parallel::adjacent_difference;
     using hpx::parallel::exclusive_scan;
     using hpx::parallel::inclusive_scan;
-    using hpx::parallel::reduce;
     using hpx::parallel::transform_exclusive_scan;
     using hpx::parallel::transform_inclusive_scan;
     using hpx::parallel::transform_reduce;

--- a/libs/algorithms/include/hpx/numeric.hpp
+++ b/libs/algorithms/include/hpx/numeric.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/parallel/numeric.hpp>
+
 #include <hpx/parallel/container_numeric.hpp>
 
 namespace hpx {

--- a/libs/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -10,47 +10,6 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/assert.hpp>
-#include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_invoke.hpp>
-#include <hpx/iterator_support/traits/is_iterator.hpp>
-
-#include <hpx/algorithms/traits/projected.hpp>
-#include <hpx/execution/algorithms/detail/is_negative.hpp>
-#include <hpx/execution/algorithms/detail/predicates.hpp>
-#include <hpx/executors/execution_policy.hpp>
-#include <hpx/parallel/algorithms/detail/dispatch.hpp>
-#include <hpx/parallel/algorithms/detail/distance.hpp>
-#include <hpx/parallel/algorithms/detail/transfer.hpp>
-#include <hpx/parallel/tagspec.hpp>
-#include <hpx/parallel/util/detail/algorithm_result.hpp>
-#include <hpx/parallel/util/foreach_partitioner.hpp>
-#include <hpx/parallel/util/loop.hpp>
-#include <hpx/parallel/util/projection_identity.hpp>
-#include <hpx/parallel/util/result_types.hpp>
-#include <hpx/parallel/util/scan_partitioner.hpp>
-#include <hpx/parallel/util/tagged_pair.hpp>
-#include <hpx/parallel/util/transfer.hpp>
-#include <hpx/parallel/util/zip_iterator.hpp>
-#include <hpx/type_support/unused.hpp>
-
-#if !defined(HPX_HAVE_CXX17_SHARED_PTR_ARRAY)
-#include <boost/shared_array.hpp>
-#endif
-
-#include <algorithm>
-#include <cstddef>
-#include <cstring>
-#include <iterator>
-#include <memory>
-#include <type_traits>
-#include <utility>
-#include <vector>
-
-#include <boost/shared_array.hpp>
-
 #if defined(DOXYGEN)
 namespace hpx {
     // clang-format off
@@ -239,6 +198,45 @@ namespace hpx {
 }    // namespace hpx
 
 #else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/assert.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+
+#include <hpx/algorithms/traits/projected.hpp>
+#include <hpx/execution/algorithms/detail/is_negative.hpp>
+#include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/algorithms/detail/distance.hpp>
+#include <hpx/parallel/algorithms/detail/transfer.hpp>
+#include <hpx/parallel/tagspec.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/foreach_partitioner.hpp>
+#include <hpx/parallel/util/loop.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+#include <hpx/parallel/util/scan_partitioner.hpp>
+#include <hpx/parallel/util/tagged_pair.hpp>
+#include <hpx/parallel/util/transfer.hpp>
+#include <hpx/parallel/util/zip_iterator.hpp>
+#include <hpx/type_support/unused.hpp>
+
+#if !defined(HPX_HAVE_CXX17_SHARED_PTR_ARRAY)
+#include <boost/shared_array.hpp>
+#endif
+
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+#include <iterator>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 namespace hpx { namespace parallel { inline namespace v1 {
 

--- a/libs/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -309,8 +309,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         // Forward Declaration of Segmented Reduce
         template <typename ExPolicy, typename FwdIterB, typename FwdIterE,
             typename T, typename F>
-        typename util::detail::algorithm_result<ExPolicy, T>::type
-        reduce_(ExPolicy&& policy, FwdIterB first, FwdIterE last, T init, F&& f,
+        typename util::detail::algorithm_result<ExPolicy, T>::type reduce_(
+            ExPolicy&& policy, FwdIterB first, FwdIterE last, T init, F&& f,
             std::true_type);
     }    // namespace detail
 

--- a/libs/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -377,7 +377,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
-    // CPO for hpx::copy_n
+    // CPO for hpx::reduce
     HPX_INLINE_CONSTEXPR_VARIABLE struct reduce_t final
       : hpx::functional::tag<reduce_t>
     {

--- a/libs/algorithms/include/hpx/parallel/container_algorithms.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms.hpp
@@ -21,6 +21,7 @@
 #include <hpx/parallel/container_algorithms/minmax.hpp>
 #include <hpx/parallel/container_algorithms/move.hpp>
 #include <hpx/parallel/container_algorithms/partition.hpp>
+#include <hpx/parallel/container_algorithms/reduce.hpp>
 #include <hpx/parallel/container_algorithms/remove.hpp>
 #include <hpx/parallel/container_algorithms/remove_copy.hpp>
 #include <hpx/parallel/container_algorithms/replace.hpp>

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/copy.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/copy.hpp
@@ -8,23 +8,6 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_invoke.hpp>
-#include <hpx/iterator_support/range.hpp>
-#include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/iterator_support/traits/is_range.hpp>
-
-#include <hpx/algorithms/traits/projected.hpp>
-#include <hpx/algorithms/traits/projected_range.hpp>
-#include <hpx/executors/execution_policy.hpp>
-#include <hpx/parallel/algorithms/copy.hpp>
-#include <hpx/parallel/util/result_types.hpp>
-
-#include <cstddef>
-#include <type_traits>
-#include <utility>
-
 #if defined(DOXYGEN)
 
 namespace hpx { namespace ranges {
@@ -363,6 +346,23 @@ namespace hpx { namespace ranges {
 }}    // namespace hpx::ranges
 
 #else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/iterator_support/traits/is_range.hpp>
+
+#include <hpx/algorithms/traits/projected.hpp>
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/algorithms/copy.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
 
 namespace hpx { namespace ranges {
 

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/reduce.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/reduce.hpp
@@ -1,16 +1,16 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file parallel/algorithms/reduce.hpp
+/// \file parallel/container_algorithms/reduce.hpp
 
 #pragma once
 
 #if defined(DOXYGEN)
 
-namespace hpx {
+namespace hpx { namespace ranges {
 
     // clang-format off
 
@@ -23,8 +23,10 @@ namespace hpx {
     ///                     It describes the manner in which the execution
     ///                     of the algorithm may be parallelized and the manner
     ///                     in which it executes the assignments.
-    /// \tparam FwdIter     The type of the source begin and end iterators used
-    ///                     (deduced).
+    /// \tparam FwdIter     The type of the source begin iterator used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel used (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
     /// \tparam F           The type of the function/function object to use
@@ -50,7 +52,7 @@ namespace hpx {
     ///                     \endcode \n
     ///                     The signature does not need to have const&.
     ///                     The types \a Type1 \a Ret must be
-    ///                     such that an object of type \a FwdIter can be
+    ///                     such that an object of type \a FwdIterB can be
     ///                     dereferenced and then implicitly converted to any
     ///                     of those types.
     /// \param init         The initial value for the generalized sum.
@@ -85,9 +87,10 @@ namespace hpx {
     /// that the behavior of reduce may be non-deterministic for
     /// non-associative or non-commutative binary predicate.
     ///
-    template <typename ExPolicy, typename FwdIter, typename T, typename F>
-    typename util::detail::algorithm_result<ExPolicy, T>::type
-    reduce(ExPolicy&& policy, FwdIter first, FwdIter last, T init, F&& f);
+    template <typename ExPolicy, typename FwdIter, typename Sent, typename T,
+        typename F>
+    typename util::detail::algorithm_result<ExPolicy, T>::type reduce(
+        ExPolicy&& policy, FwdIter first, Sent last, T init, F&& f);
 
     /// Returns GENERALIZED_SUM(+, init, *first, ..., *(first + (last - first) - 1)).
     ///
@@ -98,8 +101,10 @@ namespace hpx {
     ///                     It describes the manner in which the execution
     ///                     of the algorithm may be parallelized and the manner
     ///                     in which it executes the assignments.
-    /// \tparam FwdIter     The type of the source begin and end iterators used
-    ///                     (deduced).
+    /// \tparam FwdIter     The type of the source begin iterator used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel used (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
     /// \tparam T           The type of the value to be used as initial (and
@@ -143,9 +148,9 @@ namespace hpx {
     /// that the behavior of reduce may be non-deterministic for
     /// non-associative or non-commutative binary predicate.
     ///
-    template <typename ExPolicy, typename FwdIter, typename T>
-    typename util::detail::algorithm_result<ExPolicy, T>::type
-    reduce(ExPolicy&& policy, FwdIter first, FwdIter last, T init);
+    template <typename ExPolicy, typename FwdIter, typename Sent, typename T>
+    typename util::detail::algorithm_result<ExPolicy, T>::type reduce(
+        ExPolicy&& policy, FwdIter first, Sent last, T init);
 
     /// Returns GENERALIZED_SUM(+, T(), *first, ..., *(first + (last - first) - 1)).
     ///
@@ -156,8 +161,10 @@ namespace hpx {
     ///                     It describes the manner in which the execution
     ///                     of the algorithm may be parallelized and the manner
     ///                     in which it executes the assignments.
-    /// \tparam FwdIter     The type of the source begin and end iterators used
-    ///                     (deduced).
+    /// \tparam FwdIter     The type of the source begin iterator used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the source sentinel used (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     forward iterator.
     ///
@@ -183,13 +190,13 @@ namespace hpx {
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
     ///           returns T otherwise (where T is the value_type of
-    ///           \a FwdIter).
+    ///           \a FwdIterB).
     ///           The \a reduce algorithm returns the result of the
     ///           generalized sum (applying operator+()) over the elements given
     ///           by the input range [first, last).
     ///
     /// \note   The type of the initial value (and the result type) \a T is
-    ///         determined from the value_type of the used \a FwdIter.
+    ///         determined from the value_type of the used \a FwdIterB.
     ///
     /// \note   GENERALIZED_SUM(+, a1, ..., aN) is defined as follows:
     ///         * a1 when N is 1
@@ -202,14 +209,15 @@ namespace hpx {
     /// that the behavior of reduce may be non-deterministic for
     /// non-associative or non-commutative binary predicate.
     ///
-    template <typename ExPolicy, typename FwdIter>
+    // clang-format off
+    template <typename ExPolicy, typename FwdIter, typename Sent>
+    // clang-format on
     typename util::detail::algorithm_result<ExPolicy,
-        typename std::iterator_traits<FwdIter>::value_type
-    >::type
-    reduce(ExPolicy&& policy, FwdIter first, FwdIter last);
+        typename std::iterator_traits<FwdIter>::value_type>::type
+    reduce(ExPolicy&& policy, FwdIter first, Sent last);
 
     // clang-format on
-}    // namespace hpx
+}}    // namespace hpx::ranges
 
 #else    // DOXYGEN
 
@@ -217,16 +225,12 @@ namespace hpx {
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/tag_invoke.hpp>
 #include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/iterator_support/traits/is_range.hpp>
 #include <hpx/iterator_support/traits/is_sentinel_for.hpp>
-#include <hpx/pack_traversal/unwrap.hpp>
 
 #include <hpx/executors/execution_policy.hpp>
-#include <hpx/parallel/algorithms/detail/accumulate.hpp>
-#include <hpx/parallel/algorithms/detail/dispatch.hpp>
-#include <hpx/parallel/algorithms/detail/distance.hpp>
-#include <hpx/parallel/util/detail/algorithm_result.hpp>
-#include <hpx/parallel/util/loop.hpp>
-#include <hpx/parallel/util/partitioner.hpp>
+#include <hpx/parallel/algorithms/reduce.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -236,163 +240,25 @@ namespace hpx {
 #include <utility>
 #include <vector>
 
-namespace hpx { namespace parallel { inline namespace v1 {
-    ///////////////////////////////////////////////////////////////////////////
-    // reduce
-    namespace detail {
-        /// \cond NOINTERNAL
-        template <typename T>
-        struct reduce : public detail::algorithm<reduce<T>, T>
-        {
-            reduce()
-              : reduce::algorithm("reduce")
-            {
-            }
-
-            template <typename ExPolicy, typename InIterB, typename InIterE,
-                typename T_, typename Reduce>
-            static T sequential(
-                ExPolicy, InIterB first, InIterE last, T_&& init, Reduce&& r)
-            {
-                return detail::accumulate(first, last, std::forward<T_>(init),
-                    std::forward<Reduce>(r));
-            }
-
-            template <typename ExPolicy, typename FwdIterB, typename FwdIterE,
-                typename T_, typename Reduce>
-            static typename util::detail::algorithm_result<ExPolicy, T>::type
-            parallel(ExPolicy&& policy, FwdIterB first, FwdIterE last,
-                T_&& init, Reduce&& r)
-            {
-                if (first == last)
-                {
-                    return util::detail::algorithm_result<ExPolicy, T>::get(
-                        std::forward<T_>(init));
-                }
-
-                auto f1 = [r](FwdIterB part_begin, std::size_t part_size) -> T {
-                    T val = *part_begin;
-                    return util::accumulate_n(
-                        ++part_begin, --part_size, std::move(val), r);
-                };
-
-                return util::partitioner<ExPolicy, T>::call(
-                    std::forward<ExPolicy>(policy), first,
-                    detail::distance(first, last), std::move(f1),
-                    hpx::util::unwrapping([init = std::forward<T_>(init),
-                                              r = std::forward<Reduce>(r)](
-                                              std::vector<T>&& results) -> T {
-                        return util::accumulate_n(hpx::util::begin(results),
-                            hpx::util::size(results), init, r);
-                    }));
-            }
-        };
-        /// \endcond
-
-        // Non Segmented Reduce
-        //
-        template <typename ExPolicy, typename FwdIterB, typename FwdIterE,
-            typename T, typename F>
-        typename util::detail::algorithm_result<ExPolicy, T>::type reduce_(
-            ExPolicy&& policy, FwdIterB first, FwdIterE last, T init, F&& f,
-            std::false_type)
-        {
-            static_assert((hpx::traits::is_forward_iterator<FwdIterB>::value),
-                "Requires at least forward iterator.");
-
-            using is_seq = execution::is_sequenced_execution_policy<ExPolicy>;
-
-            return detail::reduce<T>().call(std::forward<ExPolicy>(policy),
-                is_seq(), first, last, std::move(init), std::forward<F>(f));
-        }
-
-        // Forward Declaration of Segmented Reduce
-        template <typename ExPolicy, typename FwdIterB, typename FwdIterE,
-            typename T, typename F>
-        typename util::detail::algorithm_result<ExPolicy, T>::type
-        reduce_(ExPolicy&& policy, FwdIterB first, FwdIterE last, T init, F&& f,
-            std::true_type);
-    }    // namespace detail
-
-    // clang-format off
-    template <typename ExPolicy, typename FwdIterB, typename FwdIterE,
-        typename T, typename F,
-        HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_sentinel_for<FwdIterE, FwdIterB>::value
-        )>
-    // clang-format on
-    HPX_DEPRECATED(
-        "hpx::parallel::reduce is deprecated, use hpx::ranges::reduce instead")
-        typename util::detail::algorithm_result<ExPolicy, T>::type
-        reduce(ExPolicy&& policy, FwdIterB first, FwdIterE last, T init, F&& f)
-    {
-        typedef hpx::traits::is_segmented_iterator<FwdIterB> is_segmented;
-
-        return detail::reduce_(std::forward<ExPolicy>(policy), first, last,
-            std::move(init), std::forward<F>(f), is_segmented{});
-    }
-
-    // clang-format off
-    template <typename ExPolicy, typename FwdIterB, typename FwdIterE,
-        typename T,
-        HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_sentinel_for<FwdIterE, FwdIterB>::value
-        )>
-    // clang-format on
-    HPX_DEPRECATED(
-        "hpx::parallel::reduce is deprecated, use hpx::ranges::reduce instead")
-        typename util::detail::algorithm_result<ExPolicy, T>::type
-        reduce(ExPolicy&& policy, FwdIterB first, FwdIterE last, T init)
-    {
-        typedef hpx::traits::is_segmented_iterator<FwdIterB> is_segmented;
-
-        return detail::reduce_(std::forward<ExPolicy>(policy), first, last,
-            std::move(init), std::plus<T>(), is_segmented{});
-    }
-
-    // clang-format off
-    template <typename ExPolicy, typename FwdIterB, typename FwdIterE,
-        HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_sentinel_for<FwdIterE, FwdIterB>::value
-        )>
-    // clang-format on
-    HPX_DEPRECATED(
-        "hpx::parallel::reduce is deprecated, use hpx::ranges::reduce instead")
-        typename util::detail::algorithm_result<ExPolicy,
-            typename std::iterator_traits<FwdIterB>::value_type>::type
-        reduce(ExPolicy&& policy, FwdIterB first, FwdIterE last)
-    {
-        typedef typename std::iterator_traits<FwdIterB>::value_type value_type;
-
-        typedef hpx::traits::is_segmented_iterator<FwdIterB> is_segmented;
-
-        return detail::reduce_(std::forward<ExPolicy>(policy), first, last,
-            value_type{}, std::plus<value_type>(), is_segmented{});
-    }
-}}}    // namespace hpx::parallel::v1
-
-namespace hpx {
+namespace hpx { namespace ranges {
 
     ///////////////////////////////////////////////////////////////////////////
-    // CPO for hpx::copy_n
+    // CPO for hpx::ranges::reduce
     HPX_INLINE_CONSTEXPR_VARIABLE struct reduce_t final
       : hpx::functional::tag<reduce_t>
     {
-    private:
         // clang-format off
-        template <typename ExPolicy, typename FwdIter, typename T, typename F,
+        template <typename ExPolicy, typename FwdIter, typename Sent,
+            typename T, typename F,
             HPX_CONCEPT_REQUIRES_(
                 hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter>::value
+                hpx::traits::is_sentinel_for<Sent, FwdIter>::value
             )>
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             T>::type
-        tag_invoke(hpx::reduce_t, ExPolicy&& policy, FwdIter first,
-            FwdIter last, T init, F&& f)
+        tag_invoke(hpx::ranges::reduce_t, ExPolicy&& policy, FwdIter first,
+            Sent last, T init, F&& f)
         {
             using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
 
@@ -402,16 +268,38 @@ namespace hpx {
         }
 
         // clang-format off
-        template <typename ExPolicy, typename FwdIter, typename T,
+        template <typename ExPolicy, typename Rng, typename T, typename F,
             HPX_CONCEPT_REQUIRES_(
                 hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter>::value
+                hpx::traits::is_range<Rng>::value
             )>
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             T>::type
-        tag_invoke(hpx::reduce_t, ExPolicy&& policy, FwdIter first,
-            FwdIter last, T init)
+        tag_invoke(
+            hpx::ranges::reduce_t, ExPolicy&& policy, Rng&& rng, T init, F&& f)
+        {
+            using is_segmented = hpx::traits::is_segmented_iterator<
+                typename hpx::traits::range_traits<Rng>::iterator_type>;
+
+            return hpx::parallel::v1::detail::reduce_(
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                hpx::util::end(rng), std::move(init), std::forward<F>(f),
+                is_segmented{});
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter, typename Sent,
+            typename T,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_sentinel_for<Sent, FwdIter>::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            T>::type
+        tag_invoke(hpx::ranges::reduce_t, ExPolicy&& policy, FwdIter first,
+            Sent last, T init)
         {
             using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
 
@@ -421,16 +309,36 @@ namespace hpx {
         }
 
         // clang-format off
-        template <typename ExPolicy, typename FwdIter,
+        template <typename ExPolicy, typename Rng, typename T,
             HPX_CONCEPT_REQUIRES_(
                 hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter>::value
+                hpx::traits::is_range<Rng>::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            T>::type
+        tag_invoke(hpx::ranges::reduce_t, ExPolicy&& policy, Rng&& rng, T init)
+        {
+            using is_segmented = hpx::traits::is_segmented_iterator<
+                typename hpx::traits::range_traits<Rng>::iterator_type>;
+
+            return hpx::parallel::v1::detail::reduce_(
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                hpx::util::end(rng), std::move(init), std::plus<T>{},
+                is_segmented{});
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter, typename Sent,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_sentinel_for<Sent, FwdIter>::value
             )>
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             typename std::iterator_traits<FwdIter>::value_type>::type
         tag_invoke(
-            hpx::reduce_t, ExPolicy&& policy, FwdIter first, FwdIter last)
+            hpx::ranges::reduce_t, ExPolicy&& policy, FwdIter first, Sent last)
         {
             using value_type =
                 typename std::iterator_traits<FwdIter>::value_type;
@@ -443,13 +351,39 @@ namespace hpx {
         }
 
         // clang-format off
-        template <typename FwdIter, typename T, typename F,
+        template <typename ExPolicy, typename Rng,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<FwdIter>::value
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            typename std::iterator_traits<typename hpx::traits::range_traits<
+                Rng>::iterator_type>::value_type>::type
+        tag_invoke(hpx::ranges::reduce_t, ExPolicy&& policy, Rng&& rng)
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+            using value_type =
+                typename std::iterator_traits<iterator_type>::value_type;
+            using is_segmented =
+                hpx::traits::is_segmented_iterator<iterator_type>;
+
+            return hpx::parallel::v1::detail::reduce_(
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                hpx::util::end(rng), value_type{}, std::plus<value_type>{},
+                is_segmented{});
+        }
+
+        ////////////////////////////////////////////////////////////////////////
+        // clang-format off
+        template <typename FwdIter, typename Sent, typename T, typename F,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_sentinel_for<Sent, FwdIter>::value
             )>
         // clang-format on
         friend T tag_invoke(
-            hpx::reduce_t, FwdIter first, FwdIter last, T init, F&& f)
+            hpx::ranges::reduce_t, FwdIter first, Sent last, T init, F&& f)
         {
             using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
 
@@ -459,12 +393,31 @@ namespace hpx {
         }
 
         // clang-format off
-        template <typename FwdIter, typename T,
+        template <typename Rng, typename T, typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<FwdIter>::value
+                hpx::traits::is_range<Rng>::value
             )>
         // clang-format on
-        friend T tag_invoke(hpx::reduce_t, FwdIter first, FwdIter last, T init)
+        friend T tag_invoke(hpx::ranges::reduce_t, Rng&& rng, T init, F&& f)
+        {
+            using is_segmented = hpx::traits::is_segmented_iterator<
+                typename hpx::traits::range_traits<Rng>::iterator_type>;
+
+            return hpx::parallel::v1::detail::reduce_(
+                hpx::parallel::execution::seq, hpx::util::begin(rng),
+                hpx::util::end(rng), std::move(init), std::forward<F>(f),
+                is_segmented{});
+        }
+
+        // clang-format off
+        template <typename FwdIter, typename Sent,
+            typename T,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_sentinel_for<Sent, FwdIter>::value
+            )>
+        // clang-format on
+        friend T tag_invoke(
+            hpx::ranges::reduce_t, FwdIter first, Sent last, T init)
         {
             using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
 
@@ -474,13 +427,30 @@ namespace hpx {
         }
 
         // clang-format off
-        template <typename FwdIter,
+        template <typename Rng, typename T,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<FwdIter>::value
+                hpx::traits::is_range<Rng>::value
+            )>
+        // clang-format on
+        friend T tag_invoke(hpx::ranges::reduce_t, Rng&& rng, T init)
+        {
+            using is_segmented = hpx::traits::is_segmented_iterator<
+                typename hpx::traits::range_traits<Rng>::iterator_type>;
+
+            return hpx::parallel::v1::detail::reduce_(
+                hpx::parallel::execution::seq, hpx::util::begin(rng),
+                hpx::util::end(rng), std::move(init), std::plus<T>{},
+                is_segmented{});
+        }
+
+        // clang-format off
+        template <typename FwdIter, typename Sent,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_sentinel_for<Sent, FwdIter>::value
             )>
         // clang-format on
         friend typename std::iterator_traits<FwdIter>::value_type tag_invoke(
-            hpx::reduce_t, FwdIter first, FwdIter last)
+            hpx::ranges::reduce_t, FwdIter first, Sent last)
         {
             using value_type =
                 typename std::iterator_traits<FwdIter>::value_type;
@@ -489,9 +459,32 @@ namespace hpx {
 
             return hpx::parallel::v1::detail::reduce_(
                 hpx::parallel::execution::seq, first, last, value_type{},
-                std::plus<value_type>(), is_segmented{});
+                std::plus<value_type>{}, is_segmented{});
+        }
+
+        // clang-format off
+        template <typename Rng,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value
+            )>
+        // clang-format on
+        friend typename std::iterator_traits<
+            typename hpx::traits::range_traits<Rng>::iterator_type>::value_type
+        tag_invoke(hpx::ranges::reduce_t, Rng&& rng)
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+            using value_type =
+                typename std::iterator_traits<iterator_type>::value_type;
+            using is_segmented =
+                hpx::traits::is_segmented_iterator<iterator_type>;
+
+            return hpx::parallel::v1::detail::reduce_(
+                hpx::parallel::execution::seq, hpx::util::begin(rng),
+                hpx::util::end(rng), value_type{}, std::plus<value_type>{},
+                is_segmented{});
         }
     } reduce{};
-}    // namespace hpx
+}}    // namespace hpx::ranges
 
 #endif    // DOXYGEN

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/reduce.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/reduce.hpp
@@ -209,12 +209,197 @@ namespace hpx { namespace ranges {
     /// that the behavior of reduce may be non-deterministic for
     /// non-associative or non-commutative binary predicate.
     ///
-    // clang-format off
     template <typename ExPolicy, typename FwdIter, typename Sent>
-    // clang-format on
     typename util::detail::algorithm_result<ExPolicy,
         typename std::iterator_traits<FwdIter>::value_type>::type
     reduce(ExPolicy&& policy, FwdIter first, Sent last);
+
+    /// Returns GENERALIZED_SUM(f, init, *first, ..., *(first + (last - first) - 1)).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         predicate \a f.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a copy_if requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last). This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&.
+    ///                     The types \a Type1 \a Ret must be
+    ///                     such that an object of type \a FwdIterB can be
+    ///                     dereferenced and then implicitly converted to any
+    ///                     of those types.
+    /// \param init         The initial value for the generalized sum.
+    ///
+    /// The reduce operations in the parallel \a reduce algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a copy_if algorithm invoked
+    /// with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a reduce algorithm returns a \a hpx::future<T> if the
+    ///           execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a T otherwise.
+    ///           The \a reduce algorithm returns the result of the
+    ///           generalized sum over the elements given by the input range
+    ///           [first, last).
+    ///
+    /// \note   GENERALIZED_SUM(op, a1, ..., aN) is defined as follows:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_SUM(op, b1, ..., bK), GENERALIZED_SUM(op, bM, ..., bN)),
+    ///           where:
+    ///           * b1, ..., bN may be any permutation of a1, ..., aN and
+    ///           * 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a reduce and \a accumulate is
+    /// that the behavior of reduce may be non-deterministic for
+    /// non-associative or non-commutative binary predicate.
+    ///
+    template <typename ExPolicy, typename Rng, typename T, typename F>
+    typename util::detail::algorithm_result<ExPolicy, T>::type
+    reduce(ExPolicy&& policy, Rng&& rng, T init, F&& f);
+
+    /// Returns GENERALIZED_SUM(+, init, *first, ..., *(first + (last - first) - 1)).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         operator+().
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam T           The type of the value to be used as initial (and
+    ///                     intermediate) values (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param init         The initial value for the generalized sum.
+    ///
+    /// The reduce operations in the parallel \a reduce algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a copy_if algorithm invoked
+    /// with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a reduce algorithm returns a \a hpx::future<T> if the
+    ///           execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a T otherwise.
+    ///           The \a reduce algorithm returns the result of the
+    ///           generalized sum (applying operator+()) over the elements given
+    ///           by the input range [first, last).
+    ///
+    /// \note   GENERALIZED_SUM(+, a1, ..., aN) is defined as follows:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_SUM(+, b1, ..., bK), GENERALIZED_SUM(+, bM, ..., bN)),
+    ///           where:
+    ///           * b1, ..., bN may be any permutation of a1, ..., aN and
+    ///           * 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a reduce and \a accumulate is
+    /// that the behavior of reduce may be non-deterministic for
+    /// non-associative or non-commutative binary predicate.
+    ///
+    template <typename ExPolicy, typename Rng, typename T>
+    typename util::detail::algorithm_result<ExPolicy, T>::type
+    reduce(ExPolicy&& policy, Rng&& rng, T init);
+
+    /// Returns GENERALIZED_SUM(+, T(), *first, ..., *(first + (last - first) - 1)).
+    ///
+    /// \note   Complexity: O(\a last - \a first) applications of the
+    ///         operator+().
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    ///
+    /// The reduce operations in the parallel \a reduce algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The reduce operations in the parallel \a copy_if algorithm invoked
+    /// with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a reduce algorithm returns a \a hpx::future<T> if the
+    ///           execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns T otherwise (where T is the value_type of
+    ///           \a FwdIterB).
+    ///           The \a reduce algorithm returns the result of the
+    ///           generalized sum (applying operator+()) over the elements given
+    ///           by the input range [first, last).
+    ///
+    /// \note   The type of the initial value (and the result type) \a T is
+    ///         determined from the value_type of the used \a FwdIterB.
+    ///
+    /// \note   GENERALIZED_SUM(+, a1, ..., aN) is defined as follows:
+    ///         * a1 when N is 1
+    ///         * op(GENERALIZED_SUM(+, b1, ..., bK), GENERALIZED_SUM(+, bM, ..., bN)),
+    ///           where:
+    ///           * b1, ..., bN may be any permutation of a1, ..., aN and
+    ///           * 1 < K+1 = M <= N.
+    ///
+    /// The difference between \a reduce and \a accumulate is
+    /// that the behavior of reduce may be non-deterministic for
+    /// non-associative or non-commutative binary predicate.
+    ///
+    template <typename ExPolicy, typename Rng>
+    typename util::detail::algorithm_result<ExPolicy,
+        typename std::iterator_traits<
+            typename hpx::traits::range_traits<Rng>::iterator_type
+        >::value_type
+    >::type
+    reduce(ExPolicy&& policy, Rng&& rng);
 
     // clang-format on
 }}    // namespace hpx::ranges

--- a/libs/algorithms/include/hpx/parallel/container_numeric.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_numeric.hpp
@@ -1,0 +1,12 @@
+//  Copyright (c) 2015-2020 Hartmut Kaiser
+//  Copyright (c)      2017 Taeguk Kwon
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/parallel/numeric.hpp>
+
+#include <hpx/parallel/container_algorithms/reduce.hpp>

--- a/libs/algorithms/tests/performance/transform_reduce_scaling.cpp
+++ b/libs/algorithms/tests/performance/transform_reduce_scaling.cpp
@@ -7,9 +7,9 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 
+#include <hpx/chrono.hpp>
 #include <hpx/distributed/iostream.hpp>
 #include <hpx/numeric.hpp>
-#include <hpx/chrono.hpp>
 #include "worker_timed.hpp"
 
 #include <cstddef>

--- a/libs/algorithms/tests/performance/transform_reduce_scaling.cpp
+++ b/libs/algorithms/tests/performance/transform_reduce_scaling.cpp
@@ -49,7 +49,7 @@ void measure_transform_reduce_old(std::size_t size)
         size, Point{double(gen()), double(gen())});
 
     //invoke old reduce
-    Point result = hpx::parallel::reduce(hpx::parallel::execution::par,
+    Point result = hpx::ranges::reduce(hpx::parallel::execution::par,
         std::begin(data_representation), std::end(data_representation),
         Point{0.0, 0.0}, [](Point res, Point curr) {
             return Point{res.x * res.y + curr.x * curr.y, 1.0};

--- a/libs/algorithms/tests/performance/transform_reduce_scaling.cpp
+++ b/libs/algorithms/tests/performance/transform_reduce_scaling.cpp
@@ -8,8 +8,8 @@
 #include <hpx/hpx_init.hpp>
 
 #include <hpx/distributed/iostream.hpp>
-#include <hpx/include/parallel_numeric.hpp>
-#include <hpx/timing/high_resolution_clock.hpp>
+#include <hpx/numeric.hpp>
+#include <hpx/chrono.hpp>
 #include "worker_timed.hpp"
 
 #include <cstddef>

--- a/libs/algorithms/tests/regressions/reduce_3641.cpp
+++ b/libs/algorithms/tests/regressions/reduce_3641.cpp
@@ -19,12 +19,12 @@
 
 int main()
 {
-    std::int64_t result = hpx::parallel::reduce(hpx::parallel::execution::seq,
+    std::int64_t result = hpx::ranges::reduce(hpx::parallel::execution::seq,
         Iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, std::int64_t(0));
 
     HPX_TEST_EQ(result, std::int64_t(4950));
 
-    result = hpx::parallel::reduce(hpx::parallel::execution::par,
+    result = hpx::ranges::reduce(hpx::parallel::execution::par,
         Iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, std::int64_t(0));
 
     HPX_TEST_EQ(result, std::int64_t(4950));

--- a/libs/algorithms/tests/unit/algorithms/reduce_.cpp
+++ b/libs/algorithms/tests/unit/algorithms/reduce_.cpp
@@ -59,8 +59,8 @@ void test_reduce1_async(ExPolicy p, IteratorTag)
     std::size_t val(42);
     auto op = [val](std::size_t v1, std::size_t v2) { return v1 + v2 + val; };
 
-    hpx::future<std::size_t> f = hpx::reduce(
-        p, iterator(std::begin(c)), iterator(std::end(c)), val, op);
+    hpx::future<std::size_t> f =
+        hpx::reduce(p, iterator(std::begin(c)), iterator(std::end(c)), val, op);
     f.wait();
 
     // verify values
@@ -120,8 +120,8 @@ void test_reduce2_async(ExPolicy p, IteratorTag)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t const val(42);
-    hpx::future<std::size_t> f = hpx::reduce(
-        p, iterator(std::begin(c)), iterator(std::end(c)), val);
+    hpx::future<std::size_t> f =
+        hpx::reduce(p, iterator(std::begin(c)), iterator(std::end(c)), val);
     f.wait();
 
     // verify values
@@ -162,8 +162,8 @@ void test_reduce3(ExPolicy policy, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    std::size_t r1 = hpx::reduce(
-        policy, iterator(std::begin(c)), iterator(std::end(c)));
+    std::size_t r1 =
+        hpx::reduce(policy, iterator(std::begin(c)), iterator(std::end(c)));
 
     // verify values
     std::size_t r2 =
@@ -180,8 +180,8 @@ void test_reduce3_async(ExPolicy p, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::future<std::size_t> f = hpx::reduce(
-        p, iterator(std::begin(c)), iterator(std::end(c)));
+    hpx::future<std::size_t> f =
+        hpx::reduce(p, iterator(std::begin(c)), iterator(std::end(c)));
     f.wait();
 
     // verify values
@@ -226,9 +226,8 @@ void test_reduce_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::reduce(policy, iterator(std::begin(c)),
-            iterator(std::end(c)), std::size_t(42),
-            [](std::size_t v1, std::size_t v2) {
+        hpx::reduce(policy, iterator(std::begin(c)), iterator(std::end(c)),
+            std::size_t(42), [](std::size_t v1, std::size_t v2) {
                 return throw std::runtime_error("test"), v1 + v2;
             });
 
@@ -260,11 +259,11 @@ void test_reduce_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::reduce(p, iterator(std::begin(c)),
-            iterator(std::end(c)), std::size_t(42),
-            [](std::size_t v1, std::size_t v2) {
-                return throw std::runtime_error("test"), v1 + v2;
-            });
+        hpx::future<void> f =
+            hpx::reduce(p, iterator(std::begin(c)), iterator(std::end(c)),
+                std::size_t(42), [](std::size_t v1, std::size_t v2) {
+                    return throw std::runtime_error("test"), v1 + v2;
+                });
         returned_from_algorithm = true;
         f.get();
 
@@ -322,9 +321,8 @@ void test_reduce_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::reduce(policy, iterator(std::begin(c)),
-            iterator(std::end(c)), std::size_t(42),
-            [](std::size_t v1, std::size_t v2) {
+        hpx::reduce(policy, iterator(std::begin(c)), iterator(std::end(c)),
+            std::size_t(42), [](std::size_t v1, std::size_t v2) {
                 return throw std::bad_alloc(), v1 + v2;
             });
 
@@ -355,11 +353,11 @@ void test_reduce_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::reduce(p, iterator(std::begin(c)),
-            iterator(std::end(c)), std::size_t(42),
-            [](std::size_t v1, std::size_t v2) {
-                return throw std::bad_alloc(), v1 + v2;
-            });
+        hpx::future<void> f =
+            hpx::reduce(p, iterator(std::begin(c)), iterator(std::end(c)),
+                std::size_t(42), [](std::size_t v1, std::size_t v2) {
+                    return throw std::bad_alloc(), v1 + v2;
+                });
         returned_from_algorithm = true;
         f.get();
 

--- a/libs/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -29,6 +29,7 @@ set(tests
     none_of_range
     partition_range
     partition_copy_range
+    reduce_range
     remove_range
     remove_if_range
     remove_copy_range

--- a/libs/algorithms/tests/unit/container_algorithms/reduce_range.cpp
+++ b/libs/algorithms/tests/unit/container_algorithms/reduce_range.cpp
@@ -39,8 +39,7 @@ void test_reduce1(ExPolicy policy, IteratorTag)
     std::size_t val(42);
     auto op = [val](std::size_t v1, std::size_t v2) { return v1 + v2 + val; };
 
-    std::size_t r1 = hpx::reduce(
-        policy, iterator(std::begin(c)), iterator(std::end(c)), val, op);
+    std::size_t r1 = hpx::ranges::reduce(policy, c, val, op);
 
     // verify values
     std::size_t r2 = std::accumulate(std::begin(c), std::end(c), val, op);
@@ -59,8 +58,7 @@ void test_reduce1_async(ExPolicy p, IteratorTag)
     std::size_t val(42);
     auto op = [val](std::size_t v1, std::size_t v2) { return v1 + v2 + val; };
 
-    hpx::future<std::size_t> f = hpx::reduce(
-        p, iterator(std::begin(c)), iterator(std::end(c)), val, op);
+    hpx::future<std::size_t> f = hpx::ranges::reduce(p, c, val, op);
     f.wait();
 
     // verify values
@@ -102,8 +100,7 @@ void test_reduce2(ExPolicy policy, IteratorTag)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t const val(42);
-    std::size_t r1 = hpx::reduce(
-        policy, iterator(std::begin(c)), iterator(std::end(c)), val);
+    std::size_t r1 = hpx::ranges::reduce(policy, c, val);
 
     // verify values
     std::size_t r2 = std::accumulate(std::begin(c), std::end(c), val);
@@ -120,8 +117,7 @@ void test_reduce2_async(ExPolicy p, IteratorTag)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t const val(42);
-    hpx::future<std::size_t> f = hpx::reduce(
-        p, iterator(std::begin(c)), iterator(std::end(c)), val);
+    hpx::future<std::size_t> f = hpx::ranges::reduce(p, c, val);
     f.wait();
 
     // verify values
@@ -162,8 +158,7 @@ void test_reduce3(ExPolicy policy, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    std::size_t r1 = hpx::reduce(
-        policy, iterator(std::begin(c)), iterator(std::end(c)));
+    std::size_t r1 = hpx::ranges::reduce(policy, c);
 
     // verify values
     std::size_t r2 =
@@ -180,8 +175,7 @@ void test_reduce3_async(ExPolicy p, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::future<std::size_t> f = hpx::reduce(
-        p, iterator(std::begin(c)), iterator(std::end(c)));
+    hpx::future<std::size_t> f = hpx::ranges::reduce(p, c);
     f.wait();
 
     // verify values
@@ -226,9 +220,8 @@ void test_reduce_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::reduce(policy, iterator(std::begin(c)),
-            iterator(std::end(c)), std::size_t(42),
-            [](std::size_t v1, std::size_t v2) {
+        hpx::ranges::reduce(
+            policy, c, std::size_t(42), [](std::size_t v1, std::size_t v2) {
                 return throw std::runtime_error("test"), v1 + v2;
             });
 
@@ -260,9 +253,8 @@ void test_reduce_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::reduce(p, iterator(std::begin(c)),
-            iterator(std::end(c)), std::size_t(42),
-            [](std::size_t v1, std::size_t v2) {
+        hpx::future<void> f = hpx::ranges::reduce(
+            p, c, std::size_t(42), [](std::size_t v1, std::size_t v2) {
                 return throw std::runtime_error("test"), v1 + v2;
             });
         returned_from_algorithm = true;
@@ -322,9 +314,8 @@ void test_reduce_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::reduce(policy, iterator(std::begin(c)),
-            iterator(std::end(c)), std::size_t(42),
-            [](std::size_t v1, std::size_t v2) {
+        hpx::ranges::reduce(
+            policy, c, std::size_t(42), [](std::size_t v1, std::size_t v2) {
                 return throw std::bad_alloc(), v1 + v2;
             });
 
@@ -355,9 +346,8 @@ void test_reduce_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::reduce(p, iterator(std::begin(c)),
-            iterator(std::end(c)), std::size_t(42),
-            [](std::size_t v1, std::size_t v2) {
+        hpx::future<void> f = hpx::ranges::reduce(
+            p, c, std::size_t(42), [](std::size_t v1, std::size_t v2) {
                 return throw std::bad_alloc(), v1 + v2;
             });
         returned_from_algorithm = true;

--- a/libs/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/collectives/include/hpx/collectives/all_reduce.hpp
@@ -158,8 +158,8 @@ namespace hpx { namespace traits {
                 auto& data = communicator.template access_data<arg_type>(l);
 
                 auto it = data.begin();
-                return hpx::reduce(hpx::parallel::execution::par,
-                    ++it, data.end(), *data.begin(), op);
+                return hpx::reduce(hpx::parallel::execution::par, ++it,
+                    data.end(), *data.begin(), op);
             };
 
             lock_type l(communicator_.mtx_);

--- a/libs/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/collectives/include/hpx/collectives/all_reduce.hpp
@@ -158,7 +158,7 @@ namespace hpx { namespace traits {
                 auto& data = communicator.template access_data<arg_type>(l);
 
                 auto it = data.begin();
-                return hpx::parallel::reduce(hpx::parallel::execution::par,
+                return hpx::reduce(hpx::parallel::execution::par,
                     ++it, data.end(), *data.begin(), op);
             };
 

--- a/libs/include/include/hpx/include/parallel_reduce.hpp
+++ b/libs/include/include/hpx/include/parallel_reduce.hpp
@@ -9,6 +9,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/parallel/algorithms/reduce.hpp>
+#include <hpx/parallel/container_algorithms/reduce.hpp>
 #include <hpx/parallel/algorithms/reduce_by_key.hpp>
 
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)

--- a/libs/include/include/hpx/include/parallel_reduce.hpp
+++ b/libs/include/include/hpx/include/parallel_reduce.hpp
@@ -9,8 +9,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/parallel/algorithms/reduce.hpp>
-#include <hpx/parallel/container_algorithms/reduce.hpp>
 #include <hpx/parallel/algorithms/reduce_by_key.hpp>
+#include <hpx/parallel/container_algorithms/reduce.hpp>
 
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 #include <hpx/parallel/segmented_algorithms/reduce.hpp>

--- a/libs/segmented_algorithms/include/hpx/parallel/segmented_algorithms/reduce.hpp
+++ b/libs/segmented_algorithms/include/hpx/parallel/segmented_algorithms/reduce.hpp
@@ -191,9 +191,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         // segmented implementation
         template <typename ExPolicy, typename InIterB, typename InIterE,
             typename T, typename F>
-        inline typename std::enable_if<
-            execution::is_execution_policy<ExPolicy>::value,
-            typename util::detail::algorithm_result<ExPolicy, T>::type>::type
+        typename util::detail::algorithm_result<ExPolicy, T>::type
         reduce_(ExPolicy&& policy, InIterB first, InIterE last, T init, F&& f,
             std::true_type)
         {
@@ -215,9 +213,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         // forward declare the non-segmented version of this algorithm
         template <typename ExPolicy, typename InIterB, typename InIterE,
             typename T, typename F>
-        inline typename std::enable_if<
-            execution::is_execution_policy<ExPolicy>::value,
-            typename util::detail::algorithm_result<ExPolicy, T>::type>::type
+        typename util::detail::algorithm_result<ExPolicy, T>::type
         reduce_(ExPolicy&& policy, InIterB first, InIterE last, T init, F&& f,
             std::false_type);
 

--- a/libs/segmented_algorithms/include/hpx/parallel/segmented_algorithms/reduce.hpp
+++ b/libs/segmented_algorithms/include/hpx/parallel/segmented_algorithms/reduce.hpp
@@ -191,8 +191,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         // segmented implementation
         template <typename ExPolicy, typename InIterB, typename InIterE,
             typename T, typename F>
-        typename util::detail::algorithm_result<ExPolicy, T>::type
-        reduce_(ExPolicy&& policy, InIterB first, InIterE last, T init, F&& f,
+        typename util::detail::algorithm_result<ExPolicy, T>::type reduce_(
+            ExPolicy&& policy, InIterB first, InIterE last, T init, F&& f,
             std::true_type)
         {
             typedef parallel::execution::is_sequenced_execution_policy<ExPolicy>
@@ -213,8 +213,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         // forward declare the non-segmented version of this algorithm
         template <typename ExPolicy, typename InIterB, typename InIterE,
             typename T, typename F>
-        typename util::detail::algorithm_result<ExPolicy, T>::type
-        reduce_(ExPolicy&& policy, InIterB first, InIterE last, T init, F&& f,
+        typename util::detail::algorithm_result<ExPolicy, T>::type reduce_(
+            ExPolicy&& policy, InIterB first, InIterE last, T init, F&& f,
             std::false_type);
 
         /// \endcond

--- a/libs/segmented_algorithms/tests/unit/partitioned_vector_reduce.cpp
+++ b/libs/segmented_algorithms/tests/unit/partitioned_vector_reduce.cpp
@@ -24,7 +24,7 @@
 template <typename ExPolicy, typename T>
 T test_reduce(ExPolicy&& policy, hpx::partitioned_vector<T> const& xvalues)
 {
-    return hpx::parallel::reduce(
+    return hpx::reduce(
         policy, xvalues.begin(), xvalues.end(), T(1), std::plus<T>());
 }
 
@@ -32,7 +32,7 @@ template <typename ExPolicy, typename T>
 hpx::future<T> test_reduce_async(
     ExPolicy&& policy, hpx::partitioned_vector<T> const& xvalues)
 {
-    return hpx::parallel::reduce(
+    return hpx::reduce(
         policy, xvalues.begin(), xvalues.end(), T(1), std::plus<T>());
 }
 


### PR DESCRIPTION
- also add hpx::ranges::reduce implementations
- deprecate hpx::parallel::reduce

This makes all `reduce` variations fully conforming to C++20
