### PR TITLE
Add CPOs for for_loop algorithms

### DIFF
--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -92,10 +92,10 @@ Functions
 - :cpp:func:`hpx::parallel::v1::swap_ranges`
 - :cpp:func:`hpx::parallel::v1::unique`
 - :cpp:func:`hpx::parallel::v1::unique_copy`
-- :cpp:func:`hpx::parallel::v2::for_loop`
-- :cpp:func:`hpx::parallel::v2::for_loop_strided`
-- :cpp:func:`hpx::parallel::v2::for_loop_n`
-- :cpp:func:`hpx::parallel::v2::for_loop_n_strided`
+- :cpp:func:`hpx::for_loop`
+- :cpp:func:`hpx::for_loop_strided`
+- :cpp:func:`hpx::for_loop_n`
+- :cpp:func:`hpx::for_loop_n_strided`
 
 - :cpp:func:`hpx::ranges::all_of`
 - :cpp:func:`hpx::ranges::any_of`

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -749,23 +749,23 @@ Parallel algorithms
      * ``<hpx/memory.hpp>``
      * :cppreference-memory:`uninitialized_value_construct_n`
 
-.. list-table:: Index-based for-loops (In Header: `<hpx/include/parallel_algorithm.hpp>`)
+.. list-table:: Index-based for-loops (In Header: `<hpx/algorithm.hpp>`)
 
    * * Name
      * Description
      * In header
-   * * :cpp:func:`hpx::parallel::v2::for_loop`
+   * * :cpp:func:`hpx::for_loop`
      * Implements loop functionality over a range specified by integral or iterator bounds.
-     * ``<hpx/include/parallel_for_loop.hpp>``
-   * * :cpp:func:`hpx::parallel::v2::for_loop_strided`
+     * ``<hpx/algorithm.hpp>``
+   * * :cpp:func:`hpx::for_loop_strided`
      * Implements loop functionality over a range specified by integral or iterator bounds.
-     * ``<hpx/include/parallel_for_loop.hpp>``
-   * * :cpp:func:`hpx::parallel::v2::for_loop_n`
+     * ``<hpx/algorithm.hpp>``
+   * * :cpp:func:`hpx::for_loop_n`
      * Implements loop functionality over a range specified by integral or iterator bounds.
-     * ``<hpx/include/parallel_for_loop.hpp>``
-   * * :cpp:func:`hpx::parallel::v2::for_loop_n_strided`
+     * ``<hpx/algorithm.hpp>``
+   * * :cpp:func:`hpx::for_loop_n_strided`
      * Implements loop functionality over a range specified by integral or iterator bounds.
-     * ``<hpx/include/parallel_for_loop.hpp>``
+     * ``<hpx/algorithm.hpp>``
 
 .. _executor_parameters:
 

--- a/examples/quickstart/disable_thread_stealing_executor.cpp
+++ b/examples/quickstart/disable_thread_stealing_executor.cpp
@@ -11,9 +11,9 @@
 
 #include <hpx/hpx_main.hpp>
 
+#include <hpx/algorithm.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/execution.hpp>
-#include <hpx/modules/algorithms.hpp>
 
 #include <algorithm>
 #include <atomic>
@@ -120,10 +120,10 @@ int main()
 
     // The following for_loop will be executed while thread stealing is disabled
     auto exec = executor_example::make_disable_thread_stealing_executor(
-        hpx::parallel::execution::par.executor());
+        hpx::execution::par.executor());
 
-    hpx::parallel::for_loop(hpx::parallel::execution::par.on(exec), 0, v.size(),
-        [](std::size_t i) {});
+    hpx::for_loop(
+        hpx::execution::par.on(exec), 0, v.size(), [](std::size_t i) {});
 
     return 0;
 }

--- a/examples/quickstart/executor_with_thread_hooks.cpp
+++ b/examples/quickstart/executor_with_thread_hooks.cpp
@@ -12,7 +12,7 @@
 
 #include <hpx/hpx_main.hpp>
 
-#include <hpx/modules/algorithms.hpp>
+#include <hpx/algorithm.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/execution.hpp>
 
@@ -224,10 +224,10 @@ int main()
     auto on_stop = [&]() { ++stops; };
 
     auto exec = executor_example::make_executor_with_thread_hooks(
-        hpx::parallel::execution::par.executor(), on_start, on_stop);
+        hpx::execution::par.executor(), on_start, on_stop);
 
-    hpx::parallel::for_loop(hpx::parallel::execution::par.on(exec), 0, v.size(),
-        [](std::size_t i) {});
+    hpx::for_loop(
+        hpx::execution::par.on(exec), 0, v.size(), [](std::size_t i) {});
 
     std::cout << "Executed " << starts.load() << " starts and " << stops.load()
               << " stops\n";

