### PR TITLE
Adapting mismatch to C++20

### DIFF
--- a/libs/algorithms/CMakeLists.txt
+++ b/libs/algorithms/CMakeLists.txt
@@ -90,6 +90,7 @@ set(algorithms_headers
     hpx/parallel/container_algorithms/is_heap.hpp
     hpx/parallel/container_algorithms/merge.hpp
     hpx/parallel/container_algorithms/minmax.hpp
+    hpx/parallel/container_algorithms/mismatch.hpp
     hpx/parallel/container_algorithms/move.hpp
     hpx/parallel/container_algorithms/partition.hpp
     hpx/parallel/container_algorithms/reduce.hpp

--- a/libs/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,135 +8,9 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/functional/invoke.hpp>
-#include <hpx/iterator_support/traits/is_iterator.hpp>
-
-#include <hpx/execution/algorithms/detail/predicates.hpp>
-#include <hpx/executors/execution_policy.hpp>
-#include <hpx/parallel/algorithms/detail/dispatch.hpp>
-#include <hpx/parallel/util/detail/algorithm_result.hpp>
-#include <hpx/parallel/util/loop.hpp>
-#include <hpx/parallel/util/partitioner.hpp>
-#include <hpx/parallel/util/zip_iterator.hpp>
-
-#include <algorithm>
-#include <cstddef>
-#include <iterator>
-#include <type_traits>
-#include <utility>
-#include <vector>
-
-namespace hpx { namespace parallel { inline namespace v1 {
-    ///////////////////////////////////////////////////////////////////////////
-    // mismatch (binary)
-    namespace detail {
-        /// \cond NOINTERNAL
-        template <typename InIter1, typename InIter2, typename F>
-        std::pair<InIter1, InIter2> sequential_mismatch_binary(
-            InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2, F&& f)
-        {
-            while (first1 != last1 && first2 != last2 &&
-                hpx::util::invoke(f, *first1, *first2))
-            {
-                ++first1, ++first2;
-            }
-            return std::make_pair(first1, first2);
-        }
-
-        template <typename T>
-        struct mismatch_binary : public detail::algorithm<mismatch_binary<T>, T>
-        {
-            mismatch_binary()
-              : mismatch_binary::algorithm("mismatch_binary")
-            {
-            }
-
-            template <typename ExPolicy, typename InIter1, typename InIter2,
-                typename F>
-            static T sequential(ExPolicy, InIter1 first1, InIter1 last1,
-                InIter2 first2, InIter2 last2, F&& f)
-            {
-                return sequential_mismatch_binary(
-                    first1, last1, first2, last2, std::forward<F>(f));
-            }
-
-            template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-                typename F>
-            static typename util::detail::algorithm_result<ExPolicy, T>::type
-            parallel(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
-                FwdIter2 first2, FwdIter2 last2, F&& f)
-            {
-                if (first1 == last1 || first2 == last2)
-                {
-                    return util::detail::algorithm_result<ExPolicy, T>::get(
-                        std::make_pair(first1, first2));
-                }
-
-                typedef typename std::iterator_traits<FwdIter1>::difference_type
-                    difference_type1;
-                difference_type1 count1 = std::distance(first1, last1);
-
-                // The specification of std::mismatch(_binary) states that if FwdIter1
-                // and FwdIter2 meet the requirements of RandomAccessIterator and
-                // last1 - first1 != last2 - first2 then no applications of the
-                // predicate p are made.
-                //
-                // We perform this check for any iterator type better than input
-                // iterators. This could turn into a QoI issue.
-                typedef typename std::iterator_traits<FwdIter2>::difference_type
-                    difference_type2;
-                difference_type2 count2 = std::distance(first2, last2);
-                if (count1 != count2)
-                {
-                    return util::detail::algorithm_result<ExPolicy, T>::get(
-                        std::make_pair(first1, first2));
-                }
-
-                typedef hpx::util::zip_iterator<FwdIter1, FwdIter2>
-                    zip_iterator;
-                typedef typename zip_iterator::reference reference;
-
-                util::cancellation_token<std::size_t> tok(count1);
-
-                auto f1 = [tok, f = std::forward<F>(f)](zip_iterator it,
-                              std::size_t part_count,
-                              std::size_t base_idx) mutable -> void {
-                    util::loop_idx_n(base_idx, it, part_count, tok,
-                        [&f, &tok](reference t, std::size_t i) {
-                            if (!hpx::util::invoke(f, hpx::util::get<0>(t),
-                                    hpx::util::get<1>(t)))
-                            {
-                                tok.cancel(i);
-                            }
-                        });
-                };
-
-                auto f2 = [=](std::vector<hpx::future<void>>&&) mutable
-                    -> std::pair<FwdIter1, FwdIter2> {
-                    difference_type1 mismatched =
-                        static_cast<difference_type1>(tok.get_data());
-                    if (mismatched != count1)
-                    {
-                        std::advance(first1, mismatched);
-                        std::advance(first2, mismatched);
-                    }
-                    else
-                    {
-                        first1 = last1;
-                        first2 = last2;
-                    }
-                    return std::make_pair(first1, first2);
-                };
-
-                return util::partitioner<ExPolicy, T, void>::call_with_index(
-                    std::forward<ExPolicy>(policy),
-                    hpx::util::make_zip_iterator(first1, first2), count1, 1,
-                    std::move(f1), std::move(f2));
-            }
-        };
-        /// \endcond
-    }    // namespace detail
+#if defined(DOXYGEN)
+namespace hpx {
+    // clang-format off
 
     /// Returns true if the range [first1, last1) is mismatch to the range
     /// [first2, last2), and false otherwise.
@@ -213,103 +87,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           two ranges are mismatch, otherwise it returns false.
     ///           If the length of the range [first1, last1) does not mismatch
     ///           the length of the range [first2, last2), it returns false.
+    ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Pred = detail::equal_to>
-    inline
-        typename std::enable_if<execution::is_execution_policy<ExPolicy>::value,
-            typename util::detail::algorithm_result<ExPolicy,
-                std::pair<FwdIter1, FwdIter2>>::type>::type
-        mismatch(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
-            FwdIter2 first2, FwdIter2 last2, Pred&& op = Pred())
-    {
-        static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
-            "Requires at least forward iterator.");
-        static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
-            "Requires at least forward iterator.");
-
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
-
-        typedef std::pair<FwdIter1, FwdIter2> result_type;
-        return detail::mismatch_binary<result_type>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
-            last2, std::forward<Pred>(op));
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    // mismatch
-    namespace detail {
-        /// \cond NOINTERNAL
-        template <typename T>
-        struct mismatch : public detail::algorithm<mismatch<T>, T>
-        {
-            mismatch()
-              : mismatch::algorithm("mismatch")
-            {
-            }
-
-            template <typename ExPolicy, typename InIter1, typename InIter2,
-                typename F>
-            static T sequential(
-                ExPolicy, InIter1 first1, InIter1 last1, InIter2 first2, F&& f)
-            {
-                return std::mismatch(first1, last1, first2, std::forward<F>(f));
-            }
-
-            template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-                typename F>
-            static typename util::detail::algorithm_result<ExPolicy, T>::type
-            parallel(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
-                FwdIter2 first2, F&& f)
-            {
-                if (first1 == last1)
-                {
-                    return util::detail::algorithm_result<ExPolicy, T>::get(
-                        std::make_pair(first1, first2));
-                }
-
-                typedef typename std::iterator_traits<FwdIter1>::difference_type
-                    difference_type;
-                difference_type count = std::distance(first1, last1);
-
-                typedef hpx::util::zip_iterator<FwdIter1, FwdIter2>
-                    zip_iterator;
-                typedef typename zip_iterator::reference reference;
-
-                util::cancellation_token<std::size_t> tok(count);
-
-                auto f1 = [tok, f = std::forward<F>(f)](zip_iterator it,
-                              std::size_t part_count,
-                              std::size_t base_idx) mutable -> void {
-                    util::loop_idx_n(base_idx, it, part_count, tok,
-                        [&f, &tok](reference t, std::size_t i) {
-                            if (!hpx::util::invoke(f, hpx::util::get<0>(t),
-                                    hpx::util::get<1>(t)))
-                            {
-                                tok.cancel(i);
-                            }
-                        });
-                };
-                auto f2 = [=](std::vector<hpx::future<void>>&&) mutable
-                    -> std::pair<FwdIter1, FwdIter2> {
-                    difference_type mismatched =
-                        static_cast<difference_type>(tok.get_data());
-                    if (mismatched != count)
-                        std::advance(first1, mismatched);
-                    else
-                        first1 = last1;
-
-                    std::advance(first2, mismatched);
-                    return std::make_pair(first1, first2);
-                };
-
-                return util::partitioner<ExPolicy, T, void>::call_with_index(
-                    std::forward<ExPolicy>(policy),
-                    hpx::util::make_zip_iterator(first1, first2), count, 1,
-                    std::move(f1), std::move(f2));
-            }
-        };
-        /// \endcond
-    }    // namespace detail
+    typename util::detail::algorithm_result<
+        ExPolicy, std::pair<FwdIter1, FwdIter2>>::type
+    mismatch(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+            FwdIter2 first2, FwdIter2 last2, Pred&& op = Pred());
 
     /// Returns std::pair with iterators to the first two non-equivalent
     /// elements.
@@ -379,10 +163,307 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Pred = detail::equal_to>
-    inline
-        typename std::enable_if<execution::is_execution_policy<ExPolicy>::value,
-            typename util::detail::algorithm_result<ExPolicy,
-                std::pair<FwdIter1, FwdIter2>>::type>::type
+    typename util::detail::algorithm_result<
+        ExPolicy, std::pair<FwdIter1, FwdIter2>>::type
+    mismatch(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1, FwdIter2 first2,
+        Pred&& op = Pred());
+
+    // clang-format on
+}    // namespace hpx
+
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/functional/invoke.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+
+#include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/algorithms/detail/distance.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/loop.hpp>
+#include <hpx/parallel/util/partitioner.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+#include <hpx/parallel/util/zip_iterator.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace parallel { inline namespace v1 {
+    ///////////////////////////////////////////////////////////////////////////
+    // mismatch (binary)
+    namespace detail {
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Iter1, typename Sent1, typename Iter2,
+            typename Sent2, typename F, typename Proj1, typename Proj2>
+        util::in_in_result<Iter1, Iter2> sequential_mismatch_binary(
+            Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2, F&& f,
+            Proj1&& proj1, Proj2&& proj2)
+        {
+            while (first1 != last1 && first2 != last2 &&
+                hpx::util::invoke(f, hpx::util::invoke(proj1, *first1),
+                    hpx::util::invoke(proj2, *first2)))
+            {
+                ++first1, ++first2;
+            }
+            return {first1, first2};
+        }
+
+        template <typename IterPair>
+        struct mismatch_binary
+          : public detail::algorithm<mismatch_binary<IterPair>, IterPair>
+        {
+            mismatch_binary()
+              : mismatch_binary::algorithm("mismatch_binary")
+            {
+            }
+
+            template <typename ExPolicy, typename Iter1, typename Sent1,
+                typename Iter2, typename Sent2, typename F, typename Proj1,
+                typename Proj2>
+            static util::in_in_result<Iter1, Iter2> sequential(ExPolicy,
+                Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2, F&& f,
+                Proj1&& proj1, Proj2&& proj2)
+            {
+                return sequential_mismatch_binary(first1, last1, first2, last2,
+                    std::forward<F>(f), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2));
+            }
+
+            template <typename ExPolicy, typename Iter1, typename Sent1,
+                typename Iter2, typename Sent2, typename F, typename Proj1,
+                typename Proj2>
+            static typename util::detail::algorithm_result<ExPolicy,
+                util::in_in_result<Iter1, Iter2>>::type
+            parallel(ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
+                Sent2 last2, F&& f, Proj1&& proj1, Proj2&& proj2)
+            {
+                if (first1 == last1 || first2 == last2)
+                {
+                    return util::detail::algorithm_result<ExPolicy,
+                        util::in_in_result<Iter1, Iter2>>::
+                        get(util::in_in_result<Iter1, Iter2>{first1, first2});
+                }
+
+                typedef typename std::iterator_traits<Iter1>::difference_type
+                    difference_type1;
+                difference_type1 count1 = detail::distance(first1, last1);
+
+                // The specification of std::mismatch(_binary) states that if FwdIter1
+                // and FwdIter2 meet the requirements of RandomAccessIterator and
+                // last1 - first1 != last2 - first2 then no applications of the
+                // predicate p are made.
+                //
+                // We perform this check for any iterator type better than input
+                // iterators. This could turn into a QoI issue.
+                typedef typename std::iterator_traits<Iter2>::difference_type
+                    difference_type2;
+                difference_type2 count2 = detail::distance(first2, last2);
+                if (count1 != count2)
+                {
+                    return util::detail::algorithm_result<ExPolicy,
+                        util::in_in_result<Iter1, Iter2>>::
+                        get(util::in_in_result<Iter1, Iter2>{first1, first2});
+                }
+
+                typedef hpx::util::zip_iterator<Iter1, Iter2> zip_iterator;
+                typedef typename zip_iterator::reference reference;
+
+                util::cancellation_token<std::size_t> tok(count1);
+
+                auto f1 = [tok, f = std::forward<F>(f),
+                              proj1 = std::forward<Proj1>(proj1),
+                              proj2 = std::forward<Proj2>(proj2)](
+                              zip_iterator it, std::size_t part_count,
+                              std::size_t base_idx) mutable -> void {
+                    util::loop_idx_n(base_idx, it, part_count, tok,
+                        [&f, &proj1, &proj2, &tok](reference t, std::size_t i) {
+                            if (!hpx::util::invoke(f,
+                                    hpx::util::invoke(
+                                        proj1, hpx::util::get<0>(t)),
+                                    hpx::util::invoke(
+                                        proj2, hpx::util::get<1>(t))))
+                            {
+                                tok.cancel(i);
+                            }
+                        });
+                };
+
+                auto f2 = [=](std::vector<hpx::future<void>>&&) mutable
+                    -> util::in_in_result<Iter1, Iter2> {
+                    difference_type1 mismatched =
+                        static_cast<difference_type1>(tok.get_data());
+                    if (mismatched != count1)
+                    {
+                        std::advance(first1, mismatched);
+                        std::advance(first2, mismatched);
+                    }
+                    else
+                    {
+                        first1 = last1;
+                        first2 = last2;
+                    }
+                    return {first1, first2};
+                };
+
+                return util::partitioner<ExPolicy,
+                    util::in_in_result<Iter1, Iter2>,
+                    void>::call_with_index(std::forward<ExPolicy>(policy),
+                    hpx::util::make_zip_iterator(first1, first2), count1, 1,
+                    std::move(f1), std::move(f2));
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename I1, typename I2>
+        std::pair<I1, I2> get_pair(util::in_in_result<I1, I2>&& p)
+        {
+            return {p.in1, p.in2};
+        }
+
+        template <typename I1, typename I2>
+        hpx::future<std::pair<I1, I2>> get_pair(
+            hpx::future<util::in_in_result<I1, I2>>&& f)
+        {
+            return lcos::make_future<std::pair<I1, I2>>(std::move(f),
+                [](util::in_in_result<I1, I2>&& p) -> std::pair<I1, I2> {
+                    return {std::move(p.in1), std::move(p.in2)};
+                });
+        }
+    }    // namespace detail
+
+    // clang-format off
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename Pred = detail::equal_to,
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<FwdIter1>::value &&
+            hpx::traits::is_iterator<FwdIter2>::value &&
+            hpx::traits::is_invocable<Pred,
+                typename std::iterator_traits<FwdIter1>::value_type,
+                typename std::iterator_traits<FwdIter2>::value_type
+            >::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::mismatch is deprecated, use hpx::mismatch instead")
+        typename util::detail::algorithm_result<ExPolicy,
+            std::pair<FwdIter1, FwdIter2>>::type
+        mismatch(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+            FwdIter2 first2, FwdIter2 last2, Pred&& op = Pred())
+    {
+        static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+            "Requires at least forward iterator.");
+        static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+            "Requires at least forward iterator.");
+
+        using is_seq = execution::is_sequenced_execution_policy<ExPolicy>;
+
+        return detail::get_pair(
+            detail::mismatch_binary<util::in_in_result<FwdIter1, FwdIter2>>()
+                .call(std::forward<ExPolicy>(policy), is_seq{}, first1, last1,
+                    first2, last2, std::forward<Pred>(op)));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // mismatch
+    namespace detail {
+
+        template <typename IterPair>
+        struct mismatch : public detail::algorithm<mismatch<IterPair>, IterPair>
+        {
+            mismatch()
+              : mismatch::algorithm("mismatch")
+            {
+            }
+
+            template <typename ExPolicy, typename InIter1, typename InIter2,
+                typename F>
+            static IterPair sequential(
+                ExPolicy, InIter1 first1, InIter1 last1, InIter2 first2, F&& f)
+            {
+                return std::mismatch(first1, last1, first2, std::forward<F>(f));
+            }
+
+            template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+                typename F>
+            static typename util::detail::algorithm_result<ExPolicy,
+                IterPair>::type
+            parallel(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+                FwdIter2 first2, F&& f)
+            {
+                if (first1 == last1)
+                {
+                    return util::detail::algorithm_result<ExPolicy,
+                        IterPair>::get(std::make_pair(first1, first2));
+                }
+
+                typedef typename std::iterator_traits<FwdIter1>::difference_type
+                    difference_type;
+                difference_type count = std::distance(first1, last1);
+
+                typedef hpx::util::zip_iterator<FwdIter1, FwdIter2>
+                    zip_iterator;
+                typedef typename zip_iterator::reference reference;
+
+                util::cancellation_token<std::size_t> tok(count);
+
+                auto f1 = [tok, f = std::forward<F>(f)](zip_iterator it,
+                              std::size_t part_count,
+                              std::size_t base_idx) mutable -> void {
+                    util::loop_idx_n(base_idx, it, part_count, tok,
+                        [&f, &tok](reference t, std::size_t i) {
+                            if (!hpx::util::invoke(f, hpx::util::get<0>(t),
+                                    hpx::util::get<1>(t)))
+                            {
+                                tok.cancel(i);
+                            }
+                        });
+                };
+                auto f2 = [=](std::vector<hpx::future<void>>&&) mutable
+                    -> std::pair<FwdIter1, FwdIter2> {
+                    difference_type mismatched =
+                        static_cast<difference_type>(tok.get_data());
+                    if (mismatched != count)
+                        std::advance(first1, mismatched);
+                    else
+                        first1 = last1;
+
+                    std::advance(first2, mismatched);
+                    return std::make_pair(first1, first2);
+                };
+
+                return util::partitioner<ExPolicy, IterPair,
+                    void>::call_with_index(std::forward<ExPolicy>(policy),
+                    hpx::util::make_zip_iterator(first1, first2), count, 1,
+                    std::move(f1), std::move(f2));
+            }
+        };
+    }    // namespace detail
+
+    // clang-format off
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename Pred = detail::equal_to,
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<FwdIter1>::value &&
+            hpx::traits::is_iterator<FwdIter2>::value &&
+            hpx::traits::is_invocable<Pred,
+                typename std::iterator_traits<FwdIter1>::value_type,
+                typename std::iterator_traits<FwdIter2>::value_type
+            >::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::mismatch is deprecated, use hpx::mismatch instead")
+        typename util::detail::algorithm_result<ExPolicy,
+            std::pair<FwdIter1, FwdIter2>>::type
         mismatch(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
             FwdIter2 first2, Pred&& op = Pred())
     {
@@ -395,7 +476,252 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
         typedef std::pair<FwdIter1, FwdIter2> result_type;
         return detail::mismatch<result_type>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
+            std::forward<ExPolicy>(policy), is_seq{}, first1, last1, first2,
             std::forward<Pred>(op));
     }
+
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::mismatch
+    HPX_INLINE_CONSTEXPR_VARIABLE struct mismatch_t final
+      : hpx::functional::tag<mismatch_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+            typename Pred,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_invocable<Pred,
+                    typename std::iterator_traits<FwdIter1>::value_type,
+                    typename std::iterator_traits<FwdIter2>::value_type
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            std::pair<FwdIter1, FwdIter2>>::type
+        tag_invoke(mismatch_t, ExPolicy&& policy, FwdIter1 first1,
+            FwdIter1 last1, FwdIter2 first2, FwdIter2 last2, Pred&& op)
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+                "Requires at least forward iterator.");
+
+            using is_seq =
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>;
+
+            return hpx::parallel::v1::detail::get_pair(
+                hpx::parallel::v1::detail::mismatch_binary<
+                    hpx::parallel::util::in_in_result<FwdIter1, FwdIter2>>()
+                    .call(std::forward<ExPolicy>(policy), is_seq{}, first1,
+                        last1, first2, last2, std::forward<Pred>(op),
+                        hpx::parallel::util::projection_identity{},
+                        hpx::parallel::util::projection_identity{}));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            std::pair<FwdIter1, FwdIter2>>::type
+        tag_invoke(mismatch_t, ExPolicy&& policy, FwdIter1 first1,
+            FwdIter1 last1, FwdIter2 first2, FwdIter2 last2)
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+                "Requires at least forward iterator.");
+
+            using is_seq =
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>;
+
+            return hpx::parallel::v1::detail::get_pair(
+                hpx::parallel::v1::detail::mismatch_binary<
+                    hpx::parallel::util::in_in_result<FwdIter1, FwdIter2>>()
+                    .call(std::forward<ExPolicy>(policy), is_seq{}, first1,
+                        last1, first2, last2,
+                        hpx::parallel::v1::detail::equal_to{},
+                        hpx::parallel::util::projection_identity{},
+                        hpx::parallel::util::projection_identity{}));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+            typename Pred,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_invocable<Pred,
+                    typename std::iterator_traits<FwdIter1>::value_type,
+                    typename std::iterator_traits<FwdIter2>::value_type
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            std::pair<FwdIter1, FwdIter2>>::type
+        tag_invoke(mismatch_t, ExPolicy&& policy, FwdIter1 first1,
+            FwdIter1 last1, FwdIter2 first2, Pred&& op)
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+                "Requires at least forward iterator.");
+
+            using is_seq =
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>;
+
+            return hpx::parallel::v1::detail::mismatch<
+                std::pair<FwdIter1, FwdIter2>>()
+                .call(std::forward<ExPolicy>(policy), is_seq{}, first1, last1,
+                    first2, std::forward<Pred>(op));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            std::pair<FwdIter1, FwdIter2>>::type
+        tag_invoke(mismatch_t, ExPolicy&& policy, FwdIter1 first1,
+            FwdIter1 last1, FwdIter2 first2)
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+                "Requires at least forward iterator.");
+
+            using is_seq =
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>;
+
+            return hpx::parallel::v1::detail::mismatch<
+                std::pair<FwdIter1, FwdIter2>>()
+                .call(std::forward<ExPolicy>(policy), is_seq{}, first1, last1,
+                    first2, hpx::parallel::v1::detail::equal_to{});
+        }
+
+        // clang-format off
+        template <typename FwdIter1, typename FwdIter2,
+            typename Pred,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_invocable<Pred,
+                    typename std::iterator_traits<FwdIter1>::value_type,
+                    typename std::iterator_traits<FwdIter2>::value_type
+                >::value
+            )>
+        // clang-format on
+        friend std::pair<FwdIter1, FwdIter2> tag_invoke(mismatch_t,
+            FwdIter1 first1, FwdIter1 last1, FwdIter2 first2, FwdIter2 last2,
+            Pred&& op)
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::get_pair(
+                hpx::parallel::v1::detail::mismatch_binary<
+                    hpx::parallel::util::in_in_result<FwdIter1, FwdIter2>>()
+                    .call(hpx::parallel::execution::seq, std::true_type{},
+                        first1, last1, first2, last2, std::forward<Pred>(op),
+                        hpx::parallel::util::projection_identity{},
+                        hpx::parallel::util::projection_identity{}));
+        }
+
+        // clang-format off
+        template <typename FwdIter1, typename FwdIter2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value
+            )>
+        // clang-format on
+        friend std::pair<FwdIter1, FwdIter2> tag_invoke(mismatch_t,
+            FwdIter1 first1, FwdIter1 last1, FwdIter2 first2, FwdIter2 last2)
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::get_pair(
+                hpx::parallel::v1::detail::mismatch_binary<
+                    hpx::parallel::util::in_in_result<FwdIter1, FwdIter2>>()
+                    .call(hpx::parallel::execution::seq, std::true_type{},
+                        first1, last1, first2, last2,
+                        hpx::parallel::v1::detail::equal_to{},
+                        hpx::parallel::util::projection_identity{},
+                        hpx::parallel::util::projection_identity{}));
+        }
+
+        // clang-format off
+        template <typename FwdIter1, typename FwdIter2,
+            typename Pred,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_invocable<Pred,
+                    typename std::iterator_traits<FwdIter1>::value_type,
+                    typename std::iterator_traits<FwdIter2>::value_type
+                >::value
+            )>
+        // clang-format on
+        friend std::pair<FwdIter1, FwdIter2> tag_invoke(mismatch_t,
+            FwdIter1 first1, FwdIter1 last1, FwdIter2 first2, Pred&& op)
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::mismatch<
+                std::pair<FwdIter1, FwdIter2>>()
+                .call(hpx::parallel::execution::seq, std::true_type{}, first1,
+                    last1, first2, std::forward<Pred>(op));
+        }
+
+        // clang-format off
+        template <typename FwdIter1, typename FwdIter2,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value
+            )>
+        // clang-format on
+        friend std::pair<FwdIter1, FwdIter2> tag_invoke(
+            mismatch_t, FwdIter1 first1, FwdIter1 last1, FwdIter2 first2)
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::mismatch<
+                std::pair<FwdIter1, FwdIter2>>()
+                .call(hpx::parallel::execution::seq, std::true_type{}, first1,
+                    last1, first2, hpx::parallel::v1::detail::equal_to{});
+        }
+
+    } mismatch;
+}    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/algorithms/include/hpx/parallel/container_algorithms.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms.hpp
@@ -20,6 +20,7 @@
 #include <hpx/parallel/container_algorithms/is_heap.hpp>
 #include <hpx/parallel/container_algorithms/merge.hpp>
 #include <hpx/parallel/container_algorithms/minmax.hpp>
