### PR TITLE
Aggregate initialize CPOs

### DIFF
--- a/libs/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
@@ -625,7 +625,7 @@ namespace hpx {
                 hpx::parallel::execution::seq, first, last, std::forward<F>(f),
                 hpx::parallel::util::projection_identity{}, std::false_type{});
         }
-    } none_of;
+    } none_of{};
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::any_of
@@ -663,7 +663,7 @@ namespace hpx {
                 hpx::parallel::execution::seq, first, last, std::forward<F>(f),
                 hpx::parallel::util::projection_identity{}, std::false_type{});
         }
-    } any_of;
+    } any_of{};
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::all_of
@@ -701,7 +701,7 @@ namespace hpx {
                 hpx::parallel::execution::seq, first, last, std::forward<F>(f),
                 hpx::parallel::util::projection_identity{}, std::false_type{});
         }
-    } all_of;
+    } all_of{};
 
 }    // namespace hpx
 

--- a/libs/algorithms/include/hpx/parallel/algorithms/count.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/count.hpp
@@ -518,7 +518,7 @@ namespace hpx {
                 hpx::parallel::execution::seq, first, last, value,
                 hpx::parallel::util::projection_identity{}, std::false_type{});
         }
-    } count;
+    } count{};
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::count_if
@@ -570,7 +570,7 @@ namespace hpx {
                 hpx::parallel::execution::seq, first, last, std::forward<F>(f),
                 hpx::parallel::util::projection_identity{}, std::false_type{});
         }
-    } count_if;
+    } count_if{};
 
 }    // namespace hpx
 

--- a/libs/algorithms/include/hpx/parallel/algorithms/destroy.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/destroy.hpp
@@ -341,7 +341,7 @@ namespace hpx {
             hpx::parallel::v1::detail::destroy<FwdIter>().call(
                 hpx::parallel::execution::seq, std::false_type{}, first, last);
         }
-    } destroy;
+    } destroy{};
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::destroy_n
@@ -400,7 +400,7 @@ namespace hpx {
                 hpx::parallel::execution::seq, std::false_type{}, first,
                 std::size_t(count));
         }
-    } destroy_n;
+    } destroy_n{};
 }    // namespace hpx
 
 #endif    // DOXYGEN

--- a/libs/algorithms/include/hpx/parallel/algorithms/equal.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/equal.hpp
@@ -666,7 +666,7 @@ namespace hpx {
                 hpx::parallel::execution::seq, std::true_type{}, first1, last1,
                 first2, hpx::parallel::v1::detail::equal_to{});
         }
-    } equal;
+    } equal{};
 }    // namespace hpx
 
 #endif    // DOXYGEN

--- a/libs/algorithms/include/hpx/parallel/algorithms/fill.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/fill.hpp
@@ -350,7 +350,7 @@ namespace hpx {
             hpx::parallel::v1::detail::fill_(hpx::parallel::execution::seq,
                 first, last, value, std::false_type{});
         }
-    } fill;
+    } fill{};
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::fill_n
@@ -411,7 +411,7 @@ namespace hpx {
                 hpx::parallel::execution::seq, std::true_type{}, first,
                 std::size_t(count), value);
         }
-    } fill_n;
+    } fill_n{};
 
 }    // namespace hpx
 

--- a/libs/algorithms/include/hpx/parallel/algorithms/find.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/find.hpp
@@ -1188,7 +1188,7 @@ namespace hpx {
                 hpx::parallel::util::projection_identity(), std::false_type());
         }
 
-    } find;
+    } find{};
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::find_if
@@ -1234,7 +1234,7 @@ namespace hpx {
                 hpx::parallel::util::projection_identity(), std::false_type());
         }
 
-    } find_if;
+    } find_if{};
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::find_if_not
@@ -1281,7 +1281,7 @@ namespace hpx {
                 hpx::parallel::util::projection_identity(), std::false_type());
         }
 
-    } find_if_not;
+    } find_if_not{};
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::find_end
@@ -1400,7 +1400,7 @@ namespace hpx {
                 hpx::parallel::util::projection_identity(),
                 hpx::parallel::util::projection_identity());
         }
-    } find_end;
+    } find_end{};
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::find_first_of
@@ -1518,7 +1518,7 @@ namespace hpx {
                 hpx::parallel::util::projection_identity(),
                 hpx::parallel::util::projection_identity());
         }
-    } find_first_of;
+    } find_first_of{};
 }    // namespace hpx
 
 #endif    // DOXYGEN

