### PR TITLE
Add alias targets with namespaces used for exporting

### DIFF
--- a/cmake/HPX_GeneratePackage.cmake
+++ b/cmake/HPX_GeneratePackage.cmake
@@ -41,6 +41,15 @@ export(
   FILE "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}/HPXTargets.cmake"
 )
 
+# Add aliases with the namespace for use within HPX
+foreach(export_target ${HPX_EXPORT_TARGETS})
+  add_library(HPX::${export_target} ALIAS ${export_target})
+endforeach()
+
+foreach(export_target ${HPX_EXPORT_INTERNAL_TARGETS})
+  add_library(HPXInternal::${export_target} ALIAS ${export_target})
+endforeach()
+
 # Export HPXTargets in the install directory
 install(
   EXPORT HPXTargets

--- a/cmake/HPX_SetupTarget.cmake
+++ b/cmake/HPX_SetupTarget.cmake
@@ -154,10 +154,7 @@ function(hpx_setup_target target)
 
   if("${_type}" STREQUAL "LIBRARY" AND target_PLUGIN)
     set(plugin_name "HPX_PLUGIN_NAME=hpx_${name}")
-    target_link_libraries(
-      ${target} ${__tll_private} $<TARGET_NAME_IF_EXISTS:plugin>
-      $<TARGET_NAME_IF_EXISTS:HPX::plugin>
-    )
+    target_link_libraries(${target} ${__tll_private} HPX::plugin)
   endif()
 
   if("${_type}" STREQUAL "COMPONENT")
@@ -165,23 +162,15 @@ function(hpx_setup_target target)
       ${target} PRIVATE "HPX_COMPONENT_NAME=hpx_${name}"
                         "HPX_COMPONENT_STRING=\"hpx_${name}\""
     )
-    target_link_libraries(
-      ${target} ${__tll_private} $<TARGET_NAME_IF_EXISTS:component>
-      $<TARGET_NAME_IF_EXISTS:HPX::component>
-    )
+    target_link_libraries(${target} ${__tll_private} HPX::component)
   endif()
 
   if(NOT target_NOLIBS)
     set(_wrap_main_deps)
     if("${_type}" STREQUAL "EXECUTABLE")
-      set(_wrap_main_deps $<TARGET_NAME_IF_EXISTS:wrap_main>
-                          $<TARGET_NAME_IF_EXISTS:HPX::wrap_main>
-      )
+      set(_wrap_main_deps HPX::wrap_main)
     endif()
-    target_link_libraries(
-      ${target} ${__tll_public} $<TARGET_NAME_IF_EXISTS:hpx>
-      $<TARGET_NAME_IF_EXISTS:HPX::hpx> ${_wrap_main_deps}
-    )
+    target_link_libraries(${target} ${__tll_public} HPX::hpx ${_wrap_main_deps})
     hpx_handle_component_dependencies(target_COMPONENT_DEPENDENCIES)
     target_link_libraries(
       ${target} ${__tll_public} ${target_COMPONENT_DEPENDENCIES}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -545,12 +545,7 @@ target_link_libraries(hpx INTERFACE hpx_core)
 # pkgconfig file generation.
 add_library(hpx_interface INTERFACE)
 target_link_libraries(
-  hpx_interface
-  INTERFACE $<${_is_executable}:$<TARGET_NAME_IF_EXISTS:hpx_init>>
-)
-target_link_libraries(
-  hpx_interface
-  INTERFACE $<${_is_executable}:$<TARGET_NAME_IF_EXISTS:HPXInternal::hpx_init>>
+  hpx_interface INTERFACE $<${_is_executable}:HPXInternal::hpx_init>
 )
 target_compile_definitions(
   hpx_interface
@@ -570,12 +565,7 @@ target_compile_definitions(
 
 add_library(hpx_interface_wrap_main INTERFACE)
 target_link_libraries(
-  hpx_interface_wrap_main
-  INTERFACE $<${_is_executable}:$<TARGET_NAME_IF_EXISTS:hpx_wrap>>
-)
-target_link_libraries(
-  hpx_interface_wrap_main
-  INTERFACE $<${_is_executable}:$<TARGET_NAME_IF_EXISTS:HPXInternal::hpx_wrap>>
+  hpx_interface_wrap_main INTERFACE $<${_is_executable}:HPXInternal::hpx_wrap>
 )
 
 target_link_libraries(wrap_main INTERFACE hpx_interface_wrap_main)


### PR DESCRIPTION
Adds alias targets for internal use (i.e. within the HPX CMake project) which have the namespace used when exporting. This should fix #4913, and removes some ugly `$<TARGET_NAME_IF_EXISTS:...>` generator expressions.

@kordejong would you mind trying this out for yourself?

Let's try to get this in 1.5.0 still.