+#include <hpx/parallel/container_algorithms/mismatch.hpp>
 #include <hpx/parallel/container_algorithms/move.hpp>
 #include <hpx/parallel/container_algorithms/partition.hpp>
 #include <hpx/parallel/container_algorithms/reduce.hpp>

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/equal.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/equal.hpp
@@ -215,6 +215,7 @@ namespace hpx { namespace ranges {
 
 #include <hpx/algorithms/traits/projected.hpp>
 #include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/parallel/algorithms/equal.hpp>
 #include <hpx/parallel/util/invoke_projected.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
@@ -223,8 +224,6 @@ namespace hpx { namespace ranges {
 #include <utility>
 
 namespace hpx { namespace ranges {
-
-    using equal_to = hpx::parallel::v1::detail::equal_to;
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::equal

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/mismatch.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/mismatch.hpp
@@ -1,0 +1,406 @@
+//  Copyright (c) 2007-2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/container_algorithms/mismatch.hpp
+
+#pragma once
+
+#if defined(DOXYGEN)
+namespace hpx { namespace ranges {
+    // clang-format off
+
+    /// Returns true if the range [first1, last1) is mismatch to the range
+    /// [first2, last2), and false otherwise.
+    ///
+    /// \note   Complexity: At most min(last1 - first1, last2 - first2)
+    ///         applications of the predicate \a f. If \a FwdIter1
+    ///         and \a FwdIter2 meet the requirements of \a RandomAccessIterator
+    ///         and (last1 - first1) != (last2 - first2) then no applications
+    ///         of the predicate \a f are made.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Iter1       The type of the source iterators used for the
+    ///                     first range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent1       The type of the source iterators used for the end of
+    ///                     the first range (deduced).
+    /// \tparam Iter2       The type of the source iterators used for the
+    ///                     second range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent2       The type of the source iterators used for the end of
+    ///                     the second range (deduced).
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a mismatch requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj1       The type of an optional projection function applied
+    ///                     to the first range. This
+    ///                     defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function applied
+    ///                     to the second range. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     of the first range the algorithm will be applied to.
+    /// \param last1        Refers to the end of the sequence of elements of
+    ///                     the first range the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the sequence of elements
+    ///                     of the second range the algorithm will be applied to.
+    /// \param last2        Refers to the end of the sequence of elements of
+    ///                     the second range the algorithm will be applied to.
+    /// \param op           The binary predicate which returns true if the
+    ///                     elements should be treated as mismatch. The signature
+    ///                     of the predicate function should be equivalent to
+    ///                     the following:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type2 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const &, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The types \a Type1 and \a Type2 must be such
+    ///                     that objects of types \a FwdIter1 and \a FwdIter2 can
+    ///                     be dereferenced and then implicitly converted to
+    ///                     \a Type1 and \a Type2 respectively
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     first range as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     second range as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The comparison operations in the parallel \a mismatch algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The comparison operations in the parallel \a mismatch algorithm invoked
+    /// with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \note     The two ranges are considered mismatch if, for every iterator
+    ///           i in the range [first1,last1), *i mismatchs *(first2 + (i - first1)).
+    ///           This overload of mismatch uses operator== to determine if two
+    ///           elements are mismatch.
+    ///
+    /// \returns  The \a mismatch algorithm returns a \a hpx::future<bool> if the
+    ///           execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a bool otherwise.
+    ///           The \a mismatch algorithm returns true if the elements in the
+    ///           two ranges are mismatch, otherwise it returns false.
+    ///           If the length of the range [first1, last1) does not mismatch
+    ///           the length of the range [first2, last2), it returns false.
+    ///
+    template <typename ExPolicy, typename Iter1, typename Sent1, typename Iter2,
+        typename Sent2, typename Pred = ranges::equal_to,
+        typename Proj1 = util::projection_identity,
+        typename Proj2 = util::projection_identity>
+    typename util::detail::algorithm_result<
+        ExPolicy, ranges::mismatch_result<FwdIter1, FwdIter2>>::type
+    mismatch(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+        FwdIter2 first2, FwdIter2 last2, Pred&& op = Pred(),
+        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+
+    /// Returns std::pair with iterators to the first two non-equivalent
+    /// elements.
+    ///
+    /// \note   Complexity: At most \a last1 - \a first1 applications of the
+    ///         predicate \a f.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng1        The type of the first source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an forward iterator.
+    /// \tparam Rng2        The type of the second source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an forward iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a mismatch requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::equal_to<>
+    /// \tparam Proj1       The type of an optional projection function applied
+    ///                     to the first range. This
+    ///                     defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function applied
+    ///                     to the second range. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng1         Refers to the first sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param rng2         Refers to the second sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param op           The binary predicate which returns true if the
+    ///                     elements should be treated as mismatch. The signature
+    ///                     of the predicate function should be equivalent to
+    ///                     the following:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type2 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const &, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The types \a Type1 and \a Type2 must be such
+    ///                     that objects of types \a FwdIter1 and \a FwdIter2 can
+    ///                     be dereferenced and then implicitly converted to
+    ///                     \a Type1 and \a Type2 respectively
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     first range as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     second range as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The comparison operations in the parallel \a mismatch algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The comparison operations in the parallel \a mismatch algorithm invoked
+    /// with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a mismatch algorithm returns a
+    ///           \a hpx::future<std::pair<FwdIter1, FwdIter2> > if the
+    ///           execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a std::pair<FwdIter1, FwdIter2> otherwise.
+    ///           The \a mismatch algorithm returns the first mismatching pair
+    ///           of elements from two ranges: one defined by [first1, last1)
+    ///           and another defined by [first2, last2).
+    ///
+    template <typename ExPolicy, typename Rng1, typename Rng2,
+        typename Pred = ranges::equal_to,
+        typename Proj1 = util::projection_identity,
+        typename Proj2 = util::projection_identity>
+    typename util::detail::algorithm_result<
+        ExPolicy, ranges::mimatch_result<FwdIter1, FwdIter2>>::type
+    mismatch(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2, Pred&& op = Pred(),
+        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+
+    // clang-format on
+}}    // namespace hpx::ranges
+
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_range.hpp>
+
+#include <hpx/algorithms/traits/projected.hpp>
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/parallel/algorithms/mismatch.hpp>
+#include <hpx/parallel/util/invoke_projected.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace ranges {
+
+    ///////////////////////////////////////////////////////////////////////////
+    using equal_to = hpx::parallel::v1::detail::equal_to;
+
+    template <typename Iter1, typename Iter2>
+    using mismatch_result = hpx::parallel::util::in_in_result<Iter1, Iter2>;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::mismatch
+    HPX_INLINE_CONSTEXPR_VARIABLE struct mismatch_t final
+      : hpx::functional::tag<mismatch_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename Iter1, typename Sent1,
+            typename Iter2, typename Sent2, typename Pred = equal_to,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
+                hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
+                    hpx::parallel::traits::projected<Proj1, Iter1>,
+                    hpx::parallel::traits::projected<Proj2, Iter2>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            mismatch_result<Iter1, Iter2>>::type
+        tag_invoke(mismatch_t, ExPolicy&& policy, Iter1 first1, Sent1 last1,
+            Iter2 first2, Sent2 last2, Pred&& op = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        {
+            static_assert((hpx::traits::is_forward_iterator<Iter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
+                "Requires at least forward iterator.");
+
+            using is_seq =
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>;
+
+            return hpx::parallel::v1::detail::mismatch_binary<
+                mismatch_result<Iter1, Iter2>>()
+                .call(std::forward<ExPolicy>(policy), is_seq{}, first1, last1,
+                    first2, last2, std::forward<Pred>(op),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng1, typename Rng2,
+            typename Pred = equal_to,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
+                hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
+                    hpx::parallel::traits::projected<Proj1,
+                        typename hpx::traits::range_traits<Rng1>::iterator_type>,
+                    hpx::parallel::traits::projected<Proj2,
+                        typename hpx::traits::range_traits<Rng2>::iterator_type>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            mismatch_result<
+                typename hpx::traits::range_traits<Rng1>::iterator_type,
+                typename hpx::traits::range_traits<Rng2>::iterator_type>>::type
+        tag_invoke(mismatch_t, ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2,
+            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            static_assert(
+                (hpx::traits::is_forward_iterator<typename hpx::traits::
+                        range_traits<Rng1>::iterator_type>::value),
+                "Requires at least forward iterator.");
+            static_assert(
+                (hpx::traits::is_forward_iterator<typename hpx::traits::
+                        range_traits<Rng2>::iterator_type>::value),
+                "Requires at least forward iterator.");
+
+            using is_seq =
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>;
+            using result_type = mismatch_result<
+                typename hpx::traits::range_traits<Rng1>::iterator_type,
+                typename hpx::traits::range_traits<Rng2>::iterator_type>;
+
+            return hpx::parallel::v1::detail::mismatch_binary<result_type>()
+                .call(std::forward<ExPolicy>(policy), is_seq{},
+                    hpx::util::begin(rng1), hpx::util::end(rng1),
+                    hpx::util::begin(rng2), hpx::util::end(rng2),
+                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename Iter1, typename Sent1,
+            typename Iter2, typename Sent2, typename Pred = equal_to,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
+                hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::parallel::execution::sequenced_policy, Pred,
+                    hpx::parallel::traits::projected<Proj1, Iter1>,
+                    hpx::parallel::traits::projected<Proj2, Iter2>
+                >::value
+            )>
+        // clang-format on
+        friend mismatch_result<Iter1, Iter2> tag_invoke(mismatch_t,
+            Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2,
+            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            static_assert((hpx::traits::is_forward_iterator<Iter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::mismatch_binary<
+                mismatch_result<Iter1, Iter2>>()
+                .call(hpx::parallel::execution::seq, std::true_type{}, first1,
+                    last1, first2, last2, std::forward<Pred>(op),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename Rng1, typename Rng2, typename Pred = equal_to,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
+                hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::parallel::execution::sequenced_policy, Pred,
+                    hpx::parallel::traits::projected<Proj1,
+                        typename hpx::traits::range_traits<Rng1>::iterator_type>,
+                    hpx::parallel::traits::projected<Proj2,
+                        typename hpx::traits::range_traits<Rng2>::iterator_type>
+                >::value
+            )>
+        // clang-format on
+        friend mismatch_result<
+            typename hpx::traits::range_traits<Rng1>::iterator_type,
+            typename hpx::traits::range_traits<Rng2>::iterator_type>
+        tag_invoke(mismatch_t, Rng1&& rng1, Rng2&& rng2, Pred&& op = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        {
+            static_assert(
+                (hpx::traits::is_forward_iterator<typename hpx::traits::
+                        range_traits<Rng1>::iterator_type>::value),
+                "Requires at least forward iterator.");
+            static_assert(
+                (hpx::traits::is_forward_iterator<typename hpx::traits::
+                        range_traits<Rng2>::iterator_type>::value),
+                "Requires at least forward iterator.");
+
+            using result_type = mismatch_result<
+                typename hpx::traits::range_traits<Rng1>::iterator_type,
+                typename hpx::traits::range_traits<Rng2>::iterator_type>;
+
+            return hpx::parallel::v1::detail::mismatch_binary<result_type>()
+                .call(hpx::parallel::execution::seq, std::true_type{},
+                    hpx::util::begin(rng1), hpx::util::end(rng1),
+                    hpx::util::begin(rng2), hpx::util::end(rng2),
+                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2));
+        }
+
+    } mismatch;
+}}    // namespace hpx::ranges
+
+#endif    // DOXYGEN

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/mismatch.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/mismatch.hpp
@@ -217,6 +217,7 @@ namespace hpx { namespace ranges {
 
 #include <hpx/algorithms/traits/projected.hpp>
 #include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/parallel/algorithms/mismatch.hpp>
 #include <hpx/parallel/util/invoke_projected.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
@@ -228,8 +229,6 @@ namespace hpx { namespace ranges {
 namespace hpx { namespace ranges {
 
     ///////////////////////////////////////////////////////////////////////////
-    using equal_to = hpx::parallel::v1::detail::equal_to;
-
     template <typename Iter1, typename Iter2>
     using mismatch_result = hpx::parallel::util::in_in_result<Iter1, Iter2>;
 

--- a/libs/algorithms/include/hpx/parallel/util/projection_identity.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/projection_identity.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015-2016 Hartmut Kaiser
+//  Copyright (c) 2015-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -15,7 +15,7 @@ namespace hpx { namespace parallel { namespace util {
     struct projection_identity
     {
         template <typename T>
-        HPX_HOST_DEVICE HPX_FORCEINLINE T&& operator()(T&& val) const
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr T&& operator()(T&& val) const
         {
             return std::forward<T>(val);
         }

--- a/libs/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -18,6 +18,40 @@
 namespace hpx { namespace parallel { namespace util {
 
     ///////////////////////////////////////////////////////////////////////////
+    template <typename I1, typename I2>
+    struct in_in_result
+    {
+        HPX_NO_UNIQUE_ADDRESS I1 in1;
+        HPX_NO_UNIQUE_ADDRESS I2 in2;
+
+        template <typename II1, typename II2,
+            typename Enable = typename std::enable_if<
+                std::is_convertible<I1 const&, II1&>::value &&
+                std::is_convertible<I2 const&, II2&>::value>::type>
+        constexpr operator in_in_result<II1, II2>() const&
+        {
+            return {in1, in2};
+        }
+
+        template <typename II1, typename II2,
+            typename Enable =
+                typename std::enable_if<std::is_convertible<I1, II1>::value &&
+                    std::is_convertible<I2, II2>::value>::type>
+        constexpr operator in_in_result<II1, II2>() &&
+        {
+            return {std::move(in1), std::move(in2)};
+        }
+
+        template <typename Archive>
+        void serialize(Archive& ar, unsigned)
+        {
+            // clang-format off
+            ar & in1 & in2;
+            // clang-format on
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
     template <typename I, typename O>
     struct in_out_result
     {

--- a/libs/algorithms/tests/performance/benchmark_unique.cpp
+++ b/libs/algorithms/tests/performance/benchmark_unique.cpp
@@ -64,6 +64,11 @@ struct vector_type
         return vec_ == t.vec_;
     }
 
+    bool operator!=(vector_type const& t) const
+    {
+        return vec_ != t.vec_;
+    }
+
     std::vector<int> vec_;
     static const std::size_t vec_size_{30};
 };
@@ -80,6 +85,11 @@ struct array_type
     bool operator==(array_type const& t) const
     {
         return arr_ == t.arr_;
+    }
+
+    bool operator!=(array_type const& t) const
+    {
+        return arr_ != t.arr_;
     }
 
     static const std::size_t arr_size_{30};

--- a/libs/algorithms/tests/unit/algorithms/mismatch_binary.cpp
+++ b/libs/algorithms/tests/unit/algorithms/mismatch_binary.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2014-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -25,18 +25,11 @@ int seed = std::random_device{}();
 std::mt19937 gen(seed);
 std::uniform_int_distribution<> dis(0, 10006);
 
-template <typename ExPolicy, typename IteratorTag>
-void test_mismatch_binary1(ExPolicy policy, IteratorTag)
+template <typename IteratorTag>
+void test_mismatch_binary1(IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
-
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    typedef std::pair<base_iterator, base_iterator> base_return_type;
-    typedef std::pair<iterator, base_iterator> return_type;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -49,8 +42,7 @@ void test_mismatch_binary1(ExPolicy policy, IteratorTag)
     iterator end1 = iterator(std::end(c1));
 
     {
-        return_type result = hpx::parallel::mismatch(
-            policy, begin1, end1, std::begin(c2), std::end(c2));
+        auto result = hpx::mismatch(begin1, end1, std::begin(c2), std::end(c2));
 
         // verify values
         HPX_TEST_EQ(
@@ -63,8 +55,7 @@ void test_mismatch_binary1(ExPolicy policy, IteratorTag)
         std::size_t changed_idx = dis(gen);    //-V104
         ++c1[changed_idx];
 
-        return_type result = hpx::parallel::mismatch(
-            policy, begin1, end1, std::begin(c2), std::end(c2));
+        auto result = hpx::mismatch(begin1, end1, std::begin(c2), std::end(c2));
 
         // verify values
         HPX_TEST_EQ(
@@ -75,13 +66,14 @@ void test_mismatch_binary1(ExPolicy policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_mismatch_binary1_async(ExPolicy p, IteratorTag)
+void test_mismatch_binary1(ExPolicy&& policy, IteratorTag)
 {
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    typedef std::pair<base_iterator, base_iterator> base_return_type;
-    typedef std::pair<iterator, base_iterator> return_type;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -94,12 +86,10 @@ void test_mismatch_binary1_async(ExPolicy p, IteratorTag)
     iterator end1 = iterator(std::end(c1));
 
     {
-        hpx::future<return_type> f = hpx::parallel::mismatch(
-            p, begin1, end1, std::begin(c2), std::end(c2));
-        f.wait();
+        auto result =
+            hpx::mismatch(policy, begin1, end1, std::begin(c2), std::end(c2));
 
         // verify values
-        return_type result = f.get();
         HPX_TEST_EQ(
             std::size_t(std::distance(begin1, result.first)), c1.size());
         HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
@@ -110,12 +100,54 @@ void test_mismatch_binary1_async(ExPolicy p, IteratorTag)
         std::size_t changed_idx = dis(gen);    //-V104
         ++c1[changed_idx];
 
-        hpx::future<return_type> f = hpx::parallel::mismatch(
-            p, begin1, end1, std::begin(c2), std::end(c2));
+        auto result =
+            hpx::mismatch(policy, begin1, end1, std::begin(c2), std::end(c2));
+
+        // verify values
+        HPX_TEST_EQ(
+            std::size_t(std::distance(begin1, result.first)), changed_idx);
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            changed_idx);
+    }
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_mismatch_binary1_async(ExPolicy&& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c1(10007);
+    std::vector<std::size_t> c2(c1.size());
+
+    std::size_t first_value = gen();    //-V101
+    std::iota(std::begin(c1), std::end(c1), first_value);
+    std::iota(std::begin(c2), std::end(c2), first_value);
+
+    iterator begin1 = iterator(std::begin(c1));
+    iterator end1 = iterator(std::end(c1));
+
+    {
+        auto f = hpx::mismatch(p, begin1, end1, std::begin(c2), std::end(c2));
         f.wait();
 
         // verify values
-        return_type result = f.get();
+        auto result = f.get();
+        HPX_TEST_EQ(
+            std::size_t(std::distance(begin1, result.first)), c1.size());
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            c2.size());
+    }
+
+    {
+        std::size_t changed_idx = dis(gen);    //-V104
+        ++c1[changed_idx];
+
+        auto f = hpx::mismatch(p, begin1, end1, std::begin(c2), std::end(c2));
+        f.wait();
+
+        // verify values
+        auto result = f.get();
         HPX_TEST_EQ(
             std::size_t(std::distance(begin1, result.first)), changed_idx);
         HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
@@ -127,6 +159,8 @@ template <typename IteratorTag>
 void test_mismatch_binary1()
 {
     using namespace hpx::parallel;
+
+    test_mismatch_binary1(IteratorTag());
 
     test_mismatch_binary1(execution::seq, IteratorTag());
     test_mismatch_binary1(execution::par, IteratorTag());
@@ -143,18 +177,11 @@ void mismatch_binary_test1()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-template <typename ExPolicy, typename IteratorTag>
-void test_mismatch_binary2(ExPolicy policy, IteratorTag)
+template <typename IteratorTag>
+void test_mismatch_binary2(IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
-
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    typedef std::pair<base_iterator, base_iterator> base_return_type;
-    typedef std::pair<iterator, base_iterator> return_type;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -167,8 +194,8 @@ void test_mismatch_binary2(ExPolicy policy, IteratorTag)
     iterator end1 = iterator(std::end(c1));
 
     {
-        return_type result = hpx::parallel::mismatch(policy, begin1, end1,
-            std::begin(c2), std::end(c2), std::equal_to<std::size_t>());
+        auto result = hpx::mismatch(begin1, end1, std::begin(c2), std::end(c2),
+            std::equal_to<std::size_t>());
 
         // verify values
         HPX_TEST_EQ(
@@ -181,8 +208,8 @@ void test_mismatch_binary2(ExPolicy policy, IteratorTag)
         std::size_t changed_idx = dis(gen);    //-V104
         ++c1[changed_idx];
 
-        return_type result = hpx::parallel::mismatch(policy, begin1, end1,
-            std::begin(c2), std::end(c2), std::equal_to<std::size_t>());
+        auto result = hpx::mismatch(begin1, end1, std::begin(c2), std::end(c2),
+            std::equal_to<std::size_t>());
 
         // verify values
         HPX_TEST_EQ(
@@ -193,13 +220,14 @@ void test_mismatch_binary2(ExPolicy policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_mismatch_binary2_async(ExPolicy p, IteratorTag)
+void test_mismatch_binary2(ExPolicy&& policy, IteratorTag)
 {
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    typedef std::pair<base_iterator, base_iterator> base_return_type;
-    typedef std::pair<iterator, base_iterator> return_type;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -212,12 +240,10 @@ void test_mismatch_binary2_async(ExPolicy p, IteratorTag)
     iterator end1 = iterator(std::end(c1));
 
     {
-        hpx::future<return_type> f = hpx::parallel::mismatch(p, begin1, end1,
-            std::begin(c2), std::end(c2), std::equal_to<std::size_t>());
-        f.wait();
+        auto result = hpx::mismatch(policy, begin1, end1, std::begin(c2),
+            std::end(c2), std::equal_to<std::size_t>());
 
         // verify values
-        return_type result = f.get();
         HPX_TEST_EQ(
             std::size_t(std::distance(begin1, result.first)), c1.size());
         HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
@@ -228,12 +254,56 @@ void test_mismatch_binary2_async(ExPolicy p, IteratorTag)
         std::size_t changed_idx = dis(gen);    //-V104
         ++c1[changed_idx];
 
-        hpx::future<return_type> f = hpx::parallel::mismatch(p, begin1, end1,
-            std::begin(c2), std::end(c2), std::equal_to<std::size_t>());
+        auto result = hpx::mismatch(policy, begin1, end1, std::begin(c2),
+            std::end(c2), std::equal_to<std::size_t>());
+
+        // verify values
+        HPX_TEST_EQ(
+            std::size_t(std::distance(begin1, result.first)), changed_idx);
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            changed_idx);
+    }
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_mismatch_binary2_async(ExPolicy&& p, IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c1(10007);
+    std::vector<std::size_t> c2(c1.size());
+
+    std::size_t first_value = gen();    //-V101
+    std::iota(std::begin(c1), std::end(c1), first_value);
+    std::iota(std::begin(c2), std::end(c2), first_value);
+
+    iterator begin1 = iterator(std::begin(c1));
+    iterator end1 = iterator(std::end(c1));
+
+    {
+        auto f = hpx::mismatch(p, begin1, end1, std::begin(c2), std::end(c2),
+            std::equal_to<std::size_t>());
         f.wait();
 
         // verify values
-        return_type result = f.get();
+        auto result = f.get();
+        HPX_TEST_EQ(
+            std::size_t(std::distance(begin1, result.first)), c1.size());
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            c2.size());
+    }
+
+    {
+        std::size_t changed_idx = dis(gen);    //-V104
+        ++c1[changed_idx];
+
+        auto f = hpx::mismatch(p, begin1, end1, std::begin(c2), std::end(c2),
+            std::equal_to<std::size_t>());
+        f.wait();
+
+        // verify values
+        auto result = f.get();
         HPX_TEST_EQ(
             std::size_t(std::distance(begin1, result.first)), changed_idx);
         HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
@@ -245,6 +315,8 @@ template <typename IteratorTag>
 void test_mismatch_binary2()
 {
     using namespace hpx::parallel;
+
+    test_mismatch_binary2(IteratorTag());
 
     test_mismatch_binary2(execution::seq, IteratorTag());
     test_mismatch_binary2(execution::par, IteratorTag());
@@ -261,18 +333,11 @@ void mismatch_binary_test2()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-template <typename ExPolicy, typename IteratorTag>
-void test_mismatch_binary_exception(ExPolicy policy, IteratorTag)
+template <typename IteratorTag>
+void test_mismatch_binary_exception(IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
-
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    typedef std::pair<base_iterator, base_iterator> base_return_type;
-    typedef std::pair<iterator, base_iterator> return_type;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -284,9 +349,49 @@ void test_mismatch_binary_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::mismatch(policy, iterator(std::begin(c1)),
-            iterator(std::end(c1)), std::begin(c2), std::end(c2),
-            [](std::size_t v1, std::size_t v2) {
+        hpx::mismatch(iterator(std::begin(c1)), iterator(std::end(c1)),
+            std::begin(c2), std::end(c2), [](std::size_t v1, std::size_t v2) {
+                return throw std::runtime_error("test"), true;
+            });
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
+            IteratorTag>::call(hpx::parallel::execution::seq, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_mismatch_binary_exception(ExPolicy&& policy, IteratorTag)
+{
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c1(10007);
+    std::vector<std::size_t> c2(c1.size());
+
+    std::size_t first_value = gen();    //-V101
+    std::iota(std::begin(c1), std::end(c1), first_value);
+    std::iota(std::begin(c2), std::end(c2), first_value);
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::mismatch(policy, iterator(std::begin(c1)), iterator(std::end(c1)),
+            std::begin(c2), std::end(c2), [](std::size_t v1, std::size_t v2) {
                 return throw std::runtime_error("test"), true;
             });
 
@@ -306,13 +411,10 @@ void test_mismatch_binary_exception(ExPolicy policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_mismatch_binary_exception_async(ExPolicy p, IteratorTag)
+void test_mismatch_binary_exception_async(ExPolicy&& p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    typedef std::pair<base_iterator, base_iterator> base_return_type;
-    typedef std::pair<iterator, base_iterator> return_type;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -325,9 +427,9 @@ void test_mismatch_binary_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<return_type> f = hpx::parallel::mismatch(p,
-            iterator(std::begin(c1)), iterator(std::end(c1)), std::begin(c2),
-            std::end(c2), [](std::size_t v1, std::size_t v2) {
+        auto f = hpx::mismatch(p, iterator(std::begin(c1)),
+            iterator(std::end(c1)), std::begin(c2), std::end(c2),
+            [](std::size_t v1, std::size_t v2) {
                 return throw std::runtime_error("test"), true;
             });
         returned_from_algorithm = true;
@@ -354,6 +456,8 @@ void test_mismatch_binary_exception()
 {
     using namespace hpx::parallel;
 
+    test_mismatch_binary_exception(IteratorTag());
+
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
@@ -374,7 +478,7 @@ void mismatch_binary_exception_test()
 
 /////////////////////////////////////////////////////////////////////////////
 template <typename ExPolicy, typename IteratorTag>
-void test_mismatch_binary_bad_alloc(ExPolicy policy, IteratorTag)
+void test_mismatch_binary_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
@@ -382,9 +486,6 @@ void test_mismatch_binary_bad_alloc(ExPolicy policy, IteratorTag)
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    typedef std::pair<base_iterator, base_iterator> base_return_type;
-    typedef std::pair<iterator, base_iterator> return_type;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -396,9 +497,8 @@ void test_mismatch_binary_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::mismatch(policy, iterator(std::begin(c1)),
-            iterator(std::end(c1)), std::begin(c2), std::end(c2),
-            [](std::size_t v1, std::size_t v2) {
+        hpx::mismatch(policy, iterator(std::begin(c1)), iterator(std::end(c1)),
+            std::begin(c2), std::end(c2), [](std::size_t v1, std::size_t v2) {
                 return throw std::bad_alloc(), true;
             });
 
@@ -417,13 +517,10 @@ void test_mismatch_binary_bad_alloc(ExPolicy policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_mismatch_binary_bad_alloc_async(ExPolicy p, IteratorTag)
+void test_mismatch_binary_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    typedef std::pair<base_iterator, base_iterator> base_return_type;
-    typedef std::pair<iterator, base_iterator> return_type;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -436,9 +533,9 @@ void test_mismatch_binary_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<return_type> f = hpx::parallel::mismatch(p,
-            iterator(std::begin(c1)), iterator(std::end(c1)), std::begin(c2),
-            std::end(c2), [](std::size_t v1, std::size_t v2) {
+        auto f = hpx::mismatch(p, iterator(std::begin(c1)),
+            iterator(std::end(c1)), std::begin(c2), std::end(c2),
+            [](std::size_t v1, std::size_t v2) {
                 return throw std::bad_alloc(), true;
             });
         returned_from_algorithm = true;

--- a/libs/algorithms/tests/unit/algorithms/unique_copy_tests.hpp
+++ b/libs/algorithms/tests/unit/algorithms/unique_copy_tests.hpp
@@ -75,9 +75,19 @@ struct user_defined_type
         return this->name == t.name && this->val == t.val;
     }
 
+    bool operator!=(user_defined_type const& t) const
+    {
+        return this->name != t.name || this->val != t.val;
+    }
+
     bool operator==(int rand_no) const
     {
         return this->val == rand_no;
+    }
+
+    bool operator!=(int rand_no) const
+    {
+        return this->val != rand_no;
     }
 
     static const std::vector<std::string> name_list;

--- a/libs/algorithms/tests/unit/algorithms/unique_tests.hpp
+++ b/libs/algorithms/tests/unit/algorithms/unique_tests.hpp
@@ -75,9 +75,19 @@ struct user_defined_type
         return this->name == t.name && this->val == t.val;
     }
 
+    bool operator!=(user_defined_type const& t) const
+    {
+        return this->name != t.name || this->val != t.val;
+    }
+
     bool operator==(int rand_no) const
     {
         return this->val == rand_no;
+    }
+
+    bool operator!=(int rand_no) const
+    {
+        return this->val != rand_no;
     }
 
     static const std::vector<std::string> name_list;

--- a/libs/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2015 Hartmut Kaiser
+# Copyright (c) 2014-2020 Hartmut Kaiser
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -31,6 +31,8 @@ set(tests
     merge_range
     min_element_range
     minmax_element_range
+    mismatch_binary_range
+    mismatch_range
     move_range
     none_of_range
     partition_range

--- a/libs/algorithms/tests/unit/container_algorithms/mismatch_binary_range.cpp
+++ b/libs/algorithms/tests/unit/container_algorithms/mismatch_binary_range.cpp
@@ -49,10 +49,9 @@ void test_mismatch_binary1(IteratorTag)
                 base_range(std::begin(c2), std::end(c2)));
 
         // verify values
+        HPX_TEST_EQ(std::size_t(std::distance(begin1, result.in1)), c1.size());
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.in1)), c1.size());
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
-            c2.size());
+            std::size_t(std::distance(std::begin(c2), result.in2)), c2.size());
     }
 
     {
@@ -99,10 +98,9 @@ void test_mismatch_binary1(ExPolicy&& policy, IteratorTag)
             base_range(std::begin(c2), std::end(c2)));
 
         // verify values
+        HPX_TEST_EQ(std::size_t(std::distance(begin1, result.in1)), c1.size());
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.in1)), c1.size());
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
-            c2.size());
+            std::size_t(std::distance(std::begin(c2), result.in2)), c2.size());
     }
 
     {
@@ -147,10 +145,9 @@ void test_mismatch_binary1_async(ExPolicy&& p, IteratorTag)
 
         // verify values
         auto result = f.get();
+        HPX_TEST_EQ(std::size_t(std::distance(begin1, result.in1)), c1.size());
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.in1)), c1.size());
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
-            c2.size());
+            std::size_t(std::distance(std::begin(c2), result.in2)), c2.size());
     }
 
     {
@@ -218,10 +215,9 @@ void test_mismatch_binary2(IteratorTag)
                 std::equal_to<std::size_t>());
 
         // verify values
+        HPX_TEST_EQ(std::size_t(std::distance(begin1, result.in1)), c1.size());
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.in1)), c1.size());
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
-            c2.size());
+            std::size_t(std::distance(std::begin(c2), result.in2)), c2.size());
     }
 
     {
@@ -270,10 +266,9 @@ void test_mismatch_binary2(ExPolicy&& policy, IteratorTag)
             std::equal_to<std::size_t>());
 
         // verify values
+        HPX_TEST_EQ(std::size_t(std::distance(begin1, result.in1)), c1.size());
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.in1)), c1.size());
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
-            c2.size());
+            std::size_t(std::distance(std::begin(c2), result.in2)), c2.size());
     }
 
     {
@@ -320,10 +315,9 @@ void test_mismatch_binary2_async(ExPolicy&& p, IteratorTag)
 
         // verify values
         auto result = f.get();
+        HPX_TEST_EQ(std::size_t(std::distance(begin1, result.in1)), c1.size());
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.in1)), c1.size());
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
-            c2.size());
+            std::size_t(std::distance(std::begin(c2), result.in2)), c2.size());
     }
 
     {

--- a/libs/algorithms/tests/unit/container_algorithms/mismatch_binary_range.cpp
+++ b/libs/algorithms/tests/unit/container_algorithms/mismatch_binary_range.cpp
@@ -26,10 +26,12 @@ std::mt19937 gen(seed);
 std::uniform_int_distribution<> dis(0, 10006);
 
 template <typename IteratorTag>
-void test_mismatch1(IteratorTag)
+void test_mismatch_binary1(IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -42,12 +44,14 @@ void test_mismatch1(IteratorTag)
     iterator end1 = iterator(std::end(c1));
 
     {
-        auto result = hpx::mismatch(begin1, end1, std::begin(c2));
+        auto result =
+            hpx::ranges::mismatch(range(iterator(begin1), iterator(end1)),
+                base_range(std::begin(c2), std::end(c2)));
 
         // verify values
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), c1.size());
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            std::size_t(std::distance(begin1, result.in1)), c1.size());
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
             c2.size());
     }
 
@@ -55,25 +59,29 @@ void test_mismatch1(IteratorTag)
         std::size_t changed_idx = dis(gen);    //-V104
         ++c1[changed_idx];
 
-        auto result = hpx::mismatch(begin1, end1, std::begin(c2));
+        auto result =
+            hpx::ranges::mismatch(range(iterator(begin1), iterator(end1)),
+                base_range(std::begin(c2), std::end(c2)));
 
         // verify values
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), changed_idx);
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            std::size_t(std::distance(begin1, result.in1)), changed_idx);
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
             changed_idx);
     }
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_mismatch1(ExPolicy&& policy, IteratorTag)
+void test_mismatch_binary1(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -86,12 +94,14 @@ void test_mismatch1(ExPolicy&& policy, IteratorTag)
     iterator end1 = iterator(std::end(c1));
 
     {
-        auto result = hpx::mismatch(policy, begin1, end1, std::begin(c2));
+        auto result = hpx::ranges::mismatch(policy,
+            range(iterator(begin1), iterator(end1)),
+            base_range(std::begin(c2), std::end(c2)));
 
         // verify values
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), c1.size());
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            std::size_t(std::distance(begin1, result.in1)), c1.size());
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
             c2.size());
     }
 
@@ -99,21 +109,25 @@ void test_mismatch1(ExPolicy&& policy, IteratorTag)
         std::size_t changed_idx = dis(gen);    //-V104
         ++c1[changed_idx];
 
-        auto result = hpx::mismatch(policy, begin1, end1, std::begin(c2));
+        auto result = hpx::ranges::mismatch(policy,
+            range(iterator(begin1), iterator(end1)),
+            base_range(std::begin(c2), std::end(c2)));
 
         // verify values
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), changed_idx);
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            std::size_t(std::distance(begin1, result.in1)), changed_idx);
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
             changed_idx);
     }
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_mismatch1_async(ExPolicy&& p, IteratorTag)
+void test_mismatch_binary1_async(ExPolicy&& p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -126,14 +140,16 @@ void test_mismatch1_async(ExPolicy&& p, IteratorTag)
     iterator end1 = iterator(std::end(c1));
 
     {
-        auto f = hpx::mismatch(p, begin1, end1, std::begin(c2));
+        auto f =
+            hpx::ranges::mismatch(p, range(iterator(begin1), iterator(end1)),
+                base_range(std::begin(c2), std::end(c2)));
         f.wait();
 
         // verify values
         auto result = f.get();
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), c1.size());
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            std::size_t(std::distance(begin1, result.in1)), c1.size());
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
             c2.size());
     }
 
