### PR TITLE
Adding replay_executor and replicate_executor

### DIFF
--- a/libs/resiliency/CMakeLists.txt
+++ b/libs/resiliency/CMakeLists.txt
@@ -15,9 +15,11 @@ set(resiliency_headers
     hpx/resiliency/async_replicate.hpp
     hpx/resiliency/async_replicate_executor.hpp
     hpx/resiliency/config.hpp
-    hpx/resiliency/version.hpp
+    hpx/resiliency/replay_executor.hpp
+    hpx/resiliency/replicate_executor.hpp
     hpx/resiliency/resiliency.hpp
     hpx/resiliency/resiliency_cpos.hpp
+    hpx/resiliency/version.hpp
 )
 
 # Default location is $HPX_ROOT/libs/resiliency/src
@@ -32,13 +34,17 @@ add_hpx_module(
   DEPENDENCIES
   DEPENDENCIES
     hpx_assertion
+    hpx_async_base
     hpx_async_local
     hpx_config
     hpx_concepts
     hpx_datastructures
     hpx_execution
+    hpx_executors
     hpx_functional
     hpx_futures
+    hpx_iterator_support
+    hpx_synchronization
     hpx_type_support
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/resiliency/include/hpx/resiliency/async_replay.hpp
+++ b/libs/resiliency/include/hpx/resiliency/async_replay.hpp
@@ -40,7 +40,7 @@ namespace hpx { namespace resiliency { namespace experimental {
         struct replay_validator
         {
             template <typename T>
-            bool operator()(T&& result) const
+            constexpr bool operator()(T&&) const
             {
                 return true;
             }

--- a/libs/resiliency/include/hpx/resiliency/async_replay_executor.hpp
+++ b/libs/resiliency/include/hpx/resiliency/async_replay_executor.hpp
@@ -49,20 +49,27 @@ namespace hpx { namespace resiliency { namespace experimental {
             }
 
             template <typename Executor, std::size_t... Is>
-            Result invoke(Executor&& exec, hpx::util::index_pack<Is...>)
+            typename hpx::parallel::execution::executor_future<Executor,
+                Result>::type
+            invoke(Executor&& exec, hpx::util::index_pack<Is...>)
             {
                 return hpx::parallel::execution::async_execute(
                     std::forward<Executor>(exec), f_, std::get<Is>(t_)...);
             }
 
             template <typename Executor>
-            Result call(Executor&& exec, std::size_t n)
+            typename hpx::parallel::execution::executor_future<Executor,
+                Result>::type
+            call(Executor&& exec, std::size_t n)
             {
                 // launch given function asynchronously
                 using pack_type =
                     hpx::util::make_index_pack<std::tuple_size<Tuple>::value>;
+                using result_type =
+                    typename hpx::parallel::execution::executor_future<Executor,
+                        Result>::type;
 
-                Result f = invoke(exec, pack_type{});
+                result_type f = invoke(exec, pack_type{});
 
                 // attach a continuation that will relaunch the task, if
                 // necessary
@@ -70,7 +77,7 @@ namespace hpx { namespace resiliency { namespace experimental {
                 return f.then(hpx::launch::sync,
                     [this_ = std::move(this_),
                         exec = std::forward<Executor>(exec),
-                        n](Result&& f) mutable {
+                        n](result_type&& f) mutable {
                         if (f.has_exception())
                         {
                             // rethrow abort_replay_exception, if caught
@@ -121,6 +128,82 @@ namespace hpx { namespace resiliency { namespace experimental {
             Tuple t_;
         };
 
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Pred, typename F, typename Tuple>
+        struct async_replay_executor_helper<void, Pred, F, Tuple>
+          : std::enable_shared_from_this<
+                async_replay_executor_helper<void, Pred, F, Tuple>>
+        {
+            template <typename Pred_, typename F_, typename Tuple_>
+            async_replay_executor_helper(Pred_&&, F_&& f, Tuple_&& tuple)
+              : f_(std::forward<F_>(f))
+              , t_(std::forward<Tuple_>(tuple))
+            {
+            }
+
+            template <typename Executor, std::size_t... Is>
+            typename hpx::parallel::execution::executor_future<Executor,
+                void>::type
+            invoke(Executor&& exec, hpx::util::index_pack<Is...>)
+            {
+                return hpx::parallel::execution::async_execute(
+                    std::forward<Executor>(exec), f_, std::get<Is>(t_)...);
+            }
+
+            template <typename Executor>
+            typename hpx::parallel::execution::executor_future<Executor,
+                void>::type
+            call(Executor&& exec, std::size_t n)
+            {
+                // launch given function asynchronously
+                using pack_type =
+                    hpx::util::make_index_pack<std::tuple_size<Tuple>::value>;
+                using result_type =
+                    typename hpx::parallel::execution::executor_future<Executor,
+                        void>::type;
+
+                result_type f = invoke(exec, pack_type{});
+
+                // attach a continuation that will relaunch the task, if
+                // necessary
+                auto this_ = this->shared_from_this();
+                return f.then(hpx::launch::sync,
+                    [this_ = std::move(this_),
+                        exec = std::forward<Executor>(exec),
+                        n](result_type&& f) mutable {
+                        if (f.has_exception())
+                        {
+                            // rethrow abort_replay_exception, if caught
+                            auto ex = rethrow_on_abort_replay(f);
+
+                            // execute the task again if an error occurred and
+                            // this was not the last attempt
+                            if (n != 0)
+                            {
+                                return this_->call(std::move(exec), n - 1);
+                            }
+
+                            // rethrow exception if the number of replays has
+                            // been exhausted
+                            std::rethrow_exception(ex);
+                        }
+
+                        if (n != 0)
+                        {
+                            // return result
+                            return hpx::make_ready_future();
+                        }
+
+                        // throw aborting exception as attempts were
+                        // exhausted
+                        throw abort_replay_exception();
+                    });
+            }
+
+            F f_;
+            Tuple t_;
+        };
+
         template <typename Result, typename Pred, typename F, typename... Ts>
         std::shared_ptr<async_replay_executor_helper<Result,
             typename std::decay<Pred>::type, typename std::decay<F>::type,
@@ -156,11 +239,7 @@ namespace hpx { namespace resiliency { namespace experimental {
         using result_type =
             typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type;
 
-        using future_type =
-            typename hpx::parallel::execution::executor_future<Executor,
-                result_type>::type;
-
-        auto helper = detail::make_async_replay_executor_helper<future_type>(
+        auto helper = detail::make_async_replay_executor_helper<result_type>(
             std::forward<Pred>(pred), std::forward<F>(f),
             std::forward<Ts>(ts)...);
 
@@ -184,11 +263,7 @@ namespace hpx { namespace resiliency { namespace experimental {
         using result_type =
             typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type;
 
-        using future_type =
-            typename hpx::parallel::execution::executor_future<Executor,
-                result_type>::type;
-
-        auto helper = detail::make_async_replay_executor_helper<future_type>(
+        auto helper = detail::make_async_replay_executor_helper<result_type>(
             detail::replay_validator{}, std::forward<F>(f),
             std::forward<Ts>(ts)...);
 

--- a/libs/resiliency/include/hpx/resiliency/async_replicate.hpp
+++ b/libs/resiliency/include/hpx/resiliency/async_replicate.hpp
@@ -36,7 +36,7 @@ namespace hpx { namespace resiliency { namespace experimental {
         struct replicate_voter
         {
             template <typename T>
-            T operator()(std::vector<T>&& vect) const
+            constexpr T operator()(std::vector<T>&& vect) const
             {
                 return std::move(vect.at(0));
             }
@@ -45,7 +45,7 @@ namespace hpx { namespace resiliency { namespace experimental {
         struct replicate_validator
         {
             template <typename T>
-            bool operator()(T&& result) const
+            constexpr bool operator()(T&&) const
             {
                 return true;
             }
@@ -94,8 +94,8 @@ namespace hpx { namespace resiliency { namespace experimental {
             // wait for all threads to finish executing and return the first result
             // that passes the predicate, properly handle exceptions
             return hpx::dataflow(
-                hpx::launch::
-                    sync,    // do not schedule new thread for the lambda
+                // do not schedule new thread for the lambda
+                hpx::launch::sync,
                 [pred = std::forward<Pred>(pred),
                     vote = std::forward<Vote>(vote),
                     n](std::vector<hpx::future<result_type>>&& results) mutable

--- a/libs/resiliency/include/hpx/resiliency/async_replicate_executor.hpp
+++ b/libs/resiliency/include/hpx/resiliency/async_replicate_executor.hpp
@@ -30,80 +30,150 @@ namespace hpx { namespace resiliency { namespace experimental {
     namespace detail {
 
         ///////////////////////////////////////////////////////////////////////
-        template <typename Executor, typename Vote, typename Pred, typename F,
-            typename... Ts>
-        typename hpx::traits::executor_future<Executor,
-            typename hpx::util::detail::invoke_deferred_result<F,
-                Ts...>::type>::type
-        async_replicate_vote_validate_executor(Executor&& exec, std::size_t n,
-            Vote&& vote, Pred&& pred, F&& f, Ts&&... ts)
+        template <typename Result>
+        struct async_replicate_vote_validate_executor
         {
-            using result_type =
-                typename hpx::util::detail::invoke_deferred_result<F,
-                    Ts...>::type;
+            template <typename Executor, typename Vote, typename Pred,
+                typename F, typename... Ts>
+            static typename hpx::traits::executor_future<Executor, Result>::type
+            call(Executor&& exec, std::size_t n, Vote&& vote, Pred&& pred,
+                F&& f, Ts&&... ts)
+            {
+                using result_type =
+                    typename hpx::util::detail::invoke_deferred_result<F,
+                        Ts...>::type;
 
-            using future_type = typename hpx::traits::executor_future<Executor,
-                result_type>::type;
+                using future_type =
+                    typename hpx::traits::executor_future<Executor,
+                        result_type>::type;
 
-            // launch given function n times
-            auto func = [f = std::forward<F>(f),
-                            t = hpx::util::make_tuple(std::forward<Ts>(ts)...)](
-                            std::size_t) -> result_type {
-                // ignore argument (invocation count of bulk_execute)
-                return hpx::util::invoke_fused(f, t);
-            };
+                // launch given function n times
+                auto func =
+                    [f = std::forward<F>(f),
+                        t = hpx::util::make_tuple(std::forward<Ts>(ts)...)](
+                        std::size_t) mutable -> result_type {
+                    // ignore argument (invocation count of bulk_execute)
+                    return hpx::util::invoke_fused(f, t);
+                };
 
-            std::vector<future_type> results =
-                hpx::parallel::execution::bulk_async_execute(
-                    std::forward<Executor>(exec), std::move(func), n);
+                std::vector<future_type> results =
+                    hpx::parallel::execution::bulk_async_execute(
+                        std::forward<Executor>(exec), std::move(func), n);
 
-            // wait for all threads to finish executing and return the first
-            // result that passes the predicate, properly handle exceptions
-            // do not schedule new thread for the lambda
-            return hpx::dataflow(
-                hpx::launch::sync,
-                [pred = std::forward<Pred>(pred),
-                    vote = std::forward<Vote>(vote), n](
-                    std::vector<future_type>&& results) mutable -> result_type {
-                    // Store all valid results
-                    std::vector<result_type> valid_results;
-                    valid_results.reserve(n);
+                // wait for all threads to finish executing and return the first
+                // result that passes the predicate, properly handle exceptions
+                // do not schedule new thread for the lambda
+                return hpx::dataflow(
+                    hpx::launch::sync,
+                    [pred = std::forward<Pred>(pred),
+                        vote = std::forward<Vote>(vote),
+                        n](std::vector<future_type>&& results) mutable
+                    -> result_type {
+                        // Store all valid results
+                        std::vector<result_type> valid_results;
+                        valid_results.reserve(n);
 
-                    std::exception_ptr ex;
+                        std::exception_ptr ex;
 
-                    for (auto&& f : std::move(results))
-                    {
-                        if (f.has_exception())
+                        for (auto&& f : std::move(results))
                         {
-                            // rethrow abort_replicate_exception, if caught
-                            ex = detail::rethrow_on_abort_replicate(f);
-                        }
-                        else
-                        {
-                            auto&& result = f.get();
-                            if (hpx::util::invoke(pred, result))
+                            if (f.has_exception())
                             {
-                                valid_results.emplace_back(std::move(result));
+                                // rethrow abort_replicate_exception, if caught
+                                ex = detail::rethrow_on_abort_replicate(f);
+                            }
+                            else
+                            {
+                                auto&& result = f.get();
+                                if (hpx::util::invoke(pred, result))
+                                {
+                                    valid_results.emplace_back(
+                                        std::move(result));
+                                }
                             }
                         }
-                    }
 
-                    if (!valid_results.empty())
-                    {
-                        return hpx::util::invoke(
-                            std::forward<Vote>(vote), std::move(valid_results));
-                    }
+                        if (!valid_results.empty())
+                        {
+                            return hpx::util::invoke(std::forward<Vote>(vote),
+                                std::move(valid_results));
+                        }
 
-                    if (bool(ex))
-                    {
-                        std::rethrow_exception(ex);
-                    }
+                        if (bool(ex))
+                        {
+                            std::rethrow_exception(ex);
+                        }
 
-                    // throw aborting exception no correct results ere produced
-                    throw abort_replicate_exception{};
-                },
-                std::move(results));
-        }
+                        // throw aborting exception no correct results ere produced
+                        throw abort_replicate_exception{};
+                    },
+                    std::move(results));
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <>
+        struct async_replicate_vote_validate_executor<void>
+        {
+            template <typename Executor, typename Vote, typename Pred,
+                typename F, typename... Ts>
+            static typename hpx::traits::executor_future<Executor, void>::type
+            call(Executor&& exec, std::size_t n, Vote&&, Pred&&, F&& f,
+                Ts&&... ts)
+            {
+                using future_type =
+                    typename hpx::traits::executor_future<Executor, void>::type;
+
+                // launch given function n times
+                auto func = [f = std::forward<F>(f),
+                                t = hpx::util::make_tuple(std::forward<Ts>(
+                                    ts)...)](std::size_t) mutable {
+                    // ignore argument (invocation count of bulk_execute)
+                    hpx::util::invoke_fused(f, t);
+                };
+
+                std::vector<future_type> results =
+                    hpx::parallel::execution::bulk_async_execute(
+                        std::forward<Executor>(exec), std::move(func), n);
+
+                // wait for all threads to finish executing and return the first
+                // result that passes the predicate, properly handle exceptions
+                // do not schedule new thread for the lambda
+                return hpx::dataflow(
+                    hpx::launch::sync,
+                    [](std::vector<future_type>&& results) mutable -> void {
+                        std::exception_ptr ex;
+
+                        std::size_t count = 0;
+                        for (auto&& f : std::move(results))
+                        {
+                            if (f.has_exception())
+                            {
+                                // rethrow abort_replicate_exception, if caught
+                                ex = detail::rethrow_on_abort_replicate(f);
+                            }
+                            else
+                            {
+                                ++count;
+                            }
+                        }
+
+                        if (count != 0)
+                        {
+                            return;
+                        }
+
+                        if (bool(ex))
+                        {
+                            std::rethrow_exception(ex);
+                        }
+
+                        // throw aborting exception no correct results ere produced
+                        throw abort_replicate_exception{};
+                    },
+                    std::move(results));
+            }
+        };
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
@@ -123,10 +193,13 @@ namespace hpx { namespace resiliency { namespace experimental {
     decltype(auto) tag_invoke(async_replicate_vote_validate_t, Executor&& exec,
         std::size_t n, Vote&& vote, Pred&& pred, F&& f, Ts&&... ts)
     {
-        return detail::async_replicate_vote_validate_executor(
-            std::forward<Executor>(exec), n, std::forward<Vote>(vote),
-            std::forward<Pred>(pred), std::forward<F>(f),
-            std::forward<Ts>(ts)...);
+        using result_type =
+            typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type;
+
+        return detail::async_replicate_vote_validate_executor<
+            result_type>::call(std::forward<Executor>(exec), n,
+            std::forward<Vote>(vote), std::forward<Pred>(pred),
+            std::forward<F>(f), std::forward<Ts>(ts)...);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -145,10 +218,13 @@ namespace hpx { namespace resiliency { namespace experimental {
     decltype(auto) tag_invoke(async_replicate_vote_t, Executor&& exec,
         std::size_t n, Vote&& vote, F&& f, Ts&&... ts)
     {
-        return detail::async_replicate_vote_validate_executor(
-            std::forward<Executor>(exec), n, std::forward<Vote>(vote),
-            detail::replicate_validator{}, std::forward<F>(f),
-            std::forward<Ts>(ts)...);
+        using result_type =
+            typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type;
+
+        return detail::async_replicate_vote_validate_executor<
+            result_type>::call(std::forward<Executor>(exec), n,
+            std::forward<Vote>(vote), detail::replicate_validator{},
+            std::forward<F>(f), std::forward<Ts>(ts)...);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -166,10 +242,13 @@ namespace hpx { namespace resiliency { namespace experimental {
     decltype(auto) tag_invoke(async_replicate_validate_t, Executor&& exec,
         std::size_t n, Pred&& pred, F&& f, Ts&&... ts)
     {
-        return detail::async_replicate_vote_validate_executor(
-            std::forward<Executor>(exec), n, detail::replicate_voter{},
-            std::forward<Pred>(pred), std::forward<F>(f),
-            std::forward<Ts>(ts)...);
+        using result_type =
+            typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type;
+
+        return detail::async_replicate_vote_validate_executor<
+            result_type>::call(std::forward<Executor>(exec), n,
+            detail::replicate_voter{}, std::forward<Pred>(pred),
+            std::forward<F>(f), std::forward<Ts>(ts)...);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -187,9 +266,12 @@ namespace hpx { namespace resiliency { namespace experimental {
     decltype(auto) tag_invoke(
         async_replicate_t, Executor&& exec, std::size_t n, F&& f, Ts&&... ts)
     {
-        return detail::async_replicate_vote_validate_executor(
-            std::forward<Executor>(exec), n, detail::replicate_voter{},
-            detail::replicate_validator{}, std::forward<F>(f),
-            std::forward<Ts>(ts)...);
+        using result_type =
+            typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type;
+
+        return detail::async_replicate_vote_validate_executor<
+            result_type>::call(std::forward<Executor>(exec), n,
+            detail::replicate_voter{}, detail::replicate_validator{},
+            std::forward<F>(f), std::forward<Ts>(ts)...);
     }
 }}}    // namespace hpx::resiliency::experimental

--- a/libs/resiliency/include/hpx/resiliency/async_replicate_executor.hpp
+++ b/libs/resiliency/include/hpx/resiliency/async_replicate_executor.hpp
@@ -168,7 +168,7 @@ namespace hpx { namespace resiliency { namespace experimental {
                             std::rethrow_exception(ex);
                         }
 
-                        // throw aborting exception no correct results ere produced
+                        // throw aborting exception if no correct results were produced
                         throw abort_replicate_exception{};
                     },
                     std::move(results));

--- a/libs/resiliency/include/hpx/resiliency/replay_executor.hpp
+++ b/libs/resiliency/include/hpx/resiliency/replay_executor.hpp
@@ -1,0 +1,193 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/resiliency/config.hpp>
+#include <hpx/assert.hpp>
+#include <hpx/async_base/launch_policy.hpp>
+#include <hpx/execution/executors/execution.hpp>
+#include <hpx/execution/traits/executor_traits.hpp>
+#include <hpx/execution/traits/is_executor.hpp>
+#include <hpx/executors/current_executor.hpp>
+#include <hpx/futures/future.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/resiliency/async_replay_executor.hpp>
+#include <hpx/synchronization/latch.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace resiliency { namespace experimental {
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename BaseExecutor, typename Validate>
+    class replay_executor
+    {
+    public:
+        static constexpr int num_spread = 4;
+        static constexpr int num_tasks = 128;
+
+        using execution_category = typename BaseExecutor::execution_category;
+        using executor_parameters_type =
+            typename BaseExecutor::executor_parameters_type;
+
+        template <typename Result>
+        using future_type =
+            typename hpx::parallel::execution::executor_future<BaseExecutor,
+                Result>::type;
+
+        template <typename F>
+        explicit replay_executor(BaseExecutor& exec, std::size_t n, F&& f)
+          : exec_(exec)
+          , replay_count_(n)
+          , validator_(std::forward<F>(f))
+        {
+        }
+
+        bool operator==(replay_executor const& rhs) const noexcept
+        {
+            return exec_ == rhs.exec_;
+        }
+
+        bool operator!=(replay_executor const& rhs) const noexcept
+        {
+            return !(*this == rhs);
+        }
+
+        replay_executor const& context() const noexcept
+        {
+            return *this;
+        }
+
+        // TwoWayExecutor interface
+        template <typename F, typename... Ts>
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
+        {
+            return async_replay_validate(exec_, replay_count_, validator_,
+                std::forward<F>(f), std::forward<Ts>(ts)...);
+        }
+
+        // BulkTwoWayExecutor interface
+        template <typename F, typename S, typename... Ts>
+        decltype(auto) bulk_async_execute(
+            F&& f, S const& shape, Ts&&... ts) const
+        {
+            std::size_t size = hpx::util::size(shape);
+
+            using result_type =
+                typename hpx::parallel::execution::detail::bulk_function_result<
+                    F, S, Ts...>::type;
+            using future_type =
+                typename hpx::parallel::execution::executor_future<BaseExecutor,
+                    result_type>::type;
+
+            std::vector<future_type> results;
+            results.resize(size);
+
+            hpx::lcos::local::latch l(size + 1);
+
+            spawn_hierarchical(results, l, 0, size, num_tasks, f,
+                hpx::util::begin(shape), ts...);
+
+            l.count_down_and_wait();
+
+            return results;
+        }
+
+    protected:
+        /// \cond NOINTERNAL
+        template <typename Result, typename F, typename Iter, typename... Ts>
+        void spawn_sequential(std::vector<hpx::future<Result>>& results,
+            hpx::lcos::local::latch& l, std::size_t base, std::size_t size,
+            F&& func, Iter it, Ts&&... ts) const
+        {
+            // spawn tasks sequentially
+            HPX_ASSERT(base + size <= results.size());
+
+            for (std::size_t i = 0; i != size; (void) ++i, ++it)
+            {
+                results[base + i] = async_execute(func, *it, ts...);
+            }
+
+            l.count_down(size);
+        }
+
+        template <typename Result, typename F, typename Iter, typename... Ts>
+        void spawn_hierarchical(std::vector<hpx::future<Result>>& results,
+            hpx::lcos::local::latch& l, std::size_t base, std::size_t size,
+            std::size_t num_tasks, F&& func, Iter it, Ts&&... ts) const
+        {
+            if (size > num_tasks)
+            {
+                // spawn hierarchical tasks
+                std::size_t chunk_size = (size + num_spread) / num_spread - 1;
+                chunk_size = (std::max)(chunk_size, num_tasks);
+
+                while (size > chunk_size)
+                {
+                    hpx::parallel::execution::post(
+                        hpx::this_thread::get_executor(),
+                        [&, base, chunk_size, num_tasks, it] {
+                            spawn_hierarchical(results, l, base, chunk_size,
+                                num_tasks, func, it, ts...);
+                        });
+
+                    base += chunk_size;
+                    std::advance(it, chunk_size);
+                    size -= chunk_size;
+                }
+            }
+
+            // spawn remaining tasks sequentially
+            spawn_sequential(results, l, base, size, func, it, ts...);
+        }
+        /// \endcond
+
+    private:
+        BaseExecutor& exec_;
+        std::size_t replay_count_;
+        Validate validator_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename BaseExecutor, typename Validate>
+    replay_executor<BaseExecutor, typename std::decay<Validate>::type>
+    make_replay_executor(BaseExecutor& exec, std::size_t n, Validate&& validate)
+    {
+        return replay_executor<BaseExecutor,
+            typename std::decay<Validate>::type>(
+            exec, n, std::forward<Validate>(validate));
+    }
+
+    template <typename BaseExecutor>
+    replay_executor<BaseExecutor, detail::replay_validator>
+    make_replay_executor(BaseExecutor& exec, std::size_t n)
+    {
+        return replay_executor<BaseExecutor, detail::replay_validator>(
+            exec, n, detail::replay_validator());
+    }
+}}}    // namespace hpx::resiliency::experimental
+
+namespace hpx { namespace parallel { namespace execution {
+
+    template <typename BaseExecutor, typename Validator>
+    struct is_two_way_executor<
+        hpx::resiliency::experimental::replay_executor<BaseExecutor, Validator>>
+      : std::true_type
+    {
+    };
+
+    template <typename BaseExecutor, typename Validator>
+    struct is_bulk_two_way_executor<
+        hpx::resiliency::experimental::replay_executor<BaseExecutor, Validator>>
+      : std::true_type
+    {
+    };
+}}}    // namespace hpx::parallel::execution

--- a/libs/resiliency/include/hpx/resiliency/replicate_executor.hpp
+++ b/libs/resiliency/include/hpx/resiliency/replicate_executor.hpp
@@ -1,0 +1,211 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/resiliency/config.hpp>
+#include <hpx/assert.hpp>
+#include <hpx/async_base/launch_policy.hpp>
+#include <hpx/execution/executors/execution.hpp>
+#include <hpx/execution/traits/executor_traits.hpp>
+#include <hpx/execution/traits/is_executor.hpp>
+#include <hpx/executors/current_executor.hpp>
+#include <hpx/futures/future.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/resiliency/async_replicate_executor.hpp>
+#include <hpx/synchronization/latch.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace resiliency { namespace experimental {
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename BaseExecutor, typename Vote, typename Validate>
+    class replicate_executor
+    {
+    public:
+        static constexpr int num_spread = 4;
+        static constexpr int num_tasks = 128;
+
+        using execution_category = typename BaseExecutor::execution_category;
+        using executor_parameters_type =
+            typename BaseExecutor::executor_parameters_type;
+
+        template <typename Result>
+        using future_type =
+            typename hpx::parallel::execution::executor_future<BaseExecutor,
+                Result>::type;
+
+        template <typename V, typename F>
+        explicit replicate_executor(
+            BaseExecutor& exec, std::size_t n, V&& v, F&& f)
+          : exec_(exec)
+          , replicate_count_(n)
+          , voter_(std::forward<V>(v))
+          , validator_(std::forward<F>(f))
+        {
+        }
+
+        bool operator==(replicate_executor const& rhs) const noexcept
+        {
+            return exec_ == rhs.exec_;
+        }
+
+        bool operator!=(replicate_executor const& rhs) const noexcept
+        {
+            return !(*this == rhs);
+        }
+
+        replicate_executor const& context() const noexcept
+        {
+            return *this;
+        }
+
+        // TwoWayExecutor interface
+        template <typename F, typename... Ts>
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
+        {
+            return async_replicate_vote_validate(exec_, replicate_count_,
+                voter_, validator_, std::forward<F>(f),
+                std::forward<Ts>(ts)...);
+        }
+
+        // BulkTwoWayExecutor interface
+        template <typename F, typename S, typename... Ts>
+        decltype(auto) bulk_async_execute(
+            F&& f, S const& shape, Ts&&... ts) const
+        {
+            std::size_t size = hpx::util::size(shape);
+
+            using result_type =
+                typename hpx::parallel::execution::detail::bulk_function_result<
+                    F, S, Ts...>::type;
+            using future_type =
+                typename hpx::parallel::execution::executor_future<BaseExecutor,
+                    result_type>::type;
+
+            std::vector<future_type> results;
+            results.resize(size);
+
+            hpx::lcos::local::latch l(size + 1);
+
+            spawn_hierarchical(results, l, 0, size, num_tasks, f,
+                hpx::util::begin(shape), ts...);
+
+            l.count_down_and_wait();
+
+            return results;
+        }
+
+    protected:
+        /// \cond NOINTERNAL
+        template <typename Result, typename F, typename Iter, typename... Ts>
+        void spawn_sequential(std::vector<hpx::future<Result>>& results,
+            hpx::lcos::local::latch& l, std::size_t base, std::size_t size,
+            F&& func, Iter it, Ts&&... ts) const
+        {
+            // spawn tasks sequentially
+            HPX_ASSERT(base + size <= results.size());
+
+            for (std::size_t i = 0; i != size; (void) ++i, ++it)
+            {
+                results[base + i] = async_execute(func, *it, ts...);
+            }
+
+            l.count_down(size);
+        }
+
+        template <typename Result, typename F, typename Iter, typename... Ts>
+        void spawn_hierarchical(std::vector<hpx::future<Result>>& results,
+            hpx::lcos::local::latch& l, std::size_t base, std::size_t size,
+            std::size_t num_tasks, F&& func, Iter it, Ts&&... ts) const
+        {
+            if (size > num_tasks)
+            {
+                // spawn hierarchical tasks
+                std::size_t chunk_size = (size + num_spread) / num_spread - 1;
+                chunk_size = (std::max)(chunk_size, num_tasks);
+
+                while (size > chunk_size)
+                {
+                    hpx::parallel::execution::post(
+                        hpx::this_thread::get_executor(),
+                        [&, base, chunk_size, num_tasks, it] {
+                            spawn_hierarchical(results, l, base, chunk_size,
+                                num_tasks, func, it, ts...);
+                        });
+
+                    base += chunk_size;
+                    std::advance(it, chunk_size);
+                    size -= chunk_size;
+                }
+            }
+
+            // spawn remaining tasks sequentially
+            spawn_sequential(results, l, base, size, func, it, ts...);
+        }
+        /// \endcond
+
+    private:
+        BaseExecutor& exec_;
+        std::size_t replicate_count_;
+        Vote voter_;
+        Validate validator_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename BaseExecutor, typename Voter, typename Validate>
+    replicate_executor<BaseExecutor, typename std::decay<Voter>::type,
+        typename std::decay<Validate>::type>
+    make_replicate_executor(
+        BaseExecutor& exec, std::size_t n, Voter&& voter, Validate&& validate)
+    {
+        return replicate_executor<BaseExecutor,
+            typename std::decay<Voter>::type,
+            typename std::decay<Validate>::type>(exec, n,
+            std::forward<Voter>(voter), std::forward<Validate>(validate));
+    }
+
+    template <typename BaseExecutor, typename Validate>
+    replicate_executor<BaseExecutor, detail::replicate_voter,
+        typename std::decay<Validate>::type>
+    make_replicate_executor(
+        BaseExecutor& exec, std::size_t n, Validate&& validate)
+    {
+        return replicate_executor<BaseExecutor, detail::replicate_voter,
+            typename std::decay<Validate>::type>(exec, n,
+            detail::replicate_voter(), std::forward<Validate>(validate));
+    }
+
+    template <typename BaseExecutor>
+    replicate_executor<BaseExecutor, detail::replicate_voter,
+        detail::replicate_validator>
+    make_replicate_executor(BaseExecutor& exec, std::size_t n)
+    {
+        return replicate_executor<BaseExecutor, detail::replicate_voter,
+            detail::replicate_validator>(
+            exec, n, detail::replicate_voter(), detail::replicate_validator());
+    }
+}}}    // namespace hpx::resiliency::experimental
+
+namespace hpx { namespace parallel { namespace execution {
+
+    template <typename BaseExecutor, typename Voter, typename Validator>
+    struct is_two_way_executor<hpx::resiliency::experimental::
+            replicate_executor<BaseExecutor, Voter, Validator>> : std::true_type
+    {
+    };
+
+    template <typename BaseExecutor, typename Voter, typename Validator>
+    struct is_bulk_two_way_executor<hpx::resiliency::experimental::
+            replicate_executor<BaseExecutor, Voter, Validator>> : std::true_type
+    {
+    };
+}}}    // namespace hpx::parallel::execution

--- a/libs/resiliency/tests/unit/CMakeLists.txt
+++ b/libs/resiliency/tests/unit/CMakeLists.txt
@@ -15,6 +15,8 @@ set(tests
     dataflow_replay_plain
     dataflow_replicate_executor
     dataflow_replicate_plain
+    replay_executor
+    replicate_executor
 )
 
 foreach(test ${tests})

--- a/libs/resiliency/tests/unit/replay_executor.cpp
+++ b/libs/resiliency/tests/unit/replay_executor.cpp
@@ -1,0 +1,85 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/algorithms.hpp>
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/executors.hpp>
+#include <hpx/modules/futures.hpp>
+#include <hpx/modules/resiliency.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+struct vogon_exception : std::exception
+{
+};
+
+int hpx_main(int argc, char* argv[])
+{
+    try
+    {
+        hpx::parallel::execution::parallel_executor base_exec;
+        auto exec =
+            hpx::resiliency::experimental::make_replay_executor(base_exec, 3);
+
+        std::vector<std::size_t> data(100);
+        std::iota(data.begin(), data.end(), 0);
+
+        std::atomic<std::size_t> count(0);
+        hpx::parallel::for_each(hpx::parallel::execution::par.on(exec),
+            data.begin(), data.end(), [&](std::size_t i) {
+                if (++count == 42)
+                {
+                    throw vogon_exception();
+                }
+            });
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    try
+    {
+        hpx::parallel::execution::parallel_executor base_exec;
+        auto exec =
+            hpx::resiliency::experimental::make_replay_executor(base_exec, 3);
+
+        std::vector<std::size_t> data(100);
+        std::iota(data.begin(), data.end(), 0);
+
+        std::vector<std::size_t> dest(100);
+
+        std::atomic<std::size_t> count(0);
+        hpx::parallel::transform(hpx::parallel::execution::par.on(exec),
+            data.begin(), data.end(), dest.begin(), [&](std::size_t i) {
+                if (++count == 42)
+                {
+                    throw vogon_exception();
+                }
+                return i;
+            });
+
+        HPX_TEST(data == dest);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // Initialize and run HPX
+    HPX_TEST(hpx::init(argc, argv) == 0);
+    return hpx::util::report_errors();
+}

--- a/libs/resiliency/tests/unit/replicate_executor.cpp
+++ b/libs/resiliency/tests/unit/replicate_executor.cpp
@@ -1,0 +1,85 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/algorithms.hpp>
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/executors.hpp>
+#include <hpx/modules/futures.hpp>
+#include <hpx/modules/resiliency.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+struct vogon_exception : std::exception
+{
+};
+
+int hpx_main(int argc, char* argv[])
+{
+    try
+    {
+        hpx::parallel::execution::parallel_executor base_exec;
+        auto exec = hpx::resiliency::experimental::make_replicate_executor(
+            base_exec, 2);
+
+        std::vector<std::size_t> data(100);
+        std::iota(data.begin(), data.end(), 0);
+
+        std::atomic<std::size_t> count(0);
+        hpx::parallel::for_each(hpx::parallel::execution::par.on(exec),
+            data.begin(), data.end(), [&](std::size_t i) {
+                if (++count == 42)
+                {
+                    throw vogon_exception();
+                }
+            });
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    try
+    {
+        hpx::parallel::execution::parallel_executor base_exec;
+        auto exec = hpx::resiliency::experimental::make_replicate_executor(
+            base_exec, 2);
+
+        std::vector<std::size_t> data(100);
+        std::iota(data.begin(), data.end(), 0);
+
+        std::vector<std::size_t> dest(100);
+
+        std::atomic<std::size_t> count(0);
+        hpx::parallel::transform(hpx::parallel::execution::par.on(exec),
+            data.begin(), data.end(), dest.begin(), [&](std::size_t i) {
+                if (++count == 42)
+                {
+                    throw vogon_exception();
+                }
+                return i;
+            });
+
+        HPX_TEST(data == dest);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // Initialize and run HPX
+    HPX_TEST(hpx::init(argc, argv) == 0);
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
- this allows for instance for the parallel algorithms to be resilient
  to failing iterations

