### PR TITLE
Making sure remotely thrown (non-hpx) exceptions are properly marshaled back to invocation site

### DIFF
--- a/src/util/serialize_exception.cpp
+++ b/src/util/serialize_exception.cpp
@@ -117,6 +117,10 @@ namespace hpx { namespace runtime_local { namespace detail {
             if (auxinfo_)
                 throw_auxinfo_ = *auxinfo_;
         }
+        catch (...)
+        {
+            // do nothing
+        }
 
         // figure out concrete underlying exception type
         try
@@ -216,7 +220,7 @@ namespace hpx { namespace runtime_local { namespace detail {
         else if (hpx::util::boost_system_error == type)
         {
             // clang-format off
-            ar & err_value& err_message;
+            ar & err_value & err_message;
             // clang-format on
         }
     }
@@ -262,7 +266,7 @@ namespace hpx { namespace runtime_local { namespace detail {
         else if (hpx::util::boost_system_error == type)
         {
             // clang-format off
-            ar & err_value& err_message;
+            ar & err_value & err_message;
             // clang-format on
         }
 

--- a/tests/regressions/util/CMakeLists.txt
+++ b/tests/regressions/util/CMakeLists.txt
@@ -8,9 +8,12 @@
 set(tests protect_with_nullary_pfo set_config_entry_deadlock use_all_cores_2262)
 
 if(HPX_WITH_DISTRIBUTED_RUNTIME)
-  set(tests ${tests} configuration_1572 iarchive_1237 serialize_buffer_1069)
+  set(tests ${tests} configuration_1572 iarchive_1237 serialize_buffer_1069
+            serialize_exception_4886
+  )
   set(iarchive_1237_FLAGS DEPENDENCIES iostreams_component)
   set(serialize_buffer_1069_FLAGS DEPENDENCIES iostreams_component)
+  set(serialize_exception_4886_1001_PARAMETERS LOCALITIES 2)
 endif()
 
 if(HPX_WITH_NETWORKING)

--- a/tests/regressions/util/serialize_exception_4886.cpp
+++ b/tests/regressions/util/serialize_exception_4886.cpp
@@ -1,0 +1,46 @@
+//  Copyright (c) 2020 Nikunj Gupta
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_main.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <exception>
+
+void thrower()
+{
+    throw std::exception();
+}
+HPX_PLAIN_ACTION(thrower, thrower_action);
+
+int main()
+{
+    hpx::id_type to_call = hpx::find_here();
+
+    std::vector<hpx::id_type> locales = hpx::find_all_localities();
+    for (auto const& id : locales)
+    {
+        if (id != to_call)
+        {
+            to_call = id;
+            break;
+        }
+    }
+
+    thrower_action ac;
+    hpx::future<void> f = hpx::async(ac, to_call);
+
+    bool caught_exception = false;
+    hpx::future<void> g =
+        f.then(hpx::launch::sync, [&caught_exception](hpx::future<void>&& f) {
+            caught_exception = f.has_exception();
+        });
+
+    g.get();
+    HPX_TEST(caught_exception);
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Fixes #4886

@NK-Nikunj this should solve the issue you reported

@aurianer I think this should be part of the upcoming release as it fixes a serious problem with remote exception handling
