### PR TITLE
Documentation Distributed HPX applications localvv with local_vv

### DIFF
--- a/docs/sphinx/manual/writing_distributed_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_distributed_hpx_applications.rst
@@ -1316,7 +1316,7 @@ owned by the current image::
         // Instantiate the local view from the view
         auto local_vv = hpx::local_view(vv);
 
-        for ( auto i = localvv.begin(); i != localvv.end(); i++ )
+        for ( auto i = local_vv.begin(); i != local_vv.end(); i++ )
         {
             std::vector<float> & segment = *i;
 


### PR DESCRIPTION
## Proposed Changes

Replacing the variable `localvv` with `local_vv`

## Background

While using the code snippet I found this typo in the variable name and think that it is intended to work with `local_vv`, correct? 