### PR TITLE
Adapting all_of, any_of, and none_of to C++20

### DIFF
--- a/libs/algorithms/CMakeLists.txt
+++ b/libs/algorithms/CMakeLists.txt
@@ -21,6 +21,7 @@ set(algorithms_headers
     hpx/parallel/algorithms/detail/accumulate.hpp
     hpx/parallel/algorithms/detail/dispatch.hpp
     hpx/parallel/algorithms/detail/distance.hpp
+    hpx/parallel/algorithms/detail/find.hpp
     hpx/parallel/algorithms/detail/insertion_sort.hpp
     hpx/parallel/algorithms/detail/is_sorted.hpp
     hpx/parallel/algorithms/detail/parallel_stable_sort.hpp

--- a/libs/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2018 Hartmut Kaiser
+//  Copyright (c) 2007-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,112 +8,9 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/iterator_support/range.hpp>
-#include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/type_support/void_guard.hpp>
-
-#include <hpx/algorithms/traits/projected.hpp>
-#include <hpx/executors/execution_policy.hpp>
-#include <hpx/parallel/algorithms/detail/dispatch.hpp>
-#include <hpx/parallel/util/detail/algorithm_result.hpp>
-#include <hpx/parallel/util/invoke_projected.hpp>
-#include <hpx/parallel/util/loop.hpp>
-#include <hpx/parallel/util/partitioner.hpp>
-#include <hpx/type_support/unused.hpp>
-
-#include <algorithm>
-#include <cstddef>
-#include <iterator>
-#include <type_traits>
-#include <utility>
-#include <vector>
-
-namespace hpx { namespace parallel { inline namespace v1 {
-    ///////////////////////////////////////////////////////////////////////////
-    // none_of
-    namespace detail {
-        /// \cond NOINTERNAL
-        struct none_of : public detail::algorithm<none_of, bool>
-        {
-            none_of()
-              : none_of::algorithm("none_of")
-            {
-            }
-
-            template <typename ExPolicy, typename InIter, typename F,
-                typename Proj>
-            static bool sequential(
-                ExPolicy, InIter first, InIter last, F&& f, Proj&& proj)
-            {
-                return std::none_of(first, last,
-                    util::invoke_projected<F, Proj>(
-                        std::forward<F>(f), std::forward<Proj>(proj)));
-            }
-
-            template <typename ExPolicy, typename FwdIter, typename F,
-                typename Proj>
-            static typename util::detail::algorithm_result<ExPolicy, bool>::type
-            parallel(ExPolicy&& policy, FwdIter first, FwdIter last, F&& op,
-                Proj&& proj)
-            {
-                if (first == last)
-                {
-                    return util::detail::algorithm_result<ExPolicy, bool>::get(
-                        true);
-                }
-
-                util::cancellation_token<> tok;
-                auto f1 = [op = std::forward<F>(op), tok,
-                              proj = std::forward<Proj>(proj)](
-                              FwdIter part_begin,
-                              std::size_t part_count) mutable -> bool {
-                    util::loop_n<ExPolicy>(part_begin, part_count, tok,
-                        [&op, &tok, &proj](FwdIter const& curr) {
-                            if (hpx::util::invoke(
-                                    op, hpx::util::invoke(proj, *curr)))
-                            {
-                                tok.cancel();
-                            }
-                        });
-
-                    return !tok.was_cancelled();
-                };
-
-                return util::partitioner<ExPolicy, bool>::call(
-                    std::forward<ExPolicy>(policy), first,
-                    std::distance(first, last), std::move(f1),
-                    [](std::vector<hpx::future<bool>>&& results) {
-                        return std::all_of(hpx::util::begin(results),
-                            hpx::util::end(results),
-                            [](hpx::future<bool>& val) { return val.get(); });
-                    });
-            }
-        };
-
-        template <typename ExPolicy, typename FwdIter, typename F,
-            typename Proj>
-        typename util::detail::algorithm_result<ExPolicy, bool>::type none_of_(
-            ExPolicy&& policy, FwdIter first, FwdIter last, F&& f, Proj&& proj,
-            std::false_type)
-        {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
-                "Requires at least forward iterator.");
-
-            typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
-
-            return detail::none_of().call(std::forward<ExPolicy>(policy),
-                is_seq(), first, last, std::forward<F>(f),
-                std::forward<Proj>(proj));
-        }
-
-        template <typename ExPolicy, typename FwdIter, typename F,
-            typename Proj>
-        typename util::detail::algorithm_result<ExPolicy, bool>::type none_of_(
-            ExPolicy&& policy, FwdIter first, FwdIter last, F&& f, Proj&& proj,
-            std::true_type);
-        /// \endcond
-    }    // namespace detail
+#if defined(DOXYGEN)
+namespace hpx {
+    // clang-format off
 
     ///  Checks if unary predicate \a f returns true for no elements in the
     ///  range [first, last).
@@ -180,105 +77,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           otherwise. It returns true if the range is empty.
     ///
     template <typename ExPolicy, typename FwdIter, typename F,
-        typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<FwdIter>::value&&
-                    traits::is_projected<Proj, FwdIter>::value&&
-                        traits::is_indirect_callable<ExPolicy, F,
-                            traits::projected<Proj, FwdIter>>::value)>
-    typename util::detail::algorithm_result<ExPolicy, bool>::type none_of(
-        ExPolicy&& policy, FwdIter first, FwdIter last, F&& f,
-        Proj&& proj = Proj())
-    {
-        typedef hpx::traits::is_segmented_iterator<FwdIter> is_segmented;
-        return detail::none_of_(std::forward<ExPolicy>(policy), first, last,
-            std::forward<F>(f), std::forward<Proj>(proj), is_segmented());
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    // any_of
-    namespace detail {
-        /// \cond NOINTERNAL
-        struct any_of : public detail::algorithm<any_of, bool>
-        {
-            any_of()
-              : any_of::algorithm("any_of")
-            {
-            }
-
-            template <typename ExPolicy, typename InIter, typename F,
-                typename Proj>
-            static bool sequential(
-                ExPolicy, InIter first, InIter last, F&& f, Proj&& proj)
-            {
-                return std::any_of(first, last,
-                    util::invoke_projected<F, Proj>(
-                        std::forward<F>(f), std::forward<Proj>(proj)));
-            }
-
-            template <typename ExPolicy, typename FwdIter, typename F,
-                typename Proj>
-            static typename util::detail::algorithm_result<ExPolicy, bool>::type
-            parallel(ExPolicy&& policy, FwdIter first, FwdIter last, F&& op,
-                Proj&& proj)
-            {
-                if (first == last)
-                {
-                    return util::detail::algorithm_result<ExPolicy, bool>::get(
-                        false);
-                }
-
-                util::cancellation_token<> tok;
-                auto f1 = [op = std::forward<F>(op), tok,
-                              proj = std::forward<Proj>(proj)](
-                              FwdIter part_begin,
-                              std::size_t part_count) mutable -> bool {
-                    util::loop_n<ExPolicy>(part_begin, part_count, tok,
-                        [&op, &tok, &proj](FwdIter const& curr) {
-                            if (hpx::util::invoke(
-                                    op, hpx::util::invoke(proj, *curr)))
-                            {
-                                tok.cancel();
-                            }
-                        });
-
-                    return tok.was_cancelled();
-                };
-
-                return util::partitioner<ExPolicy, bool>::call(
-                    std::forward<ExPolicy>(policy), first,
-                    std::distance(first, last), std::move(f1),
-                    [](std::vector<hpx::future<bool>>&& results) {
-                        return std::any_of(hpx::util::begin(results),
-                            hpx::util::end(results),
-                            [](hpx::future<bool>& val) { return val.get(); });
-                    });
-            }
-        };
-
-        template <typename ExPolicy, typename FwdIter, typename F,
-            typename Proj>
-        typename util::detail::algorithm_result<ExPolicy, bool>::type any_of_(
-            ExPolicy&& policy, FwdIter first, FwdIter last, F&& f, Proj&& proj,
-            std::false_type)
-        {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
-                "Requires at least forward iterator.");
-
-            typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
-
-            return detail::any_of().call(std::forward<ExPolicy>(policy),
-                is_seq(), first, last, std::forward<F>(f),
-                std::forward<Proj>(proj));
-        }
-
-        template <typename ExPolicy, typename FwdIter, typename F,
-            typename Proj>
-        typename util::detail::algorithm_result<ExPolicy, bool>::type any_of_(
-            ExPolicy&& policy, FwdIter first, FwdIter last, F&& f, Proj&& proj,
-            std::true_type);
-        /// \endcond
-    }    // namespace detail
+        typename Proj = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy, bool>::type
+    none_of(ExPolicy&& policy, FwdIter first, FwdIter last, F&& f,
+        Proj&& proj = Proj());
 
     ///  Checks if unary predicate \a f returns true for at least one element
     ///  in the range [first, last).
@@ -345,105 +147,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           false otherwise. It returns false if the range is empty.
     ///
     template <typename ExPolicy, typename FwdIter, typename F,
-        typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<FwdIter>::value&&
-                    traits::is_projected<Proj, FwdIter>::value&&
-                        traits::is_indirect_callable<ExPolicy, F,
-                            traits::projected<Proj, FwdIter>>::value)>
-    typename util::detail::algorithm_result<ExPolicy, bool>::type any_of(
-        ExPolicy&& policy, FwdIter first, FwdIter last, F&& f,
-        Proj&& proj = Proj())
-    {
-        typedef hpx::traits::is_segmented_iterator<FwdIter> is_segmented;
-        return detail::any_of_(std::forward<ExPolicy>(policy), first, last,
-            std::forward<F>(f), std::forward<Proj>(proj), is_segmented());
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    // all_of
-    namespace detail {
-        /// \cond NOINTERNAL
-        struct all_of : public detail::algorithm<all_of, bool>
-        {
-            all_of()
-              : all_of::algorithm("all_of")
-            {
-            }
-
-            template <typename ExPolicy, typename InIter, typename F,
-                typename Proj>
-            static bool sequential(
-                ExPolicy, InIter first, InIter last, F&& f, Proj&& proj)
-            {
-                return std::all_of(first, last,
-                    util::invoke_projected<F, Proj>(
-                        std::forward<F>(f), std::forward<Proj>(proj)));
-            }
-
-            template <typename ExPolicy, typename FwdIter, typename F,
-                typename Proj>
-            static typename util::detail::algorithm_result<ExPolicy, bool>::type
-            parallel(ExPolicy&& policy, FwdIter first, FwdIter last, F&& op,
-                Proj&& proj)
-            {
-                if (first == last)
-                {
-                    return util::detail::algorithm_result<ExPolicy, bool>::get(
-                        true);
-                }
-
-                util::cancellation_token<> tok;
-                auto f1 = [op = std::forward<F>(op), tok,
-                              proj = std::forward<Proj>(proj)](
-                              FwdIter part_begin,
-                              std::size_t part_count) mutable -> bool {
-                    util::loop_n<ExPolicy>(part_begin, part_count, tok,
-                        [&op, &tok, &proj](FwdIter const& curr) {
-                            if (!hpx::util::invoke(
-                                    op, hpx::util::invoke(proj, *curr)))
-                            {
-                                tok.cancel();
-                            }
-                        });
-
-                    return !tok.was_cancelled();
-                };
-
-                return util::partitioner<ExPolicy, bool>::call(
-                    std::forward<ExPolicy>(policy), first,
-                    std::distance(first, last), std::move(f1),
-                    [](std::vector<hpx::future<bool>>&& results) {
-                        return std::all_of(hpx::util::begin(results),
-                            hpx::util::end(results),
-                            [](hpx::future<bool>& val) { return val.get(); });
-                    });
-            }
-        };
-
-        template <typename ExPolicy, typename FwdIter, typename F,
-            typename Proj>
-        typename util::detail::algorithm_result<ExPolicy, bool>::type all_of_(
-            ExPolicy&& policy, FwdIter first, FwdIter last, F&& f, Proj&& proj,
-            std::false_type)
-        {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
-                "Requires at least forward iterator.");
-
-            typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
-
-            return detail::all_of().call(std::forward<ExPolicy>(policy),
-                is_seq(), first, last, std::forward<F>(f),
-                std::forward<Proj>(proj));
-        }
-
-        template <typename ExPolicy, typename FwdIter, typename F,
-            typename Proj>
-        typename util::detail::algorithm_result<ExPolicy, bool>::type all_of_(
-            ExPolicy&& policy, FwdIter first, FwdIter last, F&& f, Proj&& proj,
-            std::true_type);
-        /// \endcond
-    }    // namespace detail
+        typename Proj = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy, bool>::type
+    any_of(ExPolicy&& policy, FwdIter first, FwdIter last, F&& f,
+        Proj&& proj = Proj());
 
     /// Checks if unary predicate \a f returns true for all elements in the
     /// range [first, last).
@@ -510,18 +217,486 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           otherwise. It returns true if the range is empty.
     ///
     template <typename ExPolicy, typename FwdIter, typename F,
+        typename Proj = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy, bool>::type
+    all_of(ExPolicy&& policy, FwdIter first, FwdIter last, F&& f,
+        Proj&& proj = Proj());
+
+    // clang-format on
+}    // namespace hpx
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/type_support/void_guard.hpp>
+
+#include <hpx/algorithms/traits/projected.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/algorithms/detail/distance.hpp>
+#include <hpx/parallel/algorithms/detail/find.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/invoke_projected.hpp>
+#include <hpx/parallel/util/loop.hpp>
+#include <hpx/parallel/util/partitioner.hpp>
+#include <hpx/type_support/unused.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace parallel { inline namespace v1 {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // none_of
+    namespace detail {
+        /// \cond NOINTERNAL
+        struct none_of : public detail::algorithm<none_of, bool>
+        {
+            none_of()
+              : none_of::algorithm("none_of")
+            {
+            }
+
+            template <typename ExPolicy, typename Iter, typename Sent,
+                typename F, typename Proj>
+            static bool sequential(
+                ExPolicy, Iter first, Sent last, F&& f, Proj&& proj)
+            {
+                return detail::sequential_find_if(first, last,
+                           util::invoke_projected<F, Proj>(std::forward<F>(f),
+                               std::forward<Proj>(proj))) == last;
+            }
+
+            template <typename ExPolicy, typename FwdIter, typename Sent,
+                typename F, typename Proj>
+            static typename util::detail::algorithm_result<ExPolicy, bool>::type
+            parallel(ExPolicy&& policy, FwdIter first, Sent last, F&& op,
+                Proj&& proj)
+            {
+                if (first == last)
+                {
+                    return util::detail::algorithm_result<ExPolicy, bool>::get(
+                        true);
+                }
+
+                util::cancellation_token<> tok;
+                auto f1 = [op = std::forward<F>(op), tok,
+                              proj = std::forward<Proj>(proj)](
+                              FwdIter part_begin,
+                              std::size_t part_count) mutable -> bool {
+                    util::loop_n<ExPolicy>(part_begin, part_count, tok,
+                        [&op, &tok, &proj](FwdIter const& curr) {
+                            if (hpx::util::invoke(
+                                    op, hpx::util::invoke(proj, *curr)))
+                            {
+                                tok.cancel();
+                            }
+                        });
+
+                    return !tok.was_cancelled();
+                };
+
+                return util::partitioner<ExPolicy, bool>::call(
+                    std::forward<ExPolicy>(policy), first,
+                    detail::distance(first, last), std::move(f1),
+                    [](std::vector<hpx::future<bool>>&& results) {
+                        return detail::sequential_find_if_not(
+                                   hpx::util::begin(results),
+                                   hpx::util::end(results),
+                                   [](hpx::future<bool>& val) {
+                                       return val.get();
+                                   }) == hpx::util::end(results);
+                    });
+            }
+        };
+
+        template <typename ExPolicy, typename FwdIter, typename Sent,
+            typename F, typename Proj>
+        typename util::detail::algorithm_result<ExPolicy, bool>::type none_of_(
+            ExPolicy&& policy, FwdIter first, Sent last, F&& f, Proj&& proj,
+            std::false_type)
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
+                "Requires at least forward iterator.");
+
+            typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+
+            return detail::none_of().call(std::forward<ExPolicy>(policy),
+                is_seq(), first, last, std::forward<F>(f),
+                std::forward<Proj>(proj));
+        }
+
+        template <typename ExPolicy, typename FwdIter, typename F,
+            typename Proj>
+        typename util::detail::algorithm_result<ExPolicy, bool>::type none_of_(
+            ExPolicy&& policy, FwdIter first, FwdIter last, F&& f, Proj&& proj,
+            std::true_type);
+        /// \endcond
+    }    // namespace detail
+
+    // clang-format off
+    template <typename ExPolicy, typename FwdIter, typename F,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<FwdIter>::value&&
-                    traits::is_projected<Proj, FwdIter>::value&&
-                        traits::is_indirect_callable<ExPolicy, F,
-                            traits::projected<Proj, FwdIter>>::value)>
-    typename util::detail::algorithm_result<ExPolicy, bool>::type all_of(
-        ExPolicy&& policy, FwdIter first, FwdIter last, F&& f,
-        Proj&& proj = Proj())
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<FwdIter>::value &&
+            traits::is_projected<Proj, FwdIter>::value &&
+            traits::is_indirect_callable<ExPolicy, F,
+                traits::projected<Proj, FwdIter>
+            >::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(
+        1, 6, "hpx::parallel::none_of is deprecated, use hpx::none_of instead")
+        typename util::detail::algorithm_result<ExPolicy, bool>::type
+        none_of(ExPolicy&& policy, FwdIter first, FwdIter last, F&& f,
+            Proj&& proj = Proj())
+    {
+        typedef hpx::traits::is_segmented_iterator<FwdIter> is_segmented;
+        return detail::none_of_(std::forward<ExPolicy>(policy), first, last,
+            std::forward<F>(f), std::forward<Proj>(proj), is_segmented());
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // any_of
+    namespace detail {
+        /// \cond NOINTERNAL
+        struct any_of : public detail::algorithm<any_of, bool>
+        {
+            any_of()
+              : any_of::algorithm("any_of")
+            {
+            }
+
+            template <typename ExPolicy, typename Iter, typename Sent,
+                typename F, typename Proj>
+            static bool sequential(
+                ExPolicy, Iter first, Sent last, F&& f, Proj&& proj)
+            {
+                return detail::sequential_find_if(first, last,
+                           util::invoke_projected<F, Proj>(std::forward<F>(f),
+                               std::forward<Proj>(proj))) != last;
+            }
+
+            template <typename ExPolicy, typename FwdIter, typename Sent,
+                typename F, typename Proj>
+            static typename util::detail::algorithm_result<ExPolicy, bool>::type
+            parallel(ExPolicy&& policy, FwdIter first, Sent last, F&& op,
+                Proj&& proj)
+            {
+                if (first == last)
+                {
+                    return util::detail::algorithm_result<ExPolicy, bool>::get(
+                        false);
+                }
+
+                util::cancellation_token<> tok;
+                auto f1 = [op = std::forward<F>(op), tok,
+                              proj = std::forward<Proj>(proj)](
+                              FwdIter part_begin,
+                              std::size_t part_count) mutable -> bool {
+                    util::loop_n<ExPolicy>(part_begin, part_count, tok,
+                        [&op, &tok, &proj](FwdIter const& curr) {
+                            if (hpx::util::invoke(
+                                    op, hpx::util::invoke(proj, *curr)))
+                            {
+                                tok.cancel();
+                            }
+                        });
+
+                    return tok.was_cancelled();
+                };
+
+                return util::partitioner<ExPolicy, bool>::call(
+                    std::forward<ExPolicy>(policy), first,
+                    detail::distance(first, last), std::move(f1),
+                    [](std::vector<hpx::future<bool>>&& results) {
+                        return detail::sequential_find_if(
+                                   hpx::util::begin(results),
+                                   hpx::util::end(results),
+                                   [](hpx::future<bool>& val) {
+                                       return val.get();
+                                   }) != hpx::util::end(results);
+                    });
+            }
+        };
+
+        template <typename ExPolicy, typename FwdIter, typename Sent,
+            typename F, typename Proj>
+        typename util::detail::algorithm_result<ExPolicy, bool>::type any_of_(
+            ExPolicy&& policy, FwdIter first, Sent last, F&& f, Proj&& proj,
+            std::false_type)
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
+                "Requires at least forward iterator.");
+
+            typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+
+            return detail::any_of().call(std::forward<ExPolicy>(policy),
+                is_seq(), first, last, std::forward<F>(f),
+                std::forward<Proj>(proj));
+        }
+
+        template <typename ExPolicy, typename FwdIter, typename F,
+            typename Proj>
+        typename util::detail::algorithm_result<ExPolicy, bool>::type any_of_(
+            ExPolicy&& policy, FwdIter first, FwdIter last, F&& f, Proj&& proj,
+            std::true_type);
+        /// \endcond
+    }    // namespace detail
+
+    // clang-format off
+    template <typename ExPolicy, typename FwdIter, typename F,
+        typename Proj = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<FwdIter>::value &&
+            traits::is_projected<Proj, FwdIter>::value &&
+            traits::is_indirect_callable<ExPolicy, F,
+                traits::projected<Proj, FwdIter>
+            >::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(
+        1, 6, "hpx::parallel::any_of is deprecated, use hpx::any_of instead")
+        typename util::detail::algorithm_result<ExPolicy, bool>::type
+        any_of(ExPolicy&& policy, FwdIter first, FwdIter last, F&& f,
+            Proj&& proj = Proj())
+    {
+        typedef hpx::traits::is_segmented_iterator<FwdIter> is_segmented;
+        return detail::any_of_(std::forward<ExPolicy>(policy), first, last,
+            std::forward<F>(f), std::forward<Proj>(proj), is_segmented());
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // all_of
+    namespace detail {
+        /// \cond NOINTERNAL
+        struct all_of : public detail::algorithm<all_of, bool>
+        {
+            all_of()
+              : all_of::algorithm("all_of")
+            {
+            }
+
+            template <typename ExPolicy, typename Iter, typename Sent,
+                typename F, typename Proj>
+            static bool sequential(
+                ExPolicy, Iter first, Sent last, F&& f, Proj&& proj)
+            {
+                return detail::sequential_find_if_not(first, last,
+                           util::invoke_projected<F, Proj>(std::forward<F>(f),
+                               std::forward<Proj>(proj))) == last;
+            }
+
+            template <typename ExPolicy, typename FwdIter, typename Sent,
+                typename F, typename Proj>
+            static typename util::detail::algorithm_result<ExPolicy, bool>::type
+            parallel(ExPolicy&& policy, FwdIter first, Sent last, F&& op,
+                Proj&& proj)
+            {
+                if (first == last)
+                {
+                    return util::detail::algorithm_result<ExPolicy, bool>::get(
+                        true);
+                }
+
+                util::cancellation_token<> tok;
+                auto f1 = [op = std::forward<F>(op), tok,
+                              proj = std::forward<Proj>(proj)](
+                              FwdIter part_begin,
+                              std::size_t part_count) mutable -> bool {
+                    util::loop_n<ExPolicy>(part_begin, part_count, tok,
+                        [&op, &tok, &proj](FwdIter const& curr) {
+                            if (!hpx::util::invoke(
+                                    op, hpx::util::invoke(proj, *curr)))
+                            {
+                                tok.cancel();
+                            }
+                        });
+
+                    return !tok.was_cancelled();
+                };
+
+                return util::partitioner<ExPolicy, bool>::call(
+                    std::forward<ExPolicy>(policy), first,
+                    detail::distance(first, last), std::move(f1),
+                    [](std::vector<hpx::future<bool>>&& results) {
+                        return detail::sequential_find_if_not(
+                                   hpx::util::begin(results),
+                                   hpx::util::end(results),
+                                   [](hpx::future<bool>& val) {
+                                       return val.get();
+                                   }) == hpx::util::end(results);
+                    });
+            }
+        };
+
+        template <typename ExPolicy, typename FwdIter, typename F,
+            typename Proj>
+        typename util::detail::algorithm_result<ExPolicy, bool>::type all_of_(
+            ExPolicy&& policy, FwdIter first, FwdIter last, F&& f, Proj&& proj,
+            std::false_type)
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
+                "Requires at least forward iterator.");
+
+            typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+
+            return detail::all_of().call(std::forward<ExPolicy>(policy),
+                is_seq(), first, last, std::forward<F>(f),
+                std::forward<Proj>(proj));
+        }
+
+        template <typename ExPolicy, typename FwdIter, typename F,
+            typename Proj>
+        typename util::detail::algorithm_result<ExPolicy, bool>::type all_of_(
+            ExPolicy&& policy, FwdIter first, FwdIter last, F&& f, Proj&& proj,
+            std::true_type);
+        /// \endcond
+    }    // namespace detail
+
+    // clang-format off
+    template <typename ExPolicy, typename FwdIter, typename F,
+        typename Proj = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value&&
+            hpx::traits::is_iterator<FwdIter>::value&&
+            traits::is_projected<Proj, FwdIter>::value&&
+            traits::is_indirect_callable<ExPolicy, F,
+                traits::projected<Proj, FwdIter>
+            >::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(
+        1, 6, "hpx::parallel::all_of is deprecated, use hpx::all_of instead")
+        typename util::detail::algorithm_result<ExPolicy, bool>::type
+        all_of(ExPolicy&& policy, FwdIter first, FwdIter last, F&& f,
+            Proj&& proj = Proj())
     {
         typedef hpx::traits::is_segmented_iterator<FwdIter> is_segmented;
         return detail::all_of_(std::forward<ExPolicy>(policy), first, last,
             std::forward<F>(f), std::forward<Proj>(proj), is_segmented());
     }
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::none_of
+    HPX_INLINE_CONSTEXPR_VARIABLE struct none_of_t final
+      : hpx::functional::tag<none_of_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter, typename F,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            bool>::type
+        tag_invoke(
+            none_of_t, ExPolicy&& policy, FwdIter first, FwdIter last, F&& f)
+        {
+            typedef hpx::traits::is_segmented_iterator<FwdIter> is_segmented;
+            return hpx::parallel::v1::detail::none_of_(
+                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                hpx::parallel::util::projection_identity{}, is_segmented{});
+        }
+
+        // clang-format off
+        template <typename FwdIter, typename F,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend bool tag_invoke(none_of_t, FwdIter first, FwdIter last, F&& f)
+        {
+            return std::none_of(first, last, std::forward<F>(f));
+        }
+    } none_of;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::any_of
+    HPX_INLINE_CONSTEXPR_VARIABLE struct any_of_t final
+      : hpx::functional::tag<any_of_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter, typename F,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            bool>::type
+        tag_invoke(
+            any_of_t, ExPolicy&& policy, FwdIter first, FwdIter last, F&& f)
+        {
+            typedef hpx::traits::is_segmented_iterator<FwdIter> is_segmented;
+            return hpx::parallel::v1::detail::any_of_(
+                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                hpx::parallel::util::projection_identity{}, is_segmented{});
+        }
+
+        // clang-format off
+        template <typename FwdIter, typename F,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend bool tag_invoke(any_of_t, FwdIter first, FwdIter last, F&& f)
+        {
+            return std::any_of(first, last, std::forward<F>(f));
+        }
+    } any_of;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::all_of
+    HPX_INLINE_CONSTEXPR_VARIABLE struct all_of_t final
+      : hpx::functional::tag<all_of_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter, typename F,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            bool>::type
+        tag_invoke(
+            all_of_t, ExPolicy&& policy, FwdIter first, FwdIter last, F&& f)
+        {
+            typedef hpx::traits::is_segmented_iterator<FwdIter> is_segmented;
+            return hpx::parallel::v1::detail::all_of_(
+                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                hpx::parallel::util::projection_identity{}, is_segmented{});
+        }
+
+        // clang-format off
+        template <typename FwdIter, typename F,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend bool tag_invoke(all_of_t, FwdIter first, FwdIter last, F&& f)
+        {
+            return std::all_of(first, last, std::forward<F>(f));
+        }
+    } all_of;
+
+}    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -213,14 +213,12 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/detail/transfer.hpp>
-#include <hpx/parallel/tagspec.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 #include <hpx/parallel/util/result_types.hpp>
 #include <hpx/parallel/util/scan_partitioner.hpp>