--- a/libs/algorithms/CMakeLists.txt
+++ b/libs/algorithms/CMakeLists.txt
@@ -189,6 +189,7 @@ add_hpx_module(
     hpx_program_options
     hpx_statistics
     hpx_synchronization
+    hpx_threading_base
     hpx_timing
     hpx_type_support
   CMAKE_SUBDIRS examples tests

--- a/libs/algorithms/tests/regressions/for_loop_2281.cpp
+++ b/libs/algorithms/tests/regressions/for_loop_2281.cpp
@@ -4,9 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/algorithm.hpp>
+#include <hpx/execution.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/parallel_for_loop.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <cstddef>
@@ -21,7 +22,7 @@ int hpx_main()
     hpx::lcos::local::spinlock mtx;
     std::set<hpx::thread::id> thread_ids;
 
-    hpx::parallel::for_loop(hpx::parallel::execution::par, 0, 100, [&](int i) {
+    hpx::for_loop(hpx::parallel::execution::par, 0, 100, [&](int i) {
         std::lock_guard<hpx::lcos::local::spinlock> l(mtx);
         thread_ids.insert(hpx::this_thread::get_id());
     });
@@ -30,11 +31,10 @@ int hpx_main()
 
     thread_ids.clear();
 
-    hpx::parallel::for_loop_n(
-        hpx::parallel::execution::par, 0, 100, [&](int i) {
-            std::lock_guard<hpx::lcos::local::spinlock> l(mtx);
-            thread_ids.insert(hpx::this_thread::get_id());
-        });
+    hpx::for_loop_n(hpx::parallel::execution::par, 0, 100, [&](int i) {
+        std::lock_guard<hpx::lcos::local::spinlock> l(mtx);
+        thread_ids.insert(hpx::this_thread::get_id());
+    });
 
     HPX_TEST_LT(std::size_t(1), thread_ids.size());
 

--- a/libs/algorithms/tests/unit/algorithms/for_loop.cpp
+++ b/libs/algorithms/tests/unit/algorithms/for_loop.cpp
@@ -4,11 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/algorithm.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/modules/testing.hpp>
-
-#include <hpx/include/parallel_for_loop.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -38,9 +37,8 @@ void test_for_loop(ExPolicy&& policy, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::parallel::for_loop(std::forward<ExPolicy>(policy),
-        iterator(std::begin(c)), iterator(std::end(c)),
-        [](iterator it) { *it = 42; });
+    hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
+        iterator(std::end(c)), [](iterator it) { *it = 42; });
 
     // verify values
     std::size_t count = 0;
@@ -60,9 +58,8 @@ void test_for_loop_async(ExPolicy&& p, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f = hpx::parallel::for_loop(std::forward<ExPolicy>(p),
-        iterator(std::begin(c)), iterator(std::end(c)),
-        [](iterator it) { *it = 42; });
+    auto f = hpx::for_loop(std::forward<ExPolicy>(p), iterator(std::begin(c)),
+        iterator(std::end(c)), [](iterator it) { *it = 42; });
     f.wait();
 
     // verify values
@@ -104,7 +101,7 @@ void test_for_loop_idx(ExPolicy&& policy)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::parallel::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+    hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
         [&c](std::size_t i) { c[i] = 42; });
 
     // verify values
@@ -124,7 +121,7 @@ void test_for_loop_idx_async(ExPolicy&& p)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f = hpx::parallel::for_loop(std::forward<ExPolicy>(p), 0, c.size(),
+    auto f = hpx::for_loop(std::forward<ExPolicy>(p), 0, c.size(),
         [&c](std::size_t i) { c[i] = 42; });
     f.wait();
 

--- a/libs/algorithms/tests/unit/algorithms/for_loop_exception.cpp
+++ b/libs/algorithms/tests/unit/algorithms/for_loop_exception.cpp
@@ -4,11 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/algorithm.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/modules/testing.hpp>
-
-#include <hpx/include/parallel_for_loop.hpp>
 
 #include <algorithm>
 #include <atomic>
@@ -83,9 +82,8 @@ void test_for_loop_exception(ExPolicy&& policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::for_loop(std::forward<ExPolicy>(policy),
-            iterator(std::begin(c)), iterator(std::end(c)),
-            throw_always(dis(gen)));
+        hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
+            iterator(std::end(c)), throw_always(dis(gen)));
 
         HPX_TEST(false);
     }
@@ -117,9 +115,9 @@ void test_for_loop_exception_async(ExPolicy&& p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::for_loop(std::forward<ExPolicy>(p),
-            iterator(std::begin(c)), iterator(std::end(c)),
-            throw_always(dis(gen)));
+        auto f =
+            hpx::for_loop(std::forward<ExPolicy>(p), iterator(std::begin(c)),
+                iterator(std::end(c)), throw_always(dis(gen)));
         returned_from_algorithm = true;
         f.get();
 
@@ -158,9 +156,8 @@ void test_for_loop_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::for_loop(std::forward<ExPolicy>(policy),
-            iterator(std::begin(c)), iterator(std::end(c)),
-            throw_bad_alloc(dis(gen)));
+        hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
+            iterator(std::end(c)), throw_bad_alloc(dis(gen)));
 
         HPX_TEST(false);
     }
@@ -191,9 +188,9 @@ void test_for_loop_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::for_loop(std::forward<ExPolicy>(p),
-            iterator(std::begin(c)), iterator(std::end(c)),
-            throw_bad_alloc(dis(gen)));
+        auto f =
+            hpx::for_loop(std::forward<ExPolicy>(p), iterator(std::begin(c)),
+                iterator(std::end(c)), throw_bad_alloc(dis(gen)));
         returned_from_algorithm = true;
         f.get();
 