@@ -141,45 +157,49 @@ void test_mismatch1_async(ExPolicy&& p, IteratorTag)
         std::size_t changed_idx = dis(gen);    //-V104
         ++c1[changed_idx];
 
-        auto f = hpx::mismatch(p, begin1, end1, std::begin(c2));
+        auto f =
+            hpx::ranges::mismatch(p, range(iterator(begin1), iterator(end1)),
+                base_range(std::begin(c2), std::end(c2)));
         f.wait();
 
         // verify values
         auto result = f.get();
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), changed_idx);
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            std::size_t(std::distance(begin1, result.in1)), changed_idx);
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
             changed_idx);
     }
 }
 
 template <typename IteratorTag>
-void test_mismatch1()
+void test_mismatch_binary1()
 {
     using namespace hpx::parallel;
 
-    test_mismatch1(IteratorTag());
+    test_mismatch_binary1(IteratorTag());
 
-    test_mismatch1(execution::seq, IteratorTag());
-    test_mismatch1(execution::par, IteratorTag());
-    test_mismatch1(execution::par_unseq, IteratorTag());
+    test_mismatch_binary1(execution::seq, IteratorTag());
+    test_mismatch_binary1(execution::par, IteratorTag());
+    test_mismatch_binary1(execution::par_unseq, IteratorTag());
 
-    test_mismatch1_async(execution::seq(execution::task), IteratorTag());
-    test_mismatch1_async(execution::par(execution::task), IteratorTag());
+    test_mismatch_binary1_async(execution::seq(execution::task), IteratorTag());
+    test_mismatch_binary1_async(execution::par(execution::task), IteratorTag());
 }
 
