### PR TITLE
Fix PAPI counters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2261,17 +2261,11 @@ else()
   set(HPX_BUILD_PREFIX "${PROJECT_BINARY_DIR}")
 endif()
 
-if(MSVC)
-  hpx_add_config_cond_define(
-    HPX_DEFAULT_COMPONENT_PATH_SUFFIXES
-    "\"/${CMAKE_INSTALL_BINDIR}/hpx;/bin/hpx\""
-  )
-else()
-  hpx_add_config_cond_define(
-    HPX_DEFAULT_COMPONENT_PATH_SUFFIXES
-    "\"/${CMAKE_INSTALL_LIBDIR}/hpx:/lib/hpx\""
-  )
-endif()
+# Note: on windows systems the ':' will be converted to a ';' at runtime
+hpx_add_config_cond_define(
+  HPX_DEFAULT_COMPONENT_PATH_SUFFIXES
+  "\"/${CMAKE_INSTALL_BINDIR}/hpx:/bin/hpx\""
+)
 
 # ##############################################################################
 # search path configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2264,7 +2264,7 @@ endif()
 # Note: on windows systems the ':' will be converted to a ';' at runtime
 hpx_add_config_cond_define(
   HPX_DEFAULT_COMPONENT_PATH_SUFFIXES
-  "\"/${CMAKE_INSTALL_BINDIR}/hpx:/bin/hpx\""
+  "\"/${CMAKE_INSTALL_BINDIR}/hpx:/lib/hpx:/bin/hpx\""
 )
 
 # ##############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2261,6 +2261,18 @@ else()
   set(HPX_BUILD_PREFIX "${PROJECT_BINARY_DIR}")
 endif()
 
+if(MSVC)
+  hpx_add_config_cond_define(
+    HPX_DEFAULT_COMPONENT_PATH_SUFFIXES
+    "\"/${CMAKE_INSTALL_BINDIR}/hpx;/bin/hpx\""
+  )
+else()
+  hpx_add_config_cond_define(
+    HPX_DEFAULT_COMPONENT_PATH_SUFFIXES
+    "\"/${CMAKE_INSTALL_LIBDIR}/hpx:/lib/hpx\""
+  )
+endif()
+
 # ##############################################################################
 # search path configuration
 # ##############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -951,6 +951,11 @@ if(HPX_WITH_PAPI)
       "HPX_WITH_PAPI was set to ON, but PAPI cannot currently be used with HPX_WITH_DISTRIBUTED_RUNTIME=OFF"
     )
   endif()
