### PR TITLE
Force partitioned vector scan tests to run serially

### DIFF
--- a/cmake/HPX_AddTest.cmake
+++ b/cmake/HPX_AddTest.cmake
@@ -66,7 +66,8 @@ function(add_hpx_test category name)
 
   if(${HPX_WITH_PARALLEL_TESTS_BIND_NONE}
      AND NOT run_serial
-     AND ${name}_LOCALITIES STREQUAL "1"
+     AND NOT "${name}_RUNWRAPPER"
+     AND (${name}_LOCALITIES STREQUAL "1" OR NOT ${HPX_WITH_NETWORKING})
   )
     set(args ${args} "--hpx:bind=none")
   endif()

--- a/libs/segmented_algorithms/tests/unit/CMakeLists.txt
+++ b/libs/segmented_algorithms/tests/unit/CMakeLists.txt
@@ -50,11 +50,19 @@ if(HPX_WITH_CUDA_COMPUTE)
   )
 endif()
 
+set(partitioned_vector_inclusive_scan_PARAMETERS RUN_SERIAL)
+set(partitioned_vector_inclusive_scan2_PARAMETERS RUN_SERIAL)
+set(partitioned_vector_exclusive_scan_PARAMETERS RUN_SERIAL)
+set(partitioned_vector_exclusive_scan2_PARAMETERS RUN_SERIAL)
+set(partitioned_vector_target_PARAMETERS RUN_SERIAL)
+
 foreach(test ${tests})
   set(sources ${test}.cpp)
 
   set(${test}_FLAGS DEPENDENCIES partitioned_vector_component)
-  set(${test}_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 4)
+  set(${test}_PARAMETERS ${${test}_PARAMETERS} LOCALITIES 2
+                         THREADS_PER_LOCALITY 4
+  )
 
   source_group("Source Files" FILES ${sources})
 


### PR DESCRIPTION
I could not figure out why, but the `partitioned_vector_{in,ex}clusive_scan` tests run significantly slower (to the point of timing out like here: https://cdash.cscs.ch/viewTest.php?onlyfailed&buildid=120322, even though they do eventually finish) when run in parallel or even in parallel with `--hpx:bind=none`. This makes them run serially and makes other multi-locality tests use `--hpx:bind=none` when networking is off.