### PR TITLE
Allow combined MPI and/or CUDA polling for futures

### DIFF
--- a/libs/async_cuda/src/cuda_future.cpp
+++ b/libs/async_cuda/src/cuda_future.cpp
@@ -246,7 +246,8 @@ namespace hpx { namespace cuda { namespace experimental { namespace detail {
     {
         cud_debug.debug(debug::str<>("enable polling"));
         auto* sched = pool.get_scheduler();
-        sched->set_cuda_polling_function(&hpx::cuda::experimental::detail::poll);
+        sched->set_cuda_polling_function(
+            &hpx::cuda::experimental::detail::poll);
     }
 
     // -------------------------------------------------------------

--- a/libs/async_cuda/src/cuda_future.cpp
+++ b/libs/async_cuda/src/cuda_future.cpp
@@ -249,7 +249,7 @@ namespace hpx { namespace cuda { namespace experimental { namespace detail {
         cud_debug.debug(debug::str<>("Setting mode"), "enable_user_polling");
 
         // always set polling function before enabling polling
-        sched->set_user_polling_function(
+        sched->set_cuda_polling_function(
             &hpx::cuda::experimental::detail::poll);
         sched->add_remove_scheduler_mode(threads::policies::enable_user_polling,
             threads::policies::do_background_work);
@@ -261,6 +261,7 @@ namespace hpx { namespace cuda { namespace experimental { namespace detail {
         cud_debug.debug(debug::str<>("Setting mode"), "disable_user_polling");
         auto* sched = pool.get_scheduler();
         sched->remove_scheduler_mode(threads::policies::enable_user_polling);
+        sched->clear_cuda_polling_function();
     }
 
 }}}}    // namespace hpx::cuda::experimental::detail

--- a/libs/async_cuda/src/cuda_future.cpp
+++ b/libs/async_cuda/src/cuda_future.cpp
@@ -244,23 +244,16 @@ namespace hpx { namespace cuda { namespace experimental { namespace detail {
     // -------------------------------------------------------------
     void register_polling(hpx::threads::thread_pool_base& pool)
     {
+        cud_debug.debug(debug::str<>("enable polling"));
         auto* sched = pool.get_scheduler();
-
-        cud_debug.debug(debug::str<>("Setting mode"), "enable_user_polling");
-
-        // always set polling function before enabling polling
-        sched->set_cuda_polling_function(
-            &hpx::cuda::experimental::detail::poll);
-        sched->add_remove_scheduler_mode(threads::policies::enable_user_polling,
-            threads::policies::do_background_work);
+        sched->set_cuda_polling_function(&hpx::cuda::experimental::detail::poll);
     }
 
     // -------------------------------------------------------------
     void unregister_polling(hpx::threads::thread_pool_base& pool)
     {
-        cud_debug.debug(debug::str<>("Setting mode"), "disable_user_polling");
+        cud_debug.debug(debug::str<>("disable polling"));
         auto* sched = pool.get_scheduler();
-        sched->remove_scheduler_mode(threads::policies::enable_user_polling);
         sched->clear_cuda_polling_function();
     }
 

--- a/libs/async_mpi/src/mpi_future.cpp
+++ b/libs/async_mpi/src/mpi_future.cpp
@@ -307,28 +307,19 @@ namespace hpx { namespace mpi { namespace experimental {
     }
 
     namespace detail {
-
         // -------------------------------------------------------------
         void register_polling(hpx::threads::thread_pool_base& pool)
         {
+            mpi_debug.debug(debug::str<>("enable polling"));
             auto* sched = pool.get_scheduler();
-
-            mpi_debug.debug(debug::str<>("Setting mode"),
-                detail::get_mpi_info(), "enable_user_polling");
-
-            // always set polling function before enabling polling
             sched->set_mpi_polling_function(&hpx::mpi::experimental::poll);
-            sched->add_remove_scheduler_mode(
-                threads::policies::enable_user_polling,
-                threads::policies::do_background_work);
         }
 
         // -------------------------------------------------------------
         void unregister_polling(hpx::threads::thread_pool_base& pool)
         {
-            mpi_debug.debug(debug::str<>("Setting mode"), "disable_user_polling");
+            mpi_debug.debug(debug::str<>("disable polling"));
             auto* sched = pool.get_scheduler();
-            sched->remove_scheduler_mode(threads::policies::enable_user_polling);
             sched->clear_mpi_polling_function();
         }
     }    // namespace detail

--- a/libs/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
+++ b/libs/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
@@ -975,11 +975,7 @@ namespace hpx { namespace threads { namespace detail {
                 }
             }
 
-            if (scheduler.SchedulingPolicy::get_scheduler_mode() &
-                policies::enable_user_polling)
-            {
-                scheduler.user_polling_function();
-            }
+            scheduler.custom_polling_function();
 
             // something went badly wrong, give up
             if (HPX_UNLIKELY(this_state.load() == state_terminating))

--- a/libs/threading_base/include/hpx/threading_base/scheduler_base.hpp
+++ b/libs/threading_base/include/hpx/threading_base/scheduler_base.hpp
@@ -282,31 +282,33 @@ namespace hpx { namespace threads { namespace policies {
 
         void set_mpi_polling_function(polling_function_ptr mpi_func)
         {
-            polling_function_mpi_ = mpi_func;
+            polling_function_mpi_.store(mpi_func, std::memory_order_relaxed);
         }
 
         void clear_mpi_polling_function()
         {
-            polling_function_mpi_ = &null_polling_function;
+            polling_function_mpi_.store(
+                &null_polling_function, std::memory_order_relaxed);
         }
 
         void set_cuda_polling_function(polling_function_ptr cuda_func)
         {
-            polling_function_cuda_ = cuda_func;
+            polling_function_cuda_.store(cuda_func, std::memory_order_relaxed);
         }
 
         void clear_cuda_polling_function()
         {
-            polling_function_cuda_ = &null_polling_function;
+            polling_function_cuda_.store(
+                &null_polling_function, std::memory_order_relaxed);
         }
 
         inline void custom_polling_function() const
         {
 #if defined(HPX_HAVE_LIB_ASYNC_MPI)
-            (*polling_function_mpi_)();
+            (*polling_function_mpi_.load(std::memory_order_relaxed))();
 #endif
 #if defined(HPX_HAVE_LIB_ASYNC_CUDA)
-            (*polling_function_cuda_)();
+            (*polling_function_cuda_.load(std::memory_order_relaxed))();
 #endif
         }
 
@@ -342,8 +344,8 @@ namespace hpx { namespace threads { namespace policies {
 
         std::atomic<std::int64_t> background_thread_count_;
 
-        polling_function_ptr polling_function_mpi_;
-        polling_function_ptr polling_function_cuda_;
+        std::atomic<polling_function_ptr> polling_function_mpi_;
+        std::atomic<polling_function_ptr> polling_function_cuda_;
 
 #if defined(HPX_HAVE_SCHEDULER_LOCAL_STORAGE)
     public:

--- a/libs/threading_base/include/hpx/threading_base/scheduler_base.hpp
+++ b/libs/threading_base/include/hpx/threading_base/scheduler_base.hpp
@@ -276,11 +276,11 @@ namespace hpx { namespace threads { namespace policies {
             return thread_queue_init_.small_stacksize_;
         }
 
-        using PollingFunctionPtr = void (*)();
+        using polling_function_ptr = void (*)();
 
         static void null_polling_function() {}
 
-        void set_mpi_polling_function(PollingFunctionPtr mpi_func)
+        void set_mpi_polling_function(polling_function_ptr mpi_func)
         {
             polling_function_mpi_ = mpi_func;
         }
@@ -290,7 +290,7 @@ namespace hpx { namespace threads { namespace policies {
             polling_function_mpi_ = &null_polling_function;
         }
 
-        void set_cuda_polling_function(PollingFunctionPtr cuda_func)
+        void set_cuda_polling_function(polling_function_ptr cuda_func)
         {
             polling_function_cuda_ = cuda_func;
         }
@@ -342,9 +342,8 @@ namespace hpx { namespace threads { namespace policies {
 
         std::atomic<std::int64_t> background_thread_count_;
 
-        // the scheduler mode, protected from false sharing
-        PollingFunctionPtr polling_function_mpi_;
-        PollingFunctionPtr polling_function_cuda_;
+        polling_function_ptr polling_function_mpi_;
+        polling_function_ptr polling_function_cuda_;
 
 #if defined(HPX_HAVE_SCHEDULER_LOCAL_STORAGE)
     public:

--- a/libs/threading_base/include/hpx/threading_base/scheduler_base.hpp
+++ b/libs/threading_base/include/hpx/threading_base/scheduler_base.hpp
@@ -346,8 +346,6 @@ namespace hpx { namespace threads { namespace policies {
         PollingFunctionPtr polling_function_mpi_;
         PollingFunctionPtr polling_function_cuda_;
 
-        std::vector<util::function_nonser<void()>> user_callback_functions_;
-
 #if defined(HPX_HAVE_SCHEDULER_LOCAL_STORAGE)
     public:
         // manage scheduler-local data

--- a/libs/threading_base/include/hpx/threading_base/scheduler_mode.hpp
+++ b/libs/threading_base/include/hpx/threading_base/scheduler_mode.hpp
@@ -58,9 +58,6 @@ namespace hpx { namespace threads { namespace policies {
         /// This option allows for certain schedulers to explicitly disable
         /// exponential idle-back off
         enable_idle_backoff = 0x0800,
-        /// this option tells the scheduler to call a user supplied function
-        /// on each iteration (after execution of each task on each worker thread)
-        enable_user_polling = 0x1000,
 
         // clang-format off
         /// This option represents the default mode.
@@ -86,8 +83,7 @@ namespace hpx { namespace threads { namespace policies {
             assign_work_thread_parent |
             steal_high_priority_first |
             steal_after_local |
-            enable_idle_backoff |
-            enable_user_polling
+            enable_idle_backoff
         // clang-format on
     };
 }}}    // namespace hpx::threads::policies

--- a/libs/threading_base/src/scheduler_base.cpp
+++ b/libs/threading_base/src/scheduler_base.cpp
@@ -45,6 +45,8 @@ namespace hpx { namespace threads { namespace policies {
       , thread_queue_init_(thread_queue_init)
       , parent_pool_(nullptr)
       , background_thread_count_(0)
+      , polling_function_mpi_(&null_polling_function)
+      , polling_function_cuda_(&null_polling_function)
     {
         set_scheduler_mode(mode);
 


### PR DESCRIPTION
The polling functions will hardly ever change during normal
operation, so to avoid taking a lock, we use an function pointer
for each of the polling functions for MPI and CUDA separately.
This means they can be set/cleared by any thread and when unchanged
no cache lines are affected and overheads are minimized.