-void mismatch_test1()
+void mismatch_binary_test1()
 {
-    test_mismatch1<std::random_access_iterator_tag>();
-    test_mismatch1<std::forward_iterator_tag>();
+    test_mismatch_binary1<std::random_access_iterator_tag>();
+    test_mismatch_binary1<std::forward_iterator_tag>();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
-void test_mismatch2(IteratorTag)
+void test_mismatch_binary2(IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -192,13 +212,15 @@ void test_mismatch2(IteratorTag)
     iterator end1 = iterator(std::end(c1));
 
     {
-        auto result = hpx::mismatch(
-            begin1, end1, std::begin(c2), std::equal_to<std::size_t>());
+        auto result =
+            hpx::ranges::mismatch(range(iterator(begin1), iterator(end1)),
+                base_range(std::begin(c2), std::end(c2)),
+                std::equal_to<std::size_t>());
 
         // verify values
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), c1.size());
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            std::size_t(std::distance(begin1, result.in1)), c1.size());
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
             c2.size());
     }
 
@@ -206,26 +228,30 @@ void test_mismatch2(IteratorTag)
         std::size_t changed_idx = dis(gen);    //-V104
         ++c1[changed_idx];
 
-        auto result = hpx::mismatch(
-            begin1, end1, std::begin(c2), std::equal_to<std::size_t>());
+        auto result =
+            hpx::ranges::mismatch(range(iterator(begin1), iterator(end1)),
+                base_range(std::begin(c2), std::end(c2)),
+                std::equal_to<std::size_t>());
 
         // verify values
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), changed_idx);
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            std::size_t(std::distance(begin1, result.in1)), changed_idx);
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
             changed_idx);
     }
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_mismatch2(ExPolicy&& policy, IteratorTag)
+void test_mismatch_binary2(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -238,13 +264,15 @@ void test_mismatch2(ExPolicy&& policy, IteratorTag)
     iterator end1 = iterator(std::end(c1));
 
     {
-        auto result = hpx::mismatch(
-            policy, begin1, end1, std::begin(c2), std::equal_to<std::size_t>());
+        auto result = hpx::ranges::mismatch(policy,
+            range(iterator(begin1), iterator(end1)),
+            base_range(std::begin(c2), std::end(c2)),
+            std::equal_to<std::size_t>());
 
         // verify values
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), c1.size());
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            std::size_t(std::distance(begin1, result.in1)), c1.size());
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
             c2.size());
     }
 
