### PR TITLE
HPX_HAVE_DEPRECATION_WARNINGS needs to be set even when disabled

### DIFF
--- a/components/iostreams/include/hpx/include/iostreams.hpp
+++ b/components/iostreams/include/hpx/include/iostreams.hpp
@@ -11,7 +11,7 @@
 #include <hpx/config.hpp>
 #include <hpx/iostream.hpp>
 
-#if (HPX_HAVE_DEPRECATION_WARNINGS != 0)
+#if HPX_HAVE_DEPRECATION_WARNINGS
 #if defined(HPX_MSVC)
 #pragma message("The header hpx/include/iostreams.hpp is deprecated, \
     please include hpx/iostream.hpp instead")

--- a/libs/config/include/hpx/config/attributes.hpp
+++ b/libs/config/include/hpx/config/attributes.hpp
@@ -63,7 +63,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 // handle [[deprecated]]
-#if (HPX_HAVE_DEPRECATION_WARNINGS != 0)
+#if HPX_HAVE_DEPRECATION_WARNINGS
 #  define HPX_DEPRECATED_MSG \
    "This functionality is deprecated and will be removed in the future."
 #  define HPX_DEPRECATED(x) [[deprecated(x)]]

--- a/libs/include/include/hpx/include/compression.hpp
+++ b/libs/include/include/hpx/include/compression.hpp
@@ -14,7 +14,7 @@
 #include <hpx/plugins/binary_filter/zlib_serialization_filter.hpp>
 #endif
 
-#if (HPX_HAVE_DEPRECATION_WARNINGS != 0)
+#if HPX_HAVE_DEPRECATION_WARNINGS
 #if defined(HPX_MSVC)
 #pragma message("The header hpx/include/compression.hpp is deprecated, \
     please include directly the corresponding header \

--- a/libs/include/include/hpx/include/compression_registration.hpp
+++ b/libs/include/include/hpx/include/compression_registration.hpp
@@ -14,7 +14,7 @@
 #include <hpx/plugins/binary_filter/zlib_serialization_filter_registration.hpp>
 #endif
 
-#if (HPX_HAVE_DEPRECATION_WARNINGS != 0)
+#if HPX_HAVE_DEPRECATION_WARNINGS
 #if defined(HPX_MSVC)
 #pragma message(                                                               \
     "The header hpx/include/compression_registration.hpp is deprecated, \

--- a/plugins/binary_filter/bzip2/include/hpx/include/compression_bzip2.hpp
+++ b/plugins/binary_filter/bzip2/include/hpx/include/compression_bzip2.hpp
@@ -9,7 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/plugins/binary_filter/bzip2_serialization_filter.hpp>
 
-#if (HPX_HAVE_DEPRECATION_WARNINGS != 0)
+#if HPX_HAVE_DEPRECATION_WARNINGS
 #if defined(HPX_MSVC)
   #pragma message("The header hpx/include/compression_bzip2.hpp is deprecated, \
     please include \

--- a/plugins/binary_filter/snappy/include/hpx/include/compression_snappy.hpp
+++ b/plugins/binary_filter/snappy/include/hpx/include/compression_snappy.hpp
@@ -9,7 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/plugins/binary_filter/snappy_serialization_filter.hpp>
 
-#if (HPX_HAVE_DEPRECATION_WARNINGS != 0)
+#if HPX_HAVE_DEPRECATION_WARNINGS
 #if defined(HPX_MSVC)
   #pragma message("The header hpx/include/compression_snappy.hpp is deprecated, \
     please include \

--- a/plugins/binary_filter/zlib/include/hpx/include/compression_zlib.hpp
+++ b/plugins/binary_filter/zlib/include/hpx/include/compression_zlib.hpp
@@ -9,7 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/plugins/binary_filter/zlib_serialization_filter.hpp>
 
-#if (HPX_HAVE_DEPRECATION_WARNINGS != 0)
+#if HPX_HAVE_DEPRECATION_WARNINGS
 #if defined(HPX_MSVC)
   #pragma message("The header hpx/include/compression_zlib.hpp is deprecated, \
     please include \


### PR DESCRIPTION
if HPX_HAVE_DEPRECATION_WARNINGS is not defined, then some `#if HPX_HAVE_DEPRECATION_WARNINGS` checks are invalid, so set it to 0 when disabled instead of leaving it unset