-#include <hpx/parallel/util/tagged_pair.hpp>
 #include <hpx/parallel/util/transfer.hpp>
 #include <hpx/parallel/util/zip_iterator.hpp>
 #include <hpx/type_support/unused.hpp>

--- a/libs/algorithms/include/hpx/parallel/algorithms/detail/accumulate.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/detail/accumulate.hpp
@@ -7,23 +7,25 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/functional/invoke.hpp>
 
 #include <functional>
 
 namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     // provide implementation of std::accumulate supporting iterators/sentinels
     template <typename InIterB, typename InIterE, typename T, typename F>
-    inline T accumulate(InIterB first, InIterE last, T value, F reduce_op)
+    inline constexpr T accumulate(
+        InIterB first, InIterE last, T value, F reduce_op)
     {
         for (/**/; first != last; ++first)
         {
-            value = reduce_op(value, *first);
+            value = hpx::util::invoke(reduce_op, value, *first);
         }
         return value;
     }
 
     template <typename InIterB, typename InIterE, typename T>
-    inline T accumulate(InIterB first, InIterE last, T value)
+    inline constexpr T accumulate(InIterB first, InIterE last, T value)
     {
         return accumulate(first, last, value, std::plus<T>());
     }

--- a/libs/algorithms/include/hpx/parallel/algorithms/detail/find.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/detail/find.hpp
@@ -1,0 +1,58 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/functional/invoke.hpp>
+
+namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
+
+    // provide implementation of std::find supporting iterators/sentinels
+    template <typename Iterator, typename Sentinel, typename T>
+    inline constexpr Iterator sequential_find(
+        Iterator first, Sentinel last, T const& value)
+    {
+        for (; first != last; ++first)
+        {
+            if (*first == value)
+            {
+                return first;
+            }
+        }
+        return last;
+    }
+
+    // provide implementation of std::find_if supporting iterators/sentinels
+    template <typename Iterator, typename Sentinel, typename Pred>
+    inline constexpr Iterator sequential_find_if(
+        Iterator first, Sentinel last, Pred pred)
+    {
+        for (; first != last; ++first)
+        {
+            if (hpx::util::invoke(pred, *first))
+            {
+                return first;
+            }
+        }
+        return last;
+    }
+
+    // provide implementation of std::find_if supporting iterators/sentinels
+    template <typename Iterator, typename Sentinel, typename Pred>
+    inline constexpr Iterator sequential_find_if_not(
+        Iterator first, Sentinel last, Pred pred)
+    {
+        for (; first != last; ++first)
+        {
+            if (!hpx::util::invoke(pred, *first))
+            {
+                return first;
+            }
+        }
+        return last;
+    }
+}}}}    // namespace hpx::parallel::v1::detail

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/all_any_none.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/all_any_none.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2017 Bruno Pitrus
+//  Copyright (c) 2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,21 +9,10 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/concepts/concepts.hpp>
-#include <hpx/iterator_support/range.hpp>
-#include <hpx/iterator_support/traits/is_range.hpp>
+#if defined(DOXYGEN)
 