@@ -252,22 +280,26 @@ void test_mismatch2(ExPolicy&& policy, IteratorTag)
         std::size_t changed_idx = dis(gen);    //-V104
         ++c1[changed_idx];
 
-        auto result = hpx::mismatch(
-            policy, begin1, end1, std::begin(c2), std::equal_to<std::size_t>());
+        auto result = hpx::ranges::mismatch(policy,
+            range(iterator(begin1), iterator(end1)),
+            base_range(std::begin(c2), std::end(c2)),
+            std::equal_to<std::size_t>());
 
         // verify values
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), changed_idx);
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            std::size_t(std::distance(begin1, result.in1)), changed_idx);
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
             changed_idx);
     }
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_mismatch2_async(ExPolicy&& p, IteratorTag)
+void test_mismatch_binary2_async(ExPolicy&& p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -280,15 +312,17 @@ void test_mismatch2_async(ExPolicy&& p, IteratorTag)
     iterator end1 = iterator(std::end(c1));
 
     {
-        auto f = hpx::mismatch(
-            p, begin1, end1, std::begin(c2), std::equal_to<std::size_t>());
+        auto f =
+            hpx::ranges::mismatch(p, range(iterator(begin1), iterator(end1)),
+                base_range(std::begin(c2), std::end(c2)),
+                std::equal_to<std::size_t>());
         f.wait();
 
         // verify values
         auto result = f.get();
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), c1.size());
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            std::size_t(std::distance(begin1, result.in1)), c1.size());
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
             c2.size());
     }
 