@@ -260,7 +257,7 @@ void test_for_loop_idx_exception(ExPolicy&& policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+        hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
             throw_always(dis(gen)));
 
         HPX_TEST(false);
@@ -292,7 +289,7 @@ void test_for_loop_idx_exception_async(ExPolicy&& p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::for_loop(
+        auto f = hpx::for_loop(
             std::forward<ExPolicy>(p), 0, c.size(), throw_always(dis(gen)));
         returned_from_algorithm = true;
         f.get();
@@ -329,7 +326,7 @@ void test_for_loop_idx_bad_alloc(ExPolicy&& policy)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+        hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
             throw_bad_alloc(dis(gen)));
 
         HPX_TEST(false);
@@ -360,7 +357,7 @@ void test_for_loop_idx_bad_alloc_async(ExPolicy&& p)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::for_loop(
+        auto f = hpx::for_loop(
             std::forward<ExPolicy>(p), 0, c.size(), throw_bad_alloc(dis(gen)));
         returned_from_algorithm = true;
         f.get();

--- a/libs/algorithms/tests/unit/algorithms/for_loop_induction.cpp
+++ b/libs/algorithms/tests/unit/algorithms/for_loop_induction.cpp
@@ -4,11 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/algorithm.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/modules/testing.hpp>
-
-#include <hpx/include/parallel_for_loop.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -39,9 +38,9 @@ void test_for_loop_induction(ExPolicy&& policy, IteratorTag)
     std::vector<std::size_t> d(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::parallel::for_loop(std::forward<ExPolicy>(policy),
-        iterator(std::begin(c)), iterator(std::end(c)),
-        hpx::parallel::induction(0), [&d](iterator it, std::size_t i) {
+    hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
+        iterator(std::end(c)), hpx::parallel::induction(0),
+        [&d](iterator it, std::size_t i) {
             *it = 42;
             d[i] = 42;
         });
@@ -71,9 +70,9 @@ void test_for_loop_induction_stride(ExPolicy&& policy, IteratorTag)
     std::vector<std::size_t> d(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::parallel::for_loop(std::forward<ExPolicy>(policy),
-        iterator(std::begin(c)), iterator(std::end(c)),
-        hpx::parallel::induction(0), hpx::parallel::induction(0, 2),
+    hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
+        iterator(std::end(c)), hpx::parallel::induction(0),
+        hpx::parallel::induction(0, 2),
         [&d](iterator it, std::size_t i, std::size_t j) {
             *it = 42;
             d[i] = 42;
@@ -107,9 +106,9 @@ void test_for_loop_induction_life_out(ExPolicy&& policy, IteratorTag)
 
     std::size_t curr = 0;
 
-    hpx::parallel::for_loop(std::forward<ExPolicy>(policy),
-        iterator(std::begin(c)), iterator(std::end(c)),
-        hpx::parallel::induction(curr), [&d](iterator it, std::size_t i) {
+    hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
+        iterator(std::end(c)), hpx::parallel::induction(curr),
+        [&d](iterator it, std::size_t i) {
             *it = 42;
             d[i] = 42;
         });
@@ -143,9 +142,9 @@ void test_for_loop_induction_stride_life_out(ExPolicy&& policy, IteratorTag)
     std::size_t curr1 = 0;
     std::size_t curr2 = 0;
 
-    hpx::parallel::for_loop(std::forward<ExPolicy>(policy),
-        iterator(std::begin(c)), iterator(std::end(c)),
-        hpx::parallel::induction(curr1), hpx::parallel::induction(curr2, 2),
+    hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
+        iterator(std::end(c)), hpx::parallel::induction(curr1),
+        hpx::parallel::induction(curr2, 2),
         [&d](iterator it, std::size_t i, std::size_t j) {
             *it = 42;
             d[i] = 42;
@@ -206,7 +205,7 @@ void test_for_loop_induction_idx(ExPolicy&& policy)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::parallel::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+    hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
         hpx::parallel::induction(0), [&c](std::size_t i, std::size_t j) {
             c[i] = 42;
             HPX_TEST_EQ(i, j);
@@ -231,7 +230,7 @@ void test_for_loop_induction_stride_idx(ExPolicy&& policy)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::parallel::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+    hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
         hpx::parallel::induction(0), hpx::parallel::induction(0, 2),
         [&c](std::size_t i, std::size_t j, std::size_t k) {
             c[i] = 42;

--- a/libs/algorithms/tests/unit/algorithms/for_loop_induction_async.cpp
+++ b/libs/algorithms/tests/unit/algorithms/for_loop_induction_async.cpp
@@ -4,11 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/algorithm.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/modules/testing.hpp>
-
-#include <hpx/include/parallel_for_loop.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -39,7 +38,7 @@ void test_for_loop_induction(ExPolicy&& policy, IteratorTag)
     std::vector<std::size_t> d(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f = hpx::parallel::for_loop(std::forward<ExPolicy>(policy),
+    auto f = hpx::for_loop(std::forward<ExPolicy>(policy),
         iterator(std::begin(c)), iterator(std::end(c)),
         hpx::parallel::induction(0), [&d](iterator it, std::size_t i) {
             *it = 42;
@@ -72,7 +71,7 @@ void test_for_loop_induction_stride(ExPolicy&& policy, IteratorTag)
     std::vector<std::size_t> d(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f = hpx::parallel::for_loop(std::forward<ExPolicy>(policy),
+    auto f = hpx::for_loop(std::forward<ExPolicy>(policy),
         iterator(std::begin(c)), iterator(std::end(c)),
         hpx::parallel::induction(0), hpx::parallel::induction(0, 2),
         [&d](iterator it, std::size_t i, std::size_t j) {
@@ -109,7 +108,7 @@ void test_for_loop_induction_life_out(ExPolicy&& policy, IteratorTag)
 
     std::size_t curr = 0;
 
-    auto f = hpx::parallel::for_loop(std::forward<ExPolicy>(policy),
+    auto f = hpx::for_loop(std::forward<ExPolicy>(policy),
         iterator(std::begin(c)), iterator(std::end(c)),
         hpx::parallel::induction(curr), [&d](iterator it, std::size_t i) {
             *it = 42;
@@ -146,7 +145,7 @@ void test_for_loop_induction_stride_life_out(ExPolicy&& policy, IteratorTag)
     std::size_t curr1 = 0;
     std::size_t curr2 = 0;
 
-    auto f = hpx::parallel::for_loop(std::forward<ExPolicy>(policy),
+    auto f = hpx::for_loop(std::forward<ExPolicy>(policy),
         iterator(std::begin(c)), iterator(std::end(c)),
         hpx::parallel::induction(curr1), hpx::parallel::induction(curr2, 2),
         [&d](iterator it, std::size_t i, std::size_t j) {
@@ -211,12 +210,11 @@ void test_for_loop_induction_idx(ExPolicy&& policy)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f =
-        hpx::parallel::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
-            hpx::parallel::induction(0), [&c](std::size_t i, std::size_t j) {
-                c[i] = 42;
-                HPX_TEST_EQ(i, j);
-            });
+    auto f = hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+        hpx::parallel::induction(0), [&c](std::size_t i, std::size_t j) {
+            c[i] = 42;
+            HPX_TEST_EQ(i, j);
+        });
     f.wait();
 
     // verify values
@@ -238,8 +236,8 @@ void test_for_loop_induction_stride_idx(ExPolicy&& policy)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f = hpx::parallel::for_loop(std::forward<ExPolicy>(policy), 0,
-        c.size(), hpx::parallel::induction(0), hpx::parallel::induction(0, 2),
+    auto f = hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+        hpx::parallel::induction(0), hpx::parallel::induction(0, 2),
         [&c](std::size_t i, std::size_t j, std::size_t k) {
             c[i] = 42;
             HPX_TEST_EQ(i, j);

--- a/libs/algorithms/tests/unit/algorithms/for_loop_n.cpp
+++ b/libs/algorithms/tests/unit/algorithms/for_loop_n.cpp
@@ -4,11 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/algorithm.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/modules/testing.hpp>
-
-#include <hpx/include/parallel_for_loop.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -38,8 +37,8 @@ void test_for_loop_n(ExPolicy&& policy, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::parallel::for_loop_n(std::forward<ExPolicy>(policy),
-        iterator(std::begin(c)), c.size(), [](iterator it) { *it = 42; });
+    hpx::for_loop_n(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
+        c.size(), [](iterator it) { *it = 42; });
 
     // verify values
     std::size_t count = 0;
@@ -59,8 +58,8 @@ void test_for_loop_n_async(ExPolicy&& p, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f = hpx::parallel::for_loop_n(std::forward<ExPolicy>(p),
-        iterator(std::begin(c)), c.size(), [](iterator it) { *it = 42; });
+    auto f = hpx::for_loop_n(std::forward<ExPolicy>(p), iterator(std::begin(c)),
+        c.size(), [](iterator it) { *it = 42; });
     f.wait();
 
     // verify values
@@ -102,7 +101,7 @@ void test_for_loop_n_idx(ExPolicy&& policy)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    hpx::parallel::for_loop_n(std::forward<ExPolicy>(policy), 0, c.size(),
+    hpx::for_loop_n(std::forward<ExPolicy>(policy), 0, c.size(),
         [&c](std::size_t i) { c[i] = 42; });
 
     // verify values
@@ -122,7 +121,7 @@ void test_for_loop_n_idx_async(ExPolicy&& p)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
-    auto f = hpx::parallel::for_loop_n(std::forward<ExPolicy>(p), 0, c.size(),
+    auto f = hpx::for_loop_n(std::forward<ExPolicy>(p), 0, c.size(),
         [&c](std::size_t i) { c[i] = 42; });
     f.wait();
 

--- a/libs/algorithms/tests/unit/algorithms/for_loop_n_strided.cpp
+++ b/libs/algorithms/tests/unit/algorithms/for_loop_n_strided.cpp
@@ -4,11 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/algorithm.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/modules/testing.hpp>
-
-#include <hpx/include/parallel_for_loop.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -46,7 +45,7 @@ void test_for_loop_n_strided(ExPolicy&& policy, IteratorTag)
 
     int stride = dis(gen);    //-V103
 
-    hpx::parallel::for_loop_n_strided(std::forward<ExPolicy>(policy),
+    hpx::for_loop_n_strided(std::forward<ExPolicy>(policy),
         iterator(std::begin(c)), c.size(), stride,
         [](iterator it) { *it = 42; });
 
@@ -83,7 +82,7 @@ void test_for_loop_n_strided_async(ExPolicy&& p, IteratorTag)
 
     int stride = dis(gen);    //-V103
 
-    auto f = hpx::parallel::for_loop_n_strided(std::forward<ExPolicy>(p),
+    auto f = hpx::for_loop_n_strided(std::forward<ExPolicy>(p),
         iterator(std::begin(c)), c.size(), stride,
         [](iterator it) { *it = 42; });
     f.wait();
@@ -144,8 +143,8 @@ void test_for_loop_n_strided_idx(ExPolicy&& policy)
 
     int stride = dis(gen);    //-V103
 
-    hpx::parallel::for_loop_n_strided(std::forward<ExPolicy>(policy), 0,
-        c.size(), stride, [&c](std::size_t i) { c[i] = 42; });
+    hpx::for_loop_n_strided(std::forward<ExPolicy>(policy), 0, c.size(), stride,
+        [&c](std::size_t i) { c[i] = 42; });
 
     // verify values
     std::size_t count = 0;
@@ -179,8 +178,8 @@ void test_for_loop_n_strided_idx_async(ExPolicy&& p)
 
     int stride = dis(gen);    //-V103
 
-    auto f = hpx::parallel::for_loop_n_strided(std::forward<ExPolicy>(p), 0,
-        c.size(), stride, [&c](std::size_t i) { c[i] = 42; });
+    auto f = hpx::for_loop_n_strided(std::forward<ExPolicy>(p), 0, c.size(),
+        stride, [&c](std::size_t i) { c[i] = 42; });
     f.wait();
 
     // verify values

--- a/libs/algorithms/tests/unit/algorithms/for_loop_reduction.cpp
+++ b/libs/algorithms/tests/unit/algorithms/for_loop_reduction.cpp
@@ -4,11 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/algorithm.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/modules/testing.hpp>
-
-#include <hpx/include/parallel_for_loop.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -39,9 +38,8 @@ void test_for_loop_reduction_plus(ExPolicy&& policy, IteratorTag)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t sum = 0;
-    hpx::parallel::for_loop(std::forward<ExPolicy>(policy),
-        iterator(std::begin(c)), iterator(std::end(c)),
-        hpx::parallel::reduction_plus(sum),
+    hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
+        iterator(std::end(c)), hpx::parallel::reduction_plus(sum),
         [](iterator it, std::size_t& sum) { sum += *it; });
 
     // verify values
@@ -64,9 +62,8 @@ void test_for_loop_reduction_multiplies(ExPolicy&& policy, IteratorTag)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t prod = 0;
-    hpx::parallel::for_loop(std::forward<ExPolicy>(policy),
-        iterator(std::begin(c)), iterator(std::end(c)),
-        hpx::parallel::reduction_multiplies(prod),
+    hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
+        iterator(std::end(c)), hpx::parallel::reduction_multiplies(prod),
         [](iterator it, std::size_t& prod) { prod *= *it; });
 
     // verify values
@@ -90,9 +87,8 @@ void test_for_loop_reduction_min(ExPolicy&& policy, IteratorTag)
 
     std::size_t minval = c[0];
 
-    hpx::parallel::for_loop(std::forward<ExPolicy>(policy),
-        iterator(std::begin(c)), iterator(std::end(c)),
-        hpx::parallel::reduction_min(minval),
+    hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
+        iterator(std::end(c)), hpx::parallel::reduction_min(minval),
         [](iterator it, std::size_t& minval) {
             minval = (std::min)(minval, *it);
         });
@@ -140,7 +136,7 @@ void test_for_loop_reduction_bit_and_idx(ExPolicy&& policy)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t bits = ~std::size_t(0);
-    hpx::parallel::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+    hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
         hpx::parallel::reduction_bit_and(bits),
         [&c](std::size_t i, std::size_t& bits) { bits &= c[i]; });
 
@@ -161,7 +157,7 @@ void test_for_loop_reduction_bit_or_idx(ExPolicy&& policy)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t bits = 0;
-    hpx::parallel::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+    hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
         hpx::parallel::reduction_bit_or(bits),
         [&c](std::size_t i, std::size_t& bits) { bits |= c[i]; });
 

--- a/libs/algorithms/tests/unit/algorithms/for_loop_reduction_async.cpp
+++ b/libs/algorithms/tests/unit/algorithms/for_loop_reduction_async.cpp
@@ -4,11 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/algorithm.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/modules/testing.hpp>
-
-#include <hpx/include/parallel_for_loop.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -39,10 +38,10 @@ void test_for_loop_reduction_plus(ExPolicy&& policy, IteratorTag)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t sum = 0;
-    auto f = hpx::parallel::for_loop(std::forward<ExPolicy>(policy),
-        iterator(std::begin(c)), iterator(std::end(c)),
-        hpx::parallel::reduction_plus(sum),
-        [](iterator it, std::size_t& sum) { sum += *it; });
+    auto f =
+        hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
+            iterator(std::end(c)), hpx::parallel::reduction_plus(sum),
+            [](iterator it, std::size_t& sum) { sum += *it; });
     f.wait();
 
     // verify values
@@ -65,10 +64,10 @@ void test_for_loop_reduction_multiplies(ExPolicy&& policy, IteratorTag)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t prod = 0;
-    auto f = hpx::parallel::for_loop(std::forward<ExPolicy>(policy),
-        iterator(std::begin(c)), iterator(std::end(c)),
-        hpx::parallel::reduction_multiplies(prod),
-        [](iterator it, std::size_t& prod) { prod *= *it; });
+    auto f =
+        hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
+            iterator(std::end(c)), hpx::parallel::reduction_multiplies(prod),
+            [](iterator it, std::size_t& prod) { prod *= *it; });
     f.wait();
 
     // verify values
@@ -92,12 +91,12 @@ void test_for_loop_reduction_min(ExPolicy&& policy, IteratorTag)
 
     std::size_t minval = c[0];
 
-    auto f = hpx::parallel::for_loop(std::forward<ExPolicy>(policy),
-        iterator(std::begin(c)), iterator(std::end(c)),
-        hpx::parallel::reduction_min(minval),
-        [](iterator it, std::size_t& minval) {
-            minval = (std::min)(minval, *it);
-        });
+    auto f =
+        hpx::for_loop(std::forward<ExPolicy>(policy), iterator(std::begin(c)),
+            iterator(std::end(c)), hpx::parallel::reduction_min(minval),
+            [](iterator it, std::size_t& minval) {
+                minval = (std::min)(minval, *it);
+            });
     f.wait();
 
     // verify values
@@ -144,8 +143,8 @@ void test_for_loop_reduction_bit_and_idx(ExPolicy&& policy)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t bits = ~std::size_t(0);
-    auto f = hpx::parallel::for_loop(std::forward<ExPolicy>(policy), 0,
-        c.size(), hpx::parallel::reduction_bit_and(bits),
+    auto f = hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+        hpx::parallel::reduction_bit_and(bits),
         [&c](std::size_t i, std::size_t& bits) { bits &= c[i]; });
     f.wait();
 
@@ -166,8 +165,8 @@ void test_for_loop_reduction_bit_or_idx(ExPolicy&& policy)
     std::iota(std::begin(c), std::end(c), gen());
 
     std::size_t bits = 0;
-    auto f = hpx::parallel::for_loop(std::forward<ExPolicy>(policy), 0,
-        c.size(), hpx::parallel::reduction_bit_or(bits),
+    auto f = hpx::for_loop(std::forward<ExPolicy>(policy), 0, c.size(),
+        hpx::parallel::reduction_bit_or(bits),
         [&c](std::size_t i, std::size_t& bits) { bits |= c[i]; });
     f.wait();
 

--- a/libs/algorithms/tests/unit/algorithms/for_loop_strided.cpp
+++ b/libs/algorithms/tests/unit/algorithms/for_loop_strided.cpp
@@ -4,11 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/algorithm.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/modules/testing.hpp>
-
-#include <hpx/include/parallel_for_loop.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -46,7 +45,7 @@ void test_for_loop_strided(ExPolicy&& policy, IteratorTag)
 
     int stride = dis(gen);    //-V103
 
-    hpx::parallel::for_loop_strided(std::forward<ExPolicy>(policy),
+    hpx::for_loop_strided(std::forward<ExPolicy>(policy),
         iterator(std::begin(c)), iterator(std::end(c)), stride,
         [](iterator it) { *it = 42; });
 
@@ -83,7 +82,7 @@ void test_for_loop_strided_async(ExPolicy&& p, IteratorTag)
 
     int stride = dis(gen);    //-V103
 
-    auto f = hpx::parallel::for_loop_strided(std::forward<ExPolicy>(p),
+    auto f = hpx::for_loop_strided(std::forward<ExPolicy>(p),
         iterator(std::begin(c)), iterator(std::end(c)), stride,
         [](iterator it) { *it = 42; });
     f.wait();
@@ -142,8 +141,8 @@ void test_for_loop_strided_idx(ExPolicy&& policy)
 
     int stride = dis(gen);    //-V103
 
-    hpx::parallel::for_loop_strided(std::forward<ExPolicy>(policy), 0, c.size(),
-        stride, [&c](std::size_t i) { c[i] = 42; });
+    hpx::for_loop_strided(std::forward<ExPolicy>(policy), 0, c.size(), stride,
+        [&c](std::size_t i) { c[i] = 42; });
 
     // verify values
     std::size_t count = 0;
@@ -177,8 +176,8 @@ void test_for_loop_strided_idx_async(ExPolicy&& p)
 
     int stride = dis(gen);    //-V103
 
-    auto f = hpx::parallel::for_loop_strided(std::forward<ExPolicy>(p), 0,
-        c.size(), stride, [&c](std::size_t i) { c[i] = 42; });
+    auto f = hpx::for_loop_strided(std::forward<ExPolicy>(p), 0, c.size(),
+        stride, [&c](std::size_t i) { c[i] = 42; });
     f.wait();
 
     // verify values

--- a/libs/async_cuda/tests/unit/cublas_matmul.cpp
+++ b/libs/async_cuda/tests/unit/cublas_matmul.cpp
@@ -69,7 +69,7 @@ template <typename T>
 void matrixMulCPU(T* C, const T* A, const T* B, unsigned int hA,
     unsigned int wA, unsigned int wB)
 {
-    hpx::parallel::for_loop(hpx::parallel::execution::par, 0, hA, [&](int i) {
+    hpx::for_loop(hpx::parallel::execution::par, 0, hA, [&](int i) {
         for (unsigned int j = 0; j < wB; ++j)
         {
             T sum = 0;
@@ -94,7 +94,7 @@ inline bool compare_L2_err(const float* reference, const float* data,
     float error = 0;
     float ref = 0;
 
-    hpx::parallel::for_loop(hpx::parallel::execution::par, 0, len, [&](int i) {
+    hpx::for_loop(hpx::parallel::execution::par, 0, len, [&](int i) {
         float diff = reference[i] - data[i];
         error += diff * diff;
         ref += reference[i] * reference[i];

--- a/libs/collectives/tests/performance/osu/osu_bibw.cpp
+++ b/libs/collectives/tests/performance/osu/osu_bibw.cpp
@@ -7,9 +7,10 @@
 
 // Bidirectional network bandwidth test
 
+#include <hpx/algorithm.hpp>
+#include <hpx/execution.hpp>
 #include <hpx/hpx.hpp>
-#include <hpx/include/parallel_for_loop.hpp>
-#include <hpx/include/serialization.hpp>
+#include <hpx/serialization.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -49,9 +50,9 @@ hpx::future<void> send_async(
 {
     using buffer_type = hpx::serialization::serialize_buffer<char>;
 
-    using hpx::parallel::for_loop;
-    using hpx::parallel::execution::par;
-    using hpx::parallel::execution::task;
+    using hpx::for_loop;
+    using hpx::execution::par;
+    using hpx::execution::task;
 
     return for_loop(par(task), 0, window_size, [dest, size](std::uint64_t j) {
         // Note: The original benchmark uses MPI_Isend which does not
@@ -74,8 +75,8 @@ void recv_async(hpx::id_type dest, std::size_t size, std::size_t window_size)
 {
     using buffer_type = hpx::serialization::serialize_buffer<char>;
 
-    using hpx::parallel::for_loop;
-    using hpx::parallel::execution::par;
+    using hpx::for_loop;
+    using hpx::execution::par;
 
     for_loop(par, 0, window_size, [dest, size](std::uint64_t j) {
         irecv_action recv;

--- a/libs/compute_cuda/tests/unit/for_loop_compute.cu
+++ b/libs/compute_cuda/tests/unit/for_loop_compute.cu
@@ -8,8 +8,7 @@
 
 #include <hpx/async_cuda/target.hpp>
 #include <hpx/include/compute.hpp>
-#include <hpx/include/parallel_for_loop.hpp>
-#include <hpx/include/parallel_copy.hpp>
+#include <hpx/algorithm.hpp>
 
 #include <hpx/modules/testing.hpp>
 
@@ -35,7 +34,7 @@ void test_for_loop(executor_type& exec,
     //         result_of<> (used inside for_each()) to get the return
     //         type
 
-    hpx::parallel::for_loop_n(
+    hpx::for_loop_n(
         hpx::parallel::execution::par.on(exec),
         d_A.data(), d_A.size(),
         hpx::parallel::induction(d_B.data()),

--- a/libs/include/include/hpx/algorithm.hpp
+++ b/libs/include/include/hpx/algorithm.hpp
@@ -15,10 +15,6 @@
 
 namespace hpx {
     using hpx::parallel::adjacent_find;
-    using hpx::parallel::for_loop;
-    using hpx::parallel::for_loop_n;
-    using hpx::parallel::for_loop_n_strided;
-    using hpx::parallel::for_loop_strided;
     using hpx::parallel::includes;
     using hpx::parallel::inplace_merge;
     using hpx::parallel::is_heap;

--- a/libs/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
+++ b/libs/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
@@ -151,7 +151,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
     // test a parallel algorithm on custom pool with high priority
     hpx::parallel::execution::static_chunk_size fixed(1);
-    hpx::parallel::for_loop_strided(
+    hpx::for_loop_strided(
         hpx::parallel::execution::par.with(fixed).on(high_priority_executor), 0,
         loop_count, 1, [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
@@ -167,7 +167,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     thread_set.clear();
 
     // test a parallel algorithm on custom pool with normal priority
-    hpx::parallel::for_loop_strided(
+    hpx::for_loop_strided(
         hpx::parallel::execution::par.with(fixed).on(normal_priority_executor),
         0, loop_count, 1, [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
@@ -184,7 +184,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     thread_set.clear();
 
     // test a parallel algorithm on mpi_executor
-    hpx::parallel::for_loop_strided(
+    hpx::for_loop_strided(
         hpx::parallel::execution::par.with(fixed).on(mpi_executor), 0,
         loop_count, 1, [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
@@ -204,10 +204,9 @@ int hpx_main(hpx::program_options::variables_map& vm)
     //     auto normal_priority_async_policy = hpx::launch::async_policy();
 
     // test a parallel algorithm on custom pool with high priority
-    hpx::parallel::for_loop_strided(
-        hpx::parallel::execution::par
-            .with(fixed /*, high_priority_async_policy*/)
-            .on(mpi_executor),
+    hpx::for_loop_strided(hpx::parallel::execution::par
+                              .with(fixed /*, high_priority_async_policy*/)
+                              .on(mpi_executor),
         0, loop_count, 1, [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
             if (thread_set.insert(std::this_thread::get_id()).second)

--- a/libs/resource_partitioner/examples/simple_resource_partitioner.cpp
+++ b/libs/resource_partitioner/examples/simple_resource_partitioner.cpp
@@ -8,16 +8,15 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 //
-#include <hpx/execution/execution.hpp>
-#include <hpx/parallel/algorithms/for_loop.hpp>
-//
-#include <hpx/include/parallel_executors.hpp>
-#include <hpx/resource_partitioner/partitioner.hpp>
-#include <hpx/thread_pools/scheduled_thread_pool_impl.hpp>
-#include <hpx/topology/cpu_mask.hpp>
-//
-#include <hpx/include/runtime.hpp>
+#include <hpx/algorithm.hpp>
+#include <hpx/execution.hpp>
 #include <hpx/iostream.hpp>
+#include <hpx/runtime.hpp>
+//
+#include <hpx/modules/resource_partitioner.hpp>
+#include <hpx/modules/thread_pools.hpp>
+#include <hpx/modules/topology.hpp>
+//
 //
 #include <cmath>
 #include <cstddef>
@@ -146,7 +145,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
     // test a parallel algorithm on custom pool with high priority
     hpx::parallel::execution::static_chunk_size fixed(1);
-    hpx::parallel::for_loop_strided(
+    hpx::for_loop_strided(
         hpx::parallel::execution::par.with(fixed).on(high_priority_executor), 0,
         loop_count, 1, [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
@@ -162,7 +161,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     thread_set.clear();
 
     // test a parallel algorithm on custom pool with normal priority
-    hpx::parallel::for_loop_strided(
+    hpx::for_loop_strided(
         hpx::parallel::execution::par.with(fixed).on(normal_priority_executor),
         0, loop_count, 1, [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
@@ -179,7 +178,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     thread_set.clear();
 
     // test a parallel algorithm on mpi_executor
-    hpx::parallel::for_loop_strided(
+    hpx::for_loop_strided(
         hpx::parallel::execution::par.with(fixed).on(mpi_executor), 0,
         loop_count, 1, [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
@@ -199,10 +198,9 @@ int hpx_main(hpx::program_options::variables_map& vm)
     //     auto normal_priority_async_policy = hpx::launch::async_policy();
 
     // test a parallel algorithm on custom pool with high priority
-    hpx::parallel::for_loop_strided(
-        hpx::parallel::execution::par
-            .with(fixed /*, high_priority_async_policy*/)
-            .on(mpi_executor),
+    hpx::for_loop_strided(hpx::parallel::execution::par
+                              .with(fixed /*, high_priority_async_policy*/)
+                              .on(mpi_executor),
         0, loop_count, 1, [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
             if (thread_set.insert(std::this_thread::get_id()).second)

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -283,8 +283,8 @@ void measure_function_futures_limiting_executor(
     {
         hpx::execution::experimental::limiting_executor<Executor> signal_exec(
             exec, tasks, tasks + 1000);
-        hpx::parallel::for_loop(hpx::parallel::execution::par.with(fixed), 0,
-            count, [&](std::uint64_t) {
+        hpx::for_loop(hpx::parallel::execution::par.with(fixed), 0, count,
+            [&](std::uint64_t) {
                 hpx::apply(signal_exec, [&]() {
                     null_function();
                     sanity_check--;
@@ -350,9 +350,9 @@ void measure_function_futures_for_loop(std::uint64_t count, bool csv,
 {
     // start the clock
     high_resolution_timer walltime;
-    hpx::parallel::for_loop(hpx::parallel::execution::par.on(exec).with(
-                                hpx::parallel::execution::static_chunk_size(1),
-                                unlimited_number_of_chunks()),
+    hpx::for_loop(hpx::parallel::execution::par.on(exec).with(
+                      hpx::parallel::execution::static_chunk_size(1),
+                      unlimited_number_of_chunks()),
         0, count, [](std::uint64_t) { null_function(); });
 
     // stop the clock


### PR DESCRIPTION
Can go in 1.5.0 or 1.6.0. This should be fairly straightforward (i.e. no big surprises with builds and tests), but let's see.