### PR TITLE
Move chrono functionality to hpx::chrono namespace

### DIFF
--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -222,13 +222,15 @@ Header ``hpx/chrono.hpp``
 
 Corresponds to the C++ standard library header :cppreference-header:`chrono`.
 The following replacements and extensions are provided compared to
-:cppreference-header:`chrono`:
+:cppreference-header:`chrono`. The classes below are also available in the
+``hpx::chrono`` namespace, not in the top-level ``hpx`` namespace.
 
 Classes
 -------
 
 - :cpp:class:`hpx::util::high_resolution_clock`
 - :cpp:class:`hpx::util::high_resolution_timer`
+- :cpp:class:`hpx::util::steady_time_point`
 
 Header ``hpx/condition_variable.hpp``
 =====================================
@@ -444,7 +446,7 @@ Functions
 - :cpp:func:`hpx::resume`
 
 Header ``hpx/latch.hpp``
-==========================
+========================
 
 This header includes :ref:`public_api_header_hpx_local_latch` and
 ref:`public_api_header_hpx_distributed_latch`.
@@ -452,7 +454,7 @@ ref:`public_api_header_hpx_distributed_latch`.
 .. _public_api_header_hpx_local_latch:
 
 Header ``hpx/local/latch.hpp``
-================================
+==============================
 
 Corresponds to the C++ standard library header :cppreference-header:`latch`.
 
@@ -464,7 +466,7 @@ Classes
 .. _public_api_header_hpx_distributed_latch:
 
 Header ``hpx/distributed/latch.hpp``
-======================================
+====================================
 
 Contains a distributed latch implementation. This functionality is also exposed
 through the ``hpx::distributed`` namespace. The name in ``hpx::distributed``

--- a/libs/include/include/hpx/chrono.hpp
+++ b/libs/include/include/hpx/chrono.hpp
@@ -10,8 +10,8 @@
 #include <hpx/timing/high_resolution_timer.hpp>
 #include <hpx/timing/steady_clock.hpp>
 
-namespace hpx {
+namespace hpx { namespace chrono {
     using hpx::util::high_resolution_clock;
     using hpx::util::high_resolution_timer;
     using hpx::util::steady_time_point;
-}    // namespace hpx
+}}    // namespace hpx::chrono


### PR DESCRIPTION
I had missed this while making our public API page. I had put `high_resolution_timer` and friends in `hpx` whereas corresponding functionality in the standard library is in `std::chrono`. This moves them to `hpx::chrono` to align with the standard library. I think this is the only place where I got this wrong.