@@ -296,46 +330,50 @@ void test_mismatch2_async(ExPolicy&& p, IteratorTag)
         std::size_t changed_idx = dis(gen);    //-V104
         ++c1[changed_idx];
 
-        auto f = hpx::mismatch(
-            p, begin1, end1, std::begin(c2), std::equal_to<std::size_t>());
+        auto f =
+            hpx::ranges::mismatch(p, range(iterator(begin1), iterator(end1)),
+                base_range(std::begin(c2), std::end(c2)),
+                std::equal_to<std::size_t>());
         f.wait();
 
         // verify values
         auto result = f.get();
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), changed_idx);
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            std::size_t(std::distance(begin1, result.in1)), changed_idx);
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
             changed_idx);
     }
 }
 
 template <typename IteratorTag>
-void test_mismatch2()
+void test_mismatch_binary2()
 {
     using namespace hpx::parallel;
 
-    test_mismatch2(IteratorTag());
+    test_mismatch_binary2(IteratorTag());
 
-    test_mismatch2(execution::seq, IteratorTag());
-    test_mismatch2(execution::par, IteratorTag());
-    test_mismatch2(execution::par_unseq, IteratorTag());
+    test_mismatch_binary2(execution::seq, IteratorTag());
+    test_mismatch_binary2(execution::par, IteratorTag());
+    test_mismatch_binary2(execution::par_unseq, IteratorTag());
 
-    test_mismatch2_async(execution::seq(execution::task), IteratorTag());
-    test_mismatch2_async(execution::par(execution::task), IteratorTag());
+    test_mismatch_binary2_async(execution::seq(execution::task), IteratorTag());
+    test_mismatch_binary2_async(execution::par(execution::task), IteratorTag());
 }
 
