### PR TITLE
Add CPOs for for_each

### DIFF
--- a/examples/transpose/transpose_block_numa.cpp
+++ b/examples/transpose/transpose_block_numa.cpp
@@ -4,16 +4,16 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
 
-#include <hpx/modules/format.hpp>
 #include <hpx/algorithm.hpp>
 #include <hpx/include/parallel_executors.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/modules/format.hpp>
+#include <hpx/modules/topology.hpp>
 #include <hpx/numeric.hpp>
 #include <hpx/serialization.hpp>
-#include <hpx/modules/topology.hpp>
-#include <hpx/include/util.hpp>
 
 #include <hpx/compute/host/numa_allocator.hpp>
 
@@ -29,8 +29,8 @@
 #include <utility>
 #include <vector>
 
-#define COL_SHIFT 1000.00           // Constant to shift column index
-#define ROW_SHIFT 0.001             // Constant to shift row index
+#define COL_SHIFT 1000.00    // Constant to shift column index
+#define ROW_SHIFT 0.001      // Constant to shift row index
 
 ///////////////////////////////////////////////////////////////////////////////
 hpx::threads::topology& retrieve_topology()
@@ -46,45 +46,56 @@ char const* B_block_basename = "/transpose/block/B";
 
 struct sub_block
 {
-    enum mode {
-        reference
-      , owning
+    enum mode
+    {
+        reference,
+        owning
     };
 
     sub_block()
       : size_(0)
       , data_(nullptr)
       , mode_(reference)
-    {}
+    {
+    }
 
-    sub_block(double * data, std::uint64_t size)
+    sub_block(double* data, std::uint64_t size)
       : size_(size)
       , data_(data)
       , mode_(reference)
-    {}
+    {
+    }
 
     ~sub_block()
     {
-        if(data_ && mode_ == owning)
+        if (data_ && mode_ == owning)
         {
             delete[] data_;
         }
     }
 
-    sub_block(sub_block && other)
+    sub_block(sub_block&& other)
       : size_(other.size_)
       , data_(other.data_)
       , mode_(other.mode_)
     {
-        if(mode_ == owning) { other.data_ = nullptr; other.size_ = 0; }
+        if (mode_ == owning)
+        {
+            other.data_ = nullptr;
+            other.size_ = 0;
+        }
     }
 
-    sub_block & operator=(sub_block && other)
+    sub_block& operator=(sub_block&& other)
     {
         size_ = other.size_;
         data_ = other.data_;
         mode_ = other.mode_;
-        if(mode_ == owning) { other.data_ = nullptr; other.size_ = 0; }
+        if (mode_ == owning)
+        {
+            other.data_ = nullptr;
+            other.size_ = 0;
+        }
 
         return *this;
     }
@@ -95,17 +106,17 @@ struct sub_block
         return data_[i];
     }
 
-    double & operator[](std::size_t i)
+    double& operator[](std::size_t i)
     {
         HPX_ASSERT(data_);
         HPX_ASSERT(mode_ == reference);
         return data_[i];
     }
 
-    void load(hpx::serialization::input_archive & ar, unsigned version)
+    void load(hpx::serialization::input_archive& ar, unsigned version)
     {
-        ar & size_;
-        if(size_ > 0)
+        ar& size_;
+        if (size_ > 0)
         {
             data_ = new double[size_];
             hpx::serialization::array<double> arr(data_, size_);
@@ -114,10 +125,10 @@ struct sub_block
         }
     }
 
-    void save(hpx::serialization::output_archive & ar, unsigned version) const
+    void save(hpx::serialization::output_archive& ar, unsigned version) const
     {
-        ar & size_;
-        if(size_ > 0)
+        ar& size_;
+        if (size_ > 0)
         {
             hpx::serialization::array<double> arr(data_, size_);
             ar << arr;
@@ -127,26 +138,21 @@ struct sub_block
     HPX_SERIALIZATION_SPLIT_MEMBER()
 
     std::uint64_t size_;
-    double * data_;
+    double* data_;
     mode mode_;
 };
 
 ///////////////////////////////////////////////////////////////////////////////
 // dirty workaround to avoid serialization of executors
-typedef
-    hpx::parallel::execution::local_priority_queue_attached_executor
+typedef hpx::parallel::execution::local_priority_queue_attached_executor
     executor_type;
-typedef
-    std::vector<executor_type>
-    executors_vector;
-typedef
-    hpx::parallel::util::numa_allocator<double, executors_vector>
+typedef std::vector<executor_type> executors_vector;
+typedef hpx::parallel::util::numa_allocator<double, executors_vector>
     allocator_type;
 
 executors_vector execs;
 
-struct block_component
-  : hpx::components::component_base<block_component>
+struct block_component : hpx::components::component_base<block_component>
 {
     block_component()
       : data_(0, 0.0, allocator_type(execs_, retrieve_topology()))
@@ -158,7 +164,8 @@ struct block_component
     block_component(std::uint64_t size, std::size_t numa_domain)
       : execs_(1, execs[numa_domain])
       , data_(size, 0.0, allocator_type(execs_, retrieve_topology()))
-    {}
+    {
+    }
 
     sub_block get_sub_block(std::uint64_t offset, std::uint64_t size)
     {
@@ -172,8 +179,7 @@ struct block_component
     std::vector<double, allocator_type> data_;
 };
 
-struct block
-  : hpx::components::client_base<block, block_component>
+struct block : hpx::components::client_base<block, block_component>
 {
     typedef hpx::components::client_base<block, block_component> base_type;
 
@@ -184,14 +190,15 @@ struct block
     {
     }
 
-    block(
-        std::uint64_t id, std::uint64_t size, const char * base_name,
+    block(std::uint64_t id, std::uint64_t size, const char* base_name,
         std::size_t numa_domain)
-      : base_type(hpx::new_<block_component>(hpx::find_here(), size, numa_domain))
+      : base_type(
+            hpx::new_<block_component>(hpx::find_here(), size, numa_domain))
     {
     }
 
-    hpx::future<sub_block> get_sub_block(std::uint64_t offset, std::uint64_t size)
+    hpx::future<sub_block> get_sub_block(
+        std::uint64_t offset, std::uint64_t size)
     {
         block_component::get_sub_block_action act;
         return hpx::async(act, get_id(), offset, size);
@@ -214,12 +221,12 @@ HPX_REGISTER_ACTION(get_sub_block_action);
 void transpose(hpx::future<sub_block> Af, hpx::future<sub_block> Bf,
     std::uint64_t block_order, std::uint64_t tile_size, std::uint64_t domain);
 double test_results(std::uint64_t order, std::uint64_t block_order,
-    std::vector<block> & trans, std::uint64_t blocks_start,
+    std::vector<block>& trans, std::uint64_t blocks_start,
     std::uint64_t blocks_end, std::uint64_t domain);
 
 ///////////////////////////////////////////////////////////////////////////////
-std::size_t get_num_numa_nodes(hpx::threads::topology const& topo,
-    hpx::program_options::variables_map& vm)
+std::size_t get_num_numa_nodes(
+    hpx::threads::topology const& topo, hpx::program_options::variables_map& vm)
 {
     std::size_t numa_nodes = topo.get_number_of_numa_nodes();
     if (numa_nodes == 0)
@@ -245,7 +252,7 @@ std::pair<std::size_t, std::size_t> get_num_numa_pus(
     std::string num_threads_str = vm["transpose-threads"].as<std::string>();
     std::size_t pus = numa_pus;
 
-    if(num_threads_str != "all")
+    if (num_threads_str != "all")
     {
         pus = hpx::util::from_string<std::size_t>(num_threads_str);
     }
@@ -274,7 +281,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         std::uint64_t num_local_blocks = vm["num_blocks"].as<std::uint64_t>();
         std::uint64_t tile_size = order;
 
-        if(vm.count("tile_size"))
+        if (vm.count("tile_size"))
             tile_size = vm["tile_size"].as<std::uint64_t>();
 
         verbose = vm.count("verbose") ? true : false;
@@ -306,7 +313,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         std::uint64_t blocks_start = id * num_local_blocks;
         std::uint64_t blocks_end = (id + 1) * num_local_blocks;
 
-        std::vector<boost::integer_range<std::uint64_t> > numa_ranges;
+        std::vector<boost::integer_range<std::uint64_t>> numa_ranges;
         numa_ranges.reserve(numa_nodes);
 
         // Actually allocate the block components in AGAS
@@ -315,15 +322,15 @@ int hpx_main(hpx::program_options::variables_map& vm)
         std::uint64_t numa_blocks_allocated = 0;
 
         // Allocate our block components in AGAS
-        for(std::uint64_t b = blocks_start; b != blocks_end; ++b)
+        for (std::uint64_t b = blocks_start; b != blocks_end; ++b)
         {
             A[b] = block(b, col_block_size, A_block_basename, block_numa_node);
             B[b] = block(b, col_block_size, B_block_basename, block_numa_node);
             ++numa_blocks_allocated;
-            if(numa_blocks_allocated == num_numa_blocks)
+            if (numa_blocks_allocated == num_numa_blocks)
             {
-                std::cout << block_numa_node << ": "
-                    << numa_block_begin << " " << b + 1 << "\n";
+                std::cout << block_numa_node << ": " << numa_block_begin << " "
+                          << b + 1 << "\n";
                 numa_ranges.push_back(boost::irange(numa_block_begin, b + 1));
                 numa_block_begin = b + 1;
                 ++block_numa_node;
@@ -333,65 +340,59 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
         // establish connection between localities, refer to all blocks from
         // everywhere
-        std::vector<hpx::future<hpx::id_type> > A_ids
-            = hpx::find_all_from_basename(A_block_basename, num_blocks);
-        std::vector<hpx::future<hpx::id_type> > B_ids
-            = hpx::find_all_from_basename(B_block_basename, num_blocks);
+        std::vector<hpx::future<hpx::id_type>> A_ids =
+            hpx::find_all_from_basename(A_block_basename, num_blocks);
+        std::vector<hpx::future<hpx::id_type>> B_ids =
+            hpx::find_all_from_basename(B_block_basename, num_blocks);
 
-        if(root)
+        if (root)
         {
-            std::cout
-                << "Serial Matrix transpose: B = A^T\n"
-                << "Matrix order          = " << order << "\n"
-                << "Matrix local columns  = " << block_order << "\n"
-                << "Number of blocks      = " << num_blocks << "\n"
-                << "Number of localities  = " << num_localities << "\n";
-            if(tile_size < order)
+            std::cout << "Serial Matrix transpose: B = A^T\n"
+                      << "Matrix order          = " << order << "\n"
+                      << "Matrix local columns  = " << block_order << "\n"
+                      << "Number of blocks      = " << num_blocks << "\n"
+                      << "Number of localities  = " << num_localities << "\n";
+            if (tile_size < order)
                 std::cout << "Tile size             = " << tile_size << "\n";
             else
                 std::cout << "Untiled\n";
-            std::cout
-                << "Number of iterations  = " << iterations << "\n";
+            std::cout << "Number of iterations  = " << iterations << "\n";
         }
 
-        using hpx::parallel::for_each;
         using hpx::parallel::execution::par;
+        using hpx::ranges::for_each;
 
         // Fill the original matrix, set transpose to known garbage value.
         auto range = boost::irange(blocks_start, blocks_end);
-        for_each(par, std::begin(range), std::end(range),
-            [&](std::uint64_t b)
+        for_each(par, range, [&](std::uint64_t b) {
+            std::shared_ptr<block_component> A_ptr =
+                hpx::get_ptr<block_component>(A[b].get_id()).get();
+            std::shared_ptr<block_component> B_ptr =
+                hpx::get_ptr<block_component>(B[b].get_id()).get();
+
+            for (std::uint64_t i = 0; i != order; ++i)
             {
-                std::shared_ptr<block_component> A_ptr =
-                    hpx::get_ptr<block_component>(A[b].get_id()).get();
-                std::shared_ptr<block_component> B_ptr =
-                    hpx::get_ptr<block_component>(B[b].get_id()).get();
-
-                for(std::uint64_t i = 0; i != order; ++i)
+                for (std::uint64_t j = 0; j != block_order; ++j)
                 {
-                    for(std::uint64_t j = 0; j != block_order; ++j)
-                    {
-                        double col_val = COL_SHIFT *
-                            static_cast<double>(b * block_order + j);
-                        A_ptr->data_[i * block_order + j] =
-                            col_val + ROW_SHIFT * i;
-                        B_ptr->data_[i * block_order + j] = -1.0;
-                    }
+                    double col_val =
+                        COL_SHIFT * static_cast<double>(b * block_order + j);
+                    A_ptr->data_[i * block_order + j] = col_val + ROW_SHIFT * i;
+                    B_ptr->data_[i * block_order + j] = -1.0;
                 }
-
-                // register the blocks for other localities to discover
-                hpx::register_with_basename(A_block_basename, A[b].get_id(), b);
-                hpx::register_with_basename(B_block_basename, B[b].get_id(), b);
             }
-        );
+
+            // register the blocks for other localities to discover
+            hpx::register_with_basename(A_block_basename, A[b].get_id(), b);
+            hpx::register_with_basename(B_block_basename, B[b].get_id(), b);
+        });
 
         hpx::wait_all(A_ids);
         hpx::wait_all(B_ids);
 
-        for(std::uint64_t b = 0; b != num_blocks; ++b)
+        for (std::uint64_t b = 0; b != num_blocks; ++b)
         {
             // Convert id to our client
-            if(b < blocks_start || b >= blocks_end)
+            if (b < blocks_start || b >= blocks_end)
             {
                 A[b] = block(std::move(A_ids[b]));
                 B[b] = block(std::move(B_ids[b]));
@@ -400,128 +401,114 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
         double avgtime = 0.0;
         double maxtime = 0.0;
-        double mintime = 366.0 * 24.0*3600.0; // set the minimum time to a large value;
-                                              // one leap year should be enough
+        double mintime =
+            366.0 * 24.0 * 3600.0;    // set the minimum time to a large value;
+                                      // one leap year should be enough
 
         hpx::lcos::local::barrier b(numa_ranges.size());
 
         // perform actual transpose
-        std::vector<hpx::future<double> > numa_workers;
+        std::vector<hpx::future<double>> numa_workers;
         numa_workers.reserve(numa_ranges.size());
-        for(std::uint64_t domain = 0; domain < numa_ranges.size(); ++domain)
+        for (std::uint64_t domain = 0; domain < numa_ranges.size(); ++domain)
         {
             numa_workers.push_back(
-                hpx::async(
-                    execs[domain],
-                    [&, domain]() -> double
+                hpx::async(execs[domain], [&, domain]() -> double {
+                    double errsq = 0.0;
+                    for (std::uint64_t iter = 0; iter < iterations; ++iter)
                     {
-                        double errsq = 0.0;
-                        for(std::uint64_t iter = 0; iter < iterations; ++iter)
+                        b.wait();
+                        hpx::util::high_resolution_timer t;
+
+                        auto range = numa_ranges[domain];
+
+                        std::uint64_t block_start = *std::begin(range);
+                        std::uint64_t block_end = *std::end(range);
+                        std::uint64_t blocks_size = block_end - block_start;
+
+                        std::vector<hpx::future<void>> block_futures;
+                        block_futures.resize(blocks_size);
+
+                        for_each(par.on(execs[domain]), range,
+                            [domain, &block_futures, num_blocks, block_start,
+                                block_order, tile_size, &A,
+                                &B](std::uint64_t b) {
+                                std::vector<hpx::future<void>> phase_futures;
+                                phase_futures.reserve(num_blocks);
+
+                                auto phase_range = boost::irange(
+                                    static_cast<std::uint64_t>(0), num_blocks);
+                                for (std::uint64_t phase : phase_range)
+                                {
+                                    const std::uint64_t block_size =
+                                        block_order * block_order;
+                                    const std::uint64_t from_block = phase;
+                                    const std::uint64_t from_phase = b;
+                                    const std::uint64_t A_offset =
+                                        from_phase * block_size;
+                                    const std::uint64_t B_offset =
+                                        phase * block_size;
+
+                                    phase_futures.push_back(
+                                        hpx::dataflow(execs[domain], &transpose,
+                                            A[from_block].get_sub_block(
+                                                A_offset, block_size),
+                                            B[b].get_sub_block(
+                                                B_offset, block_size),
+                                            block_order, tile_size, domain));
+                                }
+
+                                block_futures[b - block_start] =
+                                    hpx::when_all(phase_futures);
+                            });
+
+                        hpx::wait_all(block_futures);
+
+                        b.wait();
+                        double elapsed = t.elapsed();
+
+                        if (domain == 0)
                         {
-                            b.wait();
-                            hpx::util::high_resolution_timer t;
-
-                            auto range = numa_ranges[domain];
-
-                            std::uint64_t block_start = *std::begin(range);
-                            std::uint64_t block_end = *std::end(range);
-                            std::uint64_t blocks_size = block_end - block_start;
-
-                            std::vector<hpx::future<void> > block_futures;
-                            block_futures.resize(blocks_size);
-
-                            for_each(par.on(execs[domain]),
-                                std::begin(range), std::end(range),
-                                [
-                                    domain, &block_futures, num_blocks,
-                                    block_start, block_order, tile_size, &A, &B
-                                ]
-                                (std::uint64_t b)
-                                {
-                                    std::vector<hpx::future<void> > phase_futures;
-                                    phase_futures.reserve(num_blocks);
-
-                                    auto phase_range = boost::irange(
-                                        static_cast<std::uint64_t>(0), num_blocks);
-                                    for(std::uint64_t phase: phase_range)
-                                    {
-                                        const std::uint64_t block_size =
-                                            block_order * block_order;
-                                        const std::uint64_t from_block = phase;
-                                        const std::uint64_t from_phase = b;
-                                        const std::uint64_t A_offset =
-                                            from_phase * block_size;
-                                        const std::uint64_t B_offset =
-                                            phase * block_size;
-
-                                        phase_futures.push_back(
-                                            hpx::dataflow(
-                                                execs[domain]
-                                              , &transpose
-                                              , A[from_block].get_sub_block(
-                                                    A_offset, block_size)
-                                              , B[b].get_sub_block(B_offset, block_size)
-                                              , block_order
-                                              , tile_size
-                                              , domain
-                                            )
-                                        );
-                                    }
-
-                                    block_futures[b - block_start] =
-                                        hpx::when_all(phase_futures);
-                                }
-                            );
-
-                            hpx::wait_all(block_futures);
-
-                            b.wait();
-                            double elapsed = t.elapsed();
-
-                            if(domain == 0)
+                            // Skip the first iteration
+                            if (iter > 0 || iterations == 1)
                             {
-                                // Skip the first iteration
-                                if(iter > 0 || iterations == 1)
-                                {
-                                    avgtime = avgtime + elapsed;
-                                    maxtime = (std::max)(maxtime, elapsed);
-                                    mintime = (std::min)(mintime, elapsed);
-                                }
+                                avgtime = avgtime + elapsed;
+                                maxtime = (std::max)(maxtime, elapsed);
+                                mintime = (std::min)(mintime, elapsed);
                             }
-
-                            errsq += test_results(order, block_order, B,
-                                block_start, block_end, domain);
                         }
-                        return errsq;
+
+                        errsq += test_results(order, block_order, B,
+                            block_start, block_end, domain);
                     }
-                )
-            );
+                    return errsq;
+                }));
         }
         std::vector<double> errsqs = hpx::util::unwrap(numa_workers);
 
         ///////////////////////////////////////////////////////////////////////
         // Analyze and output results
-        if(root)
+        if (root)
         {
             double errsq = std::accumulate(errsqs.begin(), errsqs.end(), 0.0);
 
             std::cout << "Solution validates\n";
-            avgtime = avgtime/static_cast<double>(
-                (std::max)(iterations-1, static_cast<std::uint64_t>(1)));
-            std::cout
-                << "Rate (MB/s): " << 1.e-6 * bytes/mintime << ", "
-                << "Avg time (s): " << avgtime << ", "
-                << "Min time (s): " << mintime << ", "
-                << "Max time (s): " << maxtime << "\n";
+            avgtime = avgtime /
+                static_cast<double>(
+                    (std::max)(iterations - 1, static_cast<std::uint64_t>(1)));
+            std::cout << "Rate (MB/s): " << 1.e-6 * bytes / mintime << ", "
+                      << "Avg time (s): " << avgtime << ", "
+                      << "Min time (s): " << mintime << ", "
+                      << "Max time (s): " << maxtime << "\n";
 
-            if(verbose)
+            if (verbose)
                 std::cout << "Squared errors: " << errsq << "\n";
         }
 
         {
             // unregister names...
             auto range = boost::irange(blocks_start, blocks_end);
-            for (auto b: range)
+            for (auto b : range)
             {
                 hpx::unregister_with_basename(A_block_basename, b);
                 hpx::unregister_with_basename(B_block_basename, b);
@@ -544,6 +531,7 @@ int main(int argc, char* argv[])
     using namespace hpx::program_options;
 
     options_description desc_commandline;
+    // clang-format off
     desc_commandline.add_options()
         ("matrix_size", value<std::uint64_t>()->default_value(1024),
          "Matrix Size")
@@ -563,14 +551,14 @@ int main(int argc, char* argv[])
          hpx::program_options::value<std::string>()->default_value("all"),
          "number of NUMA domains to use. (default: all)")
     ;
+    // clang-format on
 
     // parse command line here to extract the necessary settings for HPX
-    parsed_options opts =
-        command_line_parser(argc, argv)
-            .allow_unregistered()
-            .options(desc_commandline)
-            .style(command_line_style::unix_style)
-            .run();
+    parsed_options opts = command_line_parser(argc, argv)
+                              .allow_unregistered()
+                              .options(desc_commandline)
+                              .style(command_line_style::unix_style)
+                              .run();
 
     variables_map vm;
     store(opts, vm);
@@ -585,10 +573,10 @@ int main(int argc, char* argv[])
     // localities
     std::vector<std::string> cfg = {
         "hpx.run_hpx_main!=1",
-        "hpx.numa_sensitive=2",  // no-cross NUMA stealing
+        "hpx.numa_sensitive=2",    // no-cross NUMA stealing
         // block all cores of requested number of NUMA-domains
-//        hpx::util::format("hpx.cores={}", numa_nodes * num_cores),
-//        hpx::util::format("hpx.os_threads={}", numa_nodes * pus.second)
+        //        hpx::util::format("hpx.cores={}", numa_nodes * num_cores),
+        //        hpx::util::format("hpx.os_threads={}", numa_nodes * pus.second)
     };
 
     std::string node_name("numanode");
@@ -602,38 +590,36 @@ int main(int argc, char* argv[])
             bind_desc += ";";
 
         std::size_t base_thread = i * pus.second;
-        bind_desc += hpx::util::format(
-            "thread:{}-{}={}:{}.core:0-{}.pu:0",
-            base_thread, (base_thread+pus.second-1), // thread:%d-%d
-            node_name, i,                            // %s:%d
-            pus.second-1                             // core:0-%d
+        bind_desc += hpx::util::format("thread:{}-{}={}:{}.core:0-{}.pu:0",
+            base_thread, (base_thread + pus.second - 1),    // thread:%d-%d
+            node_name, i,                                   // %s:%d
+            pus.second - 1                                  // core:0-%d
         );
     }
-//    cfg.push_back(bind_desc);
+    //    cfg.push_back(bind_desc);
 
-//    return hpx::init();
+    //    return hpx::init();
     return hpx::init(desc_commandline, argc, argv, cfg);
 }
 
 void transpose(hpx::future<sub_block> Af, hpx::future<sub_block> Bf,
-    std::uint64_t block_order, std::uint64_t tile_size,
-    std::uint64_t domain)
+    std::uint64_t block_order, std::uint64_t tile_size, std::uint64_t domain)
 {
     sub_block const A = Af.get();
     sub_block B = Bf.get();
 
-    if(tile_size < block_order)
+    if (tile_size < block_order)
     {
-        for(std::uint64_t i = 0; i < block_order; i += tile_size)
+        for (std::uint64_t i = 0; i < block_order; i += tile_size)
         {
-            for(std::uint64_t j = 0; j < block_order; j += tile_size)
+            for (std::uint64_t j = 0; j < block_order; j += tile_size)
             {
                 std::uint64_t max_i = (std::min)(block_order, i + tile_size);
                 std::uint64_t max_j = (std::min)(block_order, j + tile_size);
 
-                for(std::uint64_t it = i; it != max_i; ++it)
+                for (std::uint64_t it = i; it != max_i; ++it)
                 {
-                    for(std::uint64_t jt = j; jt != max_j; ++jt)
+                    for (std::uint64_t jt = j; jt != max_j; ++jt)
                     {
                         B[it + block_order * jt] = A[jt + block_order * it];
                     }
@@ -643,9 +629,9 @@ void transpose(hpx::future<sub_block> Af, hpx::future<sub_block> Bf,
     }
     else
     {
-        for(std::uint64_t i = 0; i != block_order; ++i)
+        for (std::uint64_t i = 0; i != block_order; ++i)
         {
-            for(std::uint64_t j = 0; j != block_order; ++j)
+            for (std::uint64_t j = 0; j != block_order; ++j)
             {
                 B[i + block_order * j] = A[j + block_order * i];
             }
@@ -654,7 +640,7 @@ void transpose(hpx::future<sub_block> Af, hpx::future<sub_block> Bf,
 }
 
 double test_results(std::uint64_t order, std::uint64_t block_order,
-    std::vector<block> & trans, std::uint64_t blocks_start,
+    std::vector<block>& trans, std::uint64_t blocks_start,
     std::uint64_t blocks_end, std::uint64_t domain)
 {
     using hpx::parallel::transform_reduce;
@@ -662,33 +648,29 @@ double test_results(std::uint64_t order, std::uint64_t block_order,
 
     // Fill the original matrix, set transpose to known garbage value.
     auto range = boost::irange(blocks_start, blocks_end);
-    double errsq =
-        transform_reduce(
-            par.on(execs[domain]),
-            std::begin(range), std::end(range), 0.0,
-            [](double lhs, double rhs) { return lhs + rhs; },
-            [&](std::uint64_t b) -> double
+    double errsq = transform_reduce(
+        par.on(execs[domain]), std::begin(range), std::end(range), 0.0,
+        [](double lhs, double rhs) { return lhs + rhs; },
+        [&](std::uint64_t b) -> double {
+            sub_block trans_block =
+                trans[b].get_sub_block(0, order * block_order).get();
+            double errsq = 0.0;
+            for (std::uint64_t i = 0; i < order; ++i)
             {
-                sub_block trans_block =
-                    trans[b].get_sub_block(0, order * block_order).get();
-                double errsq = 0.0;
-                for(std::uint64_t i = 0; i < order; ++i)
+                double col_val = COL_SHIFT * i;
+                for (std::uint64_t j = 0; j < block_order; ++j)
                 {
-                    double col_val = COL_SHIFT * i;
-                    for(std::uint64_t j = 0; j < block_order; ++j)
-                    {
-                        double diff = trans_block[i * block_order + j] -
-                            (col_val +
-                                ROW_SHIFT *
-                                    static_cast<double>(b * block_order + j));
-                        errsq += diff * diff;
-                    }
+                    double diff = trans_block[i * block_order + j] -
+                        (col_val +
+                            ROW_SHIFT *
+                                static_cast<double>(b * block_order + j));
+                    errsq += diff * diff;
                 }
-                return errsq;
             }
-        );
+            return errsq;
+        });
 
-    if(verbose)
+    if (verbose)
         std::cout << " Squared sum of differences: " << errsq << "\n";
 
     return errsq;

--- a/examples/transpose/transpose_smp.cpp
+++ b/examples/transpose/transpose_smp.cpp
@@ -4,8 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
 
 #include <hpx/algorithm.hpp>
 #include <hpx/numeric.hpp>
@@ -17,12 +17,12 @@
 #include <iostream>
 #include <vector>
 
-#define COL_SHIFT 1000.00           // Constant to shift column index
-#define ROW_SHIFT 0.001             // Constant to shift row index
+#define COL_SHIFT 1000.00    // Constant to shift column index
+#define ROW_SHIFT 0.001      // Constant to shift row index
 
 bool verbose = false;
 
-double test_results(std::uint64_t order, std::vector<double> const & trans);
+double test_results(std::uint64_t order, std::vector<double> const& trans);
 
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(hpx::program_options::variables_map& vm)
@@ -31,7 +31,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::uint64_t iterations = vm["iterations"].as<std::uint64_t>();
     std::uint64_t tile_size = order;
 
-    if(vm.count("tile_size"))
+    if (vm.count("tile_size"))
         tile_size = vm["tile_size"].as<std::uint64_t>();
 
     verbose = vm.count("verbose") ? true : false;
@@ -42,84 +42,74 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::vector<double> A(order * order);
     std::vector<double> B(order * order);
 
-    std::cout
-        << "Serial Matrix transpose: B = A^T\n"
-        << "Matrix order          = " << order << "\n";
-    if(tile_size < order)
+    std::cout << "Serial Matrix transpose: B = A^T\n"
+              << "Matrix order          = " << order << "\n";
+    if (tile_size < order)
         std::cout << "Tile size             = " << tile_size << "\n";
     else
         std::cout << "Untiled\n";
-    std::cout
-        << "Number of iterations  = " << iterations << "\n";
+    std::cout << "Number of iterations  = " << iterations << "\n";
 
-    using hpx::parallel::for_each;
     using hpx::parallel::execution::par;
+    using hpx::ranges::for_each;
 
     const std::uint64_t start = 0;
 
     // Fill the original matrix, set transpose to known garbage value.
     auto range = boost::irange(start, order);
     // parallel for
-    for_each(par, std::begin(range), std::end(range),
-        [&](std::uint64_t i)
+    for_each(par, range, [&](std::uint64_t i) {
+        for (std::uint64_t j = 0; j < order; ++j)
         {
-            for(std::uint64_t j = 0; j < order; ++j)
-            {
-                A[i * order + j] = COL_SHIFT * j + ROW_SHIFT * i;
-                B[i * order + j] = -1.0;
-            }
+            A[i * order + j] = COL_SHIFT * j + ROW_SHIFT * i;
+            B[i * order + j] = -1.0;
         }
-    );
+    });
 
     double errsq = 0.0;
     double avgtime = 0.0;
     double maxtime = 0.0;
-    double mintime = 366.0 * 24.0*3600.0; // set the minimum time to a large value;
-                                          // one leap year should be enough
-    for(std::uint64_t iter = 0; iter < iterations; ++iter)
+    double mintime =
+        366.0 * 24.0 * 3600.0;    // set the minimum time to a large value;
+                                  // one leap year should be enough
+    for (std::uint64_t iter = 0; iter < iterations; ++iter)
     {
         hpx::util::high_resolution_timer t;
-        if(tile_size < order)
+        if (tile_size < order)
         {
-            auto range = boost::irange(start, order+tile_size, tile_size);
+            auto range = boost::irange(start, order + tile_size, tile_size);
             // parallel for
-            for_each(par, std::begin(range), std::end(range),
-                [&](std::uint64_t i)
+            for_each(par, range, [&](std::uint64_t i) {
+                for (std::uint64_t j = 0; j < order; j += tile_size)
                 {
-                    for(std::uint64_t j = 0; j < order; j += tile_size)
-                    {
-                        std::uint64_t i_max = (std::min)(order, i + tile_size);
-                        std::uint64_t j_max = (std::min)(order, j + tile_size);
+                    std::uint64_t i_max = (std::min)(order, i + tile_size);
+                    std::uint64_t j_max = (std::min)(order, j + tile_size);
 
-                        for(std::uint64_t it = i; it < i_max; ++it)
+                    for (std::uint64_t it = i; it < i_max; ++it)
+                    {
+                        for (std::uint64_t jt = j; jt < j_max; ++jt)
                         {
-                            for(std::uint64_t jt = j; jt < j_max; ++jt)
-                            {
-                                B[it + order * jt] = A[jt + order * it];
-                            }
+                            B[it + order * jt] = A[jt + order * it];
                         }
                     }
                 }
-            );
+            });
         }
         else
         {
             auto range = boost::irange(start, order);
             // parallel for
-            for_each(par, std::begin(range), std::end(range),
-                [&](std::uint64_t i)
+            for_each(par, range, [&](std::uint64_t i) {
+                for (std::uint64_t j = 0; j < order; ++j)
                 {
-                    for(std::uint64_t j = 0; j < order; ++j)
-                    {
-                        B[i + order * j] = A[j + order * i];
-                    }
+                    B[i + order * j] = A[j + order * i];
                 }
-            );
+            });
         }
 
         double elapsed = t.elapsed();
 
-        if(iter > 0 || iterations == 1) // Skip the first iteration
+        if (iter > 0 || iterations == 1)    // Skip the first iteration
         {
             avgtime = avgtime + elapsed;
             maxtime = (std::max)(maxtime, elapsed);
@@ -127,30 +117,29 @@ int hpx_main(hpx::program_options::variables_map& vm)
         }
 
         errsq += test_results(order, B);
-    } // end of iter loop
+    }    // end of iter loop
 
     // Analyze and output results
 
     double epsilon = 1.e-8;
-    if(errsq < epsilon)
+    if (errsq < epsilon)
     {
         std::cout << "Solution validates\n";
-        avgtime = avgtime/static_cast<double>(
-            (std::max)(iterations-1, static_cast<std::uint64_t>(1)));
-        std::cout
-          << "Rate (MB/s): " << 1.e-6 * bytes/mintime << ", "
-          << "Avg time (s): " << avgtime << ", "
-          << "Min time (s): " << mintime << ", "
-          << "Max time (s): " << maxtime << "\n";
+        avgtime = avgtime /
+            static_cast<double>(
+                (std::max)(iterations - 1, static_cast<std::uint64_t>(1)));
+        std::cout << "Rate (MB/s): " << 1.e-6 * bytes / mintime << ", "
+                  << "Avg time (s): " << avgtime << ", "
+                  << "Min time (s): " << mintime << ", "
+                  << "Max time (s): " << maxtime << "\n";
 
-        if(verbose)
+        if (verbose)
             std::cout << "Squared errors: " << errsq << "\n";
     }
     else
     {
-        std::cout
-          << "ERROR: Aggregate squared error " << errsq
-          << " exceeds threshold " << epsilon << "\n";
+        std::cout << "ERROR: Aggregate squared error " << errsq
+                  << " exceeds threshold " << epsilon << "\n";
         hpx::terminate();
     }
 
@@ -162,6 +151,7 @@ int main(int argc, char* argv[])
     using namespace hpx::program_options;
 
     options_description desc_commandline;
+    // clang-format off
     desc_commandline.add_options()
         ("matrix_size", value<std::uint64_t>()->default_value(1024),
          "Matrix Size")
@@ -172,13 +162,13 @@ int main(int argc, char* argv[])
          "cache and TLB performance")
         ( "verbose", "Verbose output")
     ;
+    // clang-format on
 
     return hpx::init(desc_commandline, argc, argv);
 }
 
-double test_results(std::uint64_t order, std::vector<double> const & trans)
+double test_results(std::uint64_t order, std::vector<double> const& trans)
 {
-
     using hpx::parallel::transform_reduce;
     using hpx::parallel::execution::par;
 
@@ -186,23 +176,21 @@ double test_results(std::uint64_t order, std::vector<double> const & trans)
 
     auto range = boost::irange(start, order);
     // parallel reduce
-    double errsq =
-        transform_reduce(par, std::begin(range), std::end(range), 0.0,
-            [](double lhs, double rhs) { return lhs + rhs; },
-            [&](std::uint64_t i) -> double
+    double errsq = transform_reduce(
+        par, std::begin(range), std::end(range), 0.0,
+        [](double lhs, double rhs) { return lhs + rhs; },
+        [&](std::uint64_t i) -> double {
+            double errsq = 0.0;
+            for (std::uint64_t j = 0; j < order; ++j)
             {
-                double errsq = 0.0;
-                for(std::uint64_t j = 0; j < order; ++j)
-                {
-                    double diff = trans[i * order + j] -
-                        (COL_SHIFT*i + ROW_SHIFT * j);
-                    errsq += diff * diff;
-                }
-                return errsq;
+                double diff =
+                    trans[i * order + j] - (COL_SHIFT * i + ROW_SHIFT * j);
+                errsq += diff * diff;
             }
-        );
+            return errsq;
+        });
 
-    if(verbose)
+    if (verbose)
         std::cout << " Squared sum of differences: " << errsq << "\n";
 
     return errsq;

--- a/examples/transpose/transpose_smp_block.cpp
+++ b/examples/transpose/transpose_smp_block.cpp
@@ -4,8 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
 
 #include <hpx/algorithm.hpp>
 #include <hpx/numeric.hpp>
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <vector>
 
-#define COL_SHIFT 1000.00           // Constant to shift column index
-#define ROW_SHIFT 0.001             // Constant to shift row index
+#define COL_SHIFT 1000.00    // Constant to shift column index
+#define ROW_SHIFT 0.001      // Constant to shift row index
 
 bool verbose = false;
 
@@ -28,7 +28,7 @@ typedef double* sub_block;
 void transpose(sub_block A, sub_block B, std::uint64_t block_order,
     std::uint64_t tile_size);
 double test_results(std::uint64_t order, std::uint64_t block_order,
-    std::vector<block> const & trans);
+    std::vector<block> const& trans);
 
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(hpx::program_options::variables_map& vm)
@@ -38,7 +38,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::uint64_t num_blocks = vm["num_blocks"].as<std::uint64_t>();
     std::uint64_t tile_size = order;
 
-    if(vm.count("tile_size"))
+    if (vm.count("tile_size"))
         tile_size = vm["tile_size"].as<std::uint64_t>();
 
     verbose = vm.count("verbose") ? true : false;
@@ -52,81 +52,70 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::vector<block> A(num_blocks, block(col_block_size));
     std::vector<block> B(num_blocks, block(col_block_size));
 
-    std::cout
-        << "Serial Matrix transpose: B = A^T\n"
-        << "Matrix order          = " << order << "\n";
-    if(tile_size < order)
+    std::cout << "Serial Matrix transpose: B = A^T\n"
+              << "Matrix order          = " << order << "\n";
+    if (tile_size < order)
         std::cout << "Tile size             = " << tile_size << "\n";
     else
         std::cout << "Untiled\n";
-    std::cout
-        << "Number of iterations  = " << iterations << "\n";
+    std::cout << "Number of iterations  = " << iterations << "\n";
 
-    using hpx::parallel::for_each;
     using hpx::parallel::execution::par;
     using hpx::parallel::execution::task;
+    using hpx::ranges::for_each;
 
     const std::uint64_t start = 0;
 
     // Fill the original matrix, set transpose to known garbage value.
     auto range = boost::irange(start, num_blocks);
-    for_each(par, std::begin(range), std::end(range),
-        [&](std::uint64_t b)
+    for_each(par, range, [&](std::uint64_t b) {
+        for (std::uint64_t i = 0; i < order; ++i)
         {
-            for(std::uint64_t i = 0; i < order; ++i)
+            for (std::uint64_t j = 0; j < block_order; ++j)
             {
-                for(std::uint64_t j = 0; j < block_order; ++j)
-                {
-                    double col_val =
-                        COL_SHIFT * static_cast<double>(b * block_order + j);
+                double col_val =
+                    COL_SHIFT * static_cast<double>(b * block_order + j);
 
-                    A[b][i * block_order + j] = col_val + ROW_SHIFT * i;
-                    B[b][i * block_order + j] = -1.0;
-                }
+                A[b][i * block_order + j] = col_val + ROW_SHIFT * i;
+                B[b][i * block_order + j] = -1.0;
             }
         }
-    );
+    });
 
     double errsq = 0.0;
     double avgtime = 0.0;
     double maxtime = 0.0;
-    double mintime = 366.0 * 24.0*3600.0; // set the minimum time to a large value;
-                                         // one leap year should be enough
-    for(std::uint64_t iter = 0; iter < iterations; ++iter)
+    double mintime =
+        366.0 * 24.0 * 3600.0;    // set the minimum time to a large value;
+                                  // one leap year should be enough
+    for (std::uint64_t iter = 0; iter < iterations; ++iter)
     {
         hpx::util::high_resolution_timer t;
 
         auto range = boost::irange(start, num_blocks);
 
-        std::vector<hpx::shared_future<void> > transpose_futures;
+        std::vector<hpx::shared_future<void>> transpose_futures;
         transpose_futures.resize(num_blocks);
 
-        for_each(par, std::begin(range), std::end(range),
-            [&](std::uint64_t b)
-            {
-                transpose_futures[b] =
-                    for_each(par(task),
-                        std::begin(range), std::end(range),
-                        [&, b](std::uint64_t phase)
-                        {
-                            const std::uint64_t block_size = block_order * block_order;
-                            const std::uint64_t from_block = phase;
-                            const std::uint64_t from_phase = b;
-                            const std::uint64_t A_offset = from_phase * block_size;
-                            const std::uint64_t B_offset = phase * block_size;
+        for_each(par, range, [&](std::uint64_t b) {
+            transpose_futures[b] =
+                for_each(par(task), range, [&, b](std::uint64_t phase) {
+                    const std::uint64_t block_size = block_order * block_order;
+                    const std::uint64_t from_block = phase;
+                    const std::uint64_t from_phase = b;
+                    const std::uint64_t A_offset = from_phase * block_size;
+                    const std::uint64_t B_offset = phase * block_size;
 
-                            transpose(&A[from_block][A_offset], &B[b][B_offset],
-                                block_order, tile_size);
-                        }
-                    ).share();
-            }
-        );
+                    transpose(&A[from_block][A_offset], &B[b][B_offset],
+                        block_order, tile_size);
+                }).share();
+        });
 
         hpx::wait_all(transpose_futures);
 
         double elapsed = t.elapsed();
 
-        if(iter > 0 || iterations == 1) // Skip the first iteration
+        if (iter > 0 || iterations == 1)    // Skip the first iteration
         {
             avgtime = avgtime + elapsed;
             maxtime = (std::max)(maxtime, elapsed);
@@ -134,30 +123,29 @@ int hpx_main(hpx::program_options::variables_map& vm)
         }
 
         errsq += test_results(order, block_order, B);
-    } // end of iter loop
+    }    // end of iter loop
 
     // Analyze and output results
 
     double epsilon = 1.e-8;
-    if(errsq < epsilon)
+    if (errsq < epsilon)
     {
         std::cout << "Solution validates\n";
-        avgtime = avgtime/static_cast<double>(
-            (std::max)(iterations-1, static_cast<std::uint64_t>(1)));
-        std::cout
-          << "Rate (MB/s): " << 1.e-6 * bytes/mintime << ", "
-          << "Avg time (s): " << avgtime << ", "
-          << "Min time (s): " << mintime << ", "
-          << "Max time (s): " << maxtime << "\n";
+        avgtime = avgtime /
+            static_cast<double>(
+                (std::max)(iterations - 1, static_cast<std::uint64_t>(1)));
+        std::cout << "Rate (MB/s): " << 1.e-6 * bytes / mintime << ", "
+                  << "Avg time (s): " << avgtime << ", "
+                  << "Min time (s): " << mintime << ", "
+                  << "Max time (s): " << maxtime << "\n";
 
-        if(verbose)
+        if (verbose)
             std::cout << "Squared errors: " << errsq << "\n";
     }
     else
     {
-        std::cout
-          << "ERROR: Aggregate squared error " << errsq
-          << " exceeds threshold " << epsilon << "\n";
+        std::cout << "ERROR: Aggregate squared error " << errsq
+                  << " exceeds threshold " << epsilon << "\n";
         hpx::terminate();
     }
 
@@ -169,6 +157,7 @@ int main(int argc, char* argv[])
     using namespace hpx::program_options;
 
     options_description desc_commandline;
+    // clang-format off
     desc_commandline.add_options()
         ("matrix_size", value<std::uint64_t>()->default_value(1024),
          "Matrix Size")
@@ -182,6 +171,7 @@ int main(int argc, char* argv[])
          "cache and TLB performance")
         ( "verbose", "Verbose output")
     ;
+    // clang-format on
 
     return hpx::init(desc_commandline, argc, argv);
 }
@@ -189,18 +179,18 @@ int main(int argc, char* argv[])
 void transpose(sub_block A, sub_block B, std::uint64_t block_order,
     std::uint64_t tile_size)
 {
-    if(tile_size < block_order)
+    if (tile_size < block_order)
     {
-        for(std::uint64_t i = 0; i < block_order; i += tile_size)
+        for (std::uint64_t i = 0; i < block_order; i += tile_size)
         {
-            for(std::uint64_t j = 0; j < block_order; j += tile_size)
+            for (std::uint64_t j = 0; j < block_order; j += tile_size)
             {
                 std::uint64_t i_max = (std::min)(block_order, i + tile_size);
                 std::uint64_t j_max = (std::min)(block_order, j + tile_size);
 
-                for(std::uint64_t it = i; it < i_max; ++it)
+                for (std::uint64_t it = i; it < i_max; ++it)
                 {
-                    for(std::uint64_t jt = j; jt < j_max; ++jt)
+                    for (std::uint64_t jt = j; jt < j_max; ++jt)
                     {
                         B[it + block_order * jt] = A[jt + block_order * it];
                     }
@@ -210,9 +200,9 @@ void transpose(sub_block A, sub_block B, std::uint64_t block_order,
     }
     else
     {
-        for(std::uint64_t i = 0; i < block_order; ++i)
+        for (std::uint64_t i = 0; i < block_order; ++i)
         {
-            for(std::uint64_t j = 0; j < block_order; ++j)
+            for (std::uint64_t j = 0; j < block_order; ++j)
             {
                 B[i + block_order * j] = A[j + block_order * i];
             }
@@ -221,7 +211,7 @@ void transpose(sub_block A, sub_block B, std::uint64_t block_order,
 }
 
 double test_results(std::uint64_t order, std::uint64_t block_order,
-    std::vector<block> const & trans)
+    std::vector<block> const& trans)
 {
     using hpx::parallel::transform_reduce;
     using hpx::parallel::execution::par;
@@ -231,29 +221,27 @@ double test_results(std::uint64_t order, std::uint64_t block_order,
 
     // Fill the original matrix, set transpose to known garbage value.
     auto range = boost::irange(start, end);
-    double errsq =
-        transform_reduce(par, std::begin(range), std::end(range), 0.0,
-            [](double lhs, double rhs) { return lhs + rhs; },
-            [&](std::uint64_t b) -> double
+    double errsq = transform_reduce(
+        par, std::begin(range), std::end(range), 0.0,
+        [](double lhs, double rhs) { return lhs + rhs; },
+        [&](std::uint64_t b) -> double {
+            double errsq = 0.0;
+            for (std::uint64_t i = 0; i < order; ++i)
             {
-                double errsq = 0.0;
-                for(std::uint64_t i = 0; i < order; ++i)
+                double col_val = COL_SHIFT * i;
+                for (std::uint64_t j = 0; j < block_order; ++j)
                 {
-                    double col_val = COL_SHIFT * i;
-                    for(std::uint64_t j = 0; j < block_order; ++j)
-                    {
-                        double diff = trans[b][i * block_order + j] -
-                            (col_val +
-                                ROW_SHIFT *
-                                    static_cast<double>(b * block_order + j));
-                        errsq += diff * diff;
-                    }
+                    double diff = trans[b][i * block_order + j] -
+                        (col_val +
+                            ROW_SHIFT *
+                                static_cast<double>(b * block_order + j));
+                    errsq += diff * diff;
                 }
-                return errsq;
             }
-        );
+            return errsq;
+        });
 
-    if(verbose)
+    if (verbose)
         std::cout << " Squared sum of differences: " << errsq << "\n";
 
     return errsq;

--- a/libs/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -291,7 +291,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 typedef hpx::util::zip_iterator<FwdIter1, FwdIter2>
                     zip_iterator;
 
-                return util::get_in_out_result(
+                return util::detail::get_in_out_result(
                     util::foreach_partitioner<ExPolicy>::call(
                         std::forward<ExPolicy>(policy),
                         hpx::util::make_zip_iterator(first, dest),
@@ -400,7 +400,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 typedef hpx::util::zip_iterator<FwdIter1, FwdIter2>
                     zip_iterator;
 
-                return util::get_in_out_result(
+                return util::detail::get_in_out_result(
                     util::foreach_partitioner<ExPolicy>::call(
                         std::forward<ExPolicy>(policy),
                         hpx::util::make_zip_iterator(first, dest), count,

--- a/libs/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -8,23 +8,242 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/invoke.hpp>
-#if defined(HPX_HAVE_THREAD_DESCRIPTION)
-#include <hpx/functional/traits/get_function_address.hpp>
-#include <hpx/functional/traits/get_function_annotation.hpp>
-#endif
-#include <hpx/algorithms/traits/is_value_proxy.hpp>
-#include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
-#include <hpx/functional/traits/is_invocable.hpp>
-#include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/threading_base/annotated_function.hpp>
-#include <hpx/type_support/identity.hpp>
+#if defined(DOXYGEN)
+namespace hpx {
+    /// Applies \a f to the result of dereferencing every iterator in the
+    /// range [first, last).
+    ///
+    /// \note   Complexity: Applies \a f exactly \a last - \a first times.
+    ///
+    /// If \a f returns a result, the result is ignored.
+    ///
+    /// If the type of \a first satisfies the requirements of a mutable
+    /// iterator, \a f may apply non-constant functions through the
+    /// dereferenced iterator.
+    ///
+    /// \tparam InIter      The type of the source begin and end iterator used
+    ///                     (deduced). This iterator type must meet the
+    ///                     requirements of an input iterator.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). F must meet requirements of
+    ///                     \a MoveConstructible.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).
+    ///                     The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     <ignored> pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&. The
+    ///                     type \a Type must be such that an object of
+    ///                     type \a FwdIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///
+    /// \returns            \a f.
+    template <typename InIter, typename F>
+    F for_each(InIter first, InIter last, F&& f);
 
+    /// Applies \a f to the result of dereferencing every iterator in the
+    /// range [first, last).
+    ///
+    /// \note   Complexity: Applies \a f exactly \a last - \a first times.
+    ///
+    /// If \a f returns a result, the result is ignored.
+    ///
+    /// If the type of \a first satisfies the requirements of a mutable
+    /// iterator, \a f may apply non-constant functions through the
+    /// dereferenced iterator.
+    ///
+    /// Unlike its sequential form, the parallel overload of
+    /// \a for_each does not return a copy of its \a Function parameter,
+    /// since parallelization may not permit efficient state
+    /// accumulation.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it applies user-provided function objects.
+    /// \tparam FwdIte      The type of the source begin and end iterator used
+    ///                     (deduced). This iterator type must meet the
+    ///                     requirements of an forward iterator.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a for_each requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).
+    ///                     The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     <ignored> pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&. The
+    ///                     type \a Type must be such that an object of
+    ///                     type \a FwdIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified
+    /// threads, and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a for_each algorithm returns a
+    ///           \a hpx::future<void> if the execution policy is of
+    ///           type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and returns void otherwise.
+    template <typename ExPolicy, typename FwdIter, typename F>
+    typename util::detail::algorithm_result<ExPolicy, void>::type for_each(
+        ExPolicy&& policy, FwdIter first, FwdIter last, F&& f);
+
+    /// Applies \a f to the result of dereferencing every iterator in the range
+    /// [first, first + count), starting from first and proceeding to
+    /// first + count - 1.
+    ///
+    /// \note   Complexity: Applies \a f exactly \a count times.
+    ///
+    /// If \a f returns a result, the result is ignored.
+    ///
+    /// If the type of \a first satisfies the requirements of a mutable
+    /// iterator, \a f may apply non-constant functions through the
+    /// dereferenced iterator.
+    ///
+    /// \tparam InIter      The type of the source begin and end iterator used
+    ///                     (deduced). This iterator type must meet the
+    ///                     requirements of an input iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). F must meet requirements of
+    ///                     \a MoveConstructible.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).
+    ///                     The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     <ignored> pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&. The
+    ///                     type \a Type must be such that an object of
+    ///                     type \a FwdIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///
+    /// \returns            \a first + \a count for non-negative values of
+    ///                     \a count and \a first for negative values.
+    template <typename InIter, typename Size, typename F>
+    InIter for_each_n(InIter first, Size count, F&& f);
+
+    /// Applies \a f to the result of dereferencing every iterator in the range
+    /// [first, first + count), starting from first and proceeding to
+    /// first + count - 1.
+    ///
+    /// \note   Complexity: Applies \a f exactly \a count times.
+    ///
+    /// If \a f returns a result, the result is ignored.
+    ///
+    /// If the type of \a first satisfies the requirements of a mutable
+    /// iterator, \a f may apply non-constant functions through the
+    /// dereferenced iterator.
+    ///
+    /// Unlike its sequential form, the parallel overload of
+    /// \a for_each does not return a copy of its \a Function parameter,
+    /// since parallelization may not permit efficient state
+    /// accumulation.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it applies user-provided function objects.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a for_each requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).
+    ///                     The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     <ignored> pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&. The
+    ///                     type \a Type must be such that an object of
+    ///                     type \a FwdIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified
+    /// threads, and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a for_each_n algorithm returns a
+    ///           \a hpx::future<FwdIter> if the execution policy is of
+    ///           type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and returns \a FwdIter
+    ///           otherwise.
+    ///           It returns \a first + \a count for non-negative values of
+    ///           \a count and \a first for negative values.
+    template <typename ExPolicy, typename FwdIter, typename Size, typename F>
+    typename util::detail::algorithm_result<ExPolicy, FwdIter>::type for_each_n(
+        ExPolicy&& policy, FwdIter first, Size count, F&& f);
+
+}    // namespace hpx
+
+#else
+
+#include <hpx/config.hpp>
+#include <hpx/algorithms/traits/is_value_proxy.hpp>
 #include <hpx/algorithms/traits/projected.hpp>
-#include <hpx/execution/algorithms/detail/is_negative.hpp>
-#include <hpx/executors/execution_policy.hpp>
+#include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
+#include <hpx/modules/concepts.hpp>
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/executors.hpp>
+#include <hpx/modules/functional.hpp>
+#include <hpx/modules/iterator_support.hpp>
+#include <hpx/modules/type_support.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
@@ -114,10 +333,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename ExPolicy, typename F, typename Proj>
         struct for_each_iteration
         {
-            typedef
-                typename hpx::util::decay<ExPolicy>::type execution_policy_type;
-            typedef typename hpx::util::decay<F>::type fun_type;
-            typedef typename hpx::util::decay<Proj>::type proj_type;
+            using execution_policy_type =
+                typename hpx::util::decay<ExPolicy>::type;
+            using fun_type = typename hpx::util::decay<F>::type;
+            using proj_type = typename hpx::util::decay<Proj>::type;
 
             fun_type f_;
             proj_type proj_;
@@ -211,10 +430,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typename F, typename Proj>
         typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
         for_each_n_(ExPolicy&& policy, FwdIter first, Size count, F&& f,
-            std::false_type, Proj&& proj)
+            Proj&& proj, std::false_type)
         {
-            typedef parallel::execution::is_sequenced_execution_policy<ExPolicy>
-                is_seq;
+            using is_seq =
+                parallel::execution::is_sequenced_execution_policy<ExPolicy>;
 
             return detail::for_each_n<FwdIter>().call(
                 std::forward<ExPolicy>(policy), is_seq(), first,
@@ -233,7 +452,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typename F, typename Proj>
         typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
         for_each_n_(ExPolicy&& policy, FwdIter first, Size count, F&& f,
-            std::true_type, Proj&& proj)
+            Proj&& proj, std::true_type)
         {
             auto last = first;
             detail::advance(last, std::size_t(count));
@@ -243,97 +462,22 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Applies \a f to the result of dereferencing every iterator in the range
-    /// [first, first + count), starting from first and proceeding to
-    /// first + count - 1.
-    ///
-    /// \note   Complexity: Applies \a f exactly \a count times.
-    ///
-    /// If \a f returns a result, the result is ignored.
-    ///
-    /// If the type of \a first satisfies the requirements of a mutable
-    /// iterator, \a f may apply non-constant functions through the
-    /// dereferenced iterator.
-    ///
-    /// Unlike its sequential form, the parallel overload of
-    /// \a for_each does not return a copy of its \a Function parameter,
-    /// since parallelization may not permit efficient state
-    /// accumulation.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it applies user-provided function objects.
-    /// \tparam FwdIter     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam Size        The type of the argument specifying the number of
-    ///                     elements to apply \a f to.
-    /// \tparam F           The type of the function/function object to use
-    ///                     (deduced). Unlike its sequential form, the parallel
-    ///                     overload of \a for_each requires \a F to meet the
-    ///                     requirements of \a CopyConstructible.
-    /// \tparam Proj        The type of an optional projection function. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param count        Refers to the number of elements starting at
-    ///                     \a first the algorithm will be applied to.
-    /// \param f            Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last).
-    ///                     The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     <ignored> pred(const Type &a);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&. The
-    ///                     type \a Type must be such that an object of
-    ///                     type \a FwdIter can be dereferenced and then
-    ///                     implicitly converted to Type.
-    /// \param proj         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements as a
-    ///                     projection operation before the actual predicate
-    ///                     \a f is invoked.
-    ///
-    /// The application of function objects in parallel algorithm
-    /// invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in the
-    /// calling thread.
-    ///
-    /// The application of function objects in parallel algorithm
-    /// invoked with an execution policy object of type
-    /// \a parallel_policy or \a parallel_task_policy are
-    /// permitted to execute in an unordered fashion in unspecified
-    /// threads, and indeterminately sequenced within each thread.
-    ///
-    /// \returns  The \a for_each_n algorithm returns a
-    ///           \a hpx::future<FwdIter> if the execution policy is of
-    ///           type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and returns \a FwdIter
-    ///           otherwise.
-    ///           It returns \a first + \a count for non-negative values of
-    ///           \a count and \a first for negative values.
-    ///
-    //
     // clang-format off
     template <typename ExPolicy, typename FwdIter, typename Size, typename F,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter>::value &&
-            parallel::traits::is_projected<Proj, FwdIter>::value &&
-            parallel::traits::is_indirect_callable<ExPolicy, F,
-                traits::projected<Proj, FwdIter>>::value
+            hpx::parallel::traits::is_projected<Proj, FwdIter>::value &&
+            hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
+                hpx::parallel::traits::projected<Proj, FwdIter>>::value
         )>
     // clang-format on
-    typename util::detail::algorithm_result<ExPolicy, FwdIter>::type for_each_n(
-        ExPolicy&& policy, FwdIter first, Size count, F&& f,
-        Proj&& proj = Proj())
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::for_each_n is deprecated, use hpx::for_each_n instead")
+        typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
+        for_each_n(ExPolicy&& policy, FwdIter first, Size count, F&& f,
+            Proj&& proj = Proj())
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
@@ -345,10 +489,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 std::move(first));
         }
 
-        typedef hpx::traits::is_segmented_iterator<FwdIter> is_segmented;
+        using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
 
         return detail::for_each_n_(std::forward<ExPolicy>(policy), first, count,
-            std::forward<F>(f), is_segmented(), std::forward<Proj>(proj));
+            std::forward<F>(f), std::forward<Proj>(proj), is_segmented());
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -419,13 +563,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
         for_each_(ExPolicy&& policy, FwdIterB first, FwdIterE last, F&& f,
             Proj&& proj, std::false_type)
         {
-            typedef parallel::execution::is_sequenced_execution_policy<ExPolicy>
-                is_seq;
+            using is_seq =
+                parallel::execution::is_sequenced_execution_policy<ExPolicy>;
 
             if (first == last)
             {
-                typedef util::detail::algorithm_result<ExPolicy, FwdIterB>
-                    result;
+                using result =
+                    util::detail::algorithm_result<ExPolicy, FwdIterB>;
                 return result::get(std::move(first));
             }
 
@@ -436,114 +580,132 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Applies \a f to the result of dereferencing every iterator in the
-    /// range [first, last).
-    ///
-    /// \note   Complexity: Applies \a f exactly \a last - \a first times.
-    ///
-    /// If \a f returns a result, the result is ignored.
-    ///
-    /// If the type of \a first satisfies the requirements of a mutable
-    /// iterator, \a f may apply non-constant functions through the
-    /// dereferenced iterator.
-    ///
-    /// Unlike its sequential form, the parallel overload of
-    /// \a for_each does not return a copy of its \a Function parameter,
-    /// since parallelization may not permit efficient state
-    /// accumulation.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it applies user-provided function objects.
-    /// \tparam FwdIterB    The type of the source begin iterator used (deduced).
-    ///                     This iterator type must meet the requirements of a
-    ///                     forward iterator.
-    /// \tparam FwdIterE    The type of the source end iterator used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam F           The type of the function/function object to use
-    ///                     (deduced). Unlike its sequential form, the parallel
-    ///                     overload of \a for_each requires \a F to meet the
-    ///                     requirements of \a CopyConstructible.
-    /// \tparam Proj        The type of an optional projection function. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param f            Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last).
-    ///                     The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     <ignored> pred(const Type &a);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&. The
-    ///                     type \a Type must be such that an object of
-    ///                     type \a FwdIter can be dereferenced and then
-    ///                     implicitly converted to Type.
-    /// \param proj         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements as a
-    ///                     projection operation before the actual predicate
-    ///                     \a f is invoked.
-    ///
-    /// The application of function objects in parallel algorithm
-    /// invoked with an execution policy object of type
-    /// \a sequenced_policy execute in sequential order in the
-    /// calling thread.
-    ///
-    /// The application of function objects in parallel algorithm
-    /// invoked with an execution policy object of type
-    /// \a parallel_policy or \a parallel_task_policy are
-    /// permitted to execute in an unordered fashion in unspecified
-    /// threads, and indeterminately sequenced within each thread.
-    ///
-    /// \returns  The \a for_each algorithm returns a
-    ///           \a hpx::future<FwdIter> if the execution policy is of
-    ///           type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and returns \a FwdIter
-    ///           otherwise.
-    ///           It returns \a last.
-    ///
-
-    // FIXME : is_indirect_callable does not work properly when compiling
-    //         Cuda host code
-
     // clang-format off
     template <typename ExPolicy, typename FwdIterB, typename FwdIterE,
         typename F, typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIterB>::value &&
             hpx::traits::is_sentinel_for<FwdIterE, FwdIterB>::value &&
-            parallel::traits::is_projected<Proj, FwdIterB>::value
+            hpx::parallel::traits::is_projected<Proj, FwdIterB>::value
         )
 #if (!defined(__NVCC__) && !defined(__CUDACC__)) || defined(__CUDA_ARCH__)
             ,
-        HPX_CONCEPT_REQUIRES_(parallel::traits::is_indirect_callable<ExPolicy,
+        HPX_CONCEPT_REQUIRES_(hpx::parallel::traits::is_indirect_callable<ExPolicy,
             F, traits::projected<Proj, FwdIterB>>::value)
 #endif
         >
     // clang-format on
-    typename util::detail::algorithm_result<ExPolicy, FwdIterB>::type for_each(
-        ExPolicy&& policy, FwdIterB first, FwdIterE last, F&& f,
-        Proj&& proj = Proj())
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::for_each is deprecated, use hpx::for_each instead")
+        typename util::detail::algorithm_result<ExPolicy, FwdIterB>::type
+        for_each(ExPolicy&& policy, FwdIterB first, FwdIterE last, F&& f,
+            Proj&& proj = Proj())
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIterB>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::traits::is_segmented_iterator<FwdIterB> is_segmented;
+        using is_segmented = hpx::traits::is_segmented_iterator<FwdIterB>;
 
         return detail::for_each_(std::forward<ExPolicy>(policy), first, last,
             std::forward<F>(f), std::forward<Proj>(proj), is_segmented());
     }
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx {
+    HPX_INLINE_CONSTEXPR_VARIABLE struct for_each_t final
+      : hpx::functional::tag<for_each_t>
+    {
+    private:
+        // clang-format off
+        template <typename InIter,
+            typename F,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_input_iterator<InIter>::value
+            )>
+        // clang-format on
+        friend F tag_invoke(hpx::for_each_t, InIter first, InIter last, F&& f)
+        {
+            parallel::v1::detail::for_each_(parallel::execution::seq, first,
+                last, f, parallel::util::projection_identity(),
+                std::false_type());
+            return std::forward<F>(f);
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter,
+            typename F,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            void>::type
+        tag_invoke(hpx::for_each_t, ExPolicy&& policy, FwdIter first,
+            FwdIter last, F&& f)
+        {
+            using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
+
+            return parallel::util::detail::algorithm_result<ExPolicy>::get(
+                parallel::v1::detail::for_each_(std::forward<ExPolicy>(policy),
+                    first, last, std::forward<F>(f),
+                    parallel::util::projection_identity(), is_segmented()));
+        }
+    } for_each{};
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct for_each_n_t final
+      : hpx::functional::tag<for_each_n_t>
+    {
+    private:
+        // clang-format off
+        template <typename InIter, typename Size, typename F,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_input_iterator<InIter>::value
+            )>
+        // clang-format on
+        friend InIter tag_invoke(
+            hpx::for_each_n_t, InIter first, Size count, F&& f)
+        {
+            // if count is representing a negative value, we do nothing
+            if (parallel::v1::detail::is_negative(count))
+            {
+                return first;
+            }
+
+            return parallel::v1::detail::for_each_n_(parallel::execution::seq,
+                first, count, std::forward<F>(f),
+                parallel::util::projection_identity(), std::false_type());
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter, typename Size, typename F,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter>::type
+        tag_invoke(hpx::for_each_n_t, ExPolicy&& policy, FwdIter first,
+            Size count, F&& f)
+        {
+            // if count is representing a negative value, we do nothing
+            if (parallel::v1::detail::is_negative(count))
+            {
+                return parallel::util::detail::algorithm_result<ExPolicy,
+                    FwdIter>::get(std::move(first));
+            }
+
+            using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
+
+            return parallel::v1::detail::for_each_n_(
+                std::forward<ExPolicy>(policy), first, count,
+                std::forward<F>(f), parallel::util::projection_identity(),
+                is_segmented());
+        }
+    } for_each_n{};
+}    // namespace hpx
 
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
 namespace hpx { namespace traits {
@@ -588,4 +750,5 @@ namespace hpx { namespace traits {
     };
 #endif
 }}    // namespace hpx::traits
+#endif
 #endif

--- a/libs/algorithms/include/hpx/parallel/algorithms/move.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/move.hpp
@@ -124,7 +124,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     zip_iterator;
                 typedef typename zip_iterator::reference reference;
 
-                return util::get_in_out_result(
+                return util::detail::get_in_out_result(
                     util::foreach_partitioner<ExPolicy>::call(
                         std::forward<ExPolicy>(policy),
                         hpx::util::make_zip_iterator(first, dest),

--- a/libs/algorithms/include/hpx/parallel/algorithms/reduce_by_key.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/reduce_by_key.hpp
@@ -318,7 +318,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     reduce_stencil_generate<reduce_stencil_transformer, RanIter,
                         keystate_iter_type, Compare>
                         kernel;
-                    hpx::parallel::for_each(sync_policy,
+                    hpx::for_each(sync_policy,
                         make_zip_iterator(
                             reduce_begin + 1, key_state.begin() + 1),
                         make_zip_iterator(reduce_end - 1, key_state.end() - 1),

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/for_each.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/for_each.hpp
@@ -8,19 +8,176 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/concepts/concepts.hpp>
-#include <hpx/iterator_support/range.hpp>
-#include <hpx/iterator_support/traits/is_range.hpp>
+#if defined(DOXYGEN)
+namespace hpx { namespace ranges {
+    /// Applies \a f to the result of dereferencing every iterator in the
+    /// range [first, last).
+    ///
+    /// \note   Complexity: Applies \a f exactly \a last - \a first times.
+    ///
+    /// If \a f returns a result, the result is ignored.
+    ///
+    /// If the type of \a first satisfies the requirements of a mutable
+    /// iterator, \a f may apply non-constant functions through the
+    /// dereferenced iterator.
+    ///
+    /// \tparam InIter      The type of the source begin iterator used
+    ///                     (deduced). This iterator type must meet the
+    ///                     requirements of an input iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a for_each requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).
+    ///                     The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     <ignored> pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&. The
+    ///                     type \a Type must be such that an object of
+    ///                     type \a InIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// \returns            {last, std::move(f)} where last is the iterator
+    ///                     corresponding to the input sentinel last.
+    ///
+    template <typename InIter, typename Sent, typename F,
+        typename Proj = util::projection_identity>
+    hpx::ranges::for_each_result<InIter, F> for_each(
+        InIter first, Sent last, F&& f, Proj&& proj = Proj());
 
-#include <hpx/algorithms/traits/projected_range.hpp>
-#include <hpx/parallel/algorithms/for_each.hpp>
-#include <hpx/parallel/util/projection_identity.hpp>
+    /// Applies \a f to the result of dereferencing every iterator in the
+    /// range [first, last).
+    ///
+    /// \note   Complexity: Applies \a f exactly \a last - \a first times.
+    ///
+    /// If \a f returns a result, the result is ignored.
+    ///
+    /// If the type of \a first satisfies the requirements of a mutable
+    /// iterator, \a f may apply non-constant functions through the
+    /// dereferenced iterator.
+    ///
+    /// Unlike its sequential form, the parallel overload of
+    /// \a for_each does not return a copy of its \a Function parameter,
+    /// since parallelization may not permit efficient state
+    /// accumulation.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it applies user-provided function objects.
+    /// \tparam FwdIter     The type of the source begin iterator used
+    ///                     (deduced). This iterator type must meet the
+    ///                     requirements of an forward iterator.
+    /// \tparam Sent        The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a for_each requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).
+    ///                     The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     <ignored> pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&. The
+    ///                     type \a Type must be such that an object of
+    ///                     type \a InIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// \returns  The \a for_each algorithm returns a
+    ///           \a hpx::future<FwdIter> if the execution policy is of
+    ///           type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and returns \a FwdIter
+    ///           otherwise.
+    ///           It returns \a last.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename Sent, typename F,
+        typename Proj = util::projection_identity>
+    FwdIter for_each(ExPolicy&& policy, FwdIter first, Sent last, F&& f,
+        Proj&& proj = Proj());
 
-#include <type_traits>
-#include <utility>
+    /// Applies \a f to the result of dereferencing every iterator in the
+    /// given range \a rng.
+    ///
+    /// \note   Complexity: Applies \a f exactly \a size(rng) times.
+    ///
+    /// If \a f returns a result, the result is ignored.
+    ///
+    /// If the type of \a first satisfies the requirements of a mutable
+    /// iterator, \a f may apply non-constant functions through the
+    /// dereferenced iterator.
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a for_each requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).
+    ///                     The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     <ignored> pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&. The
+    ///                     type \a Type must be such that an object of
+    ///                     type \a InIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// \returns            {std::end(rng), std::move(f)}
+    ///
+    template <typename Rng, typename F,
+        typename Proj = util::projection_identity>
+    hpx::ranges::for_each_result<
+        typename hpx::traits::range_iterator<Rng>::type, F>
+    for_each(ExPolicy&& policy, Rng&& rng, F&& f, Proj&& proj = Proj());
 
-namespace hpx { namespace parallel { inline namespace v1 {
     /// Applies \a f to the result of dereferencing every iterator in the
     /// given range \a rng.
     ///
@@ -84,24 +241,345 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// threads, and indeterminately sequenced within each thread.
     ///
     /// \returns  The \a for_each algorithm returns a
-    ///           \a hpx::future<InIter> if the execution policy is of
+    ///           \a hpx::future<FwdIter> if the execution policy is of
     ///           type
     ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and returns \a InIter
+    ///           \a parallel_task_policy and returns \a FwdIter
     ///           otherwise.
     ///           It returns \a last.
     ///
     template <typename ExPolicy, typename Rng, typename F,
-        typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
-                    Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
-                    F, traits::projected_range<Proj, Rng>>::value)>
+        typename Proj = util::projection_identity>
     typename util::detail::algorithm_result<ExPolicy,
         typename hpx::traits::range_iterator<Rng>::type>::type
-    for_each(ExPolicy&& policy, Rng&& rng, F&& f, Proj&& proj = Proj())
+    for_each(ExPolicy&& policy, Rng&& rng, F&& f, Proj&& proj = Proj());
+
+    /////////////////////////////////////////////////////
+    /// Applies \a f to the result of dereferencing every iterator in the range
+    /// [first, first + count), starting from first and proceeding to
+    /// first + count - 1.
+    ///
+    /// \note   Complexity: Applies \a f exactly \a last - \a first times.
+    ///
+    /// If \a f returns a result, the result is ignored.
+    ///
+    /// If the type of \a first satisfies the requirements of a mutable
+    /// iterator, \a f may apply non-constant functions through the
+    /// dereferenced iterator.
+    ///
+    /// \tparam InIter      The type of the source begin iterator used
+    ///                     (deduced). This iterator type must meet the
+    ///                     requirements of an input iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a for_each requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).
+    ///                     The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     <ignored> pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&. The
+    ///                     type \a Type must be such that an object of
+    ///                     type \a InIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// \returns            {first + count, std::move(f)}
+    ///
+    template <typename InIter, typename Sent, typename F,
+        typename Proj = util::projection_identity>
+    hpx::ranges::for_each_result<InIter, F> for_each(
+        InIter first, Sent last, F&& f, Proj&& proj = Proj());
+
+    /// Applies \a f to the result of dereferencing every iterator in the range
+    /// [first, first + count), starting from first and proceeding to
+    /// first + count - 1.
+    ///
+    /// \note   Complexity: Applies \a f exactly \a count times.
+    ///
+    /// If \a f returns a result, the result is ignored.
+    ///
+    /// If the type of \a first satisfies the requirements of a mutable
+    /// iterator, \a f may apply non-constant functions through the
+    /// dereferenced iterator.
+    ///
+    /// Unlike its sequential form, the parallel overload of
+    /// \a for_each does not return a copy of its \a Function parameter,
+    /// since parallelization may not permit efficient state
+    /// accumulation.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it applies user-provided function objects.
+    /// \tparam FwdIter     The type of the source begin iterator used
+    ///                     (deduced). This iterator type must meet the
+    ///                     requirements of an forward iterator.
+    /// \tparam Size        The type of the argument specifying the number of
+    ///                     elements to apply \a f to.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a for_each requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param count        Refers to the number of elements starting at
+    ///                     \a first the algorithm will be applied to.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).
+    ///                     The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     <ignored> pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&. The
+    ///                     type \a Type must be such that an object of
+    ///                     type \a InIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// \returns  The \a for_each algorithm returns a
+    ///           \a hpx::future<FwdIter> if the execution policy is of
+    ///           type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and returns \a FwdIter
+    ///           otherwise.
+    ///           It returns \a last.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename Size, typename F,
+        typename Proj = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy, FwdIter>::type for_each_n(
+        ExPolicy&& policy, FwdIter first, Size count, F&& f,
+        Proj&& proj = Proj());
+}}    // namespace hpx::ranges
+#else
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_range.hpp>
+
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/parallel/algorithms/for_each.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1 {
+    // clang-format off
+    template <typename ExPolicy, typename Rng, typename F,
+        typename Proj = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value &&
+            hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
+            hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
+                hpx::parallel::traits::projected_range<Proj, Rng>>::value)>
+    // clang-format on
+    typename util::detail::algorithm_result<ExPolicy,
+        typename hpx::traits::range_iterator<Rng>::type>::type
+        HPX_DEPRECATED_V(1, 6,
+            "hpx::parallel::for_each is deprecated, use "
+            "hpx::ranges::for_each instead")
+            for_each(ExPolicy&& policy, Rng&& rng, F&& f, Proj&& proj = Proj())
     {
         return for_each(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
             hpx::util::end(rng), std::forward<F>(f), std::forward<Proj>(proj));
     }
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx { namespace ranges {
+    template <typename I, typename F>
+    using for_each_result = in_fun_result<I, F>;
+
+    template <typename I, typename F>
+    using for_each_n_result = in_fun_result<I, F>;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::for_each
+    HPX_INLINE_CONSTEXPR_VARIABLE struct for_each_t final
+      : hpx::functional::tag<for_each_t>
+    {
+        // clang-format off
+        template <typename InIter, typename Sent, typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_input_iterator<InIter>::value &&
+                hpx::traits::is_sentinel_for<Sent, InIter>::value &&
+                hpx::parallel::traits::is_projected<Proj, InIter>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::parallel::execution::sequenced_policy, F,
+                    hpx::parallel::traits::projected<Proj, InIter>>::value)>
+        // clang-format on
+        friend for_each_result<InIter, F> tag_invoke(hpx::ranges::for_each_t,
+            InIter first, Sent last, F&& f, Proj&& proj = Proj())
+        {
+            using is_segmented = hpx::traits::is_segmented_iterator<InIter>;
+
+            auto it =
+                parallel::v1::detail::for_each_(hpx::parallel::execution::seq,
+                    first, last, f, std::forward<Proj>(proj), is_segmented());
+            return {std::move(it), std::forward<F>(f)};
+        }
+
+        // clang-format off
+        template <typename Rng, typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::parallel::execution::sequenced_policy, F,
+                    hpx::parallel::traits::projected_range<Proj, Rng>>::value)>
+        // clang-format on
+        friend for_each_result<typename hpx::traits::range_iterator<Rng>::type,
+            F>
+        tag_invoke(
+            hpx::ranges::for_each_t, Rng&& rng, F&& f, Proj&& proj = Proj())
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+            using is_segmented =
+                hpx::traits::is_segmented_iterator<iterator_type>;
+
+            auto it =
+                parallel::v1::detail::for_each_(hpx::parallel::execution::seq,
+                    hpx::util::begin(rng), hpx::util::end(rng), f,
+                    std::forward<Proj>(proj), is_segmented());
+            return {std::move(it), std::forward<F>(f)};
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter, typename Sent, typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter>::value &&
+                hpx::traits::is_sentinel_for<Sent, FwdIter>::value &&
+                hpx::parallel::traits::is_projected<Proj, FwdIter>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
+                    hpx::parallel::traits::projected<Proj, FwdIter>>::value)>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter>::type
+        tag_invoke(hpx::ranges::for_each_t, ExPolicy&& policy, FwdIter first,
+            Sent last, F&& f, Proj&& proj = Proj())
+        {
+            using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
+
+            return parallel::v1::detail::for_each_(
+                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                std::forward<Proj>(proj), is_segmented());
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng, typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
+                    hpx::parallel::traits::projected_range<Proj, Rng>>::value)>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            typename hpx::traits::range_iterator<Rng>::type>::type
+        tag_invoke(hpx::ranges::for_each_t, ExPolicy&& policy, Rng&& rng, F&& f,
+            Proj&& proj = Proj())
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+            using is_segmented =
+                hpx::traits::is_segmented_iterator<iterator_type>;
+
+            return parallel::v1::detail::for_each_(
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                hpx::util::end(rng), std::forward<F>(f),
+                std::forward<Proj>(proj), is_segmented());
+        }
+    } for_each{};
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::for_each_n
+    HPX_INLINE_CONSTEXPR_VARIABLE struct for_each_n_t final
+      : hpx::functional::tag<for_each_n_t>
+    {
+        // clang-format off
+        template <typename InIter, typename Size, typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_input_iterator<InIter>::value &&
+                hpx::parallel::traits::is_projected<Proj, InIter>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::parallel::execution::sequenced_policy, F,
+                    hpx::parallel::traits::projected<Proj, InIter>>::value)>
+        // clang-format on
+        friend for_each_n_result<InIter, F> tag_invoke(
+            hpx::ranges::for_each_n_t, InIter first, Size count, F&& f,
+            Proj&& proj = Proj())
+        {
+            // if count is representing a negative value, we do nothing
+            if (parallel::v1::detail::is_negative(count))
+            {
+                return {std::move(first), std::forward<F>(f)};
+            }
+
+            auto it = for_each_n(hpx::parallel::execution::seq, first, count, f,
+                std::forward<Proj>(proj));
+            return {std::move(it), std::forward<F>(f)};
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter, typename Size, typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter>::value &&
+                hpx::parallel::traits::is_projected<Proj, FwdIter>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
+                    hpx::parallel::traits::projected<Proj, FwdIter>>::value)>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter>::type
+        tag_invoke(hpx::ranges::for_each_n_t, ExPolicy&& policy, FwdIter first,
+            Size count, F&& f, Proj&& proj = Proj())
+        {
+            // if count is representing a negative value, we do nothing
+            if (parallel::v1::detail::is_negative(count))
+            {
+                return parallel::util::detail::algorithm_result<ExPolicy,
+                    FwdIter>::get(std::move(first));
+            }
+
+            using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
+
+            return parallel::v1::detail::for_each_n_(
+                std::forward<ExPolicy>(policy), first, count,
+                std::forward<F>(f), std::forward<Proj>(proj), is_segmented());
+        }
+    } for_each_n{};
+}}    // namespace hpx::ranges
+#endif

--- a/libs/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -86,40 +86,83 @@ namespace hpx { namespace parallel { namespace util {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename ZipIter>
-    in_out_result<typename hpx::util::tuple_element<0,
-                      typename ZipIter::iterator_tuple_type>::type,
-        typename hpx::util::tuple_element<1,
-            typename ZipIter::iterator_tuple_type>::type>
-    get_in_out_result(ZipIter&& zipiter)
+    template <typename I, typename F>
+    struct in_fun_result
     {
-        using iterator_tuple_type = typename ZipIter::iterator_tuple_type;
+        HPX_NO_UNIQUE_ADDRESS I in;
+        HPX_NO_UNIQUE_ADDRESS F fun;
 
-        using result_type = in_out_result<
-            typename hpx::util::tuple_element<0, iterator_tuple_type>::type,
-            typename hpx::util::tuple_element<1, iterator_tuple_type>::type>;
+        template <typename I2, typename F2,
+            typename Enable = typename std::enable_if<
+                std::is_convertible<I const&, I2&>::value &&
+                std::is_convertible<F const&, F2&>::value>::type>
+        constexpr operator in_fun_result<I2, F2>() const&
+        {
+            return {in, fun};
+        }
 
-        iterator_tuple_type t = zipiter.get_iterator_tuple();
-        return result_type{hpx::util::get<0>(t), hpx::util::get<1>(t)};
-    }
+        template <typename I2, typename F2,
+            typename Enable =
+                typename std::enable_if<std::is_convertible<I, I2>::value &&
+                    std::is_convertible<F, F2>::value>::type>
+        constexpr operator in_fun_result<I2, F2>() &&
+        {
+            return {std::move(in), std::move(fun)};
+        }
 
-    template <typename ZipIter>
-    hpx::future<in_out_result<typename hpx::util::tuple_element<0,
-                                  typename ZipIter::iterator_tuple_type>::type,
-        typename hpx::util::tuple_element<1,
-            typename ZipIter::iterator_tuple_type>::type>>
-    get_in_out_result(hpx::future<ZipIter>&& zipiter)
-    {
-        using iterator_tuple_type = typename ZipIter::iterator_tuple_type;
+        template <typename Archive>
+        void serialize(Archive& ar, unsigned)
+        {
+            // clang-format off
+            ar & in & fun;
+            // clang-format on
+        }
+    };
 
-        using result_type = in_out_result<
-            typename hpx::util::tuple_element<0, iterator_tuple_type>::type,
-            typename hpx::util::tuple_element<1, iterator_tuple_type>::type>;
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail {
+        template <typename ZipIter>
+        in_out_result<typename hpx::util::tuple_element<0,
+                          typename ZipIter::iterator_tuple_type>::type,
+            typename hpx::util::tuple_element<1,
+                typename ZipIter::iterator_tuple_type>::type>
+        get_in_out_result(ZipIter&& zipiter)
+        {
+            using iterator_tuple_type = typename ZipIter::iterator_tuple_type;
 
-        return lcos::make_future<result_type>(
-            std::move(zipiter), [](ZipIter zipiter) {
-                return get_in_out_result(std::move(zipiter));
-            });
-    }
+            using result_type = in_out_result<
+                typename hpx::util::tuple_element<0, iterator_tuple_type>::type,
+                typename hpx::util::tuple_element<1,
+                    iterator_tuple_type>::type>;
 
-}}}    // namespace hpx::parallel::util
+            iterator_tuple_type t = zipiter.get_iterator_tuple();
+            return result_type{hpx::util::get<0>(t), hpx::util::get<1>(t)};
+        }
+
+        template <typename ZipIter>
+        hpx::future<
+            in_out_result<typename hpx::util::tuple_element<0,
+                              typename ZipIter::iterator_tuple_type>::type,
+                typename hpx::util::tuple_element<1,
+                    typename ZipIter::iterator_tuple_type>::type>>
+        get_in_out_result(hpx::future<ZipIter>&& zipiter)
+        {
+            using iterator_tuple_type = typename ZipIter::iterator_tuple_type;
+
+            using result_type = in_out_result<
+                typename hpx::util::tuple_element<0, iterator_tuple_type>::type,
+                typename hpx::util::tuple_element<1,
+                    iterator_tuple_type>::type>;
+
+            return lcos::make_future<result_type>(
+                std::move(zipiter), [](ZipIter zipiter) {
+                    return get_in_out_result(std::move(zipiter));
+                });
+        }
+    }    // namespace detail
+}}}      // namespace hpx::parallel::util
+
+namespace hpx { namespace ranges {
+    using hpx::parallel::util::in_fun_result;
+    using hpx::parallel::util::in_out_result;
+}}    // namespace hpx::ranges

--- a/libs/algorithms/tests/regressions/for_each_annotated_function.cpp
+++ b/libs/algorithms/tests/regressions/for_each_annotated_function.cpp
@@ -4,9 +4,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/algorithm.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/parallel_for_each.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <algorithm>
@@ -21,7 +21,7 @@ int hpx_main()
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), std::random_device{}());
 
-    hpx::parallel::for_each(hpx::parallel::execution::par, c.begin(), c.end(),
+    hpx::ranges::for_each(hpx::parallel::execution::par, c,
         hpx::util::annotated_function(
             [](int i) -> void {
                 hpx::util::thread_description desc(

--- a/libs/algorithms/tests/unit/algorithms/foreach.cpp
+++ b/libs/algorithms/tests/unit/algorithms/foreach.cpp
@@ -19,6 +19,8 @@ void test_for_each()
 {
     using namespace hpx::parallel;
 
+    test_for_each_seq(IteratorTag());
+
     test_for_each(execution::seq, IteratorTag());
     test_for_each(execution::par, IteratorTag());
     test_for_each(execution::par_unseq, IteratorTag());
@@ -42,6 +44,8 @@ void test_for_each_exception()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_for_each_exception_seq(IteratorTag());
+
     test_for_each_exception(execution::seq, IteratorTag());
     test_for_each_exception(execution::par, IteratorTag());
 
@@ -66,6 +70,8 @@ void test_for_each_bad_alloc()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_for_each_bad_alloc_seq(IteratorTag());
+
     test_for_each_bad_alloc(execution::seq, IteratorTag());
     test_for_each_bad_alloc(execution::par, IteratorTag());
 

--- a/libs/algorithms/tests/unit/algorithms/foreach_tests.hpp
+++ b/libs/algorithms/tests/unit/algorithms/foreach_tests.hpp
@@ -25,32 +25,60 @@ std::mt19937 gen(seed);
 
 struct set_42
 {
+    std::size_t count = 0;
     template <typename T>
     void operator()(T& val)
     {
+        ++count;
         val = T(42);
     }
 };
 
 struct throw_always
 {
+    std::size_t count = 0;
     template <typename T>
     void operator()(T v)
     {
+        ++count;
         throw std::runtime_error("test");
     }
 };
 
 struct throw_bad_alloc
 {
+    std::size_t count = 0;
     template <typename T>
     void operator()(T v)
     {
+        ++count;
         throw std::bad_alloc();
     }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_for_each_seq(IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    set_42 f;
+    auto res = hpx::for_each(iterator(std::begin(c)), iterator(std::end(c)), f);
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](int v) -> void {
+        HPX_TEST_EQ(v, int(42));
+        ++count;
+    });
+    HPX_TEST_EQ(count, c.size());
+    HPX_TEST_EQ(res.count, c.size());
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each(ExPolicy&& policy, IteratorTag)
 {
@@ -64,10 +92,8 @@ void test_for_each(ExPolicy&& policy, IteratorTag)
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    iterator result = hpx::parallel::for_each(std::forward<ExPolicy>(policy),
-        iterator(std::begin(c)), iterator(std::end(c)), set_42());
-
-    HPX_TEST(result == iterator(std::end(c)));
+    hpx::for_each(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
+        iterator(std::end(c)), set_42());
 
     // verify values
     std::size_t count = 0;
@@ -87,11 +113,9 @@ void test_for_each_async(ExPolicy&& p, IteratorTag)
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::future<iterator> f = hpx::parallel::for_each(std::forward<ExPolicy>(p),
+    hpx::future<void> f = hpx::for_each(std::forward<ExPolicy>(p),
         iterator(std::begin(c)), iterator(std::end(c)), set_42());
-    f.wait();
-
-    HPX_TEST(f.get() == iterator(std::end(c)));
+    f.get();
 
     // verify values
     std::size_t count = 0;
@@ -103,6 +127,36 @@ void test_for_each_async(ExPolicy&& p, IteratorTag)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_for_each_exception_seq(IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    bool caught_exception = false;
+    throw_always f;
+    try
+    {
+        hpx::for_each(iterator(std::begin(c)), iterator(std::end(c)), f);
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST_EQ(f.count, std::size_t(1));
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_exception(ExPolicy policy, IteratorTag)
 {
@@ -119,8 +173,8 @@ void test_for_each_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::for_each(policy, iterator(std::begin(c)),
-            iterator(std::end(c)), throw_always());
+        hpx::for_each(policy, iterator(std::begin(c)), iterator(std::end(c)),
+            throw_always());
 
         HPX_TEST(false);
     }
@@ -150,7 +204,7 @@ void test_for_each_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<iterator> f = hpx::parallel::for_each(
+        hpx::future<void> f = hpx::for_each(
             p, iterator(std::begin(c)), iterator(std::end(c)), throw_always());
         returned_from_algorithm = true;
         f.get();
@@ -160,7 +214,6 @@ void test_for_each_exception_async(ExPolicy p, IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<ExPolicy, IteratorTag>::call(p, e);
     }
     catch (...)
     {
@@ -172,6 +225,36 @@ void test_for_each_exception_async(ExPolicy p, IteratorTag)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_for_each_bad_alloc_seq(IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    bool caught_exception = false;
+    throw_bad_alloc f;
+    try
+    {
+        hpx::for_each(iterator(std::begin(c)), iterator(std::end(c)), f);
+
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_exception = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+    HPX_TEST_EQ(f.count, std::size_t(1));
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_bad_alloc(ExPolicy policy, IteratorTag)
 {
@@ -188,8 +271,8 @@ void test_for_each_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::for_each(policy, iterator(std::begin(c)),
-            iterator(std::end(c)), throw_bad_alloc());
+        hpx::for_each(policy, iterator(std::begin(c)), iterator(std::end(c)),
+            throw_bad_alloc());
 
         HPX_TEST(false);
     }
@@ -218,8 +301,8 @@ void test_for_each_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<iterator> f = hpx::parallel::for_each(p,
-            iterator(std::begin(c)), iterator(std::end(c)), throw_bad_alloc());
+        hpx::future<void> f = hpx::for_each(p, iterator(std::begin(c)),
+            iterator(std::end(c)), throw_bad_alloc());
         returned_from_algorithm = true;
         f.get();
 
@@ -239,6 +322,29 @@ void test_for_each_bad_alloc_async(ExPolicy p, IteratorTag)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_for_each_n_seq(IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    iterator result =
+        hpx::for_each_n(iterator(std::begin(c)), c.size(), set_42());
+    iterator end = iterator(std::end(c));
+    HPX_TEST(result == end);
+
+    // verify values
+    std::size_t count = 0;
+    std::for_each(std::begin(c), std::end(c), [&count](int v) -> void {
+        HPX_TEST_EQ(v, int(42));
+        ++count;
+    });
+    HPX_TEST_EQ(count, c.size());
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_n(ExPolicy policy, IteratorTag)
 {
@@ -252,8 +358,8 @@ void test_for_each_n(ExPolicy policy, IteratorTag)
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    iterator result = hpx::parallel::for_each_n(
-        policy, iterator(std::begin(c)), c.size(), set_42());
+    iterator result =
+        hpx::for_each_n(policy, iterator(std::begin(c)), c.size(), set_42());
     iterator end = iterator(std::end(c));
     HPX_TEST(result == end);
 
@@ -275,8 +381,8 @@ void test_for_each_n_async(ExPolicy p, IteratorTag)
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::future<iterator> f = hpx::parallel::for_each_n(
-        p, iterator(std::begin(c)), c.size(), set_42());
+    hpx::future<iterator> f =
+        hpx::for_each_n(p, iterator(std::begin(c)), c.size(), set_42());
     HPX_TEST(f.get() == iterator(std::end(c)));
 
     // verify values

--- a/libs/algorithms/tests/unit/algorithms/foreach_tests_prefetching.hpp
+++ b/libs/algorithms/tests/unit/algorithms/foreach_tests_prefetching.hpp
@@ -37,8 +37,8 @@ void test_for_each_prefetching(ExPolicy&& policy, IteratorTag)
     auto ctx = hpx::parallel::util::make_prefetcher_context(
         range.begin(), range.end(), prefetch_distance_factor, c);
 
-    hpx::parallel::for_each(std::forward<ExPolicy>(policy), ctx.begin(),
-        ctx.end(), [&](std::size_t i) { c[i] = 42.1; });
+    hpx::for_each(std::forward<ExPolicy>(policy), ctx.begin(), ctx.end(),
+        [&](std::size_t i) { c[i] = 42.1; });
 
     // verify values
     std::size_t count = 0;
@@ -65,8 +65,8 @@ void test_for_each_prefetching_async(ExPolicy&& p, IteratorTag)
     auto ctx = hpx::parallel::util::make_prefetcher_context(
         range.begin(), range.end(), prefetch_distance_factor, c);
 
-    auto f = hpx::parallel::for_each(std::forward<ExPolicy>(p), ctx.begin(),
-        ctx.end(), [&](std::size_t i) { c[i] = 42.1; });
+    auto f = hpx::for_each(std::forward<ExPolicy>(p), ctx.begin(), ctx.end(),
+        [&](std::size_t i) { c[i] = 42.1; });
     f.wait();
 
     // verify values
@@ -102,7 +102,7 @@ void test_for_each_prefetching_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::for_each(policy, ctx.begin(), ctx.end(),
+        hpx::for_each(policy, ctx.begin(), ctx.end(),
             [](std::size_t i) { throw std::runtime_error("test"); });
 
         HPX_TEST(false);
@@ -140,7 +140,7 @@ void test_for_each_prefetching_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::for_each(p, ctx.begin(), ctx.end(),
+        auto f = hpx::for_each(p, ctx.begin(), ctx.end(),
             [](std::size_t i) { throw std::runtime_error("test"); });
         returned_from_algorithm = true;
         f.get();
@@ -185,7 +185,7 @@ void test_for_each_prefetching_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::for_each(policy, ctx.begin(), ctx.end(),
+        hpx::for_each(policy, ctx.begin(), ctx.end(),
             [](std::size_t i) { throw std::bad_alloc(); });
 
         HPX_TEST(false);
@@ -223,7 +223,7 @@ void test_for_each_prefetching_bad_alloc_async(ExPolicy p, IteratorTag)
 
     try
     {
-        auto f = hpx::parallel::for_each(p, ctx.begin(), ctx.end(),
+        auto f = hpx::for_each(p, ctx.begin(), ctx.end(),
             [](std::size_t i) { throw std::bad_alloc(); });
         returned_from_algorithm = true;
         f.get();

--- a/libs/algorithms/tests/unit/algorithms/foreachn.cpp
+++ b/libs/algorithms/tests/unit/algorithms/foreachn.cpp
@@ -20,6 +20,8 @@ void test_for_each_n()
 {
     using namespace hpx::parallel;
 
+    test_for_each_n_seq(IteratorTag());
+
     test_for_each_n(execution::seq, IteratorTag());
     test_for_each_n(execution::par, IteratorTag());
     test_for_each_n(execution::par_unseq, IteratorTag());

--- a/libs/algorithms/tests/unit/algorithms/foreachn_bad_alloc.cpp
+++ b/libs/algorithms/tests/unit/algorithms/foreachn_bad_alloc.cpp
@@ -23,6 +23,35 @@
 int seed = std::random_device{}();
 std::mt19937 gen(seed);
 
+template <typename IteratorTag>
+void test_for_each_n_bad_alloc_seq(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), gen());
+
+    bool caught_bad_alloc = false;
+    try
+    {
+        hpx::for_each_n(iterator(std::begin(c)), c.size(),
+            [](std::size_t& v) { throw std::bad_alloc(); });
+
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_bad_alloc = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_n_bad_alloc(ExPolicy policy, IteratorTag)
 {
@@ -39,7 +68,7 @@ void test_for_each_n_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::for_each_n(policy, iterator(std::begin(c)), c.size(),
+        hpx::for_each_n(policy, iterator(std::begin(c)), c.size(),
             [](std::size_t& v) { throw std::bad_alloc(); });
 
         HPX_TEST(false);
@@ -69,9 +98,8 @@ void test_for_each_n_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<iterator> f =
-            hpx::parallel::for_each_n(p, iterator(std::begin(c)), c.size(),
-                [](std::size_t& v) { throw std::bad_alloc(); });
+        hpx::future<iterator> f = hpx::for_each_n(p, iterator(std::begin(c)),
+            c.size(), [](std::size_t& v) { throw std::bad_alloc(); });
         returned_from_algorithm = true;
         f.get();    // rethrow bad_alloc
 
@@ -98,6 +126,8 @@ void test_for_each_n_bad_alloc()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_for_each_n_bad_alloc_seq(IteratorTag());
+
     test_for_each_n_bad_alloc(execution::seq, IteratorTag());
     test_for_each_n_bad_alloc(execution::par, IteratorTag());
 

--- a/libs/algorithms/tests/unit/container_algorithms/foreach_adapt.cpp
+++ b/libs/algorithms/tests/unit/container_algorithms/foreach_adapt.cpp
@@ -23,12 +23,12 @@ void myfunction(int i)
 void test_invoke_projected()
 {
     Iterator<std::int64_t> iter =
-        hpx::parallel::for_each(hpx::parallel::execution::seq,
+        hpx::ranges::for_each(hpx::parallel::execution::seq,
             Iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, myfunction);
 
     HPX_TEST_EQ(*iter, std::int64_t(100));
 
-    iter = hpx::parallel::for_each(hpx::parallel::execution::par,
+    iter = hpx::ranges::for_each(hpx::parallel::execution::par,
         Iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, myfunction);
 
     HPX_TEST_EQ(*iter, std::int64_t(100));
@@ -37,12 +37,12 @@ void test_invoke_projected()
 void test_begin_end_iterator()
 {
     Iterator<std::int64_t> iter =
-        hpx::parallel::for_each(hpx::parallel::execution::seq,
+        hpx::ranges::for_each(hpx::parallel::execution::seq,
             Iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, &myfunction);
 
     HPX_TEST_EQ(*iter, std::int64_t(100));
 
-    iter = hpx::parallel::for_each(hpx::parallel::execution::par,
+    iter = hpx::ranges::for_each(hpx::parallel::execution::par,
         Iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, &myfunction);
 
     HPX_TEST_EQ(*iter, std::int64_t(100));

--- a/libs/algorithms/tests/unit/container_algorithms/foreach_range.cpp
+++ b/libs/algorithms/tests/unit/container_algorithms/foreach_range.cpp
@@ -19,6 +19,8 @@ void test_for_each()
 {
     using namespace hpx::parallel;
 
+    test_for_each_seq(IteratorTag());
+
     test_for_each(execution::seq, IteratorTag());
     test_for_each(execution::par, IteratorTag());
     test_for_each(execution::par_unseq, IteratorTag());
@@ -42,6 +44,8 @@ void test_for_each_exception()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_for_each_exception_seq(IteratorTag());
+
     test_for_each_exception(execution::seq, IteratorTag());
     test_for_each_exception(execution::par, IteratorTag());
 
@@ -66,6 +70,8 @@ void test_for_each_bad_alloc()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_for_each_bad_alloc_seq(IteratorTag());
+
     test_for_each_bad_alloc(execution::seq, IteratorTag());
     test_for_each_bad_alloc(execution::par, IteratorTag());
 

--- a/libs/algorithms/tests/unit/container_algorithms/foreach_range_projection.cpp
+++ b/libs/algorithms/tests/unit/container_algorithms/foreach_range_projection.cpp
@@ -19,6 +19,8 @@ void test_for_each()
 {
     using namespace hpx::parallel;
 
+    test_for_each_seq(IteratorTag(), Proj());
+
     test_for_each(execution::seq, IteratorTag(), Proj());
     test_for_each(execution::par, IteratorTag(), Proj());
     test_for_each(execution::par_unseq, IteratorTag(), Proj());
@@ -43,6 +45,8 @@ void test_for_each_exception()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_for_each_exception_seq(IteratorTag(), Proj());
+
     test_for_each_exception(execution::seq, IteratorTag(), Proj());
     test_for_each_exception(execution::par, IteratorTag(), Proj());
 
@@ -68,6 +72,8 @@ void test_for_each_bad_alloc()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_for_each_bad_alloc_seq(IteratorTag(), Proj());
+
     test_for_each_bad_alloc(execution::seq, IteratorTag(), Proj());
     test_for_each_bad_alloc(execution::par, IteratorTag(), Proj());
 

--- a/libs/algorithms/tests/unit/datapar_algorithms/foreach_datapar_zipiter.cpp
+++ b/libs/algorithms/tests/unit/datapar_algorithms/foreach_datapar_zipiter.cpp
@@ -52,8 +52,8 @@ void for_each_zipiter_test(ExPolicy&& policy, IteratorTag)
     auto end = hpx::util::make_zip_iterator(
         iterator(std::end(c)), iterator(std::end(d)));
 
-    auto result = hpx::parallel::for_each(
-        std::forward<ExPolicy>(policy), begin, end, set_42());
+    auto result =
+        hpx::for_each(std::forward<ExPolicy>(policy), begin, end, set_42());
 
     HPX_TEST_EQ(result, end);
 

--- a/libs/algorithms/tests/unit/datapar_algorithms/foreach_tests.hpp
+++ b/libs/algorithms/tests/unit/datapar_algorithms/foreach_tests.hpp
@@ -64,7 +64,7 @@ void test_for_each(ExPolicy&& policy, IteratorTag)
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    iterator result = hpx::parallel::for_each(std::forward<ExPolicy>(policy),
+    iterator result = hpx::for_each(std::forward<ExPolicy>(policy),
         iterator(std::begin(c)), iterator(std::end(c)), set_42());
 
     HPX_TEST_EQ(result, iterator(std::end(c)));
@@ -87,7 +87,7 @@ void test_for_each_async(ExPolicy&& p, IteratorTag)
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::future<iterator> f = hpx::parallel::for_each(std::forward<ExPolicy>(p),
+    hpx::future<iterator> f = hpx::for_each(std::forward<ExPolicy>(p),
         iterator(std::begin(c)), iterator(std::end(c)), set_42());
     f.wait();
 
@@ -119,8 +119,8 @@ void test_for_each_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::for_each(policy, iterator(std::begin(c)),
-            iterator(std::end(c)), throw_always());
+        hpx::for_each(policy, iterator(std::begin(c)), iterator(std::end(c)),
+            throw_always());
 
         HPX_TEST(false);
     }
@@ -150,7 +150,7 @@ void test_for_each_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<iterator> f = hpx::parallel::for_each(
+        hpx::future<iterator> f = hpx::for_each(
             p, iterator(std::begin(c)), iterator(std::end(c)), throw_always());
         returned_from_algorithm = true;
         f.get();
@@ -188,8 +188,8 @@ void test_for_each_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::for_each(policy, iterator(std::begin(c)),
-            iterator(std::end(c)), throw_bad_alloc());
+        hpx::for_each(policy, iterator(std::begin(c)), iterator(std::end(c)),
+            throw_bad_alloc());
 
         HPX_TEST(false);
     }
@@ -218,8 +218,8 @@ void test_for_each_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<iterator> f = hpx::parallel::for_each(p,
-            iterator(std::begin(c)), iterator(std::end(c)), throw_bad_alloc());
+        hpx::future<iterator> f = hpx::for_each(p, iterator(std::begin(c)),
+            iterator(std::end(c)), throw_bad_alloc());
         returned_from_algorithm = true;
         f.get();
 
@@ -252,8 +252,8 @@ void test_for_each_n(ExPolicy policy, IteratorTag)
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    iterator result = hpx::parallel::for_each_n(
-        policy, iterator(std::begin(c)), c.size(), set_42());
+    iterator result =
+        hpx::for_each_n(policy, iterator(std::begin(c)), c.size(), set_42());
     iterator end = iterator(std::end(c));
     HPX_TEST_EQ(result, end);
 
@@ -275,8 +275,8 @@ void test_for_each_n_async(ExPolicy p, IteratorTag)
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::future<iterator> f = hpx::parallel::for_each_n(
-        p, iterator(std::begin(c)), c.size(), set_42());
+    hpx::future<iterator> f =
+        hpx::for_each_n(p, iterator(std::begin(c)), c.size(), set_42());
     HPX_TEST_EQ(f.get(), iterator(std::end(c)));
 
     // verify values

--- a/libs/async_cuda/tests/performance/cuda_executor_throughput.cpp
+++ b/libs/async_cuda/tests/performance/cuda_executor_throughput.cpp
@@ -81,8 +81,8 @@ void matrixMultiply(
 
     // Fill A and B with zeroes
     auto zerofunc = [](T& x) { x = 0; };
-    hpx::parallel::for_each(par, h_A.begin(), h_A.end(), zerofunc);
-    hpx::parallel::for_each(par, h_B.begin(), h_B.end(), zerofunc);
+    hpx::for_each(par, h_A.begin(), h_A.end(), zerofunc);
+    hpx::for_each(par, h_B.begin(), h_B.end(), zerofunc);
 
     // create a cublas executor we'll use to futurize cuda events
     hpx::cuda::experimental::cublas_executor cublas(device,

--- a/libs/async_cuda/tests/unit/cublas_matmul.cpp
+++ b/libs/async_cuda/tests/unit/cublas_matmul.cpp
@@ -133,8 +133,8 @@ void matrixMultiply(hpx::cuda::experimental::cublas_executor& cublas,
 
     // Fill A and B with random numbers
     auto randfunc = [](T& x) { x = gen() / (T) RAND_MAX; };
-    hpx::parallel::for_each(par, h_A.begin(), h_A.end(), randfunc);
-    hpx::parallel::for_each(par, h_B.begin(), h_B.end(), randfunc);
+    hpx::for_each(par, h_A.begin(), h_A.end(), randfunc);
+    hpx::for_each(par, h_B.begin(), h_B.end(), randfunc);
 
     // create a cublas executor we'll use to futurize cuda events
     using namespace hpx::cuda::experimental;

--- a/libs/checkpoint/examples/1d_stencil_4_checkpoint.cpp
+++ b/libs/checkpoint/examples/1d_stencil_4_checkpoint.cpp
@@ -24,7 +24,7 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 
-#include <hpx/include/parallel_algorithm.hpp>
+#include <hpx/algorithm.hpp>
 #include <hpx/modules/checkpoint.hpp>
 
 #include <boost/range/irange.hpp>
@@ -300,10 +300,9 @@ struct stepper
         std::size_t b = 0;
         auto range = boost::irange(b, np);
         using hpx::parallel::execution::par;
-        hpx::parallel::for_each(par, boost::begin(range), boost::end(range),
-            [&U, nx](std::size_t i) {
-                U[0][i] = hpx::make_ready_future(partition_data(nx, double(i)));
-            });
+        hpx::ranges::for_each(par, range, [&U, nx](std::size_t i) {
+            U[0][i] = hpx::make_ready_future(partition_data(nx, double(i)));
+        });
 
         //Initialize from backup
         if (rsf != "")

--- a/libs/collectives/tests/performance/osu/osu_bw.cpp
+++ b/libs/collectives/tests/performance/osu/osu_bw.cpp
@@ -7,8 +7,8 @@
 
 // Unidirectional network bandwidth test
 
+#include <hpx/algorithm.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/include/parallel_for_each.hpp>
 #include <hpx/include/serialization.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/modules/testing.hpp>
@@ -82,13 +82,13 @@ double ireceive(hpx::naming::id_type dest, std::size_t loop, std::size_t size,
         if (i == skip)
             t.restart();
 
-        using hpx::parallel::for_each;
         using hpx::parallel::execution::par;
+        using hpx::ranges::for_each;
 
         std::size_t const start = 0;
 
         auto range = boost::irange(start, window_size);
-        for_each(par, std::begin(range), std::end(range), [&](std::uint64_t j) {
+        for_each(par, range, [&](std::uint64_t j) {
             send(dest,
                 buffer_type(send_buffer.get(), size, buffer_type::reference));
         });

--- a/libs/collectives/tests/performance/osu/osu_latency.cpp
+++ b/libs/collectives/tests/performance/osu/osu_latency.cpp
@@ -7,8 +7,8 @@
 
 // Bidirectional network bandwidth test
 
+#include <hpx/algorithm.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/include/parallel_for_each.hpp>
 #include <hpx/include/serialization.hpp>
 #include <hpx/modules/program_options.hpp>
 
@@ -80,13 +80,13 @@ double receive_double(
         if (i == skip)
             t.restart();
 
-        using hpx::parallel::for_each;
         using hpx::parallel::execution::par;
+        using hpx::ranges::for_each;
 
         std::size_t const start = 0;
 
         auto range = boost::irange(start, window_size);
-        for_each(par, std::begin(range), std::end(range), [&](std::uint64_t j) {
+        for_each(par, range, [&](std::uint64_t j) {
             double d = 0.0;
             msg(dest, d);
         });

--- a/libs/collectives/tests/performance/osu/osu_multi_lat.cpp
+++ b/libs/collectives/tests/performance/osu/osu_multi_lat.cpp
@@ -7,8 +7,8 @@
 
 // Multi latency network test
 
+#include <hpx/algorithm.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/include/parallel_for_each.hpp>
 #include <hpx/include/serialization.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/modules/testing.hpp>
@@ -93,13 +93,13 @@ double ireceive(
 
         typedef hpx::serialization::serialize_buffer<char> buffer_type;
 
-        using hpx::parallel::for_each;
         using hpx::parallel::execution::par;
+        using hpx::ranges::for_each;
 
         std::size_t const start = 0;
 
         auto range = boost::irange(start, window_size);
-        for_each(par, std::begin(range), std::end(range), [&](std::uint64_t j) {
+        for_each(par, range, [&](std::uint64_t j) {
             send(dest,
                 buffer_type(aligned_send_buffer, size, buffer_type::reference));
         });

--- a/libs/compute/include/hpx/compute/host/block_allocator.hpp
+++ b/libs/compute/include/hpx/compute/host/block_allocator.hpp
@@ -21,7 +21,7 @@
 #include <hpx/executors/restricted_thread_pool_executor.hpp>
 #include <hpx/functional/invoke_fused.hpp>
 #include <hpx/iterator_support/range.hpp>
-#include <hpx/parallel/algorithms/for_each.hpp>
+#include <hpx/parallel/container_algorithms/for_each.hpp>
 #include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/partitioner_with_cleanup.hpp>
 #include <hpx/topology/topology.hpp>
@@ -202,8 +202,8 @@ namespace hpx { namespace compute { namespace host {
 
                 // keep memory locality, use executor...
                 auto irange = boost::irange(std::size_t(0), count);
-                hpx::parallel::for_each(policy_, util::begin(irange),
-                    util::end(irange), [p](std::size_t i) { (p + i)->~U(); });
+                hpx::ranges::for_each(
+                    policy_, irange, [p](std::size_t i) { (p + i)->~U(); });
             }
 
             // Calls the destructor of the object pointed to by p

--- a/libs/compute/include/hpx/compute/host/numa_allocator.hpp
+++ b/libs/compute/include/hpx/compute/host/numa_allocator.hpp
@@ -100,7 +100,7 @@ namespace hpx { namespace parallel { namespace util {
             {
                 pointer begin = p + i * part_size;
                 pointer end = begin + part_size;
-                first_touch.push_back(hpx::parallel::for_each(
+                first_touch.push_back(hpx::for_each(
                     hpx::parallel::execution::par(
                         hpx::parallel::execution::task)
                         .on(executors_[i])

--- a/libs/compute/tests/regressions/for_each_value_proxy.cpp
+++ b/libs/compute/tests/regressions/for_each_value_proxy.cpp
@@ -4,10 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/algorithm.hpp>
 #include <hpx/algorithms/traits/is_value_proxy.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/compute.hpp>
-#include <hpx/include/parallel_for_each.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <algorithm>
@@ -179,7 +179,7 @@ int hpx_main()
 {
     hpx::compute::vector<int, test_allocator<int>> v(100);
 
-    hpx::parallel::for_each(
+    hpx::ranges::for_each(
         hpx::parallel::execution::par, v.begin(), v.end(), set_42());
 
     HPX_TEST_EQ(std::count(v.begin(), v.end(), 42), std::ptrdiff_t(v.size()));

--- a/libs/compute_cuda/examples/partitioned_vector.cu
+++ b/libs/compute_cuda/examples/partitioned_vector.cu
@@ -3,9 +3,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/algorithm.hpp>
 #include <hpx/include/compute.hpp>
 #include <hpx/include/partitioned_vector.hpp>
-#include <hpx/include/parallel_for_each.hpp>
 
 #include <hpx/hpx_init.hpp>
 
@@ -36,17 +36,16 @@ struct pfo
 int hpx_main(hpx::program_options::variables_map& vm)
 {
     hpx::cuda::experimental::target_distribution_policy policy =
-        hpx::cuda::experimental::target_layout(hpx::cuda::experimental::get_local_targets());
+        hpx::cuda::experimental::target_layout(
+            hpx::cuda::experimental::get_local_targets());
 
     {
         using namespace hpx::parallel;
         hpx::partitioned_vector<int, target_vector> v(1000, policy);
-        hpx::parallel::for_each(execution::seq, v.begin(), v.end(), pfo());
-        hpx::parallel::for_each(execution::par, v.begin(), v.end(), pfo());
-        hpx::parallel::for_each(execution::seq(execution::task),
-            v.begin(), v.end(), pfo()).get();
-        hpx::parallel::for_each(execution::par(execution::task),
-            v.begin(), v.end(), pfo()).get();
+        hpx::ranges::for_each(execution::seq, v, pfo());
+        hpx::ranges::for_each(execution::par, v, pfo());
+        hpx::ranges::for_each(execution::seq(execution::task), v, pfo()).get();
+        hpx::ranges::for_each(execution::par(execution::task), v, pfo()).get();
     }
 
     // TODO: add more

--- a/libs/execution/tests/regressions/is_executor_1691.cpp
+++ b/libs/execution/tests/regressions/is_executor_1691.cpp
@@ -7,8 +7,8 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 
-#include <hpx/include/parallel_algorithm.hpp>
-#include <hpx/include/parallel_executors.hpp>
+#include <hpx/algorithm.hpp>
+#include <hpx/execution.hpp>
 
 #include <type_traits>
 #include <vector>
@@ -38,14 +38,14 @@ namespace hpx { namespace parallel { namespace execution {
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
-    using hpx::parallel::for_each;
     using hpx::parallel::execution::par;
+    using hpx::ranges::for_each;
 
     my_executor exec;
 
     std::vector<int> v(100);
 
-    for_each(par.on(exec), v.begin(), v.end(), [](int x) {});
+    for_each(par.on(exec), v, [](int x) {});
 
     return hpx::finalize();
 }

--- a/libs/execution/tests/regressions/lambda_arguments_2403.cpp
+++ b/libs/execution/tests/regressions/lambda_arguments_2403.cpp
@@ -20,8 +20,8 @@ int hpx_main()
     auto zip_it_begin = hpx::util::make_zip_iterator(large.begin());
     auto zip_it_end = hpx::util::make_zip_iterator(large.end());
 
-    hpx::parallel::for_each(hpx::parallel::execution::datapar, zip_it_begin,
-        zip_it_end, [](auto& t) -> void { hpx::util::get<0>(t) = 10.0; });
+    hpx::for_each(hpx::parallel::execution::datapar, zip_it_begin, zip_it_end,
+        [](auto& t) -> void { hpx::util::get<0>(t) = 10.0; });
 
     HPX_TEST_EQ(std::count(large.begin(), large.end(), 10.0),
         std::ptrdiff_t(large.size()));

--- a/libs/execution/tests/regressions/lambda_return_type_2402.cpp
+++ b/libs/execution/tests/regressions/lambda_return_type_2402.cpp
@@ -20,8 +20,8 @@ int hpx_main()
     auto zip_it_begin = hpx::util::make_zip_iterator(large.begin());
     auto zip_it_end = hpx::util::make_zip_iterator(large.end());
 
-    hpx::parallel::for_each(hpx::parallel::execution::datapar, zip_it_begin,
-        zip_it_end, [](auto t) {
+    hpx::for_each(hpx::parallel::execution::datapar, zip_it_begin, zip_it_end,
+        [](auto t) {
             using comp_type =
                 typename hpx::util::tuple_element<0, decltype(t)>::type;
             using var_type = typename hpx::util::decay<comp_type>::type;

--- a/libs/execution/tests/regressions/parallel_executor_1781.cpp
+++ b/libs/execution/tests/regressions/parallel_executor_1781.cpp
@@ -7,8 +7,8 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 
-#include <hpx/include/parallel_algorithm.hpp>
-#include <hpx/include/parallel_executors.hpp>
+#include <hpx/algorithm.hpp>
+#include <hpx/execution.hpp>
 
 #include <vector>
 
@@ -20,9 +20,9 @@ int hpx_main(int argc, char* argv[])
     {
         hpx::parallel::execution::static_chunk_size block(1);
         hpx::parallel::execution::parallel_executor exec;
-        hpx::parallel::for_each(
-            hpx::parallel::execution::par.on(exec).with(block), v.begin(),
-            v.end(), [](int i) {});
+        hpx::ranges::for_each(
+            hpx::parallel::execution::par.on(exec).with(block), v,
+            [](int i) {});
     }
 
     return hpx::finalize();

--- a/libs/execution/tests/unit/foreach_tests.hpp
+++ b/libs/execution/tests/unit/foreach_tests.hpp
@@ -64,10 +64,8 @@ void test_for_each(ExPolicy&& policy, IteratorTag)
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    iterator result = hpx::parallel::for_each(std::forward<ExPolicy>(policy),
-        iterator(std::begin(c)), iterator(std::end(c)), set_42());
-
-    HPX_TEST(result == iterator(std::end(c)));
+    hpx::for_each(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
+        iterator(std::end(c)), set_42());
 
     // verify values
     std::size_t count = 0;
@@ -87,11 +85,9 @@ void test_for_each_async(ExPolicy&& p, IteratorTag)
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::future<iterator> f = hpx::parallel::for_each(std::forward<ExPolicy>(p),
+    hpx::future<void> f = hpx::for_each(std::forward<ExPolicy>(p),
         iterator(std::begin(c)), iterator(std::end(c)), set_42());
-    f.wait();
-
-    HPX_TEST(f.get() == iterator(std::end(c)));
+    f.get();
 
     // verify values
     std::size_t count = 0;
@@ -119,8 +115,8 @@ void test_for_each_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::for_each(policy, iterator(std::begin(c)),
-            iterator(std::end(c)), throw_always());
+        hpx::for_each(policy, iterator(std::begin(c)), iterator(std::end(c)),
+            throw_always());
 
         HPX_TEST(false);
     }
@@ -150,7 +146,7 @@ void test_for_each_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<iterator> f = hpx::parallel::for_each(
+        hpx::future<iterator> f = hpx::for_each(
             p, iterator(std::begin(c)), iterator(std::end(c)), throw_always());
         returned_from_algorithm = true;
         f.get();
@@ -188,8 +184,8 @@ void test_for_each_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::for_each(policy, iterator(std::begin(c)),
-            iterator(std::end(c)), throw_bad_alloc());
+        hpx::for_each(policy, iterator(std::begin(c)), iterator(std::end(c)),
+            throw_bad_alloc());
 
         HPX_TEST(false);
     }
@@ -218,8 +214,8 @@ void test_for_each_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<iterator> f = hpx::parallel::for_each(p,
-            iterator(std::begin(c)), iterator(std::end(c)), throw_bad_alloc());
+        hpx::future<iterator> f = hpx::for_each(p, iterator(std::begin(c)),
+            iterator(std::end(c)), throw_bad_alloc());
         returned_from_algorithm = true;
         f.get();
 
@@ -252,8 +248,8 @@ void test_for_each_n(ExPolicy policy, IteratorTag)
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    iterator result = hpx::parallel::for_each_n(
-        policy, iterator(std::begin(c)), c.size(), set_42());
+    iterator result =
+        hpx::for_each_n(policy, iterator(std::begin(c)), c.size(), set_42());
     iterator end = iterator(std::end(c));
     HPX_TEST(result == end);
 
@@ -275,8 +271,8 @@ void test_for_each_n_async(ExPolicy p, IteratorTag)
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::future<iterator> f = hpx::parallel::for_each_n(
-        p, iterator(std::begin(c)), c.size(), set_42());
+    hpx::future<iterator> f =
+        hpx::for_each_n(p, iterator(std::begin(c)), c.size(), set_42());
     HPX_TEST_EQ(f.get(), iterator(std::end(c)));
 
     // verify values

--- a/libs/include/include/hpx/algorithm.hpp
+++ b/libs/include/include/hpx/algorithm.hpp
@@ -6,8 +6,12 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
 #include <hpx/parallel/algorithm.hpp>
 #include <hpx/parallel/container_algorithms.hpp>
+#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
+#include <hpx/parallel/segmented_algorithm.hpp>
+#endif
 
 namespace hpx {
     using hpx::parallel::adjacent_find;
@@ -16,8 +20,6 @@ namespace hpx {
     using hpx::parallel::find_first_of;
     using hpx::parallel::find_if;
     using hpx::parallel::find_if_not;
-    using hpx::parallel::for_each;
-    using hpx::parallel::for_each_n;
     using hpx::parallel::for_loop;
     using hpx::parallel::for_loop_n;
     using hpx::parallel::for_loop_n_strided;

--- a/libs/resiliency/tests/performance/replay/1d_stencil.cpp
+++ b/libs/resiliency/tests/performance/replay/1d_stencil.cpp
@@ -21,7 +21,7 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 
-#include <hpx/include/parallel_algorithm.hpp>
+#include <hpx/algorithm.hpp>
 #include <hpx/modules/synchronization.hpp>
 #include <boost/range/irange.hpp>
 
@@ -165,8 +165,8 @@ struct stepper
         std::size_t b = 0;
         auto range = boost::irange(b, subdomains);
         using hpx::parallel::execution::par;
-        hpx::parallel::for_each(par, std::begin(range), std::end(range),
-            [&U, subdomain_width, subdomains](std::size_t i) {
+        hpx::ranges::for_each(
+            par, range, [&U, subdomain_width, subdomains](std::size_t i) {
                 U[0][i] = hpx::make_ready_future(
                     partition_data(subdomain_width, double(i), subdomains));
             });

--- a/libs/resiliency/tests/performance/replay/1d_stencil_checksum.cpp
+++ b/libs/resiliency/tests/performance/replay/1d_stencil_checksum.cpp
@@ -18,9 +18,9 @@
 // computation. This example is still fully local but demonstrates nice
 // scalability on SMP machines.
 
+#include <hpx/algorithm.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/parallel_algorithm.hpp>
 #include <hpx/modules/resiliency.hpp>
 #include <hpx/modules/synchronization.hpp>
 #include <boost/range/irange.hpp>
@@ -248,8 +248,8 @@ struct stepper
         std::size_t b = 0;
         auto range = boost::irange(b, subdomains);
         using hpx::parallel::execution::par;
-        hpx::parallel::for_each(par, std::begin(range), std::end(range),
-            [&U, subdomain_width, subdomains](std::size_t i) {
+        hpx::ranges::for_each(
+            par, range, [&U, subdomain_width, subdomains](std::size_t i) {
                 U[0][i] = hpx::make_ready_future(
                     partition_data(subdomain_width, double(i), subdomains));
             });

--- a/libs/resiliency/tests/performance/replay/1d_stencil_replay.cpp
+++ b/libs/resiliency/tests/performance/replay/1d_stencil_replay.cpp
@@ -18,9 +18,9 @@
 // computation. This example is still fully local but demonstrates nice
 // scalability on SMP machines.
 
+#include <hpx/algorithm.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/parallel_algorithm.hpp>
 #include <hpx/modules/resiliency.hpp>
 #include <hpx/modules/synchronization.hpp>
 #include <boost/range/irange.hpp>
@@ -205,8 +205,8 @@ struct stepper
         std::size_t b = 0;
         auto range = boost::irange(b, subdomains);
         using hpx::parallel::execution::par;
-        hpx::parallel::for_each(par, std::begin(range), std::end(range),
-            [&U, subdomain_width, subdomains](std::size_t i) {
+        hpx::ranges::for_each(
+            par, range, [&U, subdomain_width, subdomains](std::size_t i) {
                 U[0][i] = hpx::make_ready_future(
                     partition_data(subdomain_width, double(i), subdomains));
             });

--- a/libs/resiliency/tests/performance/replay/dataflow_replay.cpp
+++ b/libs/resiliency/tests/performance/replay/dataflow_replay.cpp
@@ -18,9 +18,9 @@
 // computation. This example is still fully local but demonstrates nice
 // scalability on SMP machines.
 
+#include <hpx/algorithm.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/parallel_algorithm.hpp>
 #include <hpx/modules/resiliency.hpp>
 #include <hpx/modules/synchronization.hpp>
 #include <boost/range/irange.hpp>
@@ -250,8 +250,8 @@ struct stepper
         std::size_t b = 0;
         auto range = boost::irange(b, subdomains);
         using hpx::parallel::execution::par;
-        hpx::parallel::for_each(par, std::begin(range), std::end(range),
-            [&U, subdomain_width, subdomains](std::size_t i) {
+        hpx::ranges::for_each(
+            par, range, [&U, subdomain_width, subdomains](std::size_t i) {
                 U[0][i] = hpx::make_ready_future(
                     partition_data(subdomain_width, double(i), subdomains));
             });

--- a/libs/resiliency/tests/performance/replay/dataflow_replay_validate.cpp
+++ b/libs/resiliency/tests/performance/replay/dataflow_replay_validate.cpp
@@ -18,9 +18,9 @@
 // computation. This example is still fully local but demonstrates nice
 // scalability on SMP machines.
 
+#include <hpx/algorithm.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/parallel_algorithm.hpp>
 #include <hpx/modules/resiliency.hpp>
 #include <hpx/modules/synchronization.hpp>
 #include <boost/range/irange.hpp>
@@ -242,8 +242,8 @@ struct stepper
         std::size_t b = 0;
         auto range = boost::irange(b, subdomains);
         using hpx::parallel::execution::par;
-        hpx::parallel::for_each(par, std::begin(range), std::end(range),
-            [&U, subdomain_width, subdomains](std::size_t i) {
+        hpx::ranges::for_each(
+            par, range, [&U, subdomain_width, subdomains](std::size_t i) {
                 U[0][i] = hpx::make_ready_future(
                     partition_data(subdomain_width, double(i), subdomains));
             });

--- a/libs/resiliency/tests/performance/replay/pure_dataflow.cpp
+++ b/libs/resiliency/tests/performance/replay/pure_dataflow.cpp
@@ -21,8 +21,8 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 
+#include <hpx/algorithm.hpp>
 #include <hpx/include/lcos_local.hpp>
-#include <hpx/include/parallel_algorithm.hpp>
 #include <hpx/modules/synchronization.hpp>
 #include <boost/range/irange.hpp>
 
@@ -177,8 +177,8 @@ struct stepper
         std::size_t b = 0;
         auto range = boost::irange(b, subdomains);
         using hpx::parallel::execution::par;
-        hpx::parallel::for_each(par, std::begin(range), std::end(range),
-            [&U, subdomain_width, subdomains](std::size_t i) {
+        hpx::ranges::for_each(
+            par, range, [&U, subdomain_width, subdomains](std::size_t i) {
                 U[0][i] = hpx::make_ready_future(
                     partition_data(subdomain_width, double(i), subdomains));
             });

--- a/libs/resiliency/tests/performance/replicate/1d_stencil_replicate.cpp
+++ b/libs/resiliency/tests/performance/replicate/1d_stencil_replicate.cpp
@@ -18,9 +18,9 @@
 // computation. This example is still fully local but demonstrates nice
 // scalability on SMP machines.
 
+#include <hpx/algorithm.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/parallel_algorithm.hpp>
 #include <hpx/modules/resiliency.hpp>
 #include <hpx/modules/synchronization.hpp>
 #include <boost/range/irange.hpp>
@@ -206,8 +206,8 @@ struct stepper
         std::size_t b = 0;
         auto range = boost::irange(b, subdomains);
         using hpx::parallel::execution::par;
-        hpx::parallel::for_each(par, std::begin(range), std::end(range),
-            [&U, subdomain_width, subdomains](std::size_t i) {
+        hpx::ranges::for_each(
+            par, range, [&U, subdomain_width, subdomains](std::size_t i) {
                 U[0][i] = hpx::make_ready_future(
                     partition_data(subdomain_width, double(i), subdomains));
             });

--- a/libs/resiliency/tests/performance/replicate/1d_stencil_replicate_checksum.cpp
+++ b/libs/resiliency/tests/performance/replicate/1d_stencil_replicate_checksum.cpp
@@ -18,9 +18,9 @@
 // computation. This example is still fully local but demonstrates nice
 // scalability on SMP machines.
 
+#include <hpx/algorithm.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/parallel_algorithm.hpp>
 #include <hpx/modules/resiliency.hpp>
 #include <hpx/modules/synchronization.hpp>
 #include <boost/range/irange.hpp>
@@ -247,8 +247,8 @@ struct stepper
         std::size_t b = 0;
         auto range = boost::irange(b, subdomains);
         using hpx::parallel::execution::par;
-        hpx::parallel::for_each(par, std::begin(range), std::end(range),
-            [&U, subdomain_width, subdomains](std::size_t i) {
+        hpx::ranges::for_each(
+            par, range, [&U, subdomain_width, subdomains](std::size_t i) {
                 U[0][i] = hpx::make_ready_future(
                     partition_data(subdomain_width, double(i), subdomains));
             });

--- a/libs/segmented_algorithms/include/hpx/parallel/segmented_algorithms/fill.hpp
+++ b/libs/segmented_algorithms/include/hpx/parallel/segmented_algorithms/fill.hpp
@@ -62,8 +62,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef
                 typename std::iterator_traits<InIter>::value_type value_type;
 
-            return hpx::parallel::for_each(std::forward<ExPolicy>(policy),
-                first, last, fill_function<value_type>(value));
+            return for_each_(std::forward<ExPolicy>(policy), first, last,
+                fill_function<value_type>(value), util::projection_identity(),
+                std::true_type());
         }
 
         // forward declare the non-segmented version of this algorithm

--- a/libs/segmented_algorithms/tests/unit/partitioned_vector_for_each.cpp
+++ b/libs/segmented_algorithms/tests/unit/partitioned_vector_for_each.cpp
@@ -5,9 +5,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/algorithm.hpp>
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/parallel_count.hpp>
-#include <hpx/include/parallel_for_each.hpp>
 #include <hpx/include/partitioned_vector_predef.hpp>
 
 #include <hpx/modules/testing.hpp>
@@ -87,7 +87,7 @@ void test_for_each(ExPolicy&& policy, hpx::partitioned_vector<T>& v, T val)
     verify_values(policy, v, val);
     verify_values_count(policy, v, val);
 
-    hpx::parallel::for_each(policy, v.begin(), v.end(), pfo());
+    hpx::for_each(policy, v.begin(), v.end(), pfo());
 
     verify_values(policy, v, ++val);
     verify_values_count(policy, v, val);
@@ -99,7 +99,7 @@ void test_for_each_n(ExPolicy&& policy, hpx::partitioned_vector<T>& v, T val)
     verify_values(policy, v, val);
     verify_values_count(policy, v, val);
 
-    hpx::parallel::for_each_n(policy, v.begin(), v.end() - v.begin(), pfo());
+    hpx::for_each_n(policy, v.begin(), v.end() - v.begin(), pfo());
 
     verify_values(policy, v, ++val);
     verify_values_count(policy, v, val);
@@ -124,7 +124,7 @@ void test_for_each_async(
     verify_values(policy, v, val);
     verify_values_count_async(policy, v, val);
 
-    hpx::parallel::for_each(policy, v.begin(), v.end(), pfo()).get();
+    hpx::for_each(policy, v.begin(), v.end(), pfo()).get();
 
     verify_values(policy, v, ++val);
     verify_values_count_async(policy, v, val);
@@ -137,8 +137,7 @@ void test_for_each_n_async(
     verify_values(policy, v, val);
     verify_values_count_async(policy, v, val);
 
-    hpx::parallel::for_each_n(policy, v.begin(), v.end() - v.begin(), pfo())
-        .get();
+    hpx::for_each_n(policy, v.begin(), v.end() - v.begin(), pfo()).get();
 
     verify_values(policy, v, ++val);
     verify_values_count_async(policy, v, val);
@@ -152,15 +151,13 @@ void for_each_tests(std::vector<hpx::id_type>& localities)
 
     {
         hpx::partitioned_vector<T> v;
-        hpx::parallel::for_each(
-            hpx::parallel::execution::seq, v.begin(), v.end(), pfo());
-        hpx::parallel::for_each(
-            hpx::parallel::execution::par, v.begin(), v.end(), pfo());
-        hpx::parallel::for_each(
+        hpx::for_each(hpx::parallel::execution::seq, v.begin(), v.end(), pfo());
+        hpx::for_each(hpx::parallel::execution::par, v.begin(), v.end(), pfo());
+        hpx::for_each(
             hpx::parallel::execution::seq(hpx::parallel::execution::task),
             v.begin(), v.end(), pfo())
             .get();
-        hpx::parallel::for_each(
+        hpx::for_each(
             hpx::parallel::execution::par(hpx::parallel::execution::task),
             v.begin(), v.end(), pfo())
             .get();
@@ -190,15 +187,13 @@ void for_each_n_tests(std::vector<hpx::id_type>& localities)
 
     {
         hpx::partitioned_vector<T> v;
-        hpx::parallel::for_each_n(
-            hpx::parallel::execution::seq, v.begin(), 0, pfo());
-        hpx::parallel::for_each_n(
-            hpx::parallel::execution::par, v.begin(), 0, pfo());
-        hpx::parallel::for_each_n(
+        hpx::for_each_n(hpx::parallel::execution::seq, v.begin(), 0, pfo());
+        hpx::for_each_n(hpx::parallel::execution::par, v.begin(), 0, pfo());
+        hpx::for_each_n(
             hpx::parallel::execution::seq(hpx::parallel::execution::task),
             v.begin(), 0, pfo())
             .get();
-        hpx::parallel::for_each_n(
+        hpx::for_each_n(
             hpx::parallel::execution::par(hpx::parallel::execution::task),
             v.begin(), 0, pfo())
             .get();
@@ -206,15 +201,13 @@ void for_each_n_tests(std::vector<hpx::id_type>& localities)
 
     {
         hpx::partitioned_vector<T> v;
-        hpx::parallel::for_each_n(
-            hpx::parallel::execution::seq, v.begin(), -1, pfo());
-        hpx::parallel::for_each_n(
-            hpx::parallel::execution::par, v.begin(), -1, pfo());
-        hpx::parallel::for_each_n(
+        hpx::for_each_n(hpx::parallel::execution::seq, v.begin(), -1, pfo());
+        hpx::for_each_n(hpx::parallel::execution::par, v.begin(), -1, pfo());
+        hpx::for_each_n(
             hpx::parallel::execution::seq(hpx::parallel::execution::task),
             v.begin(), -1, pfo())
             .get();
-        hpx::parallel::for_each_n(
+        hpx::for_each_n(
             hpx::parallel::execution::par(hpx::parallel::execution::task),
             v.begin(), -1, pfo())
             .get();

--- a/tests/performance/local/partitioned_vector_foreach.cpp
+++ b/tests/performance/local/partitioned_vector_foreach.cpp
@@ -4,13 +4,12 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/hpx_init.hpp>
+#include <hpx/algorithm.hpp>
+#include <hpx/chrono.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/modules/timing.hpp>
-#include <hpx/include/parallel_algorithm.hpp>
-#include <hpx/iostream.hpp>
+#include <hpx/hpx_init.hpp>
 #include <hpx/include/partitioned_vector_predef.hpp>
-#include <hpx/include/parallel_for_each.hpp>
+#include <hpx/iostream.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -46,7 +45,7 @@ struct wait_op
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename Policy, typename Vector>
-std::uint64_t foreach_vector(Policy && policy, Vector const& v)
+std::uint64_t foreach_vector(Policy&& policy, Vector const& v)
 {
     typedef typename Vector::value_type value_type;
 
@@ -54,10 +53,8 @@ std::uint64_t foreach_vector(Policy && policy, Vector const& v)
 
     for (int i = 0; i != test_count; ++i)
     {
-        hpx::parallel::for_each(
-            std::forward<Policy>(policy),
-            std::begin(v), std::end(v), wait_op<Vector>()
-        );
+        hpx::ranges::for_each(
+            std::forward<Policy>(policy), v, wait_op<Vector>());
     }
 
     return (hpx::util::high_resolution_clock::now() - start) / test_count;
@@ -67,71 +64,79 @@ std::uint64_t foreach_vector(Policy && policy, Vector const& v)
 int hpx_main(hpx::program_options::variables_map& vm)
 {
     std::size_t vector_size = vm["vector_size"].as<std::size_t>();
-//     bool csvoutput = vm.count("csv_output") != 0;
+    //     bool csvoutput = vm.count("csv_output") != 0;
     delay = vm["work_delay"].as<int>();
     test_count = vm["test_count"].as<int>();
     chunk_size = vm["chunk_size"].as<int>();
 
     // verify that input is within domain of program
-    if (test_count == 0 || test_count < 0) {
+    if (test_count == 0 || test_count < 0)
+    {
         hpx::cout << "test_count cannot be zero or negative...\n" << hpx::flush;
     }
-    else if (delay < 0) {
+    else if (delay < 0)
+    {
         hpx::cout << "delay cannot be a negative number...\n" << hpx::flush;
     }
-    else {
+    else
+    {
         // create executor parameters object
         hpx::parallel::execution::static_chunk_size cs(chunk_size);
 
         // retrieve reference time
         std::vector<int> ref(vector_size);
-        std::uint64_t seq_ref = foreach_vector(
-            hpx::parallel::execution::seq, ref);
+        std::uint64_t seq_ref =
+            foreach_vector(hpx::parallel::execution::seq, ref);
         std::uint64_t par_ref = foreach_vector(
-            hpx::parallel::execution::par.with(cs), ref); //-V106
+            hpx::parallel::execution::par.with(cs), ref);    //-V106
 
         // sequential hpx::partitioned_vector iteration
         {
             hpx::partitioned_vector<int> v(vector_size);
 
             hpx::cout << "hpx::partitioned_vector<int>(execution::seq): "
-                << foreach_vector(hpx::parallel::execution::seq, v) /
-                        double(seq_ref)
-                << "\n";
+                      << foreach_vector(hpx::parallel::execution::seq, v) /
+                    double(seq_ref)
+                      << "\n";
             hpx::cout << "hpx::partitioned_vector<int>(execution::par): "
-                << foreach_vector(hpx::parallel::execution::par.with(cs), v) /
-                        double(par_ref) //-V106
-                << "\n";
+                      << foreach_vector(
+                             hpx::parallel::execution::par.with(cs), v) /
+                    double(par_ref)    //-V106
+                      << "\n";
         }
 
         {
-            hpx::partitioned_vector<int> v(vector_size, hpx::container_layout(2));
+            hpx::partitioned_vector<int> v(
+                vector_size, hpx::container_layout(2));
 
             hpx::cout << "hpx::partitioned_vector<int>(execution::seq, "
-                        "container_layout(2)): "
-                << foreach_vector(hpx::parallel::execution::seq, v) /
-                        double(seq_ref)
-                << "\n";
+                         "container_layout(2)): "
+                      << foreach_vector(hpx::parallel::execution::seq, v) /
+                    double(seq_ref)
+                      << "\n";
             hpx::cout << "hpx::partitioned_vector<int>(execution::par, "
-                        "container_layout(2)): "
-                << foreach_vector(hpx::parallel::execution::par.with(cs), v) /
-                        double(par_ref) //-V106
-                << "\n";
+                         "container_layout(2)): "
+                      << foreach_vector(
+                             hpx::parallel::execution::par.with(cs), v) /
+                    double(par_ref)    //-V106
+                      << "\n";
         }
 
         {
-            hpx::partitioned_vector<int> v(vector_size, hpx::container_layout(10));
+            hpx::partitioned_vector<int> v(
+                vector_size, hpx::container_layout(10));
 
             hpx::cout << "hpx::partitioned_vector<int>(execution::seq, "
-                            "container_layout(10)): "
-                << foreach_vector(hpx::parallel::execution::seq, v) /
-                        double(seq_ref)
-                << "\n";
+                         "container_layout(10)): "
+                      << foreach_vector(hpx::parallel::execution::seq, v) /
+                    double(seq_ref)
+                      << "\n";
             hpx::cout << "hpx::partitioned_vector<int>(execution::par, "
-                            "container_layout(10)): "
-                << foreach_vector(hpx::parallel::execution::par.with(cs), v) /
-                        double(par_ref) //-V106
-                << "\n";
+                         "container_layout(10)): "
+                      << foreach_vector(
+                             hpx::parallel::execution::par.with(cs), v) /
+                    double(par_ref)    //-V106
+                      << "\n";
         }
     }
 
@@ -142,13 +147,12 @@ int hpx_main(hpx::program_options::variables_map& vm)
 int main(int argc, char* argv[])
 {
     //initialize program
-    std::vector<std::string> const cfg = {
-        "hpx.os_threads=all"
-    };
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     hpx::program_options::options_description cmdline(
         "usage: " HPX_APPLICATION_STRING " [options]");
 
+    // clang-format off
     cmdline.add_options()
         ("vector_size"
         , hpx::program_options::value<std::size_t>()->default_value(1000)
@@ -166,7 +170,7 @@ int main(int argc, char* argv[])
         , hpx::program_options::value<int>()->default_value(0)
         , "number of iterations to combine while parallelization (default: 0)")
         ;
+    // clang-format on
 
     return hpx::init(cmdline, argc, argv, cfg);
 }
-


### PR DESCRIPTION
Adds CPOs for `hpx::for_each` and `hpx::ranges::for_each`. As discussed earlier, I've tried to follow the return types in the standard as closely as possible (leaving out the function when an execution policy is used). The return types are adjusted only in the `tag_invoke(for_each_t, ...)` overloads (unlike what I thought initially would need to be adjusted, namely `struct for_each(_n)` or the `foreach` partitioner).

The return types are as follows:

| policy | `hpx::for_each` | `hpx::ranges::for_each` | `hpx::for_each_n` | `hpx::ranges::for_each_n` |
|---|---|---|---|---|
| no policy | `F` | `in_fun_result` | `iter` | `in_fun_result` |
| non-task policy | `void` | `iter`* | `iter` | `iter`* |
| task policy | `future<void>`* | `future<iter>`* | `future<iter>`* | `future<iter>`* |

where `iter` is the iterator type of the input or corresponding to the input range. * is not in the standard. We could keep `iter` as the return type for the non-task policy `hpx::for_each`, even though this is different than the standard.

The iterators were restricted by `is_iterator` with SFINAE, but then in the body of `for_each` there was a `static_assert(is_input/forward_iterator)`. I've change this to only use `is_input/forward_iterator` in the template parameter list. Was the static assert there only for better error messages or also for some other reason?