### PR TITLE
Add HPX_NODISCARD to enable_user_polling structs

### DIFF
--- a/libs/async_cuda/include/hpx/async_cuda/cuda_future.hpp
+++ b/libs/async_cuda/include/hpx/async_cuda/cuda_future.hpp
@@ -309,7 +309,7 @@ namespace hpx { namespace cuda { namespace experimental {
 
     // -----------------------------------------------------------------
     // This RAII helper class enables polling for a scoped block
-    struct enable_user_polling
+    struct HPX_NODISCARD enable_user_polling
     {
         enable_user_polling(std::string const& pool_name = "")
           : pool_name_(pool_name)

--- a/libs/async_mpi/include/hpx/async_mpi/mpi_future.hpp
+++ b/libs/async_mpi/include/hpx/async_mpi/mpi_future.hpp
@@ -230,7 +230,7 @@ namespace hpx { namespace mpi { namespace experimental {
     // -----------------------------------------------------------------
     // This RAII helper class assumes that MPI initialization/finalization is
     // handled elsewhere
-    struct enable_user_polling
+    struct HPX_NODISCARD enable_user_polling
     {
         enable_user_polling(std::string const& pool_name = "")
           : pool_name_(pool_name)


### PR DESCRIPTION
Avoid mistakes where user polling is enabled and disabled immediately, instead of at the end of a scope.

@auriane this is a nice extra for the release, but it does not have to be in 1.5.0-rc3.