--- a/libs/algorithms/include/hpx/parallel/algorithms/generate.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/generate.hpp
@@ -349,7 +349,7 @@ namespace hpx {
                 hpx::parallel::execution::seq, first, last, std::forward<F>(f),
                 std::false_type());
         }
-    } generate;
+    } generate{};
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::generate_n
@@ -408,6 +408,6 @@ namespace hpx {
                 hpx::parallel::execution::seq, std::true_type(), first,
                 std::size_t(count), std::forward<F>(f));
         }
-    } generate_n;
+    } generate_n{};
 }    // namespace hpx
 #endif    // DOXYGEN

--- a/libs/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
@@ -721,7 +721,7 @@ namespace hpx {
                     last1, first2, hpx::parallel::v1::detail::equal_to{});
         }
 
-    } mismatch;
+    } mismatch{};
 }    // namespace hpx
 
 #endif    // DOXYGEN

--- a/libs/algorithms/include/hpx/parallel/algorithms/move.hpp
+++ b/libs/algorithms/include/hpx/parallel/algorithms/move.hpp
@@ -224,7 +224,7 @@ namespace hpx {
         {
             return std::move(first, last, dest);
         }
-    } move;
+    } move{};
 }    // namespace hpx
 
 #endif    // DOXYGEN

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/all_any_none.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/all_any_none.hpp
@@ -419,7 +419,7 @@ namespace hpx { namespace ranges {
                 hpx::parallel::execution::seq, first, last, std::forward<F>(f),
                 std::forward<Proj>(proj), is_segmented{});
         }
-    } none_of;
+    } none_of{};
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::any_of
@@ -527,7 +527,7 @@ namespace hpx { namespace ranges {
                 hpx::parallel::execution::seq, first, last, std::forward<F>(f),
                 std::forward<Proj>(proj), is_segmented{});
         }
-    } any_of;
+    } any_of{};
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::all_of
@@ -635,7 +635,7 @@ namespace hpx { namespace ranges {
                 hpx::parallel::execution::seq, first, last, std::forward<F>(f),
                 std::forward<Proj>(proj), is_segmented{});
         }
-    } all_of;
+    } all_of{};
 
 }}    // namespace hpx::ranges
 

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/count.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/count.hpp
@@ -336,7 +336,7 @@ namespace hpx { namespace ranges {
                 hpx::parallel::execution::seq, first, last, value,
                 std::forward<Proj>(proj), is_segmented{});
         }
-    } count;
+    } count{};
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::count_if
@@ -461,7 +461,7 @@ namespace hpx { namespace ranges {
                 hpx::parallel::execution::seq, first, last, std::forward<F>(f),
                 std::forward<Proj>(proj), is_segmented{});
         }
-    } count_if;
+    } count_if{};
 
 }}    // namespace hpx::ranges
 #endif    // DOXYGEN

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/destroy.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/destroy.hpp
@@ -218,7 +218,7 @@ namespace hpx { namespace ranges {
             return hpx::parallel::v1::detail::destroy<Iter>().call(
                 hpx::parallel::execution::seq, std::false_type{}, first, last);
         }
-    } destroy;
+    } destroy{};
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::destroy_n
@@ -277,7 +277,7 @@ namespace hpx { namespace ranges {
                 hpx::parallel::execution::seq, std::false_type{}, first,
                 std::size_t(count));
         }
-    } destroy_n;
+    } destroy_n{};
 }}    // namespace hpx::ranges
 
 #endif    // DOXYGEN

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/equal.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/equal.hpp
@@ -378,7 +378,7 @@ namespace hpx { namespace ranges {
                 std::forward<Proj2>(proj2));
         }
 
-    } equal;
+    } equal{};
 }}    // namespace hpx::ranges
 
 #endif    // DOXYGEN

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/fill.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/fill.hpp
@@ -250,7 +250,7 @@ namespace hpx { namespace ranges {
                 hpx::parallel::execution::seq, first, last, value,
                 is_segmented{});
         }
-    } fill;
+    } fill{};
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::fill_n
@@ -373,7 +373,7 @@ namespace hpx { namespace ranges {
                 hpx::parallel::execution::seq, std::true_type{}, first,
                 std::size_t(count), value);
         }
-    } fill_n;
+    } fill_n{};
 
 }}    // namespace hpx::ranges
 

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/find.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/find.hpp
@@ -713,7 +713,7 @@ namespace hpx { namespace ranges {
                 hpx::util::end(rng), val, std::forward<Proj>(proj),
                 std::false_type());
         }