-#include <hpx/algorithms/traits/projected_range.hpp>
-#include <hpx/parallel/algorithms/all_any_none.hpp>
-#include <hpx/parallel/util/projection_identity.hpp>
-
-#include <type_traits>
-#include <utility>
-
-namespace hpx { namespace parallel { inline namespace v1 {
-    ///////////////////////////////////////////////////////////////////////////
-    // none_of
+namespace hpx { namespace ranges {
+    // clang-format off
 
     ///  Checks if unary predicate \a f returns true for no elements in the
     ///  range \a rng.
@@ -87,20 +77,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           otherwise. It returns true if the range is empty.
     ///
     template <typename ExPolicy, typename Rng, typename F,
-        typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
-                    Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
-                    F, traits::projected_range<Proj, Rng>>::value)>
-    typename util::detail::algorithm_result<ExPolicy, bool>::type none_of(
-        ExPolicy&& policy, Rng&& rng, F&& f, Proj&& proj = Proj())
-    {
-        return none_of(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
-            hpx::util::end(rng), std::forward<F>(f), std::forward<Proj>(proj));
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    // any_of
+        typename Proj = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy, bool>::type
+    none_of(ExPolicy&& policy, Rng&& rng, F&& f, Proj&& proj = Proj());
 
     /// Checks if unary predicate \a f returns true for at least one element
     /// in the range \a rng.
@@ -165,20 +144,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           false otherwise. It returns false if the range is empty.
     ///
     template <typename ExPolicy, typename Rng, typename F,
-        typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
-                    Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
-                    F, traits::projected_range<Proj, Rng>>::value)>
-    typename util::detail::algorithm_result<ExPolicy, bool>::type any_of(
-        ExPolicy&& policy, Rng&& rng, F&& f, Proj&& proj = Proj())
-    {
-        return any_of(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
-            hpx::util::end(rng), std::forward<F>(f), std::forward<Proj>(proj));
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    // all_of
+        typename Proj = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy, bool>::type
+    any_of(ExPolicy&& policy, Rng&& rng, F&& f, Proj&& proj = Proj());
 
     /// Checks if unary predicate \a f returns true for all elements in the
     /// range \a rng.
@@ -243,16 +211,432 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           otherwise. It returns true if the range is empty.
     ///
     template <typename ExPolicy, typename Rng, typename F,
+        typename Proj = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy, bool>::type
+    all_of(ExPolicy&& policy, Rng&& rng, F&& f, Proj&& proj = Proj());
+
+    // clang-format on
+}}    // namespace hpx::ranges
+
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_range.hpp>
+
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/algorithms/all_any_none.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1 {
+    ///////////////////////////////////////////////////////////////////////////
+    // none_of
+
+    // clang-format off
+    template <typename ExPolicy, typename Rng, typename F,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
-                    Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
-                    F, traits::projected_range<Proj, Rng>>::value)>
-    typename util::detail::algorithm_result<ExPolicy, bool>::type all_of(
-        ExPolicy&& policy, Rng&& rng, F&& f, Proj&& proj = Proj())
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value &&
+            traits::is_projected_range<Proj, Rng>::value &&
+            traits::is_indirect_callable<ExPolicy, F,
+                traits::projected_range<Proj, Rng>
+            >::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::none_of is deprecated, use "
+        "hpx::ranges::none_of instead")
+        typename util::detail::algorithm_result<ExPolicy, bool>::type
+        none_of(ExPolicy&& policy, Rng&& rng, F&& f, Proj&& proj = Proj())
+    {
+        return none_of(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+            hpx::util::end(rng), std::forward<F>(f), std::forward<Proj>(proj));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // any_of
+
+    // clang-format off
+    template <typename ExPolicy, typename Rng, typename F,
+        typename Proj = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value&&
+            hpx::traits::is_range<Rng>::value&&
+            traits::is_projected_range<Proj, Rng>::value&&
+            traits::is_indirect_callable<ExPolicy, F,
+                traits::projected_range<Proj, Rng>
+            >::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::any_of is deprecated, use hpx::ranges::any_of instead")
+        typename util::detail::algorithm_result<ExPolicy, bool>::type
+        any_of(ExPolicy&& policy, Rng&& rng, F&& f, Proj&& proj = Proj())
+    {
+        return any_of(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+            hpx::util::end(rng), std::forward<F>(f), std::forward<Proj>(proj));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // all_of
+
+    // clang-format off
+    template <typename ExPolicy, typename Rng, typename F,
+        typename Proj = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value&&
+            hpx::traits::is_range<Rng>::value&&
+            traits::is_projected_range<Proj, Rng>::value&&
+            traits::is_indirect_callable<ExPolicy, F,
+                traits::projected_range<Proj, Rng>
+            >::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::all_of is deprecated, use hpx::ranges::all_of instead")
+        typename util::detail::algorithm_result<ExPolicy, bool>::type
+        all_of(ExPolicy&& policy, Rng&& rng, F&& f, Proj&& proj = Proj())
     {
         return all_of(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
             hpx::util::end(rng), std::forward<F>(f), std::forward<Proj>(proj));
     }
 
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx { namespace ranges {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::none_of
+    HPX_INLINE_CONSTEXPR_VARIABLE struct none_of_t final
+      : hpx::functional::tag<none_of_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename Rng, typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
+                    hpx::parallel::traits::projected_range<Proj, Rng>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            bool>::type
+        tag_invoke(none_of_t, ExPolicy&& policy, Rng&& rng, F&& f,
+            Proj&& proj = Proj())
+        {
+            using iterator_type =
+                typename hpx::traits::range_iterator<Rng>::type;
+            using is_segmented =
+                hpx::traits::is_segmented_iterator<iterator_type>;
+
+            return hpx::parallel::v1::detail::none_of_(
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                hpx::util::end(rng), std::forward<F>(f),
+                std::forward<Proj>(proj), is_segmented{});
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Iter, typename Sent, typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<Iter>::value &&
+                hpx::traits::is_sentinel_for<Sent, Iter>::value &&
+                hpx::parallel::traits::is_projected<Proj, Iter>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
+                    hpx::parallel::traits::projected<Proj, Iter>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            bool>::type
+        tag_invoke(none_of_t, ExPolicy&& policy, Iter first, Sent last, F&& f,
+            Proj&& proj = Proj())
+        {
+            using is_segmented = hpx::traits::is_segmented_iterator<Iter>;
+
+            return hpx::parallel::v1::detail::none_of_(
+                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                std::forward<Proj>(proj), is_segmented{});
+        }
+
+        // clang-format off
+        template <typename Rng, typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::parallel::execution::sequenced_policy, F,
+                    hpx::parallel::traits::projected_range<Proj, Rng>
+                >::value
+            )>
+        // clang-format on
+        friend bool tag_invoke(
+            none_of_t, Rng&& rng, F&& f, Proj&& proj = Proj())
+        {
+            using iterator_type =
+                typename hpx::traits::range_iterator<Rng>::type;
+            using is_segmented =
+                hpx::traits::is_segmented_iterator<iterator_type>;
+
+            return hpx::parallel::v1::detail::none_of_(
+                hpx::parallel::execution::seq, hpx::util::begin(rng),
+                hpx::util::end(rng), std::forward<F>(f),
+                std::forward<Proj>(proj), is_segmented{});
+        }
+
+        // clang-format off
+        template <typename Iter, typename Sent, typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<Iter>::value &&
+                hpx::traits::is_sentinel_for<Sent, Iter>::value &&
+                hpx::parallel::traits::is_projected<Proj, Iter>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::parallel::execution::sequenced_policy, F,
+                    hpx::parallel::traits::projected<Proj, Iter>
+                >::value
+            )>
+        // clang-format on
+        friend bool tag_invoke(
+            none_of_t, Iter first, Sent last, F&& f, Proj&& proj = Proj())
+        {
+            using is_segmented = hpx::traits::is_segmented_iterator<Iter>;
+
+            return hpx::parallel::v1::detail::none_of_(
+                hpx::parallel::execution::seq, first, last, std::forward<F>(f),
+                std::forward<Proj>(proj), is_segmented{});
+        }
+    } none_of;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::any_of
+    HPX_INLINE_CONSTEXPR_VARIABLE struct any_of_t final
+      : hpx::functional::tag<any_of_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename Rng, typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value&&
+                hpx::traits::is_range<Rng>::value&&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value&&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
+                    hpx::parallel::traits::projected_range<Proj, Rng>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            bool>::type
+        tag_invoke(
+            any_of_t, ExPolicy&& policy, Rng&& rng, F&& f, Proj&& proj = Proj())
+        {
+            using iterator_type =
+                typename hpx::traits::range_iterator<Rng>::type;
+            using is_segmented =
+                hpx::traits::is_segmented_iterator<iterator_type>;
+
+            return hpx::parallel::v1::detail::any_of_(
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                hpx::util::end(rng), std::forward<F>(f),
+                std::forward<Proj>(proj), is_segmented{});
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Iter, typename Sent, typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value&&
+                hpx::traits::is_iterator<Iter>::value&&
+                hpx::traits::is_sentinel_for<Sent, Iter>::value&&
+                hpx::parallel::traits::is_projected<Proj, Iter>::value&&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
+                    hpx::parallel::traits::projected<Proj, Iter>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            bool>::type
+        tag_invoke(any_of_t, ExPolicy&& policy, Iter first, Sent last, F&& f,
+            Proj&& proj = Proj())
+        {
+            using is_segmented = hpx::traits::is_segmented_iterator<Iter>;
+
+            return hpx::parallel::v1::detail::any_of_(
+                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                std::forward<Proj>(proj), is_segmented{});
+        }
+
+        // clang-format off
+        template <typename Rng, typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value&&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value&&
+                hpx::parallel::traits::is_indirect_callable<
+                hpx::parallel::execution::sequenced_policy, F,
+                    hpx::parallel::traits::projected_range<Proj, Rng>
+                >::value
+            )>
+        // clang-format on
+        friend bool tag_invoke(any_of_t, Rng&& rng, F&& f, Proj&& proj = Proj())
+        {
+            using iterator_type =
+                typename hpx::traits::range_iterator<Rng>::type;
+            using is_segmented =
+                hpx::traits::is_segmented_iterator<iterator_type>;
+
+            return hpx::parallel::v1::detail::any_of_(
+                hpx::parallel::execution::seq, hpx::util::begin(rng),
+                hpx::util::end(rng), std::forward<F>(f),
+                std::forward<Proj>(proj), is_segmented{});
+        }
+
+        // clang-format off
+        template <typename Iter, typename Sent, typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<Iter>::value&&
+                hpx::traits::is_sentinel_for<Sent, Iter>::value&&
+                hpx::parallel::traits::is_projected<Proj, Iter>::value&&
+                hpx::parallel::traits::is_indirect_callable<
+                hpx::parallel::execution::sequenced_policy, F,
+                    hpx::parallel::traits::projected<Proj, Iter>
+                >::value
+            )>
+        // clang-format on
+        friend bool tag_invoke(
+            any_of_t, Iter first, Sent last, F&& f, Proj&& proj = Proj())
+        {
+            using is_segmented = hpx::traits::is_segmented_iterator<Iter>;
+
+            return hpx::parallel::v1::detail::any_of_(
+                hpx::parallel::execution::seq, first, last, std::forward<F>(f),
+                std::forward<Proj>(proj), is_segmented{});
+        }
+    } any_of;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::all_of
+    HPX_INLINE_CONSTEXPR_VARIABLE struct all_of_t final
+      : hpx::functional::tag<all_of_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename Rng, typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value&&
+                hpx::traits::is_range<Rng>::value&&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value&&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
+                    hpx::parallel::traits::projected_range<Proj, Rng>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            bool>::type
+        tag_invoke(
+            all_of_t, ExPolicy&& policy, Rng&& rng, F&& f, Proj&& proj = Proj())
+        {
+            using iterator_type =
+                typename hpx::traits::range_iterator<Rng>::type;
+            using is_segmented =
+                hpx::traits::is_segmented_iterator<iterator_type>;
+
+            return hpx::parallel::v1::detail::all_of_(
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                hpx::util::end(rng), std::forward<F>(f),
+                std::forward<Proj>(proj), is_segmented{});
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Iter, typename Sent, typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value&&
+                hpx::traits::is_iterator<Iter>::value&&
+                hpx::traits::is_sentinel_for<Sent, Iter>::value&&
+                hpx::parallel::traits::is_projected<Proj, Iter>::value&&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
+                    hpx::parallel::traits::projected<Proj, Iter>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            bool>::type
+        tag_invoke(all_of_t, ExPolicy&& policy, Iter first, Sent last, F&& f,
+            Proj&& proj = Proj())
+        {
+            using is_segmented = hpx::traits::is_segmented_iterator<Iter>;
+
+            return hpx::parallel::v1::detail::all_of_(
+                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                std::forward<Proj>(proj), is_segmented{});
+        }
+
+        // clang-format off
+        template <typename Rng, typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value&&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value&&
+                hpx::parallel::traits::is_indirect_callable<
+                hpx::parallel::execution::sequenced_policy, F,
+                    hpx::parallel::traits::projected_range<Proj, Rng>
+                >::value
+            )>
+        // clang-format on
+        friend bool tag_invoke(all_of_t, Rng&& rng, F&& f, Proj&& proj = Proj())
+        {
+            using iterator_type =
+                typename hpx::traits::range_iterator<Rng>::type;
+            using is_segmented =
+                hpx::traits::is_segmented_iterator<iterator_type>;
+
+            return hpx::parallel::v1::detail::all_of_(
+                hpx::parallel::execution::seq, hpx::util::begin(rng),
+                hpx::util::end(rng), std::forward<F>(f),
+                std::forward<Proj>(proj), is_segmented{});
+        }
+
+        // clang-format off
+        template <typename Iter, typename Sent, typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<Iter>::value&&
+                hpx::traits::is_sentinel_for<Sent, Iter>::value&&
+                hpx::parallel::traits::is_projected<Proj, Iter>::value&&
+                hpx::parallel::traits::is_indirect_callable<
+                hpx::parallel::execution::sequenced_policy, F,
+                    hpx::parallel::traits::projected<Proj, Iter>
+                >::value
+            )>
+        // clang-format on
+        friend bool tag_invoke(
+            all_of_t, Iter first, Sent last, F&& f, Proj&& proj = Proj())
+        {
+            using is_segmented = hpx::traits::is_segmented_iterator<Iter>;
+
+            return hpx::parallel::v1::detail::all_of_(
+                hpx::parallel::execution::seq, first, last, std::forward<F>(f),
+                std::forward<Proj>(proj), is_segmented{});
+        }
+    } all_of;
+
+}}    // namespace hpx::ranges
+
+#endif    // DOXYGEN