-void mismatch_test2()
+void mismatch_binary_test2()
 {
-    test_mismatch2<std::random_access_iterator_tag>();
-    test_mismatch2<std::forward_iterator_tag>();
+    test_mismatch_binary2<std::random_access_iterator_tag>();
+    test_mismatch_binary2<std::forward_iterator_tag>();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
-void test_mismatch_exception(IteratorTag)
+void test_mismatch_binary_exception(IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -347,8 +385,10 @@ void test_mismatch_exception(IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::mismatch(iterator(std::begin(c1)), iterator(std::end(c1)),
-            std::begin(c2), [](std::size_t v1, std::size_t v2) {
+        hpx::ranges::mismatch(
+            range(iterator(std::begin(c1)), iterator(std::end(c1))),
+            base_range(std::begin(c2), std::end(c2)),
+            [](std::size_t v1, std::size_t v2) {
                 return throw std::runtime_error("test"), true;
             });
 
@@ -369,14 +409,16 @@ void test_mismatch_exception(IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_mismatch_exception(ExPolicy&& policy, IteratorTag)
+void test_mismatch_binary_exception(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -388,8 +430,10 @@ void test_mismatch_exception(ExPolicy&& policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::mismatch(policy, iterator(std::begin(c1)), iterator(std::end(c1)),
-            std::begin(c2), [](std::size_t v1, std::size_t v2) {
+        hpx::ranges::mismatch(policy,
+            range(iterator(std::begin(c1)), iterator(std::end(c1))),
+            base_range(std::begin(c2), std::end(c2)),
+            [](std::size_t v1, std::size_t v2) {
                 return throw std::runtime_error("test"), true;
             });
 
@@ -409,10 +453,12 @@ void test_mismatch_exception(ExPolicy&& policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_mismatch_exception_async(ExPolicy&& p, IteratorTag)
+void test_mismatch_binary_exception_async(ExPolicy&& p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -425,11 +471,12 @@ void test_mismatch_exception_async(ExPolicy&& p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f =
-            hpx::mismatch(p, iterator(std::begin(c1)), iterator(std::end(c1)),
-                std::begin(c2), [](std::size_t v1, std::size_t v2) {
-                    return throw std::runtime_error("test"), true;
-                });
+        auto f = hpx::ranges::mismatch(p,
+            range(iterator(std::begin(c1)), iterator(std::end(c1))),
+            base_range(std::begin(c2), std::end(c2)),
+            [](std::size_t v1, std::size_t v2) {
+                return throw std::runtime_error("test"), true;
+            });
         returned_from_algorithm = true;
         f.get();
 
@@ -450,38 +497,42 @@ void test_mismatch_exception_async(ExPolicy&& p, IteratorTag)
 }
 
 template <typename IteratorTag>
-void test_mismatch_exception()
+void test_mismatch_binary_exception()
 {
     using namespace hpx::parallel;
+
+    test_mismatch_binary_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_mismatch_exception(execution::seq, IteratorTag());
-    test_mismatch_exception(execution::par, IteratorTag());
+    test_mismatch_binary_exception(execution::seq, IteratorTag());
+    test_mismatch_binary_exception(execution::par, IteratorTag());
 
-    test_mismatch_exception_async(
+    test_mismatch_binary_exception_async(
         execution::seq(execution::task), IteratorTag());
-    test_mismatch_exception_async(
+    test_mismatch_binary_exception_async(
         execution::par(execution::task), IteratorTag());
 }
 
-void mismatch_exception_test()
+void mismatch_binary_exception_test()
 {
-    test_mismatch_exception<std::random_access_iterator_tag>();
-    test_mismatch_exception<std::forward_iterator_tag>();
+    test_mismatch_binary_exception<std::random_access_iterator_tag>();
+    test_mismatch_binary_exception<std::forward_iterator_tag>();
 }
 
 /////////////////////////////////////////////////////////////////////////////
 template <typename ExPolicy, typename IteratorTag>
-void test_mismatch_bad_alloc(ExPolicy&& policy, IteratorTag)
+void test_mismatch_binary_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -493,8 +544,10 @@ void test_mismatch_bad_alloc(ExPolicy&& policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::mismatch(policy, iterator(std::begin(c1)), iterator(std::end(c1)),
-            std::begin(c2), [](std::size_t v1, std::size_t v2) {
+        hpx::ranges::mismatch(policy,
+            range(iterator(std::begin(c1)), iterator(std::end(c1))),
+            base_range(std::begin(c2), std::end(c2)),
+            [](std::size_t v1, std::size_t v2) {
                 return throw std::bad_alloc(), true;
             });
 
@@ -513,10 +566,12 @@ void test_mismatch_bad_alloc(ExPolicy&& policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_mismatch_bad_alloc_async(ExPolicy&& p, IteratorTag)
+void test_mismatch_binary_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -529,11 +584,12 @@ void test_mismatch_bad_alloc_async(ExPolicy&& p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f =
-            hpx::mismatch(p, iterator(std::begin(c1)), iterator(std::end(c1)),
-                std::begin(c2), [](std::size_t v1, std::size_t v2) {
-                    return throw std::bad_alloc(), true;
-                });
+        auto f = hpx::ranges::mismatch(p,
+            range(iterator(std::begin(c1)), iterator(std::end(c1))),
+            base_range(std::begin(c2), std::end(c2)),
+            [](std::size_t v1, std::size_t v2) {
+                return throw std::bad_alloc(), true;
+            });
         returned_from_algorithm = true;
         f.get();
 
@@ -553,26 +609,26 @@ void test_mismatch_bad_alloc_async(ExPolicy&& p, IteratorTag)
 }
 
 template <typename IteratorTag>
-void test_mismatch_bad_alloc()
+void test_mismatch_binary_bad_alloc()
 {
     using namespace hpx::parallel;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_mismatch_bad_alloc(execution::seq, IteratorTag());
-    test_mismatch_bad_alloc(execution::par, IteratorTag());
+    test_mismatch_binary_bad_alloc(execution::seq, IteratorTag());
+    test_mismatch_binary_bad_alloc(execution::par, IteratorTag());
 
-    test_mismatch_bad_alloc_async(
+    test_mismatch_binary_bad_alloc_async(
         execution::seq(execution::task), IteratorTag());
-    test_mismatch_bad_alloc_async(
+    test_mismatch_binary_bad_alloc_async(
         execution::par(execution::task), IteratorTag());
 }
 
-void mismatch_bad_alloc_test()
+void mismatch_binary_bad_alloc_test()
 {
-    test_mismatch_bad_alloc<std::random_access_iterator_tag>();
-    test_mismatch_bad_alloc<std::forward_iterator_tag>();
+    test_mismatch_binary_bad_alloc<std::random_access_iterator_tag>();
+    test_mismatch_binary_bad_alloc<std::forward_iterator_tag>();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -585,10 +641,10 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::cout << "using seed: " << seed << std::endl;
     gen.seed(seed);
 
-    mismatch_test1();
-    mismatch_test2();
-    mismatch_exception_test();
-    mismatch_bad_alloc_test();
+    mismatch_binary_test1();
+    mismatch_binary_test2();
+    mismatch_binary_exception_test();
+    mismatch_binary_bad_alloc_test();
     return hpx::finalize();
 }
 
@@ -601,6 +657,7 @@ int main(int argc, char* argv[])
 
     desc_commandline.add_options()("seed,s", value<unsigned int>(),
         "the random number generator seed to use for this run");
+
     // By default this test should run on all available cores
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 

--- a/libs/algorithms/tests/unit/container_algorithms/mismatch_range.cpp
+++ b/libs/algorithms/tests/unit/container_algorithms/mismatch_range.cpp
@@ -29,7 +29,9 @@ template <typename IteratorTag>
 void test_mismatch1(IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -42,25 +44,26 @@ void test_mismatch1(IteratorTag)
     iterator end1 = iterator(std::end(c1));
 
     {
-        auto result = hpx::mismatch(begin1, end1, std::begin(c2));
+        auto result =
+            hpx::ranges::mismatch(begin1, end1, std::begin(c2), std::end(c2));
 
         // verify values
+        HPX_TEST_EQ(std::size_t(std::distance(begin1, result.in1)), c1.size());
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), c1.size());
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
-            c2.size());
+            std::size_t(std::distance(std::begin(c2), result.in2)), c2.size());
     }
 
     {
         std::size_t changed_idx = dis(gen);    //-V104
         ++c1[changed_idx];
 
-        auto result = hpx::mismatch(begin1, end1, std::begin(c2));
+        auto result =
+            hpx::ranges::mismatch(begin1, end1, std::begin(c2), std::end(c2));
 
         // verify values
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), changed_idx);
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            std::size_t(std::distance(begin1, result.in1)), changed_idx);
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
             changed_idx);
     }
 }
@@ -73,7 +76,9 @@ void test_mismatch1(ExPolicy&& policy, IteratorTag)
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -86,25 +91,26 @@ void test_mismatch1(ExPolicy&& policy, IteratorTag)
     iterator end1 = iterator(std::end(c1));
 
     {
-        auto result = hpx::mismatch(policy, begin1, end1, std::begin(c2));
+        auto result = hpx::ranges::mismatch(
+            policy, begin1, end1, std::begin(c2), std::end(c2));
 
         // verify values
+        HPX_TEST_EQ(std::size_t(std::distance(begin1, result.in1)), c1.size());
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), c1.size());
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
-            c2.size());
+            std::size_t(std::distance(std::begin(c2), result.in2)), c2.size());
     }
 
     {
         std::size_t changed_idx = dis(gen);    //-V104
         ++c1[changed_idx];
 
-        auto result = hpx::mismatch(policy, begin1, end1, std::begin(c2));
+        auto result = hpx::ranges::mismatch(
+            policy, begin1, end1, std::begin(c2), std::end(c2));
 
         // verify values
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), changed_idx);
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            std::size_t(std::distance(begin1, result.in1)), changed_idx);
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
             changed_idx);
     }
 }
@@ -113,7 +119,9 @@ template <typename ExPolicy, typename IteratorTag>
 void test_mismatch1_async(ExPolicy&& p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -126,29 +134,30 @@ void test_mismatch1_async(ExPolicy&& p, IteratorTag)
     iterator end1 = iterator(std::end(c1));
 
     {
-        auto f = hpx::mismatch(p, begin1, end1, std::begin(c2));
+        auto f = hpx::ranges::mismatch(
+            p, begin1, end1, std::begin(c2), std::end(c2));
         f.wait();
 
         // verify values
         auto result = f.get();
+        HPX_TEST_EQ(std::size_t(std::distance(begin1, result.in1)), c1.size());
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), c1.size());
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
-            c2.size());
+            std::size_t(std::distance(std::begin(c2), result.in2)), c2.size());
     }
 
     {
         std::size_t changed_idx = dis(gen);    //-V104
         ++c1[changed_idx];
 
-        auto f = hpx::mismatch(p, begin1, end1, std::begin(c2));
+        auto f = hpx::ranges::mismatch(
+            p, begin1, end1, std::begin(c2), std::end(c2));
         f.wait();
 
         // verify values
         auto result = f.get();
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), changed_idx);
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            std::size_t(std::distance(begin1, result.in1)), changed_idx);
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
             changed_idx);
     }
 }
@@ -179,7 +188,9 @@ template <typename IteratorTag>
 void test_mismatch2(IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -192,27 +203,26 @@ void test_mismatch2(IteratorTag)
     iterator end1 = iterator(std::end(c1));
 
     {
-        auto result = hpx::mismatch(
-            begin1, end1, std::begin(c2), std::equal_to<std::size_t>());
+        auto result = hpx::ranges::mismatch(begin1, end1, std::begin(c2),
+            std::end(c2), std::equal_to<std::size_t>());
 
         // verify values
+        HPX_TEST_EQ(std::size_t(std::distance(begin1, result.in1)), c1.size());
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), c1.size());
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
-            c2.size());
+            std::size_t(std::distance(std::begin(c2), result.in2)), c2.size());
     }
 
     {
         std::size_t changed_idx = dis(gen);    //-V104
         ++c1[changed_idx];
 
-        auto result = hpx::mismatch(
-            begin1, end1, std::begin(c2), std::equal_to<std::size_t>());
+        auto result = hpx::ranges::mismatch(begin1, end1, std::begin(c2),
+            std::end(c2), std::equal_to<std::size_t>());
 
         // verify values
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), changed_idx);
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            std::size_t(std::distance(begin1, result.in1)), changed_idx);
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
             changed_idx);
     }
 }
@@ -225,7 +235,9 @@ void test_mismatch2(ExPolicy&& policy, IteratorTag)
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -238,27 +250,26 @@ void test_mismatch2(ExPolicy&& policy, IteratorTag)
     iterator end1 = iterator(std::end(c1));
 
     {
-        auto result = hpx::mismatch(
-            policy, begin1, end1, std::begin(c2), std::equal_to<std::size_t>());
+        auto result = hpx::ranges::mismatch(policy, begin1, end1,
+            std::begin(c2), std::end(c2), std::equal_to<std::size_t>());
 
         // verify values
+        HPX_TEST_EQ(std::size_t(std::distance(begin1, result.in1)), c1.size());
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), c1.size());
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
-            c2.size());
+            std::size_t(std::distance(std::begin(c2), result.in2)), c2.size());
     }
 
     {
         std::size_t changed_idx = dis(gen);    //-V104
         ++c1[changed_idx];
 
-        auto result = hpx::mismatch(
-            policy, begin1, end1, std::begin(c2), std::equal_to<std::size_t>());
+        auto result = hpx::ranges::mismatch(policy, begin1, end1,
+            std::begin(c2), std::end(c2), std::equal_to<std::size_t>());
 
         // verify values
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), changed_idx);
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            std::size_t(std::distance(begin1, result.in1)), changed_idx);
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
             changed_idx);
     }
 }