-    } find;
+    } find{};
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::find_if
@@ -815,7 +815,7 @@ namespace hpx { namespace ranges {
                 hpx::util::end(rng), std::forward<Pred>(pred),
                 std::forward<Proj>(proj), std::false_type());
         }
-    } find_if;
+    } find_if{};
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::find_if_not
@@ -917,7 +917,7 @@ namespace hpx { namespace ranges {
                 hpx::util::end(rng), std::forward<Pred>(pred),
                 std::forward<Proj>(proj), std::false_type());
         }
-    } find_if_not;
+    } find_if_not{};
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::find_end
@@ -1071,7 +1071,7 @@ namespace hpx { namespace ranges {
                 first2, last2, std::forward<Pred>(op),
                 std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
-    } find_end;
+    } find_end{};
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::find_first_of
@@ -1226,7 +1226,7 @@ namespace hpx { namespace ranges {
                 std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
 
-    } find_first_of;
+    } find_first_of{};
 }}    // namespace hpx::ranges
 
 #endif    // DOXYGEN

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/generate.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/generate.hpp
@@ -320,7 +320,7 @@ namespace hpx { namespace ranges {
                 hpx::parallel::execution::seq, first, last, std::forward<F>(f),
                 is_segmented());
         }
-    } generate;
+    } generate{};
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::generate_n
@@ -379,6 +379,6 @@ namespace hpx { namespace ranges {
                 hpx::parallel::execution::seq, std::true_type(), first,
                 std::size_t(count), std::forward<F>(f));
         }
-    } generate_n;
+    } generate_n{};
 }}    // namespace hpx::ranges
 #endif    // DOXYGEN

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/mismatch.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/mismatch.hpp
@@ -399,7 +399,7 @@ namespace hpx { namespace ranges {
                     std::forward<Proj2>(proj2));
         }
 
-    } mismatch;
+    } mismatch{};
 }}    // namespace hpx::ranges
 
 #endif    // DOXYGEN

--- a/libs/algorithms/include/hpx/parallel/container_algorithms/move.hpp
+++ b/libs/algorithms/include/hpx/parallel/container_algorithms/move.hpp
@@ -226,7 +226,7 @@ namespace hpx { namespace ranges {
                 hpx::parallel::execution::seq, hpx::util::begin(rng),
                 hpx::util::end(rng), dest);
         }
-    } move;
+    } move{};
 
 }}    // namespace hpx::ranges
 

