### PR TITLE
Removing non-needed libCDS support functions (for now)

### DIFF
--- a/libs/coroutines/include/hpx/coroutines/coroutine.hpp
+++ b/libs/coroutines/include/hpx/coroutines/coroutine.hpp
@@ -97,16 +97,6 @@ namespace hpx { namespace threads { namespace coroutines {
         }
 
 #if defined(HPX_HAVE_LIBCDS)
-        std::size_t get_libcds_data() const
-        {
-            return impl_.get_libcds_data();
-        }
-
-        std::size_t set_libcds_data(std::size_t data)
-        {
-            return impl_.set_libcds_data(data);
-        }
-
         std::size_t get_libcds_hazard_pointer_data() const
         {
             return impl_.get_libcds_hazard_pointer_data();
@@ -115,16 +105,6 @@ namespace hpx { namespace threads { namespace coroutines {
         std::size_t set_libcds_hazard_pointer_data(std::size_t data)
         {
             return impl_.set_libcds_hazard_pointer_data(data);
-        }
-
-        std::size_t get_libcds_dynamic_hazard_pointer_data() const
-        {
-            return impl_.get_libcds_dynamic_hazard_pointer_data();
-        }
-
-        std::size_t set_libcds_dynamic_hazard_pointer_data(std::size_t data)
-        {
-            return impl_.set_libcds_dynamic_hazard_pointer_data(data);
         }
 #endif
 

--- a/libs/coroutines/include/hpx/coroutines/detail/context_base.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/context_base.hpp
@@ -87,9 +87,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
           , m_thread_data(0)
 #endif
 #if defined(HPX_HAVE_LIBCDS)
-          , libcds_data_(0)
           , libcds_hazard_pointer_data_(0)
-          , libcds_dynamic_hazard_pointer_data_(0)
 #endif
           , m_type_info()
           , m_thread_id(id)
@@ -105,9 +103,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
             m_thread_data = 0;
 #endif
 #if defined(HPX_HAVE_LIBCDS)
-            libcds_data_ = 0;
             libcds_hazard_pointer_data_ = 0;
-            libcds_dynamic_hazard_pointer_data_ = 0;
 #endif
         }
 
@@ -216,9 +212,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
             m_thread_data = 0;
 #endif
 #if defined(HPX_HAVE_LIBCDS)
-            libcds_data_ = 0;
             libcds_hazard_pointer_data_ = 0;
-            libcds_dynamic_hazard_pointer_data_ = 0;
 #endif
         }
 
@@ -245,17 +239,6 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         }
 
 #if defined(HPX_HAVE_LIBCDS)
-        std::size_t get_libcds_data() const
-        {
-            return libcds_data_;
-        }
-
-        std::size_t set_libcds_data(std::size_t data)
-        {
-            std::swap(data, libcds_data_);
-            return data;
-        }
-
         std::size_t get_libcds_hazard_pointer_data() const
         {
             return libcds_hazard_pointer_data_;
@@ -264,17 +247,6 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         std::size_t set_libcds_hazard_pointer_data(std::size_t data)
         {
             std::swap(data, libcds_hazard_pointer_data_);
-            return data;
-        }
-
-        std::size_t get_libcds_dynamic_hazard_pointer_data() const
-        {
-            return libcds_dynamic_hazard_pointer_data_;
-        }
-
-        std::size_t set_libcds_dynamic_hazard_pointer_data(std::size_t data)
-        {
-            std::swap(data, libcds_dynamic_hazard_pointer_data_);
             return data;
         }
 #endif
@@ -336,9 +308,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
             HPX_ASSERT(m_thread_data == 0);
 #endif
 #if defined(HPX_HAVE_LIBCDS)
-            HPX_ASSERT(libcds_data_ == 0);
             HPX_ASSERT(libcds_hazard_pointer_data_ == 0);
-            HPX_ASSERT(libcds_dynamic_hazard_pointer_data_ == 0);
 #endif
             // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
             m_type_info = std::exception_ptr();
@@ -402,9 +372,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         mutable std::size_t m_thread_data;
 #endif
 #if defined(HPX_HAVE_LIBCDS)
-        mutable std::size_t libcds_data_;
         mutable std::size_t libcds_hazard_pointer_data_;
-        mutable std::size_t libcds_dynamic_hazard_pointer_data_;
 #endif
 
         // This is used to generate a meaningful exception trace.

--- a/libs/coroutines/include/hpx/coroutines/detail/coroutine_self.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/coroutine_self.hpp
@@ -130,15 +130,8 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         virtual std::size_t set_thread_data(std::size_t data) = 0;
 
 #if defined(HPX_HAVE_LIBCDS)
-        virtual std::size_t get_libcds_data() const = 0;
-        virtual std::size_t set_libcds_data(std::size_t data) = 0;
-
         virtual std::size_t get_libcds_hazard_pointer_data() const = 0;
         virtual std::size_t set_libcds_hazard_pointer_data(
-            std::size_t data) = 0;
-
-        virtual std::size_t get_libcds_dynamic_hazard_pointer_data() const = 0;
-        virtual std::size_t set_libcds_dynamic_hazard_pointer_data(
             std::size_t data) = 0;
 #endif
 

--- a/libs/coroutines/include/hpx/coroutines/detail/coroutine_stackful_self.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/coroutine_stackful_self.hpp
@@ -82,17 +82,6 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         }
 
 #if defined(HPX_HAVE_LIBCDS)
-        std::size_t get_libcds_data() const override
-        {
-            HPX_ASSERT(pimpl_);
-            return pimpl_->get_libcds_data();
-        }
-        std::size_t set_libcds_data(std::size_t data) override
-        {
-            HPX_ASSERT(pimpl_);
-            return pimpl_->set_libcds_data(data);
-        }
-
         std::size_t get_libcds_hazard_pointer_data() const override
         {
             HPX_ASSERT(pimpl_);
@@ -102,18 +91,6 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         {
             HPX_ASSERT(pimpl_);
             return pimpl_->set_libcds_hazard_pointer_data(data);
-        }
-
-        std::size_t get_libcds_dynamic_hazard_pointer_data() const override
-        {
-            HPX_ASSERT(pimpl_);
-            return pimpl_->get_libcds_dynamic_hazard_pointer_data();
-        }
-        std::size_t set_libcds_dynamic_hazard_pointer_data(
-            std::size_t data) override
-        {
-            HPX_ASSERT(pimpl_);
-            return pimpl_->set_libcds_dynamic_hazard_pointer_data(data);
         }
 #endif
 

--- a/libs/coroutines/include/hpx/coroutines/detail/coroutine_stackless_self.hpp
+++ b/libs/coroutines/include/hpx/coroutines/detail/coroutine_stackless_self.hpp
@@ -74,17 +74,6 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         }
 
 #if defined(HPX_HAVE_LIBCDS)
-        std::size_t get_libcds_data() const override
-        {
-            HPX_ASSERT(pimpl_);
-            return pimpl_->get_libcds_data();
-        }
-        std::size_t set_libcds_data(std::size_t data) override
-        {
-            HPX_ASSERT(pimpl_);
-            return pimpl_->set_libcds_data(data);
-        }
-
         std::size_t get_libcds_hazard_pointer_data() const override
         {
             HPX_ASSERT(pimpl_);
@@ -94,18 +83,6 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         {
             HPX_ASSERT(pimpl_);
             return pimpl_->set_libcds_hazard_pointer_data(data);
-        }
-
-        std::size_t get_libcds_dynamic_hazard_pointer_data() const override
-        {
-            HPX_ASSERT(pimpl_);
-            return pimpl_->get_libcds_dynamic_hazard_pointer_data();
-        }
-        std::size_t set_libcds_dynamic_hazard_pointer_data(
-            std::size_t data) override
-        {
-            HPX_ASSERT(pimpl_);
-            return pimpl_->set_libcds_dynamic_hazard_pointer_data(data);
         }
 #endif
 

--- a/libs/coroutines/include/hpx/coroutines/stackless_coroutine.hpp
+++ b/libs/coroutines/include/hpx/coroutines/stackless_coroutine.hpp
@@ -122,17 +122,6 @@ namespace hpx { namespace threads { namespace coroutines {
         }
 
 #if defined(HPX_HAVE_LIBCDS)
-        std::size_t get_libcds_data() const
-        {
-            return libcds_data_;
-        }
-
-        std::size_t set_libcds_data(std::size_t data)
-        {
-            std::swap(data, libcds_data_);
-            return data;
-        }
-
         std::size_t get_libcds_hazard_pointer_data() const
         {
             return libcds_hazard_pointer_data_;
@@ -141,17 +130,6 @@ namespace hpx { namespace threads { namespace coroutines {
         std::size_t set_libcds_hazard_pointer_data(std::size_t data)
         {
             std::swap(data, libcds_hazard_pointer_data_);
-            return data;
-        }
-
-        std::size_t get_libcds_dynamic_hazard_pointer_data() const
-        {
-            return libcds_dynamic_hazard_pointer_data_;
-        }
-
-        std::size_t set_libcds_dynamic_hazard_pointer_data(std::size_t data)
-        {
-            std::swap(data, libcds_dynamic_hazard_pointer_data_);
             return data;
         }
 #endif
@@ -259,9 +237,7 @@ namespace hpx { namespace threads { namespace coroutines {
 #endif
         std::size_t continuation_recursion_count_;
 #if defined(HPX_HAVE_LIBCDS)
-        mutable std::size_t libcds_data_;
         mutable std::size_t libcds_hazard_pointer_data_;
-        mutable std::size_t libcds_dynamic_hazard_pointer_data_;
 #endif
     };
 

--- a/libs/threading/include/hpx/threading/thread.hpp
+++ b/libs/threading/include/hpx/threading/thread.hpp
@@ -121,12 +121,8 @@ namespace hpx {
         std::size_t set_thread_data(std::size_t);
 
 #if defined(HPX_HAVE_LIBCDS)
-        std::size_t get_libcds_data() const;
-        std::size_t set_libcds_data(std::size_t);
         std::size_t get_libcds_hazard_pointer_data() const;
         std::size_t set_libcds_hazard_pointer_data(std::size_t);
-        std::size_t get_libcds_dynamic_hazard_pointer_data() const;
-        std::size_t set_libcds_dynamic_hazard_pointer_data(std::size_t);
 #endif
 
     private:
@@ -266,13 +262,8 @@ namespace hpx {
         HPX_EXPORT std::size_t set_thread_data(std::size_t);
 
 #if defined(HPX_HAVE_LIBCDS)
-        HPX_EXPORT std::size_t get_libcds_data();
-        HPX_EXPORT std::size_t set_libcds_data(std::size_t);
         HPX_EXPORT std::size_t get_libcds_hazard_pointer_data();
         HPX_EXPORT std::size_t set_libcds_hazard_pointer_data(std::size_t);
-        HPX_EXPORT std::size_t get_libcds_dynamic_hazard_pointer_data();
-        HPX_EXPORT std::size_t set_libcds_dynamic_hazard_pointer_data(
-            std::size_t);
 #endif
 
         class HPX_EXPORT disable_interruption

--- a/libs/threading/src/thread.cpp
+++ b/libs/threading/src/thread.cpp
@@ -248,15 +248,6 @@ namespace hpx {
     }
 
 #if defined(HPX_HAVE_LIBCDS)
-    std::size_t thread::get_libcds_data() const
-    {
-        return threads::get_libcds_data(native_handle());
-    }
-    std::size_t thread::set_libcds_data(std::size_t data)
-    {
-        return threads::set_libcds_data(native_handle(), data);
-    }
-
     std::size_t thread::get_libcds_hazard_pointer_data() const
     {
         return threads::get_libcds_hazard_pointer_data(native_handle());
@@ -264,16 +255,6 @@ namespace hpx {
     std::size_t thread::set_libcds_hazard_pointer_data(std::size_t data)
     {
         return threads::set_libcds_hazard_pointer_data(native_handle(), data);
-    }
-
-    std::size_t thread::get_libcds_dynamic_hazard_pointer_data() const
-    {
-        return threads::get_libcds_dynamic_hazard_pointer_data(native_handle());
-    }
-    std::size_t thread::set_libcds_dynamic_hazard_pointer_data(std::size_t data)
-    {
-        return threads::set_libcds_dynamic_hazard_pointer_data(
-            native_handle(), data);
     }
 #endif
 
@@ -428,16 +409,6 @@ namespace hpx {
         }
 
 #if defined(HPX_HAVE_LIBCDS)
-        std::size_t get_libcds_data()
-        {
-            return threads::get_libcds_data(threads::get_self_id());
-        }
-
-        std::size_t set_libcds_data(std::size_t data)
-        {
-            return threads::set_libcds_data(threads::get_self_id(), data);
-        }
-
         std::size_t get_libcds_hazard_pointer_data()
         {
             return threads::get_libcds_hazard_pointer_data(
@@ -447,18 +418,6 @@ namespace hpx {
         std::size_t set_libcds_hazard_pointer_data(std::size_t data)
         {
             return threads::set_libcds_hazard_pointer_data(
-                threads::get_self_id(), data);
-        }
-
-        std::size_t get_libcds_dynamic_hazard_pointer_data()
-        {
-            return threads::get_libcds_dynamic_hazard_pointer_data(
-                threads::get_self_id());
-        }
-
-        std::size_t set_libcds_dynamic_hazard_pointer_data(std::size_t data)
-        {
-            return threads::set_libcds_dynamic_hazard_pointer_data(
                 threads::get_self_id(), data);
         }
 #endif

--- a/libs/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -553,13 +553,8 @@ namespace hpx { namespace threads {
         virtual std::size_t set_thread_data(std::size_t data) = 0;
 
 #if defined(HPX_HAVE_LIBCDS)
-        virtual std::size_t get_libcds_data() const = 0;
-        virtual std::size_t set_libcds_data(std::size_t data) = 0;
         virtual std::size_t get_libcds_hazard_pointer_data() const = 0;
         virtual std::size_t set_libcds_hazard_pointer_data(
-            std::size_t data) = 0;
-        virtual std::size_t get_libcds_dynamic_hazard_pointer_data() const = 0;
-        virtual std::size_t set_libcds_dynamic_hazard_pointer_data(
             std::size_t data) = 0;
 #endif
 

--- a/libs/threading_base/include/hpx/threading_base/thread_data_stackful.hpp
+++ b/libs/threading_base/include/hpx/threading_base/thread_data_stackful.hpp
@@ -93,16 +93,6 @@ namespace hpx { namespace threads {
         }
 
 #if defined(HPX_HAVE_LIBCDS)
-        std::size_t get_libcds_data() const override
-        {
-            return coroutine_.get_libcds_data();
-        }
-
-        std::size_t set_libcds_data(std::size_t data) override
-        {
-            return coroutine_.set_libcds_data(data);
-        }
-
         std::size_t get_libcds_hazard_pointer_data() const override
         {
             return coroutine_.get_libcds_hazard_pointer_data();
@@ -111,17 +101,6 @@ namespace hpx { namespace threads {
         std::size_t set_libcds_hazard_pointer_data(std::size_t data) override
         {
             return coroutine_.set_libcds_hazard_pointer_data(data);
-        }
-
-        std::size_t get_libcds_dynamic_hazard_pointer_data() const override
-        {
-            return coroutine_.get_libcds_dynamic_hazard_pointer_data();
-        }
-
-        std::size_t set_libcds_dynamic_hazard_pointer_data(
-            std::size_t data) override
-        {
-            return coroutine_.set_libcds_dynamic_hazard_pointer_data(data);
         }
 #endif
 

--- a/libs/threading_base/include/hpx/threading_base/thread_data_stackless.hpp
+++ b/libs/threading_base/include/hpx/threading_base/thread_data_stackless.hpp
@@ -88,16 +88,6 @@ namespace hpx { namespace threads {
         }
 
 #if defined(HPX_HAVE_LIBCDS)
-        std::size_t get_libcds_data() const override
-        {
-            return coroutine_.get_libcds_data();
-        }
-
-        std::size_t set_libcds_data(std::size_t data) override
-        {
-            return coroutine_.set_libcds_data(data);
-        }
-
         std::size_t get_libcds_hazard_pointer_data() const override
         {
             return coroutine_.get_libcds_hazard_pointer_data();
@@ -106,17 +96,6 @@ namespace hpx { namespace threads {
         std::size_t set_libcds_hazard_pointer_data(std::size_t data) override
         {
             return coroutine_.set_libcds_hazard_pointer_data(data);
-        }
-
-        std::size_t get_libcds_dynamic_hazard_pointer_data() const override
-        {
-            return coroutine_.get_libcds_dynamic_hazard_pointer_data();
-        }
-
-        std::size_t set_libcds_dynamic_hazard_pointer_data(
-            std::size_t data) override
-        {
-            return coroutine_.set_libcds_dynamic_hazard_pointer_data(data);
         }
 #endif
 

--- a/libs/threading_base/include/hpx/threading_base/thread_helpers.hpp
+++ b/libs/threading_base/include/hpx/threading_base/thread_helpers.hpp
@@ -393,22 +393,10 @@ namespace hpx { namespace threads {
         thread_id_type const& id, std::size_t data, error_code& ec = throws);
 
 #if defined(HPX_HAVE_LIBCDS)
-    HPX_EXPORT std::size_t get_libcds_data(
-        thread_id_type const& id, error_code& ec = throws);
-
-    HPX_EXPORT std::size_t set_libcds_data(
-        thread_id_type const& id, std::size_t data, error_code& ec = throws);
-
     HPX_EXPORT std::size_t get_libcds_hazard_pointer_data(
         thread_id_type const& id, error_code& ec = throws);
 
     HPX_EXPORT std::size_t set_libcds_hazard_pointer_data(
-        thread_id_type const& id, std::size_t data, error_code& ec = throws);
-
-    HPX_EXPORT std::size_t get_libcds_dynamic_hazard_pointer_data(
-        thread_id_type const& id, error_code& ec = throws);
-
-    HPX_EXPORT std::size_t set_libcds_dynamic_hazard_pointer_data(
         thread_id_type const& id, std::size_t data, error_code& ec = throws);
 #endif
 

--- a/libs/threading_base/src/thread_helpers.cpp
+++ b/libs/threading_base/src/thread_helpers.cpp
@@ -205,31 +205,6 @@ namespace hpx { namespace threads {
     }
 
 #if defined(HPX_HAVE_LIBCDS)
-    std::size_t get_libcds_data(thread_id_type const& id, error_code& ec)
-    {
-        if (HPX_UNLIKELY(!id))
-        {
-            HPX_THROWS_IF(ec, null_thread_id, "hpx::threads::get_libcds_data",
-                "null thread id encountered");
-            return 0;
-        }
-
-        return get_thread_id_data(id)->get_libcds_data();
-    }
-
-    std::size_t set_libcds_data(
-        thread_id_type const& id, std::size_t data, error_code& ec)
-    {
-        if (HPX_UNLIKELY(!id))
-        {
-            HPX_THROWS_IF(ec, null_thread_id, "hpx::threads::set_libcds_data",
-                "null thread id encountered");
-            return 0;
-        }
-
-        return get_thread_id_data(id)->set_libcds_data(data);
-    }
-
     std::size_t get_libcds_hazard_pointer_data(
         thread_id_type const& id, error_code& ec)
     {
@@ -257,36 +232,6 @@ namespace hpx { namespace threads {
 
         return get_thread_id_data(id)->set_libcds_hazard_pointer_data(data);
     }
-
-    std::size_t get_libcds_dynamic_hazard_pointer_data(
-        thread_id_type const& id, error_code& ec)
-    {
-        if (HPX_UNLIKELY(!id))
-        {
-            HPX_THROWS_IF(ec, null_thread_id,
-                "hpx::threads::get_libcds_dynamic_hazard_pointer_data",
-                "null thread id encountered");
-            return 0;
-        }
-
-        return get_thread_id_data(id)->get_libcds_dynamic_hazard_pointer_data();
-    }
-
-    std::size_t set_libcds_dynamic_hazard_pointer_data(
-        thread_id_type const& id, std::size_t data, error_code& ec)
-    {
-        if (HPX_UNLIKELY(!id))
-        {
-            HPX_THROWS_IF(ec, null_thread_id,
-                "hpx::threads::set_libcds_dynamic_hazard_pointer_data",
-                "null thread id encountered");
-            return 0;
-        }
-
-        return get_thread_id_data(id)->set_libcds_dynamic_hazard_pointer_data(
-            data);
-    }
-
 #endif
 
     ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
As discussed, this removes the libCDS support facilities that are not needed at this point. We might want to re-add those later (once dynamic hazard pointers and RCU are actually supported to be used on HPX threads).