@@ -267,7 +278,9 @@ template <typename ExPolicy, typename IteratorTag>
 void test_mismatch2_async(ExPolicy&& p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -280,31 +293,30 @@ void test_mismatch2_async(ExPolicy&& p, IteratorTag)
     iterator end1 = iterator(std::end(c1));
 
     {
-        auto f = hpx::mismatch(
-            p, begin1, end1, std::begin(c2), std::equal_to<std::size_t>());
+        auto f = hpx::ranges::mismatch(p, begin1, end1, std::begin(c2),
+            std::end(c2), std::equal_to<std::size_t>());
         f.wait();
 
         // verify values
         auto result = f.get();
+        HPX_TEST_EQ(std::size_t(std::distance(begin1, result.in1)), c1.size());
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), c1.size());
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
-            c2.size());
+            std::size_t(std::distance(std::begin(c2), result.in2)), c2.size());
     }
 
     {
         std::size_t changed_idx = dis(gen);    //-V104
         ++c1[changed_idx];
 
-        auto f = hpx::mismatch(
-            p, begin1, end1, std::begin(c2), std::equal_to<std::size_t>());
+        auto f = hpx::ranges::mismatch(p, begin1, end1, std::begin(c2),
+            std::end(c2), std::equal_to<std::size_t>());
         f.wait();
 
         // verify values
         auto result = f.get();
         HPX_TEST_EQ(
-            std::size_t(std::distance(begin1, result.first)), changed_idx);
-        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.second)),
+            std::size_t(std::distance(begin1, result.in1)), changed_idx);
+        HPX_TEST_EQ(std::size_t(std::distance(std::begin(c2), result.in2)),
             changed_idx);
     }
 }
@@ -335,7 +347,9 @@ template <typename IteratorTag>
 void test_mismatch_exception(IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -347,8 +361,8 @@ void test_mismatch_exception(IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::mismatch(iterator(std::begin(c1)), iterator(std::end(c1)),
-            std::begin(c2), [](std::size_t v1, std::size_t v2) {
+        hpx::ranges::mismatch(iterator(std::begin(c1)), iterator(std::end(c1)),
+            std::begin(c2), std::end(c2), [](std::size_t v1, std::size_t v2) {
                 return throw std::runtime_error("test"), true;
             });
 
@@ -376,7 +390,9 @@ void test_mismatch_exception(ExPolicy&& policy, IteratorTag)
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -388,8 +404,9 @@ void test_mismatch_exception(ExPolicy&& policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::mismatch(policy, iterator(std::begin(c1)), iterator(std::end(c1)),
-            std::begin(c2), [](std::size_t v1, std::size_t v2) {
+        hpx::ranges::mismatch(policy, iterator(std::begin(c1)),
+            iterator(std::end(c1)), std::begin(c2), std::end(c2),
+            [](std::size_t v1, std::size_t v2) {
                 return throw std::runtime_error("test"), true;
             });
 
@@ -412,7 +429,9 @@ template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_exception_async(ExPolicy&& p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -425,11 +444,11 @@ void test_mismatch_exception_async(ExPolicy&& p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f =
-            hpx::mismatch(p, iterator(std::begin(c1)), iterator(std::end(c1)),
-                std::begin(c2), [](std::size_t v1, std::size_t v2) {
-                    return throw std::runtime_error("test"), true;
-                });
+        auto f = hpx::ranges::mismatch(p, iterator(std::begin(c1)),
+            iterator(std::end(c1)), std::begin(c2), std::end(c2),
+            [](std::size_t v1, std::size_t v2) {
+                return throw std::runtime_error("test"), true;
+            });
         returned_from_algorithm = true;
         f.get();
 
@@ -481,7 +500,9 @@ void test_mismatch_bad_alloc(ExPolicy&& policy, IteratorTag)
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -493,8 +514,9 @@ void test_mismatch_bad_alloc(ExPolicy&& policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::mismatch(policy, iterator(std::begin(c1)), iterator(std::end(c1)),
-            std::begin(c2), [](std::size_t v1, std::size_t v2) {
+        hpx::ranges::mismatch(policy, iterator(std::begin(c1)),
+            iterator(std::end(c1)), std::begin(c2), std::end(c2),
+            [](std::size_t v1, std::size_t v2) {
                 return throw std::bad_alloc(), true;
             });
 
@@ -516,7 +538,9 @@ template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -529,11 +553,11 @@ void test_mismatch_bad_alloc_async(ExPolicy&& p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f =
-            hpx::mismatch(p, iterator(std::begin(c1)), iterator(std::end(c1)),
-                std::begin(c2), [](std::size_t v1, std::size_t v2) {
-                    return throw std::bad_alloc(), true;
-                });
+        auto f = hpx::ranges::mismatch(p, iterator(std::begin(c1)),
+            iterator(std::end(c1)), std::begin(c2), std::end(c2),
+            [](std::size_t v1, std::size_t v2) {
+                return throw std::bad_alloc(), true;
+            });
         returned_from_algorithm = true;
         f.get();
 

--- a/libs/algorithms/tests/unit/container_algorithms/unique_copy_range.cpp
+++ b/libs/algorithms/tests/unit/container_algorithms/unique_copy_range.cpp
@@ -35,6 +35,11 @@ struct user_defined_type
         return this->name == t.name && this->val == t.val;
     }
 
+    bool operator!=(user_defined_type const& t) const
+    {
+        return this->name != t.name || this->val != t.val;
+    }
+
     static const std::vector<std::string> name_list;
 
     int val;

--- a/libs/algorithms/tests/unit/container_algorithms/unique_range.cpp
+++ b/libs/algorithms/tests/unit/container_algorithms/unique_range.cpp
@@ -35,6 +35,11 @@ struct user_defined_type
         return this->name == t.name && this->val == t.val;
     }
 
+    bool operator!=(user_defined_type const& t) const
+    {
+        return this->name != t.name || this->val != t.val;
+    }
+
     static const std::vector<std::string> name_list;
 
     int val;

--- a/libs/include/include/hpx/algorithm.hpp
+++ b/libs/include/include/hpx/algorithm.hpp
@@ -36,7 +36,6 @@ namespace hpx {
     using hpx::parallel::merge;
     using hpx::parallel::min_element;
     using hpx::parallel::minmax_element;
-    using hpx::parallel::mismatch;
     using hpx::parallel::partition;
     using hpx::parallel::partition_copy;
     using hpx::parallel::remove;

--- a/libs/include/include/hpx/include/parallel_mismatch.hpp
+++ b/libs/include/include/hpx/include/parallel_mismatch.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2020 Hartmut Kaiser
 //  Copyright (c) 2014 Grant Mercer
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -8,3 +8,4 @@
 #pragma once
 
 #include <hpx/parallel/algorithms/mismatch.hpp>
+#include <hpx/parallel/container_algorithms/mismatch.hpp>

--- a/libs/iterator_support/include/hpx/iterator_support/traits/is_iterator.hpp
+++ b/libs/iterator_support/include/hpx/iterator_support/traits/is_iterator.hpp
@@ -9,6 +9,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/type_support/always_void.hpp>
+#include <hpx/type_support/equality.hpp>
 
 #include <boost/iterator/iterator_categories.hpp>
 
@@ -69,34 +70,6 @@ namespace hpx { namespace traits {
             typename util::always_void<decltype(*(std::declval<T&>()))>::type>
         {
             using type = decltype(*(std::declval<T&>()));
-        };
-
-        template <typename T, typename U, typename Enable = void>
-        struct equality_result
-        {
-        };
-
-        template <typename T, typename U>
-        struct equality_result<T, U,
-            typename util::always_void<decltype(
-                std::declval<const T&>() == std::declval<const U&>())>::type>
-        {
-            using type =
-                decltype(std::declval<const T&>() == std::declval<const U&>());
-        };
-
-        template <typename T, typename U, typename Enable = void>
-        struct inequality_result
-        {
-        };
-
-        template <typename T, typename U>
-        struct inequality_result<T, U,
-            typename util::always_void<decltype(
-                std::declval<const T&>() != std::declval<const U&>())>::type>
-        {
-            using type =
-                decltype(std::declval<const T&>() != std::declval<const U&>());
         };
 
         template <typename T, typename U, typename Enable = void>

--- a/libs/iterator_support/include/hpx/iterator_support/traits/is_sentinel_for.hpp
+++ b/libs/iterator_support/include/hpx/iterator_support/traits/is_sentinel_for.hpp
@@ -12,13 +12,13 @@
 #include <type_traits>
 #include <utility>
 
-// The trait checks whether sentinel Sent is proper for iterator I.
-// There are two requirements for this:
-// 1. iterator I should be an input or output iterator
-// 2. I and S should oblige with the weakly-equality-comparable concept
-
 namespace hpx { namespace traits {
 
+    ///////////////////////////////////////////////////////////////////////////
+    // The trait checks whether sentinel Sent is proper for iterator I.
+    // There are two requirements for this:
+    // 1. iterator I should be an input or output iterator
+    // 2. I and S should oblige with the weakly-equality-comparable concept
     template <typename Sent, typename Iter, typename Enable = void>
     struct is_sentinel_for : std::false_type
     {
@@ -26,16 +26,13 @@ namespace hpx { namespace traits {
 
     template <typename Sent, typename Iter>
     struct is_sentinel_for<Sent, Iter,
-        typename util::always_void<
-            typename std::enable_if<is_iterator<Iter>::value>::type,
-            typename detail::equality_result<Iter, Sent>::type,
-            typename detail::equality_result<Sent, Iter>::type,
-            typename detail::inequality_result<Iter, Sent>::type,
-            typename detail::inequality_result<Sent, Iter>::type>::type>
+        typename std::enable_if<is_iterator<Iter>::value &&
+            is_weakly_equality_comparable_with<Iter, Sent>::value>::type>
       : std::true_type
     {
     };
 
+    ///////////////////////////////////////////////////////////////////////////
 #if defined(HPX_HAVE_CXX20_STD_DISABLE_SIZED_SENTINEL_FOR)
     template <typename Sent, typename Iter>
     inline constexpr bool disable_sized_sentinel_for =

--- a/libs/type_support/CMakeLists.txt
+++ b/libs/type_support/CMakeLists.txt
@@ -11,6 +11,7 @@ set(type_support_headers
     hpx/type_support/always_void.hpp
     hpx/type_support/decay.hpp
     hpx/type_support/detected.hpp
+    hpx/type_support/equality.hpp
     hpx/type_support/identity.hpp
     hpx/type_support/lazy_conditional.hpp
     hpx/type_support/lazy_enable_if.hpp

--- a/libs/type_support/include/hpx/type_support/equality.hpp
+++ b/libs/type_support/include/hpx/type_support/equality.hpp
@@ -1,0 +1,82 @@
+//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2019 Austin McCartney
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/type_support/always_void.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace traits {
+    namespace detail {
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename T, typename U, typename Enable = void>
+        struct equality_result
+        {
+        };
+
+        template <typename T, typename U>
+        struct equality_result<T, U,
+            typename util::always_void<decltype(
+                std::declval<const T&>() == std::declval<const U&>())>::type>
+        {
+            using type =
+                decltype(std::declval<const T&>() == std::declval<const U&>());
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename T, typename U, typename Enable = void>
+        struct inequality_result
+        {
+        };
+
+        template <typename T, typename U>
+        struct inequality_result<T, U,
+            typename util::always_void<decltype(
+                std::declval<const T&>() != std::declval<const U&>())>::type>
+        {
+            using type =
+                decltype(std::declval<const T&>() != std::declval<const U&>());
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename T, typename U, typename Enable = void>
+        struct is_weakly_equality_comparable_with : std::false_type
+        {
+        };
+
+        template <typename T, typename U>
+        struct is_weakly_equality_comparable_with<T, U,
+            typename util::always_void<
+                typename detail::equality_result<T, U>::type,
+                typename detail::equality_result<U, T>::type,
+                typename detail::inequality_result<T, U>::type,
+                typename detail::inequality_result<U, T>::type>::type>
+          : std::true_type
+        {
+        };
+
+    }    // namespace detail
+
+    template <typename T, typename U>
+    struct is_weakly_equality_comparable_with
+      : detail::is_weakly_equality_comparable_with<typename std::decay<T>::type,
+            typename std::decay<U>::type>
+    {
+    };
+
+    // for now is_equality_comparable is equivalent to its weak version
+    template <typename T, typename U>
+    struct is_equality_comparable_with
+      : detail::is_weakly_equality_comparable_with<typename std::decay<T>::type,
+            typename std::decay<U>::type>
+    {
+    };
+}}    // namespace hpx::traits


### PR DESCRIPTION
- add overloads for mismatch taking ranges
- flyby: making projection_identity constexpr
