### PR TITLE
Adapt transform to C++20 (compilable version)

### DIFF
--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2020 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
@@ -265,8 +265,10 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                         typename traits2::local_iterator,
                         typename traits3::local_iterator> {
                     auto&& p = f.get();
-                    return util::in_in_out_result<typename traits1::local_iterator,
-                        typename traits2::local_iterator, typename traits3::local_iterator>
+                    return util::in_in_out_result<
+                        typename traits1::local_iterator,
+                        typename traits2::local_iterator,
+                        typename traits3::local_iterator>
                         {traits1::remote(p.in1),
                             traits2::remote(p.in2), traits3::remote(p.out)};
                 });

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform.hpp
@@ -264,7 +264,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typename InIter2, typename OutIter, typename F, typename Proj1,
             typename Proj2>
         static typename util::detail::algorithm_result<ExPolicy,
+<<<<<<< HEAD
             hpx::tuple<InIter1, InIter2, OutIter>>::type
+=======
+            util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
         segmented_transform(Algo&& algo, ExPolicy&& policy, InIter1 first1,
             InIter1 last1, InIter2 first2, OutIter dest, F&& f, Proj1&& proj1,
             Proj2&& proj2, std::true_type)
@@ -280,7 +284,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef typename traits3::local_iterator local_iterator_type3;
 
             typedef util::detail::algorithm_result<ExPolicy,
+<<<<<<< HEAD
                 hpx::tuple<InIter1, InIter2, OutIter>>
+=======
+                util::in_in_out_result<InIter1, InIter2, OutIter>>
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
                 result;
 
             auto last2 = first2;
@@ -300,6 +308,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type3 ldest = traits3::begin(sdest);
                 if (beg1 != end1)
                 {
+<<<<<<< HEAD
                     hpx::tuple<local_iterator_type1, local_iterator_type2,
                         local_iterator_type3>
                         out = dispatch(traits1::get_id(sit1), algo, policy,
@@ -308,6 +317,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     last1 = traits1::compose(send1, hpx::get<0>(out));
                     last2 = traits2::compose(send2, hpx::get<1>(out));
                     dest = traits3::compose(sdest, hpx::get<2>(out));
+=======
+                    util::in_in_out_result<local_iterator_type1,
+                        local_iterator_type2, local_iterator_type3>
+                        out = dispatch(traits1::get_id(sit1), algo, policy,
+                            std::true_type(), beg1, end1, beg2, ldest, f, proj1,
+                            proj2);
+                    last1 = traits1::compose(send1, out.in1);
+                    last2 = traits2::compose(send2, out.in2);
+                    dest = traits3::compose(sdest, out.out);
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
                 }
             }
             else
@@ -317,8 +336,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type1 end1 = traits1::end(sit1);
                 local_iterator_type2 beg2 = traits2::local(first2);
                 local_iterator_type3 ldest = traits3::begin(sdest);
+<<<<<<< HEAD
                 hpx::tuple<local_iterator_type1, local_iterator_type2,
                     local_iterator_type3>
+=======
+                util::in_in_out_result<local_iterator_type1,
+                    local_iterator_type2, local_iterator_type3>
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
                     out;
                 if (beg1 != end1)
                 {
@@ -354,12 +378,22 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         std::true_type(), beg1, end1, beg2, ldest, f, proj1,
                         proj2);
                 }
+<<<<<<< HEAD
                 last1 = traits1::compose(send1, hpx::get<0>(out));
                 last2 = traits2::compose(send2, hpx::get<1>(out));
                 dest = traits3::compose(sdest, hpx::get<2>(out));
             }
             return result::get(hpx::make_tuple<InIter1, InIter2, OutIter>(
                 std::move(last1), std::move(last2), std::move(dest)));
+=======
+                last1 = traits1::compose(send1, out.in1);
+                last2 = traits2::compose(send2, out.in2);
+                dest = traits3::compose(sdest, out.out);
+            }
+            return result::get(
+                util::in_in_out_result<InIter1, InIter2, OutIter>{
+                    std::move(last1), std::move(last2), std::move(dest)});
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
         }
 
         // parallel remote implementation
@@ -367,7 +401,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typename InIter2, typename OutIter, typename F, typename Proj1,
             typename Proj2>
         static typename util::detail::algorithm_result<ExPolicy,
+<<<<<<< HEAD
             hpx::tuple<InIter1, InIter2, OutIter>>::type
+=======
+            util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
         segmented_transform(Algo&& algo, ExPolicy&& policy, InIter1 first1,
             InIter1 last1, InIter2 first2, OutIter dest, F&& f, Proj1&& proj1,
             Proj2&& proj2, std::false_type)
@@ -383,7 +421,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef typename traits3::local_iterator local_iterator_type3;
 
             typedef util::detail::algorithm_result<ExPolicy,
+<<<<<<< HEAD
                 hpx::tuple<InIter1, InIter2, OutIter>>
+=======
+                util::in_in_out_result<InIter1, InIter2, OutIter>>
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
                 result;
 
             typedef std::integral_constant<bool,
@@ -400,8 +442,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
             segment_iterator2 send2 = traits2::segment(last2);
             segment_iterator3 sdest = traits3::segment(dest);
 
+<<<<<<< HEAD
             typedef std::vector<future<hpx::tuple<local_iterator_type1,
                 local_iterator_type2, local_iterator_type3>>>
+=======
+            typedef std::vector<
+                future<util::in_in_out_result<local_iterator_type1,
+                    local_iterator_type2, local_iterator_type3>>>
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
                 segment_type;
             segment_type segments;
             segments.reserve(std::distance(sit1, send1));
@@ -464,16 +512,29 @@ namespace hpx { namespace parallel { inline namespace v1 {
             }
 
             return result::get(dataflow(
+<<<<<<< HEAD
                 [=](segment_type&& r) -> hpx::tuple<InIter1, InIter2, OutIter> {
+=======
+                [=](segment_type&& r)
+                    -> util::in_in_out_result<InIter1, InIter2, OutIter> {
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
                     // handle any remote exceptions, will throw on error
                     std::list<std::exception_ptr> errors;
                     parallel::util::detail::handle_remote_exceptions<
                         ExPolicy>::call(r, errors);
                     auto rl = r.back().get();
+<<<<<<< HEAD
                     auto olast1 = traits1::compose(send1, hpx::get<0>(rl));
                     auto olast2 = traits2::compose(send2, hpx::get<1>(rl));
                     auto odest = traits3::compose(sdest, hpx::get<2>(rl));
                     return hpx::make_tuple(olast1, olast2, odest);
+=======
+                    auto olast1 = traits1::compose(send1, rl.in1);
+                    auto olast2 = traits2::compose(send2, rl.in2);
+                    auto odest = traits3::compose(sdest, rl.out);
+                    return util::in_in_out_result<InIter1, InIter2, OutIter>{
+                        olast1, olast2, odest};
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
                 },
                 std::move(segments)));
         }
@@ -483,8 +544,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename ExPolicy, typename InIter1, typename InIter2,
             typename OutIter, typename F, typename Proj1, typename Proj2>
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_tuple<tag::in1(InIter1), tag::in2(InIter2),
-                tag::out(OutIter)>>::type
+            util::in_in_out_result<InIter1, InIter2, OutIter>>::type
         transform_(ExPolicy&& policy, InIter1 first1, InIter1 last1,
             InIter2 first2, OutIter dest, F&& f, Proj1&& proj1, Proj2&& proj2,
             std::true_type)
@@ -492,8 +552,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef parallel::execution::is_sequenced_execution_policy<ExPolicy>
                 is_seq;
             typedef util::detail::algorithm_result<ExPolicy,
-                hpx::util::tagged_tuple<tag::in1(InIter1), tag::in2(InIter2),
-                    tag::out(OutIter)>>
+                util::in_in_out_result<InIter1, InIter2, OutIter>>
                 result;
 
             auto last2 = first2;
@@ -501,8 +560,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             if (first1 == last1)
             {
+<<<<<<< HEAD
                 return result::get(hpx::make_tuple<InIter1, InIter2, OutIter>(
                     std::move(last1), std::move(last2), std::move(dest)));
+=======
+                return result::get(
+                    util::in_in_out_result<InIter1, InIter2, OutIter>{
+                        std::move(last1), std::move(last2), std::move(dest)});
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
             }
 
             typedef hpx::traits::segmented_iterator_traits<InIter1>
@@ -511,6 +576,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 iterator2_traits;
             typedef hpx::traits::segmented_iterator_traits<OutIter>
                 iterator3_traits;
+<<<<<<< HEAD
             return hpx::util::make_tagged_tuple<tag::in1, tag::in2, tag::out>(
                 segmented_transform(
                     transform_binary<
@@ -520,14 +586,23 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::forward<ExPolicy>(policy), first1, last1, first2, dest,
                     std::forward<F>(f), std::forward<Proj1>(proj1),
                     std::forward<Proj2>(proj2), is_seq()));
+=======
+            return segmented_transform(
+                transform_binary<util::in_in_out_result<
+                    typename iterator1_traits::local_iterator,
+                    typename iterator2_traits::local_iterator,
+                    typename iterator3_traits::local_iterator>>(),
+                std::forward<ExPolicy>(policy), first1, last1, first2, dest,
+                std::forward<F>(f), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2), is_seq());
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
         }
 
         // forward declare the non-segmented version of this algorithm
         template <typename ExPolicy, typename InIter1, typename InIter2,
             typename OutIter, typename F, typename Proj1, typename Proj2>
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_tuple<tag::in1(InIter1), tag::in2(InIter2),
-                tag::out(OutIter)>>::type
+            util::in_in_out_result<InIter1, InIter2, OutIter>>::type
         transform_(ExPolicy&& policy, InIter1 first1, InIter1 last1,
             InIter2 first2, OutIter dest, F&& f, Proj1&& proj1, Proj2&& proj2,
             std::false_type);
@@ -539,7 +614,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typename InIter2, typename OutIter, typename F, typename Proj1,
             typename Proj2>
         static typename util::detail::algorithm_result<ExPolicy,
+<<<<<<< HEAD
             hpx::tuple<InIter1, InIter2, OutIter>>::type
+=======
+            util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
         segmented_transform(Algo&& algo, ExPolicy&& policy, InIter1 first1,
             InIter1 last1, InIter2 first2, InIter2 last2, OutIter dest, F&& f,
             Proj1&& proj1, Proj2&& proj2, std::true_type)
@@ -555,7 +634,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef typename traits3::local_iterator local_iterator_type3;
 
             typedef util::detail::algorithm_result<ExPolicy,
+<<<<<<< HEAD
                 hpx::tuple<InIter1, InIter2, OutIter>>
+=======
+                util::in_in_out_result<InIter1, InIter2, OutIter>>
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
                 result;
 
             segment_iterator1 sit1 = traits1::segment(first1);
@@ -574,6 +657,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type3 ldest = traits3::begin(sdest);
                 if (beg1 != end1 && beg2 != end2)
                 {
+<<<<<<< HEAD
                     hpx::tuple<local_iterator_type1, local_iterator_type2,
                         local_iterator_type3>
                         out = dispatch(traits1::get_id(sit1), algo, policy,
@@ -582,6 +666,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     last1 = traits1::compose(send1, hpx::get<0>(out));
                     last2 = traits2::compose(send2, hpx::get<1>(out));
                     dest = traits3::compose(sdest, hpx::get<2>(out));
+=======
+                    util::in_in_out_result<local_iterator_type1,
+                        local_iterator_type2, local_iterator_type3>
+                        out = dispatch(traits1::get_id(sit1), algo, policy,
+                            std::true_type(), beg1, end1, beg2, end2, ldest, f,
+                            proj1, proj2);
+                    last1 = traits1::compose(send1, out.in1);
+                    last2 = traits2::compose(send2, out.in2);
+                    dest = traits3::compose(sdest, out.out);
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
                 }
             }
             else
@@ -592,8 +686,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type2 beg2 = traits2::local(first2);
                 local_iterator_type2 end2 = traits2::end(sit2);
                 local_iterator_type3 ldest = traits3::begin(sdest);
+<<<<<<< HEAD
                 hpx::tuple<local_iterator_type1, local_iterator_type2,
                     local_iterator_type3>
+=======
+                util::in_in_out_result<local_iterator_type1,
+                    local_iterator_type2, local_iterator_type3>
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
                     out;
                 if (beg1 != end1 && beg2 != end2)
                 {
@@ -631,12 +730,22 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         std::true_type(), beg1, end1, beg2, end2, ldest, f,
                         proj1, proj2);
                 }
+<<<<<<< HEAD
                 last1 = traits1::compose(send1, hpx::get<0>(out));
                 last2 = traits2::compose(send2, hpx::get<1>(out));
                 dest = traits3::compose(sdest, hpx::get<2>(out));
             }
             return result::get(hpx::make_tuple<InIter1, InIter2, OutIter>(
                 std::move(last1), std::move(last2), std::move(dest)));
+=======
+                last1 = traits1::compose(send1, out.in1);
+                last2 = traits2::compose(send2, out.in2);
+                dest = traits3::compose(sdest, out.out);
+            }
+            return result::get(
+                util::in_in_out_result<InIter1, InIter2, OutIter>{
+                    std::move(last1), std::move(last2), std::move(dest)});
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
         }
 
         // parallel remote implementation
@@ -644,7 +753,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typename InIter2, typename OutIter, typename F, typename Proj1,
             typename Proj2>
         static typename util::detail::algorithm_result<ExPolicy,
+<<<<<<< HEAD
             hpx::tuple<InIter1, InIter2, OutIter>>::type
+=======
+            util::in_in_out_result<InIter1, InIter2, OutIter>>::type
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
         segmented_transform(Algo&& algo, ExPolicy&& policy, InIter1 first1,
             InIter1 last1, InIter2 first2, InIter2 last2, OutIter dest, F&& f,
             Proj1&& proj1, Proj2&& proj2, std::false_type)
@@ -660,7 +773,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef typename traits3::local_iterator local_iterator_type3;
 
             typedef util::detail::algorithm_result<ExPolicy,
+<<<<<<< HEAD
                 hpx::tuple<InIter1, InIter2, OutIter>>
+=======
+                util::in_in_out_result<InIter1, InIter2, OutIter>>
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
                 result;
 
             typedef std::integral_constant<bool,
@@ -674,8 +791,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
             segment_iterator2 send2 = traits2::segment(last2);
             segment_iterator3 sdest = traits3::segment(dest);
 
+<<<<<<< HEAD
             typedef std::vector<future<hpx::tuple<local_iterator_type1,
                 local_iterator_type2, local_iterator_type3>>>
+=======
+            typedef std::vector<
+                future<util::in_in_out_result<local_iterator_type1,
+                    local_iterator_type2, local_iterator_type3>>>
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
                 segment_type;
             segment_type segments;
             segments.reserve(std::distance(sit1, send1));
