### PR TITLE
Adds different runtime exception when registering thread with the HPX runtime

### DIFF
--- a/libs/threading_base/src/register_thread.cpp
+++ b/libs/threading_base/src/register_thread.cpp
@@ -70,7 +70,9 @@ namespace hpx { namespace threads { namespace detail {
                     "linking to libhpx_wrap. If you're using CMakeLists, make "
                     "sure to add HPX::wrap_main to target_link_libraries. "
                     "If you're using Makefile, make sure to link to "
-                    "libhpx_wrap when generating the executable.");
+                    "libhpx_wrap when generating the executable. If you're "
+                    "linking explicitly, consult the HPX docs for library "
+                    "link order and other subtle nuances.");
 
 #endif
 

--- a/libs/threading_base/src/register_thread.cpp
+++ b/libs/threading_base/src/register_thread.cpp
@@ -17,6 +17,11 @@
 #include <string>
 #include <utility>
 
+// The following implementation has been divided for Linux and Mac OSX
+#if defined(HPX_HAVE_DYNAMIC_HPX_MAIN) && \
+    (defined(__linux) || defined(__linux__) || defined(linux) || \
+    defined(__APPLE__))
+
 namespace hpx_start {
     // Redifining weak variables defined in hpx_main.hpp to facilitate error
     // checking and make sure correct errors are thrown. It is added again
@@ -25,6 +30,8 @@ namespace hpx_start {
     HPX_SYMBOL_EXPORT bool is_linked __attribute__((weak)) = false;
     HPX_SYMBOL_EXPORT bool include_libhpx_wrap __attribute__((weak)) = false;
 }   // namespace hpx_start
+
+#endif
 
 namespace hpx { namespace threads { namespace detail {
     static get_default_pool_type get_default_pool;
@@ -49,6 +56,12 @@ namespace hpx { namespace threads { namespace detail {
         }
         else
         {
+
+// The following implementation has been divided for Linux and Mac OSX
+#if defined(HPX_HAVE_DYNAMIC_HPX_MAIN) && \
+    (defined(__linux) || defined(__linux__) || defined(linux) || \
+    defined(__APPLE__))
+
             // hpx_main.hpp is included but not linked to libhpx_wrap
             if (!hpx_start::is_linked && hpx_start::include_libhpx_wrap)
                 HPX_THROW_EXCEPTION(invalid_status,
@@ -56,6 +69,8 @@ namespace hpx { namespace threads { namespace detail {
                     "Attempting to use hpx_main.hpp functionality without "
                     "linking to libhpx_wrap. Did you link to HPX::wrap_main "
                     "in your CMakeLists.txt?");
+
+#endif
 
             HPX_THROW_EXCEPTION(invalid_status,
                 "hpx::threads::detail::get_self_or_default_pool",

--- a/libs/threading_base/src/register_thread.cpp
+++ b/libs/threading_base/src/register_thread.cpp
@@ -18,9 +18,9 @@
 #include <utility>
 
 // The following implementation has been divided for Linux and Mac OSX
-#if defined(HPX_HAVE_DYNAMIC_HPX_MAIN) && \
-    (defined(__linux) || defined(__linux__) || defined(linux) || \
-    defined(__APPLE__))
+#if defined(HPX_HAVE_DYNAMIC_HPX_MAIN) &&                                      \
+    (defined(__linux) || defined(__linux__) || defined(linux) ||               \
+        defined(__APPLE__))
 
 namespace hpx_start {
     // Redefining weak variables defined in hpx_main.hpp to facilitate error
@@ -29,7 +29,7 @@ namespace hpx_start {
     // where hpx_main functionalities are not used.
     HPX_SYMBOL_EXPORT bool is_linked __attribute__((weak)) = false;
     HPX_SYMBOL_EXPORT bool include_libhpx_wrap __attribute__((weak)) = false;
-}   // namespace hpx_start
+}    // namespace hpx_start
 
 #endif
 
@@ -56,69 +56,78 @@ namespace hpx { namespace threads { namespace detail {
         }
         else
         {
-
 // The following implementation has been divided for Linux and Mac OSX
-#if defined(HPX_HAVE_DYNAMIC_HPX_MAIN) && \
-    (defined(__linux) || defined(__linux__) || defined(linux) || \
-    defined(__APPLE__))
+#if defined(HPX_HAVE_DYNAMIC_HPX_MAIN) &&                                      \
+    (defined(__linux) || defined(__linux__) || defined(linux) ||               \
+        defined(__APPLE__))
 
-            // hpx_main.hpp is included but not linked to libhpx_wrap
-            if (!hpx_start::is_linked && hpx_start::include_libhpx_wrap)
-                HPX_THROW_EXCEPTION(invalid_status,
-                    "hpx::threads::detail::get_self_or_default_pool",
-                    "Attempting to use hpx_main.hpp functionality without "
-                    "linking to libhpx_wrap. If you're using CMakeLists, make "
-                    "sure to add HPX::wrap_main to target_link_libraries. "
-                    "If you're using Makefile, make sure to link to "
-                    "libhpx_wrap when generating the executable. If you're "
-                    "linking explicitly, consult the HPX docs for library "
-                    "link order and other subtle nuances.");
+                    // hpx_main.hpp is included but not linked to libhpx_wrap
+                    if (!hpx_start::is_linked && hpx_start::include_libhpx_wrap)
+                        HPX_THROW_EXCEPTION(invalid_status,
+                            "hpx::threads::detail::get_self_or_default_pool",
+                            "Attempting to use hpx_main.hpp functionality "
+                            "without "
+                            "linking to libhpx_wrap. If you're using "
+                            "CMakeLists, make "
+                            "sure to add HPX::wrap_main to "
+                            "target_link_libraries. "
+                            "If you're using Makefile, make sure to link to "
+                            "libhpx_wrap when generating the executable. If "
+                            "you're "
+                            "linking explicitly, consult the HPX docs for "
+                            "library "
+                            "link order and other subtle nuances.");
 
 #endif
 
-            HPX_THROW_EXCEPTION(invalid_status,
-                "hpx::threads::detail::get_self_or_default_pool",
-                "Attempting to register a thread outside the HPX runtime and "
-                "no default pool handler is installed. Did you mean to run "
-                "this on an HPX thread?");
-        }
+                    HPX_THROW_EXCEPTION(invalid_status,
+                        "hpx::threads::detail::get_self_or_default_pool",
+                        "Attempting to register a thread outside the HPX "
+                        "runtime and "
+                        "no default pool handler is installed. Did you mean to "
+                        "run "
+                        "this on an HPX thread?");
+                }
 
-        return pool;
-    }
+                return pool;
+            }
 
-    static get_default_timer_service_type get_default_timer_service_f;
+            static get_default_timer_service_type get_default_timer_service_f;
 
-    void set_get_default_timer_service(get_default_timer_service_type f)
-    {
-        get_default_timer_service_f = f;
-    }
+            void set_get_default_timer_service(get_default_timer_service_type f)
+            {
+                get_default_timer_service_f = f;
+            }
 
-    boost::asio::io_service* get_default_timer_service()
-    {
-        boost::asio::io_service* timer_service = nullptr;
-        if (detail::get_default_timer_service_f)
-        {
-            timer_service = detail::get_default_timer_service_f();
-            HPX_ASSERT(timer_service);
-        }
-        else
-        {
+            boost::asio::io_service* get_default_timer_service()
+            {
+                boost::asio::io_service* timer_service = nullptr;
+                if (detail::get_default_timer_service_f)
+                {
+                    timer_service = detail::get_default_timer_service_f();
+                    HPX_ASSERT(timer_service);
+                }
+                else
+                {
 #if defined(HPX_HAVE_TIMER_POOL)
-            HPX_THROW_EXCEPTION(invalid_status,
-                "hpx::threads::detail::get_default_timer_service",
-                "No timer service installed. When running timed threads "
-                "without a runtime a timer service has to be installed "
-                "manually using "
-                "hpx::threads::detail::set_get_default_timer_service.");
+                    HPX_THROW_EXCEPTION(invalid_status,
+                        "hpx::threads::detail::get_default_timer_service",
+                        "No timer service installed. When running timed "
+                        "threads "
+                        "without a runtime a timer service has to be installed "
+                        "manually using "
+                        "hpx::threads::detail::set_get_default_timer_service.");
 #else
-            HPX_THROW_EXCEPTION(invalid_status,
-                "hpx::threads::detail::get_default_timer_service",
-                "No timer service installed. Rebuild HPX with "
-                "HPX_WITH_TIMER_POOL=ON or provide a timer service manually "
-                "using hpx::threads::detail::set_get_default_timer_service.");
+                    HPX_THROW_EXCEPTION(invalid_status,
+                        "hpx::threads::detail::get_default_timer_service",
+                        "No timer service installed. Rebuild HPX with "
+                        "HPX_WITH_TIMER_POOL=ON or provide a timer service "
+                        "manually "
+                        "using "
+                        "hpx::threads::detail::set_get_default_timer_service.");
 #endif
-        }
+                }
 
-        return timer_service;
-    }
+                return timer_service;
+            }
 }}}    // namespace hpx::threads::detail

--- a/libs/threading_base/src/register_thread.cpp
+++ b/libs/threading_base/src/register_thread.cpp
@@ -16,6 +16,15 @@
 #include <string>
 #include <utility>
 
+namespace hpx_start {
+    // Redifining weak variables defined in hpx_main.hpp to facilitate error
+    // checking and make sure correct errors are thrown. It is added again
+    // to make sure that these variables are defined correctly in cases
+    // where hpx_main functionalities are not used.
+    HPX_SYMBOL_EXPORT bool is_linked __attribute__((weak)) = false;
+    HPX_SYMBOL_EXPORT bool include_libhpx_wrap __attribute__((weak)) = false;
+}
+
 namespace hpx { namespace threads { namespace detail {
     static get_default_pool_type get_default_pool;
 
@@ -39,6 +48,14 @@ namespace hpx { namespace threads { namespace detail {
         }
         else
         {
+            // hpx_main.hpp is included but not linked to libhpx_wrap
+            if (!hpx_start::is_linked && hpx_start::include_libhpx_wrap)
+                HPX_THROW_EXCEPTION(invalid_status,
+                    "hpx::threads::detail::get_self_or_default_pool",
+                    "Attempting to use hpx_main.hpp functionality without "
+                    "linking to libhpx_wrap. Did you link to HPX::wrap_main "
+                    "in your CMakeLists.txt?");
+
             HPX_THROW_EXCEPTION(invalid_status,
                 "hpx::threads::detail::get_self_or_default_pool",
                 "Attempting to register a thread outside the HPX runtime and "

--- a/libs/threading_base/src/register_thread.cpp
+++ b/libs/threading_base/src/register_thread.cpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2007-2016 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
+//  Copyright (c)      2020 Nikunj Gupta
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -23,7 +24,7 @@ namespace hpx_start {
     // where hpx_main functionalities are not used.
     HPX_SYMBOL_EXPORT bool is_linked __attribute__((weak)) = false;
     HPX_SYMBOL_EXPORT bool include_libhpx_wrap __attribute__((weak)) = false;
-}
+}   // namespace hpx_start
 
 namespace hpx { namespace threads { namespace detail {
     static get_default_pool_type get_default_pool;

--- a/libs/threading_base/src/register_thread.cpp
+++ b/libs/threading_base/src/register_thread.cpp
@@ -23,7 +23,7 @@
     defined(__APPLE__))
 
 namespace hpx_start {
-    // Redifining weak variables defined in hpx_main.hpp to facilitate error
+    // Redefining weak variables defined in hpx_main.hpp to facilitate error
     // checking and make sure correct errors are thrown. It is added again
     // to make sure that these variables are defined correctly in cases
     // where hpx_main functionalities are not used.
@@ -67,8 +67,10 @@ namespace hpx { namespace threads { namespace detail {
                 HPX_THROW_EXCEPTION(invalid_status,
                     "hpx::threads::detail::get_self_or_default_pool",
                     "Attempting to use hpx_main.hpp functionality without "
-                    "linking to libhpx_wrap. Did you link to HPX::wrap_main "
-                    "in your CMakeLists.txt?");
+                    "linking to libhpx_wrap. If you're using CMakeLists, make "
+                    "sure to add HPX::wrap_main to target_link_libraries. "
+                    "If you're using Makefile, make sure to link to "
+                    "libhpx_wrap when generating the executable.");
 
 #endif
 

--- a/wrap/include/hpx/wrap_main.hpp
+++ b/wrap/include/hpx/wrap_main.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2007-2014 Hartmut Kaiser
-//  Copyright (c)      2018 Nikunj Gupta
+//  Copyright (c) 2018-2020 Nikunj Gupta
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -28,6 +28,14 @@ namespace hpx_start
     HPX_SYMBOL_EXPORT bool include_libhpx_wrap = true;
     HPX_SYMBOL_EXPORT extern std::string app_name_libhpx_wrap;
     HPX_SYMBOL_EXPORT std::string app_name_libhpx_wrap = HPX_APPLICATION_STRING;
+
+    // This variable declaration is added solely for the purpose to trigger
+    // a different runtime error when a user forgets to add HPX::wrap_main in
+    // their CMakeLists.txt while using hpx_main.hpp functionality.
+    // It will enable the user to know that he is required to link to
+    // HPX::wrap_main instead of an orthogonal exception about thread not
+    // registered with the HPX runtime system.
+    HPX_SYMBOL_EXPORT bool is_linked __attribute__((weak)) = false;
 }
 
 #else

--- a/wrap/src/hpx_wrap.cpp
+++ b/wrap/src/hpx_wrap.cpp
@@ -27,6 +27,12 @@ namespace hpx_start
     HPX_SYMBOL_EXPORT bool include_libhpx_wrap __attribute__((weak)) = false;
     HPX_SYMBOL_EXPORT extern std::string app_name_libhpx_wrap;
     HPX_SYMBOL_EXPORT std::string app_name_libhpx_wrap __attribute__((weak));
+
+    // Provide a definition of is_linked variable defined weak in hpx_main.hpp
+    // header. This variable is solely to trigger a different exception when
+    // trying to register thread when not linked to libhpx_wrap and using
+    // hpx_main.hpp functionality.
+    HPX_SYMBOL_EXPORT bool is_linked = true;
 }
 
 #include <hpx/hpx_finalize.hpp>

--- a/wrap/src/hpx_wrap.cpp
+++ b/wrap/src/hpx_wrap.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2018 Nikunj Gupta
+//  Copyright (c) 2018-2020 Nikunj Gupta
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying


### PR DESCRIPTION
## Proposed Changes

This PR adds a different runtime exception that will be thrown in scenarios where the user includes `hpx_main.hpp` but fails to link to `libhpx_wrap`. The error thrown is self sufficient and should let the user know that he/she is required to link to `libhpx_wrap`.

This fixes scenarios where the user faces thread registering exception that is orthogonal to the actual cause (see #4877 ).

### Following are two simple case scenarios:

Code 1:
```
#include <hpx/hpx_main.hpp>
#include <hpx/include/future.hpp>
#include <hpx/async_local/async.hpp>

int main(int argc, char * argv[])
{
    hpx::future<int> f = hpx::async([]() { return 42; });
    std::cout << f.get() << std::endl;

    return 0;
}
```

Code 2:
```
#include <hpx/include/future.hpp>
#include <hpx/async_local/async.hpp>

int main(int argc, char * argv[])
{
    hpx::future<int> f = hpx::async([]() { return 42; });
    std::cout << f.get() << std::endl;

    return 0;
}
```

CMakeLists.txt
```
cmake_minimum_required(VERSION 3.13)

find_package(HPX REQUIRED)

add_executable(main main.cpp)
target_link_libraries(main HPX::hpx)
```

All codes are written in correct standard C++ and will compile and link properly. The exception thrown by the first code is as follows:
```
terminate called after throwing an instance of 'hpx::detail::exception_with_info<hpx::exception>'
  what():  Attempting to use hpx_main.hpp functionality without linking to libhpx_wrap. Did you link to HPX::wrap_main in your CMakeLists.txt?: HPX(invalid_status)
Aborted (core dumped)
```
This is a much better explanation of what is happening under the hood and should help the user to understand the cause.

The second throws the following exception:
```
terminate called after throwing an instance of 'hpx::detail::exception_with_info<hpx::exception>'
  what():  Attempting to register a thread outside the HPX runtime and no default pool handler is installed. Did you mean to run this on an HPX thread?: HPX(invalid_status)
Aborted (core dumped)
```
This is the exception that needs to be thrown as the user forgot to choose between `hpx_init.hpp` or `hpx_main.hpp` and failed to initialize the runtime. This leads to the exception that we see above.