--- a/libs/algorithms/include/hpx/parallel/util/cancellation_token.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/cancellation_token.hpp
@@ -17,10 +17,6 @@ namespace hpx { namespace parallel { namespace util {
     namespace detail {
         struct no_data
         {
-            bool operator<=(no_data) const
-            {
-                return true;
-            }
         };
     }    // namespace detail
 

--- a/libs/algorithms/tests/unit/algorithms/all_of.cpp
+++ b/libs/algorithms/tests/unit/algorithms/all_of.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2014-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -19,9 +19,8 @@
 #include "test_utils.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
-template <typename ExPolicy, typename IteratorTag,
-    typename Proj = hpx::parallel::util::projection_identity>
-void test_all_of(ExPolicy policy, IteratorTag, Proj proj = Proj())
+template <typename ExPolicy, typename IteratorTag>
+void test_all_of(ExPolicy policy, IteratorTag)
 {
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
@@ -36,7 +35,35 @@ void test_all_of(ExPolicy policy, IteratorTag, Proj proj = Proj())
         std::vector<std::size_t> c =
             test::fill_all_any_none(10007, i);    //-V106
 
-        bool result = hpx::parallel::all_of(
+        bool result = hpx::all_of(policy, iterator(std::begin(c)),
+            iterator(std::end(c)), [](std::size_t v) { return v != 0; });
+
+        // verify values
+        bool expected = std::all_of(
+            std::begin(c), std::end(c), [](std::size_t v) { return v != 0; });
+
+        HPX_TEST_EQ(result, expected);
+    }
+}
+
+template <typename ExPolicy, typename IteratorTag,
+    typename Proj = hpx::parallel::util::projection_identity>
+void test_all_of_ranges(ExPolicy policy, IteratorTag, Proj proj = Proj())
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::size_t iseq[] = {0, 23, 10007};
+    for (std::size_t i : iseq)
+    {
+        std::vector<std::size_t> c =
+            test::fill_all_any_none(10007, i);    //-V106
+
+        bool result = hpx::ranges::all_of(
             policy, iterator(std::begin(c)), iterator(std::end(c)),
             [](std::size_t v) { return v != 0; }, proj);
 
@@ -48,9 +75,8 @@ void test_all_of(ExPolicy policy, IteratorTag, Proj proj = Proj())
     }
 }
 
-template <typename ExPolicy, typename IteratorTag,
-    typename Proj = hpx::parallel::util::projection_identity>
-void test_all_of_async(ExPolicy p, IteratorTag, Proj proj = Proj())
+template <typename ExPolicy, typename IteratorTag>
+void test_all_of_async(ExPolicy p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -61,7 +87,32 @@ void test_all_of_async(ExPolicy p, IteratorTag, Proj proj = Proj())
         std::vector<std::size_t> c =
             test::fill_all_any_none(10007, i);    //-V106
 
-        hpx::future<bool> f = hpx::parallel::all_of(
+        hpx::future<bool> f = hpx::all_of(p, iterator(std::begin(c)),
+            iterator(std::end(c)), [](std::size_t v) { return v != 0; });
+        f.wait();
+
+        // verify values
+        bool expected = std::all_of(
+            std::begin(c), std::end(c), [](std::size_t v) { return v != 0; });
+
+        HPX_TEST_EQ(expected, f.get());
+    }
+}
+
+template <typename ExPolicy, typename IteratorTag,
+    typename Proj = hpx::parallel::util::projection_identity>
+void test_all_of_ranges_async(ExPolicy p, IteratorTag, Proj proj = Proj())
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::size_t iseq[] = {0, 23, 10007};
+    for (std::size_t i : iseq)
+    {
+        std::vector<std::size_t> c =
+            test::fill_all_any_none(10007, i);    //-V106
+
+        hpx::future<bool> f = hpx::ranges::all_of(
             p, iterator(std::begin(c)), iterator(std::end(c)),
             [](std::size_t v) { return v != 0; }, proj);
         f.wait();
@@ -92,15 +143,17 @@ void test_all_of()
     test_all_of(execution::par, IteratorTag());
     test_all_of(execution::par_unseq, IteratorTag());
 
-    test_all_of(execution::seq, IteratorTag(), proj());
-    test_all_of(execution::par, IteratorTag(), proj());
-    test_all_of(execution::par_unseq, IteratorTag(), proj());
+    test_all_of_ranges(execution::seq, IteratorTag(), proj());
+    test_all_of_ranges(execution::par, IteratorTag(), proj());
+    test_all_of_ranges(execution::par_unseq, IteratorTag(), proj());
 
     test_all_of_async(execution::seq(execution::task), IteratorTag());
     test_all_of_async(execution::par(execution::task), IteratorTag());
 
-    test_all_of_async(execution::seq(execution::task), IteratorTag(), proj());
-    test_all_of_async(execution::par(execution::task), IteratorTag(), proj());
+    test_all_of_ranges_async(
+        execution::seq(execution::task), IteratorTag(), proj());
+    test_all_of_ranges_async(
+        execution::par(execution::task), IteratorTag(), proj());
 }
 
 // template <typename IteratorTag>
@@ -153,8 +206,8 @@ void test_all_of_exception(ExPolicy policy, IteratorTag)
         bool caught_exception = false;
         try
         {
-            hpx::parallel::all_of(policy, iterator(std::begin(c)),
-                iterator(std::end(c)), [](std::size_t v) {
+            hpx::all_of(policy, iterator(std::begin(c)), iterator(std::end(c)),
+                [](std::size_t v) {
                     return throw std::runtime_error("test"), v != 0;
                 });
 
@@ -190,11 +243,10 @@ void test_all_of_exception_async(ExPolicy p, IteratorTag)
         bool returned_from_algorithm = false;
         try
         {
-            hpx::future<void> f =
-                hpx::parallel::all_of(p, iterator(std::begin(c)),
-                    iterator(std::end(c)), [](std::size_t v) {
-                        return throw std::runtime_error("test"), v != 0;
-                    });
+            hpx::future<void> f = hpx::all_of(p, iterator(std::begin(c)),
+                iterator(std::end(c)), [](std::size_t v) {
+                    return throw std::runtime_error("test"), v != 0;
+                });
             returned_from_algorithm = true;
             f.get();
 
@@ -256,8 +308,7 @@ void test_all_of_bad_alloc(ExPolicy policy, IteratorTag)
         bool caught_exception = false;
         try
         {
-            hpx::parallel::all_of(policy, iterator(std::begin(c)),
-                iterator(std::end(c)),
+            hpx::all_of(policy, iterator(std::begin(c)), iterator(std::end(c)),
                 [](std::size_t v) { return throw std::bad_alloc(), v != 0; });
 
             HPX_TEST(false);
@@ -291,8 +342,8 @@ void test_all_of_bad_alloc_async(ExPolicy p, IteratorTag)
         bool returned_from_algorithm = false;
         try
         {
-            hpx::future<void> f = hpx::parallel::all_of(p,
-                iterator(std::begin(c)), iterator(std::end(c)),
+            hpx::future<void> f = hpx::all_of(p, iterator(std::begin(c)),
+                iterator(std::end(c)),
                 [](std::size_t v) { return throw std::bad_alloc(), v != 0; });
             returned_from_algorithm = true;
             f.get();

--- a/libs/algorithms/tests/unit/algorithms/any_of.cpp
+++ b/libs/algorithms/tests/unit/algorithms/any_of.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2014-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -19,9 +19,8 @@
 #include "test_utils.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
-template <typename ExPolicy, typename IteratorTag,
-    typename Proj = hpx::parallel::util::projection_identity>
-void test_any_of(ExPolicy policy, IteratorTag, Proj proj = Proj())
+template <typename ExPolicy, typename IteratorTag>
+void test_any_of(ExPolicy policy, IteratorTag)
 {
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
@@ -36,7 +35,35 @@ void test_any_of(ExPolicy policy, IteratorTag, Proj proj = Proj())
         std::vector<std::size_t> c =
             test::fill_all_any_none(10007, i);    //-V106
 
-        bool result = hpx::parallel::any_of(
+        bool result = hpx::any_of(policy, iterator(std::begin(c)),
+            iterator(std::end(c)), [](std::size_t v) { return v != 0; });
+
+        // verify values
+        bool expected = std::any_of(
+            std::begin(c), std::end(c), [](std::size_t v) { return v != 0; });
+
+        HPX_TEST_EQ(result, expected);
+    }
+}
+
+template <typename ExPolicy, typename IteratorTag,
+    typename Proj = hpx::parallel::util::projection_identity>
+void test_any_of_ranges(ExPolicy policy, IteratorTag, Proj proj = Proj())
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::size_t iseq[] = {0, 23, 10007};
+    for (std::size_t i : iseq)
+    {
+        std::vector<std::size_t> c =
+            test::fill_all_any_none(10007, i);    //-V106
+
+        bool result = hpx::ranges::any_of(
             policy, iterator(std::begin(c)), iterator(std::end(c)),
             [](std::size_t v) { return v != 0; }, proj);
 
@@ -48,9 +75,8 @@ void test_any_of(ExPolicy policy, IteratorTag, Proj proj = Proj())
     }
 }
 
-template <typename ExPolicy, typename IteratorTag,
-    typename Proj = hpx::parallel::util::projection_identity>
-void test_any_of_async(ExPolicy p, IteratorTag, Proj proj = Proj())
+template <typename ExPolicy, typename IteratorTag>
+void test_any_of_async(ExPolicy p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -61,7 +87,32 @@ void test_any_of_async(ExPolicy p, IteratorTag, Proj proj = Proj())
         std::vector<std::size_t> c =
             test::fill_all_any_none(10007, i);    //-V106
 
-        hpx::future<bool> f = hpx::parallel::any_of(
+        hpx::future<bool> f = hpx::any_of(p, iterator(std::begin(c)),
+            iterator(std::end(c)), [](std::size_t v) { return v != 0; });
+        f.wait();
+
+        // verify values
+        bool expected = std::any_of(
+            std::begin(c), std::end(c), [](std::size_t v) { return v != 0; });
+
+        HPX_TEST_EQ(expected, f.get());
+    }
+}
+
+template <typename ExPolicy, typename IteratorTag,
+    typename Proj = hpx::parallel::util::projection_identity>
+void test_any_of_ranges_async(ExPolicy p, IteratorTag, Proj proj = Proj())
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::size_t iseq[] = {0, 23, 10007};
+    for (std::size_t i : iseq)
+    {
+        std::vector<std::size_t> c =
+            test::fill_all_any_none(10007, i);    //-V106
+
+        hpx::future<bool> f = hpx::ranges::any_of(
             p, iterator(std::begin(c)), iterator(std::end(c)),
             [](std::size_t v) { return v != 0; }, proj);
         f.wait();
@@ -92,15 +143,17 @@ void test_any_of()
     test_any_of(execution::par, IteratorTag());
     test_any_of(execution::par_unseq, IteratorTag());
 
-    test_any_of(execution::seq, IteratorTag(), proj());
-    test_any_of(execution::par, IteratorTag(), proj());
-    test_any_of(execution::par_unseq, IteratorTag(), proj());
+    test_any_of_ranges(execution::seq, IteratorTag(), proj());
+    test_any_of_ranges(execution::par, IteratorTag(), proj());
+    test_any_of_ranges(execution::par_unseq, IteratorTag(), proj());
 
     test_any_of_async(execution::seq(execution::task), IteratorTag());
     test_any_of_async(execution::par(execution::task), IteratorTag());
 
-    test_any_of_async(execution::seq(execution::task), IteratorTag(), proj());
-    test_any_of_async(execution::par(execution::task), IteratorTag(), proj());
+    test_any_of_ranges_async(
+        execution::seq(execution::task), IteratorTag(), proj());
+    test_any_of_ranges_async(
+        execution::par(execution::task), IteratorTag(), proj());
 }
 
 // template <typename IteratorTag>
@@ -153,8 +206,8 @@ void test_any_of_exception(ExPolicy policy, IteratorTag)
         bool caught_exception = false;
         try
         {
-            hpx::parallel::any_of(policy, iterator(std::begin(c)),
-                iterator(std::end(c)), [](std::size_t v) {
+            hpx::any_of(policy, iterator(std::begin(c)), iterator(std::end(c)),
+                [](std::size_t v) {
                     return throw std::runtime_error("test"), v != 0;
                 });
 
@@ -190,11 +243,10 @@ void test_any_of_exception_async(ExPolicy p, IteratorTag)
         bool returned_from_algorithm = false;
         try
         {
-            hpx::future<void> f =
-                hpx::parallel::any_of(p, iterator(std::begin(c)),
-                    iterator(std::end(c)), [](std::size_t v) {
-                        return throw std::runtime_error("test"), v != 0;
-                    });
+            hpx::future<void> f = hpx::any_of(p, iterator(std::begin(c)),
+                iterator(std::end(c)), [](std::size_t v) {
+                    return throw std::runtime_error("test"), v != 0;
+                });
             returned_from_algorithm = true;
             f.get();
 
@@ -256,8 +308,7 @@ void test_any_of_bad_alloc(ExPolicy policy, IteratorTag)
         bool caught_exception = false;
         try
         {
-            hpx::parallel::any_of(policy, iterator(std::begin(c)),
-                iterator(std::end(c)),
+            hpx::any_of(policy, iterator(std::begin(c)), iterator(std::end(c)),
                 [](std::size_t v) { return throw std::bad_alloc(), v != 0; });
 
             HPX_TEST(false);
@@ -291,8 +342,8 @@ void test_any_of_bad_alloc_async(ExPolicy p, IteratorTag)
         bool returned_from_algorithm = false;
         try
         {
-            hpx::future<void> f = hpx::parallel::any_of(p,
-                iterator(std::begin(c)), iterator(std::end(c)),
+            hpx::future<void> f = hpx::any_of(p, iterator(std::begin(c)),
+                iterator(std::end(c)),
                 [](std::size_t v) { return throw std::bad_alloc(), v != 0; });
             returned_from_algorithm = true;
             f.get();

--- a/libs/algorithms/tests/unit/algorithms/none_of.cpp
+++ b/libs/algorithms/tests/unit/algorithms/none_of.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2014-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -19,9 +19,8 @@
 #include "test_utils.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
-template <typename ExPolicy, typename IteratorTag,
-    typename Proj = hpx::parallel::util::projection_identity>
-void test_none_of(ExPolicy policy, IteratorTag, Proj proj = Proj())
+template <typename ExPolicy, typename IteratorTag>
+void test_none_of(ExPolicy policy, IteratorTag)
 {
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
@@ -35,7 +34,34 @@ void test_none_of(ExPolicy policy, IteratorTag, Proj proj = Proj())
     {
         std::vector<std::size_t> c = test::fill_all_any_none(3, i);    //-V106
 
-        bool result = hpx::parallel::none_of(
+        bool result = hpx::none_of(policy, iterator(std::begin(c)),
+            iterator(std::end(c)), [](std::size_t v) { return v != 0; });
+
+        // verify values
+        bool expected = std::none_of(
+            std::begin(c), std::end(c), [](std::size_t v) { return v != 0; });
+
+        HPX_TEST_EQ(result, expected);
+    }
+}
+
+template <typename ExPolicy, typename IteratorTag,
+    typename Proj = hpx::parallel::util::projection_identity>
+void test_none_of_ranges(ExPolicy policy, IteratorTag, Proj proj = Proj())
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::size_t iseq[] = {0, 1, 3};
+    for (std::size_t i : iseq)
+    {
+        std::vector<std::size_t> c = test::fill_all_any_none(3, i);    //-V106
+
+        bool result = hpx::ranges::none_of(
             policy, iterator(std::begin(c)), iterator(std::end(c)),
             [](std::size_t v) { return v != 0; }, proj);
 
@@ -47,9 +73,8 @@ void test_none_of(ExPolicy policy, IteratorTag, Proj proj = Proj())
     }
 }
 
-template <typename ExPolicy, typename IteratorTag,
-    typename Proj = hpx::parallel::util::projection_identity>
-void test_none_of_async(ExPolicy p, IteratorTag, Proj proj = Proj())
+template <typename ExPolicy, typename IteratorTag>
+void test_none_of_async(ExPolicy p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -60,7 +85,32 @@ void test_none_of_async(ExPolicy p, IteratorTag, Proj proj = Proj())
         std::vector<std::size_t> c =
             test::fill_all_any_none(10007, i);    //-V106
 
-        hpx::future<bool> f = hpx::parallel::none_of(
+        hpx::future<bool> f = hpx::none_of(p, iterator(std::begin(c)),
+            iterator(std::end(c)), [](std::size_t v) { return v != 0; });
+        f.wait();
+
+        // verify values
+        bool expected = std::none_of(
+            std::begin(c), std::end(c), [](std::size_t v) { return v != 0; });
+
+        HPX_TEST_EQ(expected, f.get());
+    }
+}
+
+template <typename ExPolicy, typename IteratorTag,
+    typename Proj = hpx::parallel::util::projection_identity>
+void test_none_of_ranges_async(ExPolicy p, IteratorTag, Proj proj = Proj())
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::size_t iseq[] = {0, 23, 10007};
+    for (std::size_t i : iseq)
+    {
+        std::vector<std::size_t> c =
+            test::fill_all_any_none(10007, i);    //-V106
+
+        hpx::future<bool> f = hpx::ranges::none_of(
             p, iterator(std::begin(c)), iterator(std::end(c)),
             [](std::size_t v) { return v != 0; }, proj);
         f.wait();
@@ -91,15 +141,17 @@ void test_none_of()
     test_none_of(execution::par, IteratorTag());
     test_none_of(execution::par_unseq, IteratorTag());
 
-    test_none_of(execution::seq, IteratorTag(), proj());
-    test_none_of(execution::par, IteratorTag(), proj());
-    test_none_of(execution::par_unseq, IteratorTag(), proj());
+    test_none_of_ranges(execution::seq, IteratorTag(), proj());
+    test_none_of_ranges(execution::par, IteratorTag(), proj());
+    test_none_of_ranges(execution::par_unseq, IteratorTag(), proj());
 
     test_none_of_async(execution::seq(execution::task), IteratorTag());
     test_none_of_async(execution::par(execution::task), IteratorTag());
 
-    test_none_of_async(execution::seq(execution::task), IteratorTag(), proj());
-    test_none_of_async(execution::par(execution::task), IteratorTag(), proj());
+    test_none_of_ranges_async(
+        execution::seq(execution::task), IteratorTag(), proj());
+    test_none_of_ranges_async(
+        execution::par(execution::task), IteratorTag(), proj());
 }
 
 // template <typename IteratorTag>
@@ -152,8 +204,8 @@ void test_none_of_exception(ExPolicy policy, IteratorTag)
         bool caught_exception = false;
         try
         {
-            hpx::parallel::none_of(policy, iterator(std::begin(c)),
-                iterator(std::end(c)), [](std::size_t v) {
+            hpx::none_of(policy, iterator(std::begin(c)), iterator(std::end(c)),
+                [](std::size_t v) {
                     return throw std::runtime_error("test"), v != 0;
                 });
 
@@ -189,11 +241,10 @@ void test_none_of_exception_async(ExPolicy p, IteratorTag)
         bool returned_from_algorithm = false;
         try
         {
-            hpx::future<void> f =
-                hpx::parallel::none_of(p, iterator(std::begin(c)),
-                    iterator(std::end(c)), [](std::size_t v) {
-                        return throw std::runtime_error("test"), v != 0;
-                    });
+            hpx::future<void> f = hpx::none_of(p, iterator(std::begin(c)),
+                iterator(std::end(c)), [](std::size_t v) {
+                    return throw std::runtime_error("test"), v != 0;
+                });
             returned_from_algorithm = true;
             f.get();
 
@@ -257,8 +308,7 @@ void test_none_of_bad_alloc(ExPolicy policy, IteratorTag)
         bool caught_exception = false;
         try
         {
-            hpx::parallel::none_of(policy, iterator(std::begin(c)),
-                iterator(std::end(c)),
+            hpx::none_of(policy, iterator(std::begin(c)), iterator(std::end(c)),
                 [](std::size_t v) { return throw std::bad_alloc(), v != 0; });
 
             HPX_TEST(false);
@@ -292,8 +342,8 @@ void test_none_of_bad_alloc_async(ExPolicy p, IteratorTag)
         bool returned_from_algorithm = false;
         try
         {
-            hpx::future<void> f = hpx::parallel::none_of(p,
-                iterator(std::begin(c)), iterator(std::end(c)),
+            hpx::future<void> f = hpx::none_of(p, iterator(std::begin(c)),
+                iterator(std::end(c)),
                 [](std::size_t v) { return throw std::bad_alloc(), v != 0; });
             returned_from_algorithm = true;
             f.get();

--- a/libs/algorithms/tests/unit/container_algorithms/all_of_range.cpp
+++ b/libs/algorithms/tests/unit/container_algorithms/all_of_range.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2014-2020 Hartmut Kaiser
 //                2017 Bruno Pitrus
 
 //  SPDX-License-Identifier: BSL-1.0
@@ -37,7 +37,7 @@ void test_all_of(ExPolicy policy, IteratorTag, Proj proj = Proj())
         std::vector<std::size_t> c =
             test::fill_all_any_none(10007, i);    //-V106
 
-        bool result = hpx::parallel::all_of(
+        bool result = hpx::ranges::all_of(
             policy, c, [](std::size_t v) { return v != 0; }, proj);
 
         // verify values
@@ -61,7 +61,7 @@ void test_all_of_async(ExPolicy p, IteratorTag, Proj proj = Proj())
         std::vector<std::size_t> c =
             test::fill_all_any_none(10007, i);    //-V106
 
-        hpx::future<bool> f = hpx::parallel::all_of(
+        hpx::future<bool> f = hpx::ranges::all_of(
             p, c, [](std::size_t v) { return v != 0; }, proj);
         f.wait();
 
@@ -152,7 +152,7 @@ void test_all_of_exception(ExPolicy policy, IteratorTag)
         bool caught_exception = false;
         try
         {
-            hpx::parallel::all_of(policy, c, [](std::size_t v) {
+            hpx::ranges::all_of(policy, c, [](std::size_t v) {
                 return throw std::runtime_error("test"), v != 0;
             });
 
@@ -188,10 +188,9 @@ void test_all_of_exception_async(ExPolicy p, IteratorTag)
         bool returned_from_algorithm = false;
         try
         {
-            hpx::future<void> f =
-                hpx::parallel::all_of(p, c, [](std::size_t v) {
-                    return throw std::runtime_error("test"), v != 0;
-                });
+            hpx::future<void> f = hpx::ranges::all_of(p, c, [](std::size_t v) {
+                return throw std::runtime_error("test"), v != 0;
+            });
             returned_from_algorithm = true;
             f.get();
 
@@ -253,7 +252,7 @@ void test_all_of_bad_alloc(ExPolicy policy, IteratorTag)
         bool caught_exception = false;
         try
         {
-            hpx::parallel::all_of(policy, c,
+            hpx::ranges::all_of(policy, c,
                 [](std::size_t v) { return throw std::bad_alloc(), v != 0; });
 
             HPX_TEST(false);
@@ -287,7 +286,7 @@ void test_all_of_bad_alloc_async(ExPolicy p, IteratorTag)
         bool returned_from_algorithm = false;
         try
         {
-            hpx::future<void> f = hpx::parallel::all_of(p, c,
+            hpx::future<void> f = hpx::ranges::all_of(p, c,
                 [](std::size_t v) { return throw std::bad_alloc(), v != 0; });
             returned_from_algorithm = true;
             f.get();

--- a/libs/algorithms/tests/unit/container_algorithms/any_of_range.cpp
+++ b/libs/algorithms/tests/unit/container_algorithms/any_of_range.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2014-2020 Hartmut Kaiser
 //                2017 Bruno Pitrus
 
 //  SPDX-License-Identifier: BSL-1.0
@@ -37,7 +37,7 @@ void test_any_of(ExPolicy policy, IteratorTag, Proj proj = Proj())
         std::vector<std::size_t> c =
             test::fill_all_any_none(10007, i);    //-V106
 
-        bool result = hpx::parallel::any_of(
+        bool result = hpx::ranges::any_of(
             policy, c, [](std::size_t v) { return v != 0; }, proj);
 
         // verify values
@@ -61,7 +61,7 @@ void test_any_of_async(ExPolicy p, IteratorTag, Proj proj = Proj())
         std::vector<std::size_t> c =
             test::fill_all_any_none(10007, i);    //-V106
 
-        hpx::future<bool> f = hpx::parallel::any_of(
+        hpx::future<bool> f = hpx::ranges::any_of(
             p, c, [](std::size_t v) { return v != 0; }, proj);
         f.wait();
 
@@ -152,7 +152,7 @@ void test_any_of_exception(ExPolicy policy, IteratorTag)
         bool caught_exception = false;
         try
         {
-            hpx::parallel::any_of(policy, c, [](std::size_t v) {
+            hpx::ranges::any_of(policy, c, [](std::size_t v) {
                 return throw std::runtime_error("test"), v != 0;
             });
 
@@ -188,10 +188,9 @@ void test_any_of_exception_async(ExPolicy p, IteratorTag)
         bool returned_from_algorithm = false;
         try
         {
-            hpx::future<void> f =
-                hpx::parallel::any_of(p, c, [](std::size_t v) {
-                    return throw std::runtime_error("test"), v != 0;
-                });
+            hpx::future<void> f = hpx::ranges::any_of(p, c, [](std::size_t v) {
+                return throw std::runtime_error("test"), v != 0;
+            });
             returned_from_algorithm = true;
             f.get();
 
@@ -253,7 +252,7 @@ void test_any_of_bad_alloc(ExPolicy policy, IteratorTag)
         bool caught_exception = false;
         try
         {
-            hpx::parallel::any_of(policy, c,
+            hpx::ranges::any_of(policy, c,
                 [](std::size_t v) { return throw std::bad_alloc(), v != 0; });
 
             HPX_TEST(false);
@@ -287,7 +286,7 @@ void test_any_of_bad_alloc_async(ExPolicy p, IteratorTag)
         bool returned_from_algorithm = false;
         try
         {
-            hpx::future<void> f = hpx::parallel::any_of(p, c,
+            hpx::future<void> f = hpx::ranges::any_of(p, c,
                 [](std::size_t v) { return throw std::bad_alloc(), v != 0; });
             returned_from_algorithm = true;
             f.get();

--- a/libs/algorithms/tests/unit/container_algorithms/none_of_range.cpp
+++ b/libs/algorithms/tests/unit/container_algorithms/none_of_range.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2014-2020 Hartmut Kaiser
 //                2017 Bruno Pitrus
 
 //  SPDX-License-Identifier: BSL-1.0
@@ -36,7 +36,7 @@ void test_none_of(ExPolicy policy, IteratorTag, Proj proj = Proj())
     {
         std::vector<std::size_t> c = test::fill_all_any_none(3, i);    //-V106
 
-        bool result = hpx::parallel::none_of(
+        bool result = hpx::ranges::none_of(
             policy, c, [](std::size_t v) { return v != 0; }, proj);
 
         // verify values
@@ -60,7 +60,7 @@ void test_none_of_async(ExPolicy p, IteratorTag, Proj proj = Proj())
         std::vector<std::size_t> c =
             test::fill_all_any_none(10007, i);    //-V106
 
-        hpx::future<bool> f = hpx::parallel::none_of(
+        hpx::future<bool> f = hpx::ranges::none_of(
             p, c, [](std::size_t v) { return v != 0; }, proj);
         f.wait();
 
@@ -151,7 +151,7 @@ void test_none_of_exception(ExPolicy policy, IteratorTag)
         bool caught_exception = false;
         try
         {
-            hpx::parallel::none_of(policy, c, [](std::size_t v) {
+            hpx::ranges::none_of(policy, c, [](std::size_t v) {
                 return throw std::runtime_error("test"), v != 0;
             });
 
@@ -187,10 +187,9 @@ void test_none_of_exception_async(ExPolicy p, IteratorTag)
         bool returned_from_algorithm = false;
         try
         {
-            hpx::future<void> f =
-                hpx::parallel::none_of(p, c, [](std::size_t v) {
-                    return throw std::runtime_error("test"), v != 0;
-                });
+            hpx::future<void> f = hpx::ranges::none_of(p, c, [](std::size_t v) {
+                return throw std::runtime_error("test"), v != 0;
+            });
             returned_from_algorithm = true;
             f.get();
 
@@ -254,7 +253,7 @@ void test_none_of_bad_alloc(ExPolicy policy, IteratorTag)
         bool caught_exception = false;
         try
         {
-            hpx::parallel::none_of(policy, c,
+            hpx::ranges::none_of(policy, c,
                 [](std::size_t v) { return throw std::bad_alloc(), v != 0; });
 
             HPX_TEST(false);
@@ -288,7 +287,7 @@ void test_none_of_bad_alloc_async(ExPolicy p, IteratorTag)
         bool returned_from_algorithm = false;
         try
         {
-            hpx::future<void> f = hpx::parallel::none_of(p, c,
+            hpx::future<void> f = hpx::ranges::none_of(p, c,
                 [](std::size_t v) { return throw std::bad_alloc(), v != 0; });
             returned_from_algorithm = true;
             f.get();

--- a/libs/include/include/hpx/algorithm.hpp
+++ b/libs/include/include/hpx/algorithm.hpp
@@ -11,8 +11,6 @@
 
 namespace hpx {
     using hpx::parallel::adjacent_find;
-    using hpx::parallel::all_of;
-    using hpx::parallel::any_of;
     using hpx::parallel::count;
     using hpx::parallel::count_if;
     using hpx::parallel::equal;
@@ -45,7 +43,6 @@ namespace hpx {
     using hpx::parallel::minmax_element;
     using hpx::parallel::mismatch;
     using hpx::parallel::move;
-    using hpx::parallel::none_of;
     using hpx::parallel::partition;
     using hpx::parallel::partition_copy;
     using hpx::parallel::remove;

--- a/libs/segmented_algorithms/include/hpx/parallel/segmented_algorithms/all_any_none.hpp
+++ b/libs/segmented_algorithms/include/hpx/parallel/segmented_algorithms/all_any_none.hpp
@@ -197,10 +197,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 is_seq());
         }
 
-        template <typename ExPolicy, typename FwdIter, typename F,
-            typename Proj>
+        template <typename ExPolicy, typename FwdIter, typename Sent,
+            typename F, typename Proj>
         typename util::detail::algorithm_result<ExPolicy, bool>::type none_of_(
-            ExPolicy&& policy, FwdIter first, FwdIter last, F&& f, Proj&& proj,
+            ExPolicy&& policy, FwdIter first, Sent last, F&& f, Proj&& proj,
             std::false_type);
 
         ///////////////////////////////////////////////////////////////////////
@@ -370,10 +370,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 is_seq());
         }
 
-        template <typename ExPolicy, typename FwdIter, typename F,
-            typename Proj>
+        template <typename ExPolicy, typename FwdIter, typename Sent,
+            typename F, typename Proj>
         typename util::detail::algorithm_result<ExPolicy, bool>::type any_of_(
-            ExPolicy&& policy, FwdIter first, FwdIter last, F&& f, Proj&& proj,
+            ExPolicy&& policy, FwdIter first, Sent last, F&& f, Proj&& proj,
             std::false_type);
 
         ///////////////////////////////////////////////////////////////////////
@@ -543,10 +543,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 is_seq());
         }
 
-        template <typename ExPolicy, typename FwdIter, typename F,
-            typename Proj>
+        template <typename ExPolicy, typename FwdIter, typename Sent,
+            typename F, typename Proj>
         typename util::detail::algorithm_result<ExPolicy, bool>::type all_of_(
-            ExPolicy&& policy, FwdIter first, FwdIter last, F&& f, Proj&& proj,
+            ExPolicy&& policy, FwdIter first, Sent last, F&& f, Proj&& proj,
             std::false_type);
 
         /// \endcond

--- a/libs/segmented_algorithms/tests/unit/partitioned_vector_all_of1.cpp
+++ b/libs/segmented_algorithms/tests/unit/partitioned_vector_all_of1.cpp
@@ -64,8 +64,7 @@ template <typename ExPolicy, typename T, typename Func>
 void test_all(ExPolicy&& policy, hpx::partitioned_vector<T>& xvalues, Func&& f,
     bool expected_result)
 {
-    bool result =
-        hpx::parallel::all_of(policy, xvalues.begin(), xvalues.end(), f);
+    bool result = hpx::all_of(policy, xvalues.begin(), xvalues.end(), f);
     HPX_TEST_EQ(result, expected_result);
 }
 
@@ -73,8 +72,7 @@ template <typename ExPolicy, typename T, typename Func>
 void test_all_async(ExPolicy&& policy, hpx::partitioned_vector<T>& xvalues,
     Func&& f, bool expected_result)
 {
-    bool result =
-        hpx::parallel::all_of(policy, xvalues.begin(), xvalues.end(), f).get();
+    bool result = hpx::all_of(policy, xvalues.begin(), xvalues.end(), f).get();
     HPX_TEST_EQ(result, expected_result);
 }
 

--- a/libs/segmented_algorithms/tests/unit/partitioned_vector_all_of2.cpp
+++ b/libs/segmented_algorithms/tests/unit/partitioned_vector_all_of2.cpp
@@ -64,8 +64,7 @@ template <typename ExPolicy, typename T, typename Func>
 void test_all(ExPolicy&& policy, hpx::partitioned_vector<T>& xvalues, Func&& f,
     bool expected_result)
 {
-    bool result =
-        hpx::parallel::all_of(policy, xvalues.begin(), xvalues.end(), f);
+    bool result = hpx::all_of(policy, xvalues.begin(), xvalues.end(), f);
     HPX_TEST_EQ(result, expected_result);
 }
 
@@ -73,8 +72,7 @@ template <typename ExPolicy, typename T, typename Func>
 void test_all_async(ExPolicy&& policy, hpx::partitioned_vector<T>& xvalues,
     Func&& f, bool expected_result)
 {
-    bool result =
-        hpx::parallel::all_of(policy, xvalues.begin(), xvalues.end(), f).get();
+    bool result = hpx::all_of(policy, xvalues.begin(), xvalues.end(), f).get();
     HPX_TEST_EQ(result, expected_result);
 }
 

--- a/libs/segmented_algorithms/tests/unit/partitioned_vector_any_of1.cpp
+++ b/libs/segmented_algorithms/tests/unit/partitioned_vector_any_of1.cpp
@@ -64,8 +64,7 @@ template <typename ExPolicy, typename T, typename Func>
 void test_any(ExPolicy&& policy, hpx::partitioned_vector<T>& xvalues, Func&& f,
     bool expected_result)
 {
-    bool result =
-        hpx::parallel::any_of(policy, xvalues.begin(), xvalues.end(), f);
+    bool result = hpx::any_of(policy, xvalues.begin(), xvalues.end(), f);
     HPX_TEST_EQ(result, expected_result);
 }
 
@@ -73,8 +72,7 @@ template <typename ExPolicy, typename T, typename Func>
 void test_any_async(ExPolicy&& policy, hpx::partitioned_vector<T>& xvalues,
     Func&& f, bool expected_result)
 {
-    bool result =
-        hpx::parallel::any_of(policy, xvalues.begin(), xvalues.end(), f).get();
+    bool result = hpx::any_of(policy, xvalues.begin(), xvalues.end(), f).get();
     HPX_TEST_EQ(result, expected_result);
 }
 

--- a/libs/segmented_algorithms/tests/unit/partitioned_vector_any_of2.cpp
+++ b/libs/segmented_algorithms/tests/unit/partitioned_vector_any_of2.cpp
@@ -64,8 +64,7 @@ template <typename ExPolicy, typename T, typename Func>
 void test_any(ExPolicy&& policy, hpx::partitioned_vector<T>& xvalues, Func&& f,
     bool expected_result)
 {
-    bool result =
-        hpx::parallel::any_of(policy, xvalues.begin(), xvalues.end(), f);
+    bool result = hpx::any_of(policy, xvalues.begin(), xvalues.end(), f);
     HPX_TEST_EQ(result, expected_result);
 }
 
@@ -73,8 +72,7 @@ template <typename ExPolicy, typename T, typename Func>
 void test_any_async(ExPolicy&& policy, hpx::partitioned_vector<T>& xvalues,
     Func&& f, bool expected_result)
 {
-    bool result =
-        hpx::parallel::any_of(policy, xvalues.begin(), xvalues.end(), f).get();
+    bool result = hpx::any_of(policy, xvalues.begin(), xvalues.end(), f).get();
     HPX_TEST_EQ(result, expected_result);
 }
 

--- a/libs/segmented_algorithms/tests/unit/partitioned_vector_none1.cpp
+++ b/libs/segmented_algorithms/tests/unit/partitioned_vector_none1.cpp
@@ -64,8 +64,7 @@ template <typename ExPolicy, typename T, typename Func>
 void test_none(ExPolicy&& policy, hpx::partitioned_vector<T>& xvalues, Func&& f,
     bool expected_result)
 {
-    bool result =
-        hpx::parallel::none_of(policy, xvalues.begin(), xvalues.end(), f);
+    bool result = hpx::none_of(policy, xvalues.begin(), xvalues.end(), f);
     HPX_TEST_EQ(result, expected_result);
 }
 
@@ -73,8 +72,7 @@ template <typename ExPolicy, typename T, typename Func>
 void test_none_async(ExPolicy&& policy, hpx::partitioned_vector<T>& xvalues,
     Func&& f, bool expected_result)
 {
-    bool result =
-        hpx::parallel::none_of(policy, xvalues.begin(), xvalues.end(), f).get();
+    bool result = hpx::none_of(policy, xvalues.begin(), xvalues.end(), f).get();
     HPX_TEST_EQ(result, expected_result);
 }
 

--- a/libs/segmented_algorithms/tests/unit/partitioned_vector_none2.cpp
+++ b/libs/segmented_algorithms/tests/unit/partitioned_vector_none2.cpp
@@ -64,8 +64,7 @@ template <typename ExPolicy, typename T, typename Func>
 void test_none(ExPolicy&& policy, hpx::partitioned_vector<T>& xvalues, Func&& f,
     bool expected_result)
 {
-    bool result =
-        hpx::parallel::none_of(policy, xvalues.begin(), xvalues.end(), f);
+    bool result = hpx::none_of(policy, xvalues.begin(), xvalues.end(), f);
     HPX_TEST_EQ(result, expected_result);
 }
 
@@ -73,8 +72,7 @@ template <typename ExPolicy, typename T, typename Func>
 void test_none_async(ExPolicy&& policy, hpx::partitioned_vector<T>& xvalues,
     Func&& f, bool expected_result)
 {
-    bool result =
-        hpx::parallel::none_of(policy, xvalues.begin(), xvalues.end(), f).get();
+    bool result = hpx::none_of(policy, xvalues.begin(), xvalues.end(), f).get();
     HPX_TEST_EQ(result, expected_result);
 }
 


### PR DESCRIPTION
- this introduces CPOs for the algorithms
- flyby: make detail::accumulate constexpr