+  if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+    hpx_error(
+      "HPX_WITH_PAPI was set to ON, but PAPI can only be used on Linux (this is ${CMAKE_SYSTEM_NAME})"
+    )
+  endif()
   hpx_add_config_define(HPX_HAVE_PAPI)
 endif()
 hpx_option(

--- a/components/performance_counters/papi/src/server/papi.cpp
+++ b/components/performance_counters/papi/src/server/papi.cpp
@@ -27,6 +27,12 @@
 #include <string>
 #include <vector>
 
+#if defined(__linux__) && !defined(__ANDROID) && !defined(ANDROID)
+#include <sys/syscall.h>
+#else
+#error "The PAPI performance counter component can only be used on Linux"
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace papi_ns = hpx::performance_counters::papi;
 
@@ -62,8 +68,8 @@ namespace hpx { namespace performance_counters { namespace papi { namespace serv
             "could not create PAPI event set", locstr);
         papi_call(PAPI_assign_eventset_component(evset_, 0),
             "cannot assign component index to event set", locstr);
-        unsigned long tid = tm.get_thread_native_handle(tix);
-        if (tid == tm.invalid_tid)
+        pid_t tid = tm.get_linux_thread_id(tix);
+        if (tid == -1)
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 NS_STR "thread_counters::thread_counters()",
                 "unable to retrieve correct OS thread ID for profiling "

--- a/components/performance_counters/papi/src/server/papi.cpp
+++ b/components/performance_counters/papi/src/server/papi.cpp
@@ -202,7 +202,10 @@ namespace hpx { namespace performance_counters { namespace papi { namespace serv
         // create entry for the thread associated with the counter if it doesn't exist
         ttable_type::iterator it = thread_state_.find(tix);
         if (it == thread_state_.end())
+        {
+            hpx::util::ignore_all_while_checking i;
             return thread_state_[tix] = new thread_counters(tix);
+        }
         else
             return it->second;
     }

--- a/components/performance_counters/papi/tests/regressions/CMakeLists.txt
+++ b/components/performance_counters/papi/tests/regressions/CMakeLists.txt
@@ -9,6 +9,11 @@ set(tests papi_counters_active_interface papi_counters_basic_functions
           papi_counters_segfault_1890
 )
 
+# The papi_counters_basic_functions test depends on floating point counters
+# being available. They are not always available so we only add it as an
+# executable, not a test.
+set(papi_counters_basic_functions_NOTEST TRUE)
+
 foreach(test ${tests})
   set(sources ${test}.cpp)
 
@@ -23,7 +28,9 @@ foreach(test ${tests})
     FOLDER "Tests/Regressions/Components"
   )
 
-  add_hpx_regression_test(
-    "components.papi_counters" ${test} ${${test}_PARAMETERS}
-  )
+  if(NOT "${${test}_NOTEST}")
+    add_hpx_regression_test(
+      "components.papi_counters" ${test} ${${test}_PARAMETERS}
+    )
+  endif()
 endforeach()

--- a/libs/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/runtime_configuration/src/runtime_configuration.cpp
@@ -73,6 +73,21 @@ namespace hpx { namespace parcelset {
 }}    // namespace hpx::parcelset
 
 namespace hpx { namespace util {
+
+    namespace detail {
+
+        // CMake does not deal with explicit semicolons well, for this reason,
+        // the paths are delimited with ':'. On Windows those need to be
+        // converted to ';'.
+        std::string convert_delimiters(std::string paths)
+        {
+#if defined(HPX_WINDOWS)
+            std::replace(paths.begin(), paths.end(), ':', ';');
+#endif
+            return paths;
+        }
+    }    // namespace detail
+
     // pre-initialize entries with compile time based values
     void runtime_configuration::pre_initialize_ini()
     {
@@ -98,8 +113,9 @@ namespace hpx { namespace util {
             "location = ${HPX_LOCATION:$[system.prefix]}",
             "component_paths = ${HPX_COMPONENT_PATHS}",
             "component_base_paths = $[hpx.location]"    // NOLINT
-            HPX_INI_PATH_DELIMITER "$[system.executable_prefix]",
-            "component_path_suffixes = " HPX_DEFAULT_COMPONENT_PATH_SUFFIXES,
+                HPX_INI_PATH_DELIMITER "$[system.executable_prefix]",
+            "component_path_suffixes = " +
+                detail::convert_delimiters(HPX_DEFAULT_COMPONENT_PATH_SUFFIXES),
             "master_ini_path = $[hpx.location]" HPX_INI_PATH_DELIMITER
             "$[system.executable_prefix]/",
             "master_ini_path_suffixes = /share/" HPX_BASE_DIR_NAME

--- a/libs/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/runtime_configuration/src/runtime_configuration.cpp
@@ -99,8 +99,7 @@ namespace hpx { namespace util {
             "component_paths = ${HPX_COMPONENT_PATHS}",
             "component_base_paths = $[hpx.location]"    // NOLINT
             HPX_INI_PATH_DELIMITER "$[system.executable_prefix]",
-            "component_path_suffixes = /lib/hpx" HPX_INI_PATH_DELIMITER
-            "/bin/hpx",
+            "component_path_suffixes = " HPX_DEFAULT_COMPONENT_PATH_SUFFIXES,
             "master_ini_path = $[hpx.location]" HPX_INI_PATH_DELIMITER
             "$[system.executable_prefix]/",
             "master_ini_path_suffixes = /share/" HPX_BASE_DIR_NAME

--- a/libs/runtime_local/include/hpx/runtime_local/thread_mapper.hpp
+++ b/libs/runtime_local/include/hpx/runtime_local/thread_mapper.hpp
@@ -22,6 +22,11 @@
 
 #include <hpx/config/warnings_prefix.hpp>
 
+#if defined(HPX_HAVE_PAPI) && defined(__linux__) && !defined(__ANDROID) &&     \
+    !defined(ANDROID)
+#include <sys/syscall.h>
+#endif
+
 namespace hpx { namespace util {
 
     ///////////////////////////////////////////////////////////////////////////
@@ -58,6 +63,12 @@ namespace hpx { namespace util {
 
             // the native_handle() of the associated thread
             std::uint64_t tid_;
+
+#if defined(HPX_HAVE_PAPI) && defined(__linux__) && !defined(__ANDROID) &&     \
+    !defined(ANDROID)
+            // the Linux thread id (required by PAPI)
+            pid_t linux_tid_;
+#endif
 
             // callback function invoked when unregistering a thread
             thread_mapper_callback_type cleanup_;
@@ -114,6 +125,11 @@ namespace hpx { namespace util {
 
         // returns low level thread id (native_handle)
         std::uint64_t get_thread_native_handle(std::uint32_t tix) const;
+
+#if defined(HPX_HAVE_PAPI) && defined(__linux__) && !defined(__ANDROID) &&     \
+    !defined(ANDROID)
+        pid_t get_linux_thread_id(std::uint32_t tix) const;
+#endif
 
         // returns the label of registered thread tix
         std::string const& get_thread_label(std::uint32_t tix) const;


### PR DESCRIPTION
Fixes #4820. It seems like PAPI was not happy with the changes to thread ids in #4693. From my testing the only thread ids that PAPI accepts are the ones from the `gettid` syscall. This was (and is) Linux only, so I've also added a check that the PAPI counters can only be enabled on Linux (as far as I can tell they're definitely not available on Windows; other unixy platforms may support it but that would need testing by someone on those platforms).

Other changes:
- I've disabled one of the PAPI tests as it relies on the `PAPI_FP_INS` counter which doesn't seem to be available everywhere (I'm hoping the two other tests will be enough to make sure we don't completely break the PAPI counters).
- Ignoring a lock that's held if an error happens during counter construction.
- Use `CMAKE_INSTALL_LIBDIR` for component paths (`lib64` instead of `lib` on some systems). I think this fixes #4123.