--- a/libs/resiliency/include/hpx/resiliency/resiliency_cpos.hpp
+++ b/libs/resiliency/include/hpx/resiliency/resiliency_cpos.hpp
@@ -40,7 +40,7 @@ namespace hpx { namespace resiliency { namespace experimental {
     HPX_INLINE_CONSTEXPR_VARIABLE struct async_replay_validate_t final
       : hpx::functional::tag<async_replay_validate_t>
     {
-    } async_replay_validate;
+    } async_replay_validate{};
 
     /// Customization point for asynchronously launching given function \a f
     /// repeatedly. Repeat launching on error exactly \a n times (except if
@@ -48,7 +48,7 @@ namespace hpx { namespace resiliency { namespace experimental {
     HPX_INLINE_CONSTEXPR_VARIABLE struct async_replay_t final
       : hpx::functional::tag<async_replay_t>
     {
-    } async_replay;
+    } async_replay{};
 
     /// Customization point for asynchronously launching the given function \a f.
     /// repeatedly. Verify the result of those invocations using the given
@@ -60,7 +60,7 @@ namespace hpx { namespace resiliency { namespace experimental {
     HPX_INLINE_CONSTEXPR_VARIABLE struct dataflow_replay_validate_t final
       : tag_deferred<dataflow_replay_validate_t, async_replay_validate_t>
     {
-    } dataflow_replay_validate;
+    } dataflow_replay_validate{};
 
     /// Customization point for asynchronously launching the given function \a f.
     /// repeatedly.
@@ -71,7 +71,7 @@ namespace hpx { namespace resiliency { namespace experimental {
     HPX_INLINE_CONSTEXPR_VARIABLE struct dataflow_replay_t final
       : tag_deferred<dataflow_replay_t, async_replay_t>
     {
-    } dataflow_replay;
+    } dataflow_replay{};
 
     ///////////////////////////////////////////////////////////////////////////
     // Replicate customization points
@@ -84,7 +84,7 @@ namespace hpx { namespace resiliency { namespace experimental {
     HPX_INLINE_CONSTEXPR_VARIABLE struct async_replicate_vote_validate_t final
       : hpx::functional::tag<async_replicate_vote_validate_t>
     {
-    } async_replicate_vote_validate;
+    } async_replicate_vote_validate{};
 
     ///////////////////////////////////////////////////////////////////////////
     /// Customization point for asynchronously launching the given function \a f
@@ -95,7 +95,7 @@ namespace hpx { namespace resiliency { namespace experimental {
     HPX_INLINE_CONSTEXPR_VARIABLE struct async_replicate_vote_t final
       : hpx::functional::tag<async_replicate_vote_t>
     {
-    } async_replicate_vote;
+    } async_replicate_vote{};
 
     ///////////////////////////////////////////////////////////////////////////
     /// Customization point for asynchronously launching the given function \a f
@@ -105,7 +105,7 @@ namespace hpx { namespace resiliency { namespace experimental {
     HPX_INLINE_CONSTEXPR_VARIABLE struct async_replicate_validate_t final
       : hpx::functional::tag<async_replicate_validate_t>
     {
-    } async_replicate_validate;
+    } async_replicate_validate{};
 
     ///////////////////////////////////////////////////////////////////////////
     /// Customization point for asynchronously launching the given function \a f
@@ -115,7 +115,7 @@ namespace hpx { namespace resiliency { namespace experimental {
     HPX_INLINE_CONSTEXPR_VARIABLE struct async_replicate_t final
       : hpx::functional::tag<async_replicate_t>
     {
-    } async_replicate;
+    } async_replicate{};
 
     /// Customization point for asynchronously launching the given function \a f
     /// exactly \a n times concurrently. Run all the valid results against a
@@ -129,7 +129,7 @@ namespace hpx { namespace resiliency { namespace experimental {
       : tag_deferred<dataflow_replicate_vote_validate_t,
             async_replicate_vote_validate_t>
     {
-    } dataflow_replicate_vote_validate;
+    } dataflow_replicate_vote_validate{};
 
     /// Customization point for asynchronously launching the given function \a f
     /// exactly \a n times concurrently. Run all the valid results against a
@@ -141,7 +141,7 @@ namespace hpx { namespace resiliency { namespace experimental {
     HPX_INLINE_CONSTEXPR_VARIABLE struct dataflow_replicate_vote_t final
       : tag_deferred<dataflow_replicate_vote_t, async_replicate_vote_t>
     {
-    } dataflow_replicate_vote;
+    } dataflow_replicate_vote{};
 
     /// Customization point for asynchronously launching the given function \a f
     /// exactly \a n times concurrently. Verify the result of those invocations
@@ -152,7 +152,7 @@ namespace hpx { namespace resiliency { namespace experimental {
     HPX_INLINE_CONSTEXPR_VARIABLE struct dataflow_replicate_validate_t final
       : tag_deferred<dataflow_replicate_validate_t, async_replicate_validate_t>
     {
-    } dataflow_replicate_validate;
+    } dataflow_replicate_validate{};
 
     /// Customization point for asynchronously launching the given function \a f
     /// exactly \a n times concurrently. Return the first valid result.
@@ -162,5 +162,5 @@ namespace hpx { namespace resiliency { namespace experimental {
     HPX_INLINE_CONSTEXPR_VARIABLE struct dataflow_replicate_t final
       : tag_deferred<dataflow_replicate_t, async_replicate_t>
     {
-    } dataflow_replicate;
+    } dataflow_replicate{};
 }}}    // namespace hpx::resiliency::experimental


### PR DESCRIPTION
Potentially fixes some compilation problems seen by @G-071 (i.e. `/home/daissgr/external_packages/spack/opt/spack/linux-ubuntu18.04-broadwell/gcc-7.5.0/hpx-master-52nq7dny5j2onrsczqrnwazze6zduz6y/include/hpx/parallel/algorithms/all_any_none.hpp(628): error: const variable "hpx::none_of" requires an initializer -- class "hpx::none_of_t" has no user-provided default constructor`).

I'm a bit surprised by this, but it could be nvcc being dumb (gcc 8 and CUDA 10 is fine with this)? @G-071 would you mind posting the actual compiler version (gcc is apparently 7.5.0), CUDA version, and C++ standard that you're using?