### PR TITLE
Fix exception handling for tasks

### DIFF
--- a/libs/futures/tests/regressions/future_unwrap_878.cpp
+++ b/libs/futures/tests/regressions/future_unwrap_878.cpp
@@ -19,6 +19,7 @@ int main()
 {
     hpx::lcos::local::promise<hpx::future<int>> promise;
     hpx::future<hpx::future<int>> future = promise.get_future();
+    std::exception_ptr p;
     try
     {
         //promise.set_value(42);
@@ -26,8 +27,10 @@ int main()
     }
     catch (...)
     {
-        promise.set_exception(std::current_exception());
+        p = std::current_exception();
     }
+    HPX_TEST(p);
+    promise.set_exception(std::move(p));
     HPX_TEST(future.has_exception());
 
     hpx::future<int> inner(std::move(future));


### PR DESCRIPTION
Setting the exception on a future may yield (a lock is required), and thus lead to the task being resumed on another worker thread after setting the exception. Before this change the exception for a future was set directly in the catch block which could lead to the catch block being entered on one worker thread and exited on another thread. This seems to not be allowed and leads to
segfaults at least with gcc and clang. This change only gets the current exception in the catch block, but sets it after the catch block to avoid potentially yielding in the catch block.

I'm currently stress testing `partition` and `uninitialized_move` and they seem to not fail anymore locally. I'm assuming this will fix most of the other `tests.unit.modules.algorithms` tests that occasionally fail (it always seems to be the exception handling tests that fail, but time will tell if there were actually other ones lurking there as well).