### PR TITLE
Make cuda event pool dynamic instead of fixed size

### DIFF
--- a/libs/async_cuda/include/hpx/async_cuda/cuda_event.hpp
+++ b/libs/async_cuda/include/hpx/async_cuda/cuda_event.hpp
@@ -22,7 +22,7 @@ namespace hpx { namespace cuda { namespace experimental {
     // For now - Assume a maximum of 64 outstanding events is enough
     struct cuda_event_pool
     {
-        static constexpr int max_events_in_pool = 64;
+        static constexpr int initial_events_in_pool = 128;
 
         static cuda_event_pool& get_event_pool()
         {
@@ -31,18 +31,11 @@ namespace hpx { namespace cuda { namespace experimental {
         }
 
         // create a bunch of events on initialization
-        cuda_event_pool()
+        cuda_event_pool() : free_list_(initial_events_in_pool)
         {
-            for (int i = 0; i < max_events_in_pool; ++i)
+            for (int i = 0; i < initial_events_in_pool; ++i)
             {
-                cudaEvent_t event;
-                // Create an cuda_event to query a CUDA/CUBLAS kernel for completion.
-                // Timing is disabled for performance. [1]
-                //
-                // [1]: CUDA Runtime API, section 5.5 cuda_event Management
-                check_cuda_error(
-                    cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
-                free_list_.push(event);
+                add_event_to_pool();
             }
         }
 
@@ -50,16 +43,21 @@ namespace hpx { namespace cuda { namespace experimental {
         ~cuda_event_pool()
         {
             cudaEvent_t event;
-            for (int i = 0; i < max_events_in_pool; ++i)
-            {
-                free_list_.pop(event);
-                check_cuda_error(cudaEventDestroy(event));
+            bool ok = true;
+            while (ok) {
+                ok = free_list_.pop(event);
+                if (ok) check_cuda_error(cudaEventDestroy(event));
             }
         }
 
         inline bool pop(cudaEvent_t& event)
         {
-            return free_list_.pop(event);
+            // pop an event off the pool, if that fails, create a new one
+            while (!free_list_.pop(event))
+            {
+                add_event_to_pool();
+            }
+            return true;
         }
 
         inline bool push(cudaEvent_t event)
@@ -68,10 +66,23 @@ namespace hpx { namespace cuda { namespace experimental {
         }
 
     private:
+
+        void add_event_to_pool()
+        {
+            cudaEvent_t event;
+            // Create an cuda_event to query a CUDA/CUBLAS kernel for completion.
+            // Timing is disabled for performance. [1]
+            //
+            // [1]: CUDA Runtime API, section 5.5 cuda_event Management
+            check_cuda_error(
+                cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
+            free_list_.push(event);
+        }
+
         // using a fixed capacity stack means no allocations are
         // needed , throws an exception if the capacity is exceeded
         boost::lockfree::stack<cudaEvent_t,
-            boost::lockfree::capacity<max_events_in_pool>>
+            boost::lockfree::fixed_sized<false>>
             free_list_;
     };
 }}}    // namespace hpx::cuda::experimental


### PR DESCRIPTION
Fixes Problem with Octotiger caused by fixed size pool for cuda events

@G-071 - could you please try this out with octotiger and report back if it solves your problem with events. 