@@ -742,16 +865,29 @@ namespace hpx { namespace parallel { inline namespace v1 {
             }
 
             return result::get(dataflow(
+<<<<<<< HEAD
                 [=](segment_type&& r) -> hpx::tuple<InIter1, InIter2, OutIter> {
+=======
+                [=](segment_type&& r)
+                    -> util::in_in_out_result<InIter1, InIter2, OutIter> {
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
                     // handle any remote exceptions, will throw on error
                     std::list<std::exception_ptr> errors;
                     parallel::util::detail::handle_remote_exceptions<
                         ExPolicy>::call(r, errors);
                     auto rl = r.back().get();
+<<<<<<< HEAD
                     auto olast1 = traits1::compose(send1, hpx::get<0>(rl));
                     auto olast2 = traits2::compose(send2, hpx::get<1>(rl));
                     auto odest = traits3::compose(sdest, hpx::get<2>(rl));
                     return hpx::make_tuple(olast1, olast2, odest);
+=======
+                    auto olast1 = traits1::compose(send1, rl.in1);
+                    auto olast2 = traits2::compose(send2, rl.in2);
+                    auto odest = traits3::compose(sdest, rl.out);
+                    return util::in_in_out_result<InIter1, InIter2, OutIter>{
+                        olast1, olast2, odest};
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
                 },
                 std::move(segments)));
         }
@@ -761,8 +897,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename ExPolicy, typename InIter1, typename InIter2,
             typename OutIter, typename F, typename Proj1, typename Proj2>
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_tuple<tag::in1(InIter1), tag::in2(InIter2),
-                tag::out(OutIter)>>::type
+            util::in_in_out_result<InIter1, InIter2, OutIter>>::type
         transform_(ExPolicy&& policy, InIter1 first1, InIter1 last1,
             InIter2 first2, InIter2 last2, OutIter dest, F&& f, Proj1&& proj1,
             Proj2&& proj2, std::true_type)
@@ -770,14 +905,19 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef parallel::execution::is_sequenced_execution_policy<ExPolicy>
                 is_seq;
             typedef util::detail::algorithm_result<ExPolicy,
-                hpx::util::tagged_tuple<tag::in1(InIter1), tag::in2(InIter2),
-                    tag::out(OutIter)>>
+                util::in_in_out_result<InIter1, InIter2, OutIter>>
                 result;
 
             if (first1 == last1)
             {
+<<<<<<< HEAD
                 return result::get(hpx::make_tuple<InIter1, InIter2, OutIter>(
                     std::move(last1), std::move(last2), std::move(dest)));
+=======
+                return result::get(
+                    util::in_in_out_result<InIter1, InIter2, OutIter>{
+                        std::move(last1), std::move(last2), std::move(dest)});
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
             }
 
             typedef hpx::traits::segmented_iterator_traits<InIter1>
@@ -787,6 +927,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef hpx::traits::segmented_iterator_traits<OutIter>
                 iterator3_traits;
 
+<<<<<<< HEAD
             return hpx::util::make_tagged_tuple<tag::in1, tag::in2, tag::out>(
                 segmented_transform(
                     transform_binary2<
@@ -796,14 +937,23 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::forward<ExPolicy>(policy), first1, last1, first2,
                     last2, dest, std::forward<F>(f), std::forward<Proj1>(proj1),
                     std::forward<Proj2>(proj2), is_seq()));
+=======
+            return segmented_transform(
+                transform_binary2<util::in_in_out_result<
+                    typename iterator1_traits::local_iterator,
+                    typename iterator2_traits::local_iterator,
+                    typename iterator3_traits::local_iterator>>(),
+                std::forward<ExPolicy>(policy), first1, last1, first2, last2,
+                dest, std::forward<F>(f), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2), is_seq());
+>>>>>>> b54a64cfee5... Change binary transform result type to in_in_out_result
         }
 
         // forward declare the non-segmented version of this algorithm
         template <typename ExPolicy, typename InIter1, typename InIter2,
             typename OutIter, typename F, typename Proj1, typename Proj2>
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_tuple<tag::in1(InIter1), tag::in2(InIter2),
-                tag::out(OutIter)>>::type
+            util::in_in_out_result<InIter1, InIter2, OutIter>>::type
         transform_(ExPolicy&& policy, InIter1 first1, InIter1 last1,
             InIter2 first2, InIter2 last2, OutIter dest, F&& f, Proj1&& proj1,
             Proj2&& proj2, std::false_type);

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -633,7 +633,7 @@ namespace hpx {
         tag_invoke(hpx::copy_t, ExPolicy&& policy, FwdIter1 first,
             FwdIter1 last, FwdIter2 dest)
         {
-            return parallel::util::get_second_element(
+            return parallel::util::detail::get_second_element(
                 parallel::v1::detail::transfer<
                     parallel::v1::detail::copy_iter<FwdIter1, FwdIter2>>(
                     std::forward<ExPolicy>(policy), first, last, dest));
@@ -649,7 +649,7 @@ namespace hpx {
         friend FwdIter2 tag_invoke(
             hpx::copy_t, FwdIter1 first, FwdIter1 last, FwdIter2 dest)
         {
-            return parallel::util::get_second_element(
+            return parallel::util::detail::get_second_element(
                 parallel::v1::detail::transfer<
                     parallel::v1::detail::copy_iter<FwdIter1, FwdIter2>>(
                     hpx::execution::seq, first, last, dest));
@@ -692,7 +692,7 @@ namespace hpx {
                 hpx::parallel::execution::is_sequenced_execution_policy<
                     ExPolicy>;
 
-            return hpx::parallel::util::get_second_element(
+            return hpx::parallel::util::detail::get_second_element(
                 hpx::parallel::v1::detail::copy_n<
                     hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
                     .call(std::forward<ExPolicy>(policy), is_seq(), first,
@@ -722,7 +722,7 @@ namespace hpx {
                     FwdIter2>::get(std::move(dest));
             }
 
-            return hpx::parallel::util::get_second_element(
+            return hpx::parallel::util::detail::get_second_element(
                 hpx::parallel::v1::detail::copy_n<
                     hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
                     .call(hpx::execution::seq, std::true_type{}, first,
@@ -762,7 +762,7 @@ namespace hpx {
                 hpx::parallel::execution::is_sequenced_execution_policy<
                     ExPolicy>;
 
-            return hpx::parallel::util::get_second_element(
+            return hpx::parallel::util::detail::get_second_element(
                 hpx::parallel::v1::detail::copy_if<
                     hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
                     .call(std::forward<ExPolicy>(policy), is_seq(), first, last,
@@ -788,7 +788,7 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::util::get_second_element(
+            return hpx::parallel::util::detail::get_second_element(
                 hpx::parallel::v1::detail::copy_if<
                     hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
                     .call(hpx::execution::seq, std::true_type{}, first, last,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2020 Gianis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -57,7 +57,21 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     };
 
     template <typename Result1, typename Result2, typename Result3>
-    struct local_algorithm_result<hpx::tuple<Result1, Result2, Result3>>
+    struct local_algorithm_result<
+        util::in_in_out_result<Result1, Result2, Result3>>
+    {
+        typedef typename hpx::traits::segmented_local_iterator_traits<
+            Result1>::local_raw_iterator type1;
+        typedef typename hpx::traits::segmented_local_iterator_traits<
+            Result2>::local_raw_iterator type2;
+        typedef typename hpx::traits::segmented_local_iterator_traits<
+            Result3>::local_raw_iterator type3;
+
+        typedef util::in_in_out_result<type1, type2, type3> type;
+    };
+
+    template <typename Result1, typename Result2, typename Result3>
+    struct local_algorithm_result<hpx::util::tuple<Result1, Result2, Result3>>
     {
         typedef typename hpx::traits::segmented_local_iterator_traits<
             Result1>::local_raw_iterator type1;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/move.hpp
@@ -206,7 +206,7 @@ namespace hpx {
         tag_invoke(move_t, ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
             FwdIter2 dest)
         {
-            return hpx::parallel::util::get_second_element(
+            return hpx::parallel::util::detail::get_second_element(
                 hpx::parallel::v1::detail::transfer<
                     hpx::parallel::v1::detail::move<FwdIter1, FwdIter2>>(
                     std::forward<ExPolicy>(policy), first, last, dest));

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
@@ -321,21 +321,21 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
             }
 
-            template <typename ExPolicy, typename InIter, typename OutIter,
-                typename F, typename Proj>
-            HPX_HOST_DEVICE static util::in_out_result<InIter, OutIter>
-            sequential(ExPolicy&& policy, InIter first, InIter last,
+            template <typename ExPolicy, typename InIterE, typename InIterB,
+                typename OutIter, typename F, typename Proj>
+            HPX_HOST_DEVICE static util::in_out_result<InIterB, OutIter>
+            sequential(ExPolicy&& policy, InIterB first, InIterE last,
                 OutIter dest, F&& f, Proj&& proj)
             {
                 return util::transform_loop(std::forward<ExPolicy>(policy),
                     first, last, dest, transform_projected<F, Proj>{f, proj});
             }
 
-            template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-                typename F, typename Proj>
+            template <typename ExPolicy, typename FwdIter1B, typename FwdIter1E,
+                typename FwdIter2, typename F, typename Proj>
             static typename util::detail::algorithm_result<ExPolicy,
-                util::in_out_result<FwdIter1, FwdIter2>>::type
-            parallel(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+                util::in_out_result<FwdIter1B, FwdIter2>>::type
+            parallel(ExPolicy&& policy, FwdIter1B first, FwdIter1E last,
                 FwdIter2 dest, F&& f, Proj&& proj)
             {
                 if (first != last)
@@ -351,7 +351,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             util::projection_identity()));
                 }
 
-                using result_type = util::in_out_result<FwdIter1, FwdIter2>;
+                using result_type = util::in_out_result<FwdIter1B, FwdIter2>;
 
                 return util::detail::algorithm_result<ExPolicy,
                     result_type>::get(result_type{
@@ -360,21 +360,21 @@ namespace hpx { namespace parallel { inline namespace v1 {
         };
 
         /// non_segmented version
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename F, typename Proj>
+        template <typename ExPolicy, typename FwdIter1B, typename FwdIter1E,
+            typename FwdIter2, typename F, typename Proj>
         typename util::detail::algorithm_result<ExPolicy,
-            util::in_out_result<FwdIter1, FwdIter2>>::type
-        transform_(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+            util::in_out_result<FwdIter1B, FwdIter2>>::type
+        transform_(ExPolicy&& policy, FwdIter1B first, FwdIter1E last,
             FwdIter2 dest, F&& f, Proj&& proj, std::false_type)
         {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1B>::value),
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
             typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
 
-            return detail::transform<util::in_out_result<FwdIter1, FwdIter2>>()
+            return detail::transform<util::in_out_result<FwdIter1B, FwdIter2>>()
                 .call(std::forward<ExPolicy>(policy), is_seq(), first, last,
                     dest, std::forward<F>(f), std::forward<Proj>(proj));
         }
@@ -389,18 +389,22 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
+    // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename F, typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<FwdIter1>::value&&
-                    hpx::traits::is_iterator<FwdIter2>::value&&
-                        traits::is_projected<Proj, FwdIter1>::value&&
-                            traits::is_indirect_callable<ExPolicy, F,
-                                traits::projected<Proj, FwdIter1>>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value&&
+            hpx::traits::is_iterator<FwdIter1>::value&&
+            hpx::traits::is_iterator<FwdIter2>::value&&
+            traits::is_projected<Proj, FwdIter1>::value&&
+            traits::is_indirect_callable<ExPolicy, F,
+            traits::projected<Proj, FwdIter1>>::value
+            )>
+    // clang-format on
     HPX_DEPRECATED_V(1, 6,
         "hpx::parallel::transform is deprecated, use hpx::transform instead")
-    typename util::detail::algorithm_result<ExPolicy,
-        util::in_out_result<FwdIter1, FwdIter2>>::type
+        typename util::detail::algorithm_result<ExPolicy,
+            util::in_out_result<FwdIter1, FwdIter2>>::type
         transform(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
             FwdIter2 dest, F&& f, Proj&& proj = Proj())
     {
@@ -510,10 +514,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
             }
 
-            template <typename ExPolicy, typename InIter1, typename InIter2,
-                typename OutIter, typename F, typename Proj1, typename Proj2>
-            static util::in_in_out_result<InIter1, InIter2, OutIter> sequential(
-                ExPolicy&& policy, InIter1 first1, InIter1 last1,
+            template <typename ExPolicy, typename InIter1B, typename InIter1E,
+                typename InIter2, typename OutIter, typename F, typename Proj1,
+                typename Proj2>
+            static util::in_in_out_result<InIter1B, InIter2, OutIter>
+            sequential(ExPolicy&& policy, InIter1B first1, InIter1E last1,
                 InIter2 first2, OutIter dest, F&& f, Proj1&& proj1,
                 Proj2&& proj2)
             {
@@ -523,11 +528,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         f, proj1, proj2});
             }
 
-            template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-                typename FwdIter3, typename F, typename Proj1, typename Proj2>
+            template <typename ExPolicy, typename FwdIter1B, typename FwdIter1E,
+                typename FwdIter2, typename FwdIter3, typename F,
+                typename Proj1, typename Proj2>
             static typename util::detail::algorithm_result<ExPolicy,
-                util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
-            parallel(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+                util::in_in_out_result<FwdIter1B, FwdIter2, FwdIter3>>::type
+            parallel(ExPolicy&& policy, FwdIter1B first1, FwdIter1E last1,
                 FwdIter2 first2, FwdIter3 dest, F&& f, Proj1&& proj1,
                 Proj2&& proj2)
             {
@@ -547,7 +553,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 }
 
                 using result_type =
-                    util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>;
+                    util::in_in_out_result<FwdIter1B, FwdIter2, FwdIter3>;
 
                 return util::detail::algorithm_result<ExPolicy,
                     result_type>::get(result_type{
@@ -555,15 +561,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
             }
         };
 
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename FwdIter3, typename F, typename Proj1, typename Proj2>
+        template <typename ExPolicy, typename FwdIter1B, typename FwdIter1E,
+            typename FwdIter2, typename FwdIter3, typename F, typename Proj1,
+            typename Proj2>
         typename util::detail::algorithm_result<ExPolicy,
-            util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
-        transform_(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+            util::in_in_out_result<FwdIter1B, FwdIter2, FwdIter3>>::type
+        transform_(ExPolicy&& policy, FwdIter1B first1, FwdIter1E last1,
             FwdIter2 first2, FwdIter3 dest, F&& f, Proj1&& proj1, Proj2&& proj2,
             std::false_type)
         {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1B>::value),
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
@@ -571,7 +578,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 "Requires at least forward iterator.");
 
             typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
-            typedef util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>
+            typedef util::in_in_out_result<FwdIter1B, FwdIter2, FwdIter3>
                 result_type;
 
             return detail::transform_binary<result_type>().call(
@@ -580,6 +587,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 std::forward<Proj2>(proj2));
         }
 
+        /// forward declare the segmented version
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename FwdIter3, typename F, typename Proj1, typename Proj2>
         typename util::detail::algorithm_result<ExPolicy,
@@ -590,23 +598,26 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
+    // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename FwdIter3, typename F,
         typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<
-            ExPolicy>::value&& hpx::traits::is_iterator<FwdIter1>::value&&
-                hpx::traits::is_iterator<FwdIter2>::value&&
-                    hpx::traits::is_iterator<FwdIter3>::value&&
-                        traits::is_projected<Proj1, FwdIter1>::value&&
-                            traits::is_projected<Proj2, FwdIter2>::value&&
-                                traits::is_indirect_callable<ExPolicy, F,
-                                    traits::projected<Proj1, FwdIter1>,
-                                    traits::projected<Proj2, FwdIter2>>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<
+                ExPolicy>::value&& hpx::traits::is_iterator<FwdIter1>::value&&
+            hpx::traits::is_iterator<FwdIter2>::value&&
+            hpx::traits::is_iterator<FwdIter3>::value&&
+            traits::is_projected<Proj1, FwdIter1>::value&&
+            traits::is_projected<Proj2, FwdIter2>::value&&
+            traits::is_indirect_callable<ExPolicy, F,
+                traits::projected<Proj1, FwdIter1>,
+                traits::projected<Proj2, FwdIter2>>::value)>
+    // clang-format on
     HPX_DEPRECATED_V(1, 6,
         "hpx::parallel::transform is deprecated, use hpx::transform instead")
-    typename util::detail::algorithm_result<ExPolicy,
-        util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
+        typename util::detail::algorithm_result<ExPolicy,
+            util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
         transform(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
             FwdIter2 first2, FwdIter3 dest, F&& f, Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
@@ -631,10 +642,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
             }
 
-            template <typename ExPolicy, typename InIter1, typename InIter2,
-                typename OutIter, typename F, typename Proj1, typename Proj2>
-            static util::in_in_out_result<InIter1, InIter2, OutIter> sequential(
-                ExPolicy&& policy, InIter1 first1, InIter1 last1,
+            template <typename ExPolicy, typename InIter1B, typename InIter1E,
+                typename InIter2, typename OutIter, typename F, typename Proj1,
+                typename Proj2>
+            static util::in_in_out_result<InIter1B, InIter2, OutIter>
+            sequential(ExPolicy&& policy, InIter1B first1, InIter1E last1,
                 InIter2 first2, InIter2 last2, OutIter dest, F&& f,
                 Proj1&& proj1, Proj2&& proj2)
             {
@@ -644,11 +656,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         f, proj1, proj2});
             }
 
-            template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-                typename FwdIter3, typename F, typename Proj1, typename Proj2>
+            template <typename ExPolicy, typename FwdIter1B, typename FwdIter1E,
+                typename FwdIter2, typename FwdIter3, typename F,
+                typename Proj1, typename Proj2>
             static typename util::detail::algorithm_result<ExPolicy,
-                util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
-            parallel(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+                util::in_in_out_result<FwdIter1B, FwdIter2, FwdIter3>>::type
+            parallel(ExPolicy&& policy, FwdIter1B first1, FwdIter1E last1,
                 FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, F&& f,
                 Proj1&& proj1, Proj2&& proj2)
             {
@@ -669,7 +682,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 }
 
                 using result_type =
-                    util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>;
+                    util::in_in_out_result<FwdIter1B, FwdIter2, FwdIter3>;
 
                 return util::detail::algorithm_result<ExPolicy,
                     result_type>::get(result_type{
@@ -677,15 +690,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
             }
         };
 
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename FwdIter3, typename F, typename Proj1, typename Proj2>
+        template <typename ExPolicy, typename FwdIter1B, typename FwdIter1E,
+            typename FwdIter2, typename FwdIter3, typename F, typename Proj1,
+            typename Proj2>
         typename util::detail::algorithm_result<ExPolicy,
-            util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
-        transform_(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+            util::in_in_out_result<FwdIter1B, FwdIter2, FwdIter3>>::type
+        transform_(ExPolicy&& policy, FwdIter1B first1, FwdIter1E last1,
             FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, F&& f,
             Proj1&& proj1, Proj2&& proj2, std::false_type)
         {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1B>::value),
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
@@ -693,7 +707,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 "Requires at least forward iterator.");
 
             typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
-            typedef util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>
+            typedef util::in_in_out_result<FwdIter1B, FwdIter2, FwdIter3>
                 result_type;
 
             return detail::transform_binary2<result_type>().call(
@@ -701,6 +715,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 last2, dest, std::forward<F>(f), std::forward<Proj1>(proj1),
                 std::forward<Proj2>(proj2));
         }
+
+        /// forward declare the segmented version
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename FwdIter3, typename F, typename Proj1, typename Proj2>
         typename util::detail::algorithm_result<ExPolicy,
@@ -711,23 +727,26 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
+    // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename FwdIter3, typename F,
         typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<
-            ExPolicy>::value&& hpx::traits::is_iterator<FwdIter1>::value&&
-                hpx::traits::is_iterator<FwdIter2>::value&&
-                    hpx::traits::is_iterator<FwdIter3>::value&&
-                        traits::is_projected<Proj1, FwdIter1>::value&&
-                            traits::is_projected<Proj2, FwdIter2>::value&&
-                                traits::is_indirect_callable<ExPolicy, F,
-                                    traits::projected<Proj1, FwdIter1>,
-                                    traits::projected<Proj2, FwdIter2>>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<
+                ExPolicy>::value&& hpx::traits::is_iterator<FwdIter1>::value&&
+        hpx::traits::is_iterator<FwdIter2>::value&&
+        hpx::traits::is_iterator<FwdIter3>::value&&
+        traits::is_projected<Proj1, FwdIter1>::value&&
+        traits::is_projected<Proj2, FwdIter2>::value&&
+        traits::is_indirect_callable<ExPolicy, F,
+            traits::projected<Proj1, FwdIter1>,
+            traits::projected<Proj2, FwdIter2>>::value)>
+    // clang-format on
     HPX_DEPRECATED_V(1, 6,
         "hpx::parallel::transform is deprecated, use hpx::transform instead")
-    typename util::detail::algorithm_result<ExPolicy,
-        util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
+        typename util::detail::algorithm_result<ExPolicy,
+            util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
         transform(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
             FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, F&& f,
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
@@ -417,7 +417,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename ExPolicy, typename InIter1, typename InIter2,
                 typename OutIter, typename F, typename Proj1, typename Proj2>
-            static hpx::tuple<InIter1, InIter2, OutIter> sequential(
+            static util::in_in_out_result<InIter1, InIter2, OutIter> sequential(
                 ExPolicy&& policy, InIter1 first1, InIter1 last1,
                 InIter2 first2, OutIter dest, F&& f, Proj1&& proj1,
                 Proj2&& proj2)
@@ -431,7 +431,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
                 typename FwdIter3, typename F, typename Proj1, typename Proj2>
             static typename util::detail::algorithm_result<ExPolicy,
-                hpx::tuple<FwdIter1, FwdIter2, FwdIter3>>::type
+                util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
             parallel(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
                 FwdIter2 first2, FwdIter3 dest, F&& f, Proj1&& proj1,
                 Proj2&& proj2)
@@ -443,7 +443,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             std::forward<F>(f), std::forward<Proj1>(proj1),
                             std::forward<Proj2>(proj2));
 
-                    return get_iter_tuple(
+                    return parallel::util::detail::get_in_in_out_result(
                         util::foreach_partitioner<ExPolicy>::call(
                             std::forward<ExPolicy>(policy),
                             hpx::util::make_zip_iterator(first1, first2, dest),
@@ -451,18 +451,19 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             util::projection_identity()));
                 }
 
+                using result_type =
+                    util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>;
+
                 return util::detail::algorithm_result<ExPolicy,
-                    hpx::tuple<FwdIter1, FwdIter2,
-                        FwdIter3>>::get(hpx::make_tuple(std::move(first1),
-                    std::move(first2), std::move(dest)));
+                    result_type>::get(result_type{
+                    std::move(first1), std::move(first2), std::move(dest)});
             }
         };
 
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename FwdIter3, typename F, typename Proj1, typename Proj2>
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2),
-                tag::out(FwdIter3)>>::type
+            util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
         transform_(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
             FwdIter2 first2, FwdIter3 dest, F&& f, Proj1&& proj1, Proj2&& proj2,
             std::false_type)
@@ -475,20 +476,19 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 "Requires at least forward iterator.");
 
             typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
-            typedef hpx::tuple<FwdIter1, FwdIter2, FwdIter3> result_type;
+            typedef util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>
+                result_type;
 
-            return hpx::util::make_tagged_tuple<tag::in1, tag::in2, tag::out>(
-                detail::transform_binary<result_type>().call(
-                    std::forward<ExPolicy>(policy), is_seq(), first1, last1,
-                    first2, dest, std::forward<F>(f),
-                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2)));
+            return detail::transform_binary<result_type>().call(
+                std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
+                dest, std::forward<F>(f), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
         }
 
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename FwdIter3, typename F, typename Proj1, typename Proj2>
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2),
-                tag::out(FwdIter3)>>::type
+            util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
         transform_(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
             FwdIter2 first2, FwdIter3 dest, F&& f, Proj1&& proj1, Proj2&& proj2,
             std::true_type);
@@ -599,8 +599,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                     traits::projected<Proj1, FwdIter1>,
                                     traits::projected<Proj2, FwdIter2>>::value)>
     typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2),
-            tag::out(FwdIter3)>>::type
+        util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
     transform(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
         FwdIter2 first2, FwdIter3 dest, F&& f, Proj1&& proj1 = Proj1(),
         Proj2&& proj2 = Proj2())
@@ -627,7 +626,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename ExPolicy, typename InIter1, typename InIter2,
                 typename OutIter, typename F, typename Proj1, typename Proj2>
-            static hpx::tuple<InIter1, InIter2, OutIter> sequential(
+            static util::in_in_out_result<InIter1, InIter2, OutIter> sequential(
                 ExPolicy&& policy, InIter1 first1, InIter1 last1,
                 InIter2 first2, InIter2 last2, OutIter dest, F&& f,
                 Proj1&& proj1, Proj2&& proj2)
@@ -641,7 +640,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
                 typename FwdIter3, typename F, typename Proj1, typename Proj2>
             static typename util::detail::algorithm_result<ExPolicy,
-                hpx::tuple<FwdIter1, FwdIter2, FwdIter3>>::type
+                util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
             parallel(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
                 FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, F&& f,
                 Proj1&& proj1, Proj2&& proj2)
@@ -653,7 +652,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             std::forward<F>(f), std::forward<Proj1>(proj1),
                             std::forward<Proj2>(proj2));
 
-                    return get_iter_tuple(
+                    return parallel::util::detail::get_in_in_out_result(
                         util::foreach_partitioner<ExPolicy>::call(
                             std::forward<ExPolicy>(policy),
                             hpx::util::make_zip_iterator(first1, first2, dest),
@@ -662,18 +661,19 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             std::move(f1), util::projection_identity()));
                 }
 
+                using result_type =
+                    util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>;
+
                 return util::detail::algorithm_result<ExPolicy,
-                    hpx::tuple<FwdIter1, FwdIter2,
-                        FwdIter3>>::get(hpx::make_tuple(std::move(first1),
-                    std::move(first2), std::move(dest)));
+                    result_type>::get(result_type{
+                    std::move(first1), std::move(first2), std::move(dest)});
             }
         };
 
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename FwdIter3, typename F, typename Proj1, typename Proj2>
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2),
-                tag::out(FwdIter3)>>::type
+            util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
         transform_(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
             FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, F&& f,
             Proj1&& proj1, Proj2&& proj2, std::false_type)
@@ -686,19 +686,18 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 "Requires at least forward iterator.");
 
             typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
-            typedef hpx::tuple<FwdIter1, FwdIter2, FwdIter3> result_type;
+            typedef util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>
+                result_type;
 
-            return hpx::util::make_tagged_tuple<tag::in1, tag::in2, tag::out>(
-                detail::transform_binary2<result_type>().call(
-                    std::forward<ExPolicy>(policy), is_seq(), first1, last1,
-                    first2, last2, dest, std::forward<F>(f),
-                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2)));
+            return detail::transform_binary2<result_type>().call(
+                std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
+                last2, dest, std::forward<F>(f), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
         }
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename FwdIter3, typename F, typename Proj1, typename Proj2>
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2),
-                tag::out(FwdIter3)>>::type
+            util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
         transform_(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
             FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, F&& f,
             Proj1&& proj1, Proj2&& proj2, std::true_type);
@@ -815,8 +814,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                     traits::projected<Proj1, FwdIter1>,
                                     traits::projected<Proj2, FwdIter2>>::value)>
     typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2),
-            tag::out(FwdIter3)>>::type
+        util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
     transform(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
         FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, F&& f,
         Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
@@ -9,6 +9,170 @@
 
 #pragma once
 
+#if defined(DOXYGEN)
+namespace hpx {
+    // clang-format off
+
+    /// Applies the given function \a f to the range [first, last) and stores
+    /// the result in another range, beginning at dest.
+    ///
+    /// \note   Complexity: Exactly \a last - \a first applications of \a f
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the invocations of \a f.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a transform requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&.
+    ///                     The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to \a Type. The type \a Ret
+    ///                     must be such that an object of type \a FwdIter2 can
+    ///                     be dereferenced and assigned a value of type
+    ///                     \a Ret.
+    ///
+    /// The invocations of \a f in the parallel \a transform algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The invocations of \a f in the parallel \a transform algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a transform algorithm returns a
+    /// \a hpx::future<in_out_result<FwdIter1, FwdIter2> >
+    ///           if the execution policy is of type \a parallel_task_policy
+    ///           and returns
+    /// \a in_out_result<FwdIter1, FwdIter2> otherwise.
+    ///           The \a transform algorithm returns a tuple holding an iterator
+    ///           referring to the first element after the input sequence and
+    ///           the output iterator to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename F>
+    typename util::detail::algorithm_result<ExPolicy,
+        util::in_out_result<FwdIter1, FwdIter2>>::type
+    transform(ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest,
+        F&& f);
+
+    /// Applies the given function \a f to pairs of elements from two ranges:
+    /// one defined by [first1, last1) and the other beginning at first2, and
+    /// stores the result in another range, beginning at dest.
+    ///
+    /// \note   Complexity: Exactly \a last - \a first applications of \a f
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the invocations of \a f.
+    /// \tparam FwdIter1    The type of the source iterators for the first
+    ///                     range used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the source iterators for the second
+    ///                     range used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter3    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a transform requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first1       Refers to the beginning of the first sequence of
+    ///                     elements the algorithm will be applied to.
+    /// \param last1        Refers to the end of the first sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the second sequence of
+    ///                     elements the algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type2 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&.
+    ///                     The types \a Type1 and \a Type2 must be such that
+    ///                     objects of types FwdIter1 and FwdIter2 can be
+    ///                     dereferenced and then implicitly converted to
+    ///                     \a Type1 and \a Type2 respectively. The type \a Ret
+    ///                     must be such that an object of type \a FwdIter3 can
+    ///                     be dereferenced and assigned a value of type
+    ///                     \a Ret.
+    ///
+    /// The invocations of \a f in the parallel \a transform algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The invocations of \a f in the parallel \a transform algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a transform algorithm returns a
+    /// \a hpx::future<in_in_out_result<FwdIter1, FwdIter2, FwdIter3> >
+    ///           if the execution policy is of type \a parallel_task_policy
+    ///           and returns
+    /// \a in_in_out_result<FwdIter1, FwdIter2, FwdIter3>
+    ///           otherwise.
+    ///           The \a transform algorithm returns a tuple holding an iterator
+    ///           referring to the first element after the first input sequence,
+    ///           an iterator referring to the first element after the second
+    ///           input sequence, and the output iterator referring to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename FwdIter3, typename F>
+    typename util::detail::algorithm_result<ExPolicy,
+        util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
+    transform(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+        FwdIter2 first2, FwdIter3 dest, F&& f);
+
+    // clang-format on
+}    // namespace hpx
+
+#else    // DOXYGEN
+
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
@@ -225,77 +389,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Applies the given function \a f to the range [first, last) and stores
-    /// the result in another range, beginning at dest.
-    ///
-    /// \note   Complexity: Exactly \a last - \a first applications of \a f
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the invocations of \a f.
-    /// \tparam FwdIter1    The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam F           The type of the function/function object to use
-    ///                     (deduced). Unlike its sequential form, the parallel
-    ///                     overload of \a transform requires \a F to meet the
-    ///                     requirements of \a CopyConstructible.
-    /// \tparam Proj        The type of an optional projection function. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param f            Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last).This is an
-    ///                     unary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     Ret fun(const Type &a);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&.
-    ///                     The type \a Type must be such that an object of
-    ///                     type \a FwdIter can be dereferenced and then
-    ///                     implicitly converted to \a Type. The type \a Ret
-    ///                     must be such that an object of type \a FwdIter2 can
-    ///                     be dereferenced and assigned a value of type
-    ///                     \a Ret.
-    /// \param proj         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements as a
-    ///                     projection operation before the actual predicate
-    ///                     \a f is invoked.
-    ///
-    /// The invocations of \a f in the parallel \a transform algorithm invoked
-    /// with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The invocations of \a f in the parallel \a transform algorithm invoked
-    /// with an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a transform algorithm returns a
-    /// \a hpx::future<tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)> >
-    ///           if the execution policy is of type \a parallel_task_policy
-    ///           and returns
-    /// \a tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)> otherwise.
-    ///           The \a transform algorithm returns a tuple holding an iterator
-    ///           referring to the first element after the input sequence and
-    ///           the output iterator to the
-    ///           element in the destination range, one past the last element
-    ///           copied.
-    ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename F, typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
@@ -304,10 +397,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         traits::is_projected<Proj, FwdIter1>::value&&
                             traits::is_indirect_callable<ExPolicy, F,
                                 traits::projected<Proj, FwdIter1>>::value)>
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::transform is deprecated, use hpx::transform instead")
     typename util::detail::algorithm_result<ExPolicy,
         util::in_out_result<FwdIter1, FwdIter2>>::type
-    transform(ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest,
-        F&& f, Proj&& proj = Proj())
+        transform(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+            FwdIter2 dest, F&& f, Proj&& proj = Proj())
     {
         typedef hpx::traits::is_segmented_iterator<FwdIter1> is_segmented;
         return detail::transform_(std::forward<ExPolicy>(policy), first, last,
@@ -495,96 +590,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Applies the given function \a f to pairs of elements from two ranges:
-    /// one defined by [first1, last1) and the other beginning at first2, and
-    /// stores the result in another range, beginning at dest.
-    ///
-    /// \note   Complexity: Exactly \a last - \a first applications of \a f
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the invocations of \a f.
-    /// \tparam FwdIter1    The type of the source iterators for the first
-    ///                     range used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the source iterators for the second
-    ///                     range used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter3    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam F           The type of the function/function object to use
-    ///                     (deduced). Unlike its sequential form, the parallel
-    ///                     overload of \a transform requires \a F to meet the
-    ///                     requirements of \a CopyConstructible.
-    /// \tparam Proj1       The type of an optional projection function to be
-    ///                     used for elements of the first sequence. This
-    ///                     defaults to \a util::projection_identity
-    /// \tparam Proj2       The type of an optional projection function to be
-    ///                     used for elements of the second sequence. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first1       Refers to the beginning of the first sequence of
-    ///                     elements the algorithm will be applied to.
-    /// \param last1        Refers to the end of the first sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param first2       Refers to the beginning of the second sequence of
-    ///                     elements the algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param f            Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last).This is a
-    ///                     binary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     Ret fun(const Type1 &a, const Type2 &b);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&.
-    ///                     The types \a Type1 and \a Type2 must be such that
-    ///                     objects of types FwdIter1 and FwdIter2 can be
-    ///                     dereferenced and then implicitly converted to
-    ///                     \a Type1 and \a Type2 respectively. The type \a Ret
-    ///                     must be such that an object of type \a FwdIter3 can
-    ///                     be dereferenced and assigned a value of type
-    ///                     \a Ret.
-    /// \param proj1        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the
-    ///                     first sequence as a projection operation before the
-    ///                     actual predicate \a f is invoked.
-    /// \param proj2        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the
-    ///                     second sequence as a projection operation before
-    ///                     the actual predicate \a f is invoked.
-    ///
-    /// The invocations of \a f in the parallel \a transform algorithm invoked
-    /// with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The invocations of \a f in the parallel \a transform algorithm invoked
-    /// with an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a transform algorithm returns a
-    /// \a hpx::future<tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2), tag::out(FwdIter3)> >
-    ///           if the execution policy is of type \a parallel_task_policy
-    ///           and returns
-    /// \a tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2), tag::out(FwdIter3)>
-    ///           otherwise.
-    ///           The \a transform algorithm returns a tuple holding an iterator
-    ///           referring to the first element after the first input sequence,
-    ///           an iterator referring to the first element after the second
-    ///           input sequence, and the output iterator referring to the
-    ///           element in the destination range, one past the last element
-    ///           copied.
-    ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename FwdIter3, typename F,
         typename Proj1 = util::projection_identity,
@@ -598,11 +603,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                 traits::is_indirect_callable<ExPolicy, F,
                                     traits::projected<Proj1, FwdIter1>,
                                     traits::projected<Proj2, FwdIter2>>::value)>
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::transform is deprecated, use hpx::transform instead")
     typename util::detail::algorithm_result<ExPolicy,
         util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
-    transform(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
-        FwdIter2 first2, FwdIter3 dest, F&& f, Proj1&& proj1 = Proj1(),
-        Proj2&& proj2 = Proj2())
+        transform(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+            FwdIter2 first2, FwdIter3 dest, F&& f, Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
     {
         typedef hpx::traits::is_segmented_iterator<FwdIter1> is_segmented;
 
@@ -704,102 +711,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Applies the given function \a f to pairs of elements from two ranges:
-    /// one defined by [first1, last1) and the other beginning at first2, and
-    /// stores the result in another range, beginning at dest.
-    ///
-    /// \note   Complexity: Exactly min(last2-first2, last1-first1)
-    ///         applications of \a f
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the invocations of \a f.
-    /// \tparam FwdIter1    The type of the source iterators for the first
-    ///                     range used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the source iterators for the second
-    ///                     range used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter3    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam F           The type of the function/function object to use
-    ///                     (deduced). Unlike its sequential form, the parallel
-    ///                     overload of \a transform requires \a F to meet the
-    ///                     requirements of \a CopyConstructible.
-    /// \tparam Proj1       The type of an optional projection function to be
-    ///                     used for elements of the first sequence. This
-    ///                     defaults to \a util::projection_identity
-    /// \tparam Proj2       The type of an optional projection function to be
-    ///                     used for elements of the second sequence. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first1       Refers to the beginning of the first sequence of
-    ///                     elements the algorithm will be applied to.
-    /// \param last1        Refers to the end of the first sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param first2       Refers to the beginning of the second sequence of
-    ///                     elements the algorithm will be applied to.
-    /// \param last2        Refers to the end of the second sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param f            Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last).This is a
-    ///                     binary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     Ret fun(const Type1 &a, const Type2 &b);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&.
-    ///                     The types \a Type1 and \a Type2 must be such that
-    ///                     objects of types FwdIter1 and FwdIter2 can be
-    ///                     dereferenced and then implicitly converted to
-    ///                     \a Type1 and \a Type2 respectively. The type \a Ret
-    ///                     must be such that an object of type \a FwdIter3 can
-    ///                     be dereferenced and assigned a value of type
-    ///                     \a Ret.
-    /// \param proj1        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the
-    ///                     first sequence as a projection operation before the
-    ///                     actual predicate \a f is invoked.
-    /// \param proj2        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the
-    ///                     second sequence as a projection operation before
-    ///                     the actual predicate \a f is invoked.
-    ///
-    /// The invocations of \a f in the parallel \a transform algorithm invoked
-    /// with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The invocations of \a f in the parallel \a transform algorithm invoked
-    /// with an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \note The algorithm will invoke the binary predicate until it reaches
-    ///       the end of the shorter of the two given input sequences
-    ///
-    /// \returns  The \a transform algorithm returns a
-    /// \a hpx::future<tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2), tag::out(FwdIter3)> >
-    ///           if the execution policy is of type \a parallel_task_policy
-    ///           and returns
-    /// \a tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2), tag::out(FwdIter3)>
-    ///           otherwise.
-    ///           The \a transform algorithm returns a tuple holding an iterator
-    ///           referring to the first element after the first input sequence,
-    ///           an iterator referring to the first element after the second
-    ///           input sequence, and the output iterator referring to the
-    ///           element in the destination range, one past the last element
-    ///           copied.
-    ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename FwdIter3, typename F,
         typename Proj1 = util::projection_identity,
@@ -813,11 +724,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                 traits::is_indirect_callable<ExPolicy, F,
                                     traits::projected<Proj1, FwdIter1>,
                                     traits::projected<Proj2, FwdIter2>>::value)>
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::transform is deprecated, use hpx::transform instead")
     typename util::detail::algorithm_result<ExPolicy,
         util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
-    transform(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
-        FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, F&& f,
-        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        transform(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+            FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, F&& f,
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
     {
         typedef hpx::traits::is_segmented_iterator<FwdIter1> is_segmented;
 
@@ -954,7 +867,9 @@ namespace hpx {
         tag_invoke(hpx::transform_t, ExPolicy&& policy, FwdIter1 first1,
             FwdIter1 last1, FwdIter2 first2, FwdIter3 dest, F&& f)
         {
-            typedef hpx::traits::is_segmented_iterator<FwdIter1> is_segmented;
+            using is_segmented = std::integral_constant<bool,
+                hpx::traits::is_segmented_iterator<FwdIter1>::value ||
+                    hpx::traits::is_segmented_iterator<FwdIter2>::value>;
             using proj_id = hpx::parallel::util::projection_identity;
 
             return parallel::util::detail::get_third_element(
@@ -967,3 +882,5 @@ namespace hpx {
 
     } transform{};
 }    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
@@ -918,5 +918,52 @@ namespace hpx {
                     is_segmented()));
         }
 
+        // clang-format off
+        template <typename FwdIter1, typename FwdIter2, typename FwdIter3,
+            typename F, HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_iterator<FwdIter3>::value
+            )>
+        // clang-format on
+        friend FwdIter3 tag_invoke(hpx::transform_t, FwdIter1 first1,
+            FwdIter1 last1, FwdIter2 first2, FwdIter3 dest, F&& f)
+        {
+            using proj_id = hpx::parallel::util::projection_identity;
+
+            return parallel::util::detail::get_third_element(
+                parallel::v1::detail::transform_(hpx::parallel::execution::seq,
+                    first1, last1, first2, dest, std::forward<F>(f),
+                    hpx::parallel::util::projection_identity(),
+                    hpx::parallel::util::projection_identity(),
+                    std::false_type{}));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1,
+            typename FwdIter2, typename FwdIter3,
+            typename F, HPX_CONCEPT_REQUIRES_(
+                parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_iterator<FwdIter3>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter3>::type
+        tag_invoke(hpx::transform_t, ExPolicy&& policy, FwdIter1 first1,
+            FwdIter1 last1, FwdIter2 first2, FwdIter3 dest, F&& f)
+        {
+            typedef hpx::traits::is_segmented_iterator<FwdIter1> is_segmented;
+            using proj_id = hpx::parallel::util::projection_identity;
+
+            return parallel::util::detail::get_third_element(
+                parallel::v1::detail::transform_(std::forward<ExPolicy>(policy),
+                    first1, last1, first2, dest, std::forward<F>(f),
+                    hpx::parallel::util::projection_identity(),
+                    hpx::parallel::util::projection_identity(),
+                    is_segmented()));
+        }
+
     } transform{};
 }    // namespace hpx

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
@@ -344,7 +344,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
 namespace hpx { namespace ranges {
 
-    template <class I, class O>
+    template <typename I, typename O>
     using unary_transform_result = parallel::util::in_out_result<I, O>;
 
     ///////////////////////////////////////////////////////////////////////////
@@ -390,11 +390,10 @@ namespace hpx { namespace ranges {
         tag_invoke(hpx::ranges::transform_t, ExPolicy&& policy, Rng&& rng,
             FwdIter dest, F&& f, Proj&& proj = Proj())
         {
-            typedef hpx::traits::is_segmented_iterator<FwdIter> is_segmented;
-            //using iterator_type =
-            //    typename hpx::traits::range_traits<Rng>::iterator_type;
-            //using is_segmented =
-            //     hpx::traits::is_segmented_iterator<iterator_type>;
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+            using is_segmented =
+                hpx::traits::is_segmented_iterator<iterator_type>;
 
             return parallel::v1::detail::transform_(
                 std::forward<ExPolicy>(policy), hpx::util::begin(rng),
@@ -415,7 +414,7 @@ namespace hpx { namespace ranges {
             hpx::ranges::transform_t, FwdIter1 first, Sent1 last, FwdIter2 dest,
             F&& f, Proj&& proj = Proj())
         {
-            typedef hpx::traits::is_segmented_iterator<FwdIter1> is_segmented;
+            hpx::traits::is_segmented_iterator<FwdIter1> is_segmented;
 
             return parallel::v1::detail::transform_(
                 hpx::parallel::execution::seq, first, last, dest,
@@ -436,11 +435,10 @@ namespace hpx { namespace ranges {
         tag_invoke(hpx::ranges::transform_t, Rng&& rng, FwdIter dest, F&& f,
             Proj&& proj = Proj())
         {
-            typedef hpx::traits::is_segmented_iterator<FwdIter> is_segmented;
-            //using iterator_type =
-            //    typename hpx::traits::range_traits<Rng>::iterator_type;
-            //using is_segmented =
-            //     hpx::traits::is_segmented_iterator<iterator_type>;
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+            using is_segmented =
+                hpx::traits::is_segmented_iterator<iterator_type>;
 
             return parallel::v1::detail::transform_(
                 hpx::parallel::execution::seq, hpx::util::begin(rng),

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
@@ -214,9 +214,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                 traits::projected_range<Proj1, Rng>,
                                 traits::projected<Proj2, InIter2>>::value)>
     typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_tuple<
-            tag::in1(typename hpx::traits::range_iterator<Rng>::type),
-            tag::in2(InIter2), tag::out(OutIter)>>::type
+        util::in_in_out_result<typename hpx::traits::range_iterator<Rng>::type,
+            InIter2, OutIter>>::type
     transform(ExPolicy&& policy, Rng&& rng, InIter2 first2, OutIter dest, F&& f,
         Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
     {
@@ -328,10 +327,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                 traits::projected_range<Proj1, Rng1>,
                                 traits::projected_range<Proj2, Rng2>>::value)>
     typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_tuple<
-            tag::in1(typename hpx::traits::range_iterator<Rng1>::type),
-            tag::in2(typename hpx::traits::range_iterator<Rng2>::type),
-            tag::out(OutIter)>>::type
+        util::in_in_out_result<typename hpx::traits::range_iterator<Rng1>::type,
+            typename hpx::traits::range_iterator<Rng2>::type, OutIter>>::type
     transform(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2, OutIter dest, F&& f,
         Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
     {
@@ -353,9 +350,10 @@ namespace hpx { namespace ranges {
       : hpx::functional::tag<transform_t>
     {
     private:
-        // clang-format off
         template <typename ExPolicy, typename FwdIter1, typename Sent1,
-            typename FwdIter2, typename F, typename Proj = hpx::parallel::util::projection_identity,
+            typename FwdIter2, typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            // clang-format off
             HPX_CONCEPT_REQUIRES_(
                 hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
@@ -401,9 +399,10 @@ namespace hpx { namespace ranges {
                 std::forward<Proj>(proj), is_segmented());
         }
 
-        // clang-format off
-        template <typename FwdIter1, typename Sent1,
-            typename FwdIter2, typename F, typename Proj = hpx::parallel::util::projection_identity,
+        template <typename FwdIter1, typename Sent1, typename FwdIter2,
+            typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            // clang-format off
             HPX_CONCEPT_REQUIRES_(
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
@@ -102,9 +102,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     Rng>::value&& traits::is_indirect_callable<ExPolicy, F,
                     traits::projected_range<Proj, Rng>>::value)>
     typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_pair<
-            tag::in(typename hpx::traits::range_iterator<Rng>::type),
-            tag::out(OutIter)>>::type
+        util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
+            OutIter>>::type
     transform(
         ExPolicy&& policy, Rng&& rng, OutIter dest, F&& f, Proj&& proj = Proj())
     {

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
@@ -413,6 +413,7 @@ namespace hpx {
 
 namespace hpx { namespace parallel { inline namespace v1 {
 
+    // clang format-off
     template <typename ExPolicy, typename Rng, typename OutIter, typename F,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
@@ -420,10 +421,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     OutIter>::value&& traits::is_projected_range<Proj,
                     Rng>::value&& traits::is_indirect_callable<ExPolicy, F,
                     traits::projected_range<Proj, Rng>>::value)>
+    // clang format-on
     HPX_DEPRECATED_V(1, 6,
         "hpx::parallel::transform is deprecated, use hpx::ranges::transform "
-        "instead")
-    typename util::detail::algorithm_result<ExPolicy,
+        "instead") typename util::detail::algorithm_result<ExPolicy,
         util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
             OutIter>>::type transform(ExPolicy&& policy, Rng&& rng,
         OutIter dest, F&& f, Proj&& proj = Proj())
@@ -433,22 +434,25 @@ namespace hpx { namespace parallel { inline namespace v1 {
             std::forward<Proj>(proj));
     }
 
+    // clang-format off
     template <typename ExPolicy, typename Rng, typename InIter2,
         typename OutIter, typename F,
         typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
-                    InIter2>::value&& hpx::traits::is_iterator<OutIter>::value&&
-                    traits::is_projected_range<Proj1, Rng>::value&&
-                        traits::is_projected<Proj2, InIter2>::value&&
-                            traits::is_indirect_callable<ExPolicy, F,
-                                traits::projected_range<Proj1, Rng>,
-                                traits::projected<Proj2, InIter2>>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value&&
+            hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
+                InIter2>::value&& 
+            hpx::traits::is_iterator<OutIter>::value&&
+            traits::is_projected_range<Proj1, Rng>::value&&
+            traits::is_projected<Proj2, InIter2>::value&&
+            traits::is_indirect_callable<ExPolicy, F,
+                traits::projected_range<Proj1, Rng>,
+                traits::projected<Proj2, InIter2>>::value)>
+    // clang-format on
     HPX_DEPRECATED_V(1, 6,
         "hpx::parallel::transform is deprecated, use hpx::ranges::transform "
-        "instead")
-    typename util::detail::algorithm_result<ExPolicy,
+        "instead") typename util::detail::algorithm_result<ExPolicy,
         util::in_in_out_result<typename hpx::traits::range_iterator<Rng>::type,
             InIter2, OutIter>>::type
         transform(ExPolicy&& policy, Rng&& rng, InIter2 first2, OutIter dest,
@@ -460,21 +464,24 @@ namespace hpx { namespace parallel { inline namespace v1 {
             std::forward<Proj2>(proj2));
     }
 
+    // clang-format off
     template <typename ExPolicy, typename Rng1, typename Rng2, typename OutIter,
         typename F, typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng1>::value&& hpx::traits::is_range<
-                    Rng2>::value&& hpx::traits::is_iterator<OutIter>::value&&
-                    traits::is_projected_range<Proj1, Rng1>::value&&
-                        traits::is_projected_range<Proj2, Rng2>::value&&
-                            traits::is_indirect_callable<ExPolicy, F,
-                                traits::projected_range<Proj1, Rng1>,
-                                traits::projected_range<Proj2, Rng2>>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value&&
+            hpx::traits::is_range<Rng1>::value&& 
+            hpx::traits::is_range<Rng2>::value&& 
+            hpx::traits::is_iterator<OutIter>::value&&
+            traits::is_projected_range<Proj1, Rng1>::value&&
+            traits::is_projected_range<Proj2, Rng2>::value&&
+                traits::is_indirect_callable<ExPolicy, F,
+                traits::projected_range<Proj1, Rng1>,
+                traits::projected_range<Proj2, Rng2>>::value)>
+    // clang-format on
     HPX_DEPRECATED_V(1, 6,
         "hpx::parallel::transform is deprecated, use hpx::ranges::transform "
-        "instead")
-    typename util::detail::algorithm_result<ExPolicy,
+        "instead") typename util::detail::algorithm_result<ExPolicy,
         util::in_in_out_result<typename hpx::traits::range_iterator<Rng1>::type,
             typename hpx::traits::range_iterator<Rng2>::type, OutIter>>::type
         transform(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2, OutIter dest,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
@@ -9,24 +9,10 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/concepts/concepts.hpp>
-#include <hpx/iterator_support/range.hpp>
-#include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/iterator_support/traits/is_range.hpp>
-#include <hpx/parallel/util/result_types.hpp>
-#include <hpx/parallel/util/tagged_pair.hpp>
-#include <hpx/parallel/util/tagged_tuple.hpp>
+#if defined(DOXYGEN)
+namespace hpx {
+    // clang-format off
 
-#include <hpx/algorithms/traits/projected_range.hpp>
-#include <hpx/parallel/algorithms/transform.hpp>
-#include <hpx/parallel/tagspec.hpp>
-#include <hpx/parallel/util/projection_identity.hpp>
-
-#include <type_traits>
-#include <utility>
-
-namespace hpx { namespace parallel { inline namespace v1 {
     /// Applies the given function \a f to the given range \a rng and stores
     /// the result in another range, beginning at dest.
     ///
@@ -65,7 +51,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///                     \endcode \n
     ///                     The signature does not need to have const&.
     ///                     The type \a Type must be such that an object of
-    ///                     type \a InIter can be dereferenced and then
+    ///                     type \a range_iterator<Rng>::type can be dereferenced and then
     ///                     implicitly converted to \a Type. The type \a Ret
     ///                     must be such that an object of type \a OutIter can
     ///                     be dereferenced and assigned a value of type
@@ -86,9 +72,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// within each thread.
     ///
     /// \returns  The \a transform algorithm returns a
-    ///           \a hpx::future<tagged_pair<tag::in(InIter), tag::out(OutIter)> >
+    ///           \a hpx::future<ranges::unary_transform_result<range_iterator<Rng>::type, OutIter> >
     ///           if the execution policy is of type \a parallel_task_policy
-    ///           and returns \a tagged_pair<tag::in(InIter), tag::out(OutIter)>
+    ///           and returns \a ranges::unary_transform_result<range_iterator<Rng>::type, OutIter>
     ///           otherwise.
     ///           The \a transform algorithm returns a tuple holding an iterator
     ///           referring to the first element after the input sequence and
@@ -97,22 +83,95 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           copied.
     ///
     template <typename ExPolicy, typename Rng, typename OutIter, typename F,
-        typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
-                    OutIter>::value&& traits::is_projected_range<Proj,
-                    Rng>::value&& traits::is_indirect_callable<ExPolicy, F,
-                    traits::projected_range<Proj, Rng>>::value)>
+        typename Proj = util::projection_identity>
     typename util::detail::algorithm_result<ExPolicy,
-        util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
+        ranges::unary_transform_result<
+            typename hpx::traits::range_iterator<Rng>::type,
             OutIter>>::type
-    transform(
-        ExPolicy&& policy, Rng&& rng, OutIter dest, F&& f, Proj&& proj = Proj())
-    {
-        return transform(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
-            hpx::util::end(rng), std::move(dest), std::forward<F>(f),
-            std::forward<Proj>(proj));
-    }
+    transform(ExPolicy&& policy, Rng&& rng, OutIter dest, F&& f, Proj&& proj = Proj());
+
+    /// Applies the given function \a f to the given range \a rng and stores
+    /// the result in another range, beginning at dest.
+    ///
+    /// \note   Complexity: Exactly size(rng) applications of \a f
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the invocations of \a f.
+    /// \tparam FwdIter1    The type of the source iterators for the first
+    ///                     range used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent1       The type of the end source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     sentinel for FwdIter1.
+    /// \tparam FwdIter2    The type of the source iterators for the first
+    ///                     range used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a transform requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the first sequence of
+    ///                     elements the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&.
+    ///                     The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to \a Type. The type \a Ret
+    ///                     must be such that an object of type \a FwdIter2 can
+    ///                     be dereferenced and assigned a value of type
+    ///                     \a Ret.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a f is invoked.
+    ///
+    /// The invocations of \a f in the parallel \a transform algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The invocations of \a f in the parallel \a transform algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a transform algorithm returns a
+    ///           \a hpx::future<ranges::unary_transform_result<FwdIter1, FwdIter2> >
+    ///           if the execution policy is of type \a parallel_task_policy
+    ///           and returns \a ranges::unary_transform_result<FwdIter1, FwdIter2>
+    ///           otherwise.
+    ///           The \a transform algorithm returns a tuple holding an iterator
+    ///           referring to the first element after the input sequence and
+    ///           the output iterator to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename Sent1,
+            typename FwdIter2, typename F,
+            typename Proj = hpx::parallel::util::projection_identity>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+            ranges::unary_transform_result<FwdIter1, FwdIter2>>::type
+    transform(ExPolicy&& policy, FwdIter1 first,
+            Sent1 last, FwdIter2 dest, F&& f, Proj&& proj = Proj());
 
     /// Applies the given function \a f to pairs of elements from two ranges:
     /// one defined by \a rng and the other beginning at first2, and
@@ -124,17 +183,24 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///                     It describes the manner in which the execution
     ///                     of the algorithm may be parallelized and the manner
     ///                     in which it executes the invocations of \a f.
-    /// \tparam Rng         The type of the source range used (deduced).
-    ///                     The iterators extracted from this range type must
-    ///                     meet the requirements of an input iterator.
-    /// \tparam InIter2     The type of the source iterators for the second
+    /// \tparam FwdIter1    The type of the source iterators for the first
     ///                     range used (deduced).
     ///                     This iterator type must meet the requirements of an
-    ///                     input iterator.
-    /// \tparam OutIter     The type of the iterator representing the
-    ///                     destination range (deduced).
+    ///                     forward iterator.
+    /// \tparam Sent1       The type of the end source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
-    ///                     output iterator.
+    ///                     sentinel for FwdIter1.
+    /// \tparam FwdIter2    The type of the source iterators for the first
+    ///                     range used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent2       The type of the end source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     sentinel for FwdIter2.
+    /// \tparam FwdIter3    The type of the source iterators for the first
+    ///                     range used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
     /// \tparam F           The type of the function/function object to use
     ///                     (deduced). Unlike its sequential form, the parallel
     ///                     overload of \a transform requires \a F to meet the
@@ -148,10 +214,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
-    /// \param rng          Refers to the sequence of elements the algorithm
-    ///                     will be applied to.
+    /// \param first1       Refers to the beginning of the first sequence of
+    ///                     elements the algorithm will be applied to.
+    /// \param last1        Refers to the end of the first sequence of elements
+    ///                     the algorithm will be applied to.
     /// \param first2       Refers to the beginning of the second sequence of
     ///                     elements the algorithm will be applied to.
+    /// \param last2        Refers to the end of the second sequence of elements
+    ///                     the algorithm will be applied to.
     /// \param dest         Refers to the beginning of the destination range.
     /// \param f            Specifies the function (or function object) which
     ///                     will be invoked for each of the elements in the
@@ -163,10 +233,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///                     \endcode \n
     ///                     The signature does not need to have const&.
     ///                     The types \a Type1 and \a Type2 must be such that
-    ///                     objects of types InIter1 and InIter2 can be
+    ///                     objects of types FwdIter1 and FwdIter2 can be
     ///                     dereferenced and then implicitly converted to
     ///                     \a Type1 and \a Type2 respectively. The type \a Ret
-    ///                     must be such that an object of type \a OutIter can
+    ///                     must be such that an object of type \a FwdIter3 can
     ///                     be dereferenced and assigned a value of type
     ///                     \a Ret.
     /// \param proj1        Specifies the function (or function object) which
@@ -189,10 +259,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// within each thread.
     ///
     /// \returns  The \a transform algorithm returns a
-    /// \a hpx::future<tagged_tuple<tag::in1(InIter1), tag::in2(InIter2), tag::out(OutIter)> >
+    /// \a hpx::future<ranges::binary_transform_result<FwdIter1, FwdIter2, FwdIter3> >
     ///           if the execution policy is of type \a parallel_task_policy
     ///           and returns
-    /// \a tagged_tuple<tag::in1(InIter1), tag::in2(InIter2), tag::out(OutIter)>
+    /// \a ranges::binary_transform_result<FwdIter1, FwdIter2, FwdIter3>
     ///           otherwise.
     ///           The \a transform algorithm returns a tuple holding an iterator
     ///           referring to the first element after the first input sequence,
@@ -201,29 +271,15 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           element in the destination range, one past the last element
     ///           copied.
     ///
-    template <typename ExPolicy, typename Rng, typename InIter2,
-        typename OutIter, typename F,
-        typename Proj1 = util::projection_identity,
-        typename Proj2 = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
-                    InIter2>::value&& hpx::traits::is_iterator<OutIter>::value&&
-                    traits::is_projected_range<Proj1, Rng>::value&&
-                        traits::is_projected<Proj2, InIter2>::value&&
-                            traits::is_indirect_callable<ExPolicy, F,
-                                traits::projected_range<Proj1, Rng>,
-                                traits::projected<Proj2, InIter2>>::value)>
-    typename util::detail::algorithm_result<ExPolicy,
-        util::in_in_out_result<typename hpx::traits::range_iterator<Rng>::type,
-            InIter2, OutIter>>::type
-    transform(ExPolicy&& policy, Rng&& rng, InIter2 first2, OutIter dest, F&& f,
-        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
-    {
-        return transform(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
-            hpx::util::end(rng), std::move(first2), std::move(dest),
-            std::forward<F>(f), std::forward<Proj1>(proj1),
-            std::forward<Proj2>(proj2));
-    }
+    template <typename ExPolicy, typename FwdIter1, typename Sent1,
+        typename FwdIter2, typename Sent2, typename FwdIter3, typename F,
+        typename Proj1 = hpx::parallel::util::projection_identity,
+        typename Proj2 = hpx::parallel::util::projection_identity>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        ranges::binary_transform_result<FwdIter1, FwdIter2, FwdIter3>>::type
+    transform(ExPolicy&& policy, FwdIter1 first1,
+        Sent1 last1, FwdIter2 first2, Sent2 last2, FwdIter3 dest, F&& f,
+        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
 
     /// Applies the given function \a f to pairs of elements from two ranges:
     /// one defined by [first1, last1) and the other beginning at first2, and
@@ -242,7 +298,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// \tparam Rng2        The type of the second source range used (deduced).
     ///                     The iterators extracted from this range type must
     ///                     meet the requirements of an input iterator.
-    /// \tparam OutIter     The type of the iterator representing the
+    /// \tparam FwdIter     The type of the iterator representing the
     ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     output iterator.
@@ -274,10 +330,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///                     \endcode \n
     ///                     The signature does not need to have const&.
     ///                     The types \a Type1 and \a Type2 must be such that
-    ///                     objects of types InIter1 and InIter2 can be
+    ///                     objects of types range_iterator<Rng1>::type and
+    ///                     range_iterator<Rng2>::type can be
     ///                     dereferenced and then implicitly converted to
     ///                     \a Type1 and \a Type2 respectively. The type \a Ret
-    ///                     must be such that an object of type \a OutIter can
+    ///                     must be such that an object of type \a FwdIter can
     ///                     be dereferenced and assigned a value of type
     ///                     \a Ret.
     /// \param proj1        Specifies the function (or function object) which
@@ -303,18 +360,106 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///       the end of the shorter of the two given input sequences
     ///
     /// \returns  The \a transform algorithm returns a
-    /// \a hpx::future<tagged_tuple<tag::in1(InIter1), tag::in2(InIter2), tag::out(OutIter)> >
+    /// \a hpx::future<ranges::binary_transform_result<
+    ///           typename hpx::traits::range_iterator<Rng1>::type,
+    ///           typename hpx::traits::range_iterator<Rng2>::type,
+    ///           FwdIter> >
     ///           if the execution policy is of type \a parallel_task_policy
     ///           and returns
-    /// \a tagged_tuple<tag::in1(InIter1), tag::in2(InIter2), tag::out(OutIter)>
+    /// \a ranges::binary_transform_result<
+    ///           typename hpx::traits::range_iterator<Rng1>::type,
+    ///           typename hpx::traits::range_iterator<Rng2>::type,
+    ///           FwdIter>
     ///           otherwise.
     ///           The \a transform algorithm returns a tuple holding an iterator
-    ///           referring to the first element         r the first input sequence,
+    ///           referring to the first element after the first input sequence,
     ///           an iterator referring to the first element after the second
     ///           input sequence, and the output iterator referring to the
     ///           element in the destination range, one past the last element
     ///           copied.
     ///
+    template <typename ExPolicy, typename Rng1, typename Rng2, typename FwdIter,
+        typename F, typename Proj1 = hpx::parallel::util::projection_identity,
+        typename Proj2 = hpx::parallel::util::projection_identity>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        ranges::binary_transform_result<
+            typename hpx::traits::range_iterator<Rng1>::type,
+            typename hpx::traits::range_iterator<Rng2>::type,
+            FwdIter>>::type
+    tag_invoke(hpx::ranges::transform_t, ExPolicy&& policy, Rng1&& rng1,
+        Rng2&& rng2, FwdIter dest, F&& f, Proj1&& proj1 = Proj1(),
+        Proj2&& proj2 = Proj2())
+
+    // clang-format on
+}    // namespace hpx
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/iterator_support/traits/is_range.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+#include <hpx/parallel/util/tagged_pair.hpp>
+#include <hpx/parallel/util/tagged_tuple.hpp>
+
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/parallel/algorithms/transform.hpp>
+#include <hpx/parallel/tagspec.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1 {
+
+    template <typename ExPolicy, typename Rng, typename OutIter, typename F,
+        typename Proj = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+                hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
+                    OutIter>::value&& traits::is_projected_range<Proj,
+                    Rng>::value&& traits::is_indirect_callable<ExPolicy, F,
+                    traits::projected_range<Proj, Rng>>::value)>
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::transform is deprecated, use hpx::ranges::transform "
+        "instead")
+    typename util::detail::algorithm_result<ExPolicy,
+        util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
+            OutIter>>::type transform(ExPolicy&& policy, Rng&& rng,
+        OutIter dest, F&& f, Proj&& proj = Proj())
+    {
+        return transform(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+            hpx::util::end(rng), std::move(dest), std::forward<F>(f),
+            std::forward<Proj>(proj));
+    }
+
+    template <typename ExPolicy, typename Rng, typename InIter2,
+        typename OutIter, typename F,
+        typename Proj1 = util::projection_identity,
+        typename Proj2 = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+                hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
+                    InIter2>::value&& hpx::traits::is_iterator<OutIter>::value&&
+                    traits::is_projected_range<Proj1, Rng>::value&&
+                        traits::is_projected<Proj2, InIter2>::value&&
+                            traits::is_indirect_callable<ExPolicy, F,
+                                traits::projected_range<Proj1, Rng>,
+                                traits::projected<Proj2, InIter2>>::value)>
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::transform is deprecated, use hpx::ranges::transform "
+        "instead")
+    typename util::detail::algorithm_result<ExPolicy,
+        util::in_in_out_result<typename hpx::traits::range_iterator<Rng>::type,
+            InIter2, OutIter>>::type
+        transform(ExPolicy&& policy, Rng&& rng, InIter2 first2, OutIter dest,
+            F&& f, Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+    {
+        return transform(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+            hpx::util::end(rng), std::move(first2), std::move(dest),
+            std::forward<F>(f), std::forward<Proj1>(proj1),
+            std::forward<Proj2>(proj2));
+    }
+
     template <typename ExPolicy, typename Rng1, typename Rng2, typename OutIter,
         typename F, typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
@@ -326,11 +471,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             traits::is_indirect_callable<ExPolicy, F,
                                 traits::projected_range<Proj1, Rng1>,
                                 traits::projected_range<Proj2, Rng2>>::value)>
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::transform is deprecated, use hpx::ranges::transform "
+        "instead")
     typename util::detail::algorithm_result<ExPolicy,
         util::in_in_out_result<typename hpx::traits::range_iterator<Rng1>::type,
             typename hpx::traits::range_iterator<Rng2>::type, OutIter>>::type
-    transform(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2, OutIter dest, F&& f,
-        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        transform(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2, OutIter dest,
+            F&& f, Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
     {
         return transform(std::forward<ExPolicy>(policy), hpx::util::begin(rng1),
             hpx::util::end(rng1), hpx::util::begin(rng2), hpx::util::end(rng2),
@@ -378,7 +526,7 @@ namespace hpx { namespace ranges {
 
         // clang-format off
         template <typename ExPolicy, typename Rng, typename FwdIter,
-        typename F, typename Proj = hpx::parallel::util::projection_identity,
+            typename F, typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value &&
@@ -404,9 +552,9 @@ namespace hpx { namespace ranges {
 
         // clang-format off
         template <typename ExPolicy, typename FwdIter1, typename Sent1,
-        typename FwdIter2, typename Sent2, typename FwdIter3, typename F,
-        typename Proj1 = hpx::parallel::util::projection_identity,
-        typename Proj2 = hpx::parallel::util::projection_identity,
+            typename FwdIter2, typename Sent2, typename FwdIter3, typename F,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
@@ -422,7 +570,9 @@ namespace hpx { namespace ranges {
             Sent1 last1, FwdIter2 first2, Sent2 last2, FwdIter3 dest, F&& f,
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
-            typedef hpx::traits::is_segmented_iterator<FwdIter1> is_segmented;
+            using is_segmented = std::integral_constant<bool,
+                hpx::traits::is_segmented_iterator<FwdIter1>::value ||
+                    hpx::traits::is_segmented_iterator<FwdIter2>::value>;
 
             return parallel::v1::detail::transform_(
                 std::forward<ExPolicy>(policy), first1, last1, first2, last2,
@@ -432,8 +582,8 @@ namespace hpx { namespace ranges {
 
         // clang-format off
         template <typename ExPolicy, typename Rng1, typename Rng2, typename FwdIter,
-        typename F, typename Proj1 = hpx::parallel::util::projection_identity,
-        typename Proj2 = hpx::parallel::util::projection_identity,
+            typename F, typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng1>::value &&
@@ -450,10 +600,14 @@ namespace hpx { namespace ranges {
             Rng2&& rng2, FwdIter dest, F&& f, Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
         {
-            using iterator_type =
+            using iterator_type1 =
                 typename hpx::traits::range_traits<Rng1>::iterator_type;
-            using is_segmented =
-                hpx::traits::is_segmented_iterator<iterator_type>;
+            using iterator_type2 =
+                typename hpx::traits::range_traits<Rng2>::iterator_type;
+
+            using is_segmented = std::integral_constant<bool,
+                hpx::traits::is_segmented_iterator<iterator_type1>::value ||
+                    hpx::traits::is_segmented_iterator<iterator_type2>::value>;
 
             return parallel::v1::detail::transform_(
                 std::forward<ExPolicy>(policy), hpx::util::begin(rng1),
@@ -485,7 +639,7 @@ namespace hpx { namespace ranges {
 
         // clang-format off
         template <typename Rng, typename FwdIter,
-        typename F, typename Proj = hpx::parallel::util::projection_identity,
+            typename F, typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::traits::is_range<Rng>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
@@ -504,9 +658,9 @@ namespace hpx { namespace ranges {
 
         // clang-format off
         template <typename FwdIter1, typename Sent1,
-        typename FwdIter2, typename Sent2, typename FwdIter3, typename F,
-        typename Proj1 = hpx::parallel::util::projection_identity,
-        typename Proj2 = hpx::parallel::util::projection_identity,
+            typename FwdIter2, typename Sent2, typename FwdIter3, typename F,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
@@ -528,8 +682,8 @@ namespace hpx { namespace ranges {
 
         // clang-format off
         template <typename Rng1, typename Rng2, typename FwdIter,
-        typename F, typename Proj1 = hpx::parallel::util::projection_identity,
-        typename Proj2 = hpx::parallel::util::projection_identity,
+            typename F, typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::traits::is_range<Rng1>::value &&
                 hpx::traits::is_range<Rng2>::value &&
@@ -553,3 +707,5 @@ namespace hpx { namespace ranges {
 
     } transform{};
 }}    // namespace hpx::ranges
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2020 Gianis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -322,6 +322,21 @@ namespace hpx { namespace parallel { namespace util {
             return lcos::make_future<O>(std::move(f),
                 [](util::in_out_result<I, O>&& p) { return p.out; });
         }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename I1, typename I2, typename O>
+        O get_third_element(util::in_in_out_result<I1, I2, O>&& p)
+        {
+            return p.out;
+        }
+
+        template <typename I1, typename I2, typename O>
+        hpx::future<O> get_third_element(
+            hpx::future<util::in_in_out_result<I1, I2, O>>&& f)
+        {
+            return lcos::make_future<O>(std::move(f),
+                [](util::in_in_out_result<I1, I2, O>&& p) { return p.out; });
+        }
     }    // namespace detail
 }}}      // namespace hpx::parallel::util
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -153,6 +153,35 @@ namespace hpx { namespace parallel { namespace util {
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    template <typename I1, typename I2, typename O>
+    struct in_in_out_result
+    {
+        HPX_NO_UNIQUE_ADDRESS I1 in1;
+        HPX_NO_UNIQUE_ADDRESS I2 in2;
+        HPX_NO_UNIQUE_ADDRESS O out;
+
+        template <typename II1, typename II2, typename OO,
+            typename Enable = typename std::enable_if<
+                std::is_convertible<I1 const&, II1&>::value &&
+                std::is_convertible<I2 const&, II2&>::value &&
+                std::is_convertible<O const&, OO&>::value>::type>
+        constexpr operator in_in_out_result<II1, II2, OO>() const&
+        {
+            return {in1, in2, out};
+        }
+
+        template <typename II1, typename II2, typename OO,
+            typename Enable =
+                typename std::enable_if<std::is_convertible<I1, II1>::value &&
+                    std::is_convertible<I2, II2>::value &&
+                    std::is_convertible<O, OO>::value>::type>
+        constexpr operator in_in_out_result<II1, II2, OO>() &&
+        {
+            return {std::move(in1), std::move(in2), std::move(out)};
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
     template <typename I, typename F>
     struct in_fun_result
     {

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -224,6 +224,21 @@ namespace hpx { namespace parallel { namespace util {
                     return get_in_out_result(std::move(zipiter));
                 });
         }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename I, typename O>
+        O get_second_element(util::in_out_result<I, O>&& p)
+        {
+            return p.out;
+        }
+
+        template <typename I, typename O>
+        hpx::future<O> get_second_element(
+            hpx::future<util::in_out_result<I, O>>&& f)
+        {
+            return lcos::make_future<O>(
+                std::move(f), [](util::in_out_result<I, O>&& p) { return p.out; });
+        }
     }    // namespace detail
 }}}      // namespace hpx::parallel::util
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/transform_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/transform_loop.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2020 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,6 +12,7 @@
 #include <hpx/execution/traits/is_execution_policy.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/parallel/util/cancellation_token.hpp>
+#include <hpx/parallel/util/result_types.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -25,21 +27,23 @@ namespace hpx { namespace parallel { namespace util {
         struct transform_loop
         {
             template <typename InIter, typename OutIter, typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static std::pair<InIter, OutIter>
-            call(InIter first, InIter last, OutIter dest, F&& f)
+            HPX_HOST_DEVICE
+                HPX_FORCEINLINE static util::in_out_result<InIter, OutIter>
+                call(InIter first, InIter last, OutIter dest, F&& f)
             {
                 for (/* */; first != last; (void) ++first, ++dest)
                 {
                     *dest = hpx::util::invoke(std::forward<F>(f), first);
                 }
-                return std::make_pair(std::move(first), std::move(dest));
+                return util::in_out_result<InIter, OutIter>{
+                    std::move(first), std::move(dest)};
             }
         };
     }    // namespace detail
 
     template <typename ExPolicy, typename Iter, typename OutIter, typename F>
-    HPX_HOST_DEVICE HPX_FORCEINLINE std::pair<Iter, OutIter> transform_loop(
-        ExPolicy&&, Iter it, Iter end, OutIter dest, F&& f)
+    HPX_HOST_DEVICE HPX_FORCEINLINE util::in_out_result<Iter, OutIter>
+    transform_loop(ExPolicy&&, Iter it, Iter end, OutIter dest, F&& f)
     {
         return detail::transform_loop<Iter>::call(
             it, end, dest, std::forward<F>(f));

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/transform_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/transform_loop.hpp
@@ -56,26 +56,26 @@ namespace hpx { namespace parallel { namespace util {
         {
             template <typename InIter1, typename InIter2, typename OutIter,
                 typename F>
-            HPX_HOST_DEVICE
-                HPX_FORCEINLINE static hpx::tuple<InIter1, InIter2, OutIter>
-                call(InIter1 first1, InIter1 last1, InIter2 first2,
-                    OutIter dest, F&& f)
+            HPX_HOST_DEVICE HPX_FORCEINLINE static util::in_in_out_result<
+                InIter1, InIter2, OutIter>
+            call(InIter1 first1, InIter1 last1, InIter2 first2, OutIter dest,
+                F&& f)
             {
                 for (/* */; first1 != last1; (void) ++first1, ++first2, ++dest)
                 {
                     *dest =
                         hpx::util::invoke(std::forward<F>(f), first1, first2);
                 }
-                return hpx::make_tuple(
-                    std::move(first1), std::move(first2), std::move(dest));
+                return util::in_in_out_result<InIter1, InIter2, OutIter>{
+                    std::move(first1), std::move(first2), std::move(dest)};
             }
 
             template <typename InIter1, typename InIter2, typename OutIter,
                 typename F>
-            HPX_HOST_DEVICE
-                HPX_FORCEINLINE static hpx::tuple<InIter1, InIter2, OutIter>
-                call(InIter1 first1, InIter1 last1, InIter2 first2,
-                    InIter2 last2, OutIter dest, F&& f)
+            HPX_HOST_DEVICE HPX_FORCEINLINE static util::in_in_out_result<
+                InIter1, InIter2, OutIter>
+            call(InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
+                OutIter dest, F&& f)
             {
                 for (/* */; first1 != last1 && first2 != last2;
                      (void) ++first1, ++first2, ++dest)
@@ -83,7 +83,8 @@ namespace hpx { namespace parallel { namespace util {
                     *dest =
                         hpx::util::invoke(std::forward<F>(f), first1, first2);
                 }
-                return hpx::make_tuple(first1, first2, dest);
+                return util::in_in_out_result<InIter1, InIter2, OutIter>{
+                    first1, first2, dest};
             }
         };
     }    // namespace detail
@@ -91,8 +92,8 @@ namespace hpx { namespace parallel { namespace util {
     template <typename ExPolicy, typename InIter1, typename InIter2,
         typename OutIter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
-        !hpx::is_vectorpack_execution_policy<ExPolicy>::value,
-        hpx::tuple<InIter1, InIter2, OutIter>>::type
+        !execution::is_vectorpack_execution_policy<ExPolicy>::value,
+        util::in_in_out_result<InIter1, InIter2, OutIter>>::type
     transform_binary_loop(
         InIter1 first1, InIter1 last1, InIter2 first2, OutIter dest, F&& f)
     {
@@ -103,8 +104,8 @@ namespace hpx { namespace parallel { namespace util {
     template <typename ExPolicy, typename InIter1, typename InIter2,
         typename OutIter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
-        !hpx::is_vectorpack_execution_policy<ExPolicy>::value,
-        hpx::tuple<InIter1, InIter2, OutIter>>::type
+        !execution::is_vectorpack_execution_policy<ExPolicy>::value,
+        util::in_in_out_result<InIter1, InIter2, OutIter>>::type
     transform_binary_loop(InIter1 first1, InIter1 last1, InIter2 first2,
         InIter2 last2, OutIter dest, F&& f)
     {

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform.cpp
@@ -19,6 +19,8 @@ void test_transform()
 {
     using namespace hpx::execution;
 
+    test_transform(IteratorTag());
+
     test_transform(seq, IteratorTag());
     test_transform(par, IteratorTag());
     test_transform(par_unseq, IteratorTag());
@@ -38,6 +40,7 @@ void test_transform_exception()
 {
     using namespace hpx::execution;
 
+    test_transform_exception(IteratorTag());
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary2_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary2_tests.hpp
@@ -67,9 +67,9 @@ void test_transform_binary2(ExPolicy policy, IteratorTag)
         iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(d1),
         add());
 
-    HPX_TEST(hpx::get<0>(result) == iterator(std::end(c1)));
-    HPX_TEST(hpx::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::get<2>(result) == std::end(d1));
+    HPX_TEST(result.in1 == iterator(std::end(c1)));
+    HPX_TEST(result.in2 == std::end(c2));
+    HPX_TEST(result.out == std::end(d1));
 
     // verify values
     std::vector<int> d2(c1.size());
@@ -105,10 +105,10 @@ void test_transform_binary2_async(ExPolicy p, IteratorTag)
         add());
     f.wait();
 
-    hpx::tuple<iterator, base_iterator, base_iterator> result = f.get();
-    HPX_TEST(hpx::get<0>(result) == iterator(std::end(c1)));
-    HPX_TEST(hpx::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::get<2>(result) == std::end(d1));
+    auto result = f.get();
+    HPX_TEST(result.in1 == iterator(std::end(c1)));
+    HPX_TEST(result.in2 == std::end(c2));
+    HPX_TEST(result.out == std::end(d1));
 
     // verify values
     std::vector<int> d2(c1.size());

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary2_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary2_tests.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2016 Hartmut Kaiser
+//  Copyright (c) 2020 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -46,6 +47,43 @@ struct throw_bad_alloc
 };
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_binary2(IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c1(10007);
+    std::vector<int> c2(c1.size());
+    std::vector<int> d1(c1.size());    //-V656
+    std::iota(std::begin(c1), std::end(c1),
+        std::rand() % ((std::numeric_limits<int>::max)() / 2));
+    std::iota(std::begin(c2), std::end(c2),
+        std::rand() % ((std::numeric_limits<int>::max)() / 2));
+
+    auto result =
+        hpx::ranges::transform(iterator(std::begin(c1)), iterator(std::end(c1)),
+            std::begin(c2), std::end(c2), std::begin(d1), add());
+
+    HPX_TEST(result.in1 == iterator(std::end(c1)));
+    HPX_TEST(result.in2 == std::end(c2));
+    HPX_TEST(result.out == std::end(d1));
+
+    // verify values
+    std::vector<int> d2(c1.size());
+    std::transform(
+        std::begin(c1), std::end(c1), std::begin(c2), std::begin(d2), add());
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(d1), std::end(d1), std::begin(d2),
+        [&count](int v1, int v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d2.size());
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary2(ExPolicy policy, IteratorTag)
 {
@@ -63,7 +101,7 @@ void test_transform_binary2(ExPolicy policy, IteratorTag)
     std::iota(std::begin(c2), std::end(c2),
         std::rand() % ((std::numeric_limits<int>::max)() / 2));
 
-    auto result = hpx::parallel::transform(policy, iterator(std::begin(c1)),
+    auto result = hpx::ranges::transform(policy, iterator(std::begin(c1)),
         iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(d1),
         add());
 
@@ -100,7 +138,7 @@ void test_transform_binary2_async(ExPolicy p, IteratorTag)
     std::iota(std::begin(c2), std::end(c2),
         std::rand() % ((std::numeric_limits<int>::max)() / 2));
 
-    auto f = hpx::parallel::transform(p, iterator(std::begin(c1)),
+    auto f = hpx::ranges::transform(p, iterator(std::begin(c1)),
         iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(d1),
         add());
     f.wait();
@@ -126,6 +164,40 @@ void test_transform_binary2_async(ExPolicy p, IteratorTag)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_binary2_exception(IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c1(10007);
+    std::vector<int> c2(c1.size());
+    std::vector<int> d1(c1.size());    //-V656
+    std::iota(std::begin(c1), std::end(c1), std::rand());
+    std::iota(std::begin(c2), std::end(c2), std::rand());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::ranges::transform(iterator(std::begin(c1)), iterator(std::end(c1)),
+            std::begin(c2), std::end(c2), std::begin(d1), throw_always());
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
+            IteratorTag>::call(hpx::parallel::execution::seq, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary2_exception(ExPolicy policy, IteratorTag)
 {
@@ -144,7 +216,7 @@ void test_transform_binary2_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::transform(policy, iterator(std::begin(c1)),
+        hpx::ranges::transform(policy, iterator(std::begin(c1)),
             iterator(std::end(c1)), std::begin(c2), std::end(c2),
             std::begin(d1), throw_always());
 
@@ -179,7 +251,7 @@ void test_transform_binary2_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::transform(p, iterator(std::begin(c1)),
+        auto f = hpx::ranges::transform(p, iterator(std::begin(c1)),
             iterator(std::end(c1)), std::begin(c2), std::end(c2),
             std::begin(d1), throw_always());
         returned_from_algorithm = true;
@@ -220,7 +292,7 @@ void test_transform_binary2_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::transform(policy, iterator(std::begin(c1)),
+        hpx::ranges::transform(policy, iterator(std::begin(c1)),
             iterator(std::end(c1)), std::begin(c2), std::end(c2),
             std::begin(d1), throw_bad_alloc());
 
@@ -254,7 +326,7 @@ void test_transform_binary2_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::transform(p, iterator(std::begin(c1)),
+        auto f = hpx::ranges::transform(p, iterator(std::begin(c1)),
             iterator(std::end(c1)), std::begin(c2), std::end(c2),
             std::begin(d1), throw_bad_alloc());
         returned_from_algorithm = true;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary_tests.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2016 Hartmut Kaiser
+//  Copyright (c) 2020 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -66,9 +67,9 @@ void test_transform_binary(ExPolicy policy, IteratorTag)
     auto result = hpx::parallel::transform(policy, iterator(std::begin(c1)),
         iterator(std::end(c1)), std::begin(c2), std::begin(d1), add());
 
-    HPX_TEST(hpx::get<0>(result) == iterator(std::end(c1)));
-    HPX_TEST(hpx::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::get<2>(result) == std::end(d1));
+    HPX_TEST(result.in1 == iterator(std::end(c1)));
+    HPX_TEST(result.in2 == std::end(c2));
+    HPX_TEST(result.out == std::end(d1));
 
     // verify values
     std::vector<int> d2(c1.size());
@@ -103,10 +104,10 @@ void test_transform_binary_async(ExPolicy p, IteratorTag)
         iterator(std::end(c1)), std::begin(c2), std::begin(d1), add());
     f.wait();
 
-    hpx::tuple<iterator, base_iterator, base_iterator> result = f.get();
-    HPX_TEST(hpx::get<0>(result) == iterator(std::end(c1)));
-    HPX_TEST(hpx::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::get<2>(result) == std::end(d1));
+    auto result = f.get();
+    HPX_TEST(result.in1 == iterator(std::end(c1)));
+    HPX_TEST(result.in2 == std::end(c2));
+    HPX_TEST(result.out == std::end(d1));
 
     // verify values
     std::vector<int> d2(c1.size());

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary_tests.hpp
@@ -47,6 +47,40 @@ struct throw_bad_alloc
 };
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_binary(IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c1(10007);
+    std::vector<int> c2(c1.size());
+    std::vector<int> d1(c1.size());    //-V656
+    std::iota(std::begin(c1), std::end(c1),
+        std::rand() % ((std::numeric_limits<int>::max)() / 2));
+    std::iota(std::begin(c2), std::end(c2),
+        std::rand() % ((std::numeric_limits<int>::max)() / 2));
+
+    auto result = hpx::transform(iterator(std::begin(c1)),
+        iterator(std::end(c1)), std::begin(c2), std::begin(d1), add());
+
+    HPX_TEST(result == std::end(d1));
+
+    // verify values
+    std::vector<int> d2(c1.size());
+    std::transform(
+        std::begin(c1), std::end(c1), std::begin(c2), std::begin(d2), add());
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(d1), std::end(d1), std::begin(d2),
+        [&count](int v1, int v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d2.size());
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary(ExPolicy policy, IteratorTag)
 {
@@ -64,12 +98,10 @@ void test_transform_binary(ExPolicy policy, IteratorTag)
     std::iota(std::begin(c2), std::end(c2),
         std::rand() % ((std::numeric_limits<int>::max)() / 2));
 
-    auto result = hpx::parallel::transform(policy, iterator(std::begin(c1)),
+    auto result = hpx::transform(policy, iterator(std::begin(c1)),
         iterator(std::end(c1)), std::begin(c2), std::begin(d1), add());
 
-    HPX_TEST(result.in1 == iterator(std::end(c1)));
-    HPX_TEST(result.in2 == std::end(c2));
-    HPX_TEST(result.out == std::end(d1));
+    HPX_TEST(result == std::end(d1));
 
     // verify values
     std::vector<int> d2(c1.size());
@@ -100,14 +132,12 @@ void test_transform_binary_async(ExPolicy p, IteratorTag)
     std::iota(std::begin(c2), std::end(c2),
         std::rand() % ((std::numeric_limits<int>::max)() / 2));
 
-    auto f = hpx::parallel::transform(p, iterator(std::begin(c1)),
-        iterator(std::end(c1)), std::begin(c2), std::begin(d1), add());
+    auto f = hpx::transform(p, iterator(std::begin(c1)), iterator(std::end(c1)),
+        std::begin(c2), std::begin(d1), add());
     f.wait();
 
     auto result = f.get();
-    HPX_TEST(result.in1 == iterator(std::end(c1)));
-    HPX_TEST(result.in2 == std::end(c2));
-    HPX_TEST(result.out == std::end(d1));
+    HPX_TEST(result == std::end(d1));
 
     // verify values
     std::vector<int> d2(c1.size());
@@ -125,6 +155,40 @@ void test_transform_binary_async(ExPolicy p, IteratorTag)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_binary_exception(IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c1(10007);
+    std::vector<int> c2(c1.size());
+    std::vector<int> d1(c1.size());    //-V656
+    std::iota(std::begin(c1), std::end(c1), std::rand());
+    std::iota(std::begin(c2), std::end(c2), std::rand());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::transform(iterator(std::begin(c1)), iterator(std::end(c1)),
+            std::begin(c2), std::begin(d1), throw_always());
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
+            IteratorTag>::call(hpx::parallel::execution::seq, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary_exception(ExPolicy policy, IteratorTag)
 {
@@ -143,9 +207,8 @@ void test_transform_binary_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::transform(policy, iterator(std::begin(c1)),
-            iterator(std::end(c1)), std::begin(c2), std::begin(d1),
-            throw_always());
+        hpx::transform(policy, iterator(std::begin(c1)), iterator(std::end(c1)),
+            std::begin(c2), std::begin(d1), throw_always());
 
         HPX_TEST(false);
     }
@@ -178,9 +241,9 @@ void test_transform_binary_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::transform(p, iterator(std::begin(c1)),
-            iterator(std::end(c1)), std::begin(c2), std::begin(d1),
-            throw_always());
+        auto f =
+            hpx::transform(p, iterator(std::begin(c1)), iterator(std::end(c1)),
+                std::begin(c2), std::begin(d1), throw_always());
         returned_from_algorithm = true;
         f.get();
 
@@ -219,9 +282,8 @@ void test_transform_binary_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::transform(policy, iterator(std::begin(c1)),
-            iterator(std::end(c1)), std::begin(c2), std::begin(d1),
-            throw_bad_alloc());
+        hpx::transform(policy, iterator(std::begin(c1)), iterator(std::end(c1)),
+            std::begin(c2), std::begin(d1), throw_bad_alloc());
 
         HPX_TEST(false);
     }
@@ -253,9 +315,9 @@ void test_transform_binary_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::transform(p, iterator(std::begin(c1)),
-            iterator(std::end(c1)), std::begin(c2), std::begin(d1),
-            throw_bad_alloc());
+        auto f =
+            hpx::transform(p, iterator(std::begin(c1)), iterator(std::end(c1)),
+                std::begin(c2), std::begin(d1), throw_bad_alloc());
         returned_from_algorithm = true;
         f.get();
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_tests.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2016 Hartmut Kaiser
+//  Copyright (c) 2020 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -62,8 +63,13 @@ void test_transform(ExPolicy policy, IteratorTag)
     auto result = hpx::parallel::transform(policy, iterator(std::begin(c)),
         iterator(std::end(c)), std::begin(d), add_one());
 
+<<<<<<< HEAD
     HPX_TEST(hpx::get<0>(result) == iterator(std::end(c)));
     HPX_TEST(hpx::get<1>(result) == std::end(d));
+=======
+    HPX_TEST(result.in == iterator(std::end(c)));
+    HPX_TEST(result.out == std::end(d));
+>>>>>>> ca9b553f830... Change transform result type (segmented included) from pair to in_out_result
 
     // verify values
     std::size_t count = 0;
@@ -90,9 +96,15 @@ void test_transform_async(ExPolicy p, IteratorTag)
         iterator(std::end(c)), std::begin(d), add_one());
     f.wait();
 
+<<<<<<< HEAD
     hpx::tuple<iterator, base_iterator> result = f.get();
     HPX_TEST(hpx::get<0>(result) == iterator(std::end(c)));
     HPX_TEST(hpx::get<1>(result) == std::end(d));
+=======
+    auto result = f.get();
+    HPX_TEST(result.in == iterator(std::end(c)));
+    HPX_TEST(result.out == std::end(d));
+>>>>>>> ca9b553f830... Change transform result type (segmented included) from pair to in_out_result
 
     // verify values
     std::size_t count = 0;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_tests.hpp
@@ -62,11 +62,6 @@ void test_transform(ExPolicy policy, IteratorTag)
 
     auto result = hpx::transform(policy, iterator(std::begin(c)),
         iterator(std::end(c)), std::begin(d), add_one());
-
-    HPX_TEST(result.in == iterator(std::end(c)));
-    HPX_TEST(result.out == std::end(d));
-    // HPX_TEST(result.in == iterator(std::end(c)));
-    // HPX_TEST(result.out == std::end(d));
     HPX_TEST(result == std::end(d));
 
     // verify values
@@ -96,10 +91,6 @@ void test_transform_async(ExPolicy p, IteratorTag)
 
 
     auto result = f.get();
-    HPX_TEST(result.in == iterator(std::end(c)));
-    HPX_TEST(result.out == std::end(d));
-    // HPX_TEST(result.in == iterator(std::end(c)));
-    // HPX_TEST(result.out == std::end(d));
     HPX_TEST(result == std::end(d));
 
     // verify values

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_tests.hpp
@@ -60,16 +60,14 @@ void test_transform(ExPolicy policy, IteratorTag)
     std::vector<int> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
 
-    auto result = hpx::parallel::transform(policy, iterator(std::begin(c)),
+    auto result = hpx::transform(policy, iterator(std::begin(c)),
         iterator(std::end(c)), std::begin(d), add_one());
 
-<<<<<<< HEAD
-    HPX_TEST(hpx::get<0>(result) == iterator(std::end(c)));
-    HPX_TEST(hpx::get<1>(result) == std::end(d));
-=======
     HPX_TEST(result.in == iterator(std::end(c)));
     HPX_TEST(result.out == std::end(d));
->>>>>>> ca9b553f830... Change transform result type (segmented included) from pair to in_out_result
+    // HPX_TEST(result.in == iterator(std::end(c)));
+    // HPX_TEST(result.out == std::end(d));
+    HPX_TEST(result == std::end(d));
 
     // verify values
     std::size_t count = 0;
@@ -92,19 +90,17 @@ void test_transform_async(ExPolicy p, IteratorTag)
     std::vector<int> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
 
-    auto f = hpx::parallel::transform(p, iterator(std::begin(c)),
-        iterator(std::end(c)), std::begin(d), add_one());
+    auto f = hpx::transform(p, iterator(std::begin(c)), iterator(std::end(c)),
+        std::begin(d), add_one());
     f.wait();
 
-<<<<<<< HEAD
-    hpx::tuple<iterator, base_iterator> result = f.get();
-    HPX_TEST(hpx::get<0>(result) == iterator(std::end(c)));
-    HPX_TEST(hpx::get<1>(result) == std::end(d));
-=======
+
     auto result = f.get();
     HPX_TEST(result.in == iterator(std::end(c)));
     HPX_TEST(result.out == std::end(d));
->>>>>>> ca9b553f830... Change transform result type (segmented included) from pair to in_out_result
+    // HPX_TEST(result.in == iterator(std::end(c)));
+    // HPX_TEST(result.out == std::end(d));
+    HPX_TEST(result == std::end(d));
 
     // verify values
     std::size_t count = 0;
@@ -134,8 +130,8 @@ void test_transform_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::transform(policy, iterator(std::begin(c)),
-            iterator(std::end(c)), std::begin(d), throw_always());
+        hpx::transform(policy, iterator(std::begin(c)), iterator(std::end(c)),
+            std::begin(d), throw_always());
 
         HPX_TEST(false);
     }
@@ -166,7 +162,7 @@ void test_transform_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::transform(p, iterator(std::begin(c)),
+        auto f = hpx::transform(p, iterator(std::begin(c)),
             iterator(std::end(c)), std::begin(d), throw_always());
         returned_from_algorithm = true;
         f.get();
@@ -204,8 +200,8 @@ void test_transform_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::transform(policy, iterator(std::begin(c)),
-            iterator(std::end(c)), std::begin(d), throw_bad_alloc());
+        hpx::transform(policy, iterator(std::begin(c)), iterator(std::end(c)),
+            std::begin(d), throw_bad_alloc());
 
         HPX_TEST(false);
     }
@@ -235,7 +231,7 @@ void test_transform_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::transform(p, iterator(std::begin(c)),
+        auto f = hpx::transform(p, iterator(std::begin(c)),
             iterator(std::end(c)), std::begin(d), throw_bad_alloc());
         returned_from_algorithm = true;
         f.get();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2020 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -35,7 +36,7 @@ void test_transform(ExPolicy policy, IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
 
-    auto result = hpx::parallel::transform(
+    auto result = hpx::ranges::transform(
         policy, c, std::begin(d), [](std::size_t v) { return v + 1; });
 
     HPX_TEST(result.in == std::end(c));
@@ -65,7 +66,7 @@ void test_transform_async(ExPolicy p, IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
 
-    auto f = hpx::parallel::transform(
+    auto f = hpx::ranges::transform(
         p, c, std::begin(d), [](std::size_t& v) { return v + 1; });
     f.wait();
 
@@ -120,7 +121,7 @@ void test_transform_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::transform(policy,
+        hpx::ranges::transform(policy,
             hpx::util::make_iterator_range(
                 iterator(std::begin(c)), iterator(std::end(c))),
             std::begin(d),
@@ -155,7 +156,7 @@ void test_transform_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::transform(p,
+        auto f = hpx::ranges::transform(p,
             hpx::util::make_iterator_range(
                 iterator(std::begin(c)), iterator(std::end(c))),
             std::begin(d),
@@ -217,7 +218,7 @@ void test_transform_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::transform(policy,
+        hpx::ranges::transform(policy,
             hpx::util::make_iterator_range(
                 iterator(std::begin(c)), iterator(std::end(c))),
             std::begin(d),
@@ -251,7 +252,7 @@ void test_transform_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::transform(p,
+        auto f = hpx::ranges::transform(p,
             hpx::util::make_iterator_range(
                 iterator(std::begin(c)), iterator(std::end(c))),
             std::begin(d),

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range.cpp
@@ -38,8 +38,8 @@ void test_transform(ExPolicy policy, IteratorTag)
     auto result = hpx::parallel::transform(
         policy, c, std::begin(d), [](std::size_t v) { return v + 1; });
 
-    HPX_TEST(hpx::get<0>(result) == std::end(c));
-    HPX_TEST(hpx::get<1>(result) == std::end(d));
+    HPX_TEST(result.in == std::end(c));
+    HPX_TEST(result.out == std::end(d));
 
     // verify values
     std::size_t count = 0;
@@ -70,8 +70,8 @@ void test_transform_async(ExPolicy p, IteratorTag)
     f.wait();
 
     auto result = f.get();
-    HPX_TEST(hpx::get<0>(result) == std::end(c));
-    HPX_TEST(hpx::get<1>(result) == std::end(d));
+    HPX_TEST(result.in == std::end(c));
+    HPX_TEST(result.out == std::end(d));
 
     // verify values
     std::size_t count = 0;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary.cpp
@@ -82,9 +82,9 @@ void test_transform_binary_async(ExPolicy p, IteratorTag)
     f.wait();
 
     auto result = f.get();
-    HPX_TEST(hpx::get<0>(result) == std::end(c1));
-    HPX_TEST(hpx::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::get<2>(result) == std::end(d1));
+    HPX_TEST(result.in1() == std::end(c1));
+    HPX_TEST(result.in2() == std::end(c2));
+    HPX_TEST(result.out() == std::end(d1));
 
     // verify values
     std::vector<std::size_t> d2(c1.size());

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary2.cpp
@@ -41,9 +41,9 @@ void test_transform_binary(ExPolicy policy, IteratorTag)
 
     auto result = hpx::parallel::transform(policy, c1, c2, std::begin(d1), add);
 
-    HPX_TEST(hpx::get<0>(result) == std::end(c1));
-    HPX_TEST(hpx::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::get<2>(result) == std::end(d1));
+    HPX_TEST(result.in1 == std::end(c1));
+    HPX_TEST(result.in2 == std::end(c2));
+    HPX_TEST(result.out == std::end(d1));
 
     // verify values
     std::vector<std::size_t> d2(c1.size());
@@ -80,9 +80,9 @@ void test_transform_binary_async(ExPolicy p, IteratorTag)
     f.wait();
 
     auto result = f.get();
-    HPX_TEST(hpx::get<0>(result) == std::end(c1));
-    HPX_TEST(hpx::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::get<2>(result) == std::end(d1));
+    HPX_TEST(result.in1 == std::end(c1));
+    HPX_TEST(result.in2 == std::end(c2));
+    HPX_TEST(result.out == std::end(d1));
 
     // verify values
     std::vector<std::size_t> d2(c1.size());

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary2.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2020 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -20,6 +21,43 @@
 #include "test_utils.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_binary(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
+
+    test_vector c1(10007);
+    test_vector c2(10007);
+    std::vector<std::size_t> d1(c1.size());    //-V656
+    std::iota(std::begin(c1), std::end(c1), std::rand());
+    std::iota(std::begin(c2), std::end(c2), std::rand());
+
+    auto add = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+
+    auto result = hpx::ranges::transform(c1, c2, std::begin(d1), add);
+
+    HPX_TEST(result.in1 == std::end(c1));
+    HPX_TEST(result.in2 == std::end(c2));
+    HPX_TEST(result.out == std::end(d1));
+
+    // verify values
+    std::vector<std::size_t> d2(c1.size());
+    std::transform(
+        std::begin(c1), std::end(c1), std::begin(c2), std::begin(d2), add);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(d1), std::end(d1), std::begin(d2),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d2.size());
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary(ExPolicy policy, IteratorTag)
 {
@@ -39,7 +77,7 @@ void test_transform_binary(ExPolicy policy, IteratorTag)
 
     auto add = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
 
-    auto result = hpx::parallel::transform(policy, c1, c2, std::begin(d1), add);
+    auto result = hpx::ranges::transform(policy, c1, c2, std::begin(d1), add);
 
     HPX_TEST(result.in1 == std::end(c1));
     HPX_TEST(result.in2 == std::end(c2));
@@ -76,7 +114,7 @@ void test_transform_binary_async(ExPolicy p, IteratorTag)
 
     auto add = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
 
-    auto f = hpx::parallel::transform(p, c1, c2, std::begin(d1), add);
+    auto f = hpx::ranges::transform(p, c1, c2, std::begin(d1), add);
     f.wait();
 
     auto result = f.get();
@@ -119,6 +157,45 @@ void transform_binary_test()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_binary_exception(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c1(10007);
+    std::vector<std::size_t> c2(c1.size());
+    std::vector<std::size_t> d1(c1.size());    //-V656
+    std::iota(std::begin(c1), std::end(c1), std::rand());
+    std::iota(std::begin(c2), std::end(c2), std::rand());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::ranges::transform(
+            hpx::util::make_iterator_range(
+                iterator(std::begin(c1)), iterator(std::end(c1))),
+            hpx::util::make_iterator_range(std::begin(c2), std::end(c2)),
+            std::begin(d1), [](std::size_t v1, std::size_t v2) {
+                return throw std::runtime_error("test"), v1 + v2;
+            });
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary_exception(ExPolicy policy, IteratorTag)
 {
@@ -137,7 +214,7 @@ void test_transform_binary_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::transform(policy,
+        hpx::ranges::transform(policy,
             hpx::util::make_iterator_range(
                 iterator(std::begin(c1)), iterator(std::end(c1))),
             hpx::util::make_iterator_range(std::begin(c2), std::end(c2)),
@@ -176,7 +253,7 @@ void test_transform_binary_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::transform(p,
+        auto f = hpx::ranges::transform(p,
             hpx::util::make_iterator_range(
                 iterator(std::begin(c1)), iterator(std::end(c1))),
             hpx::util::make_iterator_range(std::begin(c2), std::end(c2)),
@@ -242,7 +319,7 @@ void test_transform_binary_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::transform(policy,
+        hpx::ranges::transform(policy,
             hpx::util::make_iterator_range(
                 iterator(std::begin(c1)), iterator(std::end(c1))),
             hpx::util::make_iterator_range(std::begin(c2), std::end(c2)),
@@ -280,7 +357,7 @@ void test_transform_binary_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::transform(p,
+        auto f = hpx::ranges::transform(p,
             hpx::util::make_iterator_range(
                 iterator(std::begin(c1)), iterator(std::end(c1))),
             hpx::util::make_iterator_range(std::begin(c2), std::end(c2)),


### PR DESCRIPTION
- It changes the result type of `hpx::parallel::transform` from `tagged_pair` to `in_out_result`.
- It adds CPOs for `hpx::parallel::transform` and `hpx::ranges::transform`.

The changes above, refer to the `UnaryOperation` overloads of the `transform` algorithm. Similar adaptations will be added soon for the `BinaryOperation` overloads in the existing PR.