### PR TITLE
Move public hpx::parallel::execution functionality to hpx::execution

### DIFF
--- a/components/containers/partitioned_vector/tests/regressions/partitioned_vector_2201.cpp
+++ b/components/containers/partitioned_vector/tests/regressions/partitioned_vector_2201.cpp
@@ -51,8 +51,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
         // initialize data
         // segmented version of algorithm used
-        using namespace  hpx::parallel;
-        generate(execution::par, v.begin(), v.end(), random_fill());
+        hpx::generate(hpx::execution::par, v.begin(), v.end(), random_fill());
 
         return hpx::finalize();
     }

--- a/components/containers/partitioned_vector/tests/unit/serialization_partitioned_vector.cpp
+++ b/components/containers/partitioned_vector/tests/unit/serialization_partitioned_vector.cpp
@@ -39,7 +39,7 @@ void test(T minval, T maxval)
         hpx::partitioned_vector<T> os(sz);
         os.register_as("test_vector");
         hpx::fill(
-            hpx::parallel::execution::par, std::begin(os), std::end(os), 42);
+            hpx::execution::par, std::begin(os), std::end(os), 42);
 
         oarchive << os;
 
@@ -47,7 +47,7 @@ void test(T minval, T maxval)
 
         hpx::partitioned_vector<T> is(os.size());
         hpx::fill(
-            hpx::parallel::execution::par, std::begin(is), std::end(is), 0);
+            hpx::execution::par, std::begin(is), std::end(is), 0);
 
         iarchive >> is;
 

--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -272,30 +272,30 @@ for more information about execution policies and executor parameters.
 
 .. note::
 
-   These names are also available in the ``hpx::execution`` namespace, but not
-   in the top-level ``hpx`` namespace.
+   These names are only available in the ``hpx::execution`` namespace, not in
+   the top-level ``hpx`` namespace.
 
 Constants
 ---------
 
-- :cpp:var:`hpx::parallel::execution::seq`
-- :cpp:var:`hpx::parallel::execution::par`
-- :cpp:var:`hpx::parallel::execution::par_unseq`
-- :cpp:var:`hpx::parallel::execution::task`
+- :cpp:var:`hpx::execution::seq`
+- :cpp:var:`hpx::execution::par`
+- :cpp:var:`hpx::execution::par_unseq`
+- :cpp:var:`hpx::execution::task`
 
 Classes
 -------
 
-- :cpp:class:`hpx::parallel::execution::sequenced_policy`
-- :cpp:class:`hpx::parallel::execution::parallel_policy`
-- :cpp:class:`hpx::parallel::execution::parallel_unsequenced_policy`
-- :cpp:class:`hpx::parallel::execution::sequenced_task_policy`
-- :cpp:class:`hpx::parallel::execution::parallel_task_policy`
-- :cpp:class:`hpx::parallel::execution::auto_chunk_size`
-- :cpp:class:`hpx::parallel::execution::dynamic_chunk_size`
-- :cpp:class:`hpx::parallel::execution::guided_chunk_size`
-- :cpp:class:`hpx::parallel::execution::persistent_auto_chunk_size`
-- :cpp:class:`hpx::parallel::execution::static_chunk_size`
+- :cpp:class:`hpx::execution::sequenced_policy`
+- :cpp:class:`hpx::execution::parallel_policy`
+- :cpp:class:`hpx::execution::parallel_unsequenced_policy`
+- :cpp:class:`hpx::execution::sequenced_task_policy`
+- :cpp:class:`hpx::execution::parallel_task_policy`
+- :cpp:class:`hpx::execution::auto_chunk_size`
+- :cpp:class:`hpx::execution::dynamic_chunk_size`
+- :cpp:class:`hpx::execution::guided_chunk_size`
+- :cpp:class:`hpx::execution::persistent_auto_chunk_size`
+- :cpp:class:`hpx::execution::static_chunk_size`
 
 Header ``hpx/functional.hpp``
 =============================

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -251,11 +251,11 @@ C++ Extensions for Parallelism), |cpp11_n4088|_ (Task Blocks), and
 Using parallel algorithms
 -------------------------
 
-.. |sequenced_execution_policy| replace:: :cpp:class:`hpx::parallel::execution::sequenced_policy`
-.. |sequenced_task_execution_policy| replace:: :cpp:class:`hpx::parallel::execution::sequenced_task_policy`
-.. |parallel_execution_policy| replace:: :cpp:class:`hpx::parallel::execution::parallel_policy`
-.. |parallel_unsequenced_execution_policy| replace:: :cpp:class:`hpx::parallel::execution::parallel_unsequenced_policy`
-.. |parallel_task_execution_policy| replace:: :cpp:class:`hpx::parallel::execution::parallel_task_policy`
+.. |sequenced_execution_policy| replace:: :cpp:class:`hpx::execution::sequenced_policy`
+.. |sequenced_task_execution_policy| replace:: :cpp:class:`hpx::execution::sequenced_task_policy`
+.. |parallel_execution_policy| replace:: :cpp:class:`hpx::execution::parallel_policy`
+.. |parallel_unsequenced_execution_policy| replace:: :cpp:class:`hpx::execution::parallel_unsequenced_policy`
+.. |parallel_task_execution_policy| replace:: :cpp:class:`hpx::execution::parallel_task_policy`
 .. |execution_policy| replace:: :cpp:class:`hpx::parallel::v1::execution_policy`
 .. |exception_list| replace:: :cpp:class:`hpx::exception_list`
 .. |par_for_each| replace:: :cpp:class:`hpx::parallel::v1::for_each`
@@ -799,15 +799,14 @@ number of tasks to schedule is given by ``num_tasks``. The lambda function
 exposes a means of test-probing the execution of a single iteration for
 performance measurement purposes. The execution parameter type might dynamically
 determine the execution time of one or more tasks in order to calculate the
-chunk size; see :cpp:class:`hpx::parallel::execution::auto_chunk_size` for an
-example of this executor parameter type.
+chunk size; see :cpp:class:`hpx::execution::auto_chunk_size` for an example of
+this executor parameter type.
 
 Other functions in the interface exist to discover whether an executor parameter
 type should be invoked once (i.e., it returns a static chunk size; see
-:cpp:class:`hpx::parallel::execution::static_chunk_size`) or whether it should
-be invoked for each scheduled chunk of work (i.e., it returns a variable chunk
-size; for an example, see
-:cpp:class:`hpx::parallel::execution::guided_chunk_size`).
+:cpp:class:`hpx::execution::static_chunk_size`) or whether it should be invoked
+for each scheduled chunk of work (i.e., it returns a variable chunk size; for an
+example, see :cpp:class:`hpx::execution::guided_chunk_size`).
 
 Although this interface appears to require executor parameter type authors to
 implement all different basic operations, none are required. In
@@ -816,27 +815,27 @@ parameter types will naturally specialize all operations for maximum efficiency.
 
 |hpx|  implements the following executor parameter types:
 
-* :cpp:class:`hpx::parallel::execution::auto_chunk_size`: Loop iterations are
-  divided into pieces and then assigned to threads. The number of loop
-  iterations combined is determined based on measurements of how long the
-  execution of 1% of the overall number of iterations takes. This executor
-  parameter type makes sure that as many loop iterations are combined as
-  necessary to run for the amount of time specified.
-* :cpp:class:`hpx::parallel::execution::static_chunk_size`: Loop iterations are
-  divided into pieces of a given size and then assigned to threads. If the size
-  is not specified, the iterations are, if possible, evenly divided contiguously
-  among the threads. This executor parameters type is equivalent to OpenMP's
-  STATIC scheduling directive.
-* :cpp:class:`hpx::parallel::execution::dynamic_chunk_size`: Loop iterations are
-  divided into pieces of a given size and then dynamically scheduled among the
-  cores; when a core finishes one chunk, it is dynamically assigned another. If
-  the size is not specified, the default chunk size is 1. This executor
-  parameter type is equivalent to OpenMP's DYNAMIC scheduling directive.
-* :cpp:class:`hpx::parallel::execution::guided_chunk_size`: Iterations are
-  dynamically assigned to cores in blocks as cores request them until no blocks
-  remain to be assigned. This is similar to ``dynamic_chunk_size`` except that the block
-  size decreases each time a number of loop iterations is given to a thread. The
-  size of the initial block is proportional to ``number_of_iterations /
+* :cpp:class:`hpx::execution::auto_chunk_size`: Loop iterations are divided into
+  pieces and then assigned to threads. The number of loop iterations combined is
+  determined based on measurements of how long the execution of 1% of the
+  overall number of iterations takes. This executor parameter type makes sure
+  that as many loop iterations are combined as necessary to run for the amount
+  of time specified.
+* :cpp:class:`hpx::execution::static_chunk_size`: Loop iterations are divided
+  into pieces of a given size and then assigned to threads. If the size is not
+  specified, the iterations are, if possible, evenly divided contiguously among
+  the threads. This executor parameters type is equivalent to OpenMP's STATIC
+  scheduling directive.
+* :cpp:class:`hpx::execution::dynamic_chunk_size`: Loop iterations are divided
+  into pieces of a given size and then dynamically scheduled among the cores;
+  when a core finishes one chunk, it is dynamically assigned another. If the
+  size is not specified, the default chunk size is 1. This executor parameter
+  type is equivalent to OpenMP's DYNAMIC scheduling directive.
+* :cpp:class:`hpx::execution::guided_chunk_size`: Iterations are dynamically
+  assigned to cores in blocks as cores request them until no blocks remain to be
+  assigned. This is similar to ``dynamic_chunk_size`` except that the block size
+  decreases each time a number of loop iterations is given to a thread. The size
+  of the initial block is proportional to ``number_of_iterations /
   number_of_cores``. Subsequent blocks are proportional to
   ``number_of_iterations_remaining / number_of_cores``. The optional chunk size
   parameter defines the minimum block size. The default minimal chunk size is 1.
@@ -961,11 +960,11 @@ created ``task_block``. In the following example the use of an explicit
 This also causes the :cpp:class:`hpx::parallel::v2::task_block` object to be a
 template in our implementation. The template argument is the type of the
 execution policy used to create the task block. The template argument defaults
-to :cpp:class:`hpx::parallel::execution::parallel_policy`.
+to :cpp:class:`hpx::execution::parallel_policy`.
 
 |hpx| still supports calling :cpp:func:`hpx::parallel::v2::define_task_block`
 without an explicit execution policy. In this case the task block will run using
-the :cpp:class:`hpx::parallel::execution::parallel_policy`.
+the :cpp:class:`hpx::execution::parallel_policy`.
 
 |hpx| also adds the ability to access the execution policy that was used to
 create a given ``task_block``.

--- a/examples/1d_stencil/1d_stencil_4.cpp
+++ b/examples/1d_stencil/1d_stencil_4.cpp
@@ -156,7 +156,7 @@ struct stepper
         // Initial conditions: f(0, i) = i
         std::size_t b = 0;
         auto range = boost::irange(b, np);
-        using hpx::parallel::execution::par;
+        using hpx::execution::par;
         hpx::ranges::for_each(par, range, [&U, nx](std::size_t i) {
             U[0][i] = hpx::make_ready_future(partition_data(nx, double(i)));
         });

--- a/examples/1d_stencil/1d_stencil_4_repart.cpp
+++ b/examples/1d_stencil/1d_stencil_4_repart.cpp
@@ -266,7 +266,7 @@ struct stepper
             // Initial conditions: f(0, i) = i
             std::size_t b = 0;
             auto range = boost::irange(b, np);
-            using hpx::parallel::execution::par;
+            using hpx::execution::par;
             hpx::ranges::for_each(par, range, [&U, nx](std::size_t i) {
                 U[0][i] = hpx::make_ready_future(partition_data(nx, double(i)));
             });
@@ -276,7 +276,7 @@ struct stepper
             // Initialize from existing data
             std::size_t b = 0;
             auto range = boost::irange(b, np);
-            using hpx::parallel::execution::par;
+            using hpx::execution::par;
             hpx::ranges::for_each(par, range, [&U, nx, data](std::size_t i) {
                 U[0][i] = hpx::make_ready_future(
                     partition_data(nx, data.get() + (i * nx)));

--- a/examples/1d_stencil/1d_stencil_4_throttle.cpp
+++ b/examples/1d_stencil/1d_stencil_4_throttle.cpp
@@ -233,7 +233,7 @@ struct stepper
         // Initial conditions: f(0, i) = i
         std::size_t b = 0;
         auto range = boost::irange(b, np);
-        using hpx::parallel::execution::par;
+        using hpx::execution::par;
         hpx::ranges::for_each(par, range, [&U, nx](std::size_t i) {
             U[0][i] = hpx::make_ready_future(partition_data(nx, double(i)));
         });

--- a/examples/1d_stencil/1d_stencil_channel.cpp
+++ b/examples/1d_stencil/1d_stencil_channel.cpp
@@ -88,7 +88,7 @@ int hpx_main(boost::program_options::variables_map& vm)
     auto range = boost::irange(static_cast<std::size_t>(0), nlp);
 
     executor_type executor(numa_domains);
-    auto policy = hpx::parallel::execution::par.on(executor);
+    auto policy = hpx::execution::par.on(executor);
 
     hpx::util::high_resolution_timer t;
     for (std::size_t t = 0; t < steps; ++t)

--- a/examples/quickstart/component_with_executor.cpp
+++ b/examples/quickstart/component_with_executor.cpp
@@ -16,10 +16,10 @@
 // Define a base component which exposes the required interface
 struct hello_world_server
   : hpx::components::executor_component<
-        hpx::parallel::execution::parallel_executor,
+        hpx::execution::parallel_executor,
         hpx::components::component_base<hello_world_server> >
 {
-    typedef hpx::parallel::execution::parallel_executor executor_type;
+    typedef hpx::execution::parallel_executor executor_type;
     typedef hpx::components::executor_component<
             executor_type, hpx::components::component_base<hello_world_server>
         > base_type;

--- a/examples/quickstart/partitioned_vector_spmd_foreach.cpp
+++ b/examples/quickstart/partitioned_vector_spmd_foreach.cpp
@@ -159,12 +159,12 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
         // fill the vector with random numbers
         partitioned_vector_view<int> view(v);
-        hpx::generate(hpx::parallel::execution::par, view.begin(), view.end(),
+        hpx::generate(hpx::execution::par, view.begin(), view.end(),
             [&]() { return dist(gen); });
 
         // square all numbers in the array
         hpx::ranges::for_each(
-            hpx::parallel::execution::par, view, [](int& val) { val *= val; });
+            hpx::execution::par, view, [](int& val) { val *= val; });
 
         // do the same using a plain loop
         std::size_t maxnum = view.size();

--- a/examples/quickstart/potpourri.cpp
+++ b/examples/quickstart/potpourri.cpp
@@ -56,13 +56,13 @@ int main(int, char**)
     std::vector<int> v(1000000);
 
     // We fill the vector synchronously and sequentially.
-    hpx::generate(hpx::parallel::execution::seq, std::begin(v), std::end(v),
+    hpx::generate(hpx::execution::seq, std::begin(v), std::end(v),
         &rand_wrapper);
 
     // We can launch the sort in parallel and asynchronously.
     hpx::future<void> done_sorting = hpx::parallel::sort(
-        hpx::parallel::execution::par(          // In parallel.
-            hpx::parallel::execution::task),    // Asynchronously.
+        hpx::execution::par(          // In parallel.
+            hpx::execution::task),    // Asynchronously.
         std::begin(v), std::end(v));
 
     // We launch the final task when the vector has been sorted and result is

--- a/examples/quickstart/safe_object.cpp
+++ b/examples/quickstart/safe_object.cpp
@@ -79,7 +79,7 @@ inline bool satisfies_criteria(int d)
 
 int hpx_main(int argc, char* argv[])
 {
-    using hpx::parallel::execution::par;
+    using hpx::execution::par;
     using hpx::ranges::for_each;
 
     // initialize data

--- a/examples/quickstart/sort_by_key_demo.cpp
+++ b/examples/quickstart/sort_by_key_demo.cpp
@@ -47,7 +47,7 @@ int hpx_main()
         print_sequence(keys, values);
 
         hpx::parallel::sort_by_key(
-            hpx::parallel::execution::par,
+            hpx::execution::par,
             keys.begin(),
             keys.end(),
             values.begin());

--- a/examples/quickstart/vector_counting_dotproduct.cpp
+++ b/examples/quickstart/vector_counting_dotproduct.cpp
@@ -27,7 +27,7 @@ int hpx_main()
 
     double result =
         hpx::transform_reduce(
-            hpx::parallel::execution::par,
+            hpx::execution::par,
             hpx::util::counting_iterator<size_t>(0),
             hpx::util::counting_iterator<size_t>(10007),
             0.0,

--- a/examples/quickstart/vector_zip_dotproduct.cpp
+++ b/examples/quickstart/vector_zip_dotproduct.cpp
@@ -29,7 +29,7 @@ int hpx_main()
 
     double result =
         hpx::transform_reduce(
-            hpx::parallel::execution::par,
+            hpx::execution::par,
             make_zip_iterator(std::begin(xvalues), std::begin(yvalues)),
             make_zip_iterator(std::end(xvalues), std::end(yvalues)),
             0.0,

--- a/examples/transpose/transpose_await.cpp
+++ b/examples/transpose/transpose_await.cpp
@@ -283,7 +283,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
                 std::cout << "Untiled\n";
             std::cout << "Number of iterations  = " << iterations << "\n";
         }
-        using hpx::parallel::execution::par;
+        using hpx::execution::par;
         using hpx::ranges::for_each;
 
         // Fill the original matrix, set transpose to known garbage value.

--- a/examples/transpose/transpose_block.cpp
+++ b/examples/transpose/transpose_block.cpp
@@ -252,7 +252,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
                 std::cout << "Untiled\n";
             std::cout << "Number of iterations  = " << iterations << "\n";
         }
-        using hpx::parallel::execution::par;
+        using hpx::execution::par;
         using hpx::ranges::for_each;
 
         // Fill the original matrix, set transpose to known garbage value.

--- a/examples/transpose/transpose_block_numa.cpp
+++ b/examples/transpose/transpose_block_numa.cpp
@@ -359,7 +359,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
             std::cout << "Number of iterations  = " << iterations << "\n";
         }
 
-        using hpx::parallel::execution::par;
+        using hpx::execution::par;
         using hpx::ranges::for_each;
 
         // Fill the original matrix, set transpose to known garbage value.

--- a/examples/transpose/transpose_smp.cpp
+++ b/examples/transpose/transpose_smp.cpp
@@ -50,7 +50,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         std::cout << "Untiled\n";
     std::cout << "Number of iterations  = " << iterations << "\n";
 
-    using hpx::parallel::execution::par;
+    using hpx::execution::par;
     using hpx::ranges::for_each;
 
     const std::uint64_t start = 0;

--- a/examples/transpose/transpose_smp_block.cpp
+++ b/examples/transpose/transpose_smp_block.cpp
@@ -60,8 +60,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
         std::cout << "Untiled\n";
     std::cout << "Number of iterations  = " << iterations << "\n";
 
-    using hpx::parallel::execution::par;
-    using hpx::parallel::execution::task;
+    using hpx::execution::par;
+    using hpx::execution::task;
     using hpx::ranges::for_each;
 
     const std::uint64_t start = 0;

--- a/libs/core/execution_base/include/hpx/execution_base/execution.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/execution.hpp
@@ -15,7 +15,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx { namespace execution {
     ///////////////////////////////////////////////////////////////////////////
     /// Function invocations executed by a group of sequential execution agents
     /// execute in sequential order.
@@ -49,8 +49,29 @@ namespace hpx { namespace parallel { namespace execution {
     {
         constexpr task_policy_tag() {}
     };
-    /// \endcond
+}}    // namespace hpx::execution
 
+namespace hpx { namespace parallel { namespace execution {
+    using parallel_execution_tag HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::parallel_execution_tag is deprecated. Use "
+        "hpx::execution::parallel_execution_tag instead.") =
+        hpx::execution::parallel_execution_tag;
+    using sequenced_execution_tag HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::sequenced_execution_tag is deprecated. Use "
+        "hpx::execution::sequenced_execution_tag instead.") =
+        hpx::execution::sequenced_execution_tag;
+    using task_policy_tag HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::task_policy_tag is deprecated. Use "
+        "hpx::execution::task_policy_tag instead.") =
+        hpx::execution::task_policy_tag;
+    using unsequenced_execution_tag HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::unsequenced_execution_tag is deprecated. "
+        "Use hpx::execution::unsequenced_execution_tag instead.") =
+        hpx::execution::unsequenced_execution_tag;
+}}}    // namespace hpx::parallel::execution
+/// \endcond
+
+namespace hpx { namespace parallel { namespace execution {
     ///////////////////////////////////////////////////////////////////////////
     // Define infrastructure for customization points
     namespace detail {

--- a/libs/core/threading_base/tests/regressions/thread_stacksize_current.cpp
+++ b/libs/core/threading_base/tests/regressions/thread_stacksize_current.cpp
@@ -22,8 +22,8 @@
 
 void test(hpx::threads::thread_stacksize stacksize)
 {
-    hpx::parallel::execution::parallel_executor exec(stacksize);
-    hpx::parallel::execution::parallel_executor exec_current(
+    hpx::execution::parallel_executor exec(stacksize);
+    hpx::execution::parallel_executor exec_current(
         hpx::threads::thread_stacksize_current);
 
     hpx::async(exec, [&exec_current, stacksize]() {

--- a/libs/full/async_distributed/tests/unit/apply_local_executor.cpp
+++ b/libs/full/async_distributed/tests/unit/apply_local_executor.cpp
@@ -131,12 +131,12 @@ void test_apply_with_executor(Executor& exec)
 int hpx_main()
 {
     {
-        hpx::parallel::execution::sequenced_executor exec;
+        hpx::execution::sequenced_executor exec;
         test_apply_with_executor(exec);
     }
 
     {
-        hpx::parallel::execution::parallel_executor exec;
+        hpx::execution::parallel_executor exec;
         test_apply_with_executor(exec);
     }
 

--- a/libs/full/async_distributed/tests/unit/async_local_executor.cpp
+++ b/libs/full/async_distributed/tests/unit/async_local_executor.cpp
@@ -164,12 +164,12 @@ void test_async_with_executor(Executor& exec)
 int hpx_main()
 {
     {
-        hpx::parallel::execution::sequenced_executor exec;
+        hpx::execution::sequenced_executor exec;
         test_async_with_executor(exec);
     }
 
     {
-        hpx::parallel::execution::parallel_executor exec;
+        hpx::execution::parallel_executor exec;
         test_async_with_executor(exec);
     }
 

--- a/libs/full/checkpoint/examples/1d_stencil_4_checkpoint.cpp
+++ b/libs/full/checkpoint/examples/1d_stencil_4_checkpoint.cpp
@@ -300,7 +300,7 @@ struct stepper
         // Initial conditions: f(0, i) = i
         std::size_t b = 0;
         auto range = boost::irange(b, np);
-        using hpx::parallel::execution::par;
+        using hpx::execution::par;
         hpx::ranges::for_each(par, range, [&U, nx](std::size_t i) {
             U[0][i] = hpx::make_ready_future(partition_data(nx, double(i)));
         });

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -158,8 +158,8 @@ namespace hpx { namespace traits {
                 auto& data = communicator.template access_data<arg_type>(l);
 
                 auto it = data.begin();
-                return hpx::reduce(hpx::parallel::execution::par, ++it,
-                    data.end(), *data.begin(), op);
+                return hpx::reduce(
+                    hpx::execution::par, ++it, data.end(), *data.begin(), op);
             };
 
             lock_type l(communicator_.mtx_);

--- a/libs/full/collectives/include/hpx/collectives/spmd_block.hpp
+++ b/libs/full/collectives/include/hpx/collectives/spmd_block.hpp
@@ -270,8 +270,7 @@ namespace hpx { namespace lcos {
             static void call(std::string name, std::size_t images_per_locality,
                 std::size_t num_images, Args... args)
             {
-                using executor_type =
-                    hpx::parallel::execution::parallel_executor;
+                using executor_type = hpx::execution::parallel_executor;
 
                 executor_type exec;
                 std::size_t offset =

--- a/libs/full/collectives/tests/performance/osu/osu_bw.cpp
+++ b/libs/full/collectives/tests/performance/osu/osu_bw.cpp
@@ -82,7 +82,7 @@ double ireceive(hpx::naming::id_type dest, std::size_t loop, std::size_t size,
         if (i == skip)
             t.restart();
 
-        using hpx::parallel::execution::par;
+        using hpx::execution::par;
         using hpx::ranges::for_each;
 
         std::size_t const start = 0;

--- a/libs/full/collectives/tests/performance/osu/osu_latency.cpp
+++ b/libs/full/collectives/tests/performance/osu/osu_latency.cpp
@@ -80,7 +80,7 @@ double receive_double(
         if (i == skip)
             t.restart();
 
-        using hpx::parallel::execution::par;
+        using hpx::execution::par;
         using hpx::ranges::for_each;
 
         std::size_t const start = 0;
@@ -112,8 +112,8 @@ double receive(hpx::naming::id_type dest, char* send_buffer, std::size_t size,
         if (i == skip)
             t.restart();
 
+        using hpx::execution::par;
         using hpx::parallel::for_each;
-        using hpx::parallel::execution::par;
 
         std::size_t const start = 0;
 

--- a/libs/full/collectives/tests/performance/osu/osu_multi_lat.cpp
+++ b/libs/full/collectives/tests/performance/osu/osu_multi_lat.cpp
@@ -93,7 +93,7 @@ double ireceive(
 
         typedef hpx::serialization::serialize_buffer<char> buffer_type;
 
-        using hpx::parallel::execution::par;
+        using hpx::execution::par;
         using hpx::ranges::for_each;
 
         std::size_t const start = 0;

--- a/libs/full/collectives/tests/regressions/barrier_hang.cpp
+++ b/libs/full/collectives/tests/regressions/barrier_hang.cpp
@@ -44,8 +44,7 @@ std::size_t bulk_test(
 
     local_count.store(0);
 
-    hpx::parallel::execution::bulk_sync_execute(
-        hpx::parallel::execution::par.executor(),
+    hpx::parallel::execution::bulk_sync_execute(hpx::execution::par.executor(),
         spmd_block_helper{name, num_images},
         boost::irange(offset, offset + images_per_locality));
 

--- a/libs/full/compute/include/hpx/compute/host/block_executor.hpp
+++ b/libs/full/compute/include/hpx/compute/host/block_executor.hpp
@@ -40,8 +40,7 @@ namespace hpx { namespace compute { namespace host {
     struct block_executor
     {
     public:
-        typedef hpx::parallel::execution::static_chunk_size
-            executor_parameters_type;
+        using executor_parameters_type = hpx::execution::static_chunk_size;
 
         block_executor(std::vector<host::target> const& targets,
             threads::thread_priority priority = threads::thread_priority_high,
@@ -263,7 +262,7 @@ namespace hpx { namespace parallel { namespace execution {
     template <typename Executor>
     struct executor_execution_category<compute::host::block_executor<Executor>>
     {
-        typedef parallel::execution::parallel_execution_tag type;
+        typedef hpx::execution::parallel_execution_tag type;
     };
 
     template <typename Executor>

--- a/libs/full/compute/include/hpx/compute/host/numa_allocator.hpp
+++ b/libs/full/compute/include/hpx/compute/host/numa_allocator.hpp
@@ -101,10 +101,9 @@ namespace hpx { namespace parallel { namespace util {
                 pointer begin = p + i * part_size;
                 pointer end = begin + part_size;
                 first_touch.push_back(hpx::for_each(
-                    hpx::parallel::execution::par(
-                        hpx::parallel::execution::task)
+                    hpx::execution::par(hpx::execution::task)
                         .on(executors_[i])
-                        .with(hpx::parallel::execution::static_chunk_size()),
+                        .with(hpx::execution::static_chunk_size()),
                     begin, end,
 #if defined(HPX_DEBUG)
                     [this, i]

--- a/libs/full/compute/tests/regressions/for_each_value_proxy.cpp
+++ b/libs/full/compute/tests/regressions/for_each_value_proxy.cpp
@@ -179,8 +179,7 @@ int hpx_main()
 {
     hpx::compute::vector<int, test_allocator<int>> v(100);
 
-    hpx::ranges::for_each(
-        hpx::parallel::execution::par, v.begin(), v.end(), set_42());
+    hpx::ranges::for_each(hpx::execution::par, v.begin(), v.end(), set_42());
 
     HPX_TEST_EQ(std::count(v.begin(), v.end(), 42), std::ptrdiff_t(v.size()));
     return hpx::finalize();

--- a/libs/full/compute/tests/regressions/parallel_fill_4132.cpp
+++ b/libs/full/compute/tests/regressions/parallel_fill_4132.cpp
@@ -37,8 +37,8 @@ int hpx_main()
 
             std::vector<int> v(num_elems, 0);
             // Force there to be as many chunks as elements
-            hpx::fill(hpx::parallel::execution::par.on(exec).with(
-                          hpx::parallel::execution::static_chunk_size(1)),
+            hpx::fill(hpx::execution::par.on(exec).with(
+                          hpx::execution::static_chunk_size(1)),
                 v.begin(), v.end(), 1);
 
             std::for_each(v.begin(), v.end(), [](int x) { HPX_TEST_EQ(x, 1); });

--- a/libs/full/executors_distributed/include/hpx/executors_distributed/distribution_policy_executor.hpp
+++ b/libs/full/executors_distributed/include/hpx/executors_distributed/distribution_policy_executor.hpp
@@ -145,7 +145,7 @@ namespace hpx { namespace parallel { namespace execution {
         /// \endcond
 
         /// \cond NOINTERNAL
-        typedef parallel_execution_tag execution_category;
+        using execution_category = hpx::execution::parallel_execution_tag;
 
         template <typename F, typename... Ts>
         void post(F&& f, Ts&&... ts) const

--- a/libs/full/include/include/hpx/algorithm.hpp
+++ b/libs/full/include/include/hpx/algorithm.hpp
@@ -51,6 +51,7 @@ namespace hpx {
     using hpx::parallel::stable_partition;
     using hpx::parallel::stable_sort;
     using hpx::parallel::swap_ranges;
+    using hpx::parallel::transform;
     using hpx::parallel::unique;
     using hpx::parallel::unique_copy;
 }    // namespace hpx

--- a/libs/full/include/include/hpx/local/execution.hpp
+++ b/libs/full/include/include/hpx/local/execution.hpp
@@ -9,21 +9,3 @@
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/thread_executors.hpp>
-
-namespace hpx { namespace execution {
-    using hpx::parallel::execution::par;
-    using hpx::parallel::execution::par_unseq;
-    using hpx::parallel::execution::parallel_executor;
-    using hpx::parallel::execution::parallel_policy;
-    using hpx::parallel::execution::parallel_unsequenced_policy;
-    using hpx::parallel::execution::seq;
-    using hpx::parallel::execution::sequenced_executor;
-    using hpx::parallel::execution::sequenced_policy;
-    using hpx::parallel::execution::task;
-
-    using hpx::parallel::execution::auto_chunk_size;
-    using hpx::parallel::execution::dynamic_chunk_size;
-    using hpx::parallel::execution::guided_chunk_size;
-    using hpx::parallel::execution::persistent_auto_chunk_size;
-    using hpx::parallel::execution::static_chunk_size;
-}}    // namespace hpx::execution

--- a/libs/full/resiliency/tests/performance/replay/1d_stencil.cpp
+++ b/libs/full/resiliency/tests/performance/replay/1d_stencil.cpp
@@ -164,9 +164,8 @@ struct stepper
 
         std::size_t b = 0;
         auto range = boost::irange(b, subdomains);
-        using hpx::parallel::execution::par;
-        hpx::ranges::for_each(
-            par, range, [&U, subdomain_width, subdomains](std::size_t i) {
+        hpx::ranges::for_each(hpx::execution::par, range,
+            [&U, subdomain_width, subdomains](std::size_t i) {
                 U[0][i] = hpx::make_ready_future(
                     partition_data(subdomain_width, double(i), subdomains));
             });

--- a/libs/full/resiliency/tests/performance/replay/1d_stencil_checksum.cpp
+++ b/libs/full/resiliency/tests/performance/replay/1d_stencil_checksum.cpp
@@ -247,9 +247,8 @@ struct stepper
 
         std::size_t b = 0;
         auto range = boost::irange(b, subdomains);
-        using hpx::parallel::execution::par;
-        hpx::ranges::for_each(
-            par, range, [&U, subdomain_width, subdomains](std::size_t i) {
+        hpx::ranges::for_each(hpx::execution::par, range,
+            [&U, subdomain_width, subdomains](std::size_t i) {
                 U[0][i] = hpx::make_ready_future(
                     partition_data(subdomain_width, double(i), subdomains));
             });

--- a/libs/full/resiliency/tests/performance/replay/1d_stencil_replay.cpp
+++ b/libs/full/resiliency/tests/performance/replay/1d_stencil_replay.cpp
@@ -204,9 +204,8 @@ struct stepper
 
         std::size_t b = 0;
         auto range = boost::irange(b, subdomains);
-        using hpx::parallel::execution::par;
-        hpx::ranges::for_each(
-            par, range, [&U, subdomain_width, subdomains](std::size_t i) {
+        hpx::ranges::for_each(hpx::execution::par, range,
+            [&U, subdomain_width, subdomains](std::size_t i) {
                 U[0][i] = hpx::make_ready_future(
                     partition_data(subdomain_width, double(i), subdomains));
             });

--- a/libs/full/resiliency/tests/performance/replay/dataflow_replay.cpp
+++ b/libs/full/resiliency/tests/performance/replay/dataflow_replay.cpp
@@ -249,9 +249,8 @@ struct stepper
 
         std::size_t b = 0;
         auto range = boost::irange(b, subdomains);
-        using hpx::parallel::execution::par;
-        hpx::ranges::for_each(
-            par, range, [&U, subdomain_width, subdomains](std::size_t i) {
+        hpx::ranges::for_each(hpx::execution::par, range,
+            [&U, subdomain_width, subdomains](std::size_t i) {
                 U[0][i] = hpx::make_ready_future(
                     partition_data(subdomain_width, double(i), subdomains));
             });

--- a/libs/full/resiliency/tests/performance/replay/dataflow_replay_validate.cpp
+++ b/libs/full/resiliency/tests/performance/replay/dataflow_replay_validate.cpp
@@ -241,9 +241,8 @@ struct stepper
 
         std::size_t b = 0;
         auto range = boost::irange(b, subdomains);
-        using hpx::parallel::execution::par;
-        hpx::ranges::for_each(
-            par, range, [&U, subdomain_width, subdomains](std::size_t i) {
+        hpx::ranges::for_each(hpx::execution::par, range,
+            [&U, subdomain_width, subdomains](std::size_t i) {
                 U[0][i] = hpx::make_ready_future(
                     partition_data(subdomain_width, double(i), subdomains));
             });

--- a/libs/full/resiliency/tests/performance/replay/pure_dataflow.cpp
+++ b/libs/full/resiliency/tests/performance/replay/pure_dataflow.cpp
@@ -176,9 +176,8 @@ struct stepper
 
         std::size_t b = 0;
         auto range = boost::irange(b, subdomains);
-        using hpx::parallel::execution::par;
-        hpx::ranges::for_each(
-            par, range, [&U, subdomain_width, subdomains](std::size_t i) {
+        hpx::ranges::for_each(hpx::execution::par, range,
+            [&U, subdomain_width, subdomains](std::size_t i) {
                 U[0][i] = hpx::make_ready_future(
                     partition_data(subdomain_width, double(i), subdomains));
             });

--- a/libs/full/resiliency/tests/performance/replicate/1d_stencil_replicate.cpp
+++ b/libs/full/resiliency/tests/performance/replicate/1d_stencil_replicate.cpp
@@ -205,9 +205,8 @@ struct stepper
 
         std::size_t b = 0;
         auto range = boost::irange(b, subdomains);
-        using hpx::parallel::execution::par;
-        hpx::ranges::for_each(
-            par, range, [&U, subdomain_width, subdomains](std::size_t i) {
+        hpx::ranges::for_each(hpx::execution::par, range,
+            [&U, subdomain_width, subdomains](std::size_t i) {
                 U[0][i] = hpx::make_ready_future(
                     partition_data(subdomain_width, double(i), subdomains));
             });

--- a/libs/full/resiliency/tests/performance/replicate/1d_stencil_replicate_checksum.cpp
+++ b/libs/full/resiliency/tests/performance/replicate/1d_stencil_replicate_checksum.cpp
@@ -246,9 +246,8 @@ struct stepper
 
         std::size_t b = 0;
         auto range = boost::irange(b, subdomains);
-        using hpx::parallel::execution::par;
-        hpx::ranges::for_each(
-            par, range, [&U, subdomain_width, subdomains](std::size_t i) {
+        hpx::ranges::for_each(hpx::execution::par, range,
+            [&U, subdomain_width, subdomains](std::size_t i) {
                 U[0][i] = hpx::make_ready_future(
                     partition_data(subdomain_width, double(i), subdomains));
             });

--- a/libs/full/resiliency/tests/unit/async_replay_executor.cpp
+++ b/libs/full/resiliency/tests/unit/async_replay_executor.cpp
@@ -51,7 +51,7 @@ int deep_thought()
 int hpx_main()
 {
     {
-        hpx::parallel::execution::parallel_executor exec;
+        hpx::execution::parallel_executor exec;
 
         // successful replay
         hpx::future<int> f = hpx::resiliency::experimental::async_replay(

--- a/libs/full/resiliency/tests/unit/async_replicate_executor.cpp
+++ b/libs/full/resiliency/tests/unit/async_replicate_executor.cpp
@@ -52,7 +52,7 @@ int deep_thought()
 int hpx_main()
 {
     {
-        hpx::parallel::execution::parallel_executor exec;
+        hpx::execution::parallel_executor exec;
 
         // successful replicate
         hpx::future<int> f = hpx::resiliency::experimental::async_replicate(

--- a/libs/full/resiliency/tests/unit/async_replicate_vote_executor.cpp
+++ b/libs/full/resiliency/tests/unit/async_replicate_vote_executor.cpp
@@ -41,7 +41,7 @@ bool validate(int ans)
 int hpx_main()
 {
     {
-        hpx::parallel::execution::parallel_executor exec;
+        hpx::execution::parallel_executor exec;
 
         hpx::future<int> f =
             hpx::resiliency::experimental::async_replicate_vote(
@@ -52,7 +52,7 @@ int hpx_main()
     }
 
     {
-        hpx::parallel::execution::parallel_executor exec;
+        hpx::execution::parallel_executor exec;
 
         hpx::future<int> f =
             hpx::resiliency::experimental::async_replicate_vote_validate(

--- a/libs/full/resiliency/tests/unit/dataflow_replay_executor.cpp
+++ b/libs/full/resiliency/tests/unit/dataflow_replay_executor.cpp
@@ -51,7 +51,7 @@ int deep_thought()
 int hpx_main()
 {
     {
-        hpx::parallel::execution::parallel_executor exec;
+        hpx::execution::parallel_executor exec;
 
         // successful replay
         hpx::future<int> f = hpx::resiliency::experimental::dataflow_replay(

--- a/libs/full/resiliency/tests/unit/dataflow_replicate_executor.cpp
+++ b/libs/full/resiliency/tests/unit/dataflow_replicate_executor.cpp
@@ -52,7 +52,7 @@ int deep_thought()
 int hpx_main()
 {
     {
-        hpx::parallel::execution::parallel_executor exec;
+        hpx::execution::parallel_executor exec;
 
         // successful replicate
         hpx::future<int> f = hpx::resiliency::experimental::dataflow_replicate(

--- a/libs/full/resiliency/tests/unit/replay_executor.cpp
+++ b/libs/full/resiliency/tests/unit/replay_executor.cpp
@@ -4,11 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/algorithm.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/future.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/modules/algorithms.hpp>
-#include <hpx/modules/execution.hpp>
-#include <hpx/modules/executors.hpp>
-#include <hpx/modules/futures.hpp>
 #include <hpx/modules/resiliency.hpp>
 #include <hpx/modules/testing.hpp>
 
@@ -25,7 +24,7 @@ int hpx_main(int argc, char* argv[])
 {
     try
     {
-        hpx::parallel::execution::parallel_executor base_exec;
+        hpx::execution::parallel_executor base_exec;
         auto exec =
             hpx::resiliency::experimental::make_replay_executor(base_exec, 3);
 
@@ -33,8 +32,8 @@ int hpx_main(int argc, char* argv[])
         std::iota(data.begin(), data.end(), 0);
 
         std::atomic<std::size_t> count(0);
-        hpx::parallel::for_each(hpx::parallel::execution::par.on(exec),
-            data.begin(), data.end(), [&](std::size_t i) {
+        hpx::for_each(hpx::execution::par.on(exec), data.begin(), data.end(),
+            [&](std::size_t i) {
                 if (++count == 42)
                 {
                     throw vogon_exception();
@@ -48,7 +47,7 @@ int hpx_main(int argc, char* argv[])
 
     try
     {
-        hpx::parallel::execution::parallel_executor base_exec;
+        hpx::execution::parallel_executor base_exec;
         auto exec =
             hpx::resiliency::experimental::make_replay_executor(base_exec, 3);
 
@@ -58,8 +57,8 @@ int hpx_main(int argc, char* argv[])
         std::vector<std::size_t> dest(100);
 
         std::atomic<std::size_t> count(0);
-        hpx::parallel::transform(hpx::parallel::execution::par.on(exec),
-            data.begin(), data.end(), dest.begin(), [&](std::size_t i) {
+        hpx::transform(hpx::execution::par.on(exec), data.begin(), data.end(),
+            dest.begin(), [&](std::size_t i) {
                 if (++count == 42)
                 {
                     throw vogon_exception();

--- a/libs/full/resiliency/tests/unit/replicate_executor.cpp
+++ b/libs/full/resiliency/tests/unit/replicate_executor.cpp
@@ -4,11 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/algorithm.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/future.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/modules/algorithms.hpp>
-#include <hpx/modules/execution.hpp>
-#include <hpx/modules/executors.hpp>
-#include <hpx/modules/futures.hpp>
 #include <hpx/modules/resiliency.hpp>
 #include <hpx/modules/testing.hpp>
 
@@ -25,7 +24,7 @@ int hpx_main(int argc, char* argv[])
 {
     try
     {
-        hpx::parallel::execution::parallel_executor base_exec;
+        hpx::execution::parallel_executor base_exec;
         auto exec = hpx::resiliency::experimental::make_replicate_executor(
             base_exec, 2);
 
@@ -33,8 +32,8 @@ int hpx_main(int argc, char* argv[])
         std::iota(data.begin(), data.end(), 0);
 
         std::atomic<std::size_t> count(0);
-        hpx::parallel::for_each(hpx::parallel::execution::par.on(exec),
-            data.begin(), data.end(), [&](std::size_t i) {
+        hpx::for_each(hpx::execution::par.on(exec), data.begin(), data.end(),
+            [&](std::size_t i) {
                 if (++count == 42)
                 {
                     throw vogon_exception();
@@ -48,7 +47,7 @@ int hpx_main(int argc, char* argv[])
 
     try
     {
-        hpx::parallel::execution::parallel_executor base_exec;
+        hpx::execution::parallel_executor base_exec;
         auto exec = hpx::resiliency::experimental::make_replicate_executor(
             base_exec, 2);
 
@@ -58,8 +57,8 @@ int hpx_main(int argc, char* argv[])
         std::vector<std::size_t> dest(100);
 
         std::atomic<std::size_t> count(0);
-        hpx::parallel::transform(hpx::parallel::execution::par.on(exec),
-            data.begin(), data.end(), dest.begin(), [&](std::size_t i) {
+        hpx::transform(hpx::execution::par.on(exec), data.begin(), data.end(),
+            dest.begin(), [&](std::size_t i) {
                 if (++count == 42)
                 {
                     throw vogon_exception();

--- a/libs/full/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
+++ b/libs/full/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
@@ -150,9 +150,9 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::set<std::thread::id> thread_set;
 
     // test a parallel algorithm on custom pool with high priority
-    hpx::parallel::execution::static_chunk_size fixed(1);
+    hpx::execution::static_chunk_size fixed(1);
     hpx::for_loop_strided(
-        hpx::parallel::execution::par.with(fixed).on(high_priority_executor), 0,
+        hpx::execution::par.with(fixed).on(high_priority_executor), 0,
         loop_count, 1, [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
             if (thread_set.insert(std::this_thread::get_id()).second)
@@ -168,8 +168,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
     // test a parallel algorithm on custom pool with normal priority
     hpx::for_loop_strided(
-        hpx::parallel::execution::par.with(fixed).on(normal_priority_executor),
-        0, loop_count, 1, [&](std::size_t i) {
+        hpx::execution::par.with(fixed).on(normal_priority_executor), 0,
+        loop_count, 1, [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
             if (thread_set.insert(std::this_thread::get_id()).second)
             {
@@ -184,8 +184,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     thread_set.clear();
 
     // test a parallel algorithm on mpi_executor
-    hpx::for_loop_strided(
-        hpx::parallel::execution::par.with(fixed).on(mpi_executor), 0,
+    hpx::for_loop_strided(hpx::execution::par.with(fixed).on(mpi_executor), 0,
         loop_count, 1, [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
             if (thread_set.insert(std::this_thread::get_id()).second)
@@ -204,9 +203,9 @@ int hpx_main(hpx::program_options::variables_map& vm)
     //     auto normal_priority_async_policy = hpx::launch::async_policy();
 
     // test a parallel algorithm on custom pool with high priority
-    hpx::for_loop_strided(hpx::parallel::execution::par
-                              .with(fixed /*, high_priority_async_policy*/)
-                              .on(mpi_executor),
+    hpx::for_loop_strided(
+        hpx::execution::par.with(fixed /*, high_priority_async_policy*/)
+            .on(mpi_executor),
         0, loop_count, 1, [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
             if (thread_set.insert(std::this_thread::get_id()).second)

--- a/libs/full/resource_partitioner/examples/simple_resource_partitioner.cpp
+++ b/libs/full/resource_partitioner/examples/simple_resource_partitioner.cpp
@@ -144,9 +144,9 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::set<std::thread::id> thread_set;
 
     // test a parallel algorithm on custom pool with high priority
-    hpx::parallel::execution::static_chunk_size fixed(1);
+    hpx::execution::static_chunk_size fixed(1);
     hpx::for_loop_strided(
-        hpx::parallel::execution::par.with(fixed).on(high_priority_executor), 0,
+        hpx::execution::par.with(fixed).on(high_priority_executor), 0,
         loop_count, 1, [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
             if (thread_set.insert(std::this_thread::get_id()).second)
@@ -162,8 +162,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
     // test a parallel algorithm on custom pool with normal priority
     hpx::for_loop_strided(
-        hpx::parallel::execution::par.with(fixed).on(normal_priority_executor),
-        0, loop_count, 1, [&](std::size_t i) {
+        hpx::execution::par.with(fixed).on(normal_priority_executor), 0,
+        loop_count, 1, [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
             if (thread_set.insert(std::this_thread::get_id()).second)
             {
@@ -178,8 +178,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     thread_set.clear();
 
     // test a parallel algorithm on mpi_executor
-    hpx::for_loop_strided(
-        hpx::parallel::execution::par.with(fixed).on(mpi_executor), 0,
+    hpx::for_loop_strided(hpx::execution::par.with(fixed).on(mpi_executor), 0,
         loop_count, 1, [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
             if (thread_set.insert(std::this_thread::get_id()).second)
@@ -198,9 +197,9 @@ int hpx_main(hpx::program_options::variables_map& vm)
     //     auto normal_priority_async_policy = hpx::launch::async_policy();
 
     // test a parallel algorithm on custom pool with high priority
-    hpx::for_loop_strided(hpx::parallel::execution::par
-                              .with(fixed /*, high_priority_async_policy*/)
-                              .on(mpi_executor),
+    hpx::for_loop_strided(
+        hpx::execution::par.with(fixed /*, high_priority_async_policy*/)
+            .on(mpi_executor),
         0, loop_count, 1, [&](std::size_t i) {
             std::lock_guard<hpx::lcos::local::mutex> lock(m);
             if (thread_set.insert(std::this_thread::get_id()).second)

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/scan.hpp
@@ -635,14 +635,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 // wait for 1. step of current partition to prevent race condition
                 // when used in place
                 finalitems.push_back(hpx::dataflow(policy.executor(),
-                    hpx::util::unwrapping(
-                        [=, &op, &conv](T last_value, T) -> void {
-                            dispatch(traits_out::get_id(out_it),
-                                segmented_scan_void<Algo>(),
-                                hpx::parallel::execution::seq, std::true_type(),
-                                get<0>(in_tuple), get<1>(in_tuple), out, conv,
-                                last_value, op);
-                        }),
+                    hpx::util::unwrapping([=, &op, &conv](
+                                              T last_value, T) -> void {
+                        dispatch(traits_out::get_id(out_it),
+                            segmented_scan_void<Algo>(), hpx::execution::seq,
+                            std::true_type(), get<0>(in_tuple),
+                            get<1>(in_tuple), out, conv, last_value, op);
+                    }),
                     workitems.back(), res));
 
                 // 3. Step: compute new init value for the next segment

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/exclusive_scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/exclusive_scan.hpp
@@ -108,9 +108,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return result::get(dataflow(
                     [=](vector_type r) {
                         exclusive_scan<typename vector_type::iterator>()
-                            .parallel(hpx::parallel::execution::par, first + 1,
-                                last, r.begin() + 1,
-                                std::forward<value_type>(*first), op);
+                            .parallel(hpx::execution::par, first + 1, last,
+                                r.begin() + 1, std::forward<value_type>(*first),
+                                op);
                         r[0] = op(r.back(), *(last - 1));
                         return r;
                     },

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/inclusive_scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/inclusive_scan.hpp
@@ -107,9 +107,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return result::get(dataflow(
                     [=](vector_type r) {
                         inclusive_scan<typename vector_type::iterator>()
-                            .parallel(hpx::parallel::execution::par, first + 1,
-                                last, r.begin() + 1,
-                                std::forward<value_type>(*first), op);
+                            .parallel(hpx::execution::par, first + 1, last,
+                                r.begin() + 1, std::forward<value_type>(*first),
+                                op);
                         return r;
                     },
                     std::move(res)));

--- a/libs/full/segmented_algorithms/tests/performance/minmax_element_performance.cpp
+++ b/libs/full/segmented_algorithms/tests/performance/minmax_element_performance.cpp
@@ -59,8 +59,8 @@ double run_min_element_benchmark(
     for (int i = 0; i != test_count; ++i)
     {
         // invoke minmax
-        using namespace hpx::parallel;
-        /*auto iters = */ min_element(execution::par, v.begin(), v.end());
+        /*auto iters = */ hpx::min_element(
+            hpx::execution::par, v.begin(), v.end());
     }
 
     time = hpx::util::high_resolution_clock::now() - time;
@@ -77,8 +77,8 @@ double run_max_element_benchmark(
     for (int i = 0; i != test_count; ++i)
     {
         // invoke minmax
-        using namespace hpx::parallel;
-        /*auto iters = */ max_element(execution::par, v.begin(), v.end());
+        /*auto iters = */ hpx::max_element(
+            hpx::execution::par, v.begin(), v.end());
     }
 
     time = hpx::util::high_resolution_clock::now() - time;
@@ -95,8 +95,8 @@ double run_minmax_element_benchmark(
     for (int i = 0; i != test_count; ++i)
     {
         // invoke minmax
-        using namespace hpx::parallel;
-        /*auto iters = */ minmax_element(execution::par, v.begin(), v.end());
+        /*auto iters = */ hpx::minmax_element(
+            hpx::execution::par, v.begin(), v.end());
     }
 
     time = hpx::util::high_resolution_clock::now() - time;
@@ -119,8 +119,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
             size, hpx::container_layout(hpx::find_all_localities()));
 
         // initialize data
-        using namespace hpx::parallel;
-        generate(execution::par, v.begin(), v.end(), random_fill());
+        hpx::generate(hpx::execution::par, v.begin(), v.end(), random_fill());
 
         // run benchmark
         double time_minmax = run_minmax_element_benchmark(test_count, v);

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_adjacent_difference1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_adjacent_difference1.cpp
@@ -77,16 +77,14 @@ void adjacent_difference_tests(std::vector<hpx::id_type>& localities)
     hpx::partitioned_vector<T> v(
         length, T(1), hpx::container_layout(localities));
     hpx::parallel::inclusive_scan(
-        hpx::parallel::execution::seq, v.begin(), v.end(), v.begin());
+        hpx::execution::seq, v.begin(), v.end(), v.begin());
     hpx::partitioned_vector<T> w(length, hpx::container_layout(localities));
-    test_adjacent_difference(hpx::parallel::execution::seq, v, w, T(1));
-    test_adjacent_difference(hpx::parallel::execution::par, v, w, T(1));
+    test_adjacent_difference(hpx::execution::seq, v, w, T(1));
+    test_adjacent_difference(hpx::execution::par, v, w, T(1));
     test_adjacent_difference_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), v, w,
-        T(1));
+        hpx::execution::seq(hpx::execution::task), v, w, T(1));
     test_adjacent_difference_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), v, w,
-        T(1));
+        hpx::execution::par(hpx::execution::task), v, w, T(1));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_adjacent_difference2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_adjacent_difference2.cpp
@@ -77,16 +77,14 @@ void adjacent_difference_tests(std::vector<hpx::id_type>& localities)
     hpx::partitioned_vector<T> v(
         length, T(1), hpx::container_layout(localities));
     hpx::parallel::inclusive_scan(
-        hpx::parallel::execution::seq, v.begin(), v.end(), v.begin());
+        hpx::execution::seq, v.begin(), v.end(), v.begin());
     hpx::partitioned_vector<T> w(length, hpx::container_layout(localities));
-    test_adjacent_difference(hpx::parallel::execution::seq, v, w, T(1));
-    test_adjacent_difference(hpx::parallel::execution::par, v, w, T(1));
+    test_adjacent_difference(hpx::execution::seq, v, w, T(1));
+    test_adjacent_difference(hpx::execution::par, v, w, T(1));
     test_adjacent_difference_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), v, w,
-        T(1));
+        hpx::execution::seq(hpx::execution::task), v, w, T(1));
     test_adjacent_difference_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), v, w,
-        T(1));
+        hpx::execution::par(hpx::execution::task), v, w, T(1));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_adjacent_find1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_adjacent_find1.cpp
@@ -72,12 +72,12 @@ void adjacent_find_tests(std::vector<hpx::id_type>& localities)
         SIZE, T(0), hpx::container_layout(localities));
     initialize(xvalues);
 
-    test_adjacent_find(hpx::parallel::execution::seq, xvalues);
-    test_adjacent_find(hpx::parallel::execution::par, xvalues);
+    test_adjacent_find(hpx::execution::seq, xvalues);
+    test_adjacent_find(hpx::execution::par, xvalues);
     test_adjacent_find_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues);
+        hpx::execution::seq(hpx::execution::task), xvalues);
     test_adjacent_find_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues);
+        hpx::execution::par(hpx::execution::task), xvalues);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_adjacent_find2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_adjacent_find2.cpp
@@ -72,12 +72,12 @@ void adjacent_find_tests(std::vector<hpx::id_type>& localities)
         SIZE, T(0), hpx::container_layout(localities));
     initialize(xvalues);
 
-    test_adjacent_find(hpx::parallel::execution::seq, xvalues);
-    test_adjacent_find(hpx::parallel::execution::par, xvalues);
+    test_adjacent_find(hpx::execution::seq, xvalues);
+    test_adjacent_find(hpx::execution::par, xvalues);
     test_adjacent_find_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues);
+        hpx::execution::seq(hpx::execution::task), xvalues);
     test_adjacent_find_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues);
+        hpx::execution::par(hpx::execution::task), xvalues);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_all_of1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_all_of1.cpp
@@ -83,32 +83,26 @@ void all_of_tests(std::vector<hpx::id_type>& localities)
         SIZE, T(0), hpx::container_layout(localities));
     initialize(xvalues);
 
-    test_all(hpx::parallel::execution::seq, xvalues, op8(), false);
-    test_all(hpx::parallel::execution::par, xvalues, op8(), false);
+    test_all(hpx::execution::seq, xvalues, op8(), false);
+    test_all(hpx::execution::par, xvalues, op8(), false);
     test_all_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        op8(), false);
+        hpx::execution::seq(hpx::execution::task), xvalues, op8(), false);
     test_all_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        op8(), false);
+        hpx::execution::par(hpx::execution::task), xvalues, op8(), false);
 
-    test_all(hpx::parallel::execution::seq, xvalues, op5(), false);
-    test_all(hpx::parallel::execution::par, xvalues, op5(), false);
+    test_all(hpx::execution::seq, xvalues, op5(), false);
+    test_all(hpx::execution::par, xvalues, op5(), false);
     test_all_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        op5(), false);
+        hpx::execution::seq(hpx::execution::task), xvalues, op5(), false);
     test_all_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        op5(), false);
+        hpx::execution::par(hpx::execution::task), xvalues, op5(), false);
 
-    test_all(hpx::parallel::execution::seq, xvalues, op0(), true);
-    test_all(hpx::parallel::execution::par, xvalues, op0(), true);
+    test_all(hpx::execution::seq, xvalues, op0(), true);
+    test_all(hpx::execution::par, xvalues, op0(), true);
     test_all_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        op0(), true);
+        hpx::execution::seq(hpx::execution::task), xvalues, op0(), true);
     test_all_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        op0(), true);
+        hpx::execution::par(hpx::execution::task), xvalues, op0(), true);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_all_of2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_all_of2.cpp
@@ -83,32 +83,26 @@ void all_of_tests(std::vector<hpx::id_type>& localities)
         SIZE, T(0), hpx::container_layout(localities));
     initialize(xvalues);
 
-    test_all(hpx::parallel::execution::seq, xvalues, op8(), false);
-    test_all(hpx::parallel::execution::par, xvalues, op8(), false);
+    test_all(hpx::execution::seq, xvalues, op8(), false);
+    test_all(hpx::execution::par, xvalues, op8(), false);
     test_all_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        op8(), false);
+        hpx::execution::seq(hpx::execution::task), xvalues, op8(), false);
     test_all_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        op8(), false);
+        hpx::execution::par(hpx::execution::task), xvalues, op8(), false);
 
-    test_all(hpx::parallel::execution::seq, xvalues, op5(), false);
-    test_all(hpx::parallel::execution::par, xvalues, op5(), false);
+    test_all(hpx::execution::seq, xvalues, op5(), false);
+    test_all(hpx::execution::par, xvalues, op5(), false);
     test_all_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        op5(), false);
+        hpx::execution::seq(hpx::execution::task), xvalues, op5(), false);
     test_all_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        op5(), false);
+        hpx::execution::par(hpx::execution::task), xvalues, op5(), false);
 
-    test_all(hpx::parallel::execution::seq, xvalues, op0(), true);
-    test_all(hpx::parallel::execution::par, xvalues, op0(), true);
+    test_all(hpx::execution::seq, xvalues, op0(), true);
+    test_all(hpx::execution::par, xvalues, op0(), true);
     test_all_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        op0(), true);
+        hpx::execution::seq(hpx::execution::task), xvalues, op0(), true);
     test_all_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        op0(), true);
+        hpx::execution::par(hpx::execution::task), xvalues, op0(), true);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_any_of1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_any_of1.cpp
@@ -83,23 +83,19 @@ void any_of_tests(std::vector<hpx::id_type>& localities)
         SIZE, T(0), hpx::container_layout(localities));
     initialize(xvalues);
 
-    test_any(hpx::parallel::execution::seq, xvalues, op5(), true);
-    test_any(hpx::parallel::execution::par, xvalues, op5(), true);
+    test_any(hpx::execution::seq, xvalues, op5(), true);
+    test_any(hpx::execution::par, xvalues, op5(), true);
     test_any_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        op5(), true);
+        hpx::execution::seq(hpx::execution::task), xvalues, op5(), true);
     test_any_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        op5(), true);
+        hpx::execution::par(hpx::execution::task), xvalues, op5(), true);
 
-    test_any(hpx::parallel::execution::seq, xvalues, op8(), false);
-    test_any(hpx::parallel::execution::par, xvalues, op8(), false);
+    test_any(hpx::execution::seq, xvalues, op8(), false);
+    test_any(hpx::execution::par, xvalues, op8(), false);
     test_any_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        op8(), false);
+        hpx::execution::seq(hpx::execution::task), xvalues, op8(), false);
     test_any_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        op8(), false);
+        hpx::execution::par(hpx::execution::task), xvalues, op8(), false);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_any_of2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_any_of2.cpp
@@ -83,23 +83,19 @@ void any_of_tests(std::vector<hpx::id_type>& localities)
         SIZE, T(0), hpx::container_layout(localities));
     initialize(xvalues);
 
-    test_any(hpx::parallel::execution::seq, xvalues, op5(), true);
-    test_any(hpx::parallel::execution::par, xvalues, op5(), true);
+    test_any(hpx::execution::seq, xvalues, op5(), true);
+    test_any(hpx::execution::par, xvalues, op5(), true);
     test_any_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        op5(), true);
+        hpx::execution::seq(hpx::execution::task), xvalues, op5(), true);
     test_any_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        op5(), true);
+        hpx::execution::par(hpx::execution::task), xvalues, op5(), true);
 
-    test_any(hpx::parallel::execution::seq, xvalues, op8(), false);
-    test_any(hpx::parallel::execution::par, xvalues, op8(), false);
+    test_any(hpx::execution::seq, xvalues, op8(), false);
+    test_any(hpx::execution::par, xvalues, op8(), false);
     test_any_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        op8(), false);
+        hpx::execution::seq(hpx::execution::task), xvalues, op8(), false);
     test_any_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        op8(), false);
+        hpx::execution::par(hpx::execution::task), xvalues, op8(), false);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_copy.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_copy.cpp
@@ -90,7 +90,7 @@ void copy_algo_tests_with_policy_async(std::size_t size, std::size_t localities,
     hpx::partitioned_vector<T> v1(size, policy);
     fill_vector(v1, T(43));
 
-    using hpx::parallel::execution::task;
+    using hpx::execution::task;
 
     hpx::partitioned_vector<T> v2(size, policy);
     auto f =
@@ -119,7 +119,7 @@ void copy_tests_with_policy(
     fill_vector(v3, T(43));
     compare_vectors(v1, v3, false);
 
-    using namespace hpx::parallel::execution;
+    using namespace hpx::execution;
 
     copy_algo_tests_with_policy<T>(size, localities, policy, seq);
     copy_algo_tests_with_policy<T>(size, localities, policy, par);

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_exclusive_scan.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_exclusive_scan.cpp
@@ -237,7 +237,7 @@ template <typename T, typename DistPolicy>
 void exclusive_scan_tests_with_policy(
     std::size_t size, DistPolicy const& policy)
 {
-    using namespace hpx::parallel::execution;
+    using namespace hpx::execution;
 
     // setup partitioned vector to test
     hpx::partitioned_vector<T> in(size, policy);
@@ -265,7 +265,7 @@ template <typename T, typename DistPolicy>
 void exclusive_scan_tests_segmented_out_with_policy(
     std::size_t size, DistPolicy const& in_policy, DistPolicy const& out_policy)
 {
-    using namespace hpx::parallel::execution;
+    using namespace hpx::execution;
 
     // setup partitioned vector to test
     hpx::partitioned_vector<T> in(size, in_policy);
@@ -297,7 +297,7 @@ template <typename T, typename DistPolicy>
 void exclusive_scan_tests_inplace_with_policy(
     std::size_t size, DistPolicy const& policy)
 {
-    using namespace hpx::parallel::execution;
+    using namespace hpx::execution;
 
     // setup verification vector
     std::vector<T> ver(size);

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_exclusive_scan2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_exclusive_scan2.cpp
@@ -237,7 +237,7 @@ template <typename T, typename DistPolicy>
 void exclusive_scan_tests_with_policy(
     std::size_t size, DistPolicy const& policy)
 {
-    using namespace hpx::parallel::execution;
+    using namespace hpx::execution;
 
     // setup partitioned vector to test
     hpx::partitioned_vector<T> in(size, policy);
@@ -265,7 +265,7 @@ template <typename T, typename DistPolicy>
 void exclusive_scan_tests_segmented_out_with_policy(
     std::size_t size, DistPolicy const& in_policy, DistPolicy const& out_policy)
 {
-    using namespace hpx::parallel::execution;
+    using namespace hpx::execution;
 
     // setup partitioned vector to test
     hpx::partitioned_vector<T> in(size, in_policy);
@@ -297,7 +297,7 @@ template <typename T, typename DistPolicy>
 void exclusive_scan_tests_inplace_with_policy(
     std::size_t size, DistPolicy const& policy)
 {
-    using namespace hpx::parallel::execution;
+    using namespace hpx::execution;
 
     // setup verification vector
     std::vector<T> ver(size);

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_fill.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_fill.cpp
@@ -109,7 +109,7 @@ template <typename T, typename DistPolicy>
 void fill_tests_with_policy(
     std::size_t size, std::size_t localities, DistPolicy const& policy)
 {
-    using namespace hpx::parallel::execution;
+    using namespace hpx::execution;
 
     fill_algo_tests_with_policy<T>(size, policy, seq);
     fill_algo_tests_with_policy<T>(size, policy, par);

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_find.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_find.cpp
@@ -91,35 +91,27 @@ void find_tests(std::vector<hpx::id_type>& localities)
     std::size_t const num = 1000;
     hpx::partitioned_vector<T> xvalues(
         num, T(1), hpx::container_layout(localities));
-    hpx::parallel::inclusive_scan(hpx::parallel::execution::seq,
-        xvalues.begin(), xvalues.end(), xvalues.begin(), std::plus<T>(), T(0));
+    hpx::parallel::inclusive_scan(hpx::execution::seq, xvalues.begin(),
+        xvalues.end(), xvalues.begin(), std::plus<T>(), T(0));
 
-    test_find(hpx::parallel::execution::seq, xvalues, T(512));
-    test_find(hpx::parallel::execution::par, xvalues, T(512));
-    test_find_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        T(512));
-    test_find_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        T(512));
+    test_find(hpx::execution::seq, xvalues, T(512));
+    test_find(hpx::execution::par, xvalues, T(512));
+    test_find_async(hpx::execution::seq(hpx::execution::task), xvalues, T(512));
+    test_find_async(hpx::execution::par(hpx::execution::task), xvalues, T(512));
 
-    test_find_if(hpx::parallel::execution::seq, xvalues, T(512));
-    test_find_if(hpx::parallel::execution::par, xvalues, T(512));
+    test_find_if(hpx::execution::seq, xvalues, T(512));
+    test_find_if(hpx::execution::par, xvalues, T(512));
     test_find_if_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        T(512));
+        hpx::execution::seq(hpx::execution::task), xvalues, T(512));
     test_find_if_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        T(512));
+        hpx::execution::par(hpx::execution::task), xvalues, T(512));
 
-    test_find_if_not(hpx::parallel::execution::seq, xvalues, T(512));
-    test_find_if_not(hpx::parallel::execution::par, xvalues, T(512));
+    test_find_if_not(hpx::execution::seq, xvalues, T(512));
+    test_find_if_not(hpx::execution::par, xvalues, T(512));
     test_find_if_not_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        T(512));
+        hpx::execution::seq(hpx::execution::task), xvalues, T(512));
     test_find_if_not_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        T(512));
+        hpx::execution::par(hpx::execution::task), xvalues, T(512));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_find2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_find2.cpp
@@ -91,35 +91,27 @@ void find_tests(std::vector<hpx::id_type>& localities)
     std::size_t const num = 1000;
     hpx::partitioned_vector<T> xvalues(
         num, T(1), hpx::container_layout(localities));
-    hpx::parallel::inclusive_scan(hpx::parallel::execution::seq,
-        xvalues.begin(), xvalues.end(), xvalues.begin(), std::plus<T>(), T(0));
+    hpx::parallel::inclusive_scan(hpx::execution::seq, xvalues.begin(),
+        xvalues.end(), xvalues.begin(), std::plus<T>(), T(0));
 
-    test_find(hpx::parallel::execution::seq, xvalues, T(512));
-    test_find(hpx::parallel::execution::par, xvalues, T(512));
-    test_find_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        T(512));
-    test_find_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        T(512));
+    test_find(hpx::execution::seq, xvalues, T(512));
+    test_find(hpx::execution::par, xvalues, T(512));
+    test_find_async(hpx::execution::seq(hpx::execution::task), xvalues, T(512));
+    test_find_async(hpx::execution::par(hpx::execution::task), xvalues, T(512));
 
-    test_find_if(hpx::parallel::execution::seq, xvalues, T(512));
-    test_find_if(hpx::parallel::execution::par, xvalues, T(512));
+    test_find_if(hpx::execution::seq, xvalues, T(512));
+    test_find_if(hpx::execution::par, xvalues, T(512));
     test_find_if_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        T(512));
+        hpx::execution::seq(hpx::execution::task), xvalues, T(512));
     test_find_if_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        T(512));
+        hpx::execution::par(hpx::execution::task), xvalues, T(512));
 
-    test_find_if_not(hpx::parallel::execution::seq, xvalues, T(512));
-    test_find_if_not(hpx::parallel::execution::par, xvalues, T(512));
+    test_find_if_not(hpx::execution::seq, xvalues, T(512));
+    test_find_if_not(hpx::execution::par, xvalues, T(512));
     test_find_if_not_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        T(512));
+        hpx::execution::seq(hpx::execution::task), xvalues, T(512));
     test_find_if_not_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        T(512));
+        hpx::execution::par(hpx::execution::task), xvalues, T(512));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_for_each.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_for_each.cpp
@@ -151,29 +151,23 @@ void for_each_tests(std::vector<hpx::id_type>& localities)
 
     {
         hpx::partitioned_vector<T> v;
-        hpx::for_each(hpx::parallel::execution::seq, v.begin(), v.end(), pfo());
-        hpx::for_each(hpx::parallel::execution::par, v.begin(), v.end(), pfo());
-        hpx::for_each(
-            hpx::parallel::execution::seq(hpx::parallel::execution::task),
-            v.begin(), v.end(), pfo())
+        hpx::for_each(hpx::execution::seq, v.begin(), v.end(), pfo());
+        hpx::for_each(hpx::execution::par, v.begin(), v.end(), pfo());
+        hpx::for_each(hpx::execution::seq(hpx::execution::task), v.begin(),
+            v.end(), pfo())
             .get();
-        hpx::for_each(
-            hpx::parallel::execution::par(hpx::parallel::execution::task),
-            v.begin(), v.end(), pfo())
+        hpx::for_each(hpx::execution::par(hpx::execution::task), v.begin(),
+            v.end(), pfo())
             .get();
     }
 
     {
         hpx::partitioned_vector<T> v(
             length, T(0), hpx::container_layout(localities));
-        test_for_each(hpx::parallel::execution::seq, v, T(0));
-        test_for_each(hpx::parallel::execution::par, v, T(1));
-        test_for_each_async(
-            hpx::parallel::execution::seq(hpx::parallel::execution::task), v,
-            T(2));
-        test_for_each_async(
-            hpx::parallel::execution::par(hpx::parallel::execution::task), v,
-            T(3));
+        test_for_each(hpx::execution::seq, v, T(0));
+        test_for_each(hpx::execution::par, v, T(1));
+        test_for_each_async(hpx::execution::seq(hpx::execution::task), v, T(2));
+        test_for_each_async(hpx::execution::par(hpx::execution::task), v, T(3));
     }
 }
 
@@ -187,43 +181,37 @@ void for_each_n_tests(std::vector<hpx::id_type>& localities)
 
     {
         hpx::partitioned_vector<T> v;
-        hpx::for_each_n(hpx::parallel::execution::seq, v.begin(), 0, pfo());
-        hpx::for_each_n(hpx::parallel::execution::par, v.begin(), 0, pfo());
+        hpx::for_each_n(hpx::execution::seq, v.begin(), 0, pfo());
+        hpx::for_each_n(hpx::execution::par, v.begin(), 0, pfo());
         hpx::for_each_n(
-            hpx::parallel::execution::seq(hpx::parallel::execution::task),
-            v.begin(), 0, pfo())
+            hpx::execution::seq(hpx::execution::task), v.begin(), 0, pfo())
             .get();
         hpx::for_each_n(
-            hpx::parallel::execution::par(hpx::parallel::execution::task),
-            v.begin(), 0, pfo())
+            hpx::execution::par(hpx::execution::task), v.begin(), 0, pfo())
             .get();
     }
 
     {
         hpx::partitioned_vector<T> v;
-        hpx::for_each_n(hpx::parallel::execution::seq, v.begin(), -1, pfo());
-        hpx::for_each_n(hpx::parallel::execution::par, v.begin(), -1, pfo());
+        hpx::for_each_n(hpx::execution::seq, v.begin(), -1, pfo());
+        hpx::for_each_n(hpx::execution::par, v.begin(), -1, pfo());
         hpx::for_each_n(
-            hpx::parallel::execution::seq(hpx::parallel::execution::task),
-            v.begin(), -1, pfo())
+            hpx::execution::seq(hpx::execution::task), v.begin(), -1, pfo())
             .get();
         hpx::for_each_n(
-            hpx::parallel::execution::par(hpx::parallel::execution::task),
-            v.begin(), -1, pfo())
+            hpx::execution::par(hpx::execution::task), v.begin(), -1, pfo())
             .get();
     }
 
     {
         hpx::partitioned_vector<T> v(
             length, T(0), hpx::container_layout(localities));
-        test_for_each_n(hpx::parallel::execution::seq, v, T(0));
-        test_for_each_n(hpx::parallel::execution::par, v, T(1));
+        test_for_each_n(hpx::execution::seq, v, T(0));
+        test_for_each_n(hpx::execution::par, v, T(1));
         test_for_each_n_async(
-            hpx::parallel::execution::seq(hpx::parallel::execution::task), v,
-            T(2));
+            hpx::execution::seq(hpx::execution::task), v, T(2));
         test_for_each_n_async(
-            hpx::parallel::execution::par(hpx::parallel::execution::task), v,
-            T(3));
+            hpx::execution::par(hpx::execution::task), v, T(3));
     }
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_inclusive_scan.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_inclusive_scan.cpp
@@ -232,7 +232,7 @@ template <typename T, typename DistPolicy>
 void inclusive_scan_tests_with_policy(
     std::size_t size, DistPolicy const& policy)
 {
-    using namespace hpx::parallel::execution;
+    using namespace hpx::execution;
 
     // setup partitioned vector to test
     hpx::partitioned_vector<T> in(size, policy);
@@ -260,7 +260,7 @@ template <typename T, typename DistPolicy>
 void inclusive_scan_tests_segmented_out_with_policy(
     std::size_t size, DistPolicy const& in_policy, DistPolicy const& out_policy)
 {
-    using namespace hpx::parallel::execution;
+    using namespace hpx::execution;
 
     // setup partitioned vector to test
     hpx::partitioned_vector<T> in(size, in_policy);
@@ -292,7 +292,7 @@ template <typename T, typename DistPolicy>
 void inclusive_scan_tests_inplace_with_policy(
     std::size_t size, DistPolicy const& policy)
 {
-    using namespace hpx::parallel::execution;
+    using namespace hpx::execution;
 
     // setup verification vector
     std::vector<T> ver(size);

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_inclusive_scan2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_inclusive_scan2.cpp
@@ -232,7 +232,7 @@ template <typename T, typename DistPolicy>
 void inclusive_scan_tests_with_policy(
     std::size_t size, DistPolicy const& policy)
 {
-    using namespace hpx::parallel::execution;
+    using namespace hpx::execution;
 
     // setup partitioned vector to test
     hpx::partitioned_vector<T> in(size, policy);
@@ -260,7 +260,7 @@ template <typename T, typename DistPolicy>
 void inclusive_scan_tests_segmented_out_with_policy(
     std::size_t size, DistPolicy const& in_policy, DistPolicy const& out_policy)
 {
-    using namespace hpx::parallel::execution;
+    using namespace hpx::execution;
 
     // setup partitioned vector to test
     hpx::partitioned_vector<T> in(size, in_policy);
@@ -292,7 +292,7 @@ template <typename T, typename DistPolicy>
 void inclusive_scan_tests_inplace_with_policy(
     std::size_t size, DistPolicy const& policy)
 {
-    using namespace hpx::parallel::execution;
+    using namespace hpx::execution;
 
     // setup verification vector
     std::vector<T> ver(size);

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_move.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_move.cpp
@@ -109,7 +109,7 @@ void move_algo_tests_with_policy_async(std::size_t size, std::size_t localities,
     hpx::partitioned_vector<T> v2(v1);
     compare_vectors(v1, v2);
 
-    using hpx::parallel::execution::task;
+    using hpx::execution::task;
 
     hpx::partitioned_vector<T> v3(size, policy);
     auto f = hpx::move(move_policy(task), v2.begin(), v2.end(), v3.begin());
@@ -144,7 +144,7 @@ void move_tests_with_policy(
     fill_vector(v5, T(value));
     compare_vectors(v1, v5, false);
 
-    using namespace hpx::parallel::execution;
+    using namespace hpx::execution;
 
     move_algo_tests_with_policy<T>(size, localities, policy, seq, value);
     move_algo_tests_with_policy<T>(size, localities, policy, par, value);

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_none1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_none1.cpp
@@ -83,32 +83,26 @@ void none_tests(std::vector<hpx::id_type>& localities)
         SIZE, T(0), hpx::container_layout(localities));
     initialize(xvalues);
 
-    test_none(hpx::parallel::execution::seq, xvalues, op8(), true);
-    test_none(hpx::parallel::execution::par, xvalues, op8(), true);
+    test_none(hpx::execution::seq, xvalues, op8(), true);
+    test_none(hpx::execution::par, xvalues, op8(), true);
     test_none_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        op8(), true);
+        hpx::execution::seq(hpx::execution::task), xvalues, op8(), true);
     test_none_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        op8(), true);
+        hpx::execution::par(hpx::execution::task), xvalues, op8(), true);
 
-    test_none(hpx::parallel::execution::seq, xvalues, op5(), false);
-    test_none(hpx::parallel::execution::par, xvalues, op5(), false);
+    test_none(hpx::execution::seq, xvalues, op5(), false);
+    test_none(hpx::execution::par, xvalues, op5(), false);
     test_none_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        op5(), false);
+        hpx::execution::seq(hpx::execution::task), xvalues, op5(), false);
     test_none_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        op5(), false);
+        hpx::execution::par(hpx::execution::task), xvalues, op5(), false);
 
-    test_none(hpx::parallel::execution::seq, xvalues, op0(), false);
-    test_none(hpx::parallel::execution::par, xvalues, op0(), false);
+    test_none(hpx::execution::seq, xvalues, op0(), false);
+    test_none(hpx::execution::par, xvalues, op0(), false);
     test_none_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        op0(), false);
+        hpx::execution::seq(hpx::execution::task), xvalues, op0(), false);
     test_none_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        op0(), false);
+        hpx::execution::par(hpx::execution::task), xvalues, op0(), false);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_none2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_none2.cpp
@@ -83,32 +83,26 @@ void none_tests(std::vector<hpx::id_type>& localities)
         SIZE, T(0), hpx::container_layout(localities));
     initialize(xvalues);
 
-    test_none(hpx::parallel::execution::seq, xvalues, op8(), true);
-    test_none(hpx::parallel::execution::par, xvalues, op8(), true);
+    test_none(hpx::execution::seq, xvalues, op8(), true);
+    test_none(hpx::execution::par, xvalues, op8(), true);
     test_none_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        op8(), true);
+        hpx::execution::seq(hpx::execution::task), xvalues, op8(), true);
     test_none_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        op8(), true);
+        hpx::execution::par(hpx::execution::task), xvalues, op8(), true);
 
-    test_none(hpx::parallel::execution::seq, xvalues, op5(), false);
-    test_none(hpx::parallel::execution::par, xvalues, op5(), false);
+    test_none(hpx::execution::seq, xvalues, op5(), false);
+    test_none(hpx::execution::par, xvalues, op5(), false);
     test_none_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        op5(), false);
+        hpx::execution::seq(hpx::execution::task), xvalues, op5(), false);
     test_none_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        op5(), false);
+        hpx::execution::par(hpx::execution::task), xvalues, op5(), false);
 
-    test_none(hpx::parallel::execution::seq, xvalues, op0(), false);
-    test_none(hpx::parallel::execution::par, xvalues, op0(), false);
+    test_none(hpx::execution::seq, xvalues, op0(), false);
+    test_none(hpx::execution::par, xvalues, op0(), false);
     test_none_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        op0(), false);
+        hpx::execution::seq(hpx::execution::task), xvalues, op0(), false);
     test_none_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        op0(), false);
+        hpx::execution::par(hpx::execution::task), xvalues, op0(), false);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_reduce.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_reduce.cpp
@@ -39,20 +39,16 @@ hpx::future<T> test_reduce_async(
 template <typename T>
 void reduce_tests(std::size_t num, hpx::partitioned_vector<T> const& xvalues)
 {
-    HPX_TEST_EQ(
-        test_reduce(hpx::parallel::execution::seq, xvalues), T(num + 1));
-    HPX_TEST_EQ(
-        test_reduce(hpx::parallel::execution::par, xvalues), T(num + 1));
+    HPX_TEST_EQ(test_reduce(hpx::execution::seq, xvalues), T(num + 1));
+    HPX_TEST_EQ(test_reduce(hpx::execution::par, xvalues), T(num + 1));
 
-    HPX_TEST_EQ(test_reduce_async(hpx::parallel::execution::seq(
-                                      hpx::parallel::execution::task),
-                    xvalues)
-                    .get(),
+    HPX_TEST_EQ(
+        test_reduce_async(hpx::execution::seq(hpx::execution::task), xvalues)
+            .get(),
         T(num + 1));
-    HPX_TEST_EQ(test_reduce_async(hpx::parallel::execution::par(
-                                      hpx::parallel::execution::task),
-                    xvalues)
-                    .get(),
+    HPX_TEST_EQ(
+        test_reduce_async(hpx::execution::par(hpx::execution::task), xvalues)
+            .get(),
         T(num + 1));
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_scan.hpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_scan.hpp
@@ -56,8 +56,7 @@ void iota_vector(hpx::partitioned_vector<T>& v, T val)
         local_iterator_type end = traits::end(sit);
 
         hpx::parallel::v1::detail::dispatch(traits::get_id(sit), iota(),
-            hpx::parallel::execution::seq, std::true_type(), beg, end,
-            temp_val);
+            hpx::execution::seq, std::true_type(), beg, end, temp_val);
 
         temp_val = T(temp_val + std::distance(beg, end));
     }
@@ -113,7 +112,7 @@ void verify_values(hpx::partitioned_vector<T> v1, std::vector<T> v2)
         std::copy_n(beg2, test.size(), test.begin());
 
         results.push_back(hpx::parallel::v1::detail::dispatch(
-            traits::get_id(sit), verify_<bool>(), hpx::parallel::execution::seq,
+            traits::get_id(sit), verify_<bool>(), hpx::execution::seq,
             std::true_type(), beg, end, test));
 
         beg2 += std::distance(beg, end);

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform1.cpp
@@ -135,16 +135,14 @@ void transform_tests(std::vector<hpx::id_type>& localities)
     {
         hpx::partitioned_vector<T> v;
         hpx::partitioned_vector<U> w;
-        hpx::parallel::transform(hpx::parallel::execution::seq, v.begin(),
-            v.end(), w.begin(), pfo<U>());
-        hpx::parallel::transform(hpx::parallel::execution::par, v.begin(),
-            v.end(), w.begin(), pfo<U>());
         hpx::parallel::transform(
-            hpx::parallel::execution::seq(hpx::parallel::execution::task),
+            hpx::execution::seq, v.begin(), v.end(), w.begin(), pfo<U>());
+        hpx::parallel::transform(
+            hpx::execution::par, v.begin(), v.end(), w.begin(), pfo<U>());
+        hpx::parallel::transform(hpx::execution::seq(hpx::execution::task),
             v.begin(), v.end(), w.begin(), pfo<U>())
             .get();
-        hpx::parallel::transform(
-            hpx::parallel::execution::par(hpx::parallel::execution::task),
+        hpx::parallel::transform(hpx::execution::par(hpx::execution::task),
             v.begin(), v.end(), w.begin(), pfo<U>())
             .get();
     }
@@ -153,14 +151,12 @@ void transform_tests(std::vector<hpx::id_type>& localities)
         hpx::partitioned_vector<T> v(
             length, T(1), hpx::container_layout(localities));
         hpx::partitioned_vector<U> w(length, hpx::container_layout(localities));
-        test_transform(hpx::parallel::execution::seq, v, w, U(1));
-        test_transform(hpx::parallel::execution::par, v, w, U(1));
+        test_transform(hpx::execution::seq, v, w, U(1));
+        test_transform(hpx::execution::par, v, w, U(1));
         test_transform_async(
-            hpx::parallel::execution::seq(hpx::parallel::execution::task), v, w,
-            U(1));
+            hpx::execution::seq(hpx::execution::task), v, w, U(1));
         test_transform_async(
-            hpx::parallel::execution::par(hpx::parallel::execution::task), v, w,
-            U(1));
+            hpx::execution::par(hpx::execution::task), v, w, U(1));
     }
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform2.cpp
@@ -139,16 +139,14 @@ void transform_tests(std::vector<hpx::id_type>& localities)
     {
         hpx::partitioned_vector<T> v;
         hpx::partitioned_vector<U> w;
-        hpx::parallel::transform(hpx::parallel::execution::seq, v.begin(),
-            v.end(), w.begin(), pfo<U>());
-        hpx::parallel::transform(hpx::parallel::execution::par, v.begin(),
-            v.end(), w.begin(), pfo<U>());
         hpx::parallel::transform(
-            hpx::parallel::execution::seq(hpx::parallel::execution::task),
+            hpx::execution::seq, v.begin(), v.end(), w.begin(), pfo<U>());
+        hpx::parallel::transform(
+            hpx::execution::par, v.begin(), v.end(), w.begin(), pfo<U>());
+        hpx::parallel::transform(hpx::execution::seq(hpx::execution::task),
             v.begin(), v.end(), w.begin(), pfo<U>())
             .get();
-        hpx::parallel::transform(
-            hpx::parallel::execution::par(hpx::parallel::execution::task),
+        hpx::parallel::transform(hpx::execution::par(hpx::execution::task),
             v.begin(), v.end(), w.begin(), pfo<U>())
             .get();
     }
@@ -157,14 +155,12 @@ void transform_tests(std::vector<hpx::id_type>& localities)
         hpx::partitioned_vector<T> v(
             length, T(1), hpx::container_layout(localities));
         hpx::partitioned_vector<U> w(length, hpx::container_layout(localities));
-        test_transform(hpx::parallel::execution::seq, v, w, U(1));
-        test_transform(hpx::parallel::execution::par, v, w, U(1));
+        test_transform(hpx::execution::seq, v, w, U(1));
+        test_transform(hpx::execution::par, v, w, U(1));
         test_transform_async(
-            hpx::parallel::execution::seq(hpx::parallel::execution::task), v, w,
-            U(1));
+            hpx::execution::seq(hpx::execution::task), v, w, U(1));
         test_transform_async(
-            hpx::parallel::execution::par(hpx::parallel::execution::task), v, w,
-            U(1));
+            hpx::execution::par(hpx::execution::task), v, w, U(1));
     }
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce1.cpp
@@ -60,21 +60,17 @@ void transform_reduce_tests(std::size_t num,
     hpx::partitioned_vector<T> const& xvalues,
     hpx::partitioned_vector<T> const& yvalues)
 {
-    HPX_TEST_EQ(
-        test_transform_reduce(hpx::parallel::execution::seq, xvalues, yvalues),
+    HPX_TEST_EQ(test_transform_reduce(hpx::execution::seq, xvalues, yvalues),
         T(num + 1));
-    HPX_TEST_EQ(
-        test_transform_reduce(hpx::parallel::execution::par, xvalues, yvalues),
+    HPX_TEST_EQ(test_transform_reduce(hpx::execution::par, xvalues, yvalues),
         T(num + 1));
 
-    HPX_TEST_EQ(test_transform_reduce_async(hpx::parallel::execution::seq(
-                                                hpx::parallel::execution::task),
-                    xvalues, yvalues)
+    HPX_TEST_EQ(test_transform_reduce_async(
+                    hpx::execution::seq(hpx::execution::task), xvalues, yvalues)
                     .get(),
         T(num + 1));
-    HPX_TEST_EQ(test_transform_reduce_async(hpx::parallel::execution::par(
-                                                hpx::parallel::execution::task),
-                    xvalues, yvalues)
+    HPX_TEST_EQ(test_transform_reduce_async(
+                    hpx::execution::par(hpx::execution::task), xvalues, yvalues)
                     .get(),
         T(num + 1));
 }

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce2.cpp
@@ -60,21 +60,17 @@ void transform_reduce_tests(std::size_t num,
     hpx::partitioned_vector<T> const& xvalues,
     hpx::partitioned_vector<T> const& yvalues)
 {
-    HPX_TEST_EQ(
-        test_transform_reduce(hpx::parallel::execution::seq, xvalues, yvalues),
+    HPX_TEST_EQ(test_transform_reduce(hpx::execution::seq, xvalues, yvalues),
         T(num + 1));
-    HPX_TEST_EQ(
-        test_transform_reduce(hpx::parallel::execution::par, xvalues, yvalues),
+    HPX_TEST_EQ(test_transform_reduce(hpx::execution::par, xvalues, yvalues),
         T(num + 1));
 
-    HPX_TEST_EQ(test_transform_reduce_async(hpx::parallel::execution::seq(
-                                                hpx::parallel::execution::task),
-                    xvalues, yvalues)
+    HPX_TEST_EQ(test_transform_reduce_async(
+                    hpx::execution::seq(hpx::execution::task), xvalues, yvalues)
                     .get(),
         T(num + 1));
-    HPX_TEST_EQ(test_transform_reduce_async(hpx::parallel::execution::par(
-                                                hpx::parallel::execution::task),
-                    xvalues, yvalues)
+    HPX_TEST_EQ(test_transform_reduce_async(
+                    hpx::execution::par(hpx::execution::task), xvalues, yvalues)
                     .get(),
         T(num + 1));
 }

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce_binary1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce_binary1.cpp
@@ -51,24 +51,20 @@ template <typename T>
 void transform_reduce_binary_tests(std::size_t num,
     hpx::partitioned_vector<T>& xvalues, hpx::partitioned_vector<T>& yvalues)
 {
-    HPX_TEST_EQ(test_transform_reduce_binary(
-                    hpx::parallel::execution::seq, xvalues, yvalues),
+    HPX_TEST_EQ(
+        test_transform_reduce_binary(hpx::execution::seq, xvalues, yvalues),
         T(num + 1));
-    HPX_TEST_EQ(test_transform_reduce_binary(
-                    hpx::parallel::execution::par, xvalues, yvalues),
+    HPX_TEST_EQ(
+        test_transform_reduce_binary(hpx::execution::par, xvalues, yvalues),
         T(num + 1));
 
-    HPX_TEST_EQ(
-        test_transform_reduce_binary_async(
-            hpx::parallel::execution::seq(hpx::parallel::execution::task),
-            xvalues, yvalues)
-            .get(),
+    HPX_TEST_EQ(test_transform_reduce_binary_async(
+                    hpx::execution::seq(hpx::execution::task), xvalues, yvalues)
+                    .get(),
         T(num + 1));
-    HPX_TEST_EQ(
-        test_transform_reduce_binary_async(
-            hpx::parallel::execution::par(hpx::parallel::execution::task),
-            xvalues, yvalues)
-            .get(),
+    HPX_TEST_EQ(test_transform_reduce_binary_async(
+                    hpx::execution::par(hpx::execution::task), xvalues, yvalues)
+                    .get(),
         T(num + 1));
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce_binary2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce_binary2.cpp
@@ -51,24 +51,20 @@ template <typename T>
 void transform_reduce_binary_tests(std::size_t num,
     hpx::partitioned_vector<T>& xvalues, hpx::partitioned_vector<T>& yvalues)
 {
-    HPX_TEST_EQ(test_transform_reduce_binary(
-                    hpx::parallel::execution::seq, xvalues, yvalues),
+    HPX_TEST_EQ(
+        test_transform_reduce_binary(hpx::execution::seq, xvalues, yvalues),
         T(num + 1));
-    HPX_TEST_EQ(test_transform_reduce_binary(
-                    hpx::parallel::execution::par, xvalues, yvalues),
+    HPX_TEST_EQ(
+        test_transform_reduce_binary(hpx::execution::par, xvalues, yvalues),
         T(num + 1));
 
-    HPX_TEST_EQ(
-        test_transform_reduce_binary_async(
-            hpx::parallel::execution::seq(hpx::parallel::execution::task),
-            xvalues, yvalues)
-            .get(),
+    HPX_TEST_EQ(test_transform_reduce_binary_async(
+                    hpx::execution::seq(hpx::execution::task), xvalues, yvalues)
+                    .get(),
         T(num + 1));
-    HPX_TEST_EQ(
-        test_transform_reduce_binary_async(
-            hpx::parallel::execution::par(hpx::parallel::execution::task),
-            xvalues, yvalues)
-            .get(),
+    HPX_TEST_EQ(test_transform_reduce_binary_async(
+                    hpx::execution::par(hpx::execution::task), xvalues, yvalues)
+                    .get(),
         T(num + 1));
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_scan.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_scan.cpp
@@ -70,30 +70,26 @@ template <typename T>
 void transform_scan_tests(std::size_t num, hpx::partitioned_vector<T>& xvalues,
     hpx::partitioned_vector<T>& out)
 {
-    test_transform_inclusive_scan(hpx::parallel::execution::seq, xvalues, out);
+    test_transform_inclusive_scan(hpx::execution::seq, xvalues, out);
     HPX_TEST_EQ((out[num - 1]), T(2 * num));
-    test_transform_inclusive_scan(hpx::parallel::execution::par, xvalues, out);
-    HPX_TEST_EQ((out[num - 1]), T(2 * num));
-    test_transform_inclusive_scan_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        out);
+    test_transform_inclusive_scan(hpx::execution::par, xvalues, out);
     HPX_TEST_EQ((out[num - 1]), T(2 * num));
     test_transform_inclusive_scan_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        out);
+        hpx::execution::seq(hpx::execution::task), xvalues, out);
+    HPX_TEST_EQ((out[num - 1]), T(2 * num));
+    test_transform_inclusive_scan_async(
+        hpx::execution::par(hpx::execution::task), xvalues, out);
     HPX_TEST_EQ((out[num - 1]), T(2 * num));
 
-    test_transform_exclusive_scan(hpx::parallel::execution::seq, xvalues, out);
+    test_transform_exclusive_scan(hpx::execution::seq, xvalues, out);
     HPX_TEST_EQ((out[num - 1]), T(2 * (num - 1)));
-    test_transform_exclusive_scan(hpx::parallel::execution::par, xvalues, out);
-    HPX_TEST_EQ((out[num - 1]), T(2 * (num - 1)));
-    test_transform_exclusive_scan_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        out);
+    test_transform_exclusive_scan(hpx::execution::par, xvalues, out);
     HPX_TEST_EQ((out[num - 1]), T(2 * (num - 1)));
     test_transform_exclusive_scan_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        out);
+        hpx::execution::seq(hpx::execution::task), xvalues, out);
+    HPX_TEST_EQ((out[num - 1]), T(2 * (num - 1)));
+    test_transform_exclusive_scan_async(
+        hpx::execution::par(hpx::execution::task), xvalues, out);
     HPX_TEST_EQ((out[num - 1]), T(2 * (num - 1)));
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_scan2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_scan2.cpp
@@ -70,30 +70,26 @@ template <typename T>
 void transform_scan_tests(std::size_t num, hpx::partitioned_vector<T>& xvalues,
     hpx::partitioned_vector<T>& out)
 {
-    test_transform_inclusive_scan(hpx::parallel::execution::seq, xvalues, out);
+    test_transform_inclusive_scan(hpx::execution::seq, xvalues, out);
     HPX_TEST_EQ((out[num - 1]), T(2 * num));
-    test_transform_inclusive_scan(hpx::parallel::execution::par, xvalues, out);
-    HPX_TEST_EQ((out[num - 1]), T(2 * num));
-    test_transform_inclusive_scan_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        out);
+    test_transform_inclusive_scan(hpx::execution::par, xvalues, out);
     HPX_TEST_EQ((out[num - 1]), T(2 * num));
     test_transform_inclusive_scan_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        out);
+        hpx::execution::seq(hpx::execution::task), xvalues, out);
+    HPX_TEST_EQ((out[num - 1]), T(2 * num));
+    test_transform_inclusive_scan_async(
+        hpx::execution::par(hpx::execution::task), xvalues, out);
     HPX_TEST_EQ((out[num - 1]), T(2 * num));
 
-    test_transform_exclusive_scan(hpx::parallel::execution::seq, xvalues, out);
+    test_transform_exclusive_scan(hpx::execution::seq, xvalues, out);
     HPX_TEST_EQ((out[num - 1]), T(2 * (num - 1)));
-    test_transform_exclusive_scan(hpx::parallel::execution::par, xvalues, out);
-    HPX_TEST_EQ((out[num - 1]), T(2 * (num - 1)));
-    test_transform_exclusive_scan_async(
-        hpx::parallel::execution::seq(hpx::parallel::execution::task), xvalues,
-        out);
+    test_transform_exclusive_scan(hpx::execution::par, xvalues, out);
     HPX_TEST_EQ((out[num - 1]), T(2 * (num - 1)));
     test_transform_exclusive_scan_async(
-        hpx::parallel::execution::par(hpx::parallel::execution::task), xvalues,
-        out);
+        hpx::execution::seq(hpx::execution::task), xvalues, out);
+    HPX_TEST_EQ((out[num - 1]), T(2 * (num - 1)));
+    test_transform_exclusive_scan_async(
+        hpx::execution::par(hpx::execution::task), xvalues, out);
     HPX_TEST_EQ((out[num - 1]), T(2 * (num - 1)));
 }
 

--- a/libs/full/segmented_algorithms/tests/unit/test_transform_binary.hpp
+++ b/libs/full/segmented_algorithms/tests/unit/test_transform_binary.hpp
@@ -141,16 +141,14 @@ void transform_binary_tests(std::vector<hpx::id_type>& localities)
         hpx::partitioned_vector<T> v;
         hpx::partitioned_vector<U> w;
         hpx::partitioned_vector<V> x;
-        hpx::parallel::transform(hpx::parallel::execution::seq, v.begin(),
-            v.end(), w.begin(), x.begin(), add<V>());
-        hpx::parallel::transform(hpx::parallel::execution::par, v.begin(),
-            v.end(), w.begin(), x.begin(), add<V>());
-        hpx::parallel::transform(
-            hpx::parallel::execution::seq(hpx::parallel::execution::task),
+        hpx::parallel::transform(hpx::execution::seq, v.begin(), v.end(),
+            w.begin(), x.begin(), add<V>());
+        hpx::parallel::transform(hpx::execution::par, v.begin(), v.end(),
+            w.begin(), x.begin(), add<V>());
+        hpx::parallel::transform(hpx::execution::seq(hpx::execution::task),
             v.begin(), v.end(), w.begin(), x.begin(), add<V>())
             .get();
-        hpx::parallel::transform(
-            hpx::parallel::execution::par(hpx::parallel::execution::task),
+        hpx::parallel::transform(hpx::execution::par(hpx::execution::task),
             v.begin(), v.end(), w.begin(), x.begin(), add<V>())
             .get();
     }
@@ -161,13 +159,11 @@ void transform_binary_tests(std::vector<hpx::id_type>& localities)
         hpx::partitioned_vector<U> w(
             length, U(1), hpx::container_layout(localities));
         hpx::partitioned_vector<V> x(length, hpx::container_layout(localities));
-        test_transform_binary(hpx::parallel::execution::seq, v, w, x, V(1));
-        test_transform_binary(hpx::parallel::execution::par, v, w, x, V(1));
+        test_transform_binary(hpx::execution::seq, v, w, x, V(1));
+        test_transform_binary(hpx::execution::par, v, w, x, V(1));
         test_transform_binary_async(
-            hpx::parallel::execution::seq(hpx::parallel::execution::task), v, w,
-            x, V(1));
+            hpx::execution::seq(hpx::execution::task), v, w, x, V(1));
         test_transform_binary_async(
-            hpx::parallel::execution::par(hpx::parallel::execution::task), v, w,
-            x, V(1));
+            hpx::execution::par(hpx::execution::task), v, w, x, V(1));
     }
 }

--- a/libs/full/segmented_algorithms/tests/unit/test_transform_binary2.hpp
+++ b/libs/full/segmented_algorithms/tests/unit/test_transform_binary2.hpp
@@ -140,16 +140,14 @@ void transform_binary2_tests(std::vector<hpx::id_type>& localities)
         hpx::partitioned_vector<T> v;
         hpx::partitioned_vector<U> w;
         hpx::partitioned_vector<V> x;
-        hpx::parallel::transform(hpx::parallel::execution::seq, v.begin(),
-            v.end(), w.begin(), w.end(), x.begin(), add<V>());
-        hpx::parallel::transform(hpx::parallel::execution::par, v.begin(),
-            v.end(), w.begin(), w.end(), x.begin(), add<V>());
-        hpx::parallel::transform(
-            hpx::parallel::execution::seq(hpx::parallel::execution::task),
+        hpx::parallel::transform(hpx::execution::seq, v.begin(), v.end(),
+            w.begin(), w.end(), x.begin(), add<V>());
+        hpx::parallel::transform(hpx::execution::par, v.begin(), v.end(),
+            w.begin(), w.end(), x.begin(), add<V>());
+        hpx::parallel::transform(hpx::execution::seq(hpx::execution::task),
             v.begin(), v.end(), w.begin(), w.end(), x.begin(), add<V>())
             .get();
-        hpx::parallel::transform(
-            hpx::parallel::execution::par(hpx::parallel::execution::task),
+        hpx::parallel::transform(hpx::execution::par(hpx::execution::task),
             v.begin(), v.end(), w.begin(), w.end(), x.begin(), add<V>())
             .get();
     }
@@ -160,13 +158,11 @@ void transform_binary2_tests(std::vector<hpx::id_type>& localities)
         hpx::partitioned_vector<U> w(
             length, U(1), hpx::container_layout(localities));
         hpx::partitioned_vector<V> x(length, hpx::container_layout(localities));
-        test_transform_binary2(hpx::parallel::execution::seq, v, w, x, V(1));
-        test_transform_binary2(hpx::parallel::execution::par, v, w, x, V(1));
+        test_transform_binary2(hpx::execution::seq, v, w, x, V(1));
+        test_transform_binary2(hpx::execution::par, v, w, x, V(1));
         test_transform_binary2_async(
-            hpx::parallel::execution::seq(hpx::parallel::execution::task), v, w,
-            x, V(1));
+            hpx::execution::seq(hpx::execution::task), v, w, x, V(1));
         test_transform_binary2_async(
-            hpx::parallel::execution::par(hpx::parallel::execution::task), v, w,
-            x, V(1));
+            hpx::execution::par(hpx::execution::task), v, w, x, V(1));
     }
 }

--- a/libs/full/thread_executors/include/hpx/execution/executors/default_executor.hpp
+++ b/libs/full/thread_executors/include/hpx/execution/executors/default_executor.hpp
@@ -12,5 +12,5 @@
 #include <hpx/executors/parallel_executor.hpp>
 
 namespace hpx { namespace parallel { namespace execution {
-    using default_executor = parallel_executor;
+    using default_executor = hpx::execution::parallel_executor;
 }}}    // namespace hpx::parallel::execution

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
@@ -621,8 +621,8 @@ namespace hpx {
         // clang-format on
         friend bool tag_invoke(none_of_t, FwdIter first, FwdIter last, F&& f)
         {
-            return hpx::parallel::v1::detail::none_of_(
-                hpx::parallel::execution::seq, first, last, std::forward<F>(f),
+            return hpx::parallel::v1::detail::none_of_(hpx::execution::seq,
+                first, last, std::forward<F>(f),
                 hpx::parallel::util::projection_identity{}, std::false_type{});
         }
     } none_of{};
@@ -659,8 +659,8 @@ namespace hpx {
         // clang-format on
         friend bool tag_invoke(any_of_t, FwdIter first, FwdIter last, F&& f)
         {
-            return hpx::parallel::v1::detail::any_of_(
-                hpx::parallel::execution::seq, first, last, std::forward<F>(f),
+            return hpx::parallel::v1::detail::any_of_(hpx::execution::seq,
+                first, last, std::forward<F>(f),
                 hpx::parallel::util::projection_identity{}, std::false_type{});
         }
     } any_of{};
@@ -697,8 +697,8 @@ namespace hpx {
         // clang-format on
         friend bool tag_invoke(all_of_t, FwdIter first, FwdIter last, F&& f)
         {
-            return hpx::parallel::v1::detail::all_of_(
-                hpx::parallel::execution::seq, first, last, std::forward<F>(f),
+            return hpx::parallel::v1::detail::all_of_(hpx::execution::seq,
+                first, last, std::forward<F>(f),
                 hpx::parallel::util::projection_identity{}, std::false_type{});
         }
     } all_of{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -667,7 +667,7 @@ namespace hpx {
             return parallel::v1::detail::get_second_element(
                 parallel::v1::detail::transfer<
                     parallel::v1::detail::copy_iter<FwdIter1, FwdIter2>>(
-                    hpx::parallel::execution::seq, first, last, dest));
+                    hpx::execution::seq, first, last, dest));
         }
     } copy{};
 
@@ -733,15 +733,15 @@ namespace hpx {
             if (hpx::parallel::v1::detail::is_negative(count))
             {
                 return hpx::parallel::util::detail::algorithm_result<
-                    hpx::parallel::execution::sequenced_policy,
+                    hpx::execution::sequenced_policy,
                     FwdIter2>::get(std::move(dest));
             }
 
             return hpx::parallel::v1::detail::get_second_element(
                 hpx::parallel::v1::detail::copy_n<
                     hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
-                    .call(hpx::parallel::execution::seq, std::true_type{},
-                        first, std::size_t(count), dest));
+                    .call(hpx::execution::seq, std::true_type{}, first,
+                        std::size_t(count), dest));
         }
     } copy_n{};
 
@@ -806,8 +806,8 @@ namespace hpx {
             return hpx::parallel::v1::detail::get_second_element(
                 hpx::parallel::v1::detail::copy_if<
                     hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
-                    .call(hpx::parallel::execution::seq, std::true_type{},
-                        first, last, dest, std::forward<Pred>(pred),
+                    .call(hpx::execution::seq, std::true_type{}, first, last,
+                        dest, std::forward<Pred>(pred),
                         hpx::parallel::util::projection_identity{}));
         }
     } copy_if{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/count.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/count.hpp
@@ -514,9 +514,9 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Required at least forward iterator.");
 
-            return hpx::parallel::v1::detail::count_(
-                hpx::parallel::execution::seq, first, last, value,
-                hpx::parallel::util::projection_identity{}, std::false_type{});
+            return hpx::parallel::v1::detail::count_(hpx::execution::seq, first,
+                last, value, hpx::parallel::util::projection_identity{},
+                std::false_type{});
         }
     } count{};
 
@@ -566,8 +566,8 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Required at least forward iterator.");
 
-            return hpx::parallel::v1::detail::count_if_(
-                hpx::parallel::execution::seq, first, last, std::forward<F>(f),
+            return hpx::parallel::v1::detail::count_if_(hpx::execution::seq,
+                first, last, std::forward<F>(f),
                 hpx::parallel::util::projection_identity{}, std::false_type{});
         }
     } count_if{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/destroy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/destroy.hpp
@@ -339,7 +339,7 @@ namespace hpx {
                 "Required at least forward iterator.");
 
             hpx::parallel::v1::detail::destroy<FwdIter>().call(
-                hpx::parallel::execution::seq, std::false_type{}, first, last);
+                hpx::execution::seq, std::false_type{}, first, last);
         }
     } destroy{};
 
@@ -397,7 +397,7 @@ namespace hpx {
             }
 
             return hpx::parallel::v1::detail::destroy_n<FwdIter>().call(
-                hpx::parallel::execution::seq, std::false_type{}, first,
+                hpx::execution::seq, std::false_type{}, first,
                 std::size_t(count));
         }
     } destroy_n{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -205,8 +205,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
         template <typename... Args>
         typename parallel::util::detail::algorithm_result<
-            execution::sequenced_task_policy, local_result_type>::type
-        call(execution::sequenced_task_policy policy, std::true_type,
+            hpx::execution::sequenced_task_policy, local_result_type>::type
+        call(hpx::execution::sequenced_task_policy policy, std::true_type,
             Args&&... args) const
         {
             return call_sequential(policy, std::forward<Args>(args)...);
@@ -214,20 +214,9 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
         template <typename Executor, typename Parameters, typename... Args>
         typename parallel::util::detail::algorithm_result<
-            execution::sequenced_task_policy_shim<Executor, Parameters>,
+            hpx::execution::sequenced_task_policy_shim<Executor, Parameters>,
             local_result_type>::type
-        call(
-            execution::sequenced_task_policy_shim<Executor, Parameters>& policy,
-            std::true_type, Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
-
-        template <typename Executor, typename Parameters, typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            execution::sequenced_task_policy_shim<Executor, Parameters>,
-            local_result_type>::type
-        call(execution::sequenced_task_policy_shim<Executor, Parameters>&&
+        call(hpx::execution::sequenced_task_policy_shim<Executor, Parameters>&
                  policy,
             std::true_type, Args&&... args) const
         {
@@ -236,10 +225,21 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
         template <typename Executor, typename Parameters, typename... Args>
         typename parallel::util::detail::algorithm_result<
-            execution::sequenced_task_policy_shim<Executor, Parameters>,
+            hpx::execution::sequenced_task_policy_shim<Executor, Parameters>,
             local_result_type>::type
-        call(execution::sequenced_task_policy_shim<Executor, Parameters> const&
+        call(hpx::execution::sequenced_task_policy_shim<Executor, Parameters>&&
                  policy,
+            std::true_type, Args&&... args) const
+        {
+            return call_sequential(policy, std::forward<Args>(args)...);
+        }
+
+        template <typename Executor, typename Parameters, typename... Args>
+        typename parallel::util::detail::algorithm_result<
+            hpx::execution::sequenced_task_policy_shim<Executor, Parameters>,
+            local_result_type>::type
+        call(hpx::execution::sequenced_task_policy_shim<Executor,
+                 Parameters> const& policy,
             std::true_type, Args&&... args) const
         {
             return call_sequential(policy, std::forward<Args>(args)...);
@@ -248,8 +248,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 #if defined(HPX_HAVE_DATAPAR)
         template <typename... Args>
         typename parallel::util::detail::algorithm_result<
-            execution::dataseq_task_policy, local_result_type>::type
-        call(execution::dataseq_task_policy policy, std::true_type,
+            hpx::execution::dataseq_task_policy, local_result_type>::type
+        call(hpx::execution::dataseq_task_policy policy, std::true_type,
             Args&&... args) const
         {
             return call_sequential(policy, std::forward<Args>(args)...);
@@ -257,30 +257,32 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
         template <typename Executor, typename Parameters, typename... Args>
         typename parallel::util::detail::algorithm_result<
-            execution::dataseq_task_policy_shim<Executor, Parameters>,
+            hpx::execution::dataseq_task_policy_shim<Executor, Parameters>,
             local_result_type>::type
-        call(execution::dataseq_task_policy_shim<Executor, Parameters>& policy,
-            std::true_type, Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
-
-        template <typename Executor, typename Parameters, typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            execution::dataseq_task_policy_shim<Executor, Parameters>,
-            local_result_type>::type
-        call(execution::dataseq_task_policy_shim<Executor, Parameters>&& policy,
-            std::true_type, Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
-
-        template <typename Executor, typename Parameters, typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            execution::dataseq_task_policy_shim<Executor, Parameters>,
-            local_result_type>::type
-        call(execution::dataseq_task_policy_shim<Executor, Parameters> const&
+        call(hpx::execution::dataseq_task_policy_shim<Executor, Parameters>&
                  policy,
+            std::true_type, Args&&... args) const
+        {
+            return call_sequential(policy, std::forward<Args>(args)...);
+        }
+
+        template <typename Executor, typename Parameters, typename... Args>
+        typename parallel::util::detail::algorithm_result<
+            hpx::execution::dataseq_task_policy_shim<Executor, Parameters>,
+            local_result_type>::type
+        call(hpx::execution::dataseq_task_policy_shim<Executor, Parameters>&&
+                 policy,
+            std::true_type, Args&&... args) const
+        {
+            return call_sequential(policy, std::forward<Args>(args)...);
+        }
+
+        template <typename Executor, typename Parameters, typename... Args>
+        typename parallel::util::detail::algorithm_result<
+            hpx::execution::dataseq_task_policy_shim<Executor, Parameters>,
+            local_result_type>::type
+        call(hpx::execution::dataseq_task_policy_shim<Executor,
+                 Parameters> const& policy,
             std::true_type, Args&&... args) const
         {
             return call_sequential(policy, std::forward<Args>(args)...);
@@ -290,8 +292,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         ///////////////////////////////////////////////////////////////////////
         template <typename... Args>
         typename parallel::util::detail::algorithm_result<
-            execution::parallel_task_policy, local_result_type>::type
-        call(execution::parallel_task_policy policy, std::true_type,
+            hpx::execution::parallel_task_policy, local_result_type>::type
+        call(hpx::execution::parallel_task_policy policy, std::true_type,
             Args&&... args) const
         {
             return call_sequential(policy, std::forward<Args>(args)...);
@@ -299,31 +301,32 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
         template <typename Executor, typename Parameters, typename... Args>
         typename parallel::util::detail::algorithm_result<
-            execution::parallel_task_policy_shim<Executor, Parameters>,
+            hpx::execution::parallel_task_policy_shim<Executor, Parameters>,
             local_result_type>::type
-        call(execution::parallel_task_policy_shim<Executor, Parameters>& policy,
-            std::true_type, Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
-
-        template <typename Executor, typename Parameters, typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            execution::parallel_task_policy_shim<Executor, Parameters>,
-            local_result_type>::type
-        call(
-            execution::parallel_task_policy_shim<Executor, Parameters>&& policy,
-            std::true_type, Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
-
-        template <typename Executor, typename Parameters, typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            execution::parallel_task_policy_shim<Executor, Parameters>,
-            local_result_type>::type
-        call(execution::parallel_task_policy_shim<Executor, Parameters> const&
+        call(hpx::execution::parallel_task_policy_shim<Executor, Parameters>&
                  policy,
+            std::true_type, Args&&... args) const
+        {
+            return call_sequential(policy, std::forward<Args>(args)...);
+        }
+
+        template <typename Executor, typename Parameters, typename... Args>
+        typename parallel::util::detail::algorithm_result<
+            hpx::execution::parallel_task_policy_shim<Executor, Parameters>,
+            local_result_type>::type
+        call(hpx::execution::parallel_task_policy_shim<Executor, Parameters>&&
+                 policy,
+            std::true_type, Args&&... args) const
+        {
+            return call_sequential(policy, std::forward<Args>(args)...);
+        }
+
+        template <typename Executor, typename Parameters, typename... Args>
+        typename parallel::util::detail::algorithm_result<
+            hpx::execution::parallel_task_policy_shim<Executor, Parameters>,
+            local_result_type>::type
+        call(hpx::execution::parallel_task_policy_shim<Executor,
+                 Parameters> const& policy,
             std::true_type, Args&&... args) const
         {
             return call_sequential(policy, std::forward<Args>(args)...);
@@ -332,30 +335,32 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 #if defined(HPX_HAVE_DATAPAR)
         template <typename Executor, typename Parameters, typename... Args>
         typename parallel::util::detail::algorithm_result<
-            execution::datapar_task_policy_shim<Executor, Parameters>,
+            hpx::execution::datapar_task_policy_shim<Executor, Parameters>,
             local_result_type>::type
-        call(execution::datapar_task_policy_shim<Executor, Parameters>& policy,
-            std::true_type, Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
-
-        template <typename Executor, typename Parameters, typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            execution::datapar_task_policy_shim<Executor, Parameters>,
-            local_result_type>::type
-        call(execution::datapar_task_policy_shim<Executor, Parameters>&& policy,
-            std::true_type, Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
-
-        template <typename Executor, typename Parameters, typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            execution::datapar_task_policy_shim<Executor, Parameters>,
-            local_result_type>::type
-        call(execution::datapar_task_policy_shim<Executor, Parameters> const&
+        call(hpx::execution::datapar_task_policy_shim<Executor, Parameters>&
                  policy,
+            std::true_type, Args&&... args) const
+        {
+            return call_sequential(policy, std::forward<Args>(args)...);
+        }
+
+        template <typename Executor, typename Parameters, typename... Args>
+        typename parallel::util::detail::algorithm_result<
+            hpx::execution::datapar_task_policy_shim<Executor, Parameters>,
+            local_result_type>::type
+        call(hpx::execution::datapar_task_policy_shim<Executor, Parameters>&&
+                 policy,
+            std::true_type, Args&&... args) const
+        {
+            return call_sequential(policy, std::forward<Args>(args)...);
+        }
+
+        template <typename Executor, typename Parameters, typename... Args>
+        typename parallel::util::detail::algorithm_result<
+            hpx::execution::datapar_task_policy_shim<Executor, Parameters>,
+            local_result_type>::type
+        call(hpx::execution::datapar_task_policy_shim<Executor,
+                 Parameters> const& policy,
             std::true_type, Args&&... args) const
         {
             return call_sequential(policy, std::forward<Args>(args)...);

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
@@ -186,10 +186,9 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             }
 
             // finally, copy data to destination
-            parallel::util::foreach_partitioner<
-                hpx::parallel::execution::parallel_policy>::
-                call(
-                    execution::par, chunks.get(), cores,
+            parallel::util::
+                foreach_partitioner<hpx::execution::parallel_policy>::call(
+                    hpx::execution::par, chunks.get(), cores,
                     [buffer, dest](
                         set_chunk_data* chunk, std::size_t, std::size_t) {
                         if (chunk->start == (size_t)(-1) ||

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/equal.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/equal.hpp
@@ -595,8 +595,8 @@ namespace hpx {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::equal_binary().call(
-                hpx::parallel::execution::seq, std::true_type{}, first1, last1,
-                first2, last2, std::forward<Pred>(op),
+                hpx::execution::seq, std::true_type{}, first1, last1, first2,
+                last2, std::forward<Pred>(op),
                 hpx::parallel::util::projection_identity{},
                 hpx::parallel::util::projection_identity{});
         }
@@ -617,8 +617,8 @@ namespace hpx {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::equal_binary().call(
-                hpx::parallel::execution::seq, std::true_type{}, first1, last1,
-                first2, last2, hpx::parallel::v1::detail::equal_to{},
+                hpx::execution::seq, std::true_type{}, first1, last1, first2,
+                last2, hpx::parallel::v1::detail::equal_to{},
                 hpx::parallel::util::projection_identity{},
                 hpx::parallel::util::projection_identity{});
         }
@@ -642,9 +642,9 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::v1::detail::equal().call(
-                hpx::parallel::execution::seq, std::true_type{}, first1, last1,
-                first2, std::forward<Pred>(op));
+            return hpx::parallel::v1::detail::equal().call(hpx::execution::seq,
+                std::true_type{}, first1, last1, first2,
+                std::forward<Pred>(op));
         }
 
         // clang-format off
@@ -662,9 +662,9 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::v1::detail::equal().call(
-                hpx::parallel::execution::seq, std::true_type{}, first1, last1,
-                first2, hpx::parallel::v1::detail::equal_to{});
+            return hpx::parallel::v1::detail::equal().call(hpx::execution::seq,
+                std::true_type{}, first1, last1, first2,
+                hpx::parallel::v1::detail::equal_to{});
         }
     } equal{};
 }    // namespace hpx

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/fill.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/fill.hpp
@@ -344,8 +344,8 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Requires at least forward iterator.");
 
-            hpx::parallel::v1::detail::fill_(hpx::parallel::execution::seq,
-                first, last, value, std::false_type{});
+            hpx::parallel::v1::detail::fill_(
+                hpx::execution::seq, first, last, value, std::false_type{});
         }
     } fill{};
 
@@ -405,7 +405,7 @@ namespace hpx {
             }
 
             return hpx::parallel::v1::detail::fill_n<FwdIter>().call(
-                hpx::parallel::execution::seq, std::true_type{}, first,
+                hpx::execution::seq, std::true_type{}, first,
                 std::size_t(count), value);
         }
     } fill_n{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/find.hpp
@@ -1183,9 +1183,9 @@ namespace hpx {
         friend FwdIter tag_invoke(
             find_t, FwdIter first, FwdIter last, T const& val)
         {
-            return hpx::parallel::v1::detail::find_(
-                hpx::parallel::execution::seq, first, last, val,
-                hpx::parallel::util::projection_identity(), std::false_type());
+            return hpx::parallel::v1::detail::find_(hpx::execution::seq, first,
+                last, val, hpx::parallel::util::projection_identity(),
+                std::false_type());
         }
 
     } find{};
@@ -1229,8 +1229,8 @@ namespace hpx {
         // clang-format on
         friend FwdIter tag_invoke(find_if_t, FwdIter first, FwdIter last, F&& f)
         {
-            return hpx::parallel::v1::detail::find_if_(
-                hpx::parallel::execution::seq, first, last, std::forward<F>(f),
+            return hpx::parallel::v1::detail::find_if_(hpx::execution::seq,
+                first, last, std::forward<F>(f),
                 hpx::parallel::util::projection_identity(), std::false_type());
         }
 
@@ -1276,8 +1276,8 @@ namespace hpx {
         friend FwdIter tag_invoke(
             find_if_not_t, FwdIter first, FwdIter last, F&& f)
         {
-            return hpx::parallel::v1::detail::find_if_not_(
-                hpx::parallel::execution::seq, first, last, std::forward<F>(f),
+            return hpx::parallel::v1::detail::find_if_not_(hpx::execution::seq,
+                first, last, std::forward<F>(f),
                 hpx::parallel::util::projection_identity(), std::false_type());
         }
 
@@ -1373,8 +1373,8 @@ namespace hpx {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::find_end<FwdIter1>().call(
-                hpx::parallel::execution::seq, std::true_type(), first1, last1,
-                first2, last2, std::forward<Pred>(op),
+                hpx::execution::seq, std::true_type(), first1, last1, first2,
+                last2, std::forward<Pred>(op),
                 hpx::parallel::util::projection_identity(),
                 hpx::parallel::util::projection_identity());
         }
@@ -1395,8 +1395,8 @@ namespace hpx {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::find_end<FwdIter1>().call(
-                hpx::parallel::execution::seq, std::true_type(), first1, last1,
-                first2, last2, hpx::parallel::v1::detail::equal_to{},
+                hpx::execution::seq, std::true_type(), first1, last1, first2,
+                last2, hpx::parallel::v1::detail::equal_to{},
                 hpx::parallel::util::projection_identity(),
                 hpx::parallel::util::projection_identity());
         }
@@ -1491,8 +1491,8 @@ namespace hpx {
                 "Subsequence requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::find_first_of<FwdIter1>().call(
-                hpx::parallel::execution::seq, std::true_type(), first, last,
-                s_first, s_last, std::forward<Pred>(op),
+                hpx::execution::seq, std::true_type(), first, last, s_first,
+                s_last, std::forward<Pred>(op),
                 hpx::parallel::util::projection_identity(),
                 hpx::parallel::util::projection_identity());
         }
@@ -1513,8 +1513,8 @@ namespace hpx {
                 "Subsequence requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::find_first_of<FwdIter1>().call(
-                hpx::parallel::execution::seq, std::true_type(), first, last,
-                s_first, s_last, hpx::parallel::v1::detail::equal_to{},
+                hpx::execution::seq, std::true_type(), first, last, s_first,
+                s_last, hpx::parallel::v1::detail::equal_to{},
                 hpx::parallel::util::projection_identity(),
                 hpx::parallel::util::projection_identity());
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -626,9 +626,8 @@ namespace hpx {
         // clang-format on
         friend F tag_invoke(hpx::for_each_t, InIter first, InIter last, F&& f)
         {
-            parallel::v1::detail::for_each_(parallel::execution::seq, first,
-                last, f, parallel::util::projection_identity(),
-                std::false_type());
+            parallel::v1::detail::for_each_(hpx::execution::seq, first, last, f,
+                parallel::util::projection_identity(), std::false_type());
             return std::forward<F>(f);
         }
 
@@ -673,8 +672,8 @@ namespace hpx {
                 return first;
             }
 
-            return parallel::v1::detail::for_each_n_(parallel::execution::seq,
-                first, count, std::forward<F>(f),
+            return parallel::v1::detail::for_each_n_(hpx::execution::seq, first,
+                count, std::forward<F>(f),
                 parallel::util::projection_identity(), std::false_type());
         }
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -17,7 +17,7 @@ namespace hpx {
     /// when and if to dereference the iterator.
     ///
     /// The execution of for_loop without specifying an execution policy is
-    /// equivalent to specifying \a parallel::execution::seq as the execution
+    /// equivalent to specifying \a seq as the execution
     /// policy.
     ///
     /// \tparam I           The type of the iteration variable. This could be
@@ -188,7 +188,7 @@ namespace hpx {
     /// programmer when and if to dereference the iterator.
     ///
     /// The execution of for_loop without specifying an execution policy is
-    /// equivalent to specifying \a parallel::execution::seq as the execution
+    /// equivalent to specifying \a seq as the execution
     /// policy.
     ///
     /// \tparam I           The type of the iteration variable. This could be
@@ -372,7 +372,7 @@ namespace hpx {
     /// when and if to dereference the iterator.
     ///
     /// The execution of for_loop without specifying an execution policy is
-    /// equivalent to specifying \a parallel::execution::seq as the execution
+    /// equivalent to specifying \a seq as the execution
     /// policy.
     ///
     /// \tparam I           The type of the iteration variable. This could be
@@ -546,7 +546,7 @@ namespace hpx {
     /// programmer when and if to dereference the iterator.
     ///
     /// The execution of for_loop without specifying an execution policy is
-    /// equivalent to specifying \a parallel::execution::seq as the execution
+    /// equivalent to specifying \a seq as the execution
     /// policy.
     ///
     /// \tparam I           The type of the iteration variable. This could be
@@ -1104,8 +1104,8 @@ namespace hpx {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop must be called with at least a function object");
 
-            return for_loop(parallel::execution::seq, first, last,
-                std::forward<Args>(args)...);
+            return for_loop(
+                hpx::execution::seq, first, last, std::forward<Args>(args)...);
         }
 
         template <typename ExPolicy, typename I, typename S, typename... Args,
@@ -1144,8 +1144,8 @@ namespace hpx {
                 "for_loop_strided must be called with at least a function "
                 "object");
 
-            return for_loop_strided(parallel::execution::seq, first, last,
-                stride, std::forward<Args>(args)...);
+            return for_loop_strided(hpx::execution::seq, first, last, stride,
+                std::forward<Args>(args)...);
         }
 
         template <typename ExPolicy, typename I, typename Size,
@@ -1180,8 +1180,8 @@ namespace hpx {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop_n must be called with at least a function object");
 
-            return for_loop_n(parallel::execution::seq, first, size,
-                std::forward<Args>(args)...);
+            return for_loop_n(
+                hpx::execution::seq, first, size, std::forward<Args>(args)...);
         }
 
         template <typename ExPolicy, typename I, typename Size, typename S,
@@ -1220,8 +1220,8 @@ namespace hpx {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop_n_strided must be called with at least a function "
                 "object");
-            return for_loop_strided_n(parallel::execution::seq, first, size,
-                stride, std::forward<Args>(args)...);
+            return for_loop_strided_n(hpx::execution::seq, first, size, stride,
+                std::forward<Args>(args)...);
         }
     }}    // namespace parallel::v2
 
@@ -1264,8 +1264,8 @@ namespace hpx {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop must be called with at least a function object");
 
-            return for_loop(parallel::execution::seq, first, last,
-                std::forward<Args>(args)...);
+            return for_loop(
+                hpx::execution::seq, first, last, std::forward<Args>(args)...);
         }
     } for_loop{};
 
@@ -1314,8 +1314,8 @@ namespace hpx {
                 "for_loop_strided must be called with at least a function "
                 "object");
 
-            return for_loop_strided(parallel::execution::seq, first, last,
-                stride, std::forward<Args>(args)...);
+            return for_loop_strided(hpx::execution::seq, first, last, stride,
+                std::forward<Args>(args)...);
         }
     } for_loop_strided{};
 
@@ -1361,8 +1361,8 @@ namespace hpx {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop_n must be called with at least a function object");
 
-            return for_loop_n(parallel::execution::seq, first, size,
-                std::forward<Args>(args)...);
+            return for_loop_n(
+                hpx::execution::seq, first, size, std::forward<Args>(args)...);
         }
     } for_loop_n{};
 
@@ -1411,8 +1411,8 @@ namespace hpx {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop_n_strided must be called with at least a function "
                 "object");
-            return for_loop_strided_n(parallel::execution::seq, first, size,
-                stride, std::forward<Args>(args)...);
+            return for_loop_strided_n(hpx::execution::seq, first, size, stride,
+                std::forward<Args>(args)...);
         }
     } for_loop_n_strided{};
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -17,7 +17,7 @@ namespace hpx {
     /// when and if to dereference the iterator.
     ///
     /// The execution of for_loop without specifying an execution policy is
-    /// equivalent to specifying \a seq as the execution
+    /// equivalent to specifying \a hpx::execution::seq as the execution
     /// policy.
     ///
     /// \tparam I           The type of the iteration variable. This could be
@@ -173,8 +173,8 @@ namespace hpx {
     /// \returns  The \a for_loop algorithm returns a
     ///           \a hpx::future<void> if the execution policy is of
     ///           type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and returns \a void
+    ///           \a hpx::execution::sequenced_task_policy or
+    ///           \a hpx::execution::parallel_task_policy and returns \a void
     ///           otherwise.
     ///
     template <typename ExPolicy, typename I, typename... Args>
@@ -188,7 +188,7 @@ namespace hpx {
     /// programmer when and if to dereference the iterator.
     ///
     /// The execution of for_loop without specifying an execution policy is
-    /// equivalent to specifying \a seq as the execution
+    /// equivalent to specifying \a hpx::execution::seq as the execution
     /// policy.
     ///
     /// \tparam I           The type of the iteration variable. This could be
@@ -357,8 +357,8 @@ namespace hpx {
     /// \returns  The \a for_loop_strided algorithm returns a
     ///           \a hpx::future<void> if the execution policy is of
     ///           type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and returns \a void
+    ///           \a hpx::execution::sequenced_task_policy or
+    ///           \a hpx::execution::parallel_task_policy and returns \a void
     ///           otherwise.
     ///
     template <typename ExPolicy, typename I, typename S, typename... Args>
@@ -372,7 +372,7 @@ namespace hpx {
     /// when and if to dereference the iterator.
     ///
     /// The execution of for_loop without specifying an execution policy is
-    /// equivalent to specifying \a seq as the execution
+    /// equivalent to specifying \a hpx::execution::seq as the execution
     /// policy.
     ///
     /// \tparam I           The type of the iteration variable. This could be
@@ -532,8 +532,8 @@ namespace hpx {
     /// \returns  The \a for_loop_n algorithm returns a
     ///           \a hpx::future<void> if the execution policy is of
     ///           type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and returns \a void
+    ///           \a hpx::execution::sequenced_task_policy or
+    ///           \a hpx::execution::parallel_task_policy and returns \a void
     ///           otherwise.
     ///
     template <typename ExPolicy, typename I, typename Size, typename... Args>
@@ -546,7 +546,7 @@ namespace hpx {
     /// programmer when and if to dereference the iterator.
     ///
     /// The execution of for_loop without specifying an execution policy is
-    /// equivalent to specifying \a seq as the execution
+    /// equivalent to specifying \a hpx::execution::seq as the execution
     /// policy.
     ///
     /// \tparam I           The type of the iteration variable. This could be
@@ -718,8 +718,8 @@ namespace hpx {
     /// \returns  The \a for_loop_n_strided algorithm returns a
     ///           \a hpx::future<void> if the execution policy is of
     ///           type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and returns \a void
+    ///           \a hpx::execution::sequenced_task_policy or
+    ///           \a hpx::execution::parallel_task_policy and returns \a void
     ///           otherwise.
     ///
     template <typename ExPolicy, typename I, typename Size, typename S,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/generate.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/generate.hpp
@@ -345,9 +345,8 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Required at least forward iterator.");
 
-            return hpx::parallel::v1::detail::generate_(
-                hpx::parallel::execution::seq, first, last, std::forward<F>(f),
-                std::false_type());
+            return hpx::parallel::v1::detail::generate_(hpx::execution::seq,
+                first, last, std::forward<F>(f), std::false_type());
         }
     } generate{};
 
@@ -405,7 +404,7 @@ namespace hpx {
             }
 
             return hpx::parallel::v1::detail::generate_n<FwdIter>().call(
-                hpx::parallel::execution::seq, std::true_type(), first,
+                hpx::execution::seq, std::true_type(), first,
                 std::size_t(count), std::forward<F>(f));
         }
     } generate_n{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
@@ -643,8 +643,8 @@ namespace hpx {
             return hpx::parallel::v1::detail::get_pair(
                 hpx::parallel::v1::detail::mismatch_binary<
                     hpx::parallel::util::in_in_result<FwdIter1, FwdIter2>>()
-                    .call(hpx::parallel::execution::seq, std::true_type{},
-                        first1, last1, first2, last2, std::forward<Pred>(op),
+                    .call(hpx::execution::seq, std::true_type{}, first1, last1,
+                        first2, last2, std::forward<Pred>(op),
                         hpx::parallel::util::projection_identity{},
                         hpx::parallel::util::projection_identity{}));
         }
@@ -667,9 +667,8 @@ namespace hpx {
             return hpx::parallel::v1::detail::get_pair(
                 hpx::parallel::v1::detail::mismatch_binary<
                     hpx::parallel::util::in_in_result<FwdIter1, FwdIter2>>()
-                    .call(hpx::parallel::execution::seq, std::true_type{},
-                        first1, last1, first2, last2,
-                        hpx::parallel::v1::detail::equal_to{},
+                    .call(hpx::execution::seq, std::true_type{}, first1, last1,
+                        first2, last2, hpx::parallel::v1::detail::equal_to{},
                         hpx::parallel::util::projection_identity{},
                         hpx::parallel::util::projection_identity{}));
         }
@@ -696,8 +695,8 @@ namespace hpx {
 
             return hpx::parallel::v1::detail::mismatch<
                 std::pair<FwdIter1, FwdIter2>>()
-                .call(hpx::parallel::execution::seq, std::true_type{}, first1,
-                    last1, first2, std::forward<Pred>(op));
+                .call(hpx::execution::seq, std::true_type{}, first1, last1,
+                    first2, std::forward<Pred>(op));
         }
 
         // clang-format off
@@ -717,8 +716,8 @@ namespace hpx {
 
             return hpx::parallel::v1::detail::mismatch<
                 std::pair<FwdIter1, FwdIter2>>()
-                .call(hpx::parallel::execution::seq, std::true_type{}, first1,
-                    last1, first2, hpx::parallel::v1::detail::equal_to{});
+                .call(hpx::execution::seq, std::true_type{}, first1, last1,
+                    first2, hpx::parallel::v1::detail::equal_to{});
         }
 
     } mismatch{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -453,9 +453,9 @@ namespace hpx {
         {
             using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
 
-            return hpx::parallel::v1::detail::reduce_(
-                hpx::parallel::execution::seq, first, last, std::move(init),
-                std::forward<F>(f), is_segmented{});
+            return hpx::parallel::v1::detail::reduce_(hpx::execution::seq,
+                first, last, std::move(init), std::forward<F>(f),
+                is_segmented{});
         }
 
         // clang-format off
@@ -468,9 +468,8 @@ namespace hpx {
         {
             using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
 
-            return hpx::parallel::v1::detail::reduce_(
-                hpx::parallel::execution::seq, first, last, std::move(init),
-                std::plus<T>{}, is_segmented{});
+            return hpx::parallel::v1::detail::reduce_(hpx::execution::seq,
+                first, last, std::move(init), std::plus<T>{}, is_segmented{});
         }
 
         // clang-format off
@@ -487,9 +486,9 @@ namespace hpx {
 
             using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
 
-            return hpx::parallel::v1::detail::reduce_(
-                hpx::parallel::execution::seq, first, last, value_type{},
-                std::plus<value_type>(), is_segmented{});
+            return hpx::parallel::v1::detail::reduce_(hpx::execution::seq,
+                first, last, value_type{}, std::plus<value_type>(),
+                is_segmented{});
         }
     } reduce{};
 }    // namespace hpx

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce_by_key.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce_by_key.hpp
@@ -209,38 +209,35 @@ namespace hpx { namespace parallel { inline namespace v1 {
         };
 
         template <>
-        struct remove_asynchronous<
-            hpx::parallel::execution::parallel_unsequenced_policy>
+        struct remove_asynchronous<hpx::execution::parallel_unsequenced_policy>
         {
-            typedef hpx::parallel::execution::parallel_policy type;
+            typedef hpx::execution::parallel_policy type;
         };
 
         template <>
-        struct remove_asynchronous<
-            hpx::parallel::execution::sequenced_task_policy>
+        struct remove_asynchronous<hpx::execution::sequenced_task_policy>
         {
-            typedef hpx::parallel::execution::sequenced_policy type;
+            typedef hpx::execution::sequenced_policy type;
         };
 
         template <typename Executor, typename Parameters>
         struct remove_asynchronous<hpx::parallel::execution::
                 sequenced_task_policy_shim<Executor, Parameters>>
         {
-            typedef hpx::parallel::execution::sequenced_policy type;
+            typedef hpx::execution::sequenced_policy type;
         };
 
         template <>
-        struct remove_asynchronous<
-            hpx::parallel::execution::parallel_task_policy>
+        struct remove_asynchronous<hpx::execution::parallel_task_policy>
         {
-            typedef hpx::parallel::execution::parallel_policy type;
+            typedef hpx::execution::parallel_policy type;
         };
 
         template <typename Executor, typename Parameters>
         struct remove_asynchronous<hpx::parallel::execution::
                 parallel_task_policy_shim<Executor, Parameters>>
         {
-            typedef hpx::parallel::execution::parallel_policy type;
+            typedef hpx::execution::parallel_policy type;
         };
 
         // -------------------------------------------------------------------

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/rotate.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/rotate.hpp
@@ -71,7 +71,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             typedef std::false_type non_seq;
 
-            auto p = execution::parallel_task_policy()
+            auto p = hpx::execution::parallel_task_policy()
                          .on(policy.executor())
                          .with(policy.parameters());
 
@@ -216,7 +216,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             typedef std::false_type non_seq;
 
-            auto p = execution::parallel_task_policy()
+            auto p = hpx::execution::parallel_task_policy()
                          .on(policy.executor())
                          .with(policy.parameters());
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
@@ -755,7 +755,7 @@ namespace hpx {
             using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
 
             return hpx::parallel::v1::detail::transform_reduce_(
-                hpx::parallel::execution::seq, first, last, std::move(init),
+                hpx::execution::seq, first, last, std::move(init),
                 std::forward<Reduce>(red_op), std::forward<Convert>(conv_op),
                 is_segmented());
         }
@@ -795,8 +795,8 @@ namespace hpx {
             using is_segmented = hpx::traits::is_segmented_iterator<FwdIter1>;
 
             return hpx::parallel::v1::detail::transform_reduce_(
-                hpx::parallel::execution::seq, first1, last1, first2,
-                std::move(init), hpx::parallel::v1::detail::plus(),
+                hpx::execution::seq, first1, last1, first2, std::move(init),
+                hpx::parallel::v1::detail::plus(),
                 hpx::parallel::v1::detail::multiplies(), is_segmented());
         }
 
@@ -865,9 +865,9 @@ namespace hpx {
             using is_segmented = hpx::traits::is_segmented_iterator<FwdIter1>;
 
             return hpx::parallel::v1::detail::transform_reduce_(
-                hpx::parallel::execution::seq, first1, last1, first2,
-                std::move(init), std::forward<Reduce>(red_op),
-                std::forward<Convert>(conv_op), is_segmented());
+                hpx::execution::seq, first1, last1, first2, std::move(init),
+                std::forward<Reduce>(red_op), std::forward<Convert>(conv_op),
+                is_segmented());
         }
     } transform_reduce{};
 }    // namespace hpx

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/all_any_none.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/all_any_none.hpp
@@ -378,7 +378,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_range<Rng>::value &&
                 hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
                 hpx::parallel::traits::is_indirect_callable<
-                    hpx::parallel::execution::sequenced_policy, F,
+                    hpx::execution::sequenced_policy, F,
                     hpx::parallel::traits::projected_range<Proj, Rng>
                 >::value
             )>
@@ -391,9 +391,8 @@ namespace hpx { namespace ranges {
             using is_segmented =
                 hpx::traits::is_segmented_iterator<iterator_type>;
 
-            return hpx::parallel::v1::detail::none_of_(
-                hpx::parallel::execution::seq, hpx::util::begin(rng),
-                hpx::util::end(rng), std::forward<F>(f),
+            return hpx::parallel::v1::detail::none_of_(hpx::execution::seq,
+                hpx::util::begin(rng), hpx::util::end(rng), std::forward<F>(f),
                 std::forward<Proj>(proj), is_segmented{});
         }
 
@@ -405,7 +404,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_sentinel_for<Sent, Iter>::value &&
                 hpx::parallel::traits::is_projected<Proj, Iter>::value &&
                 hpx::parallel::traits::is_indirect_callable<
-                    hpx::parallel::execution::sequenced_policy, F,
+                    hpx::execution::sequenced_policy, F,
                     hpx::parallel::traits::projected<Proj, Iter>
                 >::value
             )>
@@ -415,9 +414,9 @@ namespace hpx { namespace ranges {
         {
             using is_segmented = hpx::traits::is_segmented_iterator<Iter>;
 
-            return hpx::parallel::v1::detail::none_of_(
-                hpx::parallel::execution::seq, first, last, std::forward<F>(f),
-                std::forward<Proj>(proj), is_segmented{});
+            return hpx::parallel::v1::detail::none_of_(hpx::execution::seq,
+                first, last, std::forward<F>(f), std::forward<Proj>(proj),
+                is_segmented{});
         }
     } none_of{};
 
@@ -487,7 +486,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_range<Rng>::value&&
                 hpx::parallel::traits::is_projected_range<Proj, Rng>::value&&
                 hpx::parallel::traits::is_indirect_callable<
-                hpx::parallel::execution::sequenced_policy, F,
+                hpx::execution::sequenced_policy, F,
                     hpx::parallel::traits::projected_range<Proj, Rng>
                 >::value
             )>
@@ -499,9 +498,8 @@ namespace hpx { namespace ranges {
             using is_segmented =
                 hpx::traits::is_segmented_iterator<iterator_type>;
 
-            return hpx::parallel::v1::detail::any_of_(
-                hpx::parallel::execution::seq, hpx::util::begin(rng),
-                hpx::util::end(rng), std::forward<F>(f),
+            return hpx::parallel::v1::detail::any_of_(hpx::execution::seq,
+                hpx::util::begin(rng), hpx::util::end(rng), std::forward<F>(f),
                 std::forward<Proj>(proj), is_segmented{});
         }
 
@@ -513,7 +511,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_sentinel_for<Sent, Iter>::value&&
                 hpx::parallel::traits::is_projected<Proj, Iter>::value&&
                 hpx::parallel::traits::is_indirect_callable<
-                hpx::parallel::execution::sequenced_policy, F,
+                hpx::execution::sequenced_policy, F,
                     hpx::parallel::traits::projected<Proj, Iter>
                 >::value
             )>
@@ -523,9 +521,9 @@ namespace hpx { namespace ranges {
         {
             using is_segmented = hpx::traits::is_segmented_iterator<Iter>;
 
-            return hpx::parallel::v1::detail::any_of_(
-                hpx::parallel::execution::seq, first, last, std::forward<F>(f),
-                std::forward<Proj>(proj), is_segmented{});
+            return hpx::parallel::v1::detail::any_of_(hpx::execution::seq,
+                first, last, std::forward<F>(f), std::forward<Proj>(proj),
+                is_segmented{});
         }
     } any_of{};
 
@@ -595,7 +593,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_range<Rng>::value&&
                 hpx::parallel::traits::is_projected_range<Proj, Rng>::value&&
                 hpx::parallel::traits::is_indirect_callable<
-                hpx::parallel::execution::sequenced_policy, F,
+                hpx::execution::sequenced_policy, F,
                     hpx::parallel::traits::projected_range<Proj, Rng>
                 >::value
             )>
@@ -607,9 +605,8 @@ namespace hpx { namespace ranges {
             using is_segmented =
                 hpx::traits::is_segmented_iterator<iterator_type>;
 
-            return hpx::parallel::v1::detail::all_of_(
-                hpx::parallel::execution::seq, hpx::util::begin(rng),
-                hpx::util::end(rng), std::forward<F>(f),
+            return hpx::parallel::v1::detail::all_of_(hpx::execution::seq,
+                hpx::util::begin(rng), hpx::util::end(rng), std::forward<F>(f),
                 std::forward<Proj>(proj), is_segmented{});
         }
 
@@ -621,7 +618,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_sentinel_for<Sent, Iter>::value&&
                 hpx::parallel::traits::is_projected<Proj, Iter>::value&&
                 hpx::parallel::traits::is_indirect_callable<
-                hpx::parallel::execution::sequenced_policy, F,
+                hpx::execution::sequenced_policy, F,
                     hpx::parallel::traits::projected<Proj, Iter>
                 >::value
             )>
@@ -631,9 +628,9 @@ namespace hpx { namespace ranges {
         {
             using is_segmented = hpx::traits::is_segmented_iterator<Iter>;
 
-            return hpx::parallel::v1::detail::all_of_(
-                hpx::parallel::execution::seq, first, last, std::forward<F>(f),
-                std::forward<Proj>(proj), is_segmented{});
+            return hpx::parallel::v1::detail::all_of_(hpx::execution::seq,
+                first, last, std::forward<F>(f), std::forward<Proj>(proj),
+                is_segmented{});
         }
     } all_of{};
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/copy.hpp
@@ -442,7 +442,7 @@ namespace hpx { namespace ranges {
                 hpx::parallel::v1::detail::copy_iter<FwdIter1, FwdIter>;
 
             return hpx::parallel::v1::detail::transfer<copy_iter_t>(
-                hpx::parallel::execution::seq, iter, sent, dest);
+                hpx::execution::seq, iter, sent, dest);
         }
 
         // clang-format off
@@ -461,8 +461,8 @@ namespace hpx { namespace ranges {
                 FwdIter>;
 
             return hpx::parallel::v1::detail::transfer<copy_iter_t>(
-                hpx::parallel::execution::seq, hpx::util::begin(rng),
-                hpx::util::end(rng), dest);
+                hpx::execution::seq, hpx::util::begin(rng), hpx::util::end(rng),
+                dest);
         }
     } copy{};
 
@@ -532,7 +532,7 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::copy_n<
                 ranges::copy_n_result<FwdIter1, FwdIter2>>()
-                .call(hpx::parallel::execution::seq, std::true_type{}, first,
+                .call(hpx::execution::seq, std::true_type{}, first,
                     std::size_t(count), dest);
         }
     } copy_n{};
@@ -626,7 +626,7 @@ namespace hpx { namespace ranges {
                 hpx::parallel::traits::is_projected<Proj, FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter>::value &&
                 hpx::parallel::traits::is_indirect_callable<
-                    hpx::parallel::execution::sequenced_policy, Pred,
+                    hpx::execution::sequenced_policy, Pred,
                     hpx::parallel::traits::projected<Proj, FwdIter1>
                 >::value
             )>
@@ -643,9 +643,8 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::copy_if<
                 hpx::parallel::util::in_out_result<FwdIter1, FwdIter>>()
-                .call(hpx::parallel::execution::seq, std::true_type{}, iter,
-                    sent, dest, std::forward<Pred>(pred),
-                    std::forward<Proj>(proj));
+                .call(hpx::execution::seq, std::true_type{}, iter, sent, dest,
+                    std::forward<Pred>(pred), std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -656,7 +655,7 @@ namespace hpx { namespace ranges {
                 hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
                 hpx::traits::is_iterator<FwdIter>::value &&
                 hpx::parallel::traits::is_indirect_callable<
-                    hpx::parallel::execution::sequenced_policy, Pred,
+                    hpx::execution::sequenced_policy, Pred,
                     hpx::parallel::traits::projected_range<Proj, Rng>
                 >::value
             )>
@@ -673,7 +672,7 @@ namespace hpx { namespace ranges {
                 hpx::parallel::util::in_out_result<
                     typename hpx::traits::range_traits<Rng>::iterator_type,
                     FwdIter>>()
-                .call(hpx::parallel::execution::seq, std::true_type{},
+                .call(hpx::execution::seq, std::true_type{},
                     hpx::util::begin(rng), hpx::util::end(rng), dest,
                     std::forward<Pred>(pred), std::forward<Proj>(proj));
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/count.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/count.hpp
@@ -310,10 +310,9 @@ namespace hpx { namespace ranges {
             using is_segmented =
                 hpx::traits::is_segmented_iterator<iterator_type>;
 
-            return hpx::parallel::v1::detail::count_(
-                hpx::parallel::execution::seq, hpx::util::begin(rng),
-                hpx::util::end(rng), value, std::forward<Proj>(proj),
-                is_segmented{});
+            return hpx::parallel::v1::detail::count_(hpx::execution::seq,
+                hpx::util::begin(rng), hpx::util::end(rng), value,
+                std::forward<Proj>(proj), is_segmented{});
         }
 
         // clang-format off
@@ -332,9 +331,8 @@ namespace hpx { namespace ranges {
 
             using is_segmented = hpx::traits::is_segmented_iterator<Iter>;
 
-            return hpx::parallel::v1::detail::count_(
-                hpx::parallel::execution::seq, first, last, value,
-                std::forward<Proj>(proj), is_segmented{});
+            return hpx::parallel::v1::detail::count_(hpx::execution::seq, first,
+                last, value, std::forward<Proj>(proj), is_segmented{});
         }
     } count{};
 
@@ -412,7 +410,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_range<Rng>::value &&
                 hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
                 hpx::parallel::traits::is_indirect_callable<
-                    hpx::parallel::execution::sequenced_policy, F,
+                    hpx::execution::sequenced_policy, F,
                     hpx::parallel::traits::projected_range<Proj, Rng>
                 >::value
             )>
@@ -431,9 +429,8 @@ namespace hpx { namespace ranges {
             using is_segmented =
                 hpx::traits::is_segmented_iterator<iterator_type>;
 
-            return hpx::parallel::v1::detail::count_if_(
-                hpx::parallel::execution::seq, hpx::util::begin(rng),
-                hpx::util::end(rng), std::forward<F>(f),
+            return hpx::parallel::v1::detail::count_if_(hpx::execution::seq,
+                hpx::util::begin(rng), hpx::util::end(rng), std::forward<F>(f),
                 std::forward<Proj>(proj), is_segmented{});
         }
 
@@ -444,7 +441,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_sentinel_for<Sent, Iter>::value &&
                 hpx::parallel::traits::is_projected<Proj, Iter>::value &&
                 hpx::parallel::traits::is_indirect_callable<
-                    hpx::parallel::execution::sequenced_policy, F,
+                    hpx::execution::sequenced_policy, F,
                     hpx::parallel::traits::projected<Proj, Iter>
                 >::value
             )>
@@ -457,9 +454,9 @@ namespace hpx { namespace ranges {
 
             using is_segmented = hpx::traits::is_segmented_iterator<Iter>;
 
-            return hpx::parallel::v1::detail::count_if_(
-                hpx::parallel::execution::seq, first, last, std::forward<F>(f),
-                std::forward<Proj>(proj), is_segmented{});
+            return hpx::parallel::v1::detail::count_if_(hpx::execution::seq,
+                first, last, std::forward<F>(f), std::forward<Proj>(proj),
+                is_segmented{});
         }
     } count_if{};
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/destroy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/destroy.hpp
@@ -200,8 +200,8 @@ namespace hpx { namespace ranges {
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::destroy<iterator_type>().call(
-                hpx::parallel::execution::seq, std::false_type{},
-                hpx::util::begin(rng), hpx::util::end(rng));
+                hpx::execution::seq, std::false_type{}, hpx::util::begin(rng),
+                hpx::util::end(rng));
         }
 
         // clang-format off
@@ -216,7 +216,7 @@ namespace hpx { namespace ranges {
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::destroy<Iter>().call(
-                hpx::parallel::execution::seq, std::false_type{}, first, last);
+                hpx::execution::seq, std::false_type{}, first, last);
         }
     } destroy{};
 
@@ -274,7 +274,7 @@ namespace hpx { namespace ranges {
             }
 
             return hpx::parallel::v1::detail::destroy_n<FwdIter>().call(
-                hpx::parallel::execution::seq, std::false_type{}, first,
+                hpx::execution::seq, std::false_type{}, first,
                 std::size_t(count));
         }
     } destroy_n{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/equal.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/equal.hpp
@@ -320,7 +320,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
                 hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
                 hpx::parallel::traits::is_indirect_callable<
-                    hpx::parallel::execution::sequenced_policy, Pred,
+                    hpx::execution::sequenced_policy, Pred,
                     hpx::parallel::traits::projected<Proj1, Iter1>,
                     hpx::parallel::traits::projected<Proj2, Iter2>
                 >::value
@@ -336,9 +336,9 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::equal_binary().call(
-                hpx::parallel::execution::seq, std::true_type{}, first1, last1,
-                first2, last2, std::forward<Pred>(op),
-                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+                hpx::execution::seq, std::true_type{}, first1, last1, first2,
+                last2, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
         }
 
         // clang-format off
@@ -349,7 +349,7 @@ namespace hpx { namespace ranges {
                 hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
                 hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
                 hpx::parallel::traits::is_indirect_callable<
-                    hpx::parallel::execution::sequenced_policy, Pred,
+                    hpx::execution::sequenced_policy, Pred,
                     hpx::parallel::traits::projected<Proj1,
                         typename hpx::traits::range_traits<Rng1>::iterator_type>,
                     hpx::parallel::traits::projected<Proj2,
@@ -371,11 +371,10 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::equal_binary().call(
-                hpx::parallel::execution::seq, std::true_type{},
-                hpx::util::begin(rng1), hpx::util::end(rng1),
-                hpx::util::begin(rng2), hpx::util::end(rng2),
-                std::forward<Pred>(op), std::forward<Proj1>(proj1),
-                std::forward<Proj2>(proj2));
+                hpx::execution::seq, std::true_type{}, hpx::util::begin(rng1),
+                hpx::util::end(rng1), hpx::util::begin(rng2),
+                hpx::util::end(rng2), std::forward<Pred>(op),
+                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
 
     } equal{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/fill.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/fill.hpp
@@ -228,9 +228,9 @@ namespace hpx { namespace ranges {
             using is_segmented =
                 hpx::traits::is_segmented_iterator<iterator_type>;
 
-            return hpx::parallel::v1::detail::fill_(
-                hpx::parallel::execution::seq, hpx::util::begin(rng),
-                hpx::util::end(rng), value, is_segmented{});
+            return hpx::parallel::v1::detail::fill_(hpx::execution::seq,
+                hpx::util::begin(rng), hpx::util::end(rng), value,
+                is_segmented{});
         }
 
         // clang-format off
@@ -247,8 +247,7 @@ namespace hpx { namespace ranges {
             using is_segmented = hpx::traits::is_segmented_iterator<Iter>;
 
             return hpx::parallel::v1::detail::fill_(
-                hpx::parallel::execution::seq, first, last, value,
-                is_segmented{});
+                hpx::execution::seq, first, last, value, is_segmented{});
         }
     } fill{};
 
@@ -347,8 +346,8 @@ namespace hpx { namespace ranges {
             }
 
             return hpx::parallel::v1::detail::fill_n<iterator_type>().call(
-                hpx::parallel::execution::seq, std::true_type{},
-                hpx::util::begin(rng), hpx::util::size(rng), value);
+                hpx::execution::seq, std::true_type{}, hpx::util::begin(rng),
+                hpx::util::size(rng), value);
         }
 
         // clang-format off
@@ -370,7 +369,7 @@ namespace hpx { namespace ranges {
             }
 
             return hpx::parallel::v1::detail::fill_n<FwdIter>().call(
-                hpx::parallel::execution::seq, std::true_type{}, first,
+                hpx::execution::seq, std::true_type{}, first,
                 std::size_t(count), value);
         }
     } fill_n{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/find.hpp
@@ -692,9 +692,8 @@ namespace hpx { namespace ranges {
         friend Iter tag_invoke(
             find_t, Iter first, Sent last, T const& val, Proj&& proj = Proj())
         {
-            return hpx::parallel::v1::detail::find_(
-                hpx::parallel::execution::seq, first, last, val,
-                std::forward<Proj>(proj), std::false_type());
+            return hpx::parallel::v1::detail::find_(hpx::execution::seq, first,
+                last, val, std::forward<Proj>(proj), std::false_type());
         }
 
         // clang-format off
@@ -708,10 +707,9 @@ namespace hpx { namespace ranges {
         friend typename hpx::traits::range_iterator<Rng>::type tag_invoke(
             find_t, Rng&& rng, T const& val, Proj&& proj = Proj())
         {
-            return hpx::parallel::v1::detail::find_(
-                hpx::parallel::execution::seq, hpx::util::begin(rng),
-                hpx::util::end(rng), val, std::forward<Proj>(proj),
-                std::false_type());
+            return hpx::parallel::v1::detail::find_(hpx::execution::seq,
+                hpx::util::begin(rng), hpx::util::end(rng), val,
+                std::forward<Proj>(proj), std::false_type());
         }
     } find{};
 
@@ -788,9 +786,8 @@ namespace hpx { namespace ranges {
         friend Iter tag_invoke(
             find_if_t, Iter first, Sent last, Pred&& pred, Proj&& proj = Proj())
         {
-            return hpx::parallel::v1::detail::find_if_(
-                hpx::parallel::execution::seq, first, last,
-                std::forward<Pred>(pred), std::forward<Proj>(proj),
+            return hpx::parallel::v1::detail::find_if_(hpx::execution::seq,
+                first, last, std::forward<Pred>(pred), std::forward<Proj>(proj),
                 std::false_type());
         }
 
@@ -810,10 +807,10 @@ namespace hpx { namespace ranges {
         friend typename hpx::traits::range_iterator<Rng>::type tag_invoke(
             find_if_t, Rng&& rng, Pred&& pred, Proj&& proj = Proj())
         {
-            return hpx::parallel::v1::detail::find_if_(
-                hpx::parallel::execution::seq, hpx::util::begin(rng),
-                hpx::util::end(rng), std::forward<Pred>(pred),
-                std::forward<Proj>(proj), std::false_type());
+            return hpx::parallel::v1::detail::find_if_(hpx::execution::seq,
+                hpx::util::begin(rng), hpx::util::end(rng),
+                std::forward<Pred>(pred), std::forward<Proj>(proj),
+                std::false_type());
         }
     } find_if{};
 
@@ -890,9 +887,8 @@ namespace hpx { namespace ranges {
         friend Iter tag_invoke(find_if_not_t, Iter first, Sent last,
             Pred&& pred, Proj&& proj = Proj())
         {
-            return hpx::parallel::v1::detail::find_if_not_(
-                hpx::parallel::execution::seq, first, last,
-                std::forward<Pred>(pred), std::forward<Proj>(proj),
+            return hpx::parallel::v1::detail::find_if_not_(hpx::execution::seq,
+                first, last, std::forward<Pred>(pred), std::forward<Proj>(proj),
                 std::false_type());
         }
 
@@ -912,10 +908,10 @@ namespace hpx { namespace ranges {
         friend typename hpx::traits::range_iterator<Rng>::type tag_invoke(
             find_if_not_t, Rng&& rng, Pred&& pred, Proj&& proj = Proj())
         {
-            return hpx::parallel::v1::detail::find_if_not_(
-                hpx::parallel::execution::seq, hpx::util::begin(rng),
-                hpx::util::end(rng), std::forward<Pred>(pred),
-                std::forward<Proj>(proj), std::false_type());
+            return hpx::parallel::v1::detail::find_if_not_(hpx::execution::seq,
+                hpx::util::begin(rng), hpx::util::end(rng),
+                std::forward<Pred>(pred), std::forward<Proj>(proj),
+                std::false_type());
         }
     } find_if_not{};
 
@@ -1013,7 +1009,7 @@ namespace hpx { namespace ranges {
                 hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
                 hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
                 hpx::parallel::traits::is_indirect_callable<
-                    hpx::parallel::execution::sequenced_policy, Pred,
+                    hpx::execution::sequenced_policy, Pred,
                     hpx::parallel::traits::projected_range<Proj1, Rng1>,
                     hpx::parallel::traits::projected_range<Proj2, Rng2>
                 >::value
@@ -1035,11 +1031,10 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::find_end<iterator_type>().call(
-                hpx::parallel::execution::seq, std::true_type(),
-                hpx::util::begin(rng1), hpx::util::end(rng1),
-                hpx::util::begin(rng2), hpx::util::end(rng2),
-                std::forward<Pred>(op), std::forward<Proj1>(proj1),
-                std::forward<Proj2>(proj2));
+                hpx::execution::seq, std::true_type(), hpx::util::begin(rng1),
+                hpx::util::end(rng1), hpx::util::begin(rng2),
+                hpx::util::end(rng2), std::forward<Pred>(op),
+                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
 
         // clang-format off
@@ -1051,7 +1046,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
                 hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
                 hpx::parallel::traits::is_indirect_callable<
-                    hpx::parallel::execution::sequenced_policy, Pred,
+                    hpx::execution::sequenced_policy, Pred,
                     hpx::parallel::traits::projected<Proj1, Iter1>,
                     hpx::parallel::traits::projected<Proj2, Iter2>
                 >::value
@@ -1067,9 +1062,9 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::find_end<Iter1>().call(
-                hpx::parallel::execution::seq, std::true_type(), first1, last1,
-                first2, last2, std::forward<Pred>(op),
-                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+                hpx::execution::seq, std::true_type(), first1, last1, first2,
+                last2, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
         }
     } find_end{};
 
@@ -1167,7 +1162,7 @@ namespace hpx { namespace ranges {
                 hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
                 hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
                 hpx::parallel::traits::is_indirect_callable<
-                    hpx::parallel::execution::sequenced_policy, Pred,
+                    hpx::execution::sequenced_policy, Pred,
                     hpx::parallel::traits::projected_range<Proj1, Rng1>,
                     hpx::parallel::traits::projected_range<Proj2, Rng2>
                 >::value
@@ -1189,7 +1184,7 @@ namespace hpx { namespace ranges {
                 "Subsequence requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::find_first_of<iterator_type>()
-                .call(hpx::parallel::execution::seq, std::true_type(),
+                .call(hpx::execution::seq, std::true_type(),
                     hpx::util::begin(rng1), hpx::util::end(rng1),
                     hpx::util::begin(rng2), hpx::util::end(rng2),
                     std::forward<Pred>(op), std::forward<Proj1>(proj1),
@@ -1205,7 +1200,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
                 hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
                 hpx::parallel::traits::is_indirect_callable<
-                hpx::parallel::execution::sequenced_policy, Pred,
+                hpx::execution::sequenced_policy, Pred,
                     hpx::parallel::traits::projected<Proj1, Iter1>,
                     hpx::parallel::traits::projected<Proj2, Iter2>
                 >::value
@@ -1221,9 +1216,9 @@ namespace hpx { namespace ranges {
                 "Subsequence requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::find_first_of<Iter1>().call(
-                hpx::parallel::execution::seq, std::true_type(), first1, last1,
-                first2, last2, std::forward<Pred>(op),
-                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+                hpx::execution::seq, std::true_type(), first1, last1, first2,
+                last2, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
         }
 
     } find_first_of{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/for_each.hpp
@@ -431,7 +431,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_sentinel_for<Sent, InIter>::value &&
                 hpx::parallel::traits::is_projected<Proj, InIter>::value &&
                 hpx::parallel::traits::is_indirect_callable<
-                    hpx::parallel::execution::sequenced_policy, F,
+                    hpx::execution::sequenced_policy, F,
                     hpx::parallel::traits::projected<Proj, InIter>>::value)>
         // clang-format on
         friend for_each_result<InIter, F> tag_invoke(hpx::ranges::for_each_t,
@@ -439,9 +439,8 @@ namespace hpx { namespace ranges {
         {
             using is_segmented = hpx::traits::is_segmented_iterator<InIter>;
 
-            auto it =
-                parallel::v1::detail::for_each_(hpx::parallel::execution::seq,
-                    first, last, f, std::forward<Proj>(proj), is_segmented());
+            auto it = parallel::v1::detail::for_each_(hpx::execution::seq,
+                first, last, f, std::forward<Proj>(proj), is_segmented());
             return {std::move(it), std::forward<F>(f)};
         }
 
@@ -452,7 +451,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_range<Rng>::value &&
                 hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
                 hpx::parallel::traits::is_indirect_callable<
-                    hpx::parallel::execution::sequenced_policy, F,
+                    hpx::execution::sequenced_policy, F,
                     hpx::parallel::traits::projected_range<Proj, Rng>>::value)>
         // clang-format on
         friend for_each_result<typename hpx::traits::range_iterator<Rng>::type,
@@ -465,10 +464,9 @@ namespace hpx { namespace ranges {
             using is_segmented =
                 hpx::traits::is_segmented_iterator<iterator_type>;
 
-            auto it =
-                parallel::v1::detail::for_each_(hpx::parallel::execution::seq,
-                    hpx::util::begin(rng), hpx::util::end(rng), f,
-                    std::forward<Proj>(proj), is_segmented());
+            auto it = parallel::v1::detail::for_each_(hpx::execution::seq,
+                hpx::util::begin(rng), hpx::util::end(rng), f,
+                std::forward<Proj>(proj), is_segmented());
             return {std::move(it), std::forward<F>(f)};
         }
 
@@ -534,7 +532,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_input_iterator<InIter>::value &&
                 hpx::parallel::traits::is_projected<Proj, InIter>::value &&
                 hpx::parallel::traits::is_indirect_callable<
-                    hpx::parallel::execution::sequenced_policy, F,
+                    hpx::execution::sequenced_policy, F,
                     hpx::parallel::traits::projected<Proj, InIter>>::value)>
         // clang-format on
         friend for_each_n_result<InIter, F> tag_invoke(
@@ -547,8 +545,8 @@ namespace hpx { namespace ranges {
                 return {std::move(first), std::forward<F>(f)};
             }
 
-            auto it = for_each_n(hpx::parallel::execution::seq, first, count, f,
-                std::forward<Proj>(proj));
+            auto it = for_each_n(
+                hpx::execution::seq, first, count, f, std::forward<Proj>(proj));
             return {std::move(it), std::forward<F>(f)};
         }
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/generate.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/generate.hpp
@@ -298,9 +298,9 @@ namespace hpx { namespace ranges {
             using is_segmented =
                 hpx::traits::is_segmented_iterator<iterator_type>;
 
-            return hpx::parallel::v1::detail::generate_(
-                hpx::parallel::execution::seq, hpx::util::begin(rng),
-                hpx::util::end(rng), std::forward<F>(f), is_segmented());
+            return hpx::parallel::v1::detail::generate_(hpx::execution::seq,
+                hpx::util::begin(rng), hpx::util::end(rng), std::forward<F>(f),
+                is_segmented());
         }
 
         // clang-format off
@@ -316,9 +316,8 @@ namespace hpx { namespace ranges {
 
             using is_segmented = hpx::traits::is_segmented_iterator<Iter>;
 
-            return hpx::parallel::v1::detail::generate_(
-                hpx::parallel::execution::seq, first, last, std::forward<F>(f),
-                is_segmented());
+            return hpx::parallel::v1::detail::generate_(hpx::execution::seq,
+                first, last, std::forward<F>(f), is_segmented());
         }
     } generate{};
 
@@ -376,7 +375,7 @@ namespace hpx { namespace ranges {
             }
 
             return hpx::parallel::v1::detail::generate_n<FwdIter>().call(
-                hpx::parallel::execution::seq, std::true_type(), first,
+                hpx::execution::seq, std::true_type(), first,
                 std::size_t(count), std::forward<F>(f));
         }
     } generate_n{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/mismatch.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/mismatch.hpp
@@ -333,7 +333,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
                 hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
                 hpx::parallel::traits::is_indirect_callable<
-                    hpx::parallel::execution::sequenced_policy, Pred,
+                    hpx::execution::sequenced_policy, Pred,
                     hpx::parallel::traits::projected<Proj1, Iter1>,
                     hpx::parallel::traits::projected<Proj2, Iter2>
                 >::value
@@ -351,8 +351,8 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::mismatch_binary<
                 mismatch_result<Iter1, Iter2>>()
-                .call(hpx::parallel::execution::seq, std::true_type{}, first1,
-                    last1, first2, last2, std::forward<Pred>(op),
+                .call(hpx::execution::seq, std::true_type{}, first1, last1,
+                    first2, last2, std::forward<Pred>(op),
                     std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
 
@@ -364,7 +364,7 @@ namespace hpx { namespace ranges {
                 hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
                 hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
                 hpx::parallel::traits::is_indirect_callable<
-                    hpx::parallel::execution::sequenced_policy, Pred,
+                    hpx::execution::sequenced_policy, Pred,
                     hpx::parallel::traits::projected<Proj1,
                         typename hpx::traits::range_traits<Rng1>::iterator_type>,
                     hpx::parallel::traits::projected<Proj2,
@@ -392,7 +392,7 @@ namespace hpx { namespace ranges {
                 typename hpx::traits::range_traits<Rng2>::iterator_type>;
 
             return hpx::parallel::v1::detail::mismatch_binary<result_type>()
-                .call(hpx::parallel::execution::seq, std::true_type{},
+                .call(hpx::execution::seq, std::true_type{},
                     hpx::util::begin(rng1), hpx::util::end(rng1),
                     hpx::util::begin(rng2), hpx::util::end(rng2),
                     std::forward<Pred>(op), std::forward<Proj1>(proj1),

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/move.hpp
@@ -204,7 +204,7 @@ namespace hpx { namespace ranges {
         {
             return hpx::parallel::v1::detail::transfer<
                 hpx::parallel::v1::detail::move<Iter1, Iter2>>(
-                hpx::parallel::execution::seq, first, last, dest);
+                hpx::execution::seq, first, last, dest);
         }
 
         // clang-format off
@@ -223,8 +223,8 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::transfer<
                 hpx::parallel::v1::detail::move<iterator_type, Iter2>>(
-                hpx::parallel::execution::seq, hpx::util::begin(rng),
-                hpx::util::end(rng), dest);
+                hpx::execution::seq, hpx::util::begin(rng), hpx::util::end(rng),
+                dest);
         }
     } move{};
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/reduce.hpp
@@ -572,9 +572,9 @@ namespace hpx { namespace ranges {
         {
             using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
 
-            return hpx::parallel::v1::detail::reduce_(
-                hpx::parallel::execution::seq, first, last, std::move(init),
-                std::forward<F>(f), is_segmented{});
+            return hpx::parallel::v1::detail::reduce_(hpx::execution::seq,
+                first, last, std::move(init), std::forward<F>(f),
+                is_segmented{});
         }
 
         // clang-format off
@@ -588,10 +588,9 @@ namespace hpx { namespace ranges {
             using is_segmented = hpx::traits::is_segmented_iterator<
                 typename hpx::traits::range_traits<Rng>::iterator_type>;
 
-            return hpx::parallel::v1::detail::reduce_(
-                hpx::parallel::execution::seq, hpx::util::begin(rng),
-                hpx::util::end(rng), std::move(init), std::forward<F>(f),
-                is_segmented{});
+            return hpx::parallel::v1::detail::reduce_(hpx::execution::seq,
+                hpx::util::begin(rng), hpx::util::end(rng), std::move(init),
+                std::forward<F>(f), is_segmented{});
         }
 
         // clang-format off
@@ -606,9 +605,8 @@ namespace hpx { namespace ranges {
         {
             using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
 
-            return hpx::parallel::v1::detail::reduce_(
-                hpx::parallel::execution::seq, first, last, std::move(init),
-                std::plus<T>{}, is_segmented{});
+            return hpx::parallel::v1::detail::reduce_(hpx::execution::seq,
+                first, last, std::move(init), std::plus<T>{}, is_segmented{});
         }
 
         // clang-format off
@@ -622,10 +620,9 @@ namespace hpx { namespace ranges {
             using is_segmented = hpx::traits::is_segmented_iterator<
                 typename hpx::traits::range_traits<Rng>::iterator_type>;
 
-            return hpx::parallel::v1::detail::reduce_(
-                hpx::parallel::execution::seq, hpx::util::begin(rng),
-                hpx::util::end(rng), std::move(init), std::plus<T>{},
-                is_segmented{});
+            return hpx::parallel::v1::detail::reduce_(hpx::execution::seq,
+                hpx::util::begin(rng), hpx::util::end(rng), std::move(init),
+                std::plus<T>{}, is_segmented{});
         }
 
         // clang-format off
@@ -642,9 +639,9 @@ namespace hpx { namespace ranges {
 
             using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
 
-            return hpx::parallel::v1::detail::reduce_(
-                hpx::parallel::execution::seq, first, last, value_type{},
-                std::plus<value_type>{}, is_segmented{});
+            return hpx::parallel::v1::detail::reduce_(hpx::execution::seq,
+                first, last, value_type{}, std::plus<value_type>{},
+                is_segmented{});
         }
 
         // clang-format off
@@ -664,10 +661,9 @@ namespace hpx { namespace ranges {
             using is_segmented =
                 hpx::traits::is_segmented_iterator<iterator_type>;
 
-            return hpx::parallel::v1::detail::reduce_(
-                hpx::parallel::execution::seq, hpx::util::begin(rng),
-                hpx::util::end(rng), value_type{}, std::plus<value_type>{},
-                is_segmented{});
+            return hpx::parallel::v1::detail::reduce_(hpx::execution::seq,
+                hpx::util::begin(rng), hpx::util::end(rng), value_type{},
+                std::plus<value_type>{}, is_segmented{});
         }
     } reduce{};
 }}    // namespace hpx::ranges

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_reduce.hpp
@@ -342,7 +342,7 @@ namespace hpx { namespace ranges {
             using is_segmented = hpx::traits::is_segmented_iterator<Iter>;
 
             return hpx::parallel::v1::detail::transform_reduce_(
-                hpx::parallel::execution::seq, first, last, std::move(init),
+                hpx::execution::seq, first, last, std::move(init),
                 std::forward<Reduce>(red_op), std::forward<Convert>(conv_op),
                 is_segmented());
         }
@@ -382,8 +382,8 @@ namespace hpx { namespace ranges {
             using is_segmented = hpx::traits::is_segmented_iterator<Iter>;
 
             return hpx::parallel::v1::detail::transform_reduce_(
-                hpx::parallel::execution::seq, first, last, first2,
-                std::move(init), hpx::parallel::v1::detail::plus(),
+                hpx::execution::seq, first, last, first2, std::move(init),
+                hpx::parallel::v1::detail::plus(),
                 hpx::parallel::v1::detail::multiplies(), is_segmented());
         }
 
@@ -451,9 +451,9 @@ namespace hpx { namespace ranges {
             using is_segmented = hpx::traits::is_segmented_iterator<Iter>;
 
             return hpx::parallel::v1::detail::transform_reduce_(
-                hpx::parallel::execution::seq, first, last, first2,
-                std::move(init), std::forward<Reduce>(red_op),
-                std::forward<Convert>(conv_op), is_segmented());
+                hpx::execution::seq, first, last, first2, std::move(init),
+                std::forward<Reduce>(red_op), std::forward<Convert>(conv_op),
+                is_segmented());
         }
 
         // range based versions
@@ -528,10 +528,9 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_segmented_iterator<iterator_type>;
 
             return hpx::parallel::v1::detail::transform_reduce_(
-                hpx::parallel::execution::seq, hpx::util::begin(rng),
-                hpx::util::end(rng), std::move(init),
-                std::forward<Reduce>(red_op), std::forward<Convert>(conv_op),
-                is_segmented());
+                hpx::execution::seq, hpx::util::begin(rng), hpx::util::end(rng),
+                std::move(init), std::forward<Reduce>(red_op),
+                std::forward<Convert>(conv_op), is_segmented());
         }
 
         // clang-format off
@@ -574,9 +573,8 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_segmented_iterator<iterator_type>;
 
             return hpx::parallel::v1::detail::transform_reduce_(
-                hpx::parallel::execution::seq, hpx::util::begin(rng),
-                hpx::util::end(rng), first2, std::move(init),
-                hpx::parallel::v1::detail::plus(),
+                hpx::execution::seq, hpx::util::begin(rng), hpx::util::end(rng),
+                first2, std::move(init), hpx::parallel::v1::detail::plus(),
                 hpx::parallel::v1::detail::multiplies(), is_segmented());
         }
 
@@ -651,10 +649,9 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_segmented_iterator<iterator_type>;
 
             return hpx::parallel::v1::detail::transform_reduce_(
-                hpx::parallel::execution::seq, hpx::util::begin(rng),
-                hpx::util::end(rng), first2, std::move(init),
-                std::forward<Reduce>(red_op), std::forward<Convert>(conv_op),
-                is_segmented());
+                hpx::execution::seq, hpx::util::begin(rng), hpx::util::end(rng),
+                first2, std::move(init), std::forward<Reduce>(red_op),
+                std::forward<Convert>(conv_op), is_segmented());
         }
     } transform_reduce{};
 }}    // namespace hpx::ranges

--- a/libs/parallelism/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
@@ -79,8 +79,7 @@ namespace hpx { namespace parallel { namespace util {
                 std::pair<InIter, OutIter>>::type
             call(InIter first, std::size_t count, OutIter dest, F&& f)
             {
-                return util::transform_loop_n<
-                    parallel::execution::sequenced_policy>(
+                return util::transform_loop_n<sequenced_policy>(
                     first, count, dest, std::forward<F>(f));
             }
         };
@@ -117,8 +116,8 @@ namespace hpx { namespace parallel { namespace util {
                 std::pair<InIter, OutIter>>::type
             call(InIter first, InIter last, OutIter dest, F&& f)
             {
-                return util::transform_loop(parallel::execution::seq, first,
-                    last, dest, std::forward<F>(f));
+                return util::transform_loop(
+                    seq, first, last, dest, std::forward<F>(f));
             }
         };
 
@@ -181,8 +180,7 @@ namespace hpx { namespace parallel { namespace util {
             call(InIter1 first1, std::size_t count, InIter2 first2,
                 OutIter dest, F&& f)
             {
-                return util::transform_binary_loop_n<
-                    parallel::execution::sequenced_policy>(
+                return util::transform_binary_loop_n<sequenced_policy>(
                     first1, count, first2, dest, std::forward<F>(f));
             }
         };
@@ -235,8 +233,7 @@ namespace hpx { namespace parallel { namespace util {
             call(InIter1 first1, InIter1 last1, InIter2 first2, OutIter dest,
                 F&& f)
             {
-                return util::transform_binary_loop<
-                    parallel::execution::sequenced_policy>(
+                return util::transform_binary_loop<sequenced_policy>(
                     first1, last1, first2, dest, std::forward<F>(f));
             }
 
@@ -272,8 +269,7 @@ namespace hpx { namespace parallel { namespace util {
             call(InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
                 OutIter dest, F&& f)
             {
-                return util::transform_binary_loop<
-                    parallel::execution::sequenced_policy>(
+                return util::transform_binary_loop<sequenced_policy>(
                     first1, last1, first2, last2, dest, std::forward<F>(f));
             }
         };

--- a/libs/parallelism/algorithms/include/hpx/parallel/spmd_block.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/spmd_block.hpp
@@ -245,8 +245,8 @@ namespace hpx { namespace lcos { namespace local {
     template <typename F, typename... Args>
     void define_spmd_block(std::size_t num_images, F&& f, Args&&... args)
     {
-        define_spmd_block(parallel::execution::par, num_images,
-            std::forward<F>(f), std::forward<Args>(args)...);
+        define_spmd_block(hpx::execution::par, num_images, std::forward<F>(f),
+            std::forward<Args>(args)...);
     }
 }}}    // namespace hpx::lcos::local
 
@@ -289,7 +289,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
     template <typename F, typename... Args>
     void define_spmd_block(std::size_t num_images, F&& f, Args&&... args)
     {
-        hpx::lcos::local::define_spmd_block(parallel::execution::par,
-            num_images, std::forward<F>(f), std::forward<Args>(args)...);
+        hpx::lcos::local::define_spmd_block(hpx::execution::par, num_images,
+            std::forward<F>(f), std::forward<Args>(args)...);
     }
 }}}    // namespace hpx::parallel::v2

--- a/libs/parallelism/algorithms/include/hpx/parallel/task_block.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/task_block.hpp
@@ -113,7 +113,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
     /// \tparam ExPolicy The execution policy an instance of a \a task_block
     ///         was created with. This defaults to \a parallel_policy.
     ///
-    template <typename ExPolicy = parallel::execution::parallel_policy>
+    template <typename ExPolicy = hpx::execution::parallel_policy>
     class task_block
     {
     private:
@@ -449,7 +449,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
     template <typename F>
     void define_task_block(F&& f)
     {
-        define_task_block(parallel::execution::par, std::forward<F>(f));
+        define_task_block(hpx::execution::par, std::forward<F>(f));
     }
 
     /// Constructs a \a task_block, tr, and invokes the expression
@@ -517,7 +517,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
         // By design we always return on the same (HPX-) thread as we started
         // executing define_task_block_restore_thread.
         define_task_block_restore_thread(
-            parallel::execution::par, std::forward<F>(f));
+            hpx::execution::par, std::forward<F>(f));
     }
 }}}    // namespace hpx::parallel::v2
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
@@ -67,7 +67,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     };
 
     template <typename T>
-    struct algorithm_result_impl<execution::sequenced_task_policy, T>
+    struct algorithm_result_impl<hpx::execution::sequenced_task_policy, T>
     {
         // The return type of the initiating function.
         typedef hpx::future<T> type;
@@ -85,7 +85,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     };
 
     template <>
-    struct algorithm_result_impl<execution::sequenced_task_policy, void>
+    struct algorithm_result_impl<hpx::execution::sequenced_task_policy, void>
     {
         // The return type of the initiating function.
         typedef hpx::future<void> type;
@@ -114,7 +114,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     };
 
     template <typename T>
-    struct algorithm_result_impl<execution::parallel_task_policy, T>
+    struct algorithm_result_impl<hpx::execution::parallel_task_policy, T>
     {
         // The return type of the initiating function.
         typedef hpx::future<T> type;
@@ -132,7 +132,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     };
 
     template <>
-    struct algorithm_result_impl<execution::parallel_task_policy, void>
+    struct algorithm_result_impl<hpx::execution::parallel_task_policy, void>
     {
         // The return type of the initiating function.
         typedef hpx::future<void> type;
@@ -163,83 +163,83 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Executor, typename Parameters, typename T>
     struct algorithm_result_impl<
-        execution::sequenced_task_policy_shim<Executor, Parameters>, T>
-      : algorithm_result_impl<execution::sequenced_task_policy, T>
+        hpx::execution::sequenced_task_policy_shim<Executor, Parameters>, T>
+      : algorithm_result_impl<hpx::execution::sequenced_task_policy, T>
     {
     };
 
     template <typename Executor, typename Parameters>
     struct algorithm_result_impl<
-        execution::sequenced_task_policy_shim<Executor, Parameters>, void>
-      : algorithm_result_impl<execution::sequenced_task_policy, void>
+        hpx::execution::sequenced_task_policy_shim<Executor, Parameters>, void>
+      : algorithm_result_impl<hpx::execution::sequenced_task_policy, void>
     {
     };
 
     template <typename Executor, typename Parameters, typename T>
     struct algorithm_result_impl<
-        execution::parallel_task_policy_shim<Executor, Parameters>, T>
-      : algorithm_result_impl<execution::parallel_task_policy, T>
+        hpx::execution::parallel_task_policy_shim<Executor, Parameters>, T>
+      : algorithm_result_impl<hpx::execution::parallel_task_policy, T>
     {
     };
 
     template <typename Executor, typename Parameters>
     struct algorithm_result_impl<
-        execution::parallel_task_policy_shim<Executor, Parameters>, void>
-      : algorithm_result_impl<execution::parallel_task_policy, void>
+        hpx::execution::parallel_task_policy_shim<Executor, Parameters>, void>
+      : algorithm_result_impl<hpx::execution::parallel_task_policy, void>
     {
     };
 
 #if defined(HPX_HAVE_DATAPAR)
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    struct algorithm_result_impl<execution::dataseq_task_policy, T>
-      : algorithm_result_impl<execution::sequenced_task_policy, T>
+    struct algorithm_result_impl<hpx::execution::dataseq_task_policy, T>
+      : algorithm_result_impl<hpx::execution::sequenced_task_policy, T>
     {
     };
 
     template <>
-    struct algorithm_result_impl<execution::dataseq_task_policy, void>
-      : algorithm_result_impl<execution::sequenced_task_policy, void>
+    struct algorithm_result_impl<hpx::execution::dataseq_task_policy, void>
+      : algorithm_result_impl<hpx::execution::sequenced_task_policy, void>
     {
     };
 
     template <typename Executor, typename Parameters, typename T>
     struct algorithm_result_impl<
-        execution::dataseq_task_policy_shim<Executor, Parameters>, T>
-      : algorithm_result_impl<execution::sequenced_task_policy, T>
+        hpx::execution::dataseq_task_policy_shim<Executor, Parameters>, T>
+      : algorithm_result_impl<hpx::execution::sequenced_task_policy, T>
     {
     };
 
     template <typename Executor, typename Parameters>
     struct algorithm_result_impl<
-        execution::dataseq_task_policy_shim<Executor, Parameters>, void>
-      : algorithm_result_impl<execution::sequenced_task_policy, void>
+        hpx::execution::dataseq_task_policy_shim<Executor, Parameters>, void>
+      : algorithm_result_impl<hpx::execution::sequenced_task_policy, void>
     {
     };
 
     template <typename T>
-    struct algorithm_result_impl<execution::datapar_task_policy, T>
-      : algorithm_result_impl<execution::parallel_task_policy, T>
+    struct algorithm_result_impl<hpx::execution::datapar_task_policy, T>
+      : algorithm_result_impl<hpx::execution::parallel_task_policy, T>
     {
     };
 
     template <>
-    struct algorithm_result_impl<execution::datapar_task_policy, void>
-      : algorithm_result_impl<execution::parallel_task_policy, void>
+    struct algorithm_result_impl<hpx::execution::datapar_task_policy, void>
+      : algorithm_result_impl<hpx::execution::parallel_task_policy, void>
     {
     };
 
     template <typename Executor, typename Parameters, typename T>
     struct algorithm_result_impl<
-        execution::datapar_task_policy_shim<Executor, Parameters>, T>
-      : algorithm_result_impl<execution::parallel_task_policy, T>
+        hpx::execution::datapar_task_policy_shim<Executor, Parameters>, T>
+      : algorithm_result_impl<hpx::execution::parallel_task_policy, T>
     {
     };
 
     template <typename Executor, typename Parameters>
     struct algorithm_result_impl<
-        execution::datapar_task_policy_shim<Executor, Parameters>, void>
-      : algorithm_result_impl<execution::parallel_task_policy, void>
+        hpx::execution::datapar_task_policy_shim<Executor, Parameters>, void>
+      : algorithm_result_impl<hpx::execution::parallel_task_policy, void>
     {
     };
 #endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/handle_local_exceptions.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/handle_local_exceptions.hpp
@@ -161,7 +161,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     };
 
     template <>
-    struct handle_local_exceptions<execution::parallel_unsequenced_policy>
+    struct handle_local_exceptions<hpx::execution::parallel_unsequenced_policy>
     {
         ///////////////////////////////////////////////////////////////////////
 #if defined(HPX_COMPUTE_DEVICE_CODE)

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/handle_remote_exceptions.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/handle_remote_exceptions.hpp
@@ -76,7 +76,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     };
 
     template <>
-    struct handle_remote_exceptions<execution::parallel_unsequenced_policy>
+    struct handle_remote_exceptions<hpx::execution::parallel_unsequenced_policy>
     {
         HPX_NORETURN static void call(
             std::exception_ptr const&, std::list<std::exception_ptr>&)

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/select_partitioner.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/select_partitioner.hpp
@@ -24,34 +24,36 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
     template <template <typename...> class Partitioner,
         template <typename...> class TaskPartitioner>
-    struct select_partitioner<execution::parallel_task_policy, Partitioner,
+    struct select_partitioner<hpx::execution::parallel_task_policy, Partitioner,
         TaskPartitioner>
     {
         template <typename... Args>
-        using apply = TaskPartitioner<execution::parallel_task_policy, Args...>;
+        using apply =
+            TaskPartitioner<hpx::execution::parallel_task_policy, Args...>;
     };
 
     template <typename Executor, typename Parameters,
         template <typename...> class Partitioner,
         template <typename...> class TaskPartitioner>
     struct select_partitioner<
-        execution::parallel_task_policy_shim<Executor, Parameters>, Partitioner,
-        TaskPartitioner>
+        hpx::execution::parallel_task_policy_shim<Executor, Parameters>,
+        Partitioner, TaskPartitioner>
     {
         template <typename... Args>
         using apply = TaskPartitioner<
-            execution::parallel_task_policy_shim<Executor, Parameters>,
+            hpx::execution::parallel_task_policy_shim<Executor, Parameters>,
             Args...>;
     };
 
 #if defined(HPX_HAVE_DATAPAR)
     template <template <typename...> class Partitioner,
         template <typename...> class TaskPartitioner>
-    struct select_partitioner<execution::datapar_task_policy, Partitioner,
+    struct select_partitioner<hpx::execution::datapar_task_policy, Partitioner,
         TaskPartitioner>
     {
         template <typename... Args>
-        using apply = TaskPartitioner<execution::datapar_task_policy, Args...>;
+        using apply =
+            TaskPartitioner<hpx::execution::datapar_task_policy, Args...>;
     };
 #endif
 }}}}    // namespace hpx::parallel::util::detail

--- a/libs/parallelism/algorithms/tests/performance/benchmark_inplace_merge.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_inplace_merge.cpp
@@ -60,7 +60,7 @@ double run_inplace_merge_benchmark_std(int test_count, OrgIter org_first,
     for (int i = 0; i < test_count; ++i)
     {
         // Restore [first, last) with original data.
-        hpx::copy(hpx::parallel::execution::par, org_first, org_last, first);
+        hpx::copy(hpx::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
         std::inplace_merge(first, middle, last);
@@ -81,7 +81,7 @@ double run_inplace_merge_benchmark_hpx(int test_count, ExPolicy policy,
     for (int i = 0; i < test_count; ++i)
     {
         // Restore [first, last) with original data.
-        hpx::copy(hpx::parallel::execution::par, org_first, org_last, first);
+        hpx::copy(hpx::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
         hpx::parallel::inplace_merge(policy, first, middle, last);
@@ -110,11 +110,11 @@ void run_benchmark(std::size_t vector_left_size, std::size_t vector_right_size,
     auto last = std::end(c);
 
     // initialize data
-    using namespace hpx::parallel;
-    generate(execution::par, first, middle, random_fill(random_range));
-    generate(execution::par, middle, last, random_fill(random_range));
-    sort(execution::par, first, middle);
-    sort(execution::par, middle, last);
+    using namespace hpx::execution;
+    hpx::parallel::generate(par, first, middle, random_fill(random_range));
+    hpx::parallel::generate(par, middle, last, random_fill(random_range));
+    hpx::parallel::sort(par, first, middle);
+    hpx::parallel::sort(par, middle, last);
     org_c = c;
 
     auto org_first = std::begin(org_c);
@@ -127,15 +127,15 @@ void run_benchmark(std::size_t vector_left_size, std::size_t vector_right_size,
 
     std::cout << "--- run_inplace_merge_benchmark_seq ---" << std::endl;
     double time_seq = run_inplace_merge_benchmark_hpx(
-        test_count, execution::seq, org_first, org_last, first, middle, last);
+        test_count, seq, org_first, org_last, first, middle, last);
 
     std::cout << "--- run_inplace_merge_benchmark_par ---" << std::endl;
     double time_par = run_inplace_merge_benchmark_hpx(
-        test_count, execution::par, org_first, org_last, first, middle, last);
+        test_count, par, org_first, org_last, first, middle, last);
 
     std::cout << "--- run_inplace_merge_benchmark_par_unseq ---" << std::endl;
-    double time_par_unseq = run_inplace_merge_benchmark_hpx(test_count,
-        execution::par_unseq, org_first, org_last, first, middle, last);
+    double time_par_unseq = run_inplace_merge_benchmark_hpx(
+        test_count, par_unseq, org_first, org_last, first, middle, last);
 
     std::cout << "\n-------------- Benchmark Result --------------"
               << std::endl;

--- a/libs/parallelism/algorithms/tests/performance/benchmark_is_heap.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_is_heap.cpp
@@ -80,8 +80,8 @@ double run_is_heap_benchmark_seq(int test_count, std::vector<int> const& v)
 
     for (int i = 0; i < test_count; ++i)
     {
-        using namespace hpx::parallel;
-        result = is_heap(execution::seq, std::begin(v), std::end(v));
+        using namespace hpx::execution;
+        result = hpx::parallel::is_heap(seq, std::begin(v), std::end(v));
     }
 
     time = hpx::util::high_resolution_clock::now() - time;
@@ -100,8 +100,8 @@ double run_is_heap_benchmark_par(int test_count, std::vector<int> const& v)
 
     for (int i = 0; i < test_count; ++i)
     {
-        using namespace hpx::parallel;
-        result = is_heap(execution::par, std::begin(v), std::end(v));
+        using namespace hpx::execution;
+        result = hpx::parallel::is_heap(par, std::begin(v), std::end(v));
     }
 
     time = hpx::util::high_resolution_clock::now() - time;
@@ -121,8 +121,8 @@ double run_is_heap_benchmark_par_unseq(
 
     for (int i = 0; i < test_count; ++i)
     {
-        using namespace hpx::parallel;
-        result = is_heap(execution::par_unseq, std::begin(v), std::end(v));
+        using namespace hpx::execution;
+        result = hpx::parallel::is_heap(par_unseq, std::begin(v), std::end(v));
     }
 
     time = hpx::util::high_resolution_clock::now() - time;
@@ -164,8 +164,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::vector<int> v(vector_size);
 
     // initialize data
-    using namespace hpx::parallel;
-    generate(execution::par, std::begin(v), std::end(v), random_fill());
+    using namespace hpx::execution;
+    hpx::parallel::generate(par, std::begin(v), std::end(v), random_fill());
     std::make_heap(std::begin(v), std::next(std::begin(v), break_pos));
     if (break_pos < vector_size)
         v[break_pos] =

--- a/libs/parallelism/algorithms/tests/performance/benchmark_is_heap_until.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_is_heap_until.cpp
@@ -83,8 +83,8 @@ double run_is_heap_until_benchmark_seq(
 
     for (int i = 0; i < test_count; ++i)
     {
-        using namespace hpx::parallel;
-        result = is_heap_until(execution::seq, std::begin(v), std::end(v));
+        using namespace hpx::execution;
+        result = hpx::parallel::is_heap_until(seq, std::begin(v), std::end(v));
     }
 
     time = hpx::util::high_resolution_clock::now() - time;
@@ -105,8 +105,8 @@ double run_is_heap_until_benchmark_par(
 
     for (int i = 0; i < test_count; ++i)
     {
-        using namespace hpx::parallel;
-        result = is_heap_until(execution::par, std::begin(v), std::end(v));
+        using namespace hpx::execution;
+        result = hpx::parallel::is_heap_until(par, std::begin(v), std::end(v));
     }
 
     time = hpx::util::high_resolution_clock::now() - time;
@@ -127,9 +127,9 @@ double run_is_heap_until_benchmark_par_unseq(
 
     for (int i = 0; i < test_count; ++i)
     {
-        using namespace hpx::parallel;
+        using namespace hpx::execution;
         result =
-            is_heap_until(execution::par_unseq, std::begin(v), std::end(v));
+            hpx::parallel::is_heap_until(par_unseq, std::begin(v), std::end(v));
     }
 
     time = hpx::util::high_resolution_clock::now() - time;
@@ -172,8 +172,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::vector<int> v(vector_size);
 
     // initialize data
-    using namespace hpx::parallel;
-    generate(execution::par, std::begin(v), std::end(v), random_fill());
+    using namespace hpx::execution;
+    hpx::parallel::generate(par, std::begin(v), std::end(v), random_fill());
     std::make_heap(std::begin(v), std::next(std::begin(v), break_pos));
     if (break_pos < vector_size)
         v[break_pos] =

--- a/libs/parallelism/algorithms/tests/performance/benchmark_merge.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_merge.cpp
@@ -105,13 +105,13 @@ void run_benchmark(std::size_t vector_size1, std::size_t vector_size2,
     auto dest = std::begin(result);
 
     // initialize data
-    using namespace hpx::parallel;
-    generate(execution::par, std::begin(src1), std::end(src1),
-        random_fill(random_range));
-    generate(execution::par, std::begin(src2), std::end(src2),
-        random_fill(random_range));
-    sort(execution::par, std::begin(src1), std::end(src1));
-    sort(execution::par, std::begin(src2), std::end(src2));
+    using namespace hpx::execution;
+    hpx::parallel::generate(
+        par, std::begin(src1), std::end(src1), random_fill(random_range));
+    hpx::parallel::generate(
+        par, std::begin(src2), std::end(src2), random_fill(random_range));
+    hpx::parallel::sort(par, std::begin(src1), std::end(src1));
+    hpx::parallel::sort(par, std::begin(src2), std::end(src2));
 
     std::cout << "* Running Benchmark..." << std::endl;
     std::cout << "--- run_merge_benchmark_std ---" << std::endl;
@@ -120,15 +120,15 @@ void run_benchmark(std::size_t vector_size1, std::size_t vector_size2,
 
     std::cout << "--- run_merge_benchmark_seq ---" << std::endl;
     double time_seq = run_merge_benchmark_hpx(
-        test_count, execution::seq, first1, last1, first2, last2, dest);
+        test_count, seq, first1, last1, first2, last2, dest);
 
     std::cout << "--- run_merge_benchmark_par ---" << std::endl;
     double time_par = run_merge_benchmark_hpx(
-        test_count, execution::par, first1, last1, first2, last2, dest);
+        test_count, par, first1, last1, first2, last2, dest);
 
     std::cout << "--- run_merge_benchmark_par_unseq ---" << std::endl;
     double time_par_unseq = run_merge_benchmark_hpx(
-        test_count, execution::par_unseq, first1, last1, first2, last2, dest);
+        test_count, par_unseq, first1, last1, first2, last2, dest);
 
     std::cout << "\n-------------- Benchmark Result --------------"
               << std::endl;

--- a/libs/parallelism/algorithms/tests/performance/benchmark_partition.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_partition.cpp
@@ -60,7 +60,7 @@ double run_partition_benchmark_std(int test_count, OrgIter org_first,
     for (int i = 0; i < test_count; ++i)
     {
         // Restore [first, last) with original data.
-        hpx::copy(hpx::parallel::execution::par, org_first, org_last, first);
+        hpx::copy(hpx::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
         std::partition(first, last, pred);
@@ -80,7 +80,7 @@ double run_partition_benchmark_hpx(int test_count, ExPolicy policy,
     for (int i = 0; i < test_count; ++i)
     {
         // Restore [first, last) with original data.
-        hpx::copy(hpx::parallel::execution::par, org_first, org_last, first);
+        hpx::copy(hpx::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
         hpx::parallel::partition(policy, first, last, pred);
@@ -107,8 +107,8 @@ void run_benchmark(
     auto last = std::end(v);
 
     // initialize data
-    using namespace hpx::parallel;
-    generate(execution::par, std::begin(v), std::end(v), random_fill());
+    using namespace hpx::execution;
+    hpx::parallel::generate(par, std::begin(v), std::end(v), random_fill());
     org_v = v;
 
     auto org_first = std::begin(org_v);
@@ -124,15 +124,15 @@ void run_benchmark(
 
     std::cout << "--- run_partition_benchmark_seq ---" << std::endl;
     double time_seq = run_partition_benchmark_hpx(
-        test_count, execution::seq, org_first, org_last, first, last, pred);
+        test_count, seq, org_first, org_last, first, last, pred);
 
     std::cout << "--- run_partition_benchmark_par ---" << std::endl;
     double time_par = run_partition_benchmark_hpx(
-        test_count, execution::par, org_first, org_last, first, last, pred);
+        test_count, par, org_first, org_last, first, last, pred);
 
     std::cout << "--- run_partition_benchmark_par_unseq ---" << std::endl;
-    double time_par_unseq = run_partition_benchmark_hpx(test_count,
-        execution::par_unseq, org_first, org_last, first, last, pred);
+    double time_par_unseq = run_partition_benchmark_hpx(
+        test_count, par_unseq, org_first, org_last, first, last, pred);
 
     std::cout << "\n-------------- Benchmark Result --------------"
               << std::endl;

--- a/libs/parallelism/algorithms/tests/performance/benchmark_partition_copy.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_partition_copy.cpp
@@ -83,8 +83,9 @@ double run_partition_copy_benchmark_hpx(int test_count, ExPolicy policy,
 
     for (int i = 0; i < test_count; ++i)
     {
-        using namespace hpx::parallel;
-        partition_copy(policy, first, last, dest_true, dest_false, pred);
+        using namespace hpx::execution;
+        hpx::parallel::partition_copy(
+            policy, first, last, dest_true, dest_false, pred);
     }
 
     time = hpx::util::high_resolution_clock::now() - time;
@@ -111,8 +112,8 @@ void run_benchmark(std::size_t vector_size, int test_count, IteratorTag)
     auto dest_false = std::begin(result_false);
 
     // initialize data
-    using namespace hpx::parallel;
-    generate(execution::par, std::begin(v), std::end(v), random_fill());
+    using namespace hpx::execution;
+    hpx::parallel::generate(par, std::begin(v), std::end(v), random_fill());
 
     std::cout << "* Running Benchmark..." << std::endl;
 
@@ -126,15 +127,15 @@ void run_benchmark(std::size_t vector_size, int test_count, IteratorTag)
 
     std::cout << "--- run_partition_copy_benchmark_seq ---" << std::endl;
     double time_seq = run_partition_copy_benchmark_hpx(
-        test_count, execution::seq, first, last, dest_true, dest_false, pred);
+        test_count, seq, first, last, dest_true, dest_false, pred);
 
     std::cout << "--- run_partition_copy_benchmark_par ---" << std::endl;
     double time_par = run_partition_copy_benchmark_hpx(
-        test_count, execution::par, first, last, dest_true, dest_false, pred);
+        test_count, par, first, last, dest_true, dest_false, pred);
 
     std::cout << "--- run_partition_copy_benchmark_par_unseq ---" << std::endl;
-    double time_par_unseq = run_partition_copy_benchmark_hpx(test_count,
-        execution::par_unseq, first, last, dest_true, dest_false, pred);
+    double time_par_unseq = run_partition_copy_benchmark_hpx(
+        test_count, par_unseq, first, last, dest_true, dest_false, pred);
 
     std::cout << "\n-------------- Benchmark Result --------------"
               << std::endl;

--- a/libs/parallelism/algorithms/tests/performance/benchmark_remove.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_remove.cpp
@@ -96,7 +96,7 @@ double run_remove_benchmark_std(int test_count, OrgIter org_first,
     for (int i = 0; i < test_count; ++i)
     {
         // Restore [first, last) with original data.
-        hpx::copy(hpx::parallel::execution::par, org_first, org_last, first);
+        hpx::copy(hpx::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
         (void) std::remove(first, last, value);
@@ -118,7 +118,7 @@ double run_remove_benchmark_hpx(int test_count, ExPolicy policy,
     for (int i = 0; i < test_count; ++i)
     {
         // Restore [first, last) with original data.
-        hpx::copy(hpx::parallel::execution::par, org_first, org_last, first);
+        hpx::copy(hpx::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
         hpx::parallel::remove(policy, first, last, value);
@@ -145,9 +145,9 @@ void run_benchmark(std::size_t vector_size, int test_count,
     auto last = std::end(v);
 
     // initialize data
-    using namespace hpx::parallel;
-    generate(
-        execution::par, std::begin(v), std::end(v), random_fill(random_range));
+    using namespace hpx::execution;
+    hpx::parallel::generate(
+        par, std::begin(v), std::end(v), random_fill(random_range));
     org_v = v;
 
     auto value = DataType(static_cast<int>(random_range / 2));
@@ -168,15 +168,15 @@ void run_benchmark(std::size_t vector_size, int test_count,
 
     std::cout << "--- run_remove_benchmark_seq ---" << std::endl;
     double time_seq = run_remove_benchmark_hpx(
-        test_count, execution::seq, org_first, org_last, first, last, value);
+        test_count, seq, org_first, org_last, first, last, value);
 
     std::cout << "--- run_remove_benchmark_par ---" << std::endl;
     double time_par = run_remove_benchmark_hpx(
-        test_count, execution::par, org_first, org_last, first, last, value);
+        test_count, par, org_first, org_last, first, last, value);
 
     std::cout << "--- run_remove_benchmark_par_unseq ---" << std::endl;
-    double time_par_unseq = run_remove_benchmark_hpx(test_count,
-        execution::par_unseq, org_first, org_last, first, last, value);
+    double time_par_unseq = run_remove_benchmark_hpx(
+        test_count, par_unseq, org_first, org_last, first, last, value);
 
     std::cout << "\n-------------- Benchmark Result --------------"
               << std::endl;

--- a/libs/parallelism/algorithms/tests/performance/benchmark_remove_if.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_remove_if.cpp
@@ -96,7 +96,7 @@ double run_remove_if_benchmark_std(int test_count, OrgIter org_first,
     for (int i = 0; i < test_count; ++i)
     {
         // Restore [first, last) with original data.
-        hpx::copy(hpx::parallel::execution::par, org_first, org_last, first);
+        hpx::copy(hpx::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
         (void) std::remove_if(first, last, pred);
@@ -116,7 +116,7 @@ double run_remove_if_benchmark_hpx(int test_count, ExPolicy policy,
     for (int i = 0; i < test_count; ++i)
     {
         // Restore [first, last) with original data.
-        hpx::copy(hpx::parallel::execution::par, org_first, org_last, first);
+        hpx::copy(hpx::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
         hpx::parallel::remove_if(policy, first, last, pred);
@@ -143,9 +143,9 @@ void run_benchmark(std::size_t vector_size, int test_count,
     auto last = std::end(v);
 
     // initialize data
-    using namespace hpx::parallel;
-    generate(
-        execution::par, std::begin(v), std::end(v), random_fill(random_range));
+    using namespace hpx::execution;
+    hpx::parallel::generate(
+        par, std::begin(v), std::end(v), random_fill(random_range));
     org_v = v;
 
     auto value = DataType(static_cast<int>(random_range / 2));
@@ -167,15 +167,15 @@ void run_benchmark(std::size_t vector_size, int test_count,
 
     std::cout << "--- run_remove_if_benchmark_seq ---" << std::endl;
     double time_seq = run_remove_if_benchmark_hpx(
-        test_count, execution::seq, org_first, org_last, first, last, pred);
+        test_count, seq, org_first, org_last, first, last, pred);
 
     std::cout << "--- run_remove_if_benchmark_par ---" << std::endl;
     double time_par = run_remove_if_benchmark_hpx(
-        test_count, execution::par, org_first, org_last, first, last, pred);
+        test_count, par, org_first, org_last, first, last, pred);
 
     std::cout << "--- run_remove_if_benchmark_par_unseq ---" << std::endl;
-    double time_par_unseq = run_remove_if_benchmark_hpx(test_count,
-        execution::par_unseq, org_first, org_last, first, last, pred);
+    double time_par_unseq = run_remove_if_benchmark_hpx(
+        test_count, par_unseq, org_first, org_last, first, last, pred);
 
     std::cout << "\n-------------- Benchmark Result --------------"
               << std::endl;

--- a/libs/parallelism/algorithms/tests/performance/benchmark_unique.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_unique.cpp
@@ -106,7 +106,7 @@ double run_unique_benchmark_std(int test_count, OrgIter org_first,
     for (int i = 0; i < test_count; ++i)
     {
         // Restore [first, last) with original data.
-        hpx::copy(hpx::parallel::execution::par, org_first, org_last, first);
+        hpx::copy(hpx::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
         (void) std::unique(first, last);
@@ -126,7 +126,7 @@ double run_unique_benchmark_hpx(int test_count, ExPolicy policy,
     for (int i = 0; i < test_count; ++i)
     {
         // Restore [first, last) with original data.
-        hpx::copy(hpx::parallel::execution::par, org_first, org_last, first);
+        hpx::copy(hpx::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
         hpx::parallel::unique(policy, first, last);
@@ -153,9 +153,9 @@ void run_benchmark(std::size_t vector_size, int test_count,
     auto last = std::end(v);
 
     // initialize data
-    using namespace hpx::parallel;
-    generate(
-        execution::par, std::begin(v), std::end(v), random_fill(random_range));
+    using namespace hpx::execution;
+    hpx::parallel::generate(
+        par, std::begin(v), std::end(v), random_fill(random_range));
     org_v = v;
 
     auto dest_dist = std::distance(first, std::unique(first, last));
@@ -174,15 +174,15 @@ void run_benchmark(std::size_t vector_size, int test_count,
 
     std::cout << "--- run_unique_benchmark_seq ---" << std::endl;
     double time_seq = run_unique_benchmark_hpx(
-        test_count, execution::seq, org_first, org_last, first, last);
+        test_count, seq, org_first, org_last, first, last);
 
     std::cout << "--- run_unique_benchmark_par ---" << std::endl;
     double time_par = run_unique_benchmark_hpx(
-        test_count, execution::par, org_first, org_last, first, last);
+        test_count, par, org_first, org_last, first, last);
 
     std::cout << "--- run_unique_benchmark_par_unseq ---" << std::endl;
     double time_par_unseq = run_unique_benchmark_hpx(
-        test_count, execution::par_unseq, org_first, org_last, first, last);
+        test_count, par_unseq, org_first, org_last, first, last);
 
     std::cout << "\n-------------- Benchmark Result --------------"
               << std::endl;

--- a/libs/parallelism/algorithms/tests/performance/benchmark_unique_copy.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_unique_copy.cpp
@@ -97,9 +97,9 @@ void run_benchmark(std::size_t vector_size, int test_count,
     auto dest = std::begin(result);
 
     // initialize data
-    using namespace hpx::parallel;
-    generate(
-        execution::par, std::begin(v), std::end(v), random_fill(random_range));
+    using namespace hpx::execution;
+    hpx::parallel::generate(
+        par, std::begin(v), std::end(v), random_fill(random_range));
 
     auto dest_dist =
         std::distance(std::begin(result), std::unique_copy(first, last, dest));
@@ -114,16 +114,16 @@ void run_benchmark(std::size_t vector_size, int test_count,
         run_unique_copy_benchmark_std(test_count, first, last, dest);
 
     std::cout << "--- run_unique_copy_benchmark_seq ---" << std::endl;
-    double time_seq = run_unique_copy_benchmark_hpx(
-        test_count, execution::seq, first, last, dest);
+    double time_seq =
+        run_unique_copy_benchmark_hpx(test_count, seq, first, last, dest);
 
     std::cout << "--- run_unique_copy_benchmark_par ---" << std::endl;
-    double time_par = run_unique_copy_benchmark_hpx(
-        test_count, execution::par, first, last, dest);
+    double time_par =
+        run_unique_copy_benchmark_hpx(test_count, par, first, last, dest);
 
     std::cout << "--- run_unique_copy_benchmark_par_unseq ---" << std::endl;
-    double time_par_unseq = run_unique_copy_benchmark_hpx(
-        test_count, execution::par_unseq, first, last, dest);
+    double time_par_unseq =
+        run_unique_copy_benchmark_hpx(test_count, par_unseq, first, last, dest);
 
     std::cout << "\n-------------- Benchmark Result --------------"
               << std::endl;

--- a/libs/parallelism/algorithms/tests/performance/transform_reduce_scaling.cpp
+++ b/libs/parallelism/algorithms/tests/performance/transform_reduce_scaling.cpp
@@ -37,7 +37,7 @@ void measure_transform_reduce(std::size_t size)
         size, Point{double(gen()), double(gen())});
 
     // invoke transform_reduce
-    double result = hpx::transform_reduce(hpx::parallel::execution::par,
+    double result = hpx::transform_reduce(hpx::execution::par,
         std::begin(data_representation), std::end(data_representation), 0.0,
         std::plus<double>(), [](Point r) { return r.x * r.y; });
     HPX_UNUSED(result);
@@ -49,7 +49,7 @@ void measure_transform_reduce_old(std::size_t size)
         size, Point{double(gen()), double(gen())});
 
     //invoke old reduce
-    Point result = hpx::ranges::reduce(hpx::parallel::execution::par,
+    Point result = hpx::ranges::reduce(hpx::execution::par,
         std::begin(data_representation), std::end(data_representation),
         Point{0.0, 0.0}, [](Point res, Point curr) {
             return Point{res.x * res.y + curr.x * curr.y, 1.0};

--- a/libs/parallelism/algorithms/tests/regressions/count_3646.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/count_3646.cpp
@@ -87,12 +87,12 @@ void test_count()
     auto stdResult = std::count(Iter{0}, Iter{33}, std::int64_t{1});
 
     auto result = hpx::ranges::count(
-        hpx::parallel::execution::seq, Iter{0}, Sent{33}, std::int64_t{1});
+        hpx::execution::seq, Iter{0}, Sent{33}, std::int64_t{1});
 
     HPX_TEST_EQ(result, stdResult);
 
     result = hpx::ranges::count(
-        hpx::parallel::execution::par, Iter{0}, Sent{33}, std::int64_t{1});
+        hpx::execution::par, Iter{0}, Sent{33}, std::int64_t{1});
 
     HPX_TEST_EQ(result, stdResult);
 }
@@ -106,12 +106,12 @@ void test_count_if()
     auto stdResult = std::count_if(Iter{0}, Iter{33}, predicate);
 
     Iter::difference_type result = hpx::ranges::count_if(
-        hpx::parallel::execution::seq, Iter{0}, Sent{33}, predicate);
+        hpx::execution::seq, Iter{0}, Sent{33}, predicate);
 
     HPX_TEST_EQ(result, stdResult);
 
     result = hpx::ranges::count_if(
-        hpx::parallel::execution::par, Iter{0}, Sent{33}, predicate);
+        hpx::execution::par, Iter{0}, Sent{33}, predicate);
 
     HPX_TEST_EQ(result, stdResult);
 }

--- a/libs/parallelism/algorithms/tests/regressions/for_each_annotated_function.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/for_each_annotated_function.cpp
@@ -21,7 +21,7 @@ int hpx_main()
     std::vector<int> c(10007);
     std::iota(std::begin(c), std::end(c), std::random_device{}());
 
-    hpx::ranges::for_each(hpx::parallel::execution::par, c,
+    hpx::ranges::for_each(hpx::execution::par, c,
         hpx::util::annotated_function(
             [](int i) -> void {
                 hpx::util::thread_description desc(

--- a/libs/parallelism/algorithms/tests/regressions/for_loop_2281.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/for_loop_2281.cpp
@@ -22,7 +22,7 @@ int hpx_main()
     hpx::lcos::local::spinlock mtx;
     std::set<hpx::thread::id> thread_ids;
 
-    hpx::for_loop(hpx::parallel::execution::par, 0, 100, [&](int i) {
+    hpx::for_loop(hpx::execution::par, 0, 100, [&](int i) {
         std::lock_guard<hpx::lcos::local::spinlock> l(mtx);
         thread_ids.insert(hpx::this_thread::get_id());
     });
@@ -31,7 +31,7 @@ int hpx_main()
 
     thread_ids.clear();
 
-    hpx::for_loop_n(hpx::parallel::execution::par, 0, 100, [&](int i) {
+    hpx::for_loop_n(hpx::execution::par, 0, 100, [&](int i) {
         std::lock_guard<hpx::lcos::local::spinlock> l(mtx);
         thread_ids.insert(hpx::this_thread::get_id());
     });

--- a/libs/parallelism/algorithms/tests/regressions/reduce_3641.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/reduce_3641.cpp
@@ -19,13 +19,13 @@
 
 int main()
 {
-    std::int64_t result = hpx::ranges::reduce(hpx::parallel::execution::seq,
+    std::int64_t result = hpx::ranges::reduce(hpx::execution::seq,
         Iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, std::int64_t(0));
 
     HPX_TEST_EQ(result, std::int64_t(4950));
 
-    result = hpx::ranges::reduce(hpx::parallel::execution::par,
-        Iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, std::int64_t(0));
+    result = hpx::ranges::reduce(hpx::execution::par, Iterator<std::int64_t>{0},
+        Sentinel<int64_t>{100}, std::int64_t(0));
 
     HPX_TEST_EQ(result, std::int64_t(4950));
 

--- a/libs/parallelism/algorithms/tests/regressions/scan_different_inits.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/scan_different_inits.cpp
@@ -23,7 +23,7 @@ void test_zero()
     typedef std::vector<int>::iterator Iter;
     std::vector<int> a;
     std::vector<int> b, c, d, e, f, g;
-    auto policy = hpx::parallel::execution::par;
+    auto policy = hpx::execution::par;
 
     Iter i_inc_add = hpx::parallel::inclusive_scan(
         policy, a.begin(), a.end(), b.begin(),
@@ -57,7 +57,7 @@ void test_async_zero()
     typedef hpx::future<Iter> Fut_Iter;
     std::vector<int> a;
     std::vector<int> b, c, d, e, f, g;
-    auto policy = hpx::parallel::execution::par(hpx::parallel::execution::task);
+    auto policy = hpx::execution::par(hpx::execution::task);
 
     Fut_Iter f_inc_add = hpx::parallel::inclusive_scan(
         policy, a.begin(), a.end(), b.begin(),
@@ -97,7 +97,7 @@ void test_one(std::vector<int> a)
     auto fun_add = [](int bar, int baz) { return bar + baz + 1; };
     auto fun_mult = [](int bar, int baz) { return 2 * bar * baz; };
     auto fun_conv = [](int foo) { return foo - 3; };
-    auto policy = hpx::parallel::execution::par;
+    auto policy = hpx::execution::par;
 
     Iter f_inc_add = hpx::parallel::inclusive_scan(
         policy, a.begin(), a.end(), b.begin(), fun_add, 10);
@@ -142,7 +142,7 @@ void test_one(std::vector<int> a)
 
 void test_async_one(std::vector<int> a)
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
     typedef std::vector<int>::iterator Iter;
     typedef hpx::future<Iter> Fut_Iter;
     std::size_t n = a.size();
@@ -154,7 +154,7 @@ void test_async_one(std::vector<int> a)
     auto fun_add = [](int bar, int baz) { return bar + baz + 1; };
     auto fun_mult = [](int bar, int baz) { return 2 * bar * baz; };
     auto fun_conv = [](int foo) { return foo - 3; };
-    auto policy = hpx::parallel::execution::par(hpx::parallel::execution::task);
+    auto policy = hpx::execution::par(hpx::execution::task);
 
     Fut_Iter f_inc_add = hpx::parallel::inclusive_scan(
         policy, a.begin(), a.end(), b.begin(), fun_add, 10);

--- a/libs/parallelism/algorithms/tests/regressions/scan_non_commutative.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/scan_non_commutative.cpp
@@ -25,8 +25,7 @@ void test_scan_non_commutative()
     {
         std::vector<std::string> rs(vs.size());
         hpx::parallel::inclusive_scan(
-            hpx::parallel::execution::par.with(
-                hpx::parallel::execution::static_chunk_size(i)),
+            hpx::execution::par.with(hpx::execution::static_chunk_size(i)),
             vs.cbegin(), vs.cend(), rs.begin());
         std::cout << rs.back() << "\n";
         bool is_equal =
@@ -38,8 +37,7 @@ void test_scan_non_commutative()
     {
         std::vector<std::string> rs(vs.size());
         hpx::parallel::exclusive_scan(
-            hpx::parallel::execution::par.with(
-                hpx::parallel::execution::static_chunk_size(i)),
+            hpx::execution::par.with(hpx::execution::static_chunk_size(i)),
             vs.cbegin(), vs.cend(), rs.begin(), std::string("0"));
         std::cout << rs.back() << "\n";
         bool is_equal =

--- a/libs/parallelism/algorithms/tests/regressions/scan_shortlength.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/scan_shortlength.cpp
@@ -20,17 +20,17 @@
 #if !(defined(HPX_INTEL_VERSION) && HPX_INTEL_VERSION == 1500)
 void test_zero()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
     typedef std::vector<int>::iterator Iter;
     std::vector<int> a;
     std::vector<int> b, c, d;
 
-    auto p_copy_if = hpx::ranges::copy_if(execution::par, a.begin(), a.end(),
-        b.begin(), [](int bar) { return bar % 2 == 1; });
-    auto p_remove_copy_if = remove_copy_if(execution::par, a.begin(), a.end(),
-        c.begin(), [](int bar) { return bar % 2 != 1; });
+    auto p_copy_if = hpx::ranges::copy_if(par, a.begin(), a.end(), b.begin(),
+        [](int bar) { return bar % 2 == 1; });
+    auto p_remove_copy_if = hpx::parallel::remove_copy_if(par, a.begin(),
+        a.end(), c.begin(), [](int bar) { return bar % 2 != 1; });
     auto p_remove_copy =
-        remove_copy(execution::par, a.begin(), a.end(), d.begin(), 0);
+        hpx::parallel::remove_copy(par, a.begin(), a.end(), d.begin(), 0);
 
     Iter ans_copy_if = std::copy_if(
         a.begin(), a.end(), b.begin(), [](int bar) { return bar % 2 == 1; });
@@ -45,18 +45,18 @@ void test_zero()
 
 void test_async_zero()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
     typedef std::vector<int>::iterator Iter;
     typedef hpx::future<std::pair<Iter, Iter>> Fut_Iter;
     std::vector<int> a;
     std::vector<int> b, c, d;
 
-    auto f_copy_if = hpx::ranges::copy_if(execution::par(execution::task),
-        a.begin(), a.end(), b.begin(), [](int bar) { return bar % 2 == 1; });
-    auto f_remove_copy_if = remove_copy_if(execution::par(execution::task),
-        a.begin(), a.end(), c.begin(), [](int bar) { return bar % 2 != 1; });
-    auto f_remove_copy = remove_copy(
-        execution::par(execution::task), a.begin(), a.end(), d.begin(), 0);
+    auto f_copy_if = hpx::ranges::copy_if(par(task), a.begin(), a.end(),
+        b.begin(), [](int bar) { return bar % 2 == 1; });
+    auto f_remove_copy_if = hpx::parallel::remove_copy_if(par(task), a.begin(),
+        a.end(), c.begin(), [](int bar) { return bar % 2 != 1; });
+    auto f_remove_copy =
+        hpx::parallel::remove_copy(par(task), a.begin(), a.end(), d.begin(), 0);
 
     Iter ans_copy_if = std::copy_if(
         a.begin(), a.end(), b.begin(), [](int bar) { return bar % 2 == 1; });
@@ -71,18 +71,18 @@ void test_async_zero()
 
 void test_one(std::vector<int> a)
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
     typedef std::vector<int>::iterator Iter;
     std::size_t n = a.size();
     std::vector<int> b(n), c(n), d(n);
     std::vector<int> b_ans(n), c_ans(n), d_ans(n);
 
-    auto p_copy_if = hpx::ranges::copy_if(execution::par, a.begin(), a.end(),
-        b.begin(), [](int bar) { return bar % 2 == 1; });
-    auto p_remove_copy_if = remove_copy_if(execution::par, a.begin(), a.end(),
-        c.begin(), [](int bar) { return bar % 2 != 1; });
+    auto p_copy_if = hpx::ranges::copy_if(par, a.begin(), a.end(), b.begin(),
+        [](int bar) { return bar % 2 == 1; });
+    auto p_remove_copy_if = hpx::parallel::remove_copy_if(par, a.begin(),
+        a.end(), c.begin(), [](int bar) { return bar % 2 != 1; });
     auto p_remove_copy =
-        remove_copy(execution::par, a.begin(), a.end(), d.begin(), 0);
+        hpx::parallel::remove_copy(par, a.begin(), a.end(), d.begin(), 0);
 
     HPX_UNUSED(p_copy_if);
     HPX_UNUSED(p_remove_copy_if);
@@ -109,19 +109,19 @@ void print(std::vector<int> const& result, std::vector<int> const& correct)
 
 void test_async_one(std::vector<int> a)
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
     typedef std::vector<int>::iterator Iter;
     typedef hpx::future<std::pair<Iter, Iter>> Fut_Iter;
     std::size_t n = a.size();
     std::vector<int> b(n), c(n), d(n);
     std::vector<int> b_ans(n), c_ans(n), d_ans(n);
 
-    auto f_copy_if = hpx::ranges::copy_if(execution::par(execution::task),
-        a.begin(), a.end(), b.begin(), [](int bar) { return bar % 2 == 1; });
-    auto f_remove_copy_if = remove_copy_if(execution::par(execution::task),
-        a.begin(), a.end(), c.begin(), [](int bar) { return bar % 2 != 1; });
-    auto f_remove_copy = remove_copy(
-        execution::par(execution::task), a.begin(), a.end(), d.begin(), 0);
+    auto f_copy_if = hpx::ranges::copy_if(par(task), a.begin(), a.end(),
+        b.begin(), [](int bar) { return bar % 2 == 1; });
+    auto f_remove_copy_if = hpx::parallel::remove_copy_if(par(task), a.begin(),
+        a.end(), c.begin(), [](int bar) { return bar % 2 != 1; });
+    auto f_remove_copy =
+        hpx::parallel::remove_copy(par(task), a.begin(), a.end(), d.begin(), 0);
 
     std::copy_if(a.begin(), a.end(), b_ans.begin(),
         [](int bar) { return bar % 2 == 1; });

--- a/libs/parallelism/algorithms/tests/regressions/search_zerolength.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/search_zerolength.cpp
@@ -15,10 +15,10 @@
 
 void search_zero_dist_test()
 {
+    using hpx::execution::par;
+    using hpx::execution::seq;
+    using hpx::execution::task;
     using hpx::parallel::search;
-    using hpx::parallel::execution::par;
-    using hpx::parallel::execution::seq;
-    using hpx::parallel::execution::task;
 
     typedef std::vector<int>::iterator iterator;
 

--- a/libs/parallelism/algorithms/tests/regressions/set_operations_3442.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/set_operations_3442.cpp
@@ -21,9 +21,8 @@ void set_difference_small_test(int rounds)
 
     while (--rounds)
     {
-        hpx::parallel::set_difference(hpx::parallel::execution::par,
-            set_a.begin(), set_a.end(), set_b.begin(), set_b.end(),
-            a_minus_b.begin());
+        hpx::parallel::set_difference(hpx::execution::par, set_a.begin(),
+            set_a.end(), set_b.begin(), set_b.end(), a_minus_b.begin());
         HPX_TEST(perfect == a_minus_b);
     }
 }
@@ -44,9 +43,8 @@ void set_difference_medium_test(int rounds)
 
     while (--rounds)
     {
-        hpx::parallel::set_difference(hpx::parallel::execution::par,
-            set_a.begin(), set_a.end(), set_b.begin(), set_b.end(),
-            a_minus_b.begin());
+        hpx::parallel::set_difference(hpx::execution::par, set_a.begin(),
+            set_a.end(), set_b.begin(), set_b.end(), a_minus_b.begin());
         HPX_TEST(perfect == a_minus_b);
     }
 }
@@ -68,9 +66,8 @@ void set_difference_large_test(int rounds)
 
     while (--rounds)
     {
-        hpx::parallel::set_difference(hpx::parallel::execution::par,
-            set_a.begin(), set_a.end(), set_b.begin(), set_b.end(),
-            a_minus_b.begin());
+        hpx::parallel::set_difference(hpx::execution::par, set_a.begin(),
+            set_a.end(), set_b.begin(), set_b.end(), a_minus_b.begin());
         HPX_TEST(perfect == a_minus_b);
     }
 }
@@ -94,9 +91,8 @@ void set_intersection_small_test(int rounds)
 
     while (--rounds)
     {
-        hpx::parallel::set_intersection(hpx::parallel::execution::par,
-            set_a.begin(), set_a.end(), set_b.begin(), set_b.end(),
-            a_and_b.begin());
+        hpx::parallel::set_intersection(hpx::execution::par, set_a.begin(),
+            set_a.end(), set_b.begin(), set_b.end(), a_and_b.begin());
         HPX_TEST(perfect == a_and_b);
     }
 }
@@ -117,9 +113,8 @@ void set_intersection_medium_test(int rounds)
 
     while (--rounds)
     {
-        hpx::parallel::set_intersection(hpx::parallel::execution::par,
-            set_a.begin(), set_a.end(), set_b.begin(), set_b.end(),
-            a_and_b.begin());
+        hpx::parallel::set_intersection(hpx::execution::par, set_a.begin(),
+            set_a.end(), set_b.begin(), set_b.end(), a_and_b.begin());
         HPX_TEST(perfect == a_and_b);
     }
 }
@@ -141,9 +136,8 @@ void set_intersection_large_test(int rounds)
 
     while (--rounds)
     {
-        hpx::parallel::set_intersection(hpx::parallel::execution::par,
-            set_a.begin(), set_a.end(), set_b.begin(), set_b.end(),
-            a_and_b.begin());
+        hpx::parallel::set_intersection(hpx::execution::par, set_a.begin(),
+            set_a.end(), set_b.begin(), set_b.end(), a_and_b.begin());
         HPX_TEST(perfect == a_and_b);
     }
 }

--- a/libs/parallelism/algorithms/tests/regressions/stable_merge_2964.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/stable_merge_2964.cpp
@@ -128,9 +128,8 @@ int hpx_main(int argc, char** argv)
 
     // I expect a stable merge to order {3, 'a'} and {3, 'b'} before {3, 'c'}
     // because they come from the first sequence
-    hpx::parallel::merge(hpx::parallel::execution::par, a1.begin(), a1.end(),
-        a2.begin(), a2.end(), result.begin(),
-        [](ElemType const& a, ElemType const& b) {
+    hpx::parallel::merge(hpx::execution::par, a1.begin(), a1.end(), a2.begin(),
+        a2.end(), result.begin(), [](ElemType const& a, ElemType const& b) {
             return std::get<0>(a) < std::get<0>(b);
         });
     std::merge(a1.begin(), a1.end(), a2.begin(), a2.end(), solution.begin(),
@@ -141,9 +140,8 @@ int hpx_main(int argc, char** argv)
     HPX_TEST(result == solution);
 
     // Expect {3, 'c'}, {3, 'a'}, {3, 'b'} in order.
-    hpx::parallel::merge(hpx::parallel::execution::par, a2.begin(), a2.end(),
-        a1.begin(), a1.end(), result.begin(),
-        [](ElemType const& a, ElemType const& b) {
+    hpx::parallel::merge(hpx::execution::par, a2.begin(), a2.end(), a1.begin(),
+        a1.end(), result.begin(), [](ElemType const& a, ElemType const& b) {
             return std::get<0>(a) < std::get<0>(b);
         });
     std::merge(a2.begin(), a2.end(), a1.begin(), a1.end(), solution.begin(),
@@ -157,11 +155,11 @@ int hpx_main(int argc, char** argv)
     std::uniform_int_distribution<> dis(0, 9999);
     int rand_base = dis(_rand);
 
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_merge_stable(execution::seq, int(), rand_base);
-    test_merge_stable(execution::par, int(), rand_base);
-    test_merge_stable(execution::par_unseq, int(), rand_base);
+    test_merge_stable(seq, int(), rand_base);
+    test_merge_stable(par, int(), rand_base);
+    test_merge_stable(par_unseq, int(), rand_base);
 
     return hpx::finalize();
 }

--- a/libs/parallelism/algorithms/tests/regressions/static_chunker_2282.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/static_chunker_2282.cpp
@@ -18,7 +18,7 @@ int main()
     try
     {
         // this should throw as the HPX runtime has not been initialized
-        hpx::fill(hpx::parallel::execution::par, a, a + size, 1.0f);
+        hpx::fill(hpx::execution::par, a, a + size, 1.0f);
 
         // fill should have thrown
         HPX_TEST(false);

--- a/libs/parallelism/algorithms/tests/regressions/transform_inclusive_scan_4786.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/transform_inclusive_scan_4786.cpp
@@ -37,8 +37,7 @@ int main(int argc, char* argv[])
     std::vector<Integer> output(test.size());
 
     hpx::parallel::transform_inclusive_scan(
-        hpx::parallel::execution::par, test.cbegin(), test.cend(),
-        output.begin(),
+        hpx::execution::par, test.cbegin(), test.cend(), output.begin(),
         [](Integer acc, Integer xs) -> Integer {
             return Integer{acc.integer + xs.integer};
         },

--- a/libs/parallelism/algorithms/tests/regressions/transform_inclusive_scan_4787.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/transform_inclusive_scan_4787.cpp
@@ -31,8 +31,7 @@ int main(int argc, char* argv[])
     std::vector<Elem> output(test.size());
 
     hpx::parallel::transform_inclusive_scan(
-        hpx::parallel::execution::par, test.cbegin(), test.cend(),
-        output.begin(),
+        hpx::execution::par, test.cbegin(), test.cend(), output.begin(),
         [](Elem left, Elem right) -> Elem {
             if (right.begin)
             {

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentdifference.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentdifference.cpp
@@ -64,13 +64,13 @@ void test_adjacent_difference_async(ExPolicy p)
 
 void adjacent_difference_test()
 {
-    using namespace hpx::parallel;
-    test_adjacent_difference(execution::seq);
-    test_adjacent_difference(execution::par);
-    test_adjacent_difference(execution::par_unseq);
+    using namespace hpx::execution;
+    test_adjacent_difference(seq);
+    test_adjacent_difference(par);
+    test_adjacent_difference(par_unseq);
 
-    test_adjacent_difference_async(execution::seq(execution::task));
-    test_adjacent_difference_async(execution::par(execution::task));
+    test_adjacent_difference_async(seq(task));
+    test_adjacent_difference_async(par(task));
 }
 
 int hpx_main(hpx::program_options::variables_map& vm)

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentdifference_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentdifference_bad_alloc.cpp
@@ -97,18 +97,16 @@ void test_adjacent_difference_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_adjacent_difference_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_adjacent_difference_bad_alloc(execution::seq, IteratorTag());
-    test_adjacent_difference_bad_alloc(execution::par, IteratorTag());
+    test_adjacent_difference_bad_alloc(seq, IteratorTag());
+    test_adjacent_difference_bad_alloc(par, IteratorTag());
 
-    test_adjacent_difference_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_adjacent_difference_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_adjacent_difference_bad_alloc_async(seq(task), IteratorTag());
+    test_adjacent_difference_bad_alloc_async(par(task), IteratorTag());
 }
 
 void adjacent_difference_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentdifference_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentdifference_exception.cpp
@@ -100,18 +100,16 @@ void test_adjacent_difference_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_adjacent_difference_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_adjacent_difference_exception(execution::seq, IteratorTag());
-    test_adjacent_difference_exception(execution::par, IteratorTag());
+    test_adjacent_difference_exception(seq, IteratorTag());
+    test_adjacent_difference_exception(par, IteratorTag());
 
-    test_adjacent_difference_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_adjacent_difference_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_adjacent_difference_exception_async(seq(task), IteratorTag());
+    test_adjacent_difference_exception_async(par(task), IteratorTag());
 }
 
 void adjacent_difference_exception_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind.cpp
@@ -79,13 +79,13 @@ void test_adjacent_find_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_adjacent_find()
 {
-    using namespace hpx::parallel;
-    test_adjacent_find(execution::seq, IteratorTag());
-    test_adjacent_find(execution::par, IteratorTag());
-    test_adjacent_find(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_adjacent_find(seq, IteratorTag());
+    test_adjacent_find(par, IteratorTag());
+    test_adjacent_find(par_unseq, IteratorTag());
 
-    test_adjacent_find_async(execution::seq(execution::task), IteratorTag());
-    test_adjacent_find_async(execution::par(execution::task), IteratorTag());
+    test_adjacent_find_async(seq(task), IteratorTag());
+    test_adjacent_find_async(par(task), IteratorTag());
 }
 
 void adjacent_find_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_bad_alloc.cpp
@@ -98,18 +98,16 @@ void test_adjacent_find_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_adjacent_find_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_adjacent_find_bad_alloc(execution::seq, IteratorTag());
-    test_adjacent_find_bad_alloc(execution::par, IteratorTag());
+    test_adjacent_find_bad_alloc(seq, IteratorTag());
+    test_adjacent_find_bad_alloc(par, IteratorTag());
 
-    test_adjacent_find_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_adjacent_find_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_adjacent_find_bad_alloc_async(seq(task), IteratorTag());
+    test_adjacent_find_bad_alloc_async(par(task), IteratorTag());
 }
 
 void adjacent_find_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_binary.cpp
@@ -81,13 +81,13 @@ void test_adjacent_find_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_adjacent_find()
 {
-    using namespace hpx::parallel;
-    test_adjacent_find(execution::seq, IteratorTag());
-    test_adjacent_find(execution::par, IteratorTag());
-    test_adjacent_find(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_adjacent_find(seq, IteratorTag());
+    test_adjacent_find(par, IteratorTag());
+    test_adjacent_find(par_unseq, IteratorTag());
 
-    test_adjacent_find_async(execution::seq(execution::task), IteratorTag());
-    test_adjacent_find_async(execution::par(execution::task), IteratorTag());
+    test_adjacent_find_async(seq(task), IteratorTag());
+    test_adjacent_find_async(par(task), IteratorTag());
 }
 
 void adjacent_find_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_binary_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_binary_bad_alloc.cpp
@@ -98,18 +98,16 @@ void test_adjacent_find_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_adjacent_find_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_adjacent_find_bad_alloc(execution::seq, IteratorTag());
-    test_adjacent_find_bad_alloc(execution::par, IteratorTag());
+    test_adjacent_find_bad_alloc(seq, IteratorTag());
+    test_adjacent_find_bad_alloc(par, IteratorTag());
 
-    test_adjacent_find_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_adjacent_find_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_adjacent_find_bad_alloc_async(seq(task), IteratorTag());
+    test_adjacent_find_bad_alloc_async(par(task), IteratorTag());
 }
 
 void adjacent_find_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_binary_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_binary_exception.cpp
@@ -101,18 +101,16 @@ void test_adjacent_find_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_adjacent_find_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_adjacent_find_exception(execution::seq, IteratorTag());
-    test_adjacent_find_exception(execution::par, IteratorTag());
+    test_adjacent_find_exception(seq, IteratorTag());
+    test_adjacent_find_exception(par, IteratorTag());
 
-    test_adjacent_find_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_adjacent_find_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_adjacent_find_exception_async(seq(task), IteratorTag());
+    test_adjacent_find_exception_async(par(task), IteratorTag());
 }
 
 void adjacent_find_exception_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_exception.cpp
@@ -101,18 +101,16 @@ void test_adjacent_find_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_adjacent_find_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_adjacent_find_exception(execution::seq, IteratorTag());
-    test_adjacent_find_exception(execution::par, IteratorTag());
+    test_adjacent_find_exception(seq, IteratorTag());
+    test_adjacent_find_exception(par, IteratorTag());
 
-    test_adjacent_find_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_adjacent_find_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_adjacent_find_exception_async(seq(task), IteratorTag());
+    test_adjacent_find_exception_async(par(task), IteratorTag());
 }
 
 void adjacent_find_exception_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/all_of.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/all_of.cpp
@@ -185,36 +185,34 @@ void test_all_of()
             return !static_cast<bool>(x);
         }
     };
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_all_of(IteratorTag());
     test_all_of_ranges_seq(IteratorTag(), proj());
 
-    test_all_of(execution::seq, IteratorTag());
-    test_all_of(execution::par, IteratorTag());
-    test_all_of(execution::par_unseq, IteratorTag());
+    test_all_of(seq, IteratorTag());
+    test_all_of(par, IteratorTag());
+    test_all_of(par_unseq, IteratorTag());
 
-    test_all_of_ranges(execution::seq, IteratorTag(), proj());
-    test_all_of_ranges(execution::par, IteratorTag(), proj());
-    test_all_of_ranges(execution::par_unseq, IteratorTag(), proj());
+    test_all_of_ranges(seq, IteratorTag(), proj());
+    test_all_of_ranges(par, IteratorTag(), proj());
+    test_all_of_ranges(par_unseq, IteratorTag(), proj());
 
-    test_all_of_async(execution::seq(execution::task), IteratorTag());
-    test_all_of_async(execution::par(execution::task), IteratorTag());
+    test_all_of_async(seq(task), IteratorTag());
+    test_all_of_async(par(task), IteratorTag());
 
-    test_all_of_ranges_async(
-        execution::seq(execution::task), IteratorTag(), proj());
-    test_all_of_ranges_async(
-        execution::par(execution::task), IteratorTag(), proj());
+    test_all_of_ranges_async(seq(task), IteratorTag(), proj());
+    test_all_of_ranges_async(par(task), IteratorTag(), proj());
 }
 
 // template <typename IteratorTag>
 // void test_all_of_exec()
 // {
-//     using namespace hpx::parallel;
+//     using namespace hpx::execution;
 //
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_all_of(execution::par(exec), IteratorTag());
+//         test_all_of(par(exec), IteratorTag());
 //     }
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
@@ -223,7 +221,7 @@ void test_all_of()
 //
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_all_of(execution_policy(execution::par(exec)), IteratorTag());
+//         test_all_of(execution_policy(par(exec)), IteratorTag());
 //     }
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
@@ -303,9 +301,8 @@ void test_all_of_exception(IteratorTag)
         catch (hpx::exception_list const& e)
         {
             caught_exception = true;
-            test::test_num_exceptions<
-                hpx::parallel::execution::sequenced_policy,
-                IteratorTag>::call(hpx::parallel::execution::seq, e);
+            test::test_num_exceptions<hpx::execution::sequenced_policy,
+                IteratorTag>::call(hpx::execution::seq, e);
         }
         catch (...)
         {
@@ -359,18 +356,18 @@ void test_all_of_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_all_of_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_all_of_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_all_of_exception(execution::seq, IteratorTag());
-    test_all_of_exception(execution::par, IteratorTag());
+    test_all_of_exception(seq, IteratorTag());
+    test_all_of_exception(par, IteratorTag());
 
-    test_all_of_exception_async(execution::seq(execution::task), IteratorTag());
-    test_all_of_exception_async(execution::par(execution::task), IteratorTag());
+    test_all_of_exception_async(seq(task), IteratorTag());
+    test_all_of_exception_async(par(task), IteratorTag());
 }
 
 void all_of_exception_test()
@@ -458,16 +455,16 @@ void test_all_of_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_all_of_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_all_of_bad_alloc(execution::seq, IteratorTag());
-    test_all_of_bad_alloc(execution::par, IteratorTag());
+    test_all_of_bad_alloc(seq, IteratorTag());
+    test_all_of_bad_alloc(par, IteratorTag());
 
-    test_all_of_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_all_of_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_all_of_bad_alloc_async(seq(task), IteratorTag());
+    test_all_of_bad_alloc_async(par(task), IteratorTag());
 }
 
 void all_of_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/any_of.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/any_of.cpp
@@ -185,36 +185,34 @@ void test_any_of()
             return !static_cast<bool>(x);
         }
     };
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_any_of(IteratorTag());
     test_any_of_ranges_seq(IteratorTag(), proj());
 
-    test_any_of(execution::seq, IteratorTag());
-    test_any_of(execution::par, IteratorTag());
-    test_any_of(execution::par_unseq, IteratorTag());
+    test_any_of(seq, IteratorTag());
+    test_any_of(par, IteratorTag());
+    test_any_of(par_unseq, IteratorTag());
 
-    test_any_of_ranges(execution::seq, IteratorTag(), proj());
-    test_any_of_ranges(execution::par, IteratorTag(), proj());
-    test_any_of_ranges(execution::par_unseq, IteratorTag(), proj());
+    test_any_of_ranges(seq, IteratorTag(), proj());
+    test_any_of_ranges(par, IteratorTag(), proj());
+    test_any_of_ranges(par_unseq, IteratorTag(), proj());
 
-    test_any_of_async(execution::seq(execution::task), IteratorTag());
-    test_any_of_async(execution::par(execution::task), IteratorTag());
+    test_any_of_async(seq(task), IteratorTag());
+    test_any_of_async(par(task), IteratorTag());
 
-    test_any_of_ranges_async(
-        execution::seq(execution::task), IteratorTag(), proj());
-    test_any_of_ranges_async(
-        execution::par(execution::task), IteratorTag(), proj());
+    test_any_of_ranges_async(seq(task), IteratorTag(), proj());
+    test_any_of_ranges_async(par(task), IteratorTag(), proj());
 }
 
 // template <typename IteratorTag>
 // void test_any_of_exec()
 // {
-//     using namespace hpx::parallel;
+//     using namespace hpx::execution;
 //
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_any_of(execution::par(exec), IteratorTag());
+//         test_any_of(par(exec), IteratorTag());
 //     }
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
@@ -223,7 +221,7 @@ void test_any_of()
 //
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_any_of(execution_policy(execution::par(exec)), IteratorTag());
+//         test_any_of(execution_policy(par(exec)), IteratorTag());
 //     }
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
@@ -263,9 +261,8 @@ void test_any_of_exception(IteratorTag)
         catch (hpx::exception_list const& e)
         {
             caught_exception = true;
-            test::test_num_exceptions<
-                hpx::parallel::execution::sequenced_policy,
-                IteratorTag>::call(hpx::parallel::execution::seq, e);
+            test::test_num_exceptions<hpx::execution::sequenced_policy,
+                IteratorTag>::call(hpx::execution::seq, e);
         }
         catch (...)
         {
@@ -359,18 +356,18 @@ void test_any_of_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_any_of_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_any_of_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_any_of_exception(execution::seq, IteratorTag());
-    test_any_of_exception(execution::par, IteratorTag());
+    test_any_of_exception(seq, IteratorTag());
+    test_any_of_exception(par, IteratorTag());
 
-    test_any_of_exception_async(execution::seq(execution::task), IteratorTag());
-    test_any_of_exception_async(execution::par(execution::task), IteratorTag());
+    test_any_of_exception_async(seq(task), IteratorTag());
+    test_any_of_exception_async(par(task), IteratorTag());
 }
 
 void any_of_exception_test()
@@ -458,16 +455,16 @@ void test_any_of_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_any_of_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_any_of_bad_alloc(execution::seq, IteratorTag());
-    test_any_of_bad_alloc(execution::par, IteratorTag());
+    test_any_of_bad_alloc(seq, IteratorTag());
+    test_any_of_bad_alloc(par, IteratorTag());
 
-    test_any_of_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_any_of_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_any_of_bad_alloc_async(seq(task), IteratorTag());
+    test_any_of_bad_alloc_async(par(task), IteratorTag());
 }
 
 void any_of_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/copy.cpp
@@ -97,16 +97,16 @@ void test_copy_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_copy()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_copy(IteratorTag());
 
-    test_copy(execution::seq, IteratorTag());
-    test_copy(execution::par, IteratorTag());
-    test_copy(execution::par_unseq, IteratorTag());
+    test_copy(seq, IteratorTag());
+    test_copy(par, IteratorTag());
+    test_copy(par_unseq, IteratorTag());
 
-    test_copy_async(execution::seq(execution::task), IteratorTag());
-    test_copy_async(execution::par(execution::task), IteratorTag());
+    test_copy_async(seq(task), IteratorTag());
+    test_copy_async(par(task), IteratorTag());
 }
 
 void copy_test()
@@ -138,8 +138,8 @@ void test_copy_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -227,18 +227,18 @@ void test_copy_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_copy_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_copy_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_copy_exception(execution::seq, IteratorTag());
-    test_copy_exception(execution::par, IteratorTag());
+    test_copy_exception(seq, IteratorTag());
+    test_copy_exception(par, IteratorTag());
 
-    test_copy_exception_async(execution::seq(execution::task), IteratorTag());
-    test_copy_exception_async(execution::par(execution::task), IteratorTag());
+    test_copy_exception_async(seq(task), IteratorTag());
+    test_copy_exception_async(par(task), IteratorTag());
 }
 
 void copy_exception_test()
@@ -322,16 +322,16 @@ void test_copy_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_copy_bad_alloc()
 {
-    using namespace hpx::parallel;
-
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_copy_bad_alloc(execution::seq, IteratorTag());
-    test_copy_bad_alloc(execution::par, IteratorTag());
+    test_copy_bad_alloc(hpx::execution::seq, IteratorTag());
+    test_copy_bad_alloc(hpx::execution::par, IteratorTag());
 
-    test_copy_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_copy_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_copy_bad_alloc_async(
+        hpx::execution::seq(hpx::execution::task), IteratorTag());
+    test_copy_bad_alloc_async(
+        hpx::execution::par(hpx::execution::task), IteratorTag());
 }
 
 void copy_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/copyif_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/copyif_bad_alloc.cpp
@@ -97,18 +97,16 @@ void test_copy_if_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_copy_if_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_copy_if_bad_alloc(execution::seq, IteratorTag());
-    test_copy_if_bad_alloc(execution::par, IteratorTag());
+    test_copy_if_bad_alloc(seq, IteratorTag());
+    test_copy_if_bad_alloc(par, IteratorTag());
 
-    test_copy_if_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_copy_if_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_copy_if_bad_alloc_async(seq(task), IteratorTag());
+    test_copy_if_bad_alloc_async(par(task), IteratorTag());
 }
 
 void copy_if_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/copyif_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/copyif_exception.cpp
@@ -45,8 +45,8 @@ void test_copy_if_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -133,20 +133,18 @@ void test_copy_if_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_copy_if_exception()
 {
-    using namespace hpx::parallel;
-
     test_copy_if_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_copy_if_exception(execution::seq, IteratorTag());
-    test_copy_if_exception(execution::par, IteratorTag());
+    test_copy_if_exception(hpx::execution::seq, IteratorTag());
+    test_copy_if_exception(hpx::execution::par, IteratorTag());
 
     test_copy_if_exception_async(
-        execution::seq(execution::task), IteratorTag());
+        hpx::execution::seq(hpx::execution::task), IteratorTag());
     test_copy_if_exception_async(
-        execution::par(execution::task), IteratorTag());
+        hpx::execution::par(hpx::execution::task), IteratorTag());
 }
 
 void copy_if_exception_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/copyif_forward.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/copyif_forward.cpp
@@ -131,16 +131,14 @@ void test_copy_if_async(ExPolicy&& p)
 
 void test_copy_if()
 {
-    using namespace hpx::parallel;
-
     test_copy_if_seq();
 
-    test_copy_if(execution::seq);
-    test_copy_if(execution::par);
-    test_copy_if(execution::par_unseq);
+    test_copy_if(hpx::execution::seq);
+    test_copy_if(hpx::execution::par);
+    test_copy_if(hpx::execution::par_unseq);
 
-    test_copy_if_async(execution::seq(execution::task));
-    test_copy_if_async(execution::par(execution::task));
+    test_copy_if_async(hpx::execution::seq(hpx::execution::task));
+    test_copy_if_async(hpx::execution::par(hpx::execution::task));
 }
 
 int hpx_main(hpx::program_options::variables_map& vm)

--- a/libs/parallelism/algorithms/tests/unit/algorithms/copyif_random.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/copyif_random.cpp
@@ -132,16 +132,14 @@ void test_copy_if_async(ExPolicy&& p)
 
 void test_copy_if()
 {
-    using namespace hpx::parallel;
-
     test_copy_if_seq();
 
-    test_copy_if(execution::seq);
-    test_copy_if(execution::par);
-    test_copy_if(execution::par_unseq);
+    test_copy_if(hpx::execution::seq);
+    test_copy_if(hpx::execution::par);
+    test_copy_if(hpx::execution::par_unseq);
 
-    test_copy_if_async(execution::seq(execution::task));
-    test_copy_if_async(execution::par(execution::task));
+    test_copy_if_async(hpx::execution::seq(hpx::execution::task));
+    test_copy_if_async(hpx::execution::par(hpx::execution::task));
 }
 
 int hpx_main(hpx::program_options::variables_map& vm)

--- a/libs/parallelism/algorithms/tests/unit/algorithms/copyn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/copyn.cpp
@@ -97,16 +97,14 @@ void test_copy_n_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_copy_n()
 {
-    using namespace hpx::parallel;
-
     test_copy_n(IteratorTag());
 
-    test_copy_n(execution::seq, IteratorTag());
-    test_copy_n(execution::par, IteratorTag());
-    test_copy_n(execution::par_unseq, IteratorTag());
+    test_copy_n(hpx::execution::seq, IteratorTag());
+    test_copy_n(hpx::execution::par, IteratorTag());
+    test_copy_n(hpx::execution::par_unseq, IteratorTag());
 
-    test_copy_n_async(execution::seq(execution::task), IteratorTag());
-    test_copy_n_async(execution::par(execution::task), IteratorTag());
+    test_copy_n_async(hpx::execution::seq(hpx::execution::task), IteratorTag());
+    test_copy_n_async(hpx::execution::par(hpx::execution::task), IteratorTag());
 }
 
 void n_copy_test()
@@ -138,8 +136,8 @@ void test_copy_n_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -228,18 +226,18 @@ void test_copy_n_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_copy_n_exception()
 {
-    using namespace hpx::parallel;
-
     test_copy_n_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_copy_n_exception(execution::seq, IteratorTag());
-    test_copy_n_exception(execution::par, IteratorTag());
+    test_copy_n_exception(hpx::execution::seq, IteratorTag());
+    test_copy_n_exception(hpx::execution::par, IteratorTag());
 
-    test_copy_n_exception_async(execution::seq(execution::task), IteratorTag());
-    test_copy_n_exception_async(execution::par(execution::task), IteratorTag());
+    test_copy_n_exception_async(
+        hpx::execution::seq(hpx::execution::task), IteratorTag());
+    test_copy_n_exception_async(
+        hpx::execution::par(hpx::execution::task), IteratorTag());
 }
 
 void copy_n_exception_test()
@@ -325,16 +323,16 @@ void test_copy_n_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_copy_n_bad_alloc()
 {
-    using namespace hpx::parallel;
-
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_copy_n_bad_alloc(execution::seq, IteratorTag());
-    test_copy_n_bad_alloc(execution::par, IteratorTag());
+    test_copy_n_bad_alloc(hpx::execution::seq, IteratorTag());
+    test_copy_n_bad_alloc(hpx::execution::par, IteratorTag());
 
-    test_copy_n_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_copy_n_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_copy_n_bad_alloc_async(
+        hpx::execution::seq(hpx::execution::task), IteratorTag());
+    test_copy_n_bad_alloc_async(
+        hpx::execution::par(hpx::execution::task), IteratorTag());
 }
 
 void copy_n_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/count.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/count.cpp
@@ -18,16 +18,14 @@
 template <typename IteratorTag>
 void test_count()
 {
-    using namespace hpx::parallel;
-
     test_count(IteratorTag());
 
-    test_count(execution::seq, IteratorTag());
-    test_count(execution::par, IteratorTag());
-    test_count(execution::par_unseq, IteratorTag());
+    test_count(hpx::execution::seq, IteratorTag());
+    test_count(hpx::execution::par, IteratorTag());
+    test_count(hpx::execution::par_unseq, IteratorTag());
 
-    test_count_async(execution::seq(execution::task), IteratorTag());
-    test_count_async(execution::par(execution::task), IteratorTag());
+    test_count_async(hpx::execution::seq(hpx::execution::task), IteratorTag());
+    test_count_async(hpx::execution::par(hpx::execution::task), IteratorTag());
 }
 
 void count_test()
@@ -40,18 +38,18 @@ void count_test()
 template <typename IteratorTag>
 void test_count_exception()
 {
-    using namespace hpx::parallel;
-
     test_count_exception(IteratorTag());
 
     // If the execution policy object is of type parallel_unsequenced_policy,
     // std::terminate shall be called. Therefore we do not test exceptions
     // with a vector execution policy.
-    test_count_exception(execution::seq, IteratorTag());
-    test_count_exception(execution::par, IteratorTag());
+    test_count_exception(hpx::execution::seq, IteratorTag());
+    test_count_exception(hpx::execution::par, IteratorTag());
 
-    test_count_exception_async(execution::seq(execution::task), IteratorTag());
-    test_count_exception_async(execution::par(execution::task), IteratorTag());
+    test_count_exception_async(
+        hpx::execution::seq(hpx::execution::task), IteratorTag());
+    test_count_exception_async(
+        hpx::execution::par(hpx::execution::task), IteratorTag());
 }
 
 void count_exception_test()
@@ -64,16 +62,16 @@ void count_exception_test()
 template <typename IteratorTag>
 void test_count_bad_alloc()
 {
-    using namespace hpx::parallel;
-
     // If the execution policy object is of type parallel_unsequenced_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_count_bad_alloc(execution::seq, IteratorTag());
-    test_count_bad_alloc(execution::par, IteratorTag());
+    test_count_bad_alloc(hpx::execution::seq, IteratorTag());
+    test_count_bad_alloc(hpx::execution::par, IteratorTag());
 
-    test_count_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_count_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_count_bad_alloc_async(
+        hpx::execution::seq(hpx::execution::task), IteratorTag());
+    test_count_bad_alloc_async(
+        hpx::execution::par(hpx::execution::task), IteratorTag());
 }
 
 void count_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/count_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/count_tests.hpp
@@ -115,8 +115,8 @@ void test_count_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {

--- a/libs/parallelism/algorithms/tests/unit/algorithms/countif.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/countif.cpp
@@ -17,16 +17,16 @@
 template <typename IteratorTag>
 void test_count_if()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_count_if(IteratorTag());
 
-    test_count_if(execution::seq, IteratorTag());
-    test_count_if(execution::par, IteratorTag());
-    test_count_if(execution::par_unseq, IteratorTag());
+    test_count_if(seq, IteratorTag());
+    test_count_if(par, IteratorTag());
+    test_count_if(par_unseq, IteratorTag());
 
-    test_count_if_async(execution::seq(execution::task), IteratorTag());
-    test_count_if_async(execution::par(execution::task), IteratorTag());
+    test_count_if_async(seq(task), IteratorTag());
+    test_count_if_async(par(task), IteratorTag());
 }
 
 void count_if_test()
@@ -39,20 +39,18 @@ void count_if_test()
 template <typename IteratorTag>
 void test_count_if_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_count_if_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_count_if_exception(execution::seq, IteratorTag());
-    test_count_if_exception(execution::par, IteratorTag());
+    test_count_if_exception(seq, IteratorTag());
+    test_count_if_exception(par, IteratorTag());
 
-    test_count_if_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_count_if_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_count_if_exception_async(seq(task), IteratorTag());
+    test_count_if_exception_async(par(task), IteratorTag());
 }
 
 void count_if_exception_test()
@@ -65,18 +63,16 @@ void count_if_exception_test()
 template <typename IteratorTag>
 void test_count_if_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_count_if_bad_alloc(execution::seq, IteratorTag());
-    test_count_if_bad_alloc(execution::par, IteratorTag());
+    test_count_if_bad_alloc(seq, IteratorTag());
+    test_count_if_bad_alloc(par, IteratorTag());
 
-    test_count_if_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_count_if_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_count_if_bad_alloc_async(seq(task), IteratorTag());
+    test_count_if_bad_alloc_async(par(task), IteratorTag());
 }
 
 void count_if_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/countif_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/countif_tests.hpp
@@ -121,8 +121,8 @@ void test_count_if_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {

--- a/libs/parallelism/algorithms/tests/unit/algorithms/destroy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/destroy.cpp
@@ -17,16 +17,16 @@
 template <typename IteratorTag>
 void test_destroy()
 {
-    using namespace hpx::parallel;
-
     test_destroy(IteratorTag());
 
-    test_destroy(execution::seq, IteratorTag());
-    test_destroy(execution::par, IteratorTag());
-    test_destroy(execution::par_unseq, IteratorTag());
+    test_destroy(hpx::execution::seq, IteratorTag());
+    test_destroy(hpx::execution::par, IteratorTag());
+    test_destroy(hpx::execution::par_unseq, IteratorTag());
 
-    test_destroy_async(execution::seq(execution::task), IteratorTag());
-    test_destroy_async(execution::par(execution::task), IteratorTag());
+    test_destroy_async(
+        hpx::execution::seq(hpx::execution::task), IteratorTag());
+    test_destroy_async(
+        hpx::execution::par(hpx::execution::task), IteratorTag());
 }
 
 void destroy_test()
@@ -39,20 +39,18 @@ void destroy_test()
 template <typename IteratorTag>
 void test_destroy_exception()
 {
-    using namespace hpx::parallel;
-
     test_destroy_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_destroy_exception(execution::seq, IteratorTag());
-    test_destroy_exception(execution::par, IteratorTag());
+    test_destroy_exception(hpx::execution::seq, IteratorTag());
+    test_destroy_exception(hpx::execution::par, IteratorTag());
 
     test_destroy_exception_async(
-        execution::seq(execution::task), IteratorTag());
+        hpx::execution::seq(hpx::execution::task), IteratorTag());
     test_destroy_exception_async(
-        execution::par(execution::task), IteratorTag());
+        hpx::execution::par(hpx::execution::task), IteratorTag());
 }
 
 void destroy_exception_test()
@@ -65,18 +63,16 @@ void destroy_exception_test()
 template <typename IteratorTag>
 void test_destroy_bad_alloc()
 {
-    using namespace hpx::parallel;
-
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_destroy_bad_alloc(execution::seq, IteratorTag());
-    test_destroy_bad_alloc(execution::par, IteratorTag());
+    test_destroy_bad_alloc(hpx::execution::seq, IteratorTag());
+    test_destroy_bad_alloc(hpx::execution::par, IteratorTag());
 
     test_destroy_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
+        hpx::execution::seq(hpx::execution::task), IteratorTag());
     test_destroy_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+        hpx::execution::par(hpx::execution::task), IteratorTag());
 }
 
 void destroy_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/destroy_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/destroy_tests.hpp
@@ -162,8 +162,8 @@ void test_destroy_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {

--- a/libs/parallelism/algorithms/tests/unit/algorithms/destroyn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/destroyn.cpp
@@ -123,16 +123,16 @@ void test_destroy_n_async(ExPolicy&& policy, IteratorTag)
 template <typename IteratorTag>
 void test_destroy_n()
 {
-    using namespace hpx::parallel;
-
     test_destroy_n(IteratorTag());
 
-    test_destroy_n(execution::seq, IteratorTag());
-    test_destroy_n(execution::par, IteratorTag());
-    test_destroy_n(execution::par_unseq, IteratorTag());
+    test_destroy_n(hpx::execution::seq, IteratorTag());
+    test_destroy_n(hpx::execution::par, IteratorTag());
+    test_destroy_n(hpx::execution::par_unseq, IteratorTag());
 
-    test_destroy_n_async(execution::seq(execution::task), IteratorTag());
-    test_destroy_n_async(execution::par(execution::task), IteratorTag());
+    test_destroy_n_async(
+        hpx::execution::seq(hpx::execution::task), IteratorTag());
+    test_destroy_n_async(
+        hpx::execution::par(hpx::execution::task), IteratorTag());
 }
 
 void destroy_n_test()
@@ -180,8 +180,8 @@ void test_destroy_n_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -314,20 +314,18 @@ void test_destroy_n_exception_async(ExPolicy&& policy, IteratorTag)
 template <typename IteratorTag>
 void test_destroy_n_exception()
 {
-    using namespace hpx::parallel;
-
     test_destroy_n_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_destroy_n_exception(execution::seq, IteratorTag());
-    test_destroy_n_exception(execution::par, IteratorTag());
+    test_destroy_n_exception(hpx::execution::seq, IteratorTag());
+    test_destroy_n_exception(hpx::execution::par, IteratorTag());
 
     test_destroy_n_exception_async(
-        execution::seq(execution::task), IteratorTag());
+        hpx::execution::seq(hpx::execution::task), IteratorTag());
     test_destroy_n_exception_async(
-        execution::par(execution::task), IteratorTag());
+        hpx::execution::par(hpx::execution::task), IteratorTag());
 }
 
 void destroy_n_exception_test()
@@ -455,18 +453,16 @@ void test_destroy_n_bad_alloc_async(ExPolicy&& policy, IteratorTag)
 template <typename IteratorTag>
 void test_destroy_n_bad_alloc()
 {
-    using namespace hpx::parallel;
-
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_destroy_n_bad_alloc(execution::seq, IteratorTag());
-    test_destroy_n_bad_alloc(execution::par, IteratorTag());
+    test_destroy_n_bad_alloc(hpx::execution::seq, IteratorTag());
+    test_destroy_n_bad_alloc(hpx::execution::par, IteratorTag());
 
     test_destroy_n_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
+        hpx::execution::seq(hpx::execution::task), IteratorTag());
     test_destroy_n_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+        hpx::execution::par(hpx::execution::task), IteratorTag());
 }
 
 void destroy_n_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_parallel_stable_sort.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_parallel_stable_sort.cpp
@@ -27,7 +27,7 @@
 #endif
 
 using namespace hpx::parallel::v1::detail;
-using hpx::parallel::execution::parallel_executor;
+using hpx::execution::parallel_executor;
 using hpx::parallel::util::range;
 
 struct xk

--- a/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_sample_sort.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_sample_sort.cpp
@@ -28,7 +28,7 @@
 #endif
 
 using namespace hpx::parallel::v1::detail;
-using hpx::parallel::execution::parallel_executor;
+using hpx::execution::parallel_executor;
 using hpx::parallel::util::range;
 
 struct xk

--- a/libs/parallelism/algorithms/tests/unit/algorithms/equal.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/equal.cpp
@@ -147,16 +147,16 @@ void test_equal1_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_equal1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_equal1(IteratorTag());
 
-    test_equal1(execution::seq, IteratorTag());
-    test_equal1(execution::par, IteratorTag());
-    test_equal1(execution::par_unseq, IteratorTag());
+    test_equal1(seq, IteratorTag());
+    test_equal1(par, IteratorTag());
+    test_equal1(par_unseq, IteratorTag());
 
-    test_equal1_async(execution::seq(execution::task), IteratorTag());
-    test_equal1_async(execution::par(execution::task), IteratorTag());
+    test_equal1_async(seq(task), IteratorTag());
+    test_equal1_async(par(task), IteratorTag());
 }
 
 void equal_test1()
@@ -296,16 +296,16 @@ void test_equal2_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_equal2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_equal2(IteratorTag());
 
-    test_equal2(execution::seq, IteratorTag());
-    test_equal2(execution::par, IteratorTag());
-    test_equal2(execution::par_unseq, IteratorTag());
+    test_equal2(seq, IteratorTag());
+    test_equal2(par, IteratorTag());
+    test_equal2(par_unseq, IteratorTag());
 
-    test_equal2_async(execution::seq(execution::task), IteratorTag());
-    test_equal2_async(execution::par(execution::task), IteratorTag());
+    test_equal2_async(seq(task), IteratorTag());
+    test_equal2_async(par(task), IteratorTag());
 }
 
 void equal_test2()
@@ -341,8 +341,8 @@ void test_equal_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -436,18 +436,18 @@ void test_equal_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_equal_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_equal_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_equal_exception(execution::seq, IteratorTag());
-    test_equal_exception(execution::par, IteratorTag());
+    test_equal_exception(seq, IteratorTag());
+    test_equal_exception(par, IteratorTag());
 
-    test_equal_exception_async(execution::seq(execution::task), IteratorTag());
-    test_equal_exception_async(execution::par(execution::task), IteratorTag());
+    test_equal_exception_async(seq(task), IteratorTag());
+    test_equal_exception_async(par(task), IteratorTag());
 }
 
 void equal_exception_test()
@@ -539,16 +539,16 @@ void test_equal_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_equal_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_equal_bad_alloc(execution::seq, IteratorTag());
-    test_equal_bad_alloc(execution::par, IteratorTag());
+    test_equal_bad_alloc(seq, IteratorTag());
+    test_equal_bad_alloc(par, IteratorTag());
 
-    test_equal_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_equal_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_equal_bad_alloc_async(seq(task), IteratorTag());
+    test_equal_bad_alloc_async(par(task), IteratorTag());
 }
 
 void equal_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/equal_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/equal_binary.cpp
@@ -147,16 +147,16 @@ void test_equal_binary1_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_equal_binary1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_equal_binary1(IteratorTag());
 
-    test_equal_binary1(execution::seq, IteratorTag());
-    test_equal_binary1(execution::par, IteratorTag());
-    test_equal_binary1(execution::par_unseq, IteratorTag());
+    test_equal_binary1(seq, IteratorTag());
+    test_equal_binary1(par, IteratorTag());
+    test_equal_binary1(par_unseq, IteratorTag());
 
-    test_equal_binary1_async(execution::seq(execution::task), IteratorTag());
-    test_equal_binary1_async(execution::par(execution::task), IteratorTag());
+    test_equal_binary1_async(seq(task), IteratorTag());
+    test_equal_binary1_async(par(task), IteratorTag());
 }
 
 void equal_binary_test1()
@@ -296,16 +296,16 @@ void test_equal_binary2_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_equal_binary2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_equal_binary2(IteratorTag());
 
-    test_equal_binary2(execution::seq, IteratorTag());
-    test_equal_binary2(execution::par, IteratorTag());
-    test_equal_binary2(execution::par_unseq, IteratorTag());
+    test_equal_binary2(seq, IteratorTag());
+    test_equal_binary2(par, IteratorTag());
+    test_equal_binary2(par_unseq, IteratorTag());
 
-    test_equal_binary2_async(execution::seq(execution::task), IteratorTag());
-    test_equal_binary2_async(execution::par(execution::task), IteratorTag());
+    test_equal_binary2_async(seq(task), IteratorTag());
+    test_equal_binary2_async(par(task), IteratorTag());
 }
 
 void equal_binary_test2()
@@ -341,8 +341,8 @@ void test_equal_binary_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -436,20 +436,18 @@ void test_equal_binary_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_equal_binary_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_equal_binary_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_equal_binary_exception(execution::seq, IteratorTag());
-    test_equal_binary_exception(execution::par, IteratorTag());
+    test_equal_binary_exception(seq, IteratorTag());
+    test_equal_binary_exception(par, IteratorTag());
 
-    test_equal_binary_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_equal_binary_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_equal_binary_exception_async(seq(task), IteratorTag());
+    test_equal_binary_exception_async(par(task), IteratorTag());
 }
 
 void equal_binary_exception_test()
@@ -541,18 +539,16 @@ void test_equal_binary_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_equal_binary_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_equal_binary_bad_alloc(execution::seq, IteratorTag());
-    test_equal_binary_bad_alloc(execution::par, IteratorTag());
+    test_equal_binary_bad_alloc(seq, IteratorTag());
+    test_equal_binary_bad_alloc(par, IteratorTag());
 
-    test_equal_binary_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_equal_binary_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_equal_binary_bad_alloc_async(seq(task), IteratorTag());
+    test_equal_binary_bad_alloc_async(par(task), IteratorTag());
 }
 
 void equal_binary_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan.cpp
@@ -35,8 +35,8 @@ void exclusive_scan_benchmark()
         auto op = [](double v1, double v2) { return v1 + v2; };
 
         hpx::util::high_resolution_timer t;
-        hpx::parallel::exclusive_scan(hpx::parallel::execution::par,
-            std::begin(c), std::end(c), std::begin(d), val, op);
+        hpx::parallel::exclusive_scan(hpx::execution::par, std::begin(c),
+            std::end(c), std::begin(d), val, op);
         double elapsed = t.elapsed();
 
         // verify values
@@ -127,14 +127,14 @@ void test_exclusive_scan1_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_exclusive_scan1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_exclusive_scan1(execution::seq, IteratorTag());
-    test_exclusive_scan1(execution::par, IteratorTag());
-    test_exclusive_scan1(execution::par_unseq, IteratorTag());
+    test_exclusive_scan1(seq, IteratorTag());
+    test_exclusive_scan1(par, IteratorTag());
+    test_exclusive_scan1(par_unseq, IteratorTag());
 
-    test_exclusive_scan1_async(execution::seq(execution::task), IteratorTag());
-    test_exclusive_scan1_async(execution::par(execution::task), IteratorTag());
+    test_exclusive_scan1_async(seq(task), IteratorTag());
+    test_exclusive_scan1_async(par(task), IteratorTag());
 }
 
 void exclusive_scan_test1()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan2.cpp
@@ -70,14 +70,14 @@ void test_exclusive_scan2_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_exclusive_scan2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_exclusive_scan2(execution::seq, IteratorTag());
-    test_exclusive_scan2(execution::par, IteratorTag());
-    test_exclusive_scan2(execution::par_unseq, IteratorTag());
+    test_exclusive_scan2(seq, IteratorTag());
+    test_exclusive_scan2(par, IteratorTag());
+    test_exclusive_scan2(par_unseq, IteratorTag());
 
-    test_exclusive_scan2_async(execution::seq(execution::task), IteratorTag());
-    test_exclusive_scan2_async(execution::par(execution::task), IteratorTag());
+    test_exclusive_scan2_async(seq(task), IteratorTag());
+    test_exclusive_scan2_async(par(task), IteratorTag());
 }
 
 void exclusive_scan_test2()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_bad_alloc.cpp
@@ -96,18 +96,16 @@ void test_exclusive_scan_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_exclusive_scan_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_exclusive_scan_bad_alloc(execution::seq, IteratorTag());
-    test_exclusive_scan_bad_alloc(execution::par, IteratorTag());
+    test_exclusive_scan_bad_alloc(seq, IteratorTag());
+    test_exclusive_scan_bad_alloc(par, IteratorTag());
 
-    test_exclusive_scan_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_exclusive_scan_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_exclusive_scan_bad_alloc_async(seq(task), IteratorTag());
+    test_exclusive_scan_bad_alloc_async(par(task), IteratorTag());
 }
 
 void exclusive_scan_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_exception.cpp
@@ -98,18 +98,16 @@ void test_exclusive_scan_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_exclusive_scan_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_exclusive_scan_exception(execution::seq, IteratorTag());
-    test_exclusive_scan_exception(execution::par, IteratorTag());
+    test_exclusive_scan_exception(seq, IteratorTag());
+    test_exclusive_scan_exception(par, IteratorTag());
 
-    test_exclusive_scan_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_exclusive_scan_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_exclusive_scan_exception_async(seq(task), IteratorTag());
+    test_exclusive_scan_exception_async(par(task), IteratorTag());
 }
 
 void exclusive_scan_exception_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_validate.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_validate.cpp
@@ -48,7 +48,7 @@ template <typename ExPolicy>
 void test_exclusive_scan_validate(
     ExPolicy p, std::vector<int>& a, std::vector<int>& b)
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
     typedef std::vector<int>::iterator Iter;
 
     // test 1, fill array with numbers counting from 0, then run scan algorithm
@@ -159,17 +159,17 @@ void exclusive_scan_validate()
     std::vector<int> a, b;
     // test scan algorithms using separate array for output
     DEBUG_OUT("\nValidating separate arrays sequential");
-    test_exclusive_scan_validate(hpx::parallel::execution::seq, a, b);
+    test_exclusive_scan_validate(hpx::execution::seq, a, b);
 
     DEBUG_OUT("\nValidating separate arrays parallel");
-    test_exclusive_scan_validate(hpx::parallel::execution::par, a, b);
+    test_exclusive_scan_validate(hpx::execution::par, a, b);
 
     // test scan algorithms using same array for input and output
     DEBUG_OUT("\nValidating in_place arrays sequential ");
-    test_exclusive_scan_validate(hpx::parallel::execution::seq, a, a);
+    test_exclusive_scan_validate(hpx::execution::seq, a, a);
 
     DEBUG_OUT("\nValidating in_place arrays parallel ");
-    test_exclusive_scan_validate(hpx::parallel::execution::par, a, a);
+    test_exclusive_scan_validate(hpx::execution::par, a, a);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/algorithms/tests/unit/algorithms/fill.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/fill.cpp
@@ -92,16 +92,16 @@ void test_fill_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_fill()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_fill(IteratorTag());
 
-    test_fill(execution::seq, IteratorTag());
-    test_fill(execution::par, IteratorTag());
-    test_fill(execution::par_unseq, IteratorTag());
+    test_fill(seq, IteratorTag());
+    test_fill(par, IteratorTag());
+    test_fill(par_unseq, IteratorTag());
 
-    test_fill_async(execution::seq(execution::task), IteratorTag());
-    test_fill_async(execution::par(execution::task), IteratorTag());
+    test_fill_async(seq(task), IteratorTag());
+    test_fill_async(par(task), IteratorTag());
 }
 
 void fill_test()
@@ -131,8 +131,8 @@ void test_fill_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -217,18 +217,18 @@ void test_fill_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_fill_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_fill_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_fill_exception(execution::seq, IteratorTag());
-    test_fill_exception(execution::par, IteratorTag());
+    test_fill_exception(seq, IteratorTag());
+    test_fill_exception(par, IteratorTag());
 
-    test_fill_exception_async(execution::seq(execution::task), IteratorTag());
-    test_fill_exception_async(execution::par(execution::task), IteratorTag());
+    test_fill_exception_async(seq(task), IteratorTag());
+    test_fill_exception_async(par(task), IteratorTag());
 }
 
 void fill_exception_test()
@@ -310,16 +310,16 @@ void test_fill_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_fill_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_fill_bad_alloc(execution::seq, IteratorTag());
-    test_fill_bad_alloc(execution::par, IteratorTag());
+    test_fill_bad_alloc(seq, IteratorTag());
+    test_fill_bad_alloc(par, IteratorTag());
 
-    test_fill_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_fill_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_fill_bad_alloc_async(seq(task), IteratorTag());
+    test_fill_bad_alloc_async(par(task), IteratorTag());
 }
 
 void fill_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/filln.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/filln.cpp
@@ -92,16 +92,16 @@ void test_fill_n_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_fill_n()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_fill_n(IteratorTag());
 
-    test_fill_n(execution::seq, IteratorTag());
-    test_fill_n(execution::par, IteratorTag());
-    test_fill_n(execution::par_unseq, IteratorTag());
+    test_fill_n(seq, IteratorTag());
+    test_fill_n(par, IteratorTag());
+    test_fill_n(par_unseq, IteratorTag());
 
-    test_fill_n_async(execution::seq(execution::task), IteratorTag());
-    test_fill_n_async(execution::par(execution::task), IteratorTag());
+    test_fill_n_async(seq(task), IteratorTag());
+    test_fill_n_async(par(task), IteratorTag());
 }
 
 void fill_n_test()
@@ -131,8 +131,8 @@ void test_fill_n_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -217,18 +217,18 @@ void test_fill_n_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_fill_n_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_fill_n_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_fill_n_exception(execution::seq, IteratorTag());
-    test_fill_n_exception(execution::par, IteratorTag());
+    test_fill_n_exception(seq, IteratorTag());
+    test_fill_n_exception(par, IteratorTag());
 
-    test_fill_n_exception_async(execution::seq(execution::task), IteratorTag());
-    test_fill_n_exception_async(execution::par(execution::task), IteratorTag());
+    test_fill_n_exception_async(seq(task), IteratorTag());
+    test_fill_n_exception_async(par(task), IteratorTag());
 }
 
 void fill_n_exception_test()
@@ -310,16 +310,16 @@ void test_fill_n_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_fill_n_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_fill_n_bad_alloc(execution::seq, IteratorTag());
-    test_fill_n_bad_alloc(execution::par, IteratorTag());
+    test_fill_n_bad_alloc(seq, IteratorTag());
+    test_fill_n_bad_alloc(par, IteratorTag());
 
-    test_fill_n_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_fill_n_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_fill_n_bad_alloc_async(seq(task), IteratorTag());
+    test_fill_n_bad_alloc_async(par(task), IteratorTag());
 }
 
 void fill_n_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/find.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/find.cpp
@@ -90,16 +90,16 @@ void test_find_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find(IteratorTag());
 
-    test_find(execution::seq, IteratorTag());
-    test_find(execution::par, IteratorTag());
-    test_find(execution::par_unseq, IteratorTag());
+    test_find(seq, IteratorTag());
+    test_find(par, IteratorTag());
+    test_find(par_unseq, IteratorTag());
 
-    test_find_async(execution::seq(execution::task), IteratorTag());
-    test_find_async(execution::par(execution::task), IteratorTag());
+    test_find_async(seq(task), IteratorTag());
+    test_find_async(par(task), IteratorTag());
 }
 
 void find_test()
@@ -130,8 +130,8 @@ void test_find_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -218,18 +218,18 @@ void test_find_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_exception(execution::seq, IteratorTag());
-    test_find_exception(execution::par, IteratorTag());
+    test_find_exception(seq, IteratorTag());
+    test_find_exception(par, IteratorTag());
 
-    test_find_exception_async(execution::seq(execution::task), IteratorTag());
-    test_find_exception_async(execution::par(execution::task), IteratorTag());
+    test_find_exception_async(seq(task), IteratorTag());
+    test_find_exception_async(par(task), IteratorTag());
 }
 
 void find_exception_test()
@@ -313,16 +313,16 @@ void test_find_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_bad_alloc(execution::seq, IteratorTag());
-    test_find_bad_alloc(execution::par, IteratorTag());
+    test_find_bad_alloc(seq, IteratorTag());
+    test_find_bad_alloc(par, IteratorTag());
 
-    test_find_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_find_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_find_bad_alloc_async(seq(task), IteratorTag());
+    test_find_bad_alloc_async(par(task), IteratorTag());
 }
 
 void find_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findend.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findend.cpp
@@ -104,16 +104,16 @@ void test_find_end1_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_end1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_end1(IteratorTag());
 
-    test_find_end1(execution::seq, IteratorTag());
-    test_find_end1(execution::par, IteratorTag());
-    test_find_end1(execution::par_unseq, IteratorTag());
+    test_find_end1(seq, IteratorTag());
+    test_find_end1(par, IteratorTag());
+    test_find_end1(par_unseq, IteratorTag());
 
-    test_find_end1_async(execution::seq(execution::task), IteratorTag());
-    test_find_end1_async(execution::par(execution::task), IteratorTag());
+    test_find_end1_async(seq(task), IteratorTag());
+    test_find_end1_async(par(task), IteratorTag());
 }
 
 void find_end_test1()
@@ -207,16 +207,16 @@ void test_find_end2_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_end2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_end2(IteratorTag());
 
-    test_find_end2(execution::seq, IteratorTag());
-    test_find_end2(execution::par, IteratorTag());
-    test_find_end2(execution::par_unseq, IteratorTag());
+    test_find_end2(seq, IteratorTag());
+    test_find_end2(par, IteratorTag());
+    test_find_end2(par_unseq, IteratorTag());
 
-    test_find_end2_async(execution::seq(execution::task), IteratorTag());
-    test_find_end2_async(execution::par(execution::task), IteratorTag());
+    test_find_end2_async(seq(task), IteratorTag());
+    test_find_end2_async(par(task), IteratorTag());
 }
 
 void find_end_test2()
@@ -311,16 +311,16 @@ void test_find_end3_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_end3()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_end3(IteratorTag());
 
-    test_find_end3(execution::seq, IteratorTag());
-    test_find_end3(execution::par, IteratorTag());
-    test_find_end3(execution::par_unseq, IteratorTag());
+    test_find_end3(seq, IteratorTag());
+    test_find_end3(par, IteratorTag());
+    test_find_end3(par_unseq, IteratorTag());
 
-    test_find_end3_async(execution::seq(execution::task), IteratorTag());
-    test_find_end3_async(execution::par(execution::task), IteratorTag());
+    test_find_end3_async(seq(task), IteratorTag());
+    test_find_end3_async(par(task), IteratorTag());
 }
 
 void find_end_test3()
@@ -412,16 +412,16 @@ void test_find_end4_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_end4()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_end4(IteratorTag());
 
-    test_find_end4(execution::seq, IteratorTag());
-    test_find_end4(execution::par, IteratorTag());
-    test_find_end4(execution::par_unseq, IteratorTag());
+    test_find_end4(seq, IteratorTag());
+    test_find_end4(par, IteratorTag());
+    test_find_end4(par_unseq, IteratorTag());
 
-    test_find_end4_async(execution::seq(execution::task), IteratorTag());
-    test_find_end4_async(execution::par(execution::task), IteratorTag());
+    test_find_end4_async(seq(task), IteratorTag());
+    test_find_end4_async(par(task), IteratorTag());
 }
 
 void find_end_test4()
@@ -503,8 +503,8 @@ void test_find_end_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -560,20 +560,18 @@ void test_find_end_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_end_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_end_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_end_exception(execution::seq, IteratorTag());
-    test_find_end_exception(execution::par, IteratorTag());
+    test_find_end_exception(seq, IteratorTag());
+    test_find_end_exception(par, IteratorTag());
 
-    test_find_end_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_find_end_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_find_end_exception_async(seq(task), IteratorTag());
+    test_find_end_exception_async(par(task), IteratorTag());
 }
 
 void find_end_exception_test()
@@ -663,18 +661,16 @@ void test_find_end_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_end_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_end_bad_alloc(execution::seq, IteratorTag());
-    test_find_end_bad_alloc(execution::par, IteratorTag());
+    test_find_end_bad_alloc(seq, IteratorTag());
+    test_find_end_bad_alloc(par, IteratorTag());
 
-    test_find_end_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_find_end_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_find_end_bad_alloc_async(seq(task), IteratorTag());
+    test_find_end_bad_alloc_async(par(task), IteratorTag());
 }
 
 void find_end_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findfirstof.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findfirstof.cpp
@@ -100,16 +100,16 @@ void test_find_first_of_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_first_of()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_first_of(IteratorTag());
 
-    test_find_first_of(execution::seq, IteratorTag());
-    test_find_first_of(execution::par, IteratorTag());
-    test_find_first_of(execution::par_unseq, IteratorTag());
+    test_find_first_of(seq, IteratorTag());
+    test_find_first_of(par, IteratorTag());
+    test_find_first_of(par_unseq, IteratorTag());
 
-    test_find_first_of_async(execution::seq(execution::task), IteratorTag());
-    test_find_first_of_async(execution::par(execution::task), IteratorTag());
+    test_find_first_of_async(seq(task), IteratorTag());
+    test_find_first_of_async(par(task), IteratorTag());
 }
 
 void find_first_of_test()
@@ -142,8 +142,8 @@ void test_find_first_of_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -234,20 +234,18 @@ void test_find_first_of_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_first_of_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_first_of_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_first_of_exception(execution::seq, IteratorTag());
-    test_find_first_of_exception(execution::par, IteratorTag());
+    test_find_first_of_exception(seq, IteratorTag());
+    test_find_first_of_exception(par, IteratorTag());
 
-    test_find_first_of_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_find_first_of_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_find_first_of_exception_async(seq(task), IteratorTag());
+    test_find_first_of_exception_async(par(task), IteratorTag());
 }
 
 void find_first_of_exception_test()
@@ -335,18 +333,16 @@ void test_find_first_of_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_first_of_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_first_of_bad_alloc(execution::seq, IteratorTag());
-    test_find_first_of_bad_alloc(execution::par, IteratorTag());
+    test_find_first_of_bad_alloc(seq, IteratorTag());
+    test_find_first_of_bad_alloc(par, IteratorTag());
 
-    test_find_first_of_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_find_first_of_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_find_first_of_bad_alloc_async(seq(task), IteratorTag());
+    test_find_first_of_bad_alloc_async(par(task), IteratorTag());
 }
 
 void find_first_of_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findfirstof_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findfirstof_binary.cpp
@@ -107,16 +107,16 @@ void test_find_first_of_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_first_of()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_first_of(IteratorTag());
 
-    test_find_first_of(execution::seq, IteratorTag());
-    test_find_first_of(execution::par, IteratorTag());
-    test_find_first_of(execution::par_unseq, IteratorTag());
+    test_find_first_of(seq, IteratorTag());
+    test_find_first_of(par, IteratorTag());
+    test_find_first_of(par_unseq, IteratorTag());
 
-    test_find_first_of_async(execution::seq(execution::task), IteratorTag());
-    test_find_first_of_async(execution::par(execution::task), IteratorTag());
+    test_find_first_of_async(seq(task), IteratorTag());
+    test_find_first_of_async(par(task), IteratorTag());
 }
 
 void find_first_of_test()
@@ -151,8 +151,8 @@ void test_find_first_of_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -247,20 +247,18 @@ void test_find_first_of_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_first_of_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_first_of_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_first_of_exception(execution::seq, IteratorTag());
-    test_find_first_of_exception(execution::par, IteratorTag());
+    test_find_first_of_exception(seq, IteratorTag());
+    test_find_first_of_exception(par, IteratorTag());
 
-    test_find_first_of_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_find_first_of_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_find_first_of_exception_async(seq(task), IteratorTag());
+    test_find_first_of_exception_async(par(task), IteratorTag());
 }
 
 void find_first_of_exception_test()
@@ -352,18 +350,16 @@ void test_find_first_of_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_first_of_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_first_of_bad_alloc(execution::seq, IteratorTag());
-    test_find_first_of_bad_alloc(execution::par, IteratorTag());
+    test_find_first_of_bad_alloc(seq, IteratorTag());
+    test_find_first_of_bad_alloc(par, IteratorTag());
 
-    test_find_first_of_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_find_first_of_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_find_first_of_bad_alloc_async(seq(task), IteratorTag());
+    test_find_first_of_bad_alloc_async(par(task), IteratorTag());
 }
 
 void find_first_of_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findif.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findif.cpp
@@ -93,16 +93,16 @@ void test_find_if_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_if()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_if(IteratorTag());
 
-    test_find_if(execution::seq, IteratorTag());
-    test_find_if(execution::par, IteratorTag());
-    test_find_if(execution::par_unseq, IteratorTag());
+    test_find_if(seq, IteratorTag());
+    test_find_if(par, IteratorTag());
+    test_find_if(par_unseq, IteratorTag());
 
-    test_find_if_async(execution::seq(execution::task), IteratorTag());
-    test_find_if_async(execution::par(execution::task), IteratorTag());
+    test_find_if_async(seq(task), IteratorTag());
+    test_find_if_async(par(task), IteratorTag());
 }
 
 void find_if_test()
@@ -133,8 +133,8 @@ void test_find_if_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -221,20 +221,18 @@ void test_find_if_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_if_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_if_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_if_exception(execution::seq, IteratorTag());
-    test_find_if_exception(execution::par, IteratorTag());
+    test_find_if_exception(seq, IteratorTag());
+    test_find_if_exception(par, IteratorTag());
 
-    test_find_if_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_find_if_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_find_if_exception_async(seq(task), IteratorTag());
+    test_find_if_exception_async(par(task), IteratorTag());
 }
 
 void find_if_exception_test()
@@ -318,18 +316,16 @@ void test_find_if_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_if_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_if_bad_alloc(execution::seq, IteratorTag());
-    test_find_if_bad_alloc(execution::par, IteratorTag());
+    test_find_if_bad_alloc(seq, IteratorTag());
+    test_find_if_bad_alloc(par, IteratorTag());
 
-    test_find_if_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_find_if_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_find_if_bad_alloc_async(seq(task), IteratorTag());
+    test_find_if_bad_alloc_async(par(task), IteratorTag());
 }
 
 void find_if_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findifnot.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findifnot.cpp
@@ -92,16 +92,16 @@ void test_find_if_not_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_if_not()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_if_not(IteratorTag());
 
-    test_find_if_not(execution::seq, IteratorTag());
-    test_find_if_not(execution::par, IteratorTag());
-    test_find_if_not(execution::par_unseq, IteratorTag());
+    test_find_if_not(seq, IteratorTag());
+    test_find_if_not(par, IteratorTag());
+    test_find_if_not(par_unseq, IteratorTag());
 
-    test_find_if_not_async(execution::seq(execution::task), IteratorTag());
-    test_find_if_not_async(execution::par(execution::task), IteratorTag());
+    test_find_if_not_async(seq(task), IteratorTag());
+    test_find_if_not_async(par(task), IteratorTag());
 }
 
 void find_if_not_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findifnot_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findifnot_bad_alloc.cpp
@@ -97,18 +97,16 @@ void test_find_if_not_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_if_not_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_if_not_bad_alloc(execution::seq, IteratorTag());
-    test_find_if_not_bad_alloc(execution::par, IteratorTag());
+    test_find_if_not_bad_alloc(seq, IteratorTag());
+    test_find_if_not_bad_alloc(par, IteratorTag());
 
-    test_find_if_not_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_find_if_not_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_find_if_not_bad_alloc_async(seq(task), IteratorTag());
+    test_find_if_not_bad_alloc_async(par(task), IteratorTag());
 }
 
 void find_if_not_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findifnot_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findifnot_exception.cpp
@@ -44,8 +44,8 @@ void test_find_if_not_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -132,20 +132,18 @@ void test_find_if_not_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_if_not_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_if_not_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_if_not_exception(execution::seq, IteratorTag());
-    test_find_if_not_exception(execution::par, IteratorTag());
+    test_find_if_not_exception(seq, IteratorTag());
+    test_find_if_not_exception(par, IteratorTag());
 
-    test_find_if_not_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_find_if_not_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_find_if_not_exception_async(seq(task), IteratorTag());
+    test_find_if_not_exception_async(par(task), IteratorTag());
 }
 
 void find_if_not_exception_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop.cpp
@@ -74,14 +74,14 @@ void test_for_loop_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_for_loop()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_for_loop(execution::seq, IteratorTag());
-    test_for_loop(execution::par, IteratorTag());
-    test_for_loop(execution::par_unseq, IteratorTag());
+    test_for_loop(seq, IteratorTag());
+    test_for_loop(par, IteratorTag());
+    test_for_loop(par_unseq, IteratorTag());
 
-    test_for_loop_async(execution::seq(execution::task), IteratorTag());
-    test_for_loop_async(execution::par(execution::task), IteratorTag());
+    test_for_loop_async(seq(task), IteratorTag());
+    test_for_loop_async(par(task), IteratorTag());
 }
 
 void for_loop_test()
@@ -136,14 +136,14 @@ void test_for_loop_idx_async(ExPolicy&& p)
 
 void for_loop_test_idx()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_for_loop_idx(execution::seq);
-    test_for_loop_idx(execution::par);
-    test_for_loop_idx(execution::par_unseq);
+    test_for_loop_idx(seq);
+    test_for_loop_idx(par);
+    test_for_loop_idx(par_unseq);
 
-    test_for_loop_idx_async(execution::seq(execution::task));
-    test_for_loop_idx_async(execution::par(execution::task));
+    test_for_loop_idx_async(seq(task));
+    test_for_loop_idx_async(par(task));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_exception.cpp
@@ -213,26 +213,22 @@ void test_for_loop_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_for_loop_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_for_loop_exception(execution::seq, IteratorTag());
-    test_for_loop_exception(execution::par, IteratorTag());
+    test_for_loop_exception(seq, IteratorTag());
+    test_for_loop_exception(par, IteratorTag());
 
-    test_for_loop_bad_alloc(execution::seq, IteratorTag());
-    test_for_loop_bad_alloc(execution::par, IteratorTag());
+    test_for_loop_bad_alloc(seq, IteratorTag());
+    test_for_loop_bad_alloc(par, IteratorTag());
 
-    test_for_loop_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_for_loop_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_for_loop_exception_async(seq(task), IteratorTag());
+    test_for_loop_exception_async(par(task), IteratorTag());
 
-    test_for_loop_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_for_loop_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_for_loop_bad_alloc_async(seq(task), IteratorTag());
+    test_for_loop_bad_alloc_async(par(task), IteratorTag());
 }
 
 void for_loop_exception_test()
@@ -380,21 +376,19 @@ void test_for_loop_idx_bad_alloc_async(ExPolicy&& p)
 template <typename IteratorTag>
 void test_for_loop_exception_idx()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_for_loop_idx_exception(execution::seq, IteratorTag());
-    test_for_loop_idx_exception(execution::par, IteratorTag());
+    test_for_loop_idx_exception(seq, IteratorTag());
+    test_for_loop_idx_exception(par, IteratorTag());
 
-    test_for_loop_idx_bad_alloc(execution::seq);
-    test_for_loop_idx_bad_alloc(execution::par);
+    test_for_loop_idx_bad_alloc(seq);
+    test_for_loop_idx_bad_alloc(par);
 
-    test_for_loop_idx_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_for_loop_idx_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_for_loop_idx_exception_async(seq(task), IteratorTag());
+    test_for_loop_idx_exception_async(par(task), IteratorTag());
 
-    test_for_loop_idx_bad_alloc_async(execution::seq(execution::task));
-    test_for_loop_idx_bad_alloc_async(execution::par(execution::task));
+    test_for_loop_idx_bad_alloc_async(seq(task));
+    test_for_loop_idx_bad_alloc_async(par(task));
 }
 
 void for_loop_exception_test_idx()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_induction.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_induction.cpp
@@ -168,24 +168,23 @@ void test_for_loop_induction_stride_life_out(ExPolicy&& policy, IteratorTag)
 template <typename IteratorTag>
 void test_for_loop_induction()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_for_loop_induction(execution::seq, IteratorTag());
-    test_for_loop_induction(execution::par, IteratorTag());
-    test_for_loop_induction(execution::par_unseq, IteratorTag());
+    test_for_loop_induction(seq, IteratorTag());
+    test_for_loop_induction(par, IteratorTag());
+    test_for_loop_induction(par_unseq, IteratorTag());
 
-    test_for_loop_induction_stride(execution::seq, IteratorTag());
-    test_for_loop_induction_stride(execution::par, IteratorTag());
-    test_for_loop_induction_stride(execution::par_unseq, IteratorTag());
+    test_for_loop_induction_stride(seq, IteratorTag());
+    test_for_loop_induction_stride(par, IteratorTag());
+    test_for_loop_induction_stride(par_unseq, IteratorTag());
 
-    test_for_loop_induction_life_out(execution::seq, IteratorTag());
-    test_for_loop_induction_life_out(execution::par, IteratorTag());
-    test_for_loop_induction_life_out(execution::par_unseq, IteratorTag());
+    test_for_loop_induction_life_out(seq, IteratorTag());
+    test_for_loop_induction_life_out(par, IteratorTag());
+    test_for_loop_induction_life_out(par_unseq, IteratorTag());
 
-    test_for_loop_induction_stride_life_out(execution::seq, IteratorTag());
-    test_for_loop_induction_stride_life_out(execution::par, IteratorTag());
-    test_for_loop_induction_stride_life_out(
-        execution::par_unseq, IteratorTag());
+    test_for_loop_induction_stride_life_out(seq, IteratorTag());
+    test_for_loop_induction_stride_life_out(par, IteratorTag());
+    test_for_loop_induction_stride_life_out(par_unseq, IteratorTag());
 }
 
 void for_loop_induction_test()
@@ -249,15 +248,15 @@ void test_for_loop_induction_stride_idx(ExPolicy&& policy)
 
 void for_loop_induction_test_idx()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_for_loop_induction_idx(execution::seq);
-    test_for_loop_induction_idx(execution::par);
-    test_for_loop_induction_idx(execution::par_unseq);
+    test_for_loop_induction_idx(seq);
+    test_for_loop_induction_idx(par);
+    test_for_loop_induction_idx(par_unseq);
 
-    test_for_loop_induction_stride_idx(execution::seq);
-    test_for_loop_induction_stride_idx(execution::par);
-    test_for_loop_induction_stride_idx(execution::par_unseq);
+    test_for_loop_induction_stride_idx(seq);
+    test_for_loop_induction_stride_idx(par);
+    test_for_loop_induction_stride_idx(par_unseq);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_induction_async.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_induction_async.cpp
@@ -172,25 +172,19 @@ void test_for_loop_induction_stride_life_out(ExPolicy&& policy, IteratorTag)
 template <typename IteratorTag>
 void test_for_loop_induction()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_for_loop_induction(execution::seq(execution::task), IteratorTag());
-    test_for_loop_induction(execution::par(execution::task), IteratorTag());
+    test_for_loop_induction(seq(task), IteratorTag());
+    test_for_loop_induction(par(task), IteratorTag());
 
-    test_for_loop_induction_stride(
-        execution::seq(execution::task), IteratorTag());
-    test_for_loop_induction_stride(
-        execution::par(execution::task), IteratorTag());
+    test_for_loop_induction_stride(seq(task), IteratorTag());
+    test_for_loop_induction_stride(par(task), IteratorTag());
 
-    test_for_loop_induction_life_out(
-        execution::seq(execution::task), IteratorTag());
-    test_for_loop_induction_life_out(
-        execution::par(execution::task), IteratorTag());
+    test_for_loop_induction_life_out(seq(task), IteratorTag());
+    test_for_loop_induction_life_out(par(task), IteratorTag());
 
-    test_for_loop_induction_stride_life_out(
-        execution::seq(execution::task), IteratorTag());
-    test_for_loop_induction_stride_life_out(
-        execution::par(execution::task), IteratorTag());
+    test_for_loop_induction_stride_life_out(seq(task), IteratorTag());
+    test_for_loop_induction_stride_life_out(par(task), IteratorTag());
 }
 
 void for_loop_induction_test()
@@ -256,13 +250,13 @@ void test_for_loop_induction_stride_idx(ExPolicy&& policy)
 
 void for_loop_induction_test_idx()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_for_loop_induction_idx(execution::seq(execution::task));
-    test_for_loop_induction_idx(execution::par(execution::task));
+    test_for_loop_induction_idx(seq(task));
+    test_for_loop_induction_idx(par(task));
 
-    test_for_loop_induction_stride_idx(execution::seq(execution::task));
-    test_for_loop_induction_stride_idx(execution::par(execution::task));
+    test_for_loop_induction_stride_idx(seq(task));
+    test_for_loop_induction_stride_idx(par(task));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_n.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_n.cpp
@@ -74,14 +74,14 @@ void test_for_loop_n_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_for_loop_n()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_for_loop_n(execution::seq, IteratorTag());
-    test_for_loop_n(execution::par, IteratorTag());
-    test_for_loop_n(execution::par_unseq, IteratorTag());
+    test_for_loop_n(seq, IteratorTag());
+    test_for_loop_n(par, IteratorTag());
+    test_for_loop_n(par_unseq, IteratorTag());
 
-    test_for_loop_n_async(execution::seq(execution::task), IteratorTag());
-    test_for_loop_n_async(execution::par(execution::task), IteratorTag());
+    test_for_loop_n_async(seq(task), IteratorTag());
+    test_for_loop_n_async(par(task), IteratorTag());
 }
 
 void for_loop_n_test()
@@ -136,14 +136,14 @@ void test_for_loop_n_idx_async(ExPolicy&& p)
 
 void for_loop_n_test_idx()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_for_loop_n_idx(execution::seq);
-    test_for_loop_n_idx(execution::par);
-    test_for_loop_n_idx(execution::par_unseq);
+    test_for_loop_n_idx(seq);
+    test_for_loop_n_idx(par);
+    test_for_loop_n_idx(par_unseq);
 
-    test_for_loop_n_idx_async(execution::seq(execution::task));
-    test_for_loop_n_idx_async(execution::par(execution::task));
+    test_for_loop_n_idx_async(seq(task));
+    test_for_loop_n_idx_async(par(task));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_n_strided.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_n_strided.cpp
@@ -107,16 +107,14 @@ void test_for_loop_n_strided_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_for_loop_n_strided()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_for_loop_n_strided(execution::seq, IteratorTag());
-    test_for_loop_n_strided(execution::par, IteratorTag());
-    test_for_loop_n_strided(execution::par_unseq, IteratorTag());
+    test_for_loop_n_strided(seq, IteratorTag());
+    test_for_loop_n_strided(par, IteratorTag());
+    test_for_loop_n_strided(par_unseq, IteratorTag());
 
-    test_for_loop_n_strided_async(
-        execution::seq(execution::task), IteratorTag());
-    test_for_loop_n_strided_async(
-        execution::par(execution::task), IteratorTag());
+    test_for_loop_n_strided_async(seq(task), IteratorTag());
+    test_for_loop_n_strided_async(par(task), IteratorTag());
 }
 
 void for_loop_n_strided_test()
@@ -201,14 +199,14 @@ void test_for_loop_n_strided_idx_async(ExPolicy&& p)
 
 void for_loop_n_strided_test_idx()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_for_loop_n_strided_idx(execution::seq);
-    test_for_loop_n_strided_idx(execution::par);
-    test_for_loop_n_strided_idx(execution::par_unseq);
+    test_for_loop_n_strided_idx(seq);
+    test_for_loop_n_strided_idx(par);
+    test_for_loop_n_strided_idx(par_unseq);
 
-    test_for_loop_n_strided_idx_async(execution::seq(execution::task));
-    test_for_loop_n_strided_idx_async(execution::par(execution::task));
+    test_for_loop_n_strided_idx_async(seq(task));
+    test_for_loop_n_strided_idx_async(par(task));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_reduction.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_reduction.cpp
@@ -103,19 +103,19 @@ void test_for_loop_reduction_min(ExPolicy&& policy, IteratorTag)
 template <typename IteratorTag>
 void test_for_loop_reduction()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_for_loop_reduction_plus(execution::seq, IteratorTag());
-    test_for_loop_reduction_plus(execution::par, IteratorTag());
-    test_for_loop_reduction_plus(execution::par_unseq, IteratorTag());
+    test_for_loop_reduction_plus(seq, IteratorTag());
+    test_for_loop_reduction_plus(par, IteratorTag());
+    test_for_loop_reduction_plus(par_unseq, IteratorTag());
 
-    test_for_loop_reduction_multiplies(execution::seq, IteratorTag());
-    test_for_loop_reduction_multiplies(execution::par, IteratorTag());
-    test_for_loop_reduction_multiplies(execution::par_unseq, IteratorTag());
+    test_for_loop_reduction_multiplies(seq, IteratorTag());
+    test_for_loop_reduction_multiplies(par, IteratorTag());
+    test_for_loop_reduction_multiplies(par_unseq, IteratorTag());
 
-    test_for_loop_reduction_min(execution::seq, IteratorTag());
-    test_for_loop_reduction_min(execution::par, IteratorTag());
-    test_for_loop_reduction_min(execution::par_unseq, IteratorTag());
+    test_for_loop_reduction_min(seq, IteratorTag());
+    test_for_loop_reduction_min(par, IteratorTag());
+    test_for_loop_reduction_min(par_unseq, IteratorTag());
 }
 
 void for_loop_reduction_test()
@@ -169,15 +169,15 @@ void test_for_loop_reduction_bit_or_idx(ExPolicy&& policy)
 
 void for_loop_reduction_test_idx()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_for_loop_reduction_bit_and_idx(execution::seq);
-    test_for_loop_reduction_bit_and_idx(execution::par);
-    test_for_loop_reduction_bit_and_idx(execution::par_unseq);
+    test_for_loop_reduction_bit_and_idx(seq);
+    test_for_loop_reduction_bit_and_idx(par);
+    test_for_loop_reduction_bit_and_idx(par_unseq);
 
-    test_for_loop_reduction_bit_or_idx(execution::seq);
-    test_for_loop_reduction_bit_or_idx(execution::par);
-    test_for_loop_reduction_bit_or_idx(execution::par_unseq);
+    test_for_loop_reduction_bit_or_idx(seq);
+    test_for_loop_reduction_bit_or_idx(par);
+    test_for_loop_reduction_bit_or_idx(par_unseq);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_reduction_async.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_reduction_async.cpp
@@ -109,20 +109,16 @@ void test_for_loop_reduction_min(ExPolicy&& policy, IteratorTag)
 template <typename IteratorTag>
 void test_for_loop_reduction()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_for_loop_reduction_plus(
-        execution::seq(execution::task), IteratorTag());
-    test_for_loop_reduction_plus(
-        execution::par(execution::task), IteratorTag());
+    test_for_loop_reduction_plus(seq(task), IteratorTag());
+    test_for_loop_reduction_plus(par(task), IteratorTag());
 
-    test_for_loop_reduction_multiplies(
-        execution::seq(execution::task), IteratorTag());
-    test_for_loop_reduction_multiplies(
-        execution::par(execution::task), IteratorTag());
+    test_for_loop_reduction_multiplies(seq(task), IteratorTag());
+    test_for_loop_reduction_multiplies(par(task), IteratorTag());
 
-    test_for_loop_reduction_min(execution::seq(execution::task), IteratorTag());
-    test_for_loop_reduction_min(execution::par(execution::task), IteratorTag());
+    test_for_loop_reduction_min(seq(task), IteratorTag());
+    test_for_loop_reduction_min(par(task), IteratorTag());
 }
 
 void for_loop_reduction_test()
@@ -178,13 +174,13 @@ void test_for_loop_reduction_bit_or_idx(ExPolicy&& policy)
 
 void for_loop_reduction_test_idx()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_for_loop_reduction_bit_and_idx(execution::seq(execution::task));
-    test_for_loop_reduction_bit_and_idx(execution::par(execution::task));
+    test_for_loop_reduction_bit_and_idx(seq(task));
+    test_for_loop_reduction_bit_and_idx(par(task));
 
-    test_for_loop_reduction_bit_or_idx(execution::seq(execution::task));
-    test_for_loop_reduction_bit_or_idx(execution::par(execution::task));
+    test_for_loop_reduction_bit_or_idx(seq(task));
+    test_for_loop_reduction_bit_or_idx(par(task));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_strided.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_strided.cpp
@@ -107,14 +107,14 @@ void test_for_loop_strided_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_for_loop_strided()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_for_loop_strided(execution::seq, IteratorTag());
-    test_for_loop_strided(execution::par, IteratorTag());
-    test_for_loop_strided(execution::par_unseq, IteratorTag());
+    test_for_loop_strided(seq, IteratorTag());
+    test_for_loop_strided(par, IteratorTag());
+    test_for_loop_strided(par_unseq, IteratorTag());
 
-    test_for_loop_strided_async(execution::seq(execution::task), IteratorTag());
-    test_for_loop_strided_async(execution::par(execution::task), IteratorTag());
+    test_for_loop_strided_async(seq(task), IteratorTag());
+    test_for_loop_strided_async(par(task), IteratorTag());
 }
 
 void for_loop_strided_test()
@@ -199,14 +199,14 @@ void test_for_loop_strided_idx_async(ExPolicy&& p)
 
 void for_loop_strided_test_idx()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_for_loop_strided_idx(execution::seq);
-    test_for_loop_strided_idx(execution::par);
-    test_for_loop_strided_idx(execution::par_unseq);
+    test_for_loop_strided_idx(seq);
+    test_for_loop_strided_idx(par);
+    test_for_loop_strided_idx(par_unseq);
 
-    test_for_loop_strided_idx_async(execution::seq(execution::task));
-    test_for_loop_strided_idx_async(execution::par(execution::task));
+    test_for_loop_strided_idx_async(seq(task));
+    test_for_loop_strided_idx_async(par(task));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreach.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreach.cpp
@@ -17,16 +17,16 @@
 template <typename IteratorTag>
 void test_for_each()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_for_each_seq(IteratorTag());
 
-    test_for_each(execution::seq, IteratorTag());
-    test_for_each(execution::par, IteratorTag());
-    test_for_each(execution::par_unseq, IteratorTag());
+    test_for_each(seq, IteratorTag());
+    test_for_each(par, IteratorTag());
+    test_for_each(par_unseq, IteratorTag());
 
-    test_for_each_async(execution::seq(execution::task), IteratorTag());
-    test_for_each_async(execution::par(execution::task), IteratorTag());
+    test_for_each_async(seq(task), IteratorTag());
+    test_for_each_async(par(task), IteratorTag());
 }
 
 void for_each_test()
@@ -39,20 +39,18 @@ void for_each_test()
 template <typename IteratorTag>
 void test_for_each_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
     test_for_each_exception_seq(IteratorTag());
 
-    test_for_each_exception(execution::seq, IteratorTag());
-    test_for_each_exception(execution::par, IteratorTag());
+    test_for_each_exception(seq, IteratorTag());
+    test_for_each_exception(par, IteratorTag());
 
-    test_for_each_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_for_each_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_for_each_exception_async(seq(task), IteratorTag());
+    test_for_each_exception_async(par(task), IteratorTag());
 }
 
 void for_each_exception_test()
@@ -65,20 +63,18 @@ void for_each_exception_test()
 template <typename IteratorTag>
 void test_for_each_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
     test_for_each_bad_alloc_seq(IteratorTag());
 
-    test_for_each_bad_alloc(execution::seq, IteratorTag());
-    test_for_each_bad_alloc(execution::par, IteratorTag());
+    test_for_each_bad_alloc(seq, IteratorTag());
+    test_for_each_bad_alloc(par, IteratorTag());
 
-    test_for_each_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_for_each_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_for_each_bad_alloc_async(seq(task), IteratorTag());
+    test_for_each_bad_alloc_async(par(task), IteratorTag());
 }
 
 void for_each_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreach_executors.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreach_executors.cpp
@@ -37,23 +37,23 @@ void test_executors_async(ExPolicy&& p)
 
 void for_each_executors_test()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     {
-        execution::parallel_executor exec;
+        parallel_executor exec;
 
-        test_executors(execution::par.on(exec));
-        test_executors_async(execution::par(execution::task).on(exec));
+        test_executors(par.on(exec));
+        test_executors_async(par(task).on(exec));
     }
 
     {
-        execution::sequenced_executor exec;
+        sequenced_executor exec;
 
-        test_executors(execution::seq.on(exec));
-        test_executors_async(execution::seq(execution::task).on(exec));
+        test_executors(seq.on(exec));
+        test_executors_async(seq(task).on(exec));
 
-        test_executors(execution::par.on(exec));
-        test_executors_async(execution::par(execution::task).on(exec));
+        test_executors(par.on(exec));
+        test_executors_async(par(task).on(exec));
     }
 }
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreach_prefetching.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreach_prefetching.cpp
@@ -19,12 +19,11 @@
 template <typename IteratorTag>
 void test_for_each_prefetching()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_for_each_prefetching(execution::par, IteratorTag());
-    test_for_each_prefetching(execution::par_unseq, IteratorTag());
-    test_for_each_prefetching_async(
-        execution::par(execution::task), IteratorTag());
+    test_for_each_prefetching(par, IteratorTag());
+    test_for_each_prefetching(par_unseq, IteratorTag());
+    test_for_each_prefetching_async(par(task), IteratorTag());
 }
 
 void for_each_prefetching_test()
@@ -36,14 +35,13 @@ void for_each_prefetching_test()
 template <typename IteratorTag>
 void test_for_each_prefetching_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_for_each_prefetching_exception(execution::par, IteratorTag());
-    test_for_each_prefetching_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_for_each_prefetching_exception(par, IteratorTag());
+    test_for_each_prefetching_exception_async(par(task), IteratorTag());
 }
 
 void for_each_prefetching_exception_test()
@@ -55,14 +53,13 @@ void for_each_prefetching_exception_test()
 template <typename IteratorTag>
 void test_for_each_prefetching_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_for_each_prefetching_bad_alloc(execution::par, IteratorTag());
-    test_for_each_prefetching_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_for_each_prefetching_bad_alloc(par, IteratorTag());
+    test_for_each_prefetching_bad_alloc_async(par(task), IteratorTag());
 }
 
 void for_each_prefetching_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreach_projection.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreach_projection.cpp
@@ -17,14 +17,14 @@
 template <typename IteratorTag, typename Proj>
 void test_for_each()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_for_each(execution::seq, IteratorTag(), Proj());
-    test_for_each(execution::par, IteratorTag(), Proj());
-    test_for_each(execution::par_unseq, IteratorTag(), Proj());
+    test_for_each(seq, IteratorTag(), Proj());
+    test_for_each(par, IteratorTag(), Proj());
+    test_for_each(par_unseq, IteratorTag(), Proj());
 
-    test_for_each_async(execution::seq(execution::task), IteratorTag(), Proj());
-    test_for_each_async(execution::par(execution::task), IteratorTag(), Proj());
+    test_for_each_async(seq(task), IteratorTag(), Proj());
+    test_for_each_async(par(task), IteratorTag(), Proj());
 }
 
 template <typename Proj>
@@ -38,18 +38,16 @@ void for_each_test()
 template <typename IteratorTag, typename Proj>
 void test_for_each_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_for_each_exception(execution::seq, IteratorTag(), Proj());
-    test_for_each_exception(execution::par, IteratorTag(), Proj());
+    test_for_each_exception(seq, IteratorTag(), Proj());
+    test_for_each_exception(par, IteratorTag(), Proj());
 
-    test_for_each_exception_async(
-        execution::seq(execution::task), IteratorTag(), Proj());
-    test_for_each_exception_async(
-        execution::par(execution::task), IteratorTag(), Proj());
+    test_for_each_exception_async(seq(task), IteratorTag(), Proj());
+    test_for_each_exception_async(par(task), IteratorTag(), Proj());
 }
 
 template <typename Proj>
@@ -63,18 +61,16 @@ void for_each_exception_test()
 template <typename IteratorTag, typename Proj>
 void test_for_each_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_for_each_bad_alloc(execution::seq, IteratorTag(), Proj());
-    test_for_each_bad_alloc(execution::par, IteratorTag(), Proj());
+    test_for_each_bad_alloc(seq, IteratorTag(), Proj());
+    test_for_each_bad_alloc(par, IteratorTag(), Proj());
 
-    test_for_each_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag(), Proj());
-    test_for_each_bad_alloc_async(
-        execution::par(execution::task), IteratorTag(), Proj());
+    test_for_each_bad_alloc_async(seq(task), IteratorTag(), Proj());
+    test_for_each_bad_alloc_async(par(task), IteratorTag(), Proj());
 }
 
 template <typename Proj>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreachn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreachn.cpp
@@ -18,16 +18,16 @@
 template <typename IteratorTag>
 void test_for_each_n()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_for_each_n_seq(IteratorTag());
 
-    test_for_each_n(execution::seq, IteratorTag());
-    test_for_each_n(execution::par, IteratorTag());
-    test_for_each_n(execution::par_unseq, IteratorTag());
+    test_for_each_n(seq, IteratorTag());
+    test_for_each_n(par, IteratorTag());
+    test_for_each_n(par_unseq, IteratorTag());
 
-    test_for_each_n_async(execution::seq(execution::task), IteratorTag());
-    test_for_each_n_async(execution::par(execution::task), IteratorTag());
+    test_for_each_n_async(seq(task), IteratorTag());
+    test_for_each_n_async(par(task), IteratorTag());
 }
 
 void for_each_n_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_bad_alloc.cpp
@@ -121,20 +121,18 @@ void test_for_each_n_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_for_each_n_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
     test_for_each_n_bad_alloc_seq(IteratorTag());
 
-    test_for_each_n_bad_alloc(execution::seq, IteratorTag());
-    test_for_each_n_bad_alloc(execution::par, IteratorTag());
+    test_for_each_n_bad_alloc(seq, IteratorTag());
+    test_for_each_n_bad_alloc(par, IteratorTag());
 
-    test_for_each_n_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_for_each_n_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_for_each_n_bad_alloc_async(seq(task), IteratorTag());
+    test_for_each_n_bad_alloc_async(par(task), IteratorTag());
 }
 
 void for_each_n_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_exception.cpp
@@ -123,20 +123,18 @@ void test_for_each_n_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_for_each_n_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
     test_for_each_n_exception_seq(IteratorTag());
 
-    test_for_each_n_exception(execution::seq, IteratorTag());
-    test_for_each_n_exception(execution::par, IteratorTag());
+    test_for_each_n_exception(seq, IteratorTag());
+    test_for_each_n_exception(par, IteratorTag());
 
-    test_for_each_n_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_for_each_n_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_for_each_n_exception_async(seq(task), IteratorTag());
+    test_for_each_n_exception_async(par(task), IteratorTag());
 }
 
 void for_each_n_exception_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_projection.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_projection.cpp
@@ -72,16 +72,14 @@ void test_for_each_n_async(ExPolicy p, IteratorTag, Proj&& proj)
 template <typename IteratorTag, typename Proj>
 void test_for_each_n()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_for_each_n(execution::seq, IteratorTag(), Proj());
-    test_for_each_n(execution::par, IteratorTag(), Proj());
-    test_for_each_n(execution::par_unseq, IteratorTag(), Proj());
+    test_for_each_n(seq, IteratorTag(), Proj());
+    test_for_each_n(par, IteratorTag(), Proj());
+    test_for_each_n(par_unseq, IteratorTag(), Proj());
 
-    test_for_each_n_async(
-        execution::seq(execution::task), IteratorTag(), Proj());
-    test_for_each_n_async(
-        execution::par(execution::task), IteratorTag(), Proj());
+    test_for_each_n_async(seq(task), IteratorTag(), Proj());
+    test_for_each_n_async(par(task), IteratorTag(), Proj());
 }
 
 template <typename Proj>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_projection_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_projection_bad_alloc.cpp
@@ -94,18 +94,16 @@ void test_for_each_n_bad_alloc_async(ExPolicy p, IteratorTag, Proj&& proj)
 template <typename IteratorTag, typename Proj>
 void test_for_each_n_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_for_each_n_bad_alloc(execution::seq, IteratorTag(), Proj());
-    test_for_each_n_bad_alloc(execution::par, IteratorTag(), Proj());
+    test_for_each_n_bad_alloc(seq, IteratorTag(), Proj());
+    test_for_each_n_bad_alloc(par, IteratorTag(), Proj());
 
-    test_for_each_n_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag(), Proj());
-    test_for_each_n_bad_alloc_async(
-        execution::par(execution::task), IteratorTag(), Proj());
+    test_for_each_n_bad_alloc_async(seq(task), IteratorTag(), Proj());
+    test_for_each_n_bad_alloc_async(par(task), IteratorTag(), Proj());
 }
 
 template <typename Proj>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_projection_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_projection_exception.cpp
@@ -96,18 +96,16 @@ void test_for_each_n_exception_async(ExPolicy p, IteratorTag, Proj&& proj)
 template <typename IteratorTag, typename Proj>
 void test_for_each_n_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_for_each_n_exception(execution::seq, IteratorTag(), Proj());
-    test_for_each_n_exception(execution::par, IteratorTag(), Proj());
+    test_for_each_n_exception(seq, IteratorTag(), Proj());
+    test_for_each_n_exception(par, IteratorTag(), Proj());
 
-    test_for_each_n_exception_async(
-        execution::seq(execution::task), IteratorTag(), Proj());
-    test_for_each_n_exception_async(
-        execution::par(execution::task), IteratorTag(), Proj());
+    test_for_each_n_exception_async(seq(task), IteratorTag(), Proj());
+    test_for_each_n_exception_async(par(task), IteratorTag(), Proj());
 }
 
 template <typename Proj>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/generate.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/generate.cpp
@@ -93,16 +93,16 @@ void test_generate_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_generate()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_generate(IteratorTag());
 
-    test_generate(execution::seq, IteratorTag());
-    test_generate(execution::par, IteratorTag());
-    test_generate(execution::par_unseq, IteratorTag());
+    test_generate(seq, IteratorTag());
+    test_generate(par, IteratorTag());
+    test_generate(par_unseq, IteratorTag());
 
-    test_generate_async(execution::seq(execution::task), IteratorTag());
-    test_generate_async(execution::par(execution::task), IteratorTag());
+    test_generate_async(seq(task), IteratorTag());
+    test_generate_async(par(task), IteratorTag());
 }
 
 void generate_test()
@@ -133,8 +133,8 @@ void test_generate_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -221,20 +221,18 @@ void test_generate_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_generate_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_generate_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_generate_exception(execution::seq, IteratorTag());
-    test_generate_exception(execution::par, IteratorTag());
+    test_generate_exception(seq, IteratorTag());
+    test_generate_exception(par, IteratorTag());
 
-    test_generate_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_generate_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_generate_exception_async(seq(task), IteratorTag());
+    test_generate_exception_async(par(task), IteratorTag());
 }
 
 void generate_exception_test()
@@ -318,18 +316,16 @@ void test_generate_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_generate_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_generate_bad_alloc(execution::seq, IteratorTag());
-    test_generate_bad_alloc(execution::par, IteratorTag());
+    test_generate_bad_alloc(seq, IteratorTag());
+    test_generate_bad_alloc(par, IteratorTag());
 
-    test_generate_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_generate_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_generate_bad_alloc_async(seq(task), IteratorTag());
+    test_generate_bad_alloc_async(par(task), IteratorTag());
 }
 
 void generate_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/generaten.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/generaten.cpp
@@ -90,16 +90,16 @@ void test_generate_n_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_generate_n()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_generate_n(IteratorTag());
 
-    test_generate_n(execution::seq, IteratorTag());
-    test_generate_n(execution::par, IteratorTag());
-    test_generate_n(execution::par_unseq, IteratorTag());
+    test_generate_n(seq, IteratorTag());
+    test_generate_n(par, IteratorTag());
+    test_generate_n(par_unseq, IteratorTag());
 
-    test_generate_n_async(execution::seq(execution::task), IteratorTag());
-    test_generate_n_async(execution::par(execution::task), IteratorTag());
+    test_generate_n_async(seq(task), IteratorTag());
+    test_generate_n_async(par(task), IteratorTag());
 }
 
 void generate_n_test()
@@ -130,8 +130,8 @@ void test_generate_n_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -218,20 +218,18 @@ void test_generate_n_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_generate_n_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_generate_n_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_generate_n_exception(execution::seq, IteratorTag());
-    test_generate_n_exception(execution::par, IteratorTag());
+    test_generate_n_exception(seq, IteratorTag());
+    test_generate_n_exception(par, IteratorTag());
 
-    test_generate_n_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_generate_n_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_generate_n_exception_async(seq(task), IteratorTag());
+    test_generate_n_exception_async(par(task), IteratorTag());
 }
 
 void generate_n_exception_test()
@@ -315,18 +313,16 @@ void test_generate_n_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_generate_n_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_generate_n_bad_alloc(execution::seq, IteratorTag());
-    test_generate_n_bad_alloc(execution::par, IteratorTag());
+    test_generate_n_bad_alloc(seq, IteratorTag());
+    test_generate_n_bad_alloc(par, IteratorTag());
 
-    test_generate_n_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_generate_n_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_generate_n_bad_alloc_async(seq(task), IteratorTag());
+    test_generate_n_bad_alloc_async(par(task), IteratorTag());
 }
 
 void generate_n_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/includes.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/includes.cpp
@@ -140,14 +140,14 @@ void test_includes1_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_includes1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_includes1(execution::seq, IteratorTag());
-    test_includes1(execution::par, IteratorTag());
-    test_includes1(execution::par_unseq, IteratorTag());
+    test_includes1(seq, IteratorTag());
+    test_includes1(par, IteratorTag());
+    test_includes1(par_unseq, IteratorTag());
 
-    test_includes1_async(execution::seq(execution::task), IteratorTag());
-    test_includes1_async(execution::par(execution::task), IteratorTag());
+    test_includes1_async(seq(task), IteratorTag());
+    test_includes1_async(par(task), IteratorTag());
 }
 
 void includes_test1()
@@ -273,14 +273,14 @@ void test_includes2_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_includes2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_includes2(execution::seq, IteratorTag());
-    test_includes2(execution::par, IteratorTag());
-    test_includes2(execution::par_unseq, IteratorTag());
+    test_includes2(seq, IteratorTag());
+    test_includes2(par, IteratorTag());
+    test_includes2(par_unseq, IteratorTag());
 
-    test_includes2_async(execution::seq(execution::task), IteratorTag());
-    test_includes2_async(execution::par(execution::task), IteratorTag());
+    test_includes2_async(seq(task), IteratorTag());
+    test_includes2_async(par(task), IteratorTag());
 }
 
 void includes_test2()
@@ -399,18 +399,16 @@ void test_includes_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_includes_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_includes_exception(execution::seq, IteratorTag());
-    test_includes_exception(execution::par, IteratorTag());
+    test_includes_exception(seq, IteratorTag());
+    test_includes_exception(par, IteratorTag());
 
-    test_includes_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_includes_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_includes_exception_async(seq(task), IteratorTag());
+    test_includes_exception_async(par(task), IteratorTag());
 }
 
 void includes_exception_test()
@@ -527,18 +525,16 @@ void test_includes_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_includes_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_includes_bad_alloc(execution::seq, IteratorTag());
-    test_includes_bad_alloc(execution::par, IteratorTag());
+    test_includes_bad_alloc(seq, IteratorTag());
+    test_includes_bad_alloc(par, IteratorTag());
 
-    test_includes_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_includes_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_includes_bad_alloc_async(seq(task), IteratorTag());
+    test_includes_bad_alloc_async(par(task), IteratorTag());
 }
 
 void includes_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/inclusive_scan.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/inclusive_scan.cpp
@@ -17,14 +17,14 @@
 template <typename IteratorTag>
 void test_inclusive_scan1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_inclusive_scan1(execution::seq, IteratorTag());
-    test_inclusive_scan1(execution::par, IteratorTag());
-    test_inclusive_scan1(execution::par_unseq, IteratorTag());
+    test_inclusive_scan1(seq, IteratorTag());
+    test_inclusive_scan1(par, IteratorTag());
+    test_inclusive_scan1(par_unseq, IteratorTag());
 
-    test_inclusive_scan1_async(execution::seq(execution::task), IteratorTag());
-    test_inclusive_scan1_async(execution::par(execution::task), IteratorTag());
+    test_inclusive_scan1_async(seq(task), IteratorTag());
+    test_inclusive_scan1_async(par(task), IteratorTag());
 }
 
 void inclusive_scan_test1()
@@ -37,14 +37,14 @@ void inclusive_scan_test1()
 template <typename IteratorTag>
 void test_inclusive_scan2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_inclusive_scan2(execution::seq, IteratorTag());
-    test_inclusive_scan2(execution::par, IteratorTag());
-    test_inclusive_scan2(execution::par_unseq, IteratorTag());
+    test_inclusive_scan2(seq, IteratorTag());
+    test_inclusive_scan2(par, IteratorTag());
+    test_inclusive_scan2(par_unseq, IteratorTag());
 
-    test_inclusive_scan2_async(execution::seq(execution::task), IteratorTag());
-    test_inclusive_scan2_async(execution::par(execution::task), IteratorTag());
+    test_inclusive_scan2_async(seq(task), IteratorTag());
+    test_inclusive_scan2_async(par(task), IteratorTag());
 }
 
 void inclusive_scan_test2()
@@ -57,14 +57,14 @@ void inclusive_scan_test2()
 template <typename IteratorTag>
 void test_inclusive_scan3()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_inclusive_scan3(execution::seq, IteratorTag());
-    test_inclusive_scan3(execution::par, IteratorTag());
-    test_inclusive_scan3(execution::par_unseq, IteratorTag());
+    test_inclusive_scan3(seq, IteratorTag());
+    test_inclusive_scan3(par, IteratorTag());
+    test_inclusive_scan3(par_unseq, IteratorTag());
 
-    test_inclusive_scan3_async(execution::seq(execution::task), IteratorTag());
-    test_inclusive_scan3_async(execution::par(execution::task), IteratorTag());
+    test_inclusive_scan3_async(seq(task), IteratorTag());
+    test_inclusive_scan3_async(par(task), IteratorTag());
 }
 
 void inclusive_scan_test3()
@@ -77,18 +77,16 @@ void inclusive_scan_test3()
 template <typename IteratorTag>
 void test_inclusive_scan_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_inclusive_scan_exception(execution::seq, IteratorTag());
-    test_inclusive_scan_exception(execution::par, IteratorTag());
+    test_inclusive_scan_exception(seq, IteratorTag());
+    test_inclusive_scan_exception(par, IteratorTag());
 
-    test_inclusive_scan_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_inclusive_scan_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_inclusive_scan_exception_async(seq(task), IteratorTag());
+    test_inclusive_scan_exception_async(par(task), IteratorTag());
 }
 
 void inclusive_scan_exception_test()
@@ -101,18 +99,16 @@ void inclusive_scan_exception_test()
 template <typename IteratorTag>
 void test_inclusive_scan_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_inclusive_scan_bad_alloc(execution::seq, IteratorTag());
-    test_inclusive_scan_bad_alloc(execution::par, IteratorTag());
+    test_inclusive_scan_bad_alloc(seq, IteratorTag());
+    test_inclusive_scan_bad_alloc(par, IteratorTag());
 
-    test_inclusive_scan_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_inclusive_scan_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_inclusive_scan_bad_alloc_async(seq(task), IteratorTag());
+    test_inclusive_scan_bad_alloc_async(par(task), IteratorTag());
 }
 
 void inclusive_scan_bad_alloc_test()
@@ -127,12 +123,12 @@ void inclusive_scan_validate()
     std::vector<int> a, b;
     // test scan algorithms using separate array for output
     //  std::cout << " Validating dual arrays " <<std::endl;
-    test_inclusive_scan_validate(hpx::parallel::execution::seq, a, b);
-    test_inclusive_scan_validate(hpx::parallel::execution::par, a, b);
+    test_inclusive_scan_validate(hpx::execution::seq, a, b);
+    test_inclusive_scan_validate(hpx::execution::par, a, b);
     // test scan algorithms using same array for input and output
     //  std::cout << " Validating in_place arrays " <<std::endl;
-    test_inclusive_scan_validate(hpx::parallel::execution::seq, a, a);
-    test_inclusive_scan_validate(hpx::parallel::execution::par, a, a);
+    test_inclusive_scan_validate(hpx::execution::seq, a, a);
+    test_inclusive_scan_validate(hpx::execution::par, a, a);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/algorithms/tests/unit/algorithms/inclusive_scan_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/inclusive_scan_tests.hpp
@@ -39,8 +39,8 @@ void inclusive_scan_benchmark()
         auto op = [](double v1, double v2) { return v1 + v2; };
 
         hpx::util::high_resolution_timer t;
-        hpx::parallel::inclusive_scan(hpx::parallel::execution::par,
-            std::begin(c), std::end(c), std::begin(d), op, val);
+        hpx::parallel::inclusive_scan(hpx::execution::par, std::begin(c),
+            std::end(c), std::begin(d), op, val);
         double elapsed = t.elapsed();
 
         // verify values
@@ -433,7 +433,7 @@ template <typename ExPolicy>
 void test_inclusive_scan_validate(
     ExPolicy p, std::vector<int>& a, std::vector<int>& b)
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
     typedef std::vector<int>::iterator Iter;
 
     // test 1, fill array with numbers counting from 0, then run scan algorithm

--- a/libs/parallelism/algorithms/tests/unit/algorithms/inplace_merge_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/inplace_merge_tests.hpp
@@ -506,36 +506,36 @@ void test_inplace_merge_stable(
 template <typename IteratorTag>
 void test_inplace_merge()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     int rand_base = _gen();
 
     ////////// Test cases for 'int' type.
     test_inplace_merge(
-        execution::seq, IteratorTag(), int(),
+        seq, IteratorTag(), int(),
         [](const int a, const int b) -> bool { return a < b; }, rand_base);
     test_inplace_merge(
-        execution::par, IteratorTag(), int(),
+        par, IteratorTag(), int(),
         [](const int a, const int b) -> bool { return a < b; }, rand_base);
     test_inplace_merge(
-        execution::par_unseq, IteratorTag(), int(),
+        par_unseq, IteratorTag(), int(),
         [](const int a, const int b) -> bool { return a > b; }, rand_base);
 
     ////////// Test cases for user defined type.
     test_inplace_merge(
-        execution::seq, IteratorTag(), user_defined_type(),
+        seq, IteratorTag(), user_defined_type(),
         [](user_defined_type const& a, user_defined_type const& b) -> bool {
             return a < b;
         },
         rand_base);
     test_inplace_merge(
-        execution::par, IteratorTag(), user_defined_type(),
+        par, IteratorTag(), user_defined_type(),
         [](user_defined_type const& a, user_defined_type const& b) -> bool {
             return a > b;
         },
         rand_base);
     test_inplace_merge(
-        execution::par_unseq, IteratorTag(), user_defined_type(),
+        par_unseq, IteratorTag(), user_defined_type(),
         [](user_defined_type const& a, user_defined_type const& b) -> bool {
             return a < b;
         },
@@ -543,79 +543,72 @@ void test_inplace_merge()
 
     ////////// Asynchronous test cases for 'int' type.
     test_inplace_merge_async(
-        execution::seq(execution::task), IteratorTag(), int(),
+        seq(task), IteratorTag(), int(),
         [](const int a, const int b) -> bool { return a > b; }, rand_base);
     test_inplace_merge_async(
-        execution::par(execution::task), IteratorTag(), int(),
+        par(task), IteratorTag(), int(),
         [](const int a, const int b) -> bool { return a > b; }, rand_base);
 
     ////////// Asynchronous test cases for user defined type.
     test_inplace_merge_async(
-        execution::seq(execution::task), IteratorTag(), user_defined_type(),
+        seq(task), IteratorTag(), user_defined_type(),
         [](user_defined_type const& a, user_defined_type const& b) -> bool {
             return a < b;
         },
         rand_base);
     test_inplace_merge_async(
-        execution::par(execution::task), IteratorTag(), user_defined_type(),
+        par(task), IteratorTag(), user_defined_type(),
         [](user_defined_type const& a, user_defined_type const& b) -> bool {
             return a < b;
         },
         rand_base);
 
     ////////// Another test cases for justifying the implementation.
+    test_inplace_merge_etc(seq, IteratorTag(), user_defined_type(), rand_base);
+    test_inplace_merge_etc(par, IteratorTag(), user_defined_type(), rand_base);
     test_inplace_merge_etc(
-        execution::seq, IteratorTag(), user_defined_type(), rand_base);
-    test_inplace_merge_etc(
-        execution::par, IteratorTag(), user_defined_type(), rand_base);
-    test_inplace_merge_etc(
-        execution::par_unseq, IteratorTag(), user_defined_type(), rand_base);
+        par_unseq, IteratorTag(), user_defined_type(), rand_base);
 
     ////////// Test cases for checking whether the algorithm is stable.
-    test_inplace_merge_stable(execution::seq, IteratorTag(), int(), rand_base);
-    test_inplace_merge_stable(execution::par, IteratorTag(), int(), rand_base);
+    test_inplace_merge_stable(seq, IteratorTag(), int(), rand_base);
+    test_inplace_merge_stable(par, IteratorTag(), int(), rand_base);
+    test_inplace_merge_stable(par_unseq, IteratorTag(), int(), rand_base);
     test_inplace_merge_stable(
-        execution::par_unseq, IteratorTag(), int(), rand_base);
+        seq, IteratorTag(), user_defined_type(), rand_base);
     test_inplace_merge_stable(
-        execution::seq, IteratorTag(), user_defined_type(), rand_base);
+        par, IteratorTag(), user_defined_type(), rand_base);
     test_inplace_merge_stable(
-        execution::par, IteratorTag(), user_defined_type(), rand_base);
-    test_inplace_merge_stable(
-        execution::par_unseq, IteratorTag(), user_defined_type(), rand_base);
+        par_unseq, IteratorTag(), user_defined_type(), rand_base);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_inplace_merge_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_inplace_merge_exception(execution::seq, IteratorTag());
-    test_inplace_merge_exception(execution::par, IteratorTag());
+    test_inplace_merge_exception(seq, IteratorTag());
+    test_inplace_merge_exception(par, IteratorTag());
 
-    test_inplace_merge_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_inplace_merge_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_inplace_merge_exception_async(seq(task), IteratorTag());
+    test_inplace_merge_exception_async(par(task), IteratorTag());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_inplace_merge_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_inplace_merge_bad_alloc(execution::seq, IteratorTag());
-    test_inplace_merge_bad_alloc(execution::par, IteratorTag());
+    test_inplace_merge_bad_alloc(seq, IteratorTag());
+    test_inplace_merge_bad_alloc(par, IteratorTag());
 
-    test_inplace_merge_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_inplace_merge_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_inplace_merge_bad_alloc_async(seq(task), IteratorTag());
+    test_inplace_merge_bad_alloc_async(par(task), IteratorTag());
 }

--- a/libs/parallelism/algorithms/tests/unit/algorithms/is_heap_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/is_heap_tests.hpp
@@ -368,69 +368,61 @@ void test_is_heap_bad_alloc_async(
 template <typename IteratorTag>
 void test_is_heap(bool test_for_is_heap = true)
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_is_heap(execution::seq, IteratorTag(), int(), test_for_is_heap);
-    test_is_heap(execution::par, IteratorTag(), int(), test_for_is_heap);
-    test_is_heap(execution::par_unseq, IteratorTag(), int(), test_for_is_heap);
+    test_is_heap(seq, IteratorTag(), int(), test_for_is_heap);
+    test_is_heap(par, IteratorTag(), int(), test_for_is_heap);
+    test_is_heap(par_unseq, IteratorTag(), int(), test_for_is_heap);
 
+    test_is_heap(seq, IteratorTag(), user_defined_type(), test_for_is_heap);
+    test_is_heap(par, IteratorTag(), user_defined_type(), test_for_is_heap);
     test_is_heap(
-        execution::seq, IteratorTag(), user_defined_type(), test_for_is_heap);
-    test_is_heap(
-        execution::par, IteratorTag(), user_defined_type(), test_for_is_heap);
-    test_is_heap(execution::par_unseq, IteratorTag(), user_defined_type(),
-        test_for_is_heap);
+        par_unseq, IteratorTag(), user_defined_type(), test_for_is_heap);
 
-    test_is_heap_with_pred(execution::seq, IteratorTag(), int(),
-        std::greater<int>(), test_for_is_heap);
-    test_is_heap_with_pred(execution::par, IteratorTag(), int(),
-        std::less<int>(), test_for_is_heap);
-    test_is_heap_with_pred(execution::par_unseq, IteratorTag(), int(),
+    test_is_heap_with_pred(
+        seq, IteratorTag(), int(), std::greater<int>(), test_for_is_heap);
+    test_is_heap_with_pred(
+        par, IteratorTag(), int(), std::less<int>(), test_for_is_heap);
+    test_is_heap_with_pred(par_unseq, IteratorTag(), int(),
         std::greater_equal<int>(), test_for_is_heap);
 
-    test_is_heap_async(execution::seq(execution::task), IteratorTag(), int(),
-        test_for_is_heap);
-    test_is_heap_async(execution::par(execution::task), IteratorTag(), int(),
-        test_for_is_heap);
+    test_is_heap_async(seq(task), IteratorTag(), int(), test_for_is_heap);
+    test_is_heap_async(par(task), IteratorTag(), int(), test_for_is_heap);
 
-    test_is_heap_async(execution::seq(execution::task), IteratorTag(),
-        user_defined_type(), test_for_is_heap);
-    test_is_heap_async(execution::par(execution::task), IteratorTag(),
-        user_defined_type(), test_for_is_heap);
+    test_is_heap_async(
+        seq(task), IteratorTag(), user_defined_type(), test_for_is_heap);
+    test_is_heap_async(
+        par(task), IteratorTag(), user_defined_type(), test_for_is_heap);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_is_heap_exception(bool test_for_is_heap = true)
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_is_heap_exception(execution::seq, IteratorTag(), test_for_is_heap);
-    test_is_heap_exception(execution::par, IteratorTag(), test_for_is_heap);
+    test_is_heap_exception(seq, IteratorTag(), test_for_is_heap);
+    test_is_heap_exception(par, IteratorTag(), test_for_is_heap);
 
-    test_is_heap_exception_async(
-        execution::seq(execution::task), IteratorTag(), test_for_is_heap);
-    test_is_heap_exception_async(
-        execution::par(execution::task), IteratorTag(), test_for_is_heap);
+    test_is_heap_exception_async(seq(task), IteratorTag(), test_for_is_heap);
+    test_is_heap_exception_async(par(task), IteratorTag(), test_for_is_heap);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_is_heap_bad_alloc(bool test_for_is_heap = true)
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_is_heap_bad_alloc(execution::seq, IteratorTag(), test_for_is_heap);
-    test_is_heap_bad_alloc(execution::par, IteratorTag(), test_for_is_heap);
+    test_is_heap_bad_alloc(seq, IteratorTag(), test_for_is_heap);
+    test_is_heap_bad_alloc(par, IteratorTag(), test_for_is_heap);
 
-    test_is_heap_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag(), test_for_is_heap);
-    test_is_heap_bad_alloc_async(
-        execution::par(execution::task), IteratorTag(), test_for_is_heap);
+    test_is_heap_bad_alloc_async(seq(task), IteratorTag(), test_for_is_heap);
+    test_is_heap_bad_alloc_async(par(task), IteratorTag(), test_for_is_heap);
 }

--- a/libs/parallelism/algorithms/tests/unit/algorithms/is_partitioned.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/is_partitioned.cpp
@@ -68,13 +68,13 @@ void test_partitioned1_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_partitioned1()
 {
-    using namespace hpx::parallel;
-    test_partitioned1(execution::seq, IteratorTag());
-    test_partitioned1(execution::par, IteratorTag());
-    test_partitioned1(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_partitioned1(seq, IteratorTag());
+    test_partitioned1(par, IteratorTag());
+    test_partitioned1(par_unseq, IteratorTag());
 
-    test_partitioned1_async(execution::seq(execution::task), IteratorTag());
-    test_partitioned1_async(execution::par(execution::task), IteratorTag());
+    test_partitioned1_async(seq(task), IteratorTag());
+    test_partitioned1_async(par(task), IteratorTag());
 }
 
 void partitioned_test1()
@@ -141,13 +141,13 @@ void test_partitioned2_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_partitioned2()
 {
-    using namespace hpx::parallel;
-    test_partitioned2(execution::seq, IteratorTag());
-    test_partitioned2(execution::par, IteratorTag());
-    test_partitioned2(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_partitioned2(seq, IteratorTag());
+    test_partitioned2(par, IteratorTag());
+    test_partitioned2(par_unseq, IteratorTag());
 
-    test_partitioned2_async(execution::seq(execution::task), IteratorTag());
-    test_partitioned2_async(execution::par(execution::task), IteratorTag());
+    test_partitioned2_async(seq(task), IteratorTag());
+    test_partitioned2_async(par(task), IteratorTag());
 }
 
 void partitioned_test2()
@@ -233,13 +233,13 @@ void test_partitioned3_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_partitioned3()
 {
-    using namespace hpx::parallel;
-    test_partitioned3(execution::seq, IteratorTag());
-    test_partitioned3(execution::par, IteratorTag());
-    test_partitioned3(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_partitioned3(seq, IteratorTag());
+    test_partitioned3(par, IteratorTag());
+    test_partitioned3(par_unseq, IteratorTag());
 
-    test_partitioned3_async(execution::seq(execution::task), IteratorTag());
-    test_partitioned3_async(execution::par(execution::task), IteratorTag());
+    test_partitioned3_async(seq(task), IteratorTag());
+    test_partitioned3_async(par(task), IteratorTag());
 }
 
 void partitioned_test3()
@@ -331,17 +331,15 @@ void test_partitioned_async_exception(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_partitioned_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
     //If the execution policy object is of type vector_execution_policy,
     //  std::terminate shall be called. Therefore we do not test exceptions
     //  with a vector execution policy
-    test_partitioned_exception(execution::seq, IteratorTag());
-    test_partitioned_exception(execution::par, IteratorTag());
+    test_partitioned_exception(seq, IteratorTag());
+    test_partitioned_exception(par, IteratorTag());
 
-    test_partitioned_async_exception(
-        execution::seq(execution::task), IteratorTag());
-    test_partitioned_async_exception(
-        execution::par(execution::task), IteratorTag());
+    test_partitioned_async_exception(seq(task), IteratorTag());
+    test_partitioned_async_exception(par(task), IteratorTag());
 }
 
 void partitioned_exception_test()
@@ -428,18 +426,16 @@ void test_partitioned_async_bad_alloc(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_partitioned_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_partitioned_bad_alloc(execution::par, IteratorTag());
-    test_partitioned_bad_alloc(execution::seq, IteratorTag());
+    test_partitioned_bad_alloc(par, IteratorTag());
+    test_partitioned_bad_alloc(seq, IteratorTag());
 
-    test_partitioned_async_bad_alloc(
-        execution::seq(execution::task), IteratorTag());
-    test_partitioned_async_bad_alloc(
-        execution::par(execution::task), IteratorTag());
+    test_partitioned_async_bad_alloc(seq(task), IteratorTag());
+    test_partitioned_async_bad_alloc(par(task), IteratorTag());
 }
 
 void partitioned_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/is_sorted.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/is_sorted.cpp
@@ -17,13 +17,13 @@
 template <typename IteratorTag>
 void test_sorted1()
 {
-    using namespace hpx::parallel;
-    test_sorted1(execution::seq, IteratorTag());
-    test_sorted1(execution::par, IteratorTag());
-    test_sorted1(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_sorted1(seq, IteratorTag());
+    test_sorted1(par, IteratorTag());
+    test_sorted1(par_unseq, IteratorTag());
 
-    test_sorted1_async(execution::seq(execution::task), IteratorTag());
-    test_sorted1_async(execution::par(execution::task), IteratorTag());
+    test_sorted1_async(seq(task), IteratorTag());
+    test_sorted1_async(par(task), IteratorTag());
 }
 
 void sorted_test1()
@@ -36,13 +36,13 @@ void sorted_test1()
 template <typename IteratorTag>
 void test_sorted2()
 {
-    using namespace hpx::parallel;
-    test_sorted2(execution::seq, IteratorTag());
-    test_sorted2(execution::par, IteratorTag());
-    test_sorted2(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_sorted2(seq, IteratorTag());
+    test_sorted2(par, IteratorTag());
+    test_sorted2(par_unseq, IteratorTag());
 
-    test_sorted2_async(execution::seq(execution::task), IteratorTag());
-    test_sorted2_async(execution::par(execution::task), IteratorTag());
+    test_sorted2_async(seq(task), IteratorTag());
+    test_sorted2_async(par(task), IteratorTag());
 }
 
 void sorted_test2()
@@ -55,13 +55,13 @@ void sorted_test2()
 template <typename IteratorTag>
 void test_sorted3()
 {
-    using namespace hpx::parallel;
-    test_sorted3(execution::seq, IteratorTag());
-    test_sorted3(execution::par, IteratorTag());
-    test_sorted3(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_sorted3(seq, IteratorTag());
+    test_sorted3(par, IteratorTag());
+    test_sorted3(par_unseq, IteratorTag());
 
-    test_sorted3_async(execution::seq(execution::task), IteratorTag());
-    test_sorted3_async(execution::par(execution::task), IteratorTag());
+    test_sorted3_async(seq(task), IteratorTag());
+    test_sorted3_async(par(task), IteratorTag());
 }
 
 void sorted_test3()
@@ -74,15 +74,15 @@ void sorted_test3()
 template <typename IteratorTag>
 void test_sorted_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
     //If the execution policy object is of type vector_execution_policy,
     //  std::terminate shall be called. Therefore we do not test exceptions
     //  with a vector execution policy
-    test_sorted_exception(execution::seq, IteratorTag());
-    test_sorted_exception(execution::par, IteratorTag());
+    test_sorted_exception(seq, IteratorTag());
+    test_sorted_exception(par, IteratorTag());
 
-    test_sorted_exception_async(execution::seq(execution::task), IteratorTag());
-    test_sorted_exception_async(execution::par(execution::task), IteratorTag());
+    test_sorted_exception_async(seq(task), IteratorTag());
+    test_sorted_exception_async(par(task), IteratorTag());
 }
 
 void sorted_exception_test()
@@ -95,16 +95,16 @@ void sorted_exception_test()
 template <typename IteratorTag>
 void test_sorted_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_sorted_bad_alloc(execution::par, IteratorTag());
-    test_sorted_bad_alloc(execution::seq, IteratorTag());
+    test_sorted_bad_alloc(par, IteratorTag());
+    test_sorted_bad_alloc(seq, IteratorTag());
 
-    test_sorted_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_sorted_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_sorted_bad_alloc_async(seq(task), IteratorTag());
+    test_sorted_bad_alloc_async(par(task), IteratorTag());
 }
 
 void sorted_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/is_sorted_until.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/is_sorted_until.cpp
@@ -70,16 +70,16 @@ void test_sorted_until1_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_sorted_until1()
 {
-    using namespace hpx::parallel;
-    test_sorted_until1(execution::seq, IteratorTag());
+    using namespace hpx::execution;
+    test_sorted_until1(seq, IteratorTag());
     //calls sequential and gets iter
-    test_sorted_until1(execution::par, IteratorTag());
+    test_sorted_until1(par, IteratorTag());
     //calls parallel and gets iter
-    test_sorted_until1(execution::par_unseq, IteratorTag());
+    test_sorted_until1(par_unseq, IteratorTag());
     //calls parallel and gets iter
-    test_sorted_until1_async(execution::seq(execution::task), IteratorTag());
+    test_sorted_until1_async(seq(task), IteratorTag());
     //calls sequential and gets future
-    test_sorted_until1_async(execution::par(execution::task), IteratorTag());
+    test_sorted_until1_async(par(task), IteratorTag());
     //calls parallel and gets future
 }
 
@@ -153,13 +153,13 @@ void test_sorted_until2_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_sorted_until2()
 {
-    using namespace hpx::parallel;
-    test_sorted_until2(execution::seq, IteratorTag());
-    test_sorted_until2(execution::par, IteratorTag());
-    test_sorted_until2(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_sorted_until2(seq, IteratorTag());
+    test_sorted_until2(par, IteratorTag());
+    test_sorted_until2(par_unseq, IteratorTag());
 
-    test_sorted_until2_async(execution::seq(execution::task), IteratorTag());
-    test_sorted_until2_async(execution::par(execution::task), IteratorTag());
+    test_sorted_until2_async(seq(task), IteratorTag());
+    test_sorted_until2_async(par(task), IteratorTag());
 }
 
 void sorted_until_test2()
@@ -242,13 +242,13 @@ void test_sorted_until3_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_sorted_until3()
 {
-    using namespace hpx::parallel;
-    test_sorted_until3(execution::seq, IteratorTag());
-    test_sorted_until3(execution::par, IteratorTag());
-    test_sorted_until3(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_sorted_until3(seq, IteratorTag());
+    test_sorted_until3(par, IteratorTag());
+    test_sorted_until3(par_unseq, IteratorTag());
 
-    test_sorted_until3_async(execution::seq(execution::task), IteratorTag());
-    test_sorted_until3_async(execution::par(execution::task), IteratorTag());
+    test_sorted_until3_async(seq(task), IteratorTag());
+    test_sorted_until3_async(par(task), IteratorTag());
 }
 
 void sorted_until_test3()
@@ -334,17 +334,15 @@ void test_sorted_until_async_exception(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_sorted_until_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
     //If the execution policy object is of type vector_execution_policy,
     //  std::terminate shall be called. Therefore we do not test exceptions
     //  with a vector execution policy
-    test_sorted_until_exception(execution::seq, IteratorTag());
-    test_sorted_until_exception(execution::par, IteratorTag());
+    test_sorted_until_exception(seq, IteratorTag());
+    test_sorted_until_exception(par, IteratorTag());
 
-    test_sorted_until_async_exception(
-        execution::seq(execution::task), IteratorTag());
-    test_sorted_until_async_exception(
-        execution::par(execution::task), IteratorTag());
+    test_sorted_until_async_exception(seq(task), IteratorTag());
+    test_sorted_until_async_exception(par(task), IteratorTag());
 }
 
 void sorted_until_exception_test()
@@ -429,18 +427,16 @@ void test_sorted_until_async_bad_alloc(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_sorted_until_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_sorted_until_bad_alloc(execution::par, IteratorTag());
-    test_sorted_until_bad_alloc(execution::seq, IteratorTag());
+    test_sorted_until_bad_alloc(par, IteratorTag());
+    test_sorted_until_bad_alloc(seq, IteratorTag());
 
-    test_sorted_until_async_bad_alloc(
-        execution::seq(execution::task), IteratorTag());
-    test_sorted_until_async_bad_alloc(
-        execution::par(execution::task), IteratorTag());
+    test_sorted_until_async_bad_alloc(seq(task), IteratorTag());
+    test_sorted_until_async_bad_alloc(par(task), IteratorTag());
 }
 
 void sorted_until_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/lexicographical_compare.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/lexicographical_compare.cpp
@@ -74,15 +74,13 @@ void test_lexicographical_compare1_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_lexicographical_compare1()
 {
-    using namespace hpx::parallel;
-    test_lexicographical_compare1(execution::seq, IteratorTag());
-    test_lexicographical_compare1(execution::par, IteratorTag());
-    test_lexicographical_compare1(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_lexicographical_compare1(seq, IteratorTag());
+    test_lexicographical_compare1(par, IteratorTag());
+    test_lexicographical_compare1(par_unseq, IteratorTag());
 
-    test_lexicographical_compare1_async(
-        execution::seq(execution::task), IteratorTag());
-    test_lexicographical_compare1_async(
-        execution::par(execution::task), IteratorTag());
+    test_lexicographical_compare1_async(seq(task), IteratorTag());
+    test_lexicographical_compare1_async(par(task), IteratorTag());
 }
 
 void lexicographical_compare_test1()
@@ -141,15 +139,13 @@ void test_lexicographical_compare2_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_lexicographical_compare2()
 {
-    using namespace hpx::parallel;
-    test_lexicographical_compare2(execution::seq, IteratorTag());
-    test_lexicographical_compare2(execution::par, IteratorTag());
-    test_lexicographical_compare2(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_lexicographical_compare2(seq, IteratorTag());
+    test_lexicographical_compare2(par, IteratorTag());
+    test_lexicographical_compare2(par_unseq, IteratorTag());
 
-    test_lexicographical_compare2_async(
-        execution::seq(execution::task), IteratorTag());
-    test_lexicographical_compare2_async(
-        execution::par(execution::task), IteratorTag());
+    test_lexicographical_compare2_async(seq(task), IteratorTag());
+    test_lexicographical_compare2_async(par(task), IteratorTag());
 }
 
 void lexicographical_compare_test2()
@@ -212,15 +208,13 @@ void test_lexicographical_compare3_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_lexicographical_compare3()
 {
-    using namespace hpx::parallel;
-    test_lexicographical_compare3(execution::seq, IteratorTag());
-    test_lexicographical_compare3(execution::par, IteratorTag());
-    test_lexicographical_compare3(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_lexicographical_compare3(seq, IteratorTag());
+    test_lexicographical_compare3(par, IteratorTag());
+    test_lexicographical_compare3(par_unseq, IteratorTag());
 
-    test_lexicographical_compare3_async(
-        execution::seq(execution::task), IteratorTag());
-    test_lexicographical_compare3_async(
-        execution::par(execution::task), IteratorTag());
+    test_lexicographical_compare3_async(seq(task), IteratorTag());
+    test_lexicographical_compare3_async(par(task), IteratorTag());
 }
 
 void lexicographical_compare_test3()
@@ -316,17 +310,15 @@ void test_lexicographical_compare_async_exception(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_lexicographical_compare_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
     //If the execution policy object is of type vector_execution_policy,
     //  std::terminate shall be called. therefore we do not test exceptions
     //  with a vector execution policy
-    test_lexicographical_compare_exception(execution::seq, IteratorTag());
-    test_lexicographical_compare_exception(execution::par, IteratorTag());
+    test_lexicographical_compare_exception(seq, IteratorTag());
+    test_lexicographical_compare_exception(par, IteratorTag());
 
-    test_lexicographical_compare_async_exception(
-        execution::seq(execution::task), IteratorTag());
-    test_lexicographical_compare_async_exception(
-        execution::par(execution::task), IteratorTag());
+    test_lexicographical_compare_async_exception(seq(task), IteratorTag());
+    test_lexicographical_compare_async_exception(par(task), IteratorTag());
 }
 
 void lexicographical_compare_exception_test()
@@ -417,18 +409,16 @@ void test_lexicographical_compare_async_bad_alloc(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_lexicographical_compare_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_lexicographical_compare_bad_alloc(execution::par, IteratorTag());
-    test_lexicographical_compare_bad_alloc(execution::seq, IteratorTag());
+    test_lexicographical_compare_bad_alloc(par, IteratorTag());
+    test_lexicographical_compare_bad_alloc(seq, IteratorTag());
 
-    test_lexicographical_compare_async_bad_alloc(
-        execution::seq(execution::task), IteratorTag());
-    test_lexicographical_compare_async_bad_alloc(
-        execution::par(execution::task), IteratorTag());
+    test_lexicographical_compare_async_bad_alloc(seq(task), IteratorTag());
+    test_lexicographical_compare_async_bad_alloc(par(task), IteratorTag());
 }
 
 void lexicographical_compare_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/max_element.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/max_element.cpp
@@ -85,14 +85,14 @@ void test_max_element_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_max_element()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_max_element(execution::seq, IteratorTag());
-    test_max_element(execution::par, IteratorTag());
-    test_max_element(execution::par_unseq, IteratorTag());
+    test_max_element(seq, IteratorTag());
+    test_max_element(par, IteratorTag());
+    test_max_element(par_unseq, IteratorTag());
 
-    test_max_element_async(execution::seq(execution::task), IteratorTag());
-    test_max_element_async(execution::par(execution::task), IteratorTag());
+    test_max_element_async(seq(task), IteratorTag());
+    test_max_element_async(par(task), IteratorTag());
 }
 
 void max_element_test()
@@ -237,18 +237,16 @@ void test_max_element_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_max_element_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_max_element_exception(execution::seq, IteratorTag());
-    test_max_element_exception(execution::par, IteratorTag());
+    test_max_element_exception(seq, IteratorTag());
+    test_max_element_exception(par, IteratorTag());
 
-    test_max_element_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_max_element_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_max_element_exception_async(seq(task), IteratorTag());
+    test_max_element_exception_async(par(task), IteratorTag());
 }
 
 void max_element_exception_test()
@@ -389,18 +387,16 @@ void test_max_element_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_max_element_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_max_element_bad_alloc(execution::seq, IteratorTag());
-    test_max_element_bad_alloc(execution::par, IteratorTag());
+    test_max_element_bad_alloc(seq, IteratorTag());
+    test_max_element_bad_alloc(par, IteratorTag());
 
-    test_max_element_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_max_element_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_max_element_bad_alloc_async(seq(task), IteratorTag());
+    test_max_element_bad_alloc_async(par(task), IteratorTag());
 }
 
 void max_element_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/merge_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/merge_tests.hpp
@@ -507,36 +507,36 @@ void test_merge_stable(ExPolicy policy, IteratorTag, DataType, int rand_base)
 template <typename IteratorTag>
 void test_merge()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     int rand_base = _gen();
 
     ////////// Test cases for 'int' type.
     test_merge(
-        execution::seq, IteratorTag(), int(),
+        seq, IteratorTag(), int(),
         [](const int a, const int b) -> bool { return a < b; }, rand_base);
     test_merge(
-        execution::par, IteratorTag(), int(),
+        par, IteratorTag(), int(),
         [](const int a, const int b) -> bool { return a < b; }, rand_base);
     test_merge(
-        execution::par_unseq, IteratorTag(), int(),
+        par_unseq, IteratorTag(), int(),
         [](const int a, const int b) -> bool { return a > b; }, rand_base);
 
     ////////// Test cases for user defined type.
     test_merge(
-        execution::seq, IteratorTag(), user_defined_type(),
+        seq, IteratorTag(), user_defined_type(),
         [](user_defined_type const& a, user_defined_type const& b) -> bool {
             return a < b;
         },
         rand_base);
     test_merge(
-        execution::par, IteratorTag(), user_defined_type(),
+        par, IteratorTag(), user_defined_type(),
         [](user_defined_type const& a, user_defined_type const& b) -> bool {
             return a > b;
         },
         rand_base);
     test_merge(
-        execution::par_unseq, IteratorTag(), user_defined_type(),
+        par_unseq, IteratorTag(), user_defined_type(),
         [](user_defined_type const& a, user_defined_type const& b) -> bool {
             return a < b;
         },
@@ -544,74 +544,68 @@ void test_merge()
 
     ////////// Asynchronous test cases for 'int' type.
     test_merge_async(
-        execution::seq(execution::task), IteratorTag(), int(),
+        seq(task), IteratorTag(), int(),
         [](const int a, const int b) -> bool { return a > b; }, rand_base);
     test_merge_async(
-        execution::par(execution::task), IteratorTag(), int(),
+        par(task), IteratorTag(), int(),
         [](const int a, const int b) -> bool { return a > b; }, rand_base);
 
     ////////// Asynchronous test cases for user defined type.
     test_merge_async(
-        execution::seq(execution::task), IteratorTag(), user_defined_type(),
+        seq(task), IteratorTag(), user_defined_type(),
         [](user_defined_type const& a, user_defined_type const& b) -> bool {
             return a < b;
         },
         rand_base);
     test_merge_async(
-        execution::par(execution::task), IteratorTag(), user_defined_type(),
+        par(task), IteratorTag(), user_defined_type(),
         [](user_defined_type const& a, user_defined_type const& b) -> bool {
             return a < b;
         },
         rand_base);
 
     ////////// Another test cases for justifying the implementation.
-    test_merge_etc(
-        execution::seq, IteratorTag(), user_defined_type(), rand_base);
-    test_merge_etc(
-        execution::par, IteratorTag(), user_defined_type(), rand_base);
-    test_merge_etc(
-        execution::par_unseq, IteratorTag(), user_defined_type(), rand_base);
+    test_merge_etc(seq, IteratorTag(), user_defined_type(), rand_base);
+    test_merge_etc(par, IteratorTag(), user_defined_type(), rand_base);
+    test_merge_etc(par_unseq, IteratorTag(), user_defined_type(), rand_base);
 
     ////////// Test cases for checking whether the algorithm is stable.
-    test_merge_stable(execution::seq, IteratorTag(), int(), rand_base);
-    test_merge_stable(execution::par, IteratorTag(), int(), rand_base);
-    test_merge_stable(execution::par_unseq, IteratorTag(), int(), rand_base);
-    test_merge_stable(
-        execution::seq, IteratorTag(), user_defined_type(), rand_base);
-    test_merge_stable(
-        execution::par, IteratorTag(), user_defined_type(), rand_base);
-    test_merge_stable(
-        execution::par_unseq, IteratorTag(), user_defined_type(), rand_base);
+    test_merge_stable(seq, IteratorTag(), int(), rand_base);
+    test_merge_stable(par, IteratorTag(), int(), rand_base);
+    test_merge_stable(par_unseq, IteratorTag(), int(), rand_base);
+    test_merge_stable(seq, IteratorTag(), user_defined_type(), rand_base);
+    test_merge_stable(par, IteratorTag(), user_defined_type(), rand_base);
+    test_merge_stable(par_unseq, IteratorTag(), user_defined_type(), rand_base);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_merge_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_merge_exception(execution::seq, IteratorTag());
-    test_merge_exception(execution::par, IteratorTag());
+    test_merge_exception(seq, IteratorTag());
+    test_merge_exception(par, IteratorTag());
 
-    test_merge_exception_async(execution::seq(execution::task), IteratorTag());
-    test_merge_exception_async(execution::par(execution::task), IteratorTag());
+    test_merge_exception_async(seq(task), IteratorTag());
+    test_merge_exception_async(par(task), IteratorTag());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_merge_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_merge_bad_alloc(execution::seq, IteratorTag());
-    test_merge_bad_alloc(execution::par, IteratorTag());
+    test_merge_bad_alloc(seq, IteratorTag());
+    test_merge_bad_alloc(par, IteratorTag());
 
-    test_merge_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_merge_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_merge_bad_alloc_async(seq(task), IteratorTag());
+    test_merge_bad_alloc_async(par(task), IteratorTag());
 }

--- a/libs/parallelism/algorithms/tests/unit/algorithms/min_element.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/min_element.cpp
@@ -86,14 +86,14 @@ void test_min_element_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_min_element()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_min_element(execution::seq, IteratorTag());
-    test_min_element(execution::par, IteratorTag());
-    test_min_element(execution::par_unseq, IteratorTag());
+    test_min_element(seq, IteratorTag());
+    test_min_element(par, IteratorTag());
+    test_min_element(par_unseq, IteratorTag());
 
-    test_min_element_async(execution::seq(execution::task), IteratorTag());
-    test_min_element_async(execution::par(execution::task), IteratorTag());
+    test_min_element_async(seq(task), IteratorTag());
+    test_min_element_async(par(task), IteratorTag());
 }
 
 void min_element_test()
@@ -238,18 +238,16 @@ void test_min_element_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_min_element_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_min_element_exception(execution::seq, IteratorTag());
-    test_min_element_exception(execution::par, IteratorTag());
+    test_min_element_exception(seq, IteratorTag());
+    test_min_element_exception(par, IteratorTag());
 
-    test_min_element_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_min_element_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_min_element_exception_async(seq(task), IteratorTag());
+    test_min_element_exception_async(par(task), IteratorTag());
 }
 
 void min_element_exception_test()
@@ -390,18 +388,16 @@ void test_min_element_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_min_element_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_min_element_bad_alloc(execution::seq, IteratorTag());
-    test_min_element_bad_alloc(execution::par, IteratorTag());
+    test_min_element_bad_alloc(seq, IteratorTag());
+    test_min_element_bad_alloc(par, IteratorTag());
 
-    test_min_element_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_min_element_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_min_element_bad_alloc_async(seq(task), IteratorTag());
+    test_min_element_bad_alloc_async(par(task), IteratorTag());
 }
 
 void min_element_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/minmax_element.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/minmax_element.cpp
@@ -95,14 +95,14 @@ void test_minmax_element_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_minmax_element()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_minmax_element(execution::seq, IteratorTag());
-    test_minmax_element(execution::par, IteratorTag());
-    test_minmax_element(execution::par_unseq, IteratorTag());
+    test_minmax_element(seq, IteratorTag());
+    test_minmax_element(par, IteratorTag());
+    test_minmax_element(par_unseq, IteratorTag());
 
-    test_minmax_element_async(execution::seq(execution::task), IteratorTag());
-    test_minmax_element_async(execution::par(execution::task), IteratorTag());
+    test_minmax_element_async(seq(task), IteratorTag());
+    test_minmax_element_async(par(task), IteratorTag());
 }
 
 void minmax_element_test()
@@ -247,18 +247,16 @@ void test_minmax_element_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_minmax_element_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_minmax_element_exception(execution::seq, IteratorTag());
-    test_minmax_element_exception(execution::par, IteratorTag());
+    test_minmax_element_exception(seq, IteratorTag());
+    test_minmax_element_exception(par, IteratorTag());
 
-    test_minmax_element_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_minmax_element_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_minmax_element_exception_async(seq(task), IteratorTag());
+    test_minmax_element_exception_async(par(task), IteratorTag());
 }
 
 void minmax_element_exception_test()
@@ -399,18 +397,16 @@ void test_minmax_element_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_minmax_element_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_minmax_element_bad_alloc(execution::seq, IteratorTag());
-    test_minmax_element_bad_alloc(execution::par, IteratorTag());
+    test_minmax_element_bad_alloc(seq, IteratorTag());
+    test_minmax_element_bad_alloc(par, IteratorTag());
 
-    test_minmax_element_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_minmax_element_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_minmax_element_bad_alloc_async(seq(task), IteratorTag());
+    test_minmax_element_bad_alloc_async(par(task), IteratorTag());
 }
 
 void minmax_element_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/mismatch.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/mismatch.cpp
@@ -156,16 +156,16 @@ void test_mismatch1_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_mismatch1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_mismatch1(IteratorTag());
 
-    test_mismatch1(execution::seq, IteratorTag());
-    test_mismatch1(execution::par, IteratorTag());
-    test_mismatch1(execution::par_unseq, IteratorTag());
+    test_mismatch1(seq, IteratorTag());
+    test_mismatch1(par, IteratorTag());
+    test_mismatch1(par_unseq, IteratorTag());
 
-    test_mismatch1_async(execution::seq(execution::task), IteratorTag());
-    test_mismatch1_async(execution::par(execution::task), IteratorTag());
+    test_mismatch1_async(seq(task), IteratorTag());
+    test_mismatch1_async(par(task), IteratorTag());
 }
 
 void mismatch_test1()
@@ -312,16 +312,16 @@ void test_mismatch2_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_mismatch2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_mismatch2(IteratorTag());
 
-    test_mismatch2(execution::seq, IteratorTag());
-    test_mismatch2(execution::par, IteratorTag());
-    test_mismatch2(execution::par_unseq, IteratorTag());
+    test_mismatch2(seq, IteratorTag());
+    test_mismatch2(par, IteratorTag());
+    test_mismatch2(par_unseq, IteratorTag());
 
-    test_mismatch2_async(execution::seq(execution::task), IteratorTag());
-    test_mismatch2_async(execution::par(execution::task), IteratorTag());
+    test_mismatch2_async(seq(task), IteratorTag());
+    test_mismatch2_async(par(task), IteratorTag());
 }
 
 void mismatch_test2()
@@ -357,8 +357,8 @@ void test_mismatch_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -452,18 +452,16 @@ void test_mismatch_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_mismatch_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_mismatch_exception(execution::seq, IteratorTag());
-    test_mismatch_exception(execution::par, IteratorTag());
+    test_mismatch_exception(seq, IteratorTag());
+    test_mismatch_exception(par, IteratorTag());
 
-    test_mismatch_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_mismatch_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_mismatch_exception_async(seq(task), IteratorTag());
+    test_mismatch_exception_async(par(task), IteratorTag());
 }
 
 void mismatch_exception_test()
@@ -555,18 +553,16 @@ void test_mismatch_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_mismatch_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_mismatch_bad_alloc(execution::seq, IteratorTag());
-    test_mismatch_bad_alloc(execution::par, IteratorTag());
+    test_mismatch_bad_alloc(seq, IteratorTag());
+    test_mismatch_bad_alloc(par, IteratorTag());
 
-    test_mismatch_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_mismatch_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_mismatch_bad_alloc_async(seq(task), IteratorTag());
+    test_mismatch_bad_alloc_async(par(task), IteratorTag());
 }
 
 void mismatch_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/mismatch_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/mismatch_binary.cpp
@@ -158,16 +158,16 @@ void test_mismatch_binary1_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_mismatch_binary1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_mismatch_binary1(IteratorTag());
 
-    test_mismatch_binary1(execution::seq, IteratorTag());
-    test_mismatch_binary1(execution::par, IteratorTag());
-    test_mismatch_binary1(execution::par_unseq, IteratorTag());
+    test_mismatch_binary1(seq, IteratorTag());
+    test_mismatch_binary1(par, IteratorTag());
+    test_mismatch_binary1(par_unseq, IteratorTag());
 
-    test_mismatch_binary1_async(execution::seq(execution::task), IteratorTag());
-    test_mismatch_binary1_async(execution::par(execution::task), IteratorTag());
+    test_mismatch_binary1_async(seq(task), IteratorTag());
+    test_mismatch_binary1_async(par(task), IteratorTag());
 }
 
 void mismatch_binary_test1()
@@ -314,16 +314,16 @@ void test_mismatch_binary2_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_mismatch_binary2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_mismatch_binary2(IteratorTag());
 
-    test_mismatch_binary2(execution::seq, IteratorTag());
-    test_mismatch_binary2(execution::par, IteratorTag());
-    test_mismatch_binary2(execution::par_unseq, IteratorTag());
+    test_mismatch_binary2(seq, IteratorTag());
+    test_mismatch_binary2(par, IteratorTag());
+    test_mismatch_binary2(par_unseq, IteratorTag());
 
-    test_mismatch_binary2_async(execution::seq(execution::task), IteratorTag());
-    test_mismatch_binary2_async(execution::par(execution::task), IteratorTag());
+    test_mismatch_binary2_async(seq(task), IteratorTag());
+    test_mismatch_binary2_async(par(task), IteratorTag());
 }
 
 void mismatch_binary_test2()
@@ -359,8 +359,8 @@ void test_mismatch_binary_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -454,20 +454,18 @@ void test_mismatch_binary_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_mismatch_binary_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_mismatch_binary_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_mismatch_binary_exception(execution::seq, IteratorTag());
-    test_mismatch_binary_exception(execution::par, IteratorTag());
+    test_mismatch_binary_exception(seq, IteratorTag());
+    test_mismatch_binary_exception(par, IteratorTag());
 
-    test_mismatch_binary_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_mismatch_binary_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_mismatch_binary_exception_async(seq(task), IteratorTag());
+    test_mismatch_binary_exception_async(par(task), IteratorTag());
 }
 
 void mismatch_binary_exception_test()
@@ -559,18 +557,16 @@ void test_mismatch_binary_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_mismatch_binary_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_mismatch_binary_bad_alloc(execution::seq, IteratorTag());
-    test_mismatch_binary_bad_alloc(execution::par, IteratorTag());
+    test_mismatch_binary_bad_alloc(seq, IteratorTag());
+    test_mismatch_binary_bad_alloc(par, IteratorTag());
 
-    test_mismatch_binary_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_mismatch_binary_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_mismatch_binary_bad_alloc_async(seq(task), IteratorTag());
+    test_mismatch_binary_bad_alloc_async(par(task), IteratorTag());
 }
 
 void mismatch_binary_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/move.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/move.cpp
@@ -108,16 +108,16 @@ void test_move_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_move()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_move(IteratorTag());
 
-    test_move(execution::seq, IteratorTag());
-    test_move(execution::par, IteratorTag());
-    test_move(execution::par_unseq, IteratorTag());
+    test_move(seq, IteratorTag());
+    test_move(par, IteratorTag());
+    test_move(par_unseq, IteratorTag());
 
-    test_move_async(execution::seq(execution::task), IteratorTag());
-    test_move_async(execution::par(execution::task), IteratorTag());
+    test_move_async(seq(task), IteratorTag());
+    test_move_async(par(task), IteratorTag());
 }
 
 void move_test()
@@ -207,16 +207,16 @@ void test_move_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_move_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_move_exception(execution::seq, IteratorTag());
-    test_move_exception(execution::par, IteratorTag());
+    test_move_exception(seq, IteratorTag());
+    test_move_exception(par, IteratorTag());
 
-    test_move_exception_async(execution::seq(execution::task), IteratorTag());
-    test_move_exception_async(execution::par(execution::task), IteratorTag());
+    test_move_exception_async(seq(task), IteratorTag());
+    test_move_exception_async(par(task), IteratorTag());
 }
 
 void move_exception_test()
@@ -302,16 +302,16 @@ void test_move_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_move_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_move_bad_alloc(execution::seq, IteratorTag());
-    test_move_bad_alloc(execution::par, IteratorTag());
+    test_move_bad_alloc(seq, IteratorTag());
+    test_move_bad_alloc(par, IteratorTag());
 
-    test_move_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_move_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_move_bad_alloc_async(seq(task), IteratorTag());
+    test_move_bad_alloc_async(par(task), IteratorTag());
 }
 
 void move_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/none_of.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/none_of.cpp
@@ -181,36 +181,34 @@ void test_none_of()
             return !static_cast<bool>(x);
         }
     };
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_none_of(IteratorTag());
     test_none_of_ranges_seq(IteratorTag(), proj());
 
-    test_none_of(execution::seq, IteratorTag());
-    test_none_of(execution::par, IteratorTag());
-    test_none_of(execution::par_unseq, IteratorTag());
+    test_none_of(seq, IteratorTag());
+    test_none_of(par, IteratorTag());
+    test_none_of(par_unseq, IteratorTag());
 
-    test_none_of_ranges(execution::seq, IteratorTag(), proj());
-    test_none_of_ranges(execution::par, IteratorTag(), proj());
-    test_none_of_ranges(execution::par_unseq, IteratorTag(), proj());
+    test_none_of_ranges(seq, IteratorTag(), proj());
+    test_none_of_ranges(par, IteratorTag(), proj());
+    test_none_of_ranges(par_unseq, IteratorTag(), proj());
 
-    test_none_of_async(execution::seq(execution::task), IteratorTag());
-    test_none_of_async(execution::par(execution::task), IteratorTag());
+    test_none_of_async(seq(task), IteratorTag());
+    test_none_of_async(par(task), IteratorTag());
 
-    test_none_of_ranges_async(
-        execution::seq(execution::task), IteratorTag(), proj());
-    test_none_of_ranges_async(
-        execution::par(execution::task), IteratorTag(), proj());
+    test_none_of_ranges_async(seq(task), IteratorTag(), proj());
+    test_none_of_ranges_async(par(task), IteratorTag(), proj());
 }
 
 // template <typename IteratorTag>
 // void test_none_of_exec()
 // {
-//     using namespace hpx::parallel;
+//     using namespace hpx::execution;
 //
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_none_of(execution::par(exec), IteratorTag());
+//         test_none_of(par(exec), IteratorTag());
 //     }
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
@@ -219,7 +217,7 @@ void test_none_of()
 //
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_none_of(execution_policy(execution::par(exec)), IteratorTag());
+//         test_none_of(execution_policy(par(exec)), IteratorTag());
 //     }
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
@@ -259,9 +257,8 @@ void test_none_of_exception(IteratorTag)
         catch (hpx::exception_list const& e)
         {
             caught_exception = true;
-            test::test_num_exceptions<
-                hpx::parallel::execution::sequenced_policy,
-                IteratorTag>::call(hpx::parallel::execution::seq, e);
+            test::test_num_exceptions<hpx::execution::sequenced_policy,
+                IteratorTag>::call(hpx::execution::seq, e);
         }
         catch (...)
         {
@@ -355,20 +352,18 @@ void test_none_of_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_none_of_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_none_of_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_none_of_exception(execution::seq, IteratorTag());
-    test_none_of_exception(execution::par, IteratorTag());
+    test_none_of_exception(seq, IteratorTag());
+    test_none_of_exception(par, IteratorTag());
 
-    test_none_of_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_none_of_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_none_of_exception_async(seq(task), IteratorTag());
+    test_none_of_exception_async(par(task), IteratorTag());
 }
 
 void none_of_exception_test()
@@ -456,18 +451,16 @@ void test_none_of_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_none_of_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_none_of_bad_alloc(execution::seq, IteratorTag());
-    test_none_of_bad_alloc(execution::par, IteratorTag());
+    test_none_of_bad_alloc(seq, IteratorTag());
+    test_none_of_bad_alloc(par, IteratorTag());
 
-    test_none_of_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_none_of_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_none_of_bad_alloc_async(seq(task), IteratorTag());
+    test_none_of_bad_alloc_async(par(task), IteratorTag());
 }
 
 void none_of_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/parallel_sort.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/parallel_sort.cpp
@@ -39,8 +39,7 @@ void test1()
         V1.push_back(my_rand() % NElem);
     V2 = V1;
 
-    hpx::parallel::sort(
-        hpx::parallel::execution::par, V1.begin(), V1.end(), comp);
+    hpx::parallel::sort(hpx::execution::par, V1.begin(), V1.end(), comp);
 
     for (unsigned i = 1; i < NElem; i++)
     {
@@ -57,8 +56,7 @@ void test1()
     for (std::uint32_t i = 0; i < NElem; ++i)
         V1.push_back(i);
 
-    hpx::parallel::sort(
-        hpx::parallel::execution::par, V1.begin(), V1.end(), comp);
+    hpx::parallel::sort(hpx::execution::par, V1.begin(), V1.end(), comp);
 
     for (unsigned i = 1; i < NElem; i++)
     {
@@ -69,8 +67,7 @@ void test1()
     for (std::uint32_t i = 0; i < NElem; ++i)
         V1.push_back(NElem - i);
 
-    hpx::parallel::sort(
-        hpx::parallel::execution::par, V1.begin(), V1.end(), comp);
+    hpx::parallel::sort(hpx::execution::par, V1.begin(), V1.end(), comp);
     for (unsigned i = 1; i < NElem; i++)
     {
         HPX_TEST(V1[i] == (i + 1));
@@ -80,8 +77,7 @@ void test1()
     for (std::uint32_t i = 0; i < NElem; ++i)
         V1.push_back(1000);
 
-    hpx::parallel::sort(
-        hpx::parallel::execution::par, V1.begin(), V1.end(), comp);
+    hpx::parallel::sort(hpx::execution::par, V1.begin(), V1.end(), comp);
     for (unsigned i = 1; i < NElem; i++)
     {
         HPX_TEST(V1[i] == 1000);
@@ -108,7 +104,7 @@ void test2()
     for (std::uint32_t i = 0; i < 1000; ++i)
         A.push_back(0);
 
-    hpx::parallel::sort(hpx::parallel::execution::par, A.begin() + 1000,
+    hpx::parallel::sort(hpx::execution::par, A.begin() + 1000,
         A.begin() + (1000 + NELEM), comp);
     for (iter_t it = A.begin() + 1000; it != A.begin() + (1000 + NELEM); ++it)
     {
@@ -126,7 +122,7 @@ void test2()
     for (std::uint32_t i = 0; i < 1000; ++i)
         A.push_back(999999999);
 
-    hpx::parallel::sort(hpx::parallel::execution::par, A.begin() + 1000,
+    hpx::parallel::sort(hpx::execution::par, A.begin() + 1000,
         A.begin() + (1000 + NELEM), comp);
 
     for (iter_t it = A.begin() + 1001; it != A.begin() + (1000 + NELEM); ++it)
@@ -152,8 +148,7 @@ void test3()
 
     std::sort(V2.begin(), V2.end());
 
-    hpx::parallel::sort(
-        hpx::parallel::execution::par, V1.begin(), V1.end(), compare());
+    hpx::parallel::sort(hpx::execution::par, V1.begin(), V1.end(), compare());
 
     for (unsigned i = 0; i < V1.size(); i++)
     {
@@ -211,8 +206,7 @@ void test4()
 
     // 64 bits elements
     std::uint64_t* p64_1 = &V1[0];
-    hpx::parallel::sort(
-        hpx::parallel::execution::par, p64_1, p64_1 + NELEM, cmp64);
+    hpx::parallel::sort(hpx::execution::par, p64_1, p64_1 + NELEM, cmp64);
 
     for (unsigned i = 1; i < NELEM; i++)
     {
@@ -230,7 +224,7 @@ void test4()
     V1 = V2 = V3;
     std::uint32_t* p32_1 = reinterpret_cast<std::uint32_t*>(&V1[0]);
     hpx::parallel::sort(
-        hpx::parallel::execution::par, p32_1, p32_1 + (NELEM << 1), cmp32);
+        hpx::execution::par, p32_1, p32_1 + (NELEM << 1), cmp32);
 
     for (unsigned i = 1; i < (NELEM << 1); i++)
     {
@@ -248,7 +242,7 @@ void test4()
     V1 = V2 = V3;
     std::uint16_t* p16_1 = reinterpret_cast<std::uint16_t*>(&V1[0]);
     hpx::parallel::sort(
-        hpx::parallel::execution::par, p16_1, p16_1 + (NELEM << 2), cmp16);
+        hpx::execution::par, p16_1, p16_1 + (NELEM << 2), cmp16);
     for (unsigned i = 1; i < (NELEM << 2); i++)
     {
         HPX_TEST(p16_1[i - 1] <= p16_1[i]);
@@ -264,8 +258,7 @@ void test4()
     // 8 bits elements
     V1 = V2 = V3;
     std::uint8_t* p8_1 = reinterpret_cast<std::uint8_t*>(&V1[0]);
-    hpx::parallel::sort(
-        hpx::parallel::execution::par, p8_1, p8_1 + (NELEM << 3), cmp8);
+    hpx::parallel::sort(hpx::execution::par, p8_1, p8_1 + (NELEM << 3), cmp8);
     for (unsigned i = 1; i < (NELEM << 3); i++)
     {
         HPX_TEST(p8_1[i - 1] <= p8_1[i]);
@@ -290,8 +283,7 @@ void test_int_array(std::uint32_t NELEM)
     for (std::uint32_t i = 0; i < NELEM; ++i)
         V1.emplace_back(my_rand());
     V2 = V1;
-    hpx::parallel::sort(
-        hpx::parallel::execution::par, V1.begin(), V1.end(), compare());
+    hpx::parallel::sort(hpx::execution::par, V1.begin(), V1.end(), compare());
     for (unsigned i = 1; i < NELEM; i++)
     {
         HPX_TEST(!(V1[i] < V1[i - 1]));
@@ -363,8 +355,7 @@ void test6()
 
     VAux = V;
     typedef std::less<std::string> compare;
-    hpx::parallel::sort(
-        hpx::parallel::execution::par, V.begin(), V.end(), compare());
+    hpx::parallel::sort(hpx::execution::par, V.begin(), V.end(), compare());
 
     for (unsigned i = 1; i < NString; i++)
     {

--- a/libs/parallelism/algorithms/tests/unit/algorithms/partition_copy_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/partition_copy_tests.hpp
@@ -323,68 +323,68 @@ void test_partition_copy_bad_alloc_async(ExPolicy policy, IteratorTag)
 template <typename IteratorTag>
 void test_partition_copy()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     int rand_base = _gen();
 
     ////////// Test cases for 'int' type.
     test_partition_copy(
-        execution::seq, IteratorTag(), int(),
+        seq, IteratorTag(), int(),
         [rand_base](const int n) -> bool { return n < rand_base; }, rand_base);
     test_partition_copy(
-        execution::par, IteratorTag(), int(),
+        par, IteratorTag(), int(),
         [rand_base](const int n) -> bool { return n <= rand_base; }, rand_base);
     test_partition_copy(
-        execution::par_unseq, IteratorTag(), int(),
+        par_unseq, IteratorTag(), int(),
         [rand_base](const int n) -> bool { return n > rand_base; }, rand_base);
 
     ////////// Test cases for user defined type.
     test_partition_copy(
-        execution::seq, IteratorTag(), user_defined_type(),
+        seq, IteratorTag(), user_defined_type(),
         [rand_base](
             user_defined_type const& t) -> bool { return t < rand_base; },
         rand_base);
     test_partition_copy(
-        execution::par, IteratorTag(), user_defined_type(),
+        par, IteratorTag(), user_defined_type(),
         [rand_base](
             user_defined_type const& t) -> bool { return !(t < rand_base); },
         rand_base);
     test_partition_copy(
-        execution::par_unseq, IteratorTag(), user_defined_type(),
+        par_unseq, IteratorTag(), user_defined_type(),
         [rand_base](
             user_defined_type const& t) -> bool { return t < rand_base; },
         rand_base);
 
     ////////// Asynchronous test cases for 'int' type.
     test_partition_copy_async(
-        execution::seq(execution::task), IteratorTag(), int(),
+        seq(task), IteratorTag(), int(),
         [rand_base](const int n) -> bool { return n >= rand_base; }, rand_base);
     test_partition_copy_async(
-        execution::par(execution::task), IteratorTag(), int(),
+        par(task), IteratorTag(), int(),
         [rand_base](const int n) -> bool { return n < rand_base; }, rand_base);
 
     ////////// Asynchronous test cases for user defined type.
     test_partition_copy_async(
-        execution::seq(execution::task), IteratorTag(), user_defined_type(),
+        seq(task), IteratorTag(), user_defined_type(),
         [rand_base](
             user_defined_type const& t) -> bool { return !(t < rand_base); },
         rand_base);
     test_partition_copy_async(
-        execution::par(execution::task), IteratorTag(), user_defined_type(),
+        par(task), IteratorTag(), user_defined_type(),
         [rand_base](
             user_defined_type const& t) -> bool { return t < rand_base; },
         rand_base);
 
     ////////// Corner test cases.
     test_partition_copy(
-        execution::par, IteratorTag(), int(),
+        par, IteratorTag(), int(),
         [rand_base](const int n) -> bool {
             HPX_UNUSED(rand_base);
             return true;
         },
         rand_base);
     test_partition_copy(
-        execution::par_unseq, IteratorTag(), user_defined_type(),
+        par_unseq, IteratorTag(), user_defined_type(),
         [rand_base](user_defined_type const& t) -> bool {
             HPX_UNUSED(rand_base);
             return false;
@@ -396,34 +396,30 @@ void test_partition_copy()
 template <typename IteratorTag>
 void test_partition_copy_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_partition_copy_exception(execution::seq, IteratorTag());
-    test_partition_copy_exception(execution::par, IteratorTag());
+    test_partition_copy_exception(seq, IteratorTag());
+    test_partition_copy_exception(par, IteratorTag());
 
-    test_partition_copy_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_partition_copy_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_partition_copy_exception_async(seq(task), IteratorTag());
+    test_partition_copy_exception_async(par(task), IteratorTag());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_partition_copy_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_partition_copy_bad_alloc(execution::seq, IteratorTag());
-    test_partition_copy_bad_alloc(execution::par, IteratorTag());
+    test_partition_copy_bad_alloc(seq, IteratorTag());
+    test_partition_copy_bad_alloc(par, IteratorTag());
 
-    test_partition_copy_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_partition_copy_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_partition_copy_bad_alloc_async(seq(task), IteratorTag());
+    test_partition_copy_bad_alloc_async(par(task), IteratorTag());
 }

--- a/libs/parallelism/algorithms/tests/unit/algorithms/partition_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/partition_tests.hpp
@@ -371,70 +371,70 @@ void test_partition_heavy(
 template <typename IteratorTag>
 void test_partition()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     int rand_base = _gen();
 
     ////////// Test cases for 'int' type.
     test_partition(
-        execution::seq, IteratorTag(), int(),
+        seq, IteratorTag(), int(),
         [rand_base](const int n) -> bool { return n < rand_base; }, rand_base);
     test_partition(
-        execution::par, IteratorTag(), int(),
+        par, IteratorTag(), int(),
         [rand_base](const int n) -> bool { return n <= rand_base; }, rand_base);
     test_partition(
-        execution::par_unseq, IteratorTag(), int(),
+        par_unseq, IteratorTag(), int(),
         [rand_base](const int n) -> bool { return n > rand_base; }, rand_base);
 
     ////////// Test cases for user defined type.
     test_partition(
-        execution::seq, IteratorTag(), user_defined_type(),
+        seq, IteratorTag(), user_defined_type(),
         [rand_base](
             user_defined_type const& t) -> bool { return t < rand_base; },
         rand_base);
     test_partition(
-        execution::par, IteratorTag(), user_defined_type(),
+        par, IteratorTag(), user_defined_type(),
         [rand_base](
             user_defined_type const& t) -> bool { return !(t < rand_base); },
         rand_base);
     test_partition(
-        execution::par_unseq, IteratorTag(), user_defined_type(),
+        par_unseq, IteratorTag(), user_defined_type(),
         [rand_base](
             user_defined_type const& t) -> bool { return t < rand_base; },
         rand_base);
 
     ////////// Asynchronous test cases for 'int' type.
     test_partition_async(
-        execution::seq(execution::task), IteratorTag(), int(),
+        seq(task), IteratorTag(), int(),
         [rand_base](const int n) -> bool { return n >= rand_base; }, rand_base);
     test_partition_async(
-        execution::par(execution::task), IteratorTag(), int(),
+        par(task), IteratorTag(), int(),
         [rand_base](const int n) -> bool { return n < rand_base; }, rand_base);
 
     ////////// Asynchronous test cases for user defined type.
     test_partition_async(
-        execution::seq(execution::task), IteratorTag(), user_defined_type(),
+        seq(task), IteratorTag(), user_defined_type(),
         [rand_base](
             user_defined_type const& t) -> bool { return !(t < rand_base); },
         rand_base);
     test_partition_async(
-        execution::par(execution::task), IteratorTag(), user_defined_type(),
+        par(task), IteratorTag(), user_defined_type(),
         [rand_base](
             user_defined_type const& t) -> bool { return t < rand_base; },
         rand_base);
 
     ////////// Corner test cases.
     test_partition(
-        execution::par, IteratorTag(), int(),
-        [](const int n) -> bool { return true; }, rand_base);
+        par, IteratorTag(), int(), [](const int n) -> bool { return true; },
+        rand_base);
     test_partition(
-        execution::par_unseq, IteratorTag(), user_defined_type(),
+        par_unseq, IteratorTag(), user_defined_type(),
         [](user_defined_type const& t) -> bool { return false; }, rand_base);
 
     ////////// Many test cases for meticulous tests.
 #if !defined(HPX_DEBUG) && !defined(HPX_HAVE_SANITIZERS)
     test_partition_heavy(
-        execution::par, IteratorTag(), int(),
+        par, IteratorTag(), int(),
         [rand_base](const int n) -> bool { return n < rand_base; }, rand_base);
 #endif
 }
@@ -443,34 +443,30 @@ void test_partition()
 template <typename IteratorTag>
 void test_partition_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_partition_exception(execution::seq, IteratorTag());
-    test_partition_exception(execution::par, IteratorTag());
+    test_partition_exception(seq, IteratorTag());
+    test_partition_exception(par, IteratorTag());
 
-    test_partition_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_partition_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_partition_exception_async(seq(task), IteratorTag());
+    test_partition_exception_async(par(task), IteratorTag());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_partition_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_partition_bad_alloc(execution::seq, IteratorTag());
-    test_partition_bad_alloc(execution::par, IteratorTag());
+    test_partition_bad_alloc(seq, IteratorTag());
+    test_partition_bad_alloc(par, IteratorTag());
 
-    test_partition_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_partition_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_partition_bad_alloc_async(seq(task), IteratorTag());
+    test_partition_bad_alloc_async(par(task), IteratorTag());
 }

--- a/libs/parallelism/algorithms/tests/unit/algorithms/reduce_.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/reduce_.cpp
@@ -71,14 +71,14 @@ void test_reduce1_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reduce1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_reduce1(execution::seq, IteratorTag());
-    test_reduce1(execution::par, IteratorTag());
-    test_reduce1(execution::par_unseq, IteratorTag());
+    test_reduce1(seq, IteratorTag());
+    test_reduce1(par, IteratorTag());
+    test_reduce1(par_unseq, IteratorTag());
 
-    test_reduce1_async(execution::seq(execution::task), IteratorTag());
-    test_reduce1_async(execution::par(execution::task), IteratorTag());
+    test_reduce1_async(seq(task), IteratorTag());
+    test_reduce1_async(par(task), IteratorTag());
 }
 
 void reduce_test1()
@@ -132,14 +132,14 @@ void test_reduce2_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reduce2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_reduce2(execution::seq, IteratorTag());
-    test_reduce2(execution::par, IteratorTag());
-    test_reduce2(execution::par_unseq, IteratorTag());
+    test_reduce2(seq, IteratorTag());
+    test_reduce2(par, IteratorTag());
+    test_reduce2(par_unseq, IteratorTag());
 
-    test_reduce2_async(execution::seq(execution::task), IteratorTag());
-    test_reduce2_async(execution::par(execution::task), IteratorTag());
+    test_reduce2_async(seq(task), IteratorTag());
+    test_reduce2_async(par(task), IteratorTag());
 }
 
 void reduce_test2()
@@ -193,14 +193,14 @@ void test_reduce3_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reduce3()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_reduce3(execution::seq, IteratorTag());
-    test_reduce3(execution::par, IteratorTag());
-    test_reduce3(execution::par_unseq, IteratorTag());
+    test_reduce3(seq, IteratorTag());
+    test_reduce3(par, IteratorTag());
+    test_reduce3(par_unseq, IteratorTag());
 
-    test_reduce3_async(execution::seq(execution::task), IteratorTag());
-    test_reduce3_async(execution::par(execution::task), IteratorTag());
+    test_reduce3_async(seq(task), IteratorTag());
+    test_reduce3_async(par(task), IteratorTag());
 }
 
 void reduce_test3()
@@ -286,16 +286,16 @@ void test_reduce_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reduce_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_reduce_exception(execution::seq, IteratorTag());
-    test_reduce_exception(execution::par, IteratorTag());
+    test_reduce_exception(seq, IteratorTag());
+    test_reduce_exception(par, IteratorTag());
 
-    test_reduce_exception_async(execution::seq(execution::task), IteratorTag());
-    test_reduce_exception_async(execution::par(execution::task), IteratorTag());
+    test_reduce_exception_async(seq(task), IteratorTag());
+    test_reduce_exception_async(par(task), IteratorTag());
 }
 
 void reduce_exception_test()
@@ -379,16 +379,16 @@ void test_reduce_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reduce_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_reduce_bad_alloc(execution::seq, IteratorTag());
-    test_reduce_bad_alloc(execution::par, IteratorTag());
+    test_reduce_bad_alloc(seq, IteratorTag());
+    test_reduce_bad_alloc(par, IteratorTag());
 
-    test_reduce_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_reduce_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_reduce_bad_alloc_async(seq(task), IteratorTag());
+    test_reduce_bad_alloc_async(par(task), IteratorTag());
 }
 
 void reduce_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/reduce_by_key.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/reduce_by_key.cpp
@@ -406,41 +406,41 @@ void test_reduce_by_key_async(
 ////////////////////////////////////////////////////////////////////////////////
 void test_reduce_by_key1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
     //
     hpx::util::high_resolution_timer t;
     do
     {
-        test_reduce_by_key1(execution::seq, int(), int(), false,
-            std::equal_to<int>(), [](int key) { return key; });
-        test_reduce_by_key1(execution::par, int(), int(), false,
-            std::equal_to<int>(), [](int key) { return key; });
-        test_reduce_by_key1(execution::par_unseq, int(), int(), false,
+        test_reduce_by_key1(seq, int(), int(), false, std::equal_to<int>(),
+            [](int key) { return key; });
+        test_reduce_by_key1(par, int(), int(), false, std::equal_to<int>(),
+            [](int key) { return key; });
+        test_reduce_by_key1(par_unseq, int(), int(), false,
             std::equal_to<int>(), [](int key) { return key; });
         //
         // default comparison operator (std::equal_to)
-        test_reduce_by_key1(execution::seq, int(), double(), false,
-            almost_equal(), [](int key) { return key; });
-        test_reduce_by_key1(execution::par, int(), double(), false,
-            almost_equal(), [](int key) { return key; });
-        test_reduce_by_key1(execution::par_unseq, int(), double(), false,
-            almost_equal(), [](int key) { return key; });
+        test_reduce_by_key1(seq, int(), double(), false, almost_equal(),
+            [](int key) { return key; });
+        test_reduce_by_key1(par, int(), double(), false, almost_equal(),
+            [](int key) { return key; });
+        test_reduce_by_key1(par_unseq, int(), double(), false, almost_equal(),
+            [](int key) { return key; });
         //
         //
         test_reduce_by_key1(
-            execution::seq, double(), double(), false,
+            seq, double(), double(), false,
             [](double a, double b) {
                 return std::abs(std::floor(a) - std::floor(b)) < 1e-15;
             },    //-V550
             [](double a) { return std::floor(a); });
         test_reduce_by_key1(
-            execution::par, double(), double(), false,
+            par, double(), double(), false,
             [](double a, double b) {
                 return std::abs(std::floor(a) - std::floor(b)) < 1e-15;
             },    //-V550
             [](double a) { return std::floor(a); });
         test_reduce_by_key1(
-            execution::par_unseq, double(), double(), false,
+            par_unseq, double(), double(), false,
             [](double a, double b) {
                 return std::abs(std::floor(a) - std::floor(b)) < 1e-15;
             },    //-V550
@@ -450,15 +450,15 @@ void test_reduce_by_key1()
     hpx::util::high_resolution_timer t3;
     do
     {
-        test_reduce_by_key_const(execution::seq, int(), int(), false,
-            std::equal_to<int>(), [](int key) { return key; });
+        test_reduce_by_key_const(seq, int(), int(), false, std::equal_to<int>(),
+            [](int key) { return key; });
         //
         // default comparison operator (std::equal_to)
-        test_reduce_by_key_const(execution::seq, int(), double(), false,
-            almost_equal(), [](int key) { return key; });
+        test_reduce_by_key_const(seq, int(), double(), false, almost_equal(),
+            [](int key) { return key; });
         //
         test_reduce_by_key_const(
-            execution::seq, double(), double(), false,
+            seq, double(), double(), false,
             [](double a, double b) {
                 return std::abs(std::floor(a) - std::floor(b)) < 1e-15;
             },    //-V550
@@ -468,20 +468,20 @@ void test_reduce_by_key1()
     hpx::util::high_resolution_timer t2;
     do
     {
-        test_reduce_by_key_async(execution::seq(execution::task), int(), int(),
-            std::equal_to<int>(), [](int key) { return key; });
-        test_reduce_by_key_async(execution::par(execution::task), int(), int(),
-            std::equal_to<int>(), [](int key) { return key; });
+        test_reduce_by_key_async(seq(task), int(), int(), std::equal_to<int>(),
+            [](int key) { return key; });
+        test_reduce_by_key_async(par(task), int(), int(), std::equal_to<int>(),
+            [](int key) { return key; });
         //
-        test_reduce_by_key_async(execution::seq(execution::task), int(),
-            double(), almost_equal(), [](int key) { return key; });
-        test_reduce_by_key_async(execution::par(execution::task), int(),
-            double(), almost_equal(), [](int key) { return key; });
+        test_reduce_by_key_async(seq(task), int(), double(), almost_equal(),
+            [](int key) { return key; });
+        test_reduce_by_key_async(par(task), int(), double(), almost_equal(),
+            [](int key) { return key; });
     } while (t2.elapsed() < 2);
 
     // one last test with timing output enabled
     test_reduce_by_key1(
-        execution::par, double(), double(), true,
+        par, double(), double(), true,
         [](double a, double b) {
             return std::abs(std::floor(a) - std::floor(b)) < 1e-15;
         },    //-V550

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy.cpp
@@ -151,13 +151,13 @@ void test_remove_copy_outiter_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_remove_copy()
 {
-    using namespace hpx::parallel;
-    test_remove_copy(execution::seq, IteratorTag());
-    test_remove_copy(execution::par, IteratorTag());
-    test_remove_copy(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_remove_copy(seq, IteratorTag());
+    test_remove_copy(par, IteratorTag());
+    test_remove_copy(par_unseq, IteratorTag());
 
-    test_remove_copy_async(execution::seq(execution::task), IteratorTag());
-    test_remove_copy_async(execution::par(execution::task), IteratorTag());
+    test_remove_copy_async(seq(task), IteratorTag());
+    test_remove_copy_async(par(task), IteratorTag());
 }
 
 void remove_copy_test()
@@ -245,18 +245,16 @@ void test_remove_copy_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_remove_copy_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_remove_copy_exception(execution::seq, IteratorTag());
-    test_remove_copy_exception(execution::par, IteratorTag());
+    test_remove_copy_exception(seq, IteratorTag());
+    test_remove_copy_exception(par, IteratorTag());
 
-    test_remove_copy_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_remove_copy_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_remove_copy_exception_async(seq(task), IteratorTag());
+    test_remove_copy_exception_async(par(task), IteratorTag());
 }
 
 void remove_copy_exception_test()
@@ -340,18 +338,16 @@ void test_remove_copy_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_remove_copy_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_remove_copy_bad_alloc(execution::seq, IteratorTag());
-    test_remove_copy_bad_alloc(execution::par, IteratorTag());
+    test_remove_copy_bad_alloc(seq, IteratorTag());
+    test_remove_copy_bad_alloc(par, IteratorTag());
 
-    test_remove_copy_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_remove_copy_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_remove_copy_bad_alloc_async(seq(task), IteratorTag());
+    test_remove_copy_bad_alloc_async(par(task), IteratorTag());
 }
 
 void remove_copy_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy_if.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy_if.cpp
@@ -168,14 +168,14 @@ void test_remove_copy_if_outiter_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_remove_copy_if()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_remove_copy_if(execution::seq, IteratorTag());
-    test_remove_copy_if(execution::par, IteratorTag());
-    test_remove_copy_if(execution::par_unseq, IteratorTag());
+    test_remove_copy_if(seq, IteratorTag());
+    test_remove_copy_if(par, IteratorTag());
+    test_remove_copy_if(par_unseq, IteratorTag());
 
-    test_remove_copy_if_async(execution::seq(execution::task), IteratorTag());
-    test_remove_copy_if_async(execution::par(execution::task), IteratorTag());
+    test_remove_copy_if_async(seq(task), IteratorTag());
+    test_remove_copy_if_async(par(task), IteratorTag());
 }
 
 void remove_copy_if_test()
@@ -262,18 +262,16 @@ void test_remove_copy_if_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_remove_copy_if_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_remove_copy_if_exception(execution::seq, IteratorTag());
-    test_remove_copy_if_exception(execution::par, IteratorTag());
+    test_remove_copy_if_exception(seq, IteratorTag());
+    test_remove_copy_if_exception(par, IteratorTag());
 
-    test_remove_copy_if_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_remove_copy_if_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_remove_copy_if_exception_async(seq(task), IteratorTag());
+    test_remove_copy_if_exception_async(par(task), IteratorTag());
 }
 
 void remove_copy_if_exception_test()
@@ -357,18 +355,16 @@ void test_remove_copy_if_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_remove_copy_if_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_remove_copy_if_bad_alloc(execution::seq, IteratorTag());
-    test_remove_copy_if_bad_alloc(execution::par, IteratorTag());
+    test_remove_copy_if_bad_alloc(seq, IteratorTag());
+    test_remove_copy_if_bad_alloc(par, IteratorTag());
 
-    test_remove_copy_if_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_remove_copy_if_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_remove_copy_if_bad_alloc_async(seq(task), IteratorTag());
+    test_remove_copy_if_bad_alloc_async(par(task), IteratorTag());
 }
 
 void remove_copy_if_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove_tests.hpp
@@ -473,97 +473,94 @@ void test_remove_etc(ExPolicy policy, IteratorTag, DataType, int rand_base,
 template <typename IteratorTag>
 void test_remove(IteratorTag, int rand_base)
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     ////////// Test cases for 'int' type.
-    test_remove(
-        execution::seq, IteratorTag(), int(), int(rand_base + 1), rand_base);
-    test_remove(
-        execution::par, IteratorTag(), int(), int(rand_base), rand_base);
-    test_remove(execution::par_unseq, IteratorTag(), int(), int(rand_base - 1),
-        rand_base);
+    test_remove(seq, IteratorTag(), int(), int(rand_base + 1), rand_base);
+    test_remove(par, IteratorTag(), int(), int(rand_base), rand_base);
+    test_remove(par_unseq, IteratorTag(), int(), int(rand_base - 1), rand_base);
 
     ////////// Test cases for user defined type.
-    test_remove(execution::seq, IteratorTag(), user_defined_type(),
+    test_remove(seq, IteratorTag(), user_defined_type(),
         user_defined_type(rand_base), rand_base);
-    test_remove(execution::par, IteratorTag(), user_defined_type(),
+    test_remove(par, IteratorTag(), user_defined_type(),
         user_defined_type(rand_base + 1), rand_base);
 
     ////////// Asynchronous test cases for 'int' type.
-    test_remove_async(execution::seq(execution::task), IteratorTag(), int(),
-        int(rand_base), rand_base);
-    test_remove_async(execution::par(execution::task), IteratorTag(), int(),
-        int(rand_base - 1), rand_base);
+    test_remove_async(
+        seq(task), IteratorTag(), int(), int(rand_base), rand_base);
+    test_remove_async(
+        par(task), IteratorTag(), int(), int(rand_base - 1), rand_base);
 
     ////////// Asynchronous test cases for user defined type.
-    test_remove_async(execution::seq(execution::task), IteratorTag(),
-        user_defined_type(), user_defined_type(rand_base - 1), rand_base);
-    test_remove_async(execution::par(execution::task), IteratorTag(),
-        user_defined_type(), user_defined_type(rand_base), rand_base);
+    test_remove_async(seq(task), IteratorTag(), user_defined_type(),
+        user_defined_type(rand_base - 1), rand_base);
+    test_remove_async(par(task), IteratorTag(), user_defined_type(),
+        user_defined_type(rand_base), rand_base);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_remove_if(IteratorTag, int rand_base)
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     ////////// Test cases for 'int' type.
     test_remove_if(
-        execution::seq, IteratorTag(), int(),
+        seq, IteratorTag(), int(),
         [rand_base](const int a) -> bool { return a == rand_base; }, rand_base);
     test_remove_if(
-        execution::par, IteratorTag(), int(),
+        par, IteratorTag(), int(),
         [rand_base](const int a) -> bool { return !(a == rand_base); },
         rand_base);
     test_remove_if(
-        execution::par_unseq, IteratorTag(), int(),
+        par_unseq, IteratorTag(), int(),
         [rand_base](const int a) -> bool { return a == rand_base; }, rand_base);
 
     ////////// Test cases for user defined type.
     test_remove_if(
-        execution::seq, IteratorTag(), user_defined_type(),
+        seq, IteratorTag(), user_defined_type(),
         [rand_base](
             user_defined_type const& a) -> bool { return !(a == rand_base); },
         rand_base);
     test_remove_if(
-        execution::par, IteratorTag(), user_defined_type(),
+        par, IteratorTag(), user_defined_type(),
         [rand_base](
             user_defined_type const& a) -> bool { return a == rand_base; },
         rand_base);
     test_remove_if(
-        execution::par_unseq, IteratorTag(), user_defined_type(),
+        par_unseq, IteratorTag(), user_defined_type(),
         [rand_base](
             user_defined_type const& a) -> bool { return !(a == rand_base); },
         rand_base);
 
     ////////// Asynchronous test cases for 'int' type.
     test_remove_if_async(
-        execution::seq(execution::task), IteratorTag(), int(),
+        seq(task), IteratorTag(), int(),
         [rand_base](const int a) -> bool { return !(a == rand_base); },
         rand_base);
     test_remove_if_async(
-        execution::par(execution::task), IteratorTag(), int(),
+        par(task), IteratorTag(), int(),
         [rand_base](const int a) -> bool { return a == rand_base; }, rand_base);
 
     ////////// Asynchronous test cases for user defined type.
     test_remove_if_async(
-        execution::seq(execution::task), IteratorTag(), user_defined_type(),
+        seq(task), IteratorTag(), user_defined_type(),
         [rand_base](
             user_defined_type const& a) -> bool { return a == rand_base; },
         rand_base);
     test_remove_if_async(
-        execution::par(execution::task), IteratorTag(), user_defined_type(),
+        par(task), IteratorTag(), user_defined_type(),
         [rand_base](
             user_defined_type const& a) -> bool { return !(a == rand_base); },
         rand_base);
 
     ////////// Corner test cases.
     test_remove_if(
-        execution::par, IteratorTag(), int(),
-        [](const int) -> bool { return true; }, rand_base);
+        par, IteratorTag(), int(), [](const int) -> bool { return true; },
+        rand_base);
     test_remove_if(
-        execution::par_unseq, IteratorTag(), user_defined_type(),
+        par_unseq, IteratorTag(), user_defined_type(),
         [](user_defined_type const&) -> bool { return false; }, rand_base);
 }
 
@@ -583,42 +580,38 @@ void test_remove(bool test_for_remove_if = false)
     }
 
     ////////// Another test cases for justifying the implementation.
-    test_remove_etc(hpx::parallel::execution::seq, IteratorTag(),
-        user_defined_type(), rand_base, test_for_remove_if);
+    test_remove_etc(hpx::execution::seq, IteratorTag(), user_defined_type(),
+        rand_base, test_for_remove_if);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_remove_exception(bool test_for_remove_if = false)
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_remove_exception(execution::seq, IteratorTag(), test_for_remove_if);
-    test_remove_exception(execution::par, IteratorTag(), test_for_remove_if);
+    test_remove_exception(seq, IteratorTag(), test_for_remove_if);
+    test_remove_exception(par, IteratorTag(), test_for_remove_if);
 
-    test_remove_exception_async(
-        execution::seq(execution::task), IteratorTag(), test_for_remove_if);
-    test_remove_exception_async(
-        execution::par(execution::task), IteratorTag(), test_for_remove_if);
+    test_remove_exception_async(seq(task), IteratorTag(), test_for_remove_if);
+    test_remove_exception_async(par(task), IteratorTag(), test_for_remove_if);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_remove_bad_alloc(bool test_for_remove_if = false)
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_remove_bad_alloc(execution::seq, IteratorTag(), test_for_remove_if);
-    test_remove_bad_alloc(execution::par, IteratorTag(), test_for_remove_if);
+    test_remove_bad_alloc(seq, IteratorTag(), test_for_remove_if);
+    test_remove_bad_alloc(par, IteratorTag(), test_for_remove_if);
 
-    test_remove_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag(), test_for_remove_if);
-    test_remove_bad_alloc_async(
-        execution::par(execution::task), IteratorTag(), test_for_remove_if);
+    test_remove_bad_alloc_async(seq(task), IteratorTag(), test_for_remove_if);
+    test_remove_bad_alloc_async(par(task), IteratorTag(), test_for_remove_if);
 }

--- a/libs/parallelism/algorithms/tests/unit/algorithms/replace.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/replace.cpp
@@ -83,13 +83,13 @@ void test_replace_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace()
 {
-    using namespace hpx::parallel;
-    test_replace(execution::seq, IteratorTag());
-    test_replace(execution::par, IteratorTag());
-    test_replace(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_replace(seq, IteratorTag());
+    test_replace(par, IteratorTag());
+    test_replace(par_unseq, IteratorTag());
 
-    test_replace_async(execution::seq(execution::task), IteratorTag());
-    test_replace_async(execution::par(execution::task), IteratorTag());
+    test_replace_async(seq(task), IteratorTag());
+    test_replace_async(par(task), IteratorTag());
 }
 
 void replace_test()
@@ -175,18 +175,16 @@ void test_replace_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_replace_exception(execution::seq, IteratorTag());
-    test_replace_exception(execution::par, IteratorTag());
+    test_replace_exception(seq, IteratorTag());
+    test_replace_exception(par, IteratorTag());
 
-    test_replace_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_replace_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_replace_exception_async(seq(task), IteratorTag());
+    test_replace_exception_async(par(task), IteratorTag());
 }
 
 void replace_exception_test()
@@ -268,18 +266,16 @@ void test_replace_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_replace_bad_alloc(execution::seq, IteratorTag());
-    test_replace_bad_alloc(execution::par, IteratorTag());
+    test_replace_bad_alloc(seq, IteratorTag());
+    test_replace_bad_alloc(par, IteratorTag());
 
-    test_replace_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_replace_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_replace_bad_alloc_async(seq(task), IteratorTag());
+    test_replace_bad_alloc_async(par(task), IteratorTag());
 }
 
 void replace_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/replace_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/replace_copy.cpp
@@ -87,13 +87,13 @@ void test_replace_copy_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_copy()
 {
-    using namespace hpx::parallel;
-    test_replace_copy(execution::seq, IteratorTag());
-    test_replace_copy(execution::par, IteratorTag());
-    test_replace_copy(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_replace_copy(seq, IteratorTag());
+    test_replace_copy(par, IteratorTag());
+    test_replace_copy(par_unseq, IteratorTag());
 
-    test_replace_copy_async(execution::seq(execution::task), IteratorTag());
-    test_replace_copy_async(execution::par(execution::task), IteratorTag());
+    test_replace_copy_async(seq(task), IteratorTag());
+    test_replace_copy_async(par(task), IteratorTag());
 }
 
 void replace_copy_test()
@@ -183,18 +183,16 @@ void test_replace_copy_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_copy_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_replace_copy_exception(execution::seq, IteratorTag());
-    test_replace_copy_exception(execution::par, IteratorTag());
+    test_replace_copy_exception(seq, IteratorTag());
+    test_replace_copy_exception(par, IteratorTag());
 
-    test_replace_copy_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_replace_copy_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_replace_copy_exception_async(seq(task), IteratorTag());
+    test_replace_copy_exception_async(par(task), IteratorTag());
 }
 
 void replace_copy_exception_test()
@@ -280,18 +278,16 @@ void test_replace_copy_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_copy_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_replace_copy_bad_alloc(execution::seq, IteratorTag());
-    test_replace_copy_bad_alloc(execution::par, IteratorTag());
+    test_replace_copy_bad_alloc(seq, IteratorTag());
+    test_replace_copy_bad_alloc(par, IteratorTag());
 
-    test_replace_copy_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_replace_copy_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_replace_copy_bad_alloc_async(seq(task), IteratorTag());
+    test_replace_copy_bad_alloc_async(par(task), IteratorTag());
 }
 
 void replace_copy_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/replace_copy_if.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/replace_copy_if.cpp
@@ -102,13 +102,13 @@ void test_replace_copy_if_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_copy_if()
 {
-    using namespace hpx::parallel;
-    test_replace_copy_if(execution::seq, IteratorTag());
-    test_replace_copy_if(execution::par, IteratorTag());
-    test_replace_copy_if(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_replace_copy_if(seq, IteratorTag());
+    test_replace_copy_if(par, IteratorTag());
+    test_replace_copy_if(par_unseq, IteratorTag());
 
-    test_replace_copy_if_async(execution::seq(execution::task), IteratorTag());
-    test_replace_copy_if_async(execution::par(execution::task), IteratorTag());
+    test_replace_copy_if_async(seq(task), IteratorTag());
+    test_replace_copy_if_async(par(task), IteratorTag());
 }
 
 void replace_copy_if_test()
@@ -198,18 +198,16 @@ void test_replace_copy_if_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_copy_if_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_replace_copy_if_exception(execution::seq, IteratorTag());
-    test_replace_copy_if_exception(execution::par, IteratorTag());
+    test_replace_copy_if_exception(seq, IteratorTag());
+    test_replace_copy_if_exception(par, IteratorTag());
 
-    test_replace_copy_if_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_replace_copy_if_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_replace_copy_if_exception_async(seq(task), IteratorTag());
+    test_replace_copy_if_exception_async(par(task), IteratorTag());
 }
 
 void replace_copy_if_exception_test()
@@ -295,18 +293,16 @@ void test_replace_copy_if_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_copy_if_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_replace_copy_if_bad_alloc(execution::seq, IteratorTag());
-    test_replace_copy_if_bad_alloc(execution::par, IteratorTag());
+    test_replace_copy_if_bad_alloc(seq, IteratorTag());
+    test_replace_copy_if_bad_alloc(par, IteratorTag());
 
-    test_replace_copy_if_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_replace_copy_if_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_replace_copy_if_bad_alloc_async(seq(task), IteratorTag());
+    test_replace_copy_if_bad_alloc_async(par(task), IteratorTag());
 }
 
 void replace_copy_if_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/replace_if.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/replace_if.cpp
@@ -98,13 +98,13 @@ void test_replace_if_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_if()
 {
-    using namespace hpx::parallel;
-    test_replace_if(execution::seq, IteratorTag());
-    test_replace_if(execution::par, IteratorTag());
-    test_replace_if(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_replace_if(seq, IteratorTag());
+    test_replace_if(par, IteratorTag());
+    test_replace_if(par_unseq, IteratorTag());
 
-    test_replace_if_async(execution::seq(execution::task), IteratorTag());
-    test_replace_if_async(execution::par(execution::task), IteratorTag());
+    test_replace_if_async(seq(task), IteratorTag());
+    test_replace_if_async(par(task), IteratorTag());
 }
 
 void replace_if_test()
@@ -190,18 +190,16 @@ void test_replace_if_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_if_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_replace_if_exception(execution::seq, IteratorTag());
-    test_replace_if_exception(execution::par, IteratorTag());
+    test_replace_if_exception(seq, IteratorTag());
+    test_replace_if_exception(par, IteratorTag());
 
-    test_replace_if_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_replace_if_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_replace_if_exception_async(seq(task), IteratorTag());
+    test_replace_if_exception_async(par(task), IteratorTag());
 }
 
 void replace_if_exception_test()
@@ -283,18 +281,16 @@ void test_replace_if_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_if_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_replace_if_bad_alloc(execution::seq, IteratorTag());
-    test_replace_if_bad_alloc(execution::par, IteratorTag());
+    test_replace_if_bad_alloc(seq, IteratorTag());
+    test_replace_if_bad_alloc(par, IteratorTag());
 
-    test_replace_if_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_replace_if_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_replace_if_bad_alloc_async(seq(task), IteratorTag());
+    test_replace_if_bad_alloc_async(par(task), IteratorTag());
 }
 
 void replace_if_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/reverse.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/reverse.cpp
@@ -81,13 +81,13 @@ void test_reverse_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reverse()
 {
-    using namespace hpx::parallel;
-    test_reverse(execution::seq, IteratorTag());
-    test_reverse(execution::par, IteratorTag());
-    test_reverse(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_reverse(seq, IteratorTag());
+    test_reverse(par, IteratorTag());
+    test_reverse(par_unseq, IteratorTag());
 
-    test_reverse_async(execution::seq(execution::task), IteratorTag());
-    test_reverse_async(execution::par(execution::task), IteratorTag());
+    test_reverse_async(seq(task), IteratorTag());
+    test_reverse_async(par(task), IteratorTag());
 }
 
 void reverse_test()
@@ -172,18 +172,16 @@ void test_reverse_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reverse_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_reverse_exception(execution::seq, IteratorTag());
-    test_reverse_exception(execution::par, IteratorTag());
+    test_reverse_exception(seq, IteratorTag());
+    test_reverse_exception(par, IteratorTag());
 
-    test_reverse_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_reverse_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_reverse_exception_async(seq(task), IteratorTag());
+    test_reverse_exception_async(par(task), IteratorTag());
 }
 
 void reverse_exception_test()
@@ -264,18 +262,16 @@ void test_reverse_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reverse_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_reverse_bad_alloc(execution::seq, IteratorTag());
-    test_reverse_bad_alloc(execution::par, IteratorTag());
+    test_reverse_bad_alloc(seq, IteratorTag());
+    test_reverse_bad_alloc(par, IteratorTag());
 
-    test_reverse_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_reverse_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_reverse_bad_alloc_async(seq(task), IteratorTag());
+    test_reverse_bad_alloc_async(par(task), IteratorTag());
 }
 
 void reverse_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/reverse_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/reverse_copy.cpp
@@ -81,13 +81,13 @@ void test_reverse_copy_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reverse_copy()
 {
-    using namespace hpx::parallel;
-    test_reverse_copy(execution::seq, IteratorTag());
-    test_reverse_copy(execution::par, IteratorTag());
-    test_reverse_copy(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_reverse_copy(seq, IteratorTag());
+    test_reverse_copy(par, IteratorTag());
+    test_reverse_copy(par_unseq, IteratorTag());
 
-    test_reverse_copy_async(execution::seq(execution::task), IteratorTag());
-    test_reverse_copy_async(execution::par(execution::task), IteratorTag());
+    test_reverse_copy_async(seq(task), IteratorTag());
+    test_reverse_copy_async(par(task), IteratorTag());
 }
 
 void reverse_copy_test()
@@ -176,18 +176,16 @@ void test_reverse_copy_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reverse_copy_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_reverse_copy_exception(execution::seq, IteratorTag());
-    test_reverse_copy_exception(execution::par, IteratorTag());
+    test_reverse_copy_exception(seq, IteratorTag());
+    test_reverse_copy_exception(par, IteratorTag());
 
-    test_reverse_copy_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_reverse_copy_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_reverse_copy_exception_async(seq(task), IteratorTag());
+    test_reverse_copy_exception_async(par(task), IteratorTag());
 }
 
 void reverse_copy_exception_test()
@@ -272,18 +270,16 @@ void test_reverse_copy_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reverse_copy_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_reverse_copy_bad_alloc(execution::seq, IteratorTag());
-    test_reverse_copy_bad_alloc(execution::par, IteratorTag());
+    test_reverse_copy_bad_alloc(seq, IteratorTag());
+    test_reverse_copy_bad_alloc(par, IteratorTag());
 
-    test_reverse_copy_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_reverse_copy_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_reverse_copy_bad_alloc_async(seq(task), IteratorTag());
+    test_reverse_copy_bad_alloc_async(par(task), IteratorTag());
 }
 
 void reverse_copy_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/rotate.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/rotate.cpp
@@ -94,13 +94,13 @@ void test_rotate_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_rotate()
 {
-    using namespace hpx::parallel;
-    test_rotate(execution::seq, IteratorTag());
-    test_rotate(execution::par, IteratorTag());
-    test_rotate(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_rotate(seq, IteratorTag());
+    test_rotate(par, IteratorTag());
+    test_rotate(par_unseq, IteratorTag());
 
-    test_rotate_async(execution::seq(execution::task), IteratorTag());
-    test_rotate_async(execution::par(execution::task), IteratorTag());
+    test_rotate_async(seq(task), IteratorTag());
+    test_rotate_async(par(task), IteratorTag());
 }
 
 void rotate_test()
@@ -200,16 +200,16 @@ void test_rotate_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_rotate_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_rotate_exception(execution::seq, IteratorTag());
-    test_rotate_exception(execution::par, IteratorTag());
+    test_rotate_exception(seq, IteratorTag());
+    test_rotate_exception(par, IteratorTag());
 
-    test_rotate_exception_async(execution::seq(execution::task), IteratorTag());
-    test_rotate_exception_async(execution::par(execution::task), IteratorTag());
+    test_rotate_exception_async(seq(task), IteratorTag());
+    test_rotate_exception_async(par(task), IteratorTag());
 }
 
 void rotate_exception_test()
@@ -305,16 +305,16 @@ void test_rotate_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_rotate_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_rotate_bad_alloc(execution::seq, IteratorTag());
-    test_rotate_bad_alloc(execution::par, IteratorTag());
+    test_rotate_bad_alloc(seq, IteratorTag());
+    test_rotate_bad_alloc(par, IteratorTag());
 
-    test_rotate_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_rotate_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_rotate_bad_alloc_async(seq(task), IteratorTag());
+    test_rotate_bad_alloc_async(par(task), IteratorTag());
 }
 
 void rotate_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/rotate_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/rotate_copy.cpp
@@ -87,13 +87,13 @@ void test_rotate_copy_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_rotate_copy()
 {
-    using namespace hpx::parallel;
-    test_rotate_copy(execution::seq, IteratorTag());
-    test_rotate_copy(execution::par, IteratorTag());
-    test_rotate_copy(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_rotate_copy(seq, IteratorTag());
+    test_rotate_copy(par, IteratorTag());
+    test_rotate_copy(par_unseq, IteratorTag());
 
-    test_rotate_copy_async(execution::seq(execution::task), IteratorTag());
-    test_rotate_copy_async(execution::par(execution::task), IteratorTag());
+    test_rotate_copy_async(seq(task), IteratorTag());
+    test_rotate_copy_async(par(task), IteratorTag());
 }
 
 void rotate_copy_test()
@@ -197,18 +197,16 @@ void test_rotate_copy_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_rotate_copy_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_rotate_copy_exception(execution::seq, IteratorTag());
-    test_rotate_copy_exception(execution::par, IteratorTag());
+    test_rotate_copy_exception(seq, IteratorTag());
+    test_rotate_copy_exception(par, IteratorTag());
 
-    test_rotate_copy_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_rotate_copy_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_rotate_copy_exception_async(seq(task), IteratorTag());
+    test_rotate_copy_exception_async(par(task), IteratorTag());
 }
 
 void rotate_copy_exception_test()
@@ -308,18 +306,16 @@ void test_rotate_copy_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_rotate_copy_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_rotate_copy_bad_alloc(execution::seq, IteratorTag());
-    test_rotate_copy_bad_alloc(execution::par, IteratorTag());
+    test_rotate_copy_bad_alloc(seq, IteratorTag());
+    test_rotate_copy_bad_alloc(par, IteratorTag());
 
-    test_rotate_copy_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_rotate_copy_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_rotate_copy_bad_alloc_async(seq(task), IteratorTag());
+    test_rotate_copy_bad_alloc_async(par(task), IteratorTag());
 }
 
 void rotate_copy_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/search.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/search.cpp
@@ -74,13 +74,13 @@ void test_search1_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search1()
 {
-    using namespace hpx::parallel;
-    test_search1(execution::seq, IteratorTag());
-    test_search1(execution::par, IteratorTag());
-    test_search1(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_search1(seq, IteratorTag());
+    test_search1(par, IteratorTag());
+    test_search1(par_unseq, IteratorTag());
 
-    test_search1_async(execution::seq(execution::task), IteratorTag());
-    test_search1_async(execution::par(execution::task), IteratorTag());
+    test_search1_async(seq(task), IteratorTag());
+    test_search1_async(par(task), IteratorTag());
 }
 
 void search_test1()
@@ -148,13 +148,13 @@ void test_search2_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search2()
 {
-    using namespace hpx::parallel;
-    test_search2(execution::seq, IteratorTag());
-    test_search2(execution::par, IteratorTag());
-    test_search2(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_search2(seq, IteratorTag());
+    test_search2(par, IteratorTag());
+    test_search2(par_unseq, IteratorTag());
 
-    test_search2_async(execution::seq(execution::task), IteratorTag());
-    test_search2_async(execution::par(execution::task), IteratorTag());
+    test_search2_async(seq(task), IteratorTag());
+    test_search2_async(par(task), IteratorTag());
 }
 
 void search_test2()
@@ -220,13 +220,13 @@ void test_search3_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search3()
 {
-    using namespace hpx::parallel;
-    test_search3(execution::seq, IteratorTag());
-    test_search3(execution::par, IteratorTag());
-    test_search3(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_search3(seq, IteratorTag());
+    test_search3(par, IteratorTag());
+    test_search3(par_unseq, IteratorTag());
 
-    test_search3_async(execution::seq(execution::task), IteratorTag());
-    test_search3_async(execution::par(execution::task), IteratorTag());
+    test_search3_async(seq(task), IteratorTag());
+    test_search3_async(par(task), IteratorTag());
 }
 
 void search_test3()
@@ -295,13 +295,13 @@ void test_search4_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search4()
 {
-    using namespace hpx::parallel;
-    test_search4(execution::seq, IteratorTag());
-    test_search4(execution::par, IteratorTag());
-    test_search4(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_search4(seq, IteratorTag());
+    test_search4(par, IteratorTag());
+    test_search4(par_unseq, IteratorTag());
 
-    test_search4_async(execution::seq(execution::task), IteratorTag());
-    test_search4_async(execution::par(execution::task), IteratorTag());
+    test_search4_async(seq(task), IteratorTag());
+    test_search4_async(par(task), IteratorTag());
 }
 
 void search_test4()
@@ -397,15 +397,15 @@ void test_search_async_exception(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
     //If the execution policy object is of type vector_execution_policy,
     //  std::terminate shall be called. therefore we do not test exceptions
     //  with a vector execution policy
-    test_search_exception(execution::seq, IteratorTag());
-    test_search_exception(execution::par, IteratorTag());
+    test_search_exception(seq, IteratorTag());
+    test_search_exception(par, IteratorTag());
 
-    test_search_async_exception(execution::seq(execution::task), IteratorTag());
-    test_search_async_exception(execution::par(execution::task), IteratorTag());
+    test_search_async_exception(seq(task), IteratorTag());
+    test_search_async_exception(par(task), IteratorTag());
 }
 
 void search_exception_test()
@@ -493,16 +493,16 @@ void test_search_async_bad_alloc(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_search_bad_alloc(execution::par, IteratorTag());
-    test_search_bad_alloc(execution::seq, IteratorTag());
+    test_search_bad_alloc(par, IteratorTag());
+    test_search_bad_alloc(seq, IteratorTag());
 
-    test_search_async_bad_alloc(execution::seq(execution::task), IteratorTag());
-    test_search_async_bad_alloc(execution::par(execution::task), IteratorTag());
+    test_search_async_bad_alloc(seq(task), IteratorTag());
+    test_search_async_bad_alloc(par(task), IteratorTag());
 }
 
 void search_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/searchn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/searchn.cpp
@@ -74,13 +74,13 @@ void test_search_n1_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search_n1()
 {
-    using namespace hpx::parallel;
-    test_search_n1(execution::seq, IteratorTag());
-    test_search_n1(execution::par, IteratorTag());
-    test_search_n1(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_search_n1(seq, IteratorTag());
+    test_search_n1(par, IteratorTag());
+    test_search_n1(par_unseq, IteratorTag());
 
-    test_search_n1_async(execution::seq(execution::task), IteratorTag());
-    test_search_n1_async(execution::par(execution::task), IteratorTag());
+    test_search_n1_async(seq(task), IteratorTag());
+    test_search_n1_async(par(task), IteratorTag());
 }
 
 void search_n_test1()
@@ -148,13 +148,13 @@ void test_search_n2_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search_n2()
 {
-    using namespace hpx::parallel;
-    test_search_n2(execution::seq, IteratorTag());
-    test_search_n2(execution::par, IteratorTag());
-    test_search_n2(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_search_n2(seq, IteratorTag());
+    test_search_n2(par, IteratorTag());
+    test_search_n2(par_unseq, IteratorTag());
 
-    test_search_n2_async(execution::seq(execution::task), IteratorTag());
-    test_search_n2_async(execution::par(execution::task), IteratorTag());
+    test_search_n2_async(seq(task), IteratorTag());
+    test_search_n2_async(par(task), IteratorTag());
 }
 
 void search_n_test2()
@@ -220,13 +220,13 @@ void test_search_n3_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search_n3()
 {
-    using namespace hpx::parallel;
-    test_search_n3(execution::seq, IteratorTag());
-    test_search_n3(execution::par, IteratorTag());
-    test_search_n3(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_search_n3(seq, IteratorTag());
+    test_search_n3(par, IteratorTag());
+    test_search_n3(par_unseq, IteratorTag());
 
-    test_search_n3_async(execution::seq(execution::task), IteratorTag());
-    test_search_n3_async(execution::par(execution::task), IteratorTag());
+    test_search_n3_async(seq(task), IteratorTag());
+    test_search_n3_async(par(task), IteratorTag());
 }
 
 void search_n_test3()
@@ -296,13 +296,13 @@ void test_search_n4_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search_n4()
 {
-    using namespace hpx::parallel;
-    test_search_n4(execution::seq, IteratorTag());
-    test_search_n4(execution::par, IteratorTag());
-    test_search_n4(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_search_n4(seq, IteratorTag());
+    test_search_n4(par, IteratorTag());
+    test_search_n4(par_unseq, IteratorTag());
 
-    test_search_n4_async(execution::seq(execution::task), IteratorTag());
-    test_search_n4_async(execution::par(execution::task), IteratorTag());
+    test_search_n4_async(seq(task), IteratorTag());
+    test_search_n4_async(par(task), IteratorTag());
 }
 
 void search_n_test4()
@@ -370,13 +370,13 @@ void test_search_n5_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search_n5()
 {
-    using namespace hpx::parallel;
-    test_search_n5(execution::seq, IteratorTag());
-    test_search_n5(execution::par, IteratorTag());
-    test_search_n5(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_search_n5(seq, IteratorTag());
+    test_search_n5(par, IteratorTag());
+    test_search_n5(par_unseq, IteratorTag());
 
-    test_search_n5_async(execution::seq(execution::task), IteratorTag());
-    test_search_n5_async(execution::par(execution::task), IteratorTag());
+    test_search_n5_async(seq(task), IteratorTag());
+    test_search_n5_async(par(task), IteratorTag());
 }
 
 void search_n_test5()
@@ -468,17 +468,15 @@ void test_search_n_async_exception(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search_n_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
     //If the execution policy object is of type vector_execution_policy,
     //  std::terminate shall be called. therefore we do not test exceptions
     //  with a vector execution policy
-    test_search_n_exception(execution::seq, IteratorTag());
-    test_search_n_exception(execution::par, IteratorTag());
+    test_search_n_exception(seq, IteratorTag());
+    test_search_n_exception(par, IteratorTag());
 
-    test_search_n_async_exception(
-        execution::seq(execution::task), IteratorTag());
-    test_search_n_async_exception(
-        execution::par(execution::task), IteratorTag());
+    test_search_n_async_exception(seq(task), IteratorTag());
+    test_search_n_async_exception(par(task), IteratorTag());
 }
 
 void search_n_exception_test()
@@ -564,18 +562,16 @@ void test_search_n_async_bad_alloc(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search_n_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_search_n_bad_alloc(execution::par, IteratorTag());
-    test_search_n_bad_alloc(execution::seq, IteratorTag());
+    test_search_n_bad_alloc(par, IteratorTag());
+    test_search_n_bad_alloc(seq, IteratorTag());
 
-    test_search_n_async_bad_alloc(
-        execution::seq(execution::task), IteratorTag());
-    test_search_n_async_bad_alloc(
-        execution::par(execution::task), IteratorTag());
+    test_search_n_async_bad_alloc(seq(task), IteratorTag());
+    test_search_n_async_bad_alloc(par(task), IteratorTag());
 }
 
 void search_n_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/set_difference.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/set_difference.cpp
@@ -75,14 +75,14 @@ void test_set_difference1_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_set_difference1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_set_difference1(execution::seq, IteratorTag());
-    test_set_difference1(execution::par, IteratorTag());
-    test_set_difference1(execution::par_unseq, IteratorTag());
+    test_set_difference1(seq, IteratorTag());
+    test_set_difference1(par, IteratorTag());
+    test_set_difference1(par_unseq, IteratorTag());
 
-    test_set_difference1_async(execution::seq(execution::task), IteratorTag());
-    test_set_difference1_async(execution::par(execution::task), IteratorTag());
+    test_set_difference1_async(seq(task), IteratorTag());
+    test_set_difference1_async(par(task), IteratorTag());
 }
 
 void set_difference_test1()
@@ -158,14 +158,14 @@ void test_set_difference2_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_set_difference2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_set_difference2(execution::seq, IteratorTag());
-    test_set_difference2(execution::par, IteratorTag());
-    test_set_difference2(execution::par_unseq, IteratorTag());
+    test_set_difference2(seq, IteratorTag());
+    test_set_difference2(par, IteratorTag());
+    test_set_difference2(par_unseq, IteratorTag());
 
-    test_set_difference2_async(execution::seq(execution::task), IteratorTag());
-    test_set_difference2_async(execution::par(execution::task), IteratorTag());
+    test_set_difference2_async(seq(task), IteratorTag());
+    test_set_difference2_async(par(task), IteratorTag());
 }
 
 void set_difference_test2()
@@ -269,18 +269,16 @@ void test_set_difference_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_set_difference_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_set_difference_exception(execution::seq, IteratorTag());
-    test_set_difference_exception(execution::par, IteratorTag());
+    test_set_difference_exception(seq, IteratorTag());
+    test_set_difference_exception(par, IteratorTag());
 
-    test_set_difference_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_set_difference_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_set_difference_exception_async(seq(task), IteratorTag());
+    test_set_difference_exception_async(par(task), IteratorTag());
 }
 
 void set_difference_exception_test()
@@ -382,18 +380,16 @@ void test_set_difference_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_set_difference_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_set_difference_bad_alloc(execution::seq, IteratorTag());
-    test_set_difference_bad_alloc(execution::par, IteratorTag());
+    test_set_difference_bad_alloc(seq, IteratorTag());
+    test_set_difference_bad_alloc(par, IteratorTag());
 
-    test_set_difference_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_set_difference_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_set_difference_bad_alloc_async(seq(task), IteratorTag());
+    test_set_difference_bad_alloc_async(par(task), IteratorTag());
 }
 
 void set_difference_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/set_intersection.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/set_intersection.cpp
@@ -75,16 +75,14 @@ void test_set_intersection1_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_set_intersection1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_set_intersection1(execution::seq, IteratorTag());
-    test_set_intersection1(execution::par, IteratorTag());
-    test_set_intersection1(execution::par_unseq, IteratorTag());
+    test_set_intersection1(seq, IteratorTag());
+    test_set_intersection1(par, IteratorTag());
+    test_set_intersection1(par_unseq, IteratorTag());
 
-    test_set_intersection1_async(
-        execution::seq(execution::task), IteratorTag());
-    test_set_intersection1_async(
-        execution::par(execution::task), IteratorTag());
+    test_set_intersection1_async(seq(task), IteratorTag());
+    test_set_intersection1_async(par(task), IteratorTag());
 }
 
 void set_intersection_test1()
@@ -160,16 +158,14 @@ void test_set_intersection2_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_set_intersection2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_set_intersection2(execution::seq, IteratorTag());
-    test_set_intersection2(execution::par, IteratorTag());
-    test_set_intersection2(execution::par_unseq, IteratorTag());
+    test_set_intersection2(seq, IteratorTag());
+    test_set_intersection2(par, IteratorTag());
+    test_set_intersection2(par_unseq, IteratorTag());
 
-    test_set_intersection2_async(
-        execution::seq(execution::task), IteratorTag());
-    test_set_intersection2_async(
-        execution::par(execution::task), IteratorTag());
+    test_set_intersection2_async(seq(task), IteratorTag());
+    test_set_intersection2_async(par(task), IteratorTag());
 }
 
 void set_intersection_test2()
@@ -273,18 +269,16 @@ void test_set_intersection_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_set_intersection_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_set_intersection_exception(execution::seq, IteratorTag());
-    test_set_intersection_exception(execution::par, IteratorTag());
+    test_set_intersection_exception(seq, IteratorTag());
+    test_set_intersection_exception(par, IteratorTag());
 
-    test_set_intersection_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_set_intersection_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_set_intersection_exception_async(seq(task), IteratorTag());
+    test_set_intersection_exception_async(par(task), IteratorTag());
 }
 
 void set_intersection_exception_test()
@@ -386,18 +380,16 @@ void test_set_intersection_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_set_intersection_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_set_intersection_bad_alloc(execution::seq, IteratorTag());
-    test_set_intersection_bad_alloc(execution::par, IteratorTag());
+    test_set_intersection_bad_alloc(seq, IteratorTag());
+    test_set_intersection_bad_alloc(par, IteratorTag());
 
-    test_set_intersection_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_set_intersection_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_set_intersection_bad_alloc_async(seq(task), IteratorTag());
+    test_set_intersection_bad_alloc_async(par(task), IteratorTag());
 }
 
 void set_intersection_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/set_symmetric_difference.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/set_symmetric_difference.cpp
@@ -75,16 +75,14 @@ void test_set_symmetric_difference1_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_set_symmetric_difference1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_set_symmetric_difference1(execution::seq, IteratorTag());
-    test_set_symmetric_difference1(execution::par, IteratorTag());
-    test_set_symmetric_difference1(execution::par_unseq, IteratorTag());
+    test_set_symmetric_difference1(seq, IteratorTag());
+    test_set_symmetric_difference1(par, IteratorTag());
+    test_set_symmetric_difference1(par_unseq, IteratorTag());
 
-    test_set_symmetric_difference1_async(
-        execution::seq(execution::task), IteratorTag());
-    test_set_symmetric_difference1_async(
-        execution::par(execution::task), IteratorTag());
+    test_set_symmetric_difference1_async(seq(task), IteratorTag());
+    test_set_symmetric_difference1_async(par(task), IteratorTag());
 }
 
 void set_symmetric_difference_test1()
@@ -160,16 +158,14 @@ void test_set_symmetric_difference2_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_set_symmetric_difference2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_set_symmetric_difference2(execution::seq, IteratorTag());
-    test_set_symmetric_difference2(execution::par, IteratorTag());
-    test_set_symmetric_difference2(execution::par_unseq, IteratorTag());
+    test_set_symmetric_difference2(seq, IteratorTag());
+    test_set_symmetric_difference2(par, IteratorTag());
+    test_set_symmetric_difference2(par_unseq, IteratorTag());
 
-    test_set_symmetric_difference2_async(
-        execution::seq(execution::task), IteratorTag());
-    test_set_symmetric_difference2_async(
-        execution::par(execution::task), IteratorTag());
+    test_set_symmetric_difference2_async(seq(task), IteratorTag());
+    test_set_symmetric_difference2_async(par(task), IteratorTag());
 }
 
 void set_symmetric_difference_test2()
@@ -273,18 +269,16 @@ void test_set_symmetric_difference_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_set_symmetric_difference_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_set_symmetric_difference_exception(execution::seq, IteratorTag());
-    test_set_symmetric_difference_exception(execution::par, IteratorTag());
+    test_set_symmetric_difference_exception(seq, IteratorTag());
+    test_set_symmetric_difference_exception(par, IteratorTag());
 
-    test_set_symmetric_difference_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_set_symmetric_difference_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_set_symmetric_difference_exception_async(seq(task), IteratorTag());
+    test_set_symmetric_difference_exception_async(par(task), IteratorTag());
 }
 
 void set_symmetric_difference_exception_test()
@@ -386,18 +380,16 @@ void test_set_symmetric_difference_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_set_symmetric_difference_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_set_symmetric_difference_bad_alloc(execution::seq, IteratorTag());
-    test_set_symmetric_difference_bad_alloc(execution::par, IteratorTag());
+    test_set_symmetric_difference_bad_alloc(seq, IteratorTag());
+    test_set_symmetric_difference_bad_alloc(par, IteratorTag());
 
-    test_set_symmetric_difference_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_set_symmetric_difference_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_set_symmetric_difference_bad_alloc_async(seq(task), IteratorTag());
+    test_set_symmetric_difference_bad_alloc_async(par(task), IteratorTag());
 }
 
 void set_symmetric_difference_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/set_union.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/set_union.cpp
@@ -75,14 +75,14 @@ void test_set_union1_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_set_union1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_set_union1(execution::seq, IteratorTag());
-    test_set_union1(execution::par, IteratorTag());
-    test_set_union1(execution::par_unseq, IteratorTag());
+    test_set_union1(seq, IteratorTag());
+    test_set_union1(par, IteratorTag());
+    test_set_union1(par_unseq, IteratorTag());
 
-    test_set_union1_async(execution::seq(execution::task), IteratorTag());
-    test_set_union1_async(execution::par(execution::task), IteratorTag());
+    test_set_union1_async(seq(task), IteratorTag());
+    test_set_union1_async(par(task), IteratorTag());
 }
 
 void set_union_test1()
@@ -158,14 +158,14 @@ void test_set_union2_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_set_union2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_set_union2(execution::seq, IteratorTag());
-    test_set_union2(execution::par, IteratorTag());
-    test_set_union2(execution::par_unseq, IteratorTag());
+    test_set_union2(seq, IteratorTag());
+    test_set_union2(par, IteratorTag());
+    test_set_union2(par_unseq, IteratorTag());
 
-    test_set_union2_async(execution::seq(execution::task), IteratorTag());
-    test_set_union2_async(execution::par(execution::task), IteratorTag());
+    test_set_union2_async(seq(task), IteratorTag());
+    test_set_union2_async(par(task), IteratorTag());
 }
 
 void set_union_test2()
@@ -269,18 +269,16 @@ void test_set_union_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_set_union_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_set_union_exception(execution::seq, IteratorTag());
-    test_set_union_exception(execution::par, IteratorTag());
+    test_set_union_exception(seq, IteratorTag());
+    test_set_union_exception(par, IteratorTag());
 
-    test_set_union_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_set_union_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_set_union_exception_async(seq(task), IteratorTag());
+    test_set_union_exception_async(par(task), IteratorTag());
 }
 
 void set_union_exception_test()
@@ -382,18 +380,16 @@ void test_set_union_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_set_union_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_set_union_bad_alloc(execution::seq, IteratorTag());
-    test_set_union_bad_alloc(execution::par, IteratorTag());
+    test_set_union_bad_alloc(seq, IteratorTag());
+    test_set_union_bad_alloc(par, IteratorTag());
 
-    test_set_union_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_set_union_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_set_union_bad_alloc_async(seq(task), IteratorTag());
+    test_set_union_bad_alloc_async(par(task), IteratorTag());
 }
 
 void set_union_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/sort.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/sort.cpp
@@ -27,7 +27,7 @@ void sort_benchmark()
 {
     try
     {
-        using namespace hpx::parallel;
+        using namespace hpx::execution;
         // Fill vector with random values
         std::vector<double> c(HPX_SORT_TEST_SIZE << 4);
         rnd_fill<double>(c, (std::numeric_limits<double>::min)(),
@@ -35,7 +35,7 @@ void sort_benchmark()
 
         hpx::util::high_resolution_timer t;
         // sort, blocking when seq, par, par_vec
-        hpx::parallel::sort(execution::par, c.begin(), c.end());
+        hpx::parallel::sort(par, c.begin(), c.end());
         auto elapsed = static_cast<std::uint64_t>(t.elapsed_nanoseconds());
 
         bool is_sorted = (verify_(c, std::less<double>(), elapsed, true) != 0);
@@ -55,103 +55,92 @@ void sort_benchmark()
 ////////////////////////////////////////////////////////////////////////////////
 void test_sort1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // default comparison operator (std::less)
-    test_sort1(execution::seq, int());
-    test_sort1(execution::par, int());
-    test_sort1(execution::par_unseq, int());
+    test_sort1(seq, int());
+    test_sort1(par, int());
+    test_sort1(par_unseq, int());
 
     // default comparison operator (std::less)
-    test_sort1(execution::seq, double());
-    test_sort1(execution::par, double());
-    test_sort1(execution::par_unseq, double());
+    test_sort1(seq, double());
+    test_sort1(par, double());
+    test_sort1(par_unseq, double());
 
     // default comparison operator (std::less)
-    test_sort1(execution::seq, std::string());
-    test_sort1(execution::par, std::string());
-    test_sort1(execution::par_unseq, std::string());
+    test_sort1(seq, std::string());
+    test_sort1(par, std::string());
+    test_sort1(par_unseq, std::string());
 
     // user supplied comparison operator (std::less)
-    test_sort1_comp(execution::seq, int(), std::less<std::size_t>());
-    test_sort1_comp(execution::par, int(), std::less<std::size_t>());
-    test_sort1_comp(execution::par_unseq, int(), std::less<std::size_t>());
+    test_sort1_comp(seq, int(), std::less<std::size_t>());
+    test_sort1_comp(par, int(), std::less<std::size_t>());
+    test_sort1_comp(par_unseq, int(), std::less<std::size_t>());
 
     // user supplied comparison operator (std::greater)
-    test_sort1_comp(execution::seq, double(), std::greater<double>());
-    test_sort1_comp(execution::par, double(), std::greater<double>());
-    test_sort1_comp(execution::par_unseq, double(), std::greater<double>());
+    test_sort1_comp(seq, double(), std::greater<double>());
+    test_sort1_comp(par, double(), std::greater<double>());
+    test_sort1_comp(par_unseq, double(), std::greater<double>());
 
     // default comparison operator (std::less)
-    test_sort1_comp(execution::seq, std::string(), std::greater<std::string>());
-    test_sort1_comp(execution::par, std::string(), std::greater<std::string>());
-    test_sort1_comp(
-        execution::par_unseq, std::string(), std::greater<std::string>());
+    test_sort1_comp(seq, std::string(), std::greater<std::string>());
+    test_sort1_comp(par, std::string(), std::greater<std::string>());
+    test_sort1_comp(par_unseq, std::string(), std::greater<std::string>());
 
     // Async execution, default comparison operator
-    test_sort1_async(execution::seq(execution::task), int());
-    test_sort1_async(execution::par(execution::task), char());
-    test_sort1_async(execution::seq(execution::task), double());
-    test_sort1_async(execution::par(execution::task), float());
-    test_sort1_async_str(execution::seq(execution::task));
-    test_sort1_async_str(execution::par(execution::task));
+    test_sort1_async(seq(task), int());
+    test_sort1_async(par(task), char());
+    test_sort1_async(seq(task), double());
+    test_sort1_async(par(task), float());
+    test_sort1_async_str(seq(task));
+    test_sort1_async_str(par(task));
 
     // Async execution, user comparison operator
-    test_sort1_async(
-        execution::seq(execution::task), int(), std::less<unsigned int>());
-    test_sort1_async(
-        execution::par(execution::task), char(), std::less<char>());
+    test_sort1_async(seq(task), int(), std::less<unsigned int>());
+    test_sort1_async(par(task), char(), std::less<char>());
     //
-    test_sort1_async(
-        execution::seq(execution::task), double(), std::greater<double>());
-    test_sort1_async(
-        execution::par(execution::task), float(), std::greater<float>());
+    test_sort1_async(seq(task), double(), std::greater<double>());
+    test_sort1_async(par(task), float(), std::greater<float>());
     //
-    test_sort1_async_str(
-        execution::seq(execution::task), std::greater<std::string>());
-    test_sort1_async_str(
-        execution::par(execution::task), std::greater<std::string>());
+    test_sort1_async_str(seq(task), std::greater<std::string>());
+    test_sort1_async_str(par(task), std::greater<std::string>());
 }
 
 void test_sort2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
     // default comparison operator (std::less)
-    test_sort2(execution::seq, int());
-    test_sort2(execution::par, int());
-    test_sort2(execution::par_unseq, int());
+    test_sort2(seq, int());
+    test_sort2(par, int());
+    test_sort2(par_unseq, int());
 
     // default comparison operator (std::less)
-    test_sort2(execution::seq, double());
-    test_sort2(execution::par, double());
-    test_sort2(execution::par_unseq, double());
+    test_sort2(seq, double());
+    test_sort2(par, double());
+    test_sort2(par_unseq, double());
 
     // user supplied comparison operator (std::less)
-    test_sort2_comp(execution::seq, int(), std::less<std::size_t>());
-    test_sort2_comp(execution::par, int(), std::less<std::size_t>());
-    test_sort2_comp(execution::par_unseq, int(), std::less<std::size_t>());
+    test_sort2_comp(seq, int(), std::less<std::size_t>());
+    test_sort2_comp(par, int(), std::less<std::size_t>());
+    test_sort2_comp(par_unseq, int(), std::less<std::size_t>());
 
     // user supplied comparison operator (std::greater)
-    test_sort2_comp(execution::seq, double(), std::greater<double>());
-    test_sort2_comp(execution::par, double(), std::greater<double>());
-    test_sort2_comp(execution::par_unseq, double(), std::greater<double>());
+    test_sort2_comp(seq, double(), std::greater<double>());
+    test_sort2_comp(par, double(), std::greater<double>());
+    test_sort2_comp(par_unseq, double(), std::greater<double>());
 
     // Async execution, default comparison operator
-    test_sort2_async(execution::seq(execution::task), int());
-    test_sort2_async(execution::par(execution::task), char());
-    test_sort2_async(execution::seq(execution::task), double());
-    test_sort2_async(execution::par(execution::task), float());
+    test_sort2_async(seq(task), int());
+    test_sort2_async(par(task), char());
+    test_sort2_async(seq(task), double());
+    test_sort2_async(par(task), float());
 
     // Async execution, user comparison operator
-    test_sort2_async(
-        execution::seq(execution::task), int(), std::less<unsigned int>());
-    test_sort2_async(
-        execution::par(execution::task), char(), std::less<char>());
+    test_sort2_async(seq(task), int(), std::less<unsigned int>());
+    test_sort2_async(par(task), char(), std::less<char>());
     //
-    test_sort2_async(
-        execution::seq(execution::task), double(), std::greater<double>());
-    test_sort2_async(
-        execution::par(execution::task), float(), std::greater<float>());
+    test_sort2_async(seq(task), double(), std::greater<double>());
+    test_sort2_async(par(task), float(), std::greater<float>());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/algorithms/tests/unit/algorithms/sort_by_key.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/sort_by_key.cpp
@@ -93,8 +93,8 @@ void sort_by_key_benchmark()
         o_values = values;
 
         hpx::util::high_resolution_timer t;
-        hpx::parallel::sort_by_key(hpx::parallel::execution::par, keys.begin(),
-            keys.end(), values.begin());
+        hpx::parallel::sort_by_key(
+            hpx::execution::par, keys.begin(), keys.end(), values.begin());
         auto elapsed = static_cast<std::uint64_t>(t.elapsed_nanoseconds());
 
         // after sorting by key, the values should be equal to the original keys
@@ -224,7 +224,7 @@ void test_sort_by_key_async(
 ////////////////////////////////////////////////////////////////////////////////
 void test_sort_by_key1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
     //
     // run many tests in a loop for N seconds just to play safe
     //
@@ -234,34 +234,34 @@ void test_sort_by_key1()
     do
     {
         //
-        test_sort_by_key1(execution::seq, int(), int(), std::equal_to<int>(),
+        test_sort_by_key1(seq, int(), int(), std::equal_to<int>(),
             [](int key) { return key; });
-        test_sort_by_key1(execution::par, int(), int(), std::equal_to<int>(),
+        test_sort_by_key1(par, int(), int(), std::equal_to<int>(),
             [](int key) { return key; });
-        test_sort_by_key1(execution::par_unseq, int(), int(),
-            std::equal_to<int>(), [](int key) { return key; });
+        test_sort_by_key1(par_unseq, int(), int(), std::equal_to<int>(),
+            [](int key) { return key; });
         //
-        test_sort_by_key1(execution::seq, int(), double(),
-            std::equal_to<double>(), [](int key) { return key; });
-        test_sort_by_key1(execution::par, int(), double(),
-            std::equal_to<double>(), [](int key) { return key; });
-        test_sort_by_key1(execution::par_unseq, int(), double(),
-            std::equal_to<double>(), [](int key) { return key; });
+        test_sort_by_key1(seq, int(), double(), std::equal_to<double>(),
+            [](int key) { return key; });
+        test_sort_by_key1(par, int(), double(), std::equal_to<double>(),
+            [](int key) { return key; });
+        test_sort_by_key1(par_unseq, int(), double(), std::equal_to<double>(),
+            [](int key) { return key; });
         // custom compare
         test_sort_by_key1(
-            execution::seq, double(), double(),
+            seq, double(), double(),
             [](double a, double b) {
                 return std::floor(a) == std::floor(b);
             },    //-V550
             [](double a) { return std::floor(a); });
         test_sort_by_key1(
-            execution::par, double(), double(),
+            par, double(), double(),
             [](double a, double b) {
                 return std::floor(a) == std::floor(b);
             },    //-V550
             [](double a) { return std::floor(a); });
         test_sort_by_key1(
-            execution::par_unseq, double(), double(),
+            par_unseq, double(), double(),
             [](double a, double b) {
                 return std::floor(a) == std::floor(b);
             },    //-V550
@@ -271,14 +271,14 @@ void test_sort_by_key1()
     hpx::util::high_resolution_timer t2;
     do
     {
-        test_sort_by_key_async(execution::seq(execution::task), int(), int(),
-            std::equal_to<int>(), [](int key) { return key; });
-        test_sort_by_key_async(execution::par(execution::task), int(), int(),
-            std::equal_to<int>(), [](int key) { return key; });
+        test_sort_by_key_async(seq(task), int(), int(), std::equal_to<int>(),
+            [](int key) { return key; });
+        test_sort_by_key_async(par(task), int(), int(), std::equal_to<int>(),
+            [](int key) { return key; });
         //
-        test_sort_by_key_async(execution::seq(execution::task), int(), double(),
+        test_sort_by_key_async(seq(task), int(), double(),
             std::equal_to<double>(), [](int key) { return key; });
-        test_sort_by_key_async(execution::par(execution::task), int(), double(),
+        test_sort_by_key_async(par(task), int(), double(),
             std::equal_to<double>(), [](int key) { return key; });
     } while (t2.elapsed() < seconds);
 }

--- a/libs/parallelism/algorithms/tests/unit/algorithms/sort_exceptions.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/sort_exceptions.cpp
@@ -22,25 +22,23 @@
 ///////////////////////////////////////////////////////////////////////////////
 void test_exceptions()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // default comparison operator (std::less)
-    test_sort_exception(execution::seq, int());
-    test_sort_exception(execution::par, int());
+    test_sort_exception(seq, int());
+    test_sort_exception(par, int());
 
     // user supplied comparison operator (std::less)
-    test_sort_exception(execution::seq, int(), std::less<int>());
-    test_sort_exception(execution::par, int(), std::less<int>());
+    test_sort_exception(seq, int(), std::less<int>());
+    test_sort_exception(par, int(), std::less<int>());
 
     // Async execution, default comparison operator
-    test_sort_exception_async(execution::seq(execution::task), int());
-    test_sort_exception_async(execution::par(execution::task), int());
+    test_sort_exception_async(seq(task), int());
+    test_sort_exception_async(par(task), int());
 
     // Async execution, user comparison operator
-    test_sort_exception_async(
-        execution::seq(execution::task), int(), std::less<int>());
-    test_sort_exception_async(
-        execution::par(execution::task), int(), std::less<int>());
+    test_sort_exception_async(seq(task), int(), std::less<int>());
+    test_sort_exception_async(par(task), int(), std::less<int>());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/algorithms/tests/unit/algorithms/stable_partition.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/stable_partition.cpp
@@ -17,14 +17,14 @@
 template <typename IteratorTag>
 void test_stable_partition()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_stable_partition(execution::seq, IteratorTag());
-    test_stable_partition(execution::par, IteratorTag());
-    test_stable_partition(execution::par_unseq, IteratorTag());
+    test_stable_partition(seq, IteratorTag());
+    test_stable_partition(par, IteratorTag());
+    test_stable_partition(par_unseq, IteratorTag());
 
-    test_stable_partition_async(execution::seq(execution::task), IteratorTag());
-    test_stable_partition_async(execution::par(execution::task), IteratorTag());
+    test_stable_partition_async(seq(task), IteratorTag());
+    test_stable_partition_async(par(task), IteratorTag());
 }
 
 void stable_partition_test()
@@ -36,18 +36,16 @@ void stable_partition_test()
 template <typename IteratorTag>
 void test_stable_partition_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_stable_partition_exception(execution::seq, IteratorTag());
-    test_stable_partition_exception(execution::par, IteratorTag());
+    test_stable_partition_exception(seq, IteratorTag());
+    test_stable_partition_exception(par, IteratorTag());
 
-    test_stable_partition_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_stable_partition_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_stable_partition_exception_async(seq(task), IteratorTag());
+    test_stable_partition_exception_async(par(task), IteratorTag());
 }
 
 void stable_partition_exception_test()
@@ -60,18 +58,16 @@ void stable_partition_exception_test()
 template <typename IteratorTag>
 void test_stable_partition_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_stable_partition_bad_alloc(execution::seq, IteratorTag());
-    test_stable_partition_bad_alloc(execution::par, IteratorTag());
+    test_stable_partition_bad_alloc(seq, IteratorTag());
+    test_stable_partition_bad_alloc(par, IteratorTag());
 
-    test_stable_partition_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_stable_partition_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_stable_partition_bad_alloc_async(seq(task), IteratorTag());
+    test_stable_partition_bad_alloc_async(par(task), IteratorTag());
 }
 
 void stable_partition_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/stable_sort.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/stable_sort.cpp
@@ -27,7 +27,7 @@ void sort_benchmark()
 {
     try
     {
-        using namespace hpx::parallel;
+        using namespace hpx::execution;
         // Fill vector with random values
         std::vector<double> c(HPX_SORT_TEST_SIZE << 4);
         rnd_fill<double>(c, (std::numeric_limits<double>::min)(),
@@ -35,7 +35,7 @@ void sort_benchmark()
 
         hpx::util::high_resolution_timer t;
         // sort, blocking when seq, par, par_vec
-        hpx::parallel::stable_sort(execution::par, c.begin(), c.end());
+        hpx::parallel::stable_sort(par, c.begin(), c.end());
         auto elapsed = static_cast<std::uint64_t>(t.elapsed_nanoseconds());
 
         bool is_sorted = (verify_(c, std::less<double>(), elapsed, true) != 0);
@@ -55,109 +55,93 @@ void sort_benchmark()
 ////////////////////////////////////////////////////////////////////////////////
 void test_stable_sort1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // default comparison operator (std::less)
-    test_stable_sort1(execution::seq, int());
-    test_stable_sort1(execution::par, int());
-    test_stable_sort1(execution::par_unseq, int());
+    test_stable_sort1(seq, int());
+    test_stable_sort1(par, int());
+    test_stable_sort1(par_unseq, int());
 
     // default comparison operator (std::less)
-    test_stable_sort1(execution::seq, double());
-    test_stable_sort1(execution::par, double());
-    test_stable_sort1(execution::par_unseq, double());
+    test_stable_sort1(seq, double());
+    test_stable_sort1(par, double());
+    test_stable_sort1(par_unseq, double());
 
     // default comparison operator (std::less)
-    test_stable_sort1(execution::seq, std::string());
-    test_stable_sort1(execution::par, std::string());
-    test_stable_sort1(execution::par_unseq, std::string());
+    test_stable_sort1(seq, std::string());
+    test_stable_sort1(par, std::string());
+    test_stable_sort1(par_unseq, std::string());
 
     // user supplied comparison operator (std::less)
-    test_stable_sort1_comp(execution::seq, int(), std::less<std::size_t>());
-    test_stable_sort1_comp(execution::par, int(), std::less<std::size_t>());
-    test_stable_sort1_comp(
-        execution::par_unseq, int(), std::less<std::size_t>());
+    test_stable_sort1_comp(seq, int(), std::less<std::size_t>());
+    test_stable_sort1_comp(par, int(), std::less<std::size_t>());
+    test_stable_sort1_comp(par_unseq, int(), std::less<std::size_t>());
 
     // user supplied comparison operator (std::greater)
-    test_stable_sort1_comp(execution::seq, double(), std::greater<double>());
-    test_stable_sort1_comp(execution::par, double(), std::greater<double>());
-    test_stable_sort1_comp(
-        execution::par_unseq, double(), std::greater<double>());
+    test_stable_sort1_comp(seq, double(), std::greater<double>());
+    test_stable_sort1_comp(par, double(), std::greater<double>());
+    test_stable_sort1_comp(par_unseq, double(), std::greater<double>());
 
     // default comparison operator (std::less)
+    test_stable_sort1_comp(seq, std::string(), std::greater<std::string>());
+    test_stable_sort1_comp(par, std::string(), std::greater<std::string>());
     test_stable_sort1_comp(
-        execution::seq, std::string(), std::greater<std::string>());
-    test_stable_sort1_comp(
-        execution::par, std::string(), std::greater<std::string>());
-    test_stable_sort1_comp(
-        execution::par_unseq, std::string(), std::greater<std::string>());
+        par_unseq, std::string(), std::greater<std::string>());
 
     // Async execution, default comparison operator
-    test_stable_sort1_async(execution::seq(execution::task), int());
-    test_stable_sort1_async(execution::par(execution::task), char());
-    test_stable_sort1_async(execution::seq(execution::task), double());
-    test_stable_sort1_async(execution::par(execution::task), float());
-    test_stable_sort1_async_str(execution::seq(execution::task));
-    test_stable_sort1_async_str(execution::par(execution::task));
+    test_stable_sort1_async(seq(task), int());
+    test_stable_sort1_async(par(task), char());
+    test_stable_sort1_async(seq(task), double());
+    test_stable_sort1_async(par(task), float());
+    test_stable_sort1_async_str(seq(task));
+    test_stable_sort1_async_str(par(task));
 
     // Async execution, user comparison operator
-    test_stable_sort1_async(
-        execution::seq(execution::task), int(), std::less<unsigned int>());
-    test_stable_sort1_async(
-        execution::par(execution::task), char(), std::less<char>());
+    test_stable_sort1_async(seq(task), int(), std::less<unsigned int>());
+    test_stable_sort1_async(par(task), char(), std::less<char>());
     //
-    test_stable_sort1_async(
-        execution::seq(execution::task), double(), std::greater<double>());
-    test_stable_sort1_async(
-        execution::par(execution::task), float(), std::greater<float>());
+    test_stable_sort1_async(seq(task), double(), std::greater<double>());
+    test_stable_sort1_async(par(task), float(), std::greater<float>());
     //
-    test_stable_sort1_async_str(
-        execution::seq(execution::task), std::greater<std::string>());
-    test_stable_sort1_async_str(
-        execution::par(execution::task), std::greater<std::string>());
+    test_stable_sort1_async_str(seq(task), std::greater<std::string>());
+    test_stable_sort1_async_str(par(task), std::greater<std::string>());
 }
 
 void test_stable_sort2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
     // default comparison operator (std::less)
-    test_stable_sort2(execution::seq, int());
-    test_stable_sort2(execution::par, int());
-    test_stable_sort2(execution::par_unseq, int());
+    test_stable_sort2(seq, int());
+    test_stable_sort2(par, int());
+    test_stable_sort2(par_unseq, int());
 
     // default comparison operator (std::less)
-    test_stable_sort2(execution::seq, double());
-    test_stable_sort2(execution::par, double());
-    test_stable_sort2(execution::par_unseq, double());
+    test_stable_sort2(seq, double());
+    test_stable_sort2(par, double());
+    test_stable_sort2(par_unseq, double());
 
     // user supplied comparison operator (std::less)
-    test_stable_sort2_comp(execution::seq, int(), std::less<std::size_t>());
-    test_stable_sort2_comp(execution::par, int(), std::less<std::size_t>());
-    test_stable_sort2_comp(
-        execution::par_unseq, int(), std::less<std::size_t>());
+    test_stable_sort2_comp(seq, int(), std::less<std::size_t>());
+    test_stable_sort2_comp(par, int(), std::less<std::size_t>());
+    test_stable_sort2_comp(par_unseq, int(), std::less<std::size_t>());
 
     // user supplied comparison operator (std::greater)
-    test_stable_sort2_comp(execution::seq, double(), std::greater<double>());
-    test_stable_sort2_comp(execution::par, double(), std::greater<double>());
-    test_stable_sort2_comp(
-        execution::par_unseq, double(), std::greater<double>());
+    test_stable_sort2_comp(seq, double(), std::greater<double>());
+    test_stable_sort2_comp(par, double(), std::greater<double>());
+    test_stable_sort2_comp(par_unseq, double(), std::greater<double>());
 
     // Async execution, default comparison operator
-    test_stable_sort2_async(execution::seq(execution::task), int());
-    test_stable_sort2_async(execution::par(execution::task), char());
-    test_stable_sort2_async(execution::seq(execution::task), double());
-    test_stable_sort2_async(execution::par(execution::task), float());
+    test_stable_sort2_async(seq(task), int());
+    test_stable_sort2_async(par(task), char());
+    test_stable_sort2_async(seq(task), double());
+    test_stable_sort2_async(par(task), float());
 
     // Async execution, user comparison operator
-    test_stable_sort2_async(
-        execution::seq(execution::task), int(), std::less<unsigned int>());
-    test_stable_sort2_async(
-        execution::par(execution::task), char(), std::less<char>());
+    test_stable_sort2_async(seq(task), int(), std::less<unsigned int>());
+    test_stable_sort2_async(par(task), char(), std::less<char>());
     //
-    test_stable_sort2_async(
-        execution::seq(execution::task), double(), std::greater<double>());
-    test_stable_sort2_async(
-        execution::par(execution::task), float(), std::greater<float>());
+    test_stable_sort2_async(seq(task), double(), std::greater<double>());
+    test_stable_sort2_async(par(task), float(), std::greater<float>());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/algorithms/tests/unit/algorithms/stable_sort_exceptions.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/stable_sort_exceptions.cpp
@@ -22,25 +22,23 @@
 ///////////////////////////////////////////////////////////////////////////////
 void test_exceptions()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // default comparison operator (std::less)
-    test_stable_sort_exception(execution::seq, int());
-    test_stable_sort_exception(execution::par, int());
+    test_stable_sort_exception(seq, int());
+    test_stable_sort_exception(par, int());
 
     // user supplied comparison operator (std::less)
-    test_stable_sort_exception(execution::seq, int(), std::less<int>());
-    test_stable_sort_exception(execution::par, int(), std::less<int>());
+    test_stable_sort_exception(seq, int(), std::less<int>());
+    test_stable_sort_exception(par, int(), std::less<int>());
 
     // Async execution, default comparison operator
-    test_stable_sort_exception_async(execution::seq(execution::task), int());
-    test_stable_sort_exception_async(execution::par(execution::task), int());
+    test_stable_sort_exception_async(seq(task), int());
+    test_stable_sort_exception_async(par(task), int());
 
     // Async execution, user comparison operator
-    test_stable_sort_exception_async(
-        execution::seq(execution::task), int(), std::less<int>());
-    test_stable_sort_exception_async(
-        execution::par(execution::task), int(), std::less<int>());
+    test_stable_sort_exception_async(seq(task), int(), std::less<int>());
+    test_stable_sort_exception_async(par(task), int(), std::less<int>());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/algorithms/tests/unit/algorithms/swapranges.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/swapranges.cpp
@@ -94,13 +94,13 @@ void test_swap_ranges_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_swap_ranges()
 {
-    using namespace hpx::parallel;
-    test_swap_ranges(execution::seq, IteratorTag());
-    test_swap_ranges(execution::par, IteratorTag());
-    test_swap_ranges(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_swap_ranges(seq, IteratorTag());
+    test_swap_ranges(par, IteratorTag());
+    test_swap_ranges(par_unseq, IteratorTag());
 
-    test_swap_ranges_async(execution::seq(execution::task), IteratorTag());
-    test_swap_ranges_async(execution::par(execution::task), IteratorTag());
+    test_swap_ranges_async(seq(task), IteratorTag());
+    test_swap_ranges_async(par(task), IteratorTag());
 }
 
 void swap_ranges_test()
@@ -190,18 +190,16 @@ void test_swap_ranges_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_swap_ranges_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_swap_ranges_exception(execution::seq, IteratorTag());
-    test_swap_ranges_exception(execution::par, IteratorTag());
+    test_swap_ranges_exception(seq, IteratorTag());
+    test_swap_ranges_exception(par, IteratorTag());
 
-    test_swap_ranges_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_swap_ranges_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_swap_ranges_exception_async(seq(task), IteratorTag());
+    test_swap_ranges_exception_async(par(task), IteratorTag());
 }
 
 void swap_ranges_exception_test()
@@ -287,18 +285,16 @@ void test_swap_ranges_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_swap_ranges_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_swap_ranges_bad_alloc(execution::seq, IteratorTag());
-    test_swap_ranges_bad_alloc(execution::par, IteratorTag());
+    test_swap_ranges_bad_alloc(seq, IteratorTag());
+    test_swap_ranges_bad_alloc(par, IteratorTag());
 
-    test_swap_ranges_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_swap_ranges_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_swap_ranges_bad_alloc_async(seq(task), IteratorTag());
+    test_swap_ranges_bad_alloc_async(par(task), IteratorTag());
 }
 
 void swap_ranges_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/test_utils.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/test_utils.hpp
@@ -154,10 +154,9 @@ namespace test {
     };
 
     template <typename IteratorTag>
-    struct test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-        IteratorTag>
+    struct test_num_exceptions<hpx::execution::sequenced_policy, IteratorTag>
     {
-        static void call(hpx::parallel::execution::sequenced_policy const&,
+        static void call(hpx::execution::sequenced_policy const&,
             hpx::exception_list const& e)
         {
             HPX_TEST_EQ(e.size(), 1u);
@@ -174,10 +173,10 @@ namespace test {
     };
 
     template <>
-    struct test_num_exceptions<hpx::parallel::execution::sequenced_policy,
+    struct test_num_exceptions<hpx::execution::sequenced_policy,
         std::input_iterator_tag>
     {
-        static void call(hpx::parallel::execution::sequenced_policy const&,
+        static void call(hpx::execution::sequenced_policy const&,
             hpx::exception_list const& e)
         {
             HPX_TEST_EQ(e.size(), 1u);

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform.cpp
@@ -17,14 +17,14 @@
 template <typename IteratorTag>
 void test_transform()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_transform(execution::seq, IteratorTag());
-    test_transform(execution::par, IteratorTag());
-    test_transform(execution::par_unseq, IteratorTag());
+    test_transform(seq, IteratorTag());
+    test_transform(par, IteratorTag());
+    test_transform(par_unseq, IteratorTag());
 
-    test_transform_async(execution::seq(execution::task), IteratorTag());
-    test_transform_async(execution::par(execution::task), IteratorTag());
+    test_transform_async(seq(task), IteratorTag());
+    test_transform_async(par(task), IteratorTag());
 }
 
 void transform_test()
@@ -36,18 +36,16 @@ void transform_test()
 template <typename IteratorTag>
 void test_transform_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_exception(execution::seq, IteratorTag());
-    test_transform_exception(execution::par, IteratorTag());
+    test_transform_exception(seq, IteratorTag());
+    test_transform_exception(par, IteratorTag());
 
-    test_transform_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_exception_async(seq(task), IteratorTag());
+    test_transform_exception_async(par(task), IteratorTag());
 }
 
 void transform_exception_test()
@@ -60,18 +58,16 @@ void transform_exception_test()
 template <typename IteratorTag>
 void test_transform_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_bad_alloc(execution::seq, IteratorTag());
-    test_transform_bad_alloc(execution::par, IteratorTag());
+    test_transform_bad_alloc(seq, IteratorTag());
+    test_transform_bad_alloc(par, IteratorTag());
 
-    test_transform_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_bad_alloc_async(seq(task), IteratorTag());
+    test_transform_bad_alloc_async(par(task), IteratorTag());
 }
 
 void transform_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary.cpp
@@ -17,14 +17,14 @@
 template <typename IteratorTag>
 void test_transform_binary()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_transform_binary(execution::seq, IteratorTag());
-    test_transform_binary(execution::par, IteratorTag());
-    test_transform_binary(execution::par_unseq, IteratorTag());
+    test_transform_binary(seq, IteratorTag());
+    test_transform_binary(par, IteratorTag());
+    test_transform_binary(par_unseq, IteratorTag());
 
-    test_transform_binary_async(execution::seq(execution::task), IteratorTag());
-    test_transform_binary_async(execution::par(execution::task), IteratorTag());
+    test_transform_binary_async(seq(task), IteratorTag());
+    test_transform_binary_async(par(task), IteratorTag());
 }
 
 void transform_binary_test()
@@ -37,18 +37,16 @@ void transform_binary_test()
 template <typename IteratorTag>
 void test_transform_binary_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_binary_exception(execution::seq, IteratorTag());
-    test_transform_binary_exception(execution::par, IteratorTag());
+    test_transform_binary_exception(seq, IteratorTag());
+    test_transform_binary_exception(par, IteratorTag());
 
-    test_transform_binary_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_binary_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_binary_exception_async(seq(task), IteratorTag());
+    test_transform_binary_exception_async(par(task), IteratorTag());
 }
 
 void transform_binary_exception_test()
@@ -61,18 +59,16 @@ void transform_binary_exception_test()
 template <typename IteratorTag>
 void test_transform_binary_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_binary_bad_alloc(execution::seq, IteratorTag());
-    test_transform_binary_bad_alloc(execution::par, IteratorTag());
+    test_transform_binary_bad_alloc(seq, IteratorTag());
+    test_transform_binary_bad_alloc(par, IteratorTag());
 
-    test_transform_binary_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_binary_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_binary_bad_alloc_async(seq(task), IteratorTag());
+    test_transform_binary_bad_alloc_async(par(task), IteratorTag());
 }
 
 void transform_binary_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary2.cpp
@@ -17,16 +17,14 @@
 template <typename IteratorTag>
 void test_transform_binary2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_transform_binary2(execution::seq, IteratorTag());
-    test_transform_binary2(execution::par, IteratorTag());
-    test_transform_binary2(execution::par_unseq, IteratorTag());
+    test_transform_binary2(seq, IteratorTag());
+    test_transform_binary2(par, IteratorTag());
+    test_transform_binary2(par_unseq, IteratorTag());
 
-    test_transform_binary2_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_binary2_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_binary2_async(seq(task), IteratorTag());
+    test_transform_binary2_async(par(task), IteratorTag());
 }
 
 void transform_binary2_test()
@@ -39,18 +37,16 @@ void transform_binary2_test()
 template <typename IteratorTag>
 void test_transform_binary2_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_binary2_exception(execution::seq, IteratorTag());
-    test_transform_binary2_exception(execution::par, IteratorTag());
+    test_transform_binary2_exception(seq, IteratorTag());
+    test_transform_binary2_exception(par, IteratorTag());
 
-    test_transform_binary2_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_binary2_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_binary2_exception_async(seq(task), IteratorTag());
+    test_transform_binary2_exception_async(par(task), IteratorTag());
 }
 
 void transform_binary2_exception_test()
@@ -63,18 +59,16 @@ void transform_binary2_exception_test()
 template <typename IteratorTag>
 void test_transform_binary2_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_binary2_bad_alloc(execution::seq, IteratorTag());
-    test_transform_binary2_bad_alloc(execution::par, IteratorTag());
+    test_transform_binary2_bad_alloc(seq, IteratorTag());
+    test_transform_binary2_bad_alloc(par, IteratorTag());
 
-    test_transform_binary2_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_binary2_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_binary2_bad_alloc_async(seq(task), IteratorTag());
+    test_transform_binary2_bad_alloc_async(par(task), IteratorTag());
 }
 
 void transform_binary2_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_exclusive_scan.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_exclusive_scan.cpp
@@ -94,16 +94,14 @@ void test_transform_exclusive_scan_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_exclusive_scan()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_transform_exclusive_scan(execution::seq, IteratorTag());
-    test_transform_exclusive_scan(execution::par, IteratorTag());
-    test_transform_exclusive_scan(execution::par_unseq, IteratorTag());
+    test_transform_exclusive_scan(seq, IteratorTag());
+    test_transform_exclusive_scan(par, IteratorTag());
+    test_transform_exclusive_scan(par_unseq, IteratorTag());
 
-    test_transform_exclusive_scan_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_exclusive_scan_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_exclusive_scan_async(seq(task), IteratorTag());
+    test_transform_exclusive_scan_async(par(task), IteratorTag());
 }
 
 void transform_exclusive_scan_test()
@@ -197,18 +195,16 @@ void test_transform_exclusive_scan_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_exclusive_scan_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_exclusive_scan_exception(execution::seq, IteratorTag());
-    test_transform_exclusive_scan_exception(execution::par, IteratorTag());
+    test_transform_exclusive_scan_exception(seq, IteratorTag());
+    test_transform_exclusive_scan_exception(par, IteratorTag());
 
-    test_transform_exclusive_scan_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_exclusive_scan_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_exclusive_scan_exception_async(seq(task), IteratorTag());
+    test_transform_exclusive_scan_exception_async(par(task), IteratorTag());
 }
 
 void transform_exclusive_scan_exception_test()
@@ -300,18 +296,16 @@ void test_transform_exclusive_scan_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_exclusive_scan_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_exclusive_scan_bad_alloc(execution::seq, IteratorTag());
-    test_transform_exclusive_scan_bad_alloc(execution::par, IteratorTag());
+    test_transform_exclusive_scan_bad_alloc(seq, IteratorTag());
+    test_transform_exclusive_scan_bad_alloc(par, IteratorTag());
 
-    test_transform_exclusive_scan_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_exclusive_scan_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_exclusive_scan_bad_alloc_async(seq(task), IteratorTag());
+    test_transform_exclusive_scan_bad_alloc_async(par(task), IteratorTag());
 }
 
 void transform_exclusive_scan_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_inclusive_scan.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_inclusive_scan.cpp
@@ -94,16 +94,14 @@ void test_transform_inclusive_scan1_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_inclusive_scan1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_transform_inclusive_scan1(execution::seq, IteratorTag());
-    test_transform_inclusive_scan1(execution::par, IteratorTag());
-    test_transform_inclusive_scan1(execution::par_unseq, IteratorTag());
+    test_transform_inclusive_scan1(seq, IteratorTag());
+    test_transform_inclusive_scan1(par, IteratorTag());
+    test_transform_inclusive_scan1(par_unseq, IteratorTag());
 
-    test_transform_inclusive_scan1_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_inclusive_scan1_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_inclusive_scan1_async(seq(task), IteratorTag());
+    test_transform_inclusive_scan1_async(par(task), IteratorTag());
 }
 
 void transform_inclusive_scan_test1()
@@ -186,16 +184,14 @@ void test_transform_inclusive_scan2_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_inclusive_scan2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_transform_inclusive_scan2(execution::seq, IteratorTag());
-    test_transform_inclusive_scan2(execution::par, IteratorTag());
-    test_transform_inclusive_scan2(execution::par_unseq, IteratorTag());
+    test_transform_inclusive_scan2(seq, IteratorTag());
+    test_transform_inclusive_scan2(par, IteratorTag());
+    test_transform_inclusive_scan2(par_unseq, IteratorTag());
 
-    test_transform_inclusive_scan2_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_inclusive_scan2_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_inclusive_scan2_async(seq(task), IteratorTag());
+    test_transform_inclusive_scan2_async(par(task), IteratorTag());
 }
 
 void transform_inclusive_scan_test2()
@@ -288,18 +284,16 @@ void test_transform_inclusive_scan_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_inclusive_scan_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_inclusive_scan_exception(execution::seq, IteratorTag());
-    test_transform_inclusive_scan_exception(execution::par, IteratorTag());
+    test_transform_inclusive_scan_exception(seq, IteratorTag());
+    test_transform_inclusive_scan_exception(par, IteratorTag());
 
-    test_transform_inclusive_scan_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_inclusive_scan_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_inclusive_scan_exception_async(seq(task), IteratorTag());
+    test_transform_inclusive_scan_exception_async(par(task), IteratorTag());
 }
 
 void transform_inclusive_scan_exception_test()
@@ -390,18 +384,16 @@ void test_transform_inclusive_scan_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_inclusive_scan_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_inclusive_scan_bad_alloc(execution::seq, IteratorTag());
-    test_transform_inclusive_scan_bad_alloc(execution::par, IteratorTag());
+    test_transform_inclusive_scan_bad_alloc(seq, IteratorTag());
+    test_transform_inclusive_scan_bad_alloc(par, IteratorTag());
 
-    test_transform_inclusive_scan_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_inclusive_scan_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_inclusive_scan_bad_alloc_async(seq(task), IteratorTag());
+    test_transform_inclusive_scan_bad_alloc_async(par(task), IteratorTag());
 }
 
 void transform_inclusive_scan_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce.cpp
@@ -123,16 +123,16 @@ void test_transform_reduce_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_reduce()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_reduce(IteratorTag());
 
-    test_transform_reduce(execution::seq, IteratorTag());
-    test_transform_reduce(execution::par, IteratorTag());
-    test_transform_reduce(execution::par_unseq, IteratorTag());
+    test_transform_reduce(seq, IteratorTag());
+    test_transform_reduce(par, IteratorTag());
+    test_transform_reduce(par_unseq, IteratorTag());
 
-    test_transform_reduce_async(execution::seq(execution::task), IteratorTag());
-    test_transform_reduce_async(execution::par(execution::task), IteratorTag());
+    test_transform_reduce_async(seq(task), IteratorTag());
+    test_transform_reduce_async(par(task), IteratorTag());
 }
 
 void transform_reduce_test()
@@ -257,20 +257,18 @@ void test_transform_reduce_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_reduce_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_reduce_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_reduce_exception(execution::seq, IteratorTag());
-    test_transform_reduce_exception(execution::par, IteratorTag());
+    test_transform_reduce_exception(seq, IteratorTag());
+    test_transform_reduce_exception(par, IteratorTag());
 
-    test_transform_reduce_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_reduce_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_reduce_exception_async(seq(task), IteratorTag());
+    test_transform_reduce_exception_async(par(task), IteratorTag());
 }
 
 void transform_reduce_exception_test()
@@ -391,20 +389,18 @@ void test_transform_reduce_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_reduce_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_reduce_bad_alloc(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_reduce_bad_alloc(execution::seq, IteratorTag());
-    test_transform_reduce_bad_alloc(execution::par, IteratorTag());
+    test_transform_reduce_bad_alloc(seq, IteratorTag());
+    test_transform_reduce_bad_alloc(par, IteratorTag());
 
-    test_transform_reduce_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_reduce_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_reduce_bad_alloc_async(seq(task), IteratorTag());
+    test_transform_reduce_bad_alloc_async(par(task), IteratorTag());
 }
 
 void transform_reduce_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce_binary.cpp
@@ -18,18 +18,16 @@
 template <typename IteratorTag>
 void test_transform_reduce_binary()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_reduce_binary(IteratorTag());
 
-    test_transform_reduce_binary(execution::seq, IteratorTag());
-    test_transform_reduce_binary(execution::par, IteratorTag());
-    test_transform_reduce_binary(execution::par_unseq, IteratorTag());
+    test_transform_reduce_binary(seq, IteratorTag());
+    test_transform_reduce_binary(par, IteratorTag());
+    test_transform_reduce_binary(par_unseq, IteratorTag());
 
-    test_transform_reduce_binary_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_reduce_binary_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_reduce_binary_async(seq(task), IteratorTag());
+    test_transform_reduce_binary_async(par(task), IteratorTag());
 }
 
 void transform_reduce_binary_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce_binary_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce_binary_bad_alloc.cpp
@@ -127,20 +127,18 @@ void test_transform_reduce_binary_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_reduce_binary_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_reduce_binary_bad_alloc(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_reduce_binary_bad_alloc(execution::seq, IteratorTag());
-    test_transform_reduce_binary_bad_alloc(execution::par, IteratorTag());
+    test_transform_reduce_binary_bad_alloc(seq, IteratorTag());
+    test_transform_reduce_binary_bad_alloc(par, IteratorTag());
 
-    test_transform_reduce_binary_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_reduce_binary_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_reduce_binary_bad_alloc_async(seq(task), IteratorTag());
+    test_transform_reduce_binary_bad_alloc_async(par(task), IteratorTag());
 }
 
 void transform_reduce_binary_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce_binary_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce_binary_exception.cpp
@@ -129,18 +129,17 @@ void test_transform_reduce_binary_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_reduce_binary_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_reduce_binary_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_reduce_binary_exception(execution::seq, IteratorTag());
-    test_transform_reduce_binary_exception(execution::par, IteratorTag());
+    test_transform_reduce_binary_exception(seq, IteratorTag());
+    test_transform_reduce_binary_exception(par, IteratorTag());
 
-    test_transform_reduce_binary_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_reduce_binary_exception_async(par(task), IteratorTag());
 }
 
 void transform_reduce_binary_exception_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_copy.cpp
@@ -17,15 +17,13 @@
 template <typename IteratorTag>
 void test_uninitialized_copy()
 {
-    using namespace hpx::parallel;
-    test_uninitialized_copy(execution::seq, IteratorTag());
-    test_uninitialized_copy(execution::par, IteratorTag());
-    test_uninitialized_copy(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_uninitialized_copy(seq, IteratorTag());
+    test_uninitialized_copy(par, IteratorTag());
+    test_uninitialized_copy(par_unseq, IteratorTag());
 
-    test_uninitialized_copy_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_copy_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_copy_async(seq(task), IteratorTag());
+    test_uninitialized_copy_async(par(task), IteratorTag());
 }
 
 void uninitialized_copy_test()
@@ -38,18 +36,16 @@ void uninitialized_copy_test()
 template <typename IteratorTag>
 void test_uninitialized_copy_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_uninitialized_copy_exception(execution::seq, IteratorTag());
-    test_uninitialized_copy_exception(execution::par, IteratorTag());
+    test_uninitialized_copy_exception(seq, IteratorTag());
+    test_uninitialized_copy_exception(par, IteratorTag());
 
-    test_uninitialized_copy_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_copy_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_copy_exception_async(seq(task), IteratorTag());
+    test_uninitialized_copy_exception_async(par(task), IteratorTag());
 }
 
 void uninitialized_copy_exception_test()
@@ -62,18 +58,16 @@ void uninitialized_copy_exception_test()
 template <typename IteratorTag>
 void test_uninitialized_copy_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_uninitialized_copy_bad_alloc(execution::seq, IteratorTag());
-    test_uninitialized_copy_bad_alloc(execution::par, IteratorTag());
+    test_uninitialized_copy_bad_alloc(seq, IteratorTag());
+    test_uninitialized_copy_bad_alloc(par, IteratorTag());
 
-    test_uninitialized_copy_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_copy_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_copy_bad_alloc_async(seq(task), IteratorTag());
+    test_uninitialized_copy_bad_alloc_async(par(task), IteratorTag());
 }
 
 void uninitialized_copy_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_copyn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_copyn.cpp
@@ -74,16 +74,14 @@ void test_uninitialized_copy_n_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_uninitialized_copy_n()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_uninitialized_copy_n(execution::seq, IteratorTag());
-    test_uninitialized_copy_n(execution::par, IteratorTag());
-    test_uninitialized_copy_n(execution::par_unseq, IteratorTag());
+    test_uninitialized_copy_n(seq, IteratorTag());
+    test_uninitialized_copy_n(par, IteratorTag());
+    test_uninitialized_copy_n(par_unseq, IteratorTag());
 
-    test_uninitialized_copy_n_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_copy_n_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_copy_n_async(seq(task), IteratorTag());
+    test_uninitialized_copy_n_async(par(task), IteratorTag());
 }
 
 void uninitialized_copy_n_test()
@@ -186,18 +184,16 @@ void test_uninitialized_copy_n_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_uninitialized_copy_n_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_uninitialized_copy_n_exception(execution::seq, IteratorTag());
-    test_uninitialized_copy_n_exception(execution::par, IteratorTag());
+    test_uninitialized_copy_n_exception(seq, IteratorTag());
+    test_uninitialized_copy_n_exception(par, IteratorTag());
 
-    test_uninitialized_copy_n_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_copy_n_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_copy_n_exception_async(seq(task), IteratorTag());
+    test_uninitialized_copy_n_exception_async(par(task), IteratorTag());
 }
 
 void uninitialized_copy_n_exception_test()
@@ -299,18 +295,16 @@ void test_uninitialized_copy_n_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_uninitialized_copy_n_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_uninitialized_copy_n_bad_alloc(execution::seq, IteratorTag());
-    test_uninitialized_copy_n_bad_alloc(execution::par, IteratorTag());
+    test_uninitialized_copy_n_bad_alloc(seq, IteratorTag());
+    test_uninitialized_copy_n_bad_alloc(par, IteratorTag());
 
-    test_uninitialized_copy_n_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_copy_n_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_copy_n_bad_alloc_async(seq(task), IteratorTag());
+    test_uninitialized_copy_n_bad_alloc_async(par(task), IteratorTag());
 }
 
 void uninitialized_copy_n_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_default_construct.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_default_construct.cpp
@@ -17,24 +17,20 @@
 template <typename IteratorTag>
 void test_uninitialized_default_construct()
 {
-    using namespace hpx::parallel;
-    test_uninitialized_default_construct(execution::seq, IteratorTag());
-    test_uninitialized_default_construct(execution::par, IteratorTag());
-    test_uninitialized_default_construct(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_uninitialized_default_construct(seq, IteratorTag());
+    test_uninitialized_default_construct(par, IteratorTag());
+    test_uninitialized_default_construct(par_unseq, IteratorTag());
 
-    test_uninitialized_default_construct_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_default_construct_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_default_construct_async(seq(task), IteratorTag());
+    test_uninitialized_default_construct_async(par(task), IteratorTag());
 
-    test_uninitialized_default_construct2(execution::seq, IteratorTag());
-    test_uninitialized_default_construct2(execution::par, IteratorTag());
-    test_uninitialized_default_construct2(execution::par_unseq, IteratorTag());
+    test_uninitialized_default_construct2(seq, IteratorTag());
+    test_uninitialized_default_construct2(par, IteratorTag());
+    test_uninitialized_default_construct2(par_unseq, IteratorTag());
 
-    test_uninitialized_default_construct_async2(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_default_construct_async2(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_default_construct_async2(seq(task), IteratorTag());
+    test_uninitialized_default_construct_async2(par(task), IteratorTag());
 }
 
 void uninitialized_default_construct_test()
@@ -47,20 +43,18 @@ void uninitialized_default_construct_test()
 template <typename IteratorTag>
 void test_uninitialized_default_construct_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_uninitialized_default_construct_exception(
-        execution::seq, IteratorTag());
-    test_uninitialized_default_construct_exception(
-        execution::par, IteratorTag());
+    test_uninitialized_default_construct_exception(seq, IteratorTag());
+    test_uninitialized_default_construct_exception(par, IteratorTag());
 
     test_uninitialized_default_construct_exception_async(
-        execution::seq(execution::task), IteratorTag());
+        seq(task), IteratorTag());
     test_uninitialized_default_construct_exception_async(
-        execution::par(execution::task), IteratorTag());
+        par(task), IteratorTag());
 }
 
 void uninitialized_default_construct_exception_test()
@@ -74,20 +68,18 @@ void uninitialized_default_construct_exception_test()
 template <typename IteratorTag>
 void test_uninitialized_default_construct_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_uninitialized_default_construct_bad_alloc(
-        execution::seq, IteratorTag());
-    test_uninitialized_default_construct_bad_alloc(
-        execution::par, IteratorTag());
+    test_uninitialized_default_construct_bad_alloc(seq, IteratorTag());
+    test_uninitialized_default_construct_bad_alloc(par, IteratorTag());
 
     test_uninitialized_default_construct_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
+        seq(task), IteratorTag());
     test_uninitialized_default_construct_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+        par(task), IteratorTag());
 }
 
 void uninitialized_default_construct_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_default_constructn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_default_constructn.cpp
@@ -146,26 +146,21 @@ void test_uninitialized_default_construct_n_async2(ExPolicy policy, IteratorTag)
 template <typename IteratorTag>
 void test_uninitialized_default_construct_n()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_uninitialized_default_construct_n(execution::seq, IteratorTag());
-    test_uninitialized_default_construct_n(execution::par, IteratorTag());
-    test_uninitialized_default_construct_n(execution::par_unseq, IteratorTag());
+    test_uninitialized_default_construct_n(seq, IteratorTag());
+    test_uninitialized_default_construct_n(par, IteratorTag());
+    test_uninitialized_default_construct_n(par_unseq, IteratorTag());
 
-    test_uninitialized_default_construct_n_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_default_construct_n_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_default_construct_n_async(seq(task), IteratorTag());
+    test_uninitialized_default_construct_n_async(par(task), IteratorTag());
 
-    test_uninitialized_default_construct_n2(execution::seq, IteratorTag());
-    test_uninitialized_default_construct_n2(execution::par, IteratorTag());
-    test_uninitialized_default_construct_n2(
-        execution::par_unseq, IteratorTag());
+    test_uninitialized_default_construct_n2(seq, IteratorTag());
+    test_uninitialized_default_construct_n2(par, IteratorTag());
+    test_uninitialized_default_construct_n2(par_unseq, IteratorTag());
 
-    test_uninitialized_default_construct_n_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_default_construct_n_async2(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_default_construct_n_async(seq(task), IteratorTag());
+    test_uninitialized_default_construct_n_async2(par(task), IteratorTag());
 }
 
 void uninitialized_default_construct_n_test()
@@ -282,20 +277,18 @@ void test_uninitialized_default_construct_n_exception_async(
 template <typename IteratorTag>
 void test_uninitialized_default_construct_n_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_uninitialized_default_construct_n_exception(
-        execution::seq, IteratorTag());
-    test_uninitialized_default_construct_n_exception(
-        execution::par, IteratorTag());
+    test_uninitialized_default_construct_n_exception(seq, IteratorTag());
+    test_uninitialized_default_construct_n_exception(par, IteratorTag());
 
     test_uninitialized_default_construct_n_exception_async(
-        execution::seq(execution::task), IteratorTag());
+        seq(task), IteratorTag());
     test_uninitialized_default_construct_n_exception_async(
-        execution::par(execution::task), IteratorTag());
+        par(task), IteratorTag());
 }
 
 void uninitialized_default_construct_n_exception_test()
@@ -413,20 +406,18 @@ void test_uninitialized_default_construct_n_bad_alloc_async(
 template <typename IteratorTag>
 void test_uninitialized_default_construct_n_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_uninitialized_default_construct_n_bad_alloc(
-        execution::seq, IteratorTag());
-    test_uninitialized_default_construct_n_bad_alloc(
-        execution::par, IteratorTag());
+    test_uninitialized_default_construct_n_bad_alloc(seq, IteratorTag());
+    test_uninitialized_default_construct_n_bad_alloc(par, IteratorTag());
 
     test_uninitialized_default_construct_n_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
+        seq(task), IteratorTag());
     test_uninitialized_default_construct_n_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+        par(task), IteratorTag());
 }
 
 void uninitialized_default_construct_n_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_fill.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_fill.cpp
@@ -69,15 +69,13 @@ void test_uninitialized_fill_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_uninitialized_fill()
 {
-    using namespace hpx::parallel;
-    test_uninitialized_fill(execution::seq, IteratorTag());
-    test_uninitialized_fill(execution::par, IteratorTag());
-    test_uninitialized_fill(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_uninitialized_fill(seq, IteratorTag());
+    test_uninitialized_fill(par, IteratorTag());
+    test_uninitialized_fill(par_unseq, IteratorTag());
 
-    test_uninitialized_fill_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_fill_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_fill_async(seq(task), IteratorTag());
+    test_uninitialized_fill_async(par(task), IteratorTag());
 }
 
 void uninitialized_fill_test()
@@ -179,18 +177,16 @@ void test_uninitialized_fill_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_uninitialized_fill_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_uninitialized_fill_exception(execution::seq, IteratorTag());
-    test_uninitialized_fill_exception(execution::par, IteratorTag());
+    test_uninitialized_fill_exception(seq, IteratorTag());
+    test_uninitialized_fill_exception(par, IteratorTag());
 
-    test_uninitialized_fill_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_fill_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_fill_exception_async(seq(task), IteratorTag());
+    test_uninitialized_fill_exception_async(par(task), IteratorTag());
 }
 
 void uninitialized_fill_exception_test()
@@ -290,18 +286,16 @@ void test_uninitialized_fill_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_uninitialized_fill_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_uninitialized_fill_bad_alloc(execution::seq, IteratorTag());
-    test_uninitialized_fill_bad_alloc(execution::par, IteratorTag());
+    test_uninitialized_fill_bad_alloc(seq, IteratorTag());
+    test_uninitialized_fill_bad_alloc(par, IteratorTag());
 
-    test_uninitialized_fill_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_fill_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_fill_bad_alloc_async(seq(task), IteratorTag());
+    test_uninitialized_fill_bad_alloc_async(par(task), IteratorTag());
 }
 
 void uninitialized_fill_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_filln.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_filln.cpp
@@ -69,15 +69,13 @@ void test_uninitialized_fill_n_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_uninitialized_fill_n()
 {
-    using namespace hpx::parallel;
-    test_uninitialized_fill_n(execution::seq, IteratorTag());
-    test_uninitialized_fill_n(execution::par, IteratorTag());
-    test_uninitialized_fill_n(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_uninitialized_fill_n(seq, IteratorTag());
+    test_uninitialized_fill_n(par, IteratorTag());
+    test_uninitialized_fill_n(par_unseq, IteratorTag());
 
-    test_uninitialized_fill_n_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_fill_n_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_fill_n_async(seq(task), IteratorTag());
+    test_uninitialized_fill_n_async(par(task), IteratorTag());
 }
 
 void uninitialized_fill_n_test()
@@ -179,18 +177,16 @@ void test_uninitialized_fill_n_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_uninitialized_fill_n_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_uninitialized_fill_n_exception(execution::seq, IteratorTag());
-    test_uninitialized_fill_n_exception(execution::par, IteratorTag());
+    test_uninitialized_fill_n_exception(seq, IteratorTag());
+    test_uninitialized_fill_n_exception(par, IteratorTag());
 
-    test_uninitialized_fill_n_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_fill_n_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_fill_n_exception_async(seq(task), IteratorTag());
+    test_uninitialized_fill_n_exception_async(par(task), IteratorTag());
 }
 
 void uninitialized_fill_n_exception_test()
@@ -290,18 +286,16 @@ void test_uninitialized_fill_n_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_uninitialized_fill_n_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_uninitialized_fill_n_bad_alloc(execution::seq, IteratorTag());
-    test_uninitialized_fill_n_bad_alloc(execution::par, IteratorTag());
+    test_uninitialized_fill_n_bad_alloc(seq, IteratorTag());
+    test_uninitialized_fill_n_bad_alloc(par, IteratorTag());
 
-    test_uninitialized_fill_n_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_fill_n_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_fill_n_bad_alloc_async(seq(task), IteratorTag());
+    test_uninitialized_fill_n_bad_alloc_async(par(task), IteratorTag());
 }
 
 void uninitialized_fill_n_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_move.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_move.cpp
@@ -17,15 +17,13 @@
 template <typename IteratorTag>
 void test_uninitialized_move()
 {
-    using namespace hpx::parallel;
-    test_uninitialized_move(execution::seq, IteratorTag());
-    test_uninitialized_move(execution::par, IteratorTag());
-    test_uninitialized_move(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_uninitialized_move(seq, IteratorTag());
+    test_uninitialized_move(par, IteratorTag());
+    test_uninitialized_move(par_unseq, IteratorTag());
 
-    test_uninitialized_move_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_move_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_move_async(seq(task), IteratorTag());
+    test_uninitialized_move_async(par(task), IteratorTag());
 }
 
 void uninitialized_move_test()
@@ -38,18 +36,16 @@ void uninitialized_move_test()
 template <typename IteratorTag>
 void test_uninitialized_move_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_uninitialized_move_exception(execution::seq, IteratorTag());
-    test_uninitialized_move_exception(execution::par, IteratorTag());
+    test_uninitialized_move_exception(seq, IteratorTag());
+    test_uninitialized_move_exception(par, IteratorTag());
 
-    test_uninitialized_move_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_move_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_move_exception_async(seq(task), IteratorTag());
+    test_uninitialized_move_exception_async(par(task), IteratorTag());
 }
 
 void uninitialized_move_exception_test()
@@ -62,18 +58,16 @@ void uninitialized_move_exception_test()
 template <typename IteratorTag>
 void test_uninitialized_move_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_uninitialized_move_bad_alloc(execution::seq, IteratorTag());
-    test_uninitialized_move_bad_alloc(execution::par, IteratorTag());
+    test_uninitialized_move_bad_alloc(seq, IteratorTag());
+    test_uninitialized_move_bad_alloc(par, IteratorTag());
 
-    test_uninitialized_move_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_move_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_move_bad_alloc_async(seq(task), IteratorTag());
+    test_uninitialized_move_bad_alloc_async(par(task), IteratorTag());
 }
 
 void uninitialized_move_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_moven.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_moven.cpp
@@ -74,16 +74,14 @@ void test_uninitialized_move_n_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_uninitialized_move_n()
 {
-    using namespace hpx::parallel;
-
-    test_uninitialized_move_n(execution::seq, IteratorTag());
-    test_uninitialized_move_n(execution::par, IteratorTag());
-    test_uninitialized_move_n(execution::par_unseq, IteratorTag());
+    test_uninitialized_move_n(hpx::execution::seq, IteratorTag());
+    test_uninitialized_move_n(hpx::execution::par, IteratorTag());
+    test_uninitialized_move_n(hpx::execution::par_unseq, IteratorTag());
 
     test_uninitialized_move_n_async(
-        execution::seq(execution::task), IteratorTag());
+        hpx::execution::seq(hpx::execution::task), IteratorTag());
     test_uninitialized_move_n_async(
-        execution::par(execution::task), IteratorTag());
+        hpx::execution::par(hpx::execution::task), IteratorTag());
 }
 
 void uninitialized_move_n_test()
@@ -186,18 +184,16 @@ void test_uninitialized_move_n_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_uninitialized_move_n_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_uninitialized_move_n_exception(execution::seq, IteratorTag());
-    test_uninitialized_move_n_exception(execution::par, IteratorTag());
+    test_uninitialized_move_n_exception(seq, IteratorTag());
+    test_uninitialized_move_n_exception(par, IteratorTag());
 
-    test_uninitialized_move_n_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_move_n_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_move_n_exception_async(seq(task), IteratorTag());
+    test_uninitialized_move_n_exception_async(par(task), IteratorTag());
 }
 
 void uninitialized_move_n_exception_test()
@@ -299,18 +295,16 @@ void test_uninitialized_move_n_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_uninitialized_move_n_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_uninitialized_move_n_bad_alloc(execution::seq, IteratorTag());
-    test_uninitialized_move_n_bad_alloc(execution::par, IteratorTag());
+    test_uninitialized_move_n_bad_alloc(seq, IteratorTag());
+    test_uninitialized_move_n_bad_alloc(par, IteratorTag());
 
-    test_uninitialized_move_n_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_move_n_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_move_n_bad_alloc_async(seq(task), IteratorTag());
+    test_uninitialized_move_n_bad_alloc_async(par(task), IteratorTag());
 }
 
 void uninitialized_move_n_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_value_construct.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_value_construct.cpp
@@ -17,15 +17,13 @@
 template <typename IteratorTag>
 void test_uninitialized_value_construct()
 {
-    using namespace hpx::parallel;
-    test_uninitialized_value_construct(execution::seq, IteratorTag());
-    test_uninitialized_value_construct(execution::par, IteratorTag());
-    test_uninitialized_value_construct(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_uninitialized_value_construct(seq, IteratorTag());
+    test_uninitialized_value_construct(par, IteratorTag());
+    test_uninitialized_value_construct(par_unseq, IteratorTag());
 
-    test_uninitialized_value_construct_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_value_construct_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_value_construct_async(seq(task), IteratorTag());
+    test_uninitialized_value_construct_async(par(task), IteratorTag());
 }
 
 void uninitialized_value_construct_test()
@@ -38,18 +36,18 @@ void uninitialized_value_construct_test()
 template <typename IteratorTag>
 void test_uninitialized_value_construct_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_uninitialized_value_construct_exception(execution::seq, IteratorTag());
-    test_uninitialized_value_construct_exception(execution::par, IteratorTag());
+    test_uninitialized_value_construct_exception(seq, IteratorTag());
+    test_uninitialized_value_construct_exception(par, IteratorTag());
 
     test_uninitialized_value_construct_exception_async(
-        execution::seq(execution::task), IteratorTag());
+        seq(task), IteratorTag());
     test_uninitialized_value_construct_exception_async(
-        execution::par(execution::task), IteratorTag());
+        par(task), IteratorTag());
 }
 
 void uninitialized_value_construct_exception_test()
@@ -63,18 +61,18 @@ void uninitialized_value_construct_exception_test()
 template <typename IteratorTag>
 void test_uninitialized_value_construct_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_uninitialized_value_construct_bad_alloc(execution::seq, IteratorTag());
-    test_uninitialized_value_construct_bad_alloc(execution::par, IteratorTag());
+    test_uninitialized_value_construct_bad_alloc(seq, IteratorTag());
+    test_uninitialized_value_construct_bad_alloc(par, IteratorTag());
 
     test_uninitialized_value_construct_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
+        seq(task), IteratorTag());
     test_uninitialized_value_construct_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+        par(task), IteratorTag());
 }
 
 void uninitialized_value_construct_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_value_constructn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_value_constructn.cpp
@@ -83,16 +83,14 @@ void test_uninitialized_value_construct_n_async(ExPolicy policy, IteratorTag)
 template <typename IteratorTag>
 void test_uninitialized_value_construct_n()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_uninitialized_value_construct_n(execution::seq, IteratorTag());
-    test_uninitialized_value_construct_n(execution::par, IteratorTag());
-    test_uninitialized_value_construct_n(execution::par_unseq, IteratorTag());
+    test_uninitialized_value_construct_n(seq, IteratorTag());
+    test_uninitialized_value_construct_n(par, IteratorTag());
+    test_uninitialized_value_construct_n(par_unseq, IteratorTag());
 
-    test_uninitialized_value_construct_n_async(
-        execution::seq(execution::task), IteratorTag());
-    test_uninitialized_value_construct_n_async(
-        execution::par(execution::task), IteratorTag());
+    test_uninitialized_value_construct_n_async(seq(task), IteratorTag());
+    test_uninitialized_value_construct_n_async(par(task), IteratorTag());
 }
 
 void uninitialized_value_construct_n_test()
@@ -209,20 +207,18 @@ void test_uninitialized_value_construct_n_exception_async(
 template <typename IteratorTag>
 void test_uninitialized_value_construct_n_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_uninitialized_value_construct_n_exception(
-        execution::seq, IteratorTag());
-    test_uninitialized_value_construct_n_exception(
-        execution::par, IteratorTag());
+    test_uninitialized_value_construct_n_exception(seq, IteratorTag());
+    test_uninitialized_value_construct_n_exception(par, IteratorTag());
 
     test_uninitialized_value_construct_n_exception_async(
-        execution::seq(execution::task), IteratorTag());
+        seq(task), IteratorTag());
     test_uninitialized_value_construct_n_exception_async(
-        execution::par(execution::task), IteratorTag());
+        par(task), IteratorTag());
 }
 
 void uninitialized_value_construct_n_exception_test()
@@ -339,20 +335,18 @@ void test_uninitialized_value_construct_n_bad_alloc_async(
 template <typename IteratorTag>
 void test_uninitialized_value_construct_n_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_uninitialized_value_construct_n_bad_alloc(
-        execution::seq, IteratorTag());
-    test_uninitialized_value_construct_n_bad_alloc(
-        execution::par, IteratorTag());
+    test_uninitialized_value_construct_n_bad_alloc(seq, IteratorTag());
+    test_uninitialized_value_construct_n_bad_alloc(par, IteratorTag());
 
     test_uninitialized_value_construct_n_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
+        seq(task), IteratorTag());
     test_uninitialized_value_construct_n_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+        par(task), IteratorTag());
 }
 
 void uninitialized_value_construct_n_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/unique_copy_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/unique_copy_tests.hpp
@@ -400,119 +400,113 @@ void test_unique_copy_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
 template <typename IteratorTag>
 void test_unique_copy()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     int rand_base = std::rand();
 
     ////////// Test cases for 'int' type.
     test_unique_copy(
-        execution::seq, IteratorTag(), int(),
+        seq, IteratorTag(), int(),
         [](const int a, const int b) -> bool { return a == b; }, rand_base);
     test_unique_copy(
-        execution::par, IteratorTag(), int(),
+        par, IteratorTag(), int(),
         [rand_base](const int a, const int b) -> bool {
             return a == b && b == rand_base;
         },
         rand_base);
     test_unique_copy(
-        execution::par_unseq, IteratorTag(), int(),
+        par_unseq, IteratorTag(), int(),
         [](const int a, const int b) -> bool { return a == b; }, rand_base);
 
     ////////// Test cases for user defined type.
     test_unique_copy(
-        execution::seq, IteratorTag(), user_defined_type(),
+        seq, IteratorTag(), user_defined_type(),
         [](user_defined_type const& a, user_defined_type const& b) -> bool {
             return a == b;
         },
         rand_base);
     test_unique_copy(
-        execution::par, IteratorTag(), user_defined_type(),
+        par, IteratorTag(), user_defined_type(),
         [](user_defined_type const& a, user_defined_type const& b) -> bool {
             return a == b;
         },
         rand_base);
     test_unique_copy(
-        execution::par_unseq, IteratorTag(), user_defined_type(),
+        par_unseq, IteratorTag(), user_defined_type(),
         [rand_base](user_defined_type const& a, user_defined_type const& b)
             -> bool { return a == b && b == rand_base; },
         rand_base);
 
     ////////// Asynchronous test cases for 'int' type.
     test_unique_copy_async(
-        execution::seq(execution::task), IteratorTag(), int(),
+        seq(task), IteratorTag(), int(),
         [rand_base](const int a, const int b) -> bool {
             return a == b && b == rand_base;
         },
         rand_base);
     test_unique_copy_async(
-        execution::par(execution::task), IteratorTag(), int(),
+        par(task), IteratorTag(), int(),
         [](const int a, const int b) -> bool { return a == b; }, rand_base);
 
     ////////// Asynchronous test cases for user defined type.
     test_unique_copy_async(
-        execution::seq(execution::task), IteratorTag(), user_defined_type(),
+        seq(task), IteratorTag(), user_defined_type(),
         [](user_defined_type const& a, user_defined_type const& b) -> bool {
             return a == b;
         },
         rand_base);
     test_unique_copy_async(
-        execution::par(execution::task), IteratorTag(), user_defined_type(),
+        par(task), IteratorTag(), user_defined_type(),
         [rand_base](user_defined_type const& a, user_defined_type const& b)
             -> bool { return a == rand_base && b == rand_base; },
         rand_base);
 
     ////////// Corner test cases.
     test_unique_copy(
-        execution::par, IteratorTag(), int(),
+        par, IteratorTag(), int(),
         [](const int, const int) -> bool { return true; }, rand_base);
     test_unique_copy(
-        execution::par_unseq, IteratorTag(), user_defined_type(),
+        par_unseq, IteratorTag(), user_defined_type(),
         [](user_defined_type const&, user_defined_type const&) -> bool {
             return false;
         },
         rand_base);
 
     ////////// Another test cases for justifying the implementation.
+    test_unique_copy_etc(seq, IteratorTag(), user_defined_type(), rand_base);
+    test_unique_copy_etc(par, IteratorTag(), user_defined_type(), rand_base);
     test_unique_copy_etc(
-        execution::seq, IteratorTag(), user_defined_type(), rand_base);
-    test_unique_copy_etc(
-        execution::par, IteratorTag(), user_defined_type(), rand_base);
-    test_unique_copy_etc(
-        execution::par_unseq, IteratorTag(), user_defined_type(), rand_base);
+        par_unseq, IteratorTag(), user_defined_type(), rand_base);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_unique_copy_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_unique_copy_exception(execution::seq, IteratorTag());
-    test_unique_copy_exception(execution::par, IteratorTag());
+    test_unique_copy_exception(seq, IteratorTag());
+    test_unique_copy_exception(par, IteratorTag());
 
-    test_unique_copy_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_unique_copy_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_unique_copy_exception_async(seq(task), IteratorTag());
+    test_unique_copy_exception_async(par(task), IteratorTag());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_unique_copy_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_unique_copy_bad_alloc(execution::seq, IteratorTag());
-    test_unique_copy_bad_alloc(execution::par, IteratorTag());
+    test_unique_copy_bad_alloc(seq, IteratorTag());
+    test_unique_copy_bad_alloc(par, IteratorTag());
 
-    test_unique_copy_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_unique_copy_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_unique_copy_bad_alloc_async(seq(task), IteratorTag());
+    test_unique_copy_bad_alloc_async(par(task), IteratorTag());
 }

--- a/libs/parallelism/algorithms/tests/unit/algorithms/unique_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/unique_tests.hpp
@@ -388,111 +388,110 @@ void test_unique_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
 template <typename IteratorTag>
 void test_unique()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     int rand_base = std::rand();
 
     ////////// Test cases for 'int' type.
     test_unique(
-        execution::seq, IteratorTag(), int(),
+        seq, IteratorTag(), int(),
         [](const int a, const int b) -> bool { return a == b; }, rand_base);
     test_unique(
-        execution::par, IteratorTag(), int(),
+        par, IteratorTag(), int(),
         [rand_base](const int a, const int b) -> bool {
             return a == b && b == rand_base;
         },
         rand_base);
     test_unique(
-        execution::par_unseq, IteratorTag(), int(),
+        par_unseq, IteratorTag(), int(),
         [](const int a, const int b) -> bool { return a == b; }, rand_base);
 
     ////////// Test cases for user defined type.
     test_unique(
-        execution::seq, IteratorTag(), user_defined_type(),
+        seq, IteratorTag(), user_defined_type(),
         [](user_defined_type const& a, user_defined_type const& b) -> bool {
             return a == b;
         },
         rand_base);
     test_unique(
-        execution::par, IteratorTag(), user_defined_type(),
+        par, IteratorTag(), user_defined_type(),
         [](user_defined_type const& a, user_defined_type const& b) -> bool {
             return a == b;
         },
         rand_base);
     test_unique(
-        execution::par_unseq, IteratorTag(), user_defined_type(),
+        par_unseq, IteratorTag(), user_defined_type(),
         [rand_base](user_defined_type const& a, user_defined_type const& b)
             -> bool { return a == b && b == rand_base; },
         rand_base);
 
     ////////// Asynchronous test cases for 'int' type.
     test_unique_async(
-        execution::seq(execution::task), IteratorTag(), int(),
+        seq(task), IteratorTag(), int(),
         [rand_base](const int a, const int b) -> bool {
             return a == b && b == rand_base;
         },
         rand_base);
     test_unique_async(
-        execution::par(execution::task), IteratorTag(), int(),
+        par(task), IteratorTag(), int(),
         [](const int a, const int b) -> bool { return a == b; }, rand_base);
 
     ////////// Asynchronous test cases for user defined type.
     test_unique_async(
-        execution::seq(execution::task), IteratorTag(), user_defined_type(),
+        seq(task), IteratorTag(), user_defined_type(),
         [](user_defined_type const& a, user_defined_type const& b) -> bool {
             return a == b;
         },
         rand_base);
     test_unique_async(
-        execution::par(execution::task), IteratorTag(), user_defined_type(),
+        par(task), IteratorTag(), user_defined_type(),
         [rand_base](user_defined_type const& a, user_defined_type const& b)
             -> bool { return a == rand_base && b == rand_base; },
         rand_base);
 
     ////////// Corner test cases.
     test_unique(
-        execution::par, IteratorTag(), int(),
+        par, IteratorTag(), int(),
         [](const int, const int) -> bool { return true; }, rand_base);
     test_unique(
-        execution::par_unseq, IteratorTag(), user_defined_type(),
+        par_unseq, IteratorTag(), user_defined_type(),
         [](user_defined_type const&, user_defined_type const&) -> bool {
             return false;
         },
         rand_base);
 
     ////////// Another test cases for justifying the implementation.
-    test_unique_etc(
-        execution::seq, IteratorTag(), user_defined_type(), rand_base);
+    test_unique_etc(seq, IteratorTag(), user_defined_type(), rand_base);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_unique_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_unique_exception(execution::seq, IteratorTag());
-    test_unique_exception(execution::par, IteratorTag());
+    test_unique_exception(seq, IteratorTag());
+    test_unique_exception(par, IteratorTag());
 
-    test_unique_exception_async(execution::seq(execution::task), IteratorTag());
-    test_unique_exception_async(execution::par(execution::task), IteratorTag());
+    test_unique_exception_async(seq(task), IteratorTag());
+    test_unique_exception_async(par(task), IteratorTag());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_unique_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_unique_bad_alloc(execution::seq, IteratorTag());
-    test_unique_bad_alloc(execution::par, IteratorTag());
+    test_unique_bad_alloc(seq, IteratorTag());
+    test_unique_bad_alloc(par, IteratorTag());
 
-    test_unique_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_unique_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_unique_bad_alloc_async(seq(task), IteratorTag());
+    test_unique_bad_alloc_async(par(task), IteratorTag());
 }

--- a/libs/parallelism/algorithms/tests/unit/block/spmd_block.cpp
+++ b/libs/parallelism/algorithms/tests/unit/block/spmd_block.cpp
@@ -91,8 +91,8 @@ void bulk_test_function(
 
 int main()
 {
-    using hpx::parallel::execution::par;
-    using hpx::parallel::execution::task;
+    using hpx::execution::par;
+    using hpx::execution::task;
 
     auto bulk_test = [](hpx::parallel::spmd_block block,
                          std::atomic<std::size_t>* c) {

--- a/libs/parallelism/algorithms/tests/unit/block/task_block.cpp
+++ b/libs/parallelism/algorithms/tests/unit/block/task_block.cpp
@@ -15,11 +15,11 @@
 #include <string>
 #include <vector>
 
+using hpx::execution::par;
+using hpx::execution::parallel_task_policy;
+using hpx::execution::task;
 using hpx::parallel::define_task_block;
 using hpx::parallel::task_block;
-using hpx::parallel::execution::par;
-using hpx::parallel::execution::parallel_task_policy;
-using hpx::parallel::execution::task;
 
 ///////////////////////////////////////////////////////////////////////////////
 void define_task_block_test1()

--- a/libs/parallelism/algorithms/tests/unit/block/task_block_executor.cpp
+++ b/libs/parallelism/algorithms/tests/unit/block/task_block_executor.cpp
@@ -16,15 +16,15 @@
 #include <string>
 #include <vector>
 
+using hpx::execution::par;
+using hpx::execution::parallel_policy;
+using hpx::execution::parallel_policy_shim;
+using hpx::execution::parallel_task_policy;
+using hpx::execution::parallel_task_policy_shim;
+using hpx::execution::static_chunk_size;
+using hpx::execution::task;
 using hpx::parallel::define_task_block;
 using hpx::parallel::task_block;
-using hpx::parallel::execution::par;
-using hpx::parallel::execution::parallel_policy;
-using hpx::parallel::execution::parallel_policy_shim;
-using hpx::parallel::execution::parallel_task_policy;
-using hpx::parallel::execution::parallel_task_policy_shim;
-using hpx::parallel::execution::static_chunk_size;
-using hpx::parallel::execution::task;
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename Executor>
@@ -399,12 +399,12 @@ void test_executor_task_block(Executor& exec)
 int hpx_main()
 {
     {
-        hpx::parallel::execution::sequenced_executor exec;
+        hpx::execution::sequenced_executor exec;
         test_executor_task_block(exec);
     }
 
     {
-        hpx::parallel::execution::parallel_executor exec;
+        hpx::execution::parallel_executor exec;
         test_executor_task_block(exec);
 
         define_task_block_exceptions_test3(exec);

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/all_of_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/all_of_range.cpp
@@ -109,34 +109,34 @@ void test_all_of()
             return !static_cast<bool>(x);
         }
     };
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_all_of_seq(IteratorTag());
     test_all_of_seq(IteratorTag(), proj());
 
-    test_all_of(execution::seq, IteratorTag());
-    test_all_of(execution::par, IteratorTag());
-    test_all_of(execution::par_unseq, IteratorTag());
+    test_all_of(seq, IteratorTag());
+    test_all_of(par, IteratorTag());
+    test_all_of(par_unseq, IteratorTag());
 
-    test_all_of(execution::seq, IteratorTag(), proj());
-    test_all_of(execution::par, IteratorTag(), proj());
-    test_all_of(execution::par_unseq, IteratorTag(), proj());
+    test_all_of(seq, IteratorTag(), proj());
+    test_all_of(par, IteratorTag(), proj());
+    test_all_of(par_unseq, IteratorTag(), proj());
 
-    test_all_of_async(execution::seq(execution::task), IteratorTag());
-    test_all_of_async(execution::par(execution::task), IteratorTag());
+    test_all_of_async(seq(task), IteratorTag());
+    test_all_of_async(par(task), IteratorTag());
 
-    test_all_of_async(execution::seq(execution::task), IteratorTag(), proj());
-    test_all_of_async(execution::par(execution::task), IteratorTag(), proj());
+    test_all_of_async(seq(task), IteratorTag(), proj());
+    test_all_of_async(par(task), IteratorTag(), proj());
 }
 
 // template <typename IteratorTag>
 // void test_all_of_exec()
 // {
-//     using namespace hpx::parallel;
+//     using namespace hpx::execution;
 //
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_all_of(execution::par(exec), IteratorTag());
+//         test_all_of(par(exec), IteratorTag());
 //     }
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
@@ -145,7 +145,7 @@ void test_all_of()
 //
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_all_of(execution_policy(execution::par(exec)), IteratorTag());
+//         test_all_of(execution_policy(par(exec)), IteratorTag());
 //     }
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
@@ -184,9 +184,8 @@ void test_all_of_exception(IteratorTag)
         catch (hpx::exception_list const& e)
         {
             caught_exception = true;
-            test::test_num_exceptions<
-                hpx::parallel::execution::sequenced_policy,
-                IteratorTag>::call(hpx::parallel::execution::seq, e);
+            test::test_num_exceptions<hpx::execution::sequenced_policy,
+                IteratorTag>::call(hpx::execution::seq, e);
         }
         catch (...)
         {
@@ -278,18 +277,18 @@ void test_all_of_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_all_of_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_all_of_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_all_of_exception(execution::seq, IteratorTag());
-    test_all_of_exception(execution::par, IteratorTag());
+    test_all_of_exception(seq, IteratorTag());
+    test_all_of_exception(par, IteratorTag());
 
-    test_all_of_exception_async(execution::seq(execution::task), IteratorTag());
-    test_all_of_exception_async(execution::par(execution::task), IteratorTag());
+    test_all_of_exception_async(seq(task), IteratorTag());
+    test_all_of_exception_async(par(task), IteratorTag());
 }
 
 void all_of_exception_test()
@@ -376,16 +375,16 @@ void test_all_of_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_all_of_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_all_of_bad_alloc(execution::seq, IteratorTag());
-    test_all_of_bad_alloc(execution::par, IteratorTag());
+    test_all_of_bad_alloc(seq, IteratorTag());
+    test_all_of_bad_alloc(par, IteratorTag());
 
-    test_all_of_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_all_of_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_all_of_bad_alloc_async(seq(task), IteratorTag());
+    test_all_of_bad_alloc_async(par(task), IteratorTag());
 }
 
 void all_of_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/any_of_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/any_of_range.cpp
@@ -109,34 +109,34 @@ void test_any_of()
             return !static_cast<bool>(x);
         }
     };
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_any_of_seq(IteratorTag());
     test_any_of_seq(IteratorTag(), proj());
 
-    test_any_of(execution::seq, IteratorTag());
-    test_any_of(execution::par, IteratorTag());
-    test_any_of(execution::par_unseq, IteratorTag());
+    test_any_of(seq, IteratorTag());
+    test_any_of(par, IteratorTag());
+    test_any_of(par_unseq, IteratorTag());
 
-    test_any_of(execution::seq, IteratorTag(), proj());
-    test_any_of(execution::par, IteratorTag(), proj());
-    test_any_of(execution::par_unseq, IteratorTag(), proj());
+    test_any_of(seq, IteratorTag(), proj());
+    test_any_of(par, IteratorTag(), proj());
+    test_any_of(par_unseq, IteratorTag(), proj());
 
-    test_any_of_async(execution::seq(execution::task), IteratorTag());
-    test_any_of_async(execution::par(execution::task), IteratorTag());
+    test_any_of_async(seq(task), IteratorTag());
+    test_any_of_async(par(task), IteratorTag());
 
-    test_any_of_async(execution::seq(execution::task), IteratorTag(), proj());
-    test_any_of_async(execution::par(execution::task), IteratorTag(), proj());
+    test_any_of_async(seq(task), IteratorTag(), proj());
+    test_any_of_async(par(task), IteratorTag(), proj());
 }
 
 // template <typename IteratorTag>
 // void test_any_of_exec()
 // {
-//     using namespace hpx::parallel;
+//     using namespace hpx::execution;
 //
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_any_of(execution::par(exec), IteratorTag());
+//         test_any_of(par(exec), IteratorTag());
 //     }
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
@@ -145,7 +145,7 @@ void test_any_of()
 //
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_any_of(execution_policy(execution::par(exec)), IteratorTag());
+//         test_any_of(execution_policy(par(exec)), IteratorTag());
 //     }
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
@@ -184,9 +184,8 @@ void test_any_of_exception(IteratorTag)
         catch (hpx::exception_list const& e)
         {
             caught_exception = true;
-            test::test_num_exceptions<
-                hpx::parallel::execution::sequenced_policy,
-                IteratorTag>::call(hpx::parallel::execution::seq, e);
+            test::test_num_exceptions<hpx::execution::sequenced_policy,
+                IteratorTag>::call(hpx::execution::seq, e);
         }
         catch (...)
         {
@@ -278,18 +277,18 @@ void test_any_of_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_any_of_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_any_of_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_any_of_exception(execution::seq, IteratorTag());
-    test_any_of_exception(execution::par, IteratorTag());
+    test_any_of_exception(seq, IteratorTag());
+    test_any_of_exception(par, IteratorTag());
 
-    test_any_of_exception_async(execution::seq(execution::task), IteratorTag());
-    test_any_of_exception_async(execution::par(execution::task), IteratorTag());
+    test_any_of_exception_async(seq(task), IteratorTag());
+    test_any_of_exception_async(par(task), IteratorTag());
 }
 
 void any_of_exception_test()
@@ -376,16 +375,16 @@ void test_any_of_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_any_of_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_any_of_bad_alloc(execution::seq, IteratorTag());
-    test_any_of_bad_alloc(execution::par, IteratorTag());
+    test_any_of_bad_alloc(seq, IteratorTag());
+    test_any_of_bad_alloc(par, IteratorTag());
 
-    test_any_of_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_any_of_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_any_of_bad_alloc_async(seq(task), IteratorTag());
+    test_any_of_bad_alloc_async(par(task), IteratorTag());
 }
 
 void any_of_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/copy_range.cpp
@@ -99,16 +99,16 @@ void test_copy_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_copy()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_copy(IteratorTag());
 
-    test_copy(execution::seq, IteratorTag());
-    test_copy(execution::par, IteratorTag());
-    test_copy(execution::par_unseq, IteratorTag());
+    test_copy(seq, IteratorTag());
+    test_copy(par, IteratorTag());
+    test_copy(par_unseq, IteratorTag());
 
-    test_copy_async(execution::seq(execution::task), IteratorTag());
-    test_copy_async(execution::par(execution::task), IteratorTag());
+    test_copy_async(seq(task), IteratorTag());
+    test_copy_async(par(task), IteratorTag());
 }
 
 void copy_test()
@@ -142,8 +142,8 @@ void test_copy_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -235,16 +235,16 @@ void test_copy_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_copy_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_copy_exception(execution::seq, IteratorTag());
-    test_copy_exception(execution::par, IteratorTag());
+    test_copy_exception(seq, IteratorTag());
+    test_copy_exception(par, IteratorTag());
 
-    test_copy_exception_async(execution::seq(execution::task), IteratorTag());
-    test_copy_exception_async(execution::par(execution::task), IteratorTag());
+    test_copy_exception_async(seq(task), IteratorTag());
+    test_copy_exception_async(par(task), IteratorTag());
 }
 
 void copy_exception_test()
@@ -334,16 +334,16 @@ void test_copy_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_copy_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_copy_bad_alloc(execution::seq, IteratorTag());
-    test_copy_bad_alloc(execution::par, IteratorTag());
+    test_copy_bad_alloc(seq, IteratorTag());
+    test_copy_bad_alloc(par, IteratorTag());
 
-    test_copy_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_copy_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_copy_bad_alloc_async(seq(task), IteratorTag());
+    test_copy_bad_alloc_async(par(task), IteratorTag());
 }
 
 void copy_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/copyif_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/copyif_range.cpp
@@ -127,16 +127,16 @@ void test_copy_if_async(ExPolicy&& p)
 
 void test_copy_if()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_copy_if_seq();
 
-    test_copy_if(execution::seq);
-    test_copy_if(execution::par);
-    test_copy_if(execution::par_unseq);
+    test_copy_if(seq);
+    test_copy_if(par);
+    test_copy_if(par_unseq);
 
-    test_copy_if_async(execution::seq(execution::task));
-    test_copy_if_async(execution::par(execution::task));
+    test_copy_if_async(seq(task));
+    test_copy_if_async(par(task));
 }
 
 int hpx_main(hpx::program_options::variables_map& vm)

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/copyn_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/copyn_range.cpp
@@ -100,16 +100,16 @@ void test_copy_n_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_copy_n()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_copy_n(IteratorTag());
 
-    test_copy_n(execution::seq, IteratorTag());
-    test_copy_n(execution::par, IteratorTag());
-    test_copy_n(execution::par_unseq, IteratorTag());
+    test_copy_n(seq, IteratorTag());
+    test_copy_n(par, IteratorTag());
+    test_copy_n(par_unseq, IteratorTag());
 
-    test_copy_n_async(execution::seq(execution::task), IteratorTag());
-    test_copy_n_async(execution::par(execution::task), IteratorTag());
+    test_copy_n_async(seq(task), IteratorTag());
+    test_copy_n_async(par(task), IteratorTag());
 }
 
 void n_copy_test()
@@ -141,8 +141,8 @@ void test_copy_n_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -231,18 +231,18 @@ void test_copy_n_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_copy_n_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_copy_n_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_copy_n_exception(execution::seq, IteratorTag());
-    test_copy_n_exception(execution::par, IteratorTag());
+    test_copy_n_exception(seq, IteratorTag());
+    test_copy_n_exception(par, IteratorTag());
 
-    test_copy_n_exception_async(execution::seq(execution::task), IteratorTag());
-    test_copy_n_exception_async(execution::par(execution::task), IteratorTag());
+    test_copy_n_exception_async(seq(task), IteratorTag());
+    test_copy_n_exception_async(par(task), IteratorTag());
 }
 
 void copy_n_exception_test()
@@ -328,16 +328,16 @@ void test_copy_n_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_copy_n_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_copy_n_bad_alloc(execution::seq, IteratorTag());
-    test_copy_n_bad_alloc(execution::par, IteratorTag());
+    test_copy_n_bad_alloc(seq, IteratorTag());
+    test_copy_n_bad_alloc(par, IteratorTag());
 
-    test_copy_n_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_copy_n_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_copy_n_bad_alloc_async(seq(task), IteratorTag());
+    test_copy_n_bad_alloc_async(par(task), IteratorTag());
 }
 
 void copy_n_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/count_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/count_range.cpp
@@ -110,22 +110,16 @@ void test_count_async(ExPolicy&& policy, IteratorTag, DataType)
 template <typename IteratorTag, typename DataType>
 void test_count()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_count(IteratorTag(), DataType());
-
-    auto seq = execution::seq;
-    auto par = execution::par;
-    auto par_unseq = execution::par_unseq;
 
     test_count(seq, IteratorTag(), DataType());
     test_count(par, IteratorTag(), DataType());
     test_count(par_unseq, IteratorTag(), DataType());
 
-    test_count_async(
-        execution::seq(execution::task), IteratorTag(), DataType());
-    test_count_async(
-        execution::par(execution::task), IteratorTag(), DataType());
+    test_count_async(seq(task), IteratorTag(), DataType());
+    test_count_async(par(task), IteratorTag(), DataType());
 }
 
 void count_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/countif_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/countif_range.cpp
@@ -115,22 +115,16 @@ void test_count_async(ExPolicy&& policy, IteratorTag, DataType)
 template <typename IteratorTag, typename DataType>
 void test_count()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_count(IteratorTag(), DataType());
-
-    auto seq = execution::seq;
-    auto par = execution::par;
-    auto par_unseq = execution::par_unseq;
 
     test_count(seq, IteratorTag(), DataType());
     test_count(par, IteratorTag(), DataType());
     test_count(par_unseq, IteratorTag(), DataType());
 
-    test_count_async(
-        execution::seq(execution::task), IteratorTag(), DataType());
-    test_count_async(
-        execution::par(execution::task), IteratorTag(), DataType());
+    test_count_async(seq(task), IteratorTag(), DataType());
+    test_count_async(par(task), IteratorTag(), DataType());
 }
 
 void count_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/destroy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/destroy_range.cpp
@@ -17,16 +17,16 @@
 template <typename IteratorTag>
 void test_destroy()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_destroy(IteratorTag());
 
-    test_destroy(execution::seq, IteratorTag());
-    test_destroy(execution::par, IteratorTag());
-    test_destroy(execution::par_unseq, IteratorTag());
+    test_destroy(seq, IteratorTag());
+    test_destroy(par, IteratorTag());
+    test_destroy(par_unseq, IteratorTag());
 
-    test_destroy_async(execution::seq(execution::task), IteratorTag());
-    test_destroy_async(execution::par(execution::task), IteratorTag());
+    test_destroy_async(seq(task), IteratorTag());
+    test_destroy_async(par(task), IteratorTag());
 }
 
 void destroy_test()
@@ -39,20 +39,18 @@ void destroy_test()
 template <typename IteratorTag>
 void test_destroy_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_destroy_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_destroy_exception(execution::seq, IteratorTag());
-    test_destroy_exception(execution::par, IteratorTag());
+    test_destroy_exception(seq, IteratorTag());
+    test_destroy_exception(par, IteratorTag());
 
-    test_destroy_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_destroy_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_destroy_exception_async(seq(task), IteratorTag());
+    test_destroy_exception_async(par(task), IteratorTag());
 }
 
 void destroy_exception_test()
@@ -65,18 +63,16 @@ void destroy_exception_test()
 template <typename IteratorTag>
 void test_destroy_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_destroy_bad_alloc(execution::seq, IteratorTag());
-    test_destroy_bad_alloc(execution::par, IteratorTag());
+    test_destroy_bad_alloc(seq, IteratorTag());
+    test_destroy_bad_alloc(par, IteratorTag());
 
-    test_destroy_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_destroy_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_destroy_bad_alloc_async(seq(task), IteratorTag());
+    test_destroy_bad_alloc_async(par(task), IteratorTag());
 }
 
 void destroy_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/destroy_range_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/destroy_range_tests.hpp
@@ -162,8 +162,8 @@ void test_destroy_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/destroyn_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/destroyn_range.cpp
@@ -124,16 +124,16 @@ void test_destroy_n_async(ExPolicy&& policy, IteratorTag)
 template <typename IteratorTag>
 void test_destroy_n()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_destroy_n(IteratorTag());
 
-    test_destroy_n(execution::seq, IteratorTag());
-    test_destroy_n(execution::par, IteratorTag());
-    test_destroy_n(execution::par_unseq, IteratorTag());
+    test_destroy_n(seq, IteratorTag());
+    test_destroy_n(par, IteratorTag());
+    test_destroy_n(par_unseq, IteratorTag());
 
-    test_destroy_n_async(execution::seq(execution::task), IteratorTag());
-    test_destroy_n_async(execution::par(execution::task), IteratorTag());
+    test_destroy_n_async(seq(task), IteratorTag());
+    test_destroy_n_async(par(task), IteratorTag());
 }
 
 void destroy_n_test()
@@ -181,8 +181,8 @@ void test_destroy_n_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -315,20 +315,18 @@ void test_destroy_n_exception_async(ExPolicy&& policy, IteratorTag)
 template <typename IteratorTag>
 void test_destroy_n_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_destroy_n_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_destroy_n_exception(execution::seq, IteratorTag());
-    test_destroy_n_exception(execution::par, IteratorTag());
+    test_destroy_n_exception(seq, IteratorTag());
+    test_destroy_n_exception(par, IteratorTag());
 
-    test_destroy_n_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_destroy_n_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_destroy_n_exception_async(seq(task), IteratorTag());
+    test_destroy_n_exception_async(par(task), IteratorTag());
 }
 
 void destroy_n_exception_test()
@@ -456,18 +454,16 @@ void test_destroy_n_bad_alloc_async(ExPolicy&& policy, IteratorTag)
 template <typename IteratorTag>
 void test_destroy_n_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_destroy_n_bad_alloc(execution::seq, IteratorTag());
-    test_destroy_n_bad_alloc(execution::par, IteratorTag());
+    test_destroy_n_bad_alloc(seq, IteratorTag());
+    test_destroy_n_bad_alloc(par, IteratorTag());
 
-    test_destroy_n_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_destroy_n_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_destroy_n_bad_alloc_async(seq(task), IteratorTag());
+    test_destroy_n_bad_alloc_async(par(task), IteratorTag());
 }
 
 void destroy_n_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/equal_binary_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/equal_binary_range.cpp
@@ -159,16 +159,16 @@ void test_equal_binary1_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_equal_binary1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_equal_binary1(IteratorTag());
 
-    test_equal_binary1(execution::seq, IteratorTag());
-    test_equal_binary1(execution::par, IteratorTag());
-    test_equal_binary1(execution::par_unseq, IteratorTag());
+    test_equal_binary1(seq, IteratorTag());
+    test_equal_binary1(par, IteratorTag());
+    test_equal_binary1(par_unseq, IteratorTag());
 
-    test_equal_binary1_async(execution::seq(execution::task), IteratorTag());
-    test_equal_binary1_async(execution::par(execution::task), IteratorTag());
+    test_equal_binary1_async(seq(task), IteratorTag());
+    test_equal_binary1_async(par(task), IteratorTag());
 }
 
 void equal_binary_test1()
@@ -320,16 +320,16 @@ void test_equal_binary2_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_equal_binary2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_equal_binary2(IteratorTag());
 
-    test_equal_binary2(execution::seq, IteratorTag());
-    test_equal_binary2(execution::par, IteratorTag());
-    test_equal_binary2(execution::par_unseq, IteratorTag());
+    test_equal_binary2(seq, IteratorTag());
+    test_equal_binary2(par, IteratorTag());
+    test_equal_binary2(par_unseq, IteratorTag());
 
-    test_equal_binary2_async(execution::seq(execution::task), IteratorTag());
-    test_equal_binary2_async(execution::par(execution::task), IteratorTag());
+    test_equal_binary2_async(seq(task), IteratorTag());
+    test_equal_binary2_async(par(task), IteratorTag());
 }
 
 void equal_binary_test2()
@@ -369,8 +369,8 @@ void test_equal_binary_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -471,20 +471,18 @@ void test_equal_binary_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_equal_binary_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_equal_binary_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_equal_binary_exception(execution::seq, IteratorTag());
-    test_equal_binary_exception(execution::par, IteratorTag());
+    test_equal_binary_exception(seq, IteratorTag());
+    test_equal_binary_exception(par, IteratorTag());
 
-    test_equal_binary_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_equal_binary_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_equal_binary_exception_async(seq(task), IteratorTag());
+    test_equal_binary_exception_async(par(task), IteratorTag());
 }
 
 void equal_binary_exception_test()
@@ -583,18 +581,16 @@ void test_equal_binary_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_equal_binary_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_equal_binary_bad_alloc(execution::seq, IteratorTag());
-    test_equal_binary_bad_alloc(execution::par, IteratorTag());
+    test_equal_binary_bad_alloc(seq, IteratorTag());
+    test_equal_binary_bad_alloc(par, IteratorTag());
 
-    test_equal_binary_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_equal_binary_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_equal_binary_bad_alloc_async(seq(task), IteratorTag());
+    test_equal_binary_bad_alloc_async(par(task), IteratorTag());
 }
 
 void equal_binary_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/equal_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/equal_range.cpp
@@ -149,16 +149,16 @@ void test_equal1_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_equal1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_equal1(IteratorTag());
 
-    test_equal1(execution::seq, IteratorTag());
-    test_equal1(execution::par, IteratorTag());
-    test_equal1(execution::par_unseq, IteratorTag());
+    test_equal1(seq, IteratorTag());
+    test_equal1(par, IteratorTag());
+    test_equal1(par_unseq, IteratorTag());
 
-    test_equal1_async(execution::seq(execution::task), IteratorTag());
-    test_equal1_async(execution::par(execution::task), IteratorTag());
+    test_equal1_async(seq(task), IteratorTag());
+    test_equal1_async(par(task), IteratorTag());
 }
 
 void equal_test1()
@@ -298,16 +298,16 @@ void test_equal2_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_equal2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_equal2(IteratorTag());
 
-    test_equal2(execution::seq, IteratorTag());
-    test_equal2(execution::par, IteratorTag());
-    test_equal2(execution::par_unseq, IteratorTag());
+    test_equal2(seq, IteratorTag());
+    test_equal2(par, IteratorTag());
+    test_equal2(par_unseq, IteratorTag());
 
-    test_equal2_async(execution::seq(execution::task), IteratorTag());
-    test_equal2_async(execution::par(execution::task), IteratorTag());
+    test_equal2_async(seq(task), IteratorTag());
+    test_equal2_async(par(task), IteratorTag());
 }
 
 void equal_test2()
@@ -343,8 +343,8 @@ void test_equal_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -439,18 +439,18 @@ void test_equal_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_equal_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_equal_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_equal_exception(execution::seq, IteratorTag());
-    test_equal_exception(execution::par, IteratorTag());
+    test_equal_exception(seq, IteratorTag());
+    test_equal_exception(par, IteratorTag());
 
-    test_equal_exception_async(execution::seq(execution::task), IteratorTag());
-    test_equal_exception_async(execution::par(execution::task), IteratorTag());
+    test_equal_exception_async(seq(task), IteratorTag());
+    test_equal_exception_async(par(task), IteratorTag());
 }
 
 void equal_exception_test()
@@ -543,16 +543,16 @@ void test_equal_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_equal_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_equal_bad_alloc(execution::seq, IteratorTag());
-    test_equal_bad_alloc(execution::par, IteratorTag());
+    test_equal_bad_alloc(seq, IteratorTag());
+    test_equal_bad_alloc(par, IteratorTag());
 
-    test_equal_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_equal_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_equal_bad_alloc_async(seq(task), IteratorTag());
+    test_equal_bad_alloc_async(par(task), IteratorTag());
 }
 
 void equal_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/fill_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/fill_range.cpp
@@ -81,16 +81,16 @@ void test_fill_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_fill()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_fill(IteratorTag());
 
-    test_fill(execution::seq, IteratorTag());
-    test_fill(execution::par, IteratorTag());
-    test_fill(execution::par_unseq, IteratorTag());
+    test_fill(seq, IteratorTag());
+    test_fill(par, IteratorTag());
+    test_fill(par_unseq, IteratorTag());
 
-    test_fill_async(execution::seq(execution::task), IteratorTag());
-    test_fill_async(execution::par(execution::task), IteratorTag());
+    test_fill_async(seq(task), IteratorTag());
+    test_fill_async(par(task), IteratorTag());
 }
 
 void fill_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/filln_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/filln_range.cpp
@@ -80,16 +80,16 @@ void test_fill_n_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_fill_n()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_fill_n(IteratorTag());
 
-    test_fill_n(execution::seq, IteratorTag());
-    test_fill_n(execution::par, IteratorTag());
-    test_fill_n(execution::par_unseq, IteratorTag());
+    test_fill_n(seq, IteratorTag());
+    test_fill_n(par, IteratorTag());
+    test_fill_n(par_unseq, IteratorTag());
 
-    test_fill_n_async(execution::seq(execution::task), IteratorTag());
-    test_fill_n_async(execution::par(execution::task), IteratorTag());
+    test_fill_n_async(seq(task), IteratorTag());
+    test_fill_n_async(par(task), IteratorTag());
 }
 
 void fill_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_end_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_end_range.cpp
@@ -178,22 +178,22 @@ void test_find_end1_async_proj(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_end1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_end1(IteratorTag());
-    test_find_end1(execution::seq, IteratorTag());
-    test_find_end1(execution::par, IteratorTag());
-    test_find_end1(execution::par_unseq, IteratorTag());
+    test_find_end1(seq, IteratorTag());
+    test_find_end1(par, IteratorTag());
+    test_find_end1(par_unseq, IteratorTag());
 
     test_find_end1_proj(IteratorTag());
-    test_find_end1_proj(execution::seq, IteratorTag());
-    test_find_end1_proj(execution::par, IteratorTag());
-    test_find_end1_proj(execution::par_unseq, IteratorTag());
+    test_find_end1_proj(seq, IteratorTag());
+    test_find_end1_proj(par, IteratorTag());
+    test_find_end1_proj(par_unseq, IteratorTag());
 
-    test_find_end1_async(execution::seq(execution::task), IteratorTag());
-    test_find_end1_async(execution::par(execution::task), IteratorTag());
-    test_find_end1_async_proj(execution::seq(execution::task), IteratorTag());
-    test_find_end1_async_proj(execution::par(execution::task), IteratorTag());
+    test_find_end1_async(seq(task), IteratorTag());
+    test_find_end1_async(par(task), IteratorTag());
+    test_find_end1_async_proj(seq(task), IteratorTag());
+    test_find_end1_async_proj(par(task), IteratorTag());
 }
 
 void find_end_test1()
@@ -371,22 +371,22 @@ void test_find_end2_async_proj(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_end2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_end2(IteratorTag());
-    test_find_end2(execution::seq, IteratorTag());
-    test_find_end2(execution::par, IteratorTag());
-    test_find_end2(execution::par_unseq, IteratorTag());
+    test_find_end2(seq, IteratorTag());
+    test_find_end2(par, IteratorTag());
+    test_find_end2(par_unseq, IteratorTag());
 
     test_find_end2_proj(IteratorTag());
-    test_find_end2_proj(execution::seq, IteratorTag());
-    test_find_end2_proj(execution::par, IteratorTag());
-    test_find_end2_proj(execution::par_unseq, IteratorTag());
+    test_find_end2_proj(seq, IteratorTag());
+    test_find_end2_proj(par, IteratorTag());
+    test_find_end2_proj(par_unseq, IteratorTag());
 
-    test_find_end2_async(execution::seq(execution::task), IteratorTag());
-    test_find_end2_async(execution::par(execution::task), IteratorTag());
-    test_find_end2_async_proj(execution::seq(execution::task), IteratorTag());
-    test_find_end2_async_proj(execution::par(execution::task), IteratorTag());
+    test_find_end2_async(seq(task), IteratorTag());
+    test_find_end2_async(par(task), IteratorTag());
+    test_find_end2_async_proj(seq(task), IteratorTag());
+    test_find_end2_async_proj(par(task), IteratorTag());
 }
 
 void find_end_test2()
@@ -561,22 +561,22 @@ void test_find_end3_async_proj(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_end3()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_end3(IteratorTag());
-    test_find_end3(execution::seq, IteratorTag());
-    test_find_end3(execution::par, IteratorTag());
-    test_find_end3(execution::par_unseq, IteratorTag());
+    test_find_end3(seq, IteratorTag());
+    test_find_end3(par, IteratorTag());
+    test_find_end3(par_unseq, IteratorTag());
 
     test_find_end3_proj(IteratorTag());
-    test_find_end3_proj(execution::seq, IteratorTag());
-    test_find_end3_proj(execution::par, IteratorTag());
-    test_find_end3_proj(execution::par_unseq, IteratorTag());
+    test_find_end3_proj(seq, IteratorTag());
+    test_find_end3_proj(par, IteratorTag());
+    test_find_end3_proj(par_unseq, IteratorTag());
 
-    test_find_end3_async(execution::seq(execution::task), IteratorTag());
-    test_find_end3_async(execution::par(execution::task), IteratorTag());
-    test_find_end3_async_proj(execution::seq(execution::task), IteratorTag());
-    test_find_end3_async_proj(execution::par(execution::task), IteratorTag());
+    test_find_end3_async(seq(task), IteratorTag());
+    test_find_end3_async(par(task), IteratorTag());
+    test_find_end3_async_proj(seq(task), IteratorTag());
+    test_find_end3_async_proj(par(task), IteratorTag());
 }
 
 void find_end_test3()
@@ -748,22 +748,22 @@ void test_find_end4_async_proj(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_end4()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_end4(IteratorTag());
-    test_find_end4(execution::seq, IteratorTag());
-    test_find_end4(execution::par, IteratorTag());
-    test_find_end4(execution::par_unseq, IteratorTag());
+    test_find_end4(seq, IteratorTag());
+    test_find_end4(par, IteratorTag());
+    test_find_end4(par_unseq, IteratorTag());
 
     test_find_end4_proj(IteratorTag());
-    test_find_end4_proj(execution::seq, IteratorTag());
-    test_find_end4_proj(execution::par, IteratorTag());
-    test_find_end4_proj(execution::par_unseq, IteratorTag());
+    test_find_end4_proj(seq, IteratorTag());
+    test_find_end4_proj(par, IteratorTag());
+    test_find_end4_proj(par_unseq, IteratorTag());
 
-    test_find_end4_async(execution::seq(execution::task), IteratorTag());
-    test_find_end4_async(execution::par(execution::task), IteratorTag());
-    test_find_end4_async_proj(execution::seq(execution::task), IteratorTag());
-    test_find_end4_async_proj(execution::par(execution::task), IteratorTag());
+    test_find_end4_async(seq(task), IteratorTag());
+    test_find_end4_async(par(task), IteratorTag());
+    test_find_end4_async_proj(seq(task), IteratorTag());
+    test_find_end4_async_proj(par(task), IteratorTag());
 }
 
 void find_end_test4()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_end_range2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_end_range2.cpp
@@ -114,16 +114,16 @@ void test_find_end1_async_proj(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_end1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_end1_proj(IteratorTag());
 
-    test_find_end1_proj(execution::seq, IteratorTag());
-    test_find_end1_proj(execution::par, IteratorTag());
-    test_find_end1_proj(execution::par_unseq, IteratorTag());
+    test_find_end1_proj(seq, IteratorTag());
+    test_find_end1_proj(par, IteratorTag());
+    test_find_end1_proj(par_unseq, IteratorTag());
 
-    test_find_end1_async_proj(execution::seq(execution::task), IteratorTag());
-    test_find_end1_async_proj(execution::par(execution::task), IteratorTag());
+    test_find_end1_async_proj(seq(task), IteratorTag());
+    test_find_end1_async_proj(par(task), IteratorTag());
 }
 
 void find_end_test1()
@@ -229,16 +229,16 @@ void test_find_end2_async_proj(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_end2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_end2_proj(IteratorTag());
 
-    test_find_end2_proj(execution::seq, IteratorTag());
-    test_find_end2_proj(execution::par, IteratorTag());
-    test_find_end2_proj(execution::par_unseq, IteratorTag());
+    test_find_end2_proj(seq, IteratorTag());
+    test_find_end2_proj(par, IteratorTag());
+    test_find_end2_proj(par_unseq, IteratorTag());
 
-    test_find_end2_async_proj(execution::seq(execution::task), IteratorTag());
-    test_find_end2_async_proj(execution::par(execution::task), IteratorTag());
+    test_find_end2_async_proj(seq(task), IteratorTag());
+    test_find_end2_async_proj(par(task), IteratorTag());
 }
 
 void find_end_test2()
@@ -343,16 +343,16 @@ void test_find_end3_async_proj(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_end3()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_end3_proj(IteratorTag());
 
-    test_find_end3_proj(execution::seq, IteratorTag());
-    test_find_end3_proj(execution::par, IteratorTag());
-    test_find_end3_proj(execution::par_unseq, IteratorTag());
+    test_find_end3_proj(seq, IteratorTag());
+    test_find_end3_proj(par, IteratorTag());
+    test_find_end3_proj(par_unseq, IteratorTag());
 
-    test_find_end3_async_proj(execution::seq(execution::task), IteratorTag());
-    test_find_end3_async_proj(execution::par(execution::task), IteratorTag());
+    test_find_end3_async_proj(seq(task), IteratorTag());
+    test_find_end3_async_proj(par(task), IteratorTag());
 }
 
 void find_end_test3()
@@ -454,16 +454,16 @@ void test_find_end4_async_proj(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_end4()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_end4_proj(IteratorTag());
 
-    test_find_end4_proj(execution::seq, IteratorTag());
-    test_find_end4_proj(execution::par, IteratorTag());
-    test_find_end4_proj(execution::par_unseq, IteratorTag());
+    test_find_end4_proj(seq, IteratorTag());
+    test_find_end4_proj(par, IteratorTag());
+    test_find_end4_proj(par_unseq, IteratorTag());
 
-    test_find_end4_async_proj(execution::seq(execution::task), IteratorTag());
-    test_find_end4_async_proj(execution::par(execution::task), IteratorTag());
+    test_find_end4_async_proj(seq(task), IteratorTag());
+    test_find_end4_async_proj(par(task), IteratorTag());
 }
 
 void find_end_test4()
@@ -545,8 +545,8 @@ void test_find_end_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -602,20 +602,18 @@ void test_find_end_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_end_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_end_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_end_exception(execution::seq, IteratorTag());
-    test_find_end_exception(execution::par, IteratorTag());
+    test_find_end_exception(seq, IteratorTag());
+    test_find_end_exception(par, IteratorTag());
 
-    test_find_end_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_find_end_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_find_end_exception_async(seq(task), IteratorTag());
+    test_find_end_exception_async(par(task), IteratorTag());
 }
 
 void find_end_exception_test()
@@ -705,18 +703,16 @@ void test_find_end_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_end_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_end_bad_alloc(execution::seq, IteratorTag());
-    test_find_end_bad_alloc(execution::par, IteratorTag());
+    test_find_end_bad_alloc(seq, IteratorTag());
+    test_find_end_bad_alloc(par, IteratorTag());
 
-    test_find_end_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_find_end_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_find_end_bad_alloc_async(seq(task), IteratorTag());
+    test_find_end_bad_alloc_async(par(task), IteratorTag());
 }
 
 void find_end_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_first_of_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_first_of_range.cpp
@@ -169,24 +169,22 @@ void test_find_first_of_async_proj(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_first_of()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_first_of(IteratorTag());
-    test_find_first_of(execution::seq, IteratorTag());
-    test_find_first_of(execution::par, IteratorTag());
-    test_find_first_of(execution::par_unseq, IteratorTag());
+    test_find_first_of(seq, IteratorTag());
+    test_find_first_of(par, IteratorTag());
+    test_find_first_of(par_unseq, IteratorTag());
 
     test_find_first_of_proj(IteratorTag());
-    test_find_first_of_proj(execution::seq, IteratorTag());
-    test_find_first_of_proj(execution::par, IteratorTag());
-    test_find_first_of_proj(execution::par_unseq, IteratorTag());
+    test_find_first_of_proj(seq, IteratorTag());
+    test_find_first_of_proj(par, IteratorTag());
+    test_find_first_of_proj(par_unseq, IteratorTag());
 
-    test_find_first_of_async(execution::seq(execution::task), IteratorTag());
-    test_find_first_of_async(execution::par(execution::task), IteratorTag());
-    test_find_first_of_async_proj(
-        execution::seq(execution::task), IteratorTag());
-    test_find_first_of_async_proj(
-        execution::par(execution::task), IteratorTag());
+    test_find_first_of_async(seq(task), IteratorTag());
+    test_find_first_of_async(par(task), IteratorTag());
+    test_find_first_of_async_proj(seq(task), IteratorTag());
+    test_find_first_of_async_proj(par(task), IteratorTag());
 }
 
 void find_first_of_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_first_of_range2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_first_of_range2.cpp
@@ -109,18 +109,16 @@ void test_find_first_of_async_proj(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_first_of()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_first_of_proj(IteratorTag());
 
-    test_find_first_of_proj(execution::seq, IteratorTag());
-    test_find_first_of_proj(execution::par, IteratorTag());
-    test_find_first_of_proj(execution::par_unseq, IteratorTag());
+    test_find_first_of_proj(seq, IteratorTag());
+    test_find_first_of_proj(par, IteratorTag());
+    test_find_first_of_proj(par_unseq, IteratorTag());
 
-    test_find_first_of_async_proj(
-        execution::seq(execution::task), IteratorTag());
-    test_find_first_of_async_proj(
-        execution::par(execution::task), IteratorTag());
+    test_find_first_of_async_proj(seq(task), IteratorTag());
+    test_find_first_of_async_proj(par(task), IteratorTag());
 }
 
 void find_first_of_test()
@@ -154,8 +152,8 @@ void test_find_first_of_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -246,20 +244,18 @@ void test_find_first_of_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_first_of_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_first_of_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_first_of_exception(execution::seq, IteratorTag());
-    test_find_first_of_exception(execution::par, IteratorTag());
+    test_find_first_of_exception(seq, IteratorTag());
+    test_find_first_of_exception(par, IteratorTag());
 
-    test_find_first_of_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_find_first_of_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_find_first_of_exception_async(seq(task), IteratorTag());
+    test_find_first_of_exception_async(par(task), IteratorTag());
 }
 
 void find_first_of_exception_test()
@@ -347,18 +343,16 @@ void test_find_first_of_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_first_of_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_first_of_bad_alloc(execution::seq, IteratorTag());
-    test_find_first_of_bad_alloc(execution::par, IteratorTag());
+    test_find_first_of_bad_alloc(seq, IteratorTag());
+    test_find_first_of_bad_alloc(par, IteratorTag());
 
-    test_find_first_of_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_find_first_of_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_find_first_of_bad_alloc_async(seq(task), IteratorTag());
+    test_find_first_of_bad_alloc_async(par(task), IteratorTag());
 }
 
 void find_first_of_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_if_not_exception_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_if_not_exception_range.cpp
@@ -45,8 +45,8 @@ void test_find_if_not_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -133,20 +133,18 @@ void test_find_if_not_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_if_not_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_if_not_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_if_not_exception(execution::seq, IteratorTag());
-    test_find_if_not_exception(execution::par, IteratorTag());
+    test_find_if_not_exception(seq, IteratorTag());
+    test_find_if_not_exception(par, IteratorTag());
 
-    test_find_if_not_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_find_if_not_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_find_if_not_exception_async(seq(task), IteratorTag());
+    test_find_if_not_exception_async(par(task), IteratorTag());
 }
 
 void find_if_not_exception_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_if_not_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_if_not_range.cpp
@@ -92,16 +92,16 @@ void test_find_if_not_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_if_not()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_if_not(IteratorTag());
 
-    test_find_if_not(execution::seq, IteratorTag());
-    test_find_if_not(execution::par, IteratorTag());
-    test_find_if_not(execution::par_unseq, IteratorTag());
+    test_find_if_not(seq, IteratorTag());
+    test_find_if_not(par, IteratorTag());
+    test_find_if_not(par_unseq, IteratorTag());
 
-    test_find_if_not_async(execution::seq(execution::task), IteratorTag());
-    test_find_if_not_async(execution::par(execution::task), IteratorTag());
+    test_find_if_not_async(seq(task), IteratorTag());
+    test_find_if_not_async(par(task), IteratorTag());
 }
 
 void find_if_not_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_if_range.cpp
@@ -93,16 +93,16 @@ void test_find_if_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_if()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_if(IteratorTag());
 
-    test_find_if(execution::seq, IteratorTag());
-    test_find_if(execution::par, IteratorTag());
-    test_find_if(execution::par_unseq, IteratorTag());
+    test_find_if(seq, IteratorTag());
+    test_find_if(par, IteratorTag());
+    test_find_if(par_unseq, IteratorTag());
 
-    test_find_if_async(execution::seq(execution::task), IteratorTag());
-    test_find_if_async(execution::par(execution::task), IteratorTag());
+    test_find_if_async(seq(task), IteratorTag());
+    test_find_if_async(par(task), IteratorTag());
 }
 
 void find_if_test()
@@ -133,8 +133,8 @@ void test_find_if_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -221,20 +221,18 @@ void test_find_if_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_if_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_if_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_if_exception(execution::seq, IteratorTag());
-    test_find_if_exception(execution::par, IteratorTag());
+    test_find_if_exception(seq, IteratorTag());
+    test_find_if_exception(par, IteratorTag());
 
-    test_find_if_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_find_if_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_find_if_exception_async(seq(task), IteratorTag());
+    test_find_if_exception_async(par(task), IteratorTag());
 }
 
 void find_if_exception_test()
@@ -318,18 +316,16 @@ void test_find_if_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_if_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_if_bad_alloc(execution::seq, IteratorTag());
-    test_find_if_bad_alloc(execution::par, IteratorTag());
+    test_find_if_bad_alloc(seq, IteratorTag());
+    test_find_if_bad_alloc(par, IteratorTag());
 
-    test_find_if_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_find_if_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_find_if_bad_alloc_async(seq(task), IteratorTag());
+    test_find_if_bad_alloc_async(par(task), IteratorTag());
 }
 
 void find_if_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_range.cpp
@@ -90,16 +90,16 @@ void test_find_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find(IteratorTag());
 
-    test_find(execution::seq, IteratorTag());
-    test_find(execution::par, IteratorTag());
-    test_find(execution::par_unseq, IteratorTag());
+    test_find(seq, IteratorTag());
+    test_find(par, IteratorTag());
+    test_find(par_unseq, IteratorTag());
 
-    test_find_async(execution::seq(execution::task), IteratorTag());
-    test_find_async(execution::par(execution::task), IteratorTag());
+    test_find_async(seq(task), IteratorTag());
+    test_find_async(par(task), IteratorTag());
 }
 
 void find_test()
@@ -130,8 +130,8 @@ void test_find_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -218,18 +218,18 @@ void test_find_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_find_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_exception(execution::seq, IteratorTag());
-    test_find_exception(execution::par, IteratorTag());
+    test_find_exception(seq, IteratorTag());
+    test_find_exception(par, IteratorTag());
 
-    test_find_exception_async(execution::seq(execution::task), IteratorTag());
-    test_find_exception_async(execution::par(execution::task), IteratorTag());
+    test_find_exception_async(seq(task), IteratorTag());
+    test_find_exception_async(par(task), IteratorTag());
 }
 
 void find_exception_test()
@@ -313,16 +313,16 @@ void test_find_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_find_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_find_bad_alloc(execution::seq, IteratorTag());
-    test_find_bad_alloc(execution::par, IteratorTag());
+    test_find_bad_alloc(seq, IteratorTag());
+    test_find_bad_alloc(par, IteratorTag());
 
-    test_find_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_find_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_find_bad_alloc_async(seq(task), IteratorTag());
+    test_find_bad_alloc_async(par(task), IteratorTag());
 }
 
 void find_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_adapt.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_adapt.cpp
@@ -22,28 +22,26 @@ void myfunction(int i)
 
 void test_invoke_projected()
 {
-    Iterator<std::int64_t> iter =
-        hpx::ranges::for_each(hpx::parallel::execution::seq,
-            Iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, myfunction);
+    Iterator<std::int64_t> iter = hpx::ranges::for_each(hpx::execution::seq,
+        Iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, myfunction);
 
     HPX_TEST_EQ(*iter, std::int64_t(100));
 
-    iter = hpx::ranges::for_each(hpx::parallel::execution::par,
-        Iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, myfunction);
+    iter = hpx::ranges::for_each(hpx::execution::par, Iterator<std::int64_t>{0},
+        Sentinel<int64_t>{100}, myfunction);
 
     HPX_TEST_EQ(*iter, std::int64_t(100));
 }
 
 void test_begin_end_iterator()
 {
-    Iterator<std::int64_t> iter =
-        hpx::ranges::for_each(hpx::parallel::execution::seq,
-            Iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, &myfunction);
+    Iterator<std::int64_t> iter = hpx::ranges::for_each(hpx::execution::seq,
+        Iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, &myfunction);
 
     HPX_TEST_EQ(*iter, std::int64_t(100));
 
-    iter = hpx::ranges::for_each(hpx::parallel::execution::par,
-        Iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, &myfunction);
+    iter = hpx::ranges::for_each(hpx::execution::par, Iterator<std::int64_t>{0},
+        Sentinel<int64_t>{100}, &myfunction);
 
     HPX_TEST_EQ(*iter, std::int64_t(100));
 }

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_range.cpp
@@ -17,16 +17,16 @@
 template <typename IteratorTag>
 void test_for_each()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_for_each_seq(IteratorTag());
 
-    test_for_each(execution::seq, IteratorTag());
-    test_for_each(execution::par, IteratorTag());
-    test_for_each(execution::par_unseq, IteratorTag());
+    test_for_each(seq, IteratorTag());
+    test_for_each(par, IteratorTag());
+    test_for_each(par_unseq, IteratorTag());
 
-    test_for_each_async(execution::seq(execution::task), IteratorTag());
-    test_for_each_async(execution::par(execution::task), IteratorTag());
+    test_for_each_async(seq(task), IteratorTag());
+    test_for_each_async(par(task), IteratorTag());
 }
 
 void for_each_test()
@@ -39,20 +39,18 @@ void for_each_test()
 template <typename IteratorTag>
 void test_for_each_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
     test_for_each_exception_seq(IteratorTag());
 
-    test_for_each_exception(execution::seq, IteratorTag());
-    test_for_each_exception(execution::par, IteratorTag());
+    test_for_each_exception(seq, IteratorTag());
+    test_for_each_exception(par, IteratorTag());
 
-    test_for_each_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_for_each_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_for_each_exception_async(seq(task), IteratorTag());
+    test_for_each_exception_async(par(task), IteratorTag());
 }
 
 void for_each_exception_test()
@@ -65,20 +63,18 @@ void for_each_exception_test()
 template <typename IteratorTag>
 void test_for_each_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
     test_for_each_bad_alloc_seq(IteratorTag());
 
-    test_for_each_bad_alloc(execution::seq, IteratorTag());
-    test_for_each_bad_alloc(execution::par, IteratorTag());
+    test_for_each_bad_alloc(seq, IteratorTag());
+    test_for_each_bad_alloc(par, IteratorTag());
 
-    test_for_each_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_for_each_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_for_each_bad_alloc_async(seq(task), IteratorTag());
+    test_for_each_bad_alloc_async(par(task), IteratorTag());
 }
 
 void for_each_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_range_projection.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_range_projection.cpp
@@ -17,16 +17,16 @@
 template <typename IteratorTag, typename Proj>
 void test_for_each()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_for_each_seq(IteratorTag(), Proj());
 
-    test_for_each(execution::seq, IteratorTag(), Proj());
-    test_for_each(execution::par, IteratorTag(), Proj());
-    test_for_each(execution::par_unseq, IteratorTag(), Proj());
+    test_for_each(seq, IteratorTag(), Proj());
+    test_for_each(par, IteratorTag(), Proj());
+    test_for_each(par_unseq, IteratorTag(), Proj());
 
-    test_for_each_async(execution::seq(execution::task), IteratorTag(), Proj());
-    test_for_each_async(execution::par(execution::task), IteratorTag(), Proj());
+    test_for_each_async(seq(task), IteratorTag(), Proj());
+    test_for_each_async(par(task), IteratorTag(), Proj());
 }
 
 template <typename Proj>
@@ -40,20 +40,18 @@ void for_each_test()
 template <typename IteratorTag, typename Proj>
 void test_for_each_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
     test_for_each_exception_seq(IteratorTag(), Proj());
 
-    test_for_each_exception(execution::seq, IteratorTag(), Proj());
-    test_for_each_exception(execution::par, IteratorTag(), Proj());
+    test_for_each_exception(seq, IteratorTag(), Proj());
+    test_for_each_exception(par, IteratorTag(), Proj());
 
-    test_for_each_exception_async(
-        execution::seq(execution::task), IteratorTag(), Proj());
-    test_for_each_exception_async(
-        execution::par(execution::task), IteratorTag(), Proj());
+    test_for_each_exception_async(seq(task), IteratorTag(), Proj());
+    test_for_each_exception_async(par(task), IteratorTag(), Proj());
 }
 
 template <typename Proj>
@@ -67,20 +65,18 @@ void for_each_exception_test()
 template <typename IteratorTag, typename Proj>
 void test_for_each_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
     test_for_each_bad_alloc_seq(IteratorTag(), Proj());
 
-    test_for_each_bad_alloc(execution::seq, IteratorTag(), Proj());
-    test_for_each_bad_alloc(execution::par, IteratorTag(), Proj());
+    test_for_each_bad_alloc(seq, IteratorTag(), Proj());
+    test_for_each_bad_alloc(par, IteratorTag(), Proj());
 
-    test_for_each_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag(), Proj());
-    test_for_each_bad_alloc_async(
-        execution::par(execution::task), IteratorTag(), Proj());
+    test_for_each_bad_alloc_async(seq(task), IteratorTag(), Proj());
+    test_for_each_bad_alloc_async(par(task), IteratorTag(), Proj());
 }
 
 template <typename Proj>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/generate_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/generate_range.cpp
@@ -104,16 +104,16 @@ void test_generate_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_generate()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_generate(IteratorTag());
 
-    test_generate(execution::seq, IteratorTag());
-    test_generate(execution::par, IteratorTag());
-    test_generate(execution::par_unseq, IteratorTag());
+    test_generate(seq, IteratorTag());
+    test_generate(par, IteratorTag());
+    test_generate(par_unseq, IteratorTag());
 
-    test_generate_async(execution::seq(execution::task), IteratorTag());
-    test_generate_async(execution::par(execution::task), IteratorTag());
+    test_generate_async(seq(task), IteratorTag());
+    test_generate_async(par(task), IteratorTag());
 }
 
 void generate_test()
@@ -147,8 +147,8 @@ void test_generate_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -239,20 +239,18 @@ void test_generate_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_generate_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_generate_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_generate_exception(execution::seq, IteratorTag());
-    test_generate_exception(execution::par, IteratorTag());
+    test_generate_exception(seq, IteratorTag());
+    test_generate_exception(par, IteratorTag());
 
-    test_generate_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_generate_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_generate_exception_async(seq(task), IteratorTag());
+    test_generate_exception_async(par(task), IteratorTag());
 }
 
 void generate_exception_test()
@@ -342,18 +340,16 @@ void test_generate_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_generate_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_generate_bad_alloc(execution::seq, IteratorTag());
-    test_generate_bad_alloc(execution::par, IteratorTag());
+    test_generate_bad_alloc(seq, IteratorTag());
+    test_generate_bad_alloc(par, IteratorTag());
 
-    test_generate_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_generate_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_generate_bad_alloc_async(seq(task), IteratorTag());
+    test_generate_bad_alloc_async(par(task), IteratorTag());
 }
 
 void generate_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/inplace_merge_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/inplace_merge_range.cpp
@@ -163,14 +163,14 @@ void test_inplace_merge_async(ExPolicy policy, DataType)
 template <typename DataType>
 void test_inplace_merge()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_inplace_merge(execution::seq, DataType());
-    test_inplace_merge(execution::par, DataType());
-    test_inplace_merge(execution::par_unseq, DataType());
+    test_inplace_merge(seq, DataType());
+    test_inplace_merge(par, DataType());
+    test_inplace_merge(par_unseq, DataType());
 
-    test_inplace_merge_async(execution::seq(execution::task), DataType());
-    test_inplace_merge_async(execution::par(execution::task), DataType());
+    test_inplace_merge_async(seq(task), DataType());
+    test_inplace_merge_async(par(task), DataType());
 }
 
 void test_inplace_merge()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/is_heap_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/is_heap_range.cpp
@@ -100,14 +100,14 @@ void test_is_heap_async(ExPolicy policy, DataType)
 template <typename DataType>
 void test_is_heap()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_is_heap(execution::seq, DataType());
-    test_is_heap(execution::par, DataType());
-    test_is_heap(execution::par_unseq, DataType());
+    test_is_heap(seq, DataType());
+    test_is_heap(par, DataType());
+    test_is_heap(par_unseq, DataType());
 
-    test_is_heap_async(execution::seq(execution::task), DataType());
-    test_is_heap_async(execution::par(execution::task), DataType());
+    test_is_heap_async(seq(task), DataType());
+    test_is_heap_async(par(task), DataType());
 }
 
 void test_is_heap()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/is_heap_until_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/is_heap_until_range.cpp
@@ -100,14 +100,14 @@ void test_is_heap_until_async(ExPolicy policy, DataType)
 template <typename DataType>
 void test_is_heap_until()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_is_heap_until(execution::seq, DataType());
-    test_is_heap_until(execution::par, DataType());
-    test_is_heap_until(execution::par_unseq, DataType());
+    test_is_heap_until(seq, DataType());
+    test_is_heap_until(par, DataType());
+    test_is_heap_until(par_unseq, DataType());
 
-    test_is_heap_until_async(execution::seq(execution::task), DataType());
-    test_is_heap_until_async(execution::par(execution::task), DataType());
+    test_is_heap_until_async(seq(task), DataType());
+    test_is_heap_until_async(par(task), DataType());
 }
 
 void test_is_heap_until()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/max_element_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/max_element_range.cpp
@@ -85,14 +85,14 @@ void test_max_element_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_max_element()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_max_element(execution::seq, IteratorTag());
-    test_max_element(execution::par, IteratorTag());
-    test_max_element(execution::par_unseq, IteratorTag());
+    test_max_element(seq, IteratorTag());
+    test_max_element(par, IteratorTag());
+    test_max_element(par_unseq, IteratorTag());
 
-    test_max_element_async(execution::seq(execution::task), IteratorTag());
-    test_max_element_async(execution::par(execution::task), IteratorTag());
+    test_max_element_async(seq(task), IteratorTag());
+    test_max_element_async(par(task), IteratorTag());
 }
 
 void max_element_test()
@@ -240,18 +240,16 @@ void test_max_element_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_max_element_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_max_element_exception(execution::seq, IteratorTag());
-    test_max_element_exception(execution::par, IteratorTag());
+    test_max_element_exception(seq, IteratorTag());
+    test_max_element_exception(par, IteratorTag());
 
-    test_max_element_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_max_element_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_max_element_exception_async(seq(task), IteratorTag());
+    test_max_element_exception_async(par(task), IteratorTag());
 }
 
 void max_element_exception_test()
@@ -398,18 +396,16 @@ void test_max_element_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_max_element_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_max_element_bad_alloc(execution::seq, IteratorTag());
-    test_max_element_bad_alloc(execution::par, IteratorTag());
+    test_max_element_bad_alloc(seq, IteratorTag());
+    test_max_element_bad_alloc(par, IteratorTag());
 
-    test_max_element_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_max_element_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_max_element_bad_alloc_async(seq(task), IteratorTag());
+    test_max_element_bad_alloc_async(par(task), IteratorTag());
 }
 
 void max_element_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/merge_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/merge_range.cpp
@@ -157,14 +157,14 @@ void test_merge_async(ExPolicy policy, DataType)
 template <typename DataType>
 void test_merge()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_merge(execution::seq, DataType());
-    test_merge(execution::par, DataType());
-    test_merge(execution::par_unseq, DataType());
+    test_merge(seq, DataType());
+    test_merge(par, DataType());
+    test_merge(par_unseq, DataType());
 
-    test_merge_async(execution::seq(execution::task), DataType());
-    test_merge_async(execution::par(execution::task), DataType());
+    test_merge_async(seq(task), DataType());
+    test_merge_async(par(task), DataType());
 }
 
 void test_merge()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/min_element_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/min_element_range.cpp
@@ -84,14 +84,14 @@ void test_min_element_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_min_element()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_min_element(execution::seq, IteratorTag());
-    test_min_element(execution::par, IteratorTag());
-    test_min_element(execution::par_unseq, IteratorTag());
+    test_min_element(seq, IteratorTag());
+    test_min_element(par, IteratorTag());
+    test_min_element(par_unseq, IteratorTag());
 
-    test_min_element_async(execution::seq(execution::task), IteratorTag());
-    test_min_element_async(execution::par(execution::task), IteratorTag());
+    test_min_element_async(seq(task), IteratorTag());
+    test_min_element_async(par(task), IteratorTag());
 }
 
 void min_element_test()
@@ -242,18 +242,16 @@ void test_min_element_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_min_element_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_min_element_exception(execution::seq, IteratorTag());
-    test_min_element_exception(execution::par, IteratorTag());
+    test_min_element_exception(seq, IteratorTag());
+    test_min_element_exception(par, IteratorTag());
 
-    test_min_element_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_min_element_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_min_element_exception_async(seq(task), IteratorTag());
+    test_min_element_exception_async(par(task), IteratorTag());
 }
 
 void min_element_exception_test()
@@ -400,18 +398,16 @@ void test_min_element_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_min_element_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_min_element_bad_alloc(execution::seq, IteratorTag());
-    test_min_element_bad_alloc(execution::par, IteratorTag());
+    test_min_element_bad_alloc(seq, IteratorTag());
+    test_min_element_bad_alloc(par, IteratorTag());
 
-    test_min_element_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_min_element_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_min_element_bad_alloc_async(seq(task), IteratorTag());
+    test_min_element_bad_alloc_async(par(task), IteratorTag());
 }
 
 void min_element_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/minmax_element_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/minmax_element_range.cpp
@@ -96,14 +96,14 @@ void test_minmax_element_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_minmax_element()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_minmax_element(execution::seq, IteratorTag());
-    test_minmax_element(execution::par, IteratorTag());
-    test_minmax_element(execution::par_unseq, IteratorTag());
+    test_minmax_element(seq, IteratorTag());
+    test_minmax_element(par, IteratorTag());
+    test_minmax_element(par_unseq, IteratorTag());
 
-    test_minmax_element_async(execution::seq(execution::task), IteratorTag());
-    test_minmax_element_async(execution::par(execution::task), IteratorTag());
+    test_minmax_element_async(seq(task), IteratorTag());
+    test_minmax_element_async(par(task), IteratorTag());
 }
 
 void minmax_element_test()
@@ -254,18 +254,16 @@ void test_minmax_element_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_minmax_element_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_minmax_element_exception(execution::seq, IteratorTag());
-    test_minmax_element_exception(execution::par, IteratorTag());
+    test_minmax_element_exception(seq, IteratorTag());
+    test_minmax_element_exception(par, IteratorTag());
 
-    test_minmax_element_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_minmax_element_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_minmax_element_exception_async(seq(task), IteratorTag());
+    test_minmax_element_exception_async(par(task), IteratorTag());
 }
 
 void minmax_element_exception_test()
@@ -412,18 +410,16 @@ void test_minmax_element_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_minmax_element_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_minmax_element_bad_alloc(execution::seq, IteratorTag());
-    test_minmax_element_bad_alloc(execution::par, IteratorTag());
+    test_minmax_element_bad_alloc(seq, IteratorTag());
+    test_minmax_element_bad_alloc(par, IteratorTag());
 
-    test_minmax_element_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_minmax_element_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_minmax_element_bad_alloc_async(seq(task), IteratorTag());
+    test_minmax_element_bad_alloc_async(par(task), IteratorTag());
 }
 
 void minmax_element_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/mismatch_binary_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/mismatch_binary_range.cpp
@@ -171,16 +171,16 @@ void test_mismatch_binary1_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_mismatch_binary1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_mismatch_binary1(IteratorTag());
 
-    test_mismatch_binary1(execution::seq, IteratorTag());
-    test_mismatch_binary1(execution::par, IteratorTag());
-    test_mismatch_binary1(execution::par_unseq, IteratorTag());
+    test_mismatch_binary1(seq, IteratorTag());
+    test_mismatch_binary1(par, IteratorTag());
+    test_mismatch_binary1(par_unseq, IteratorTag());
 
-    test_mismatch_binary1_async(execution::seq(execution::task), IteratorTag());
-    test_mismatch_binary1_async(execution::par(execution::task), IteratorTag());
+    test_mismatch_binary1_async(seq(task), IteratorTag());
+    test_mismatch_binary1_async(par(task), IteratorTag());
 }
 
 void mismatch_binary_test1()
@@ -342,16 +342,16 @@ void test_mismatch_binary2_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_mismatch_binary2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_mismatch_binary2(IteratorTag());
 
-    test_mismatch_binary2(execution::seq, IteratorTag());
-    test_mismatch_binary2(execution::par, IteratorTag());
-    test_mismatch_binary2(execution::par_unseq, IteratorTag());
+    test_mismatch_binary2(seq, IteratorTag());
+    test_mismatch_binary2(par, IteratorTag());
+    test_mismatch_binary2(par_unseq, IteratorTag());
 
-    test_mismatch_binary2_async(execution::seq(execution::task), IteratorTag());
-    test_mismatch_binary2_async(execution::par(execution::task), IteratorTag());
+    test_mismatch_binary2_async(seq(task), IteratorTag());
+    test_mismatch_binary2_async(par(task), IteratorTag());
 }
 
 void mismatch_binary_test2()
@@ -391,8 +391,8 @@ void test_mismatch_binary_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -493,20 +493,18 @@ void test_mismatch_binary_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_mismatch_binary_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_mismatch_binary_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_mismatch_binary_exception(execution::seq, IteratorTag());
-    test_mismatch_binary_exception(execution::par, IteratorTag());
+    test_mismatch_binary_exception(seq, IteratorTag());
+    test_mismatch_binary_exception(par, IteratorTag());
 
-    test_mismatch_binary_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_mismatch_binary_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_mismatch_binary_exception_async(seq(task), IteratorTag());
+    test_mismatch_binary_exception_async(par(task), IteratorTag());
 }
 
 void mismatch_binary_exception_test()
@@ -605,18 +603,16 @@ void test_mismatch_binary_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_mismatch_binary_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_mismatch_binary_bad_alloc(execution::seq, IteratorTag());
-    test_mismatch_binary_bad_alloc(execution::par, IteratorTag());
+    test_mismatch_binary_bad_alloc(seq, IteratorTag());
+    test_mismatch_binary_bad_alloc(par, IteratorTag());
 
-    test_mismatch_binary_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_mismatch_binary_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_mismatch_binary_bad_alloc_async(seq(task), IteratorTag());
+    test_mismatch_binary_bad_alloc_async(par(task), IteratorTag());
 }
 
 void mismatch_binary_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/mismatch_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/mismatch_range.cpp
@@ -165,16 +165,16 @@ void test_mismatch1_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_mismatch1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_mismatch1(IteratorTag());
 
-    test_mismatch1(execution::seq, IteratorTag());
-    test_mismatch1(execution::par, IteratorTag());
-    test_mismatch1(execution::par_unseq, IteratorTag());
+    test_mismatch1(seq, IteratorTag());
+    test_mismatch1(par, IteratorTag());
+    test_mismatch1(par_unseq, IteratorTag());
 
-    test_mismatch1_async(execution::seq(execution::task), IteratorTag());
-    test_mismatch1_async(execution::par(execution::task), IteratorTag());
+    test_mismatch1_async(seq(task), IteratorTag());
+    test_mismatch1_async(par(task), IteratorTag());
 }
 
 void mismatch_test1()
@@ -324,16 +324,16 @@ void test_mismatch2_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_mismatch2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_mismatch2(IteratorTag());
 
-    test_mismatch2(execution::seq, IteratorTag());
-    test_mismatch2(execution::par, IteratorTag());
-    test_mismatch2(execution::par_unseq, IteratorTag());
+    test_mismatch2(seq, IteratorTag());
+    test_mismatch2(par, IteratorTag());
+    test_mismatch2(par_unseq, IteratorTag());
 
-    test_mismatch2_async(execution::seq(execution::task), IteratorTag());
-    test_mismatch2_async(execution::par(execution::task), IteratorTag());
+    test_mismatch2_async(seq(task), IteratorTag());
+    test_mismatch2_async(par(task), IteratorTag());
 }
 
 void mismatch_test2()
@@ -371,8 +371,8 @@ void test_mismatch_exception(IteratorTag)
     catch (hpx::exception_list const& e)
     {
         caught_exception = true;
-        test::test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-            IteratorTag>::call(hpx::parallel::execution::seq, e);
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
     }
     catch (...)
     {
@@ -471,18 +471,16 @@ void test_mismatch_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_mismatch_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_mismatch_exception(execution::seq, IteratorTag());
-    test_mismatch_exception(execution::par, IteratorTag());
+    test_mismatch_exception(seq, IteratorTag());
+    test_mismatch_exception(par, IteratorTag());
 
-    test_mismatch_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_mismatch_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_mismatch_exception_async(seq(task), IteratorTag());
+    test_mismatch_exception_async(par(task), IteratorTag());
 }
 
 void mismatch_exception_test()
@@ -579,18 +577,16 @@ void test_mismatch_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_mismatch_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_mismatch_bad_alloc(execution::seq, IteratorTag());
-    test_mismatch_bad_alloc(execution::par, IteratorTag());
+    test_mismatch_bad_alloc(seq, IteratorTag());
+    test_mismatch_bad_alloc(par, IteratorTag());
 
-    test_mismatch_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_mismatch_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_mismatch_bad_alloc_async(seq(task), IteratorTag());
+    test_mismatch_bad_alloc_async(par(task), IteratorTag());
 }
 
 void mismatch_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/move_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/move_range.cpp
@@ -114,16 +114,16 @@ void test_move_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_move()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_move(IteratorTag());
 
-    test_move(execution::seq, IteratorTag());
-    test_move(execution::par, IteratorTag());
-    test_move(execution::par_unseq, IteratorTag());
+    test_move(seq, IteratorTag());
+    test_move(par, IteratorTag());
+    test_move(par_unseq, IteratorTag());
 
-    test_move_async(execution::seq(execution::task), IteratorTag());
-    test_move_async(execution::par(execution::task), IteratorTag());
+    test_move_async(seq(task), IteratorTag());
+    test_move_async(par(task), IteratorTag());
 }
 
 void move_test()
@@ -215,16 +215,16 @@ void test_move_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_move_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_move_exception(execution::seq, IteratorTag());
-    test_move_exception(execution::par, IteratorTag());
+    test_move_exception(seq, IteratorTag());
+    test_move_exception(par, IteratorTag());
 
-    test_move_exception_async(execution::seq(execution::task), IteratorTag());
-    test_move_exception_async(execution::par(execution::task), IteratorTag());
+    test_move_exception_async(seq(task), IteratorTag());
+    test_move_exception_async(par(task), IteratorTag());
 }
 
 void move_exception_test()
@@ -314,16 +314,16 @@ void test_move_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_move_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_move_bad_alloc(execution::seq, IteratorTag());
-    test_move_bad_alloc(execution::par, IteratorTag());
+    test_move_bad_alloc(seq, IteratorTag());
+    test_move_bad_alloc(par, IteratorTag());
 
-    test_move_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_move_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_move_bad_alloc_async(seq(task), IteratorTag());
+    test_move_bad_alloc_async(par(task), IteratorTag());
 }
 
 void move_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/none_of_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/none_of_range.cpp
@@ -107,34 +107,34 @@ void test_none_of()
             return !static_cast<bool>(x);
         }
     };
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_none_of_seq(IteratorTag());
     test_none_of_seq(IteratorTag(), proj());
 
-    test_none_of(execution::seq, IteratorTag());
-    test_none_of(execution::par, IteratorTag());
-    test_none_of(execution::par_unseq, IteratorTag());
+    test_none_of(seq, IteratorTag());
+    test_none_of(par, IteratorTag());
+    test_none_of(par_unseq, IteratorTag());
 
-    test_none_of(execution::seq, IteratorTag(), proj());
-    test_none_of(execution::par, IteratorTag(), proj());
-    test_none_of(execution::par_unseq, IteratorTag(), proj());
+    test_none_of(seq, IteratorTag(), proj());
+    test_none_of(par, IteratorTag(), proj());
+    test_none_of(par_unseq, IteratorTag(), proj());
 
-    test_none_of_async(execution::seq(execution::task), IteratorTag());
-    test_none_of_async(execution::par(execution::task), IteratorTag());
+    test_none_of_async(seq(task), IteratorTag());
+    test_none_of_async(par(task), IteratorTag());
 
-    test_none_of_async(execution::seq(execution::task), IteratorTag(), proj());
-    test_none_of_async(execution::par(execution::task), IteratorTag(), proj());
+    test_none_of_async(seq(task), IteratorTag(), proj());
+    test_none_of_async(par(task), IteratorTag(), proj());
 }
 
 // template <typename IteratorTag>
 // void test_none_of_exec()
 // {
-//     using namespace hpx::parallel;
+//     using namespace hpx::execution;
 //
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_none_of(execution::par(exec), IteratorTag());
+//         test_none_of(par(exec), IteratorTag());
 //     }
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
@@ -143,7 +143,7 @@ void test_none_of()
 //
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
-//         test_none_of(execution_policy(execution::par(exec)), IteratorTag());
+//         test_none_of(execution_policy(par(exec)), IteratorTag());
 //     }
 //     {
 //         hpx::threads::executors::local_priority_queue_executor exec;
@@ -182,9 +182,8 @@ void test_none_of_exception(IteratorTag)
         catch (hpx::exception_list const& e)
         {
             caught_exception = true;
-            test::test_num_exceptions<
-                hpx::parallel::execution::sequenced_policy,
-                IteratorTag>::call(hpx::parallel::execution::seq, e);
+            test::test_num_exceptions<hpx::execution::sequenced_policy,
+                IteratorTag>::call(hpx::execution::seq, e);
         }
         catch (...)
         {
@@ -276,20 +275,18 @@ void test_none_of_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_none_of_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_none_of_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_none_of_exception(execution::seq, IteratorTag());
-    test_none_of_exception(execution::par, IteratorTag());
+    test_none_of_exception(seq, IteratorTag());
+    test_none_of_exception(par, IteratorTag());
 
-    test_none_of_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_none_of_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_none_of_exception_async(seq(task), IteratorTag());
+    test_none_of_exception_async(par(task), IteratorTag());
 }
 
 void none_of_exception_test()
@@ -376,18 +373,16 @@ void test_none_of_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_none_of_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_none_of_bad_alloc(execution::seq, IteratorTag());
-    test_none_of_bad_alloc(execution::par, IteratorTag());
+    test_none_of_bad_alloc(seq, IteratorTag());
+    test_none_of_bad_alloc(par, IteratorTag());
 
-    test_none_of_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_none_of_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_none_of_bad_alloc_async(seq(task), IteratorTag());
+    test_none_of_bad_alloc_async(par(task), IteratorTag());
 }
 
 void none_of_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/partition_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/partition_copy_range.cpp
@@ -156,14 +156,14 @@ void test_partition_copy_async(ExPolicy policy, DataType)
 template <typename DataType>
 void test_partition_copy()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_partition_copy(execution::seq, DataType());
-    test_partition_copy(execution::par, DataType());
-    test_partition_copy(execution::par_unseq, DataType());
+    test_partition_copy(seq, DataType());
+    test_partition_copy(par, DataType());
+    test_partition_copy(par_unseq, DataType());
 
-    test_partition_copy_async(execution::seq(execution::task), DataType());
-    test_partition_copy_async(execution::par(execution::task), DataType());
+    test_partition_copy_async(seq(task), DataType());
+    test_partition_copy_async(par(task), DataType());
 }
 
 void test_partition_copy()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/partition_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/partition_range.cpp
@@ -166,14 +166,14 @@ void test_partition_async(ExPolicy policy, DataType)
 template <typename DataType>
 void test_partition()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_partition(execution::seq, DataType());
-    test_partition(execution::par, DataType());
-    test_partition(execution::par_unseq, DataType());
+    test_partition(seq, DataType());
+    test_partition(par, DataType());
+    test_partition(par_unseq, DataType());
 
-    test_partition_async(execution::seq(execution::task), DataType());
-    test_partition_async(execution::par(execution::task), DataType());
+    test_partition_async(seq(task), DataType());
+    test_partition_async(par(task), DataType());
 }
 
 void test_partition()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/reduce_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/reduce_range.cpp
@@ -69,14 +69,14 @@ void test_reduce1_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reduce1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_reduce1(execution::seq, IteratorTag());
-    test_reduce1(execution::par, IteratorTag());
-    test_reduce1(execution::par_unseq, IteratorTag());
+    test_reduce1(seq, IteratorTag());
+    test_reduce1(par, IteratorTag());
+    test_reduce1(par_unseq, IteratorTag());
 
-    test_reduce1_async(execution::seq(execution::task), IteratorTag());
-    test_reduce1_async(execution::par(execution::task), IteratorTag());
+    test_reduce1_async(seq(task), IteratorTag());
+    test_reduce1_async(par(task), IteratorTag());
 }
 
 void reduce_test1()
@@ -128,14 +128,14 @@ void test_reduce2_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reduce2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_reduce2(execution::seq, IteratorTag());
-    test_reduce2(execution::par, IteratorTag());
-    test_reduce2(execution::par_unseq, IteratorTag());
+    test_reduce2(seq, IteratorTag());
+    test_reduce2(par, IteratorTag());
+    test_reduce2(par_unseq, IteratorTag());
 
-    test_reduce2_async(execution::seq(execution::task), IteratorTag());
-    test_reduce2_async(execution::par(execution::task), IteratorTag());
+    test_reduce2_async(seq(task), IteratorTag());
+    test_reduce2_async(par(task), IteratorTag());
 }
 
 void reduce_test2()
@@ -187,14 +187,14 @@ void test_reduce3_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reduce3()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_reduce3(execution::seq, IteratorTag());
-    test_reduce3(execution::par, IteratorTag());
-    test_reduce3(execution::par_unseq, IteratorTag());
+    test_reduce3(seq, IteratorTag());
+    test_reduce3(par, IteratorTag());
+    test_reduce3(par_unseq, IteratorTag());
 
-    test_reduce3_async(execution::seq(execution::task), IteratorTag());
-    test_reduce3_async(execution::par(execution::task), IteratorTag());
+    test_reduce3_async(seq(task), IteratorTag());
+    test_reduce3_async(par(task), IteratorTag());
 }
 
 void reduce_test3()
@@ -279,16 +279,16 @@ void test_reduce_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reduce_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_reduce_exception(execution::seq, IteratorTag());
-    test_reduce_exception(execution::par, IteratorTag());
+    test_reduce_exception(seq, IteratorTag());
+    test_reduce_exception(par, IteratorTag());
 
-    test_reduce_exception_async(execution::seq(execution::task), IteratorTag());
-    test_reduce_exception_async(execution::par(execution::task), IteratorTag());
+    test_reduce_exception_async(seq(task), IteratorTag());
+    test_reduce_exception_async(par(task), IteratorTag());
 }
 
 void reduce_exception_test()
@@ -371,16 +371,16 @@ void test_reduce_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reduce_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_reduce_bad_alloc(execution::seq, IteratorTag());
-    test_reduce_bad_alloc(execution::par, IteratorTag());
+    test_reduce_bad_alloc(seq, IteratorTag());
+    test_reduce_bad_alloc(par, IteratorTag());
 
-    test_reduce_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_reduce_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_reduce_bad_alloc_async(seq(task), IteratorTag());
+    test_reduce_bad_alloc_async(par(task), IteratorTag());
 }
 
 void reduce_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_if_range.cpp
@@ -166,14 +166,14 @@ void test_remove_copy_if_outiter_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_remove_copy_if()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_remove_copy_if(execution::seq, IteratorTag());
-    test_remove_copy_if(execution::par, IteratorTag());
-    test_remove_copy_if(execution::par_unseq, IteratorTag());
+    test_remove_copy_if(seq, IteratorTag());
+    test_remove_copy_if(par, IteratorTag());
+    test_remove_copy_if(par_unseq, IteratorTag());
 
-    test_remove_copy_if_async(execution::seq(execution::task), IteratorTag());
-    test_remove_copy_if_async(execution::par(execution::task), IteratorTag());
+    test_remove_copy_if_async(seq(task), IteratorTag());
+    test_remove_copy_if_async(par(task), IteratorTag());
 }
 
 void remove_copy_if_test()
@@ -264,18 +264,16 @@ void test_remove_copy_if_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_remove_copy_if_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_remove_copy_if_exception(execution::seq, IteratorTag());
-    test_remove_copy_if_exception(execution::par, IteratorTag());
+    test_remove_copy_if_exception(seq, IteratorTag());
+    test_remove_copy_if_exception(par, IteratorTag());
 
-    test_remove_copy_if_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_remove_copy_if_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_remove_copy_if_exception_async(seq(task), IteratorTag());
+    test_remove_copy_if_exception_async(par(task), IteratorTag());
 }
 
 void remove_copy_if_exception_test()
@@ -361,18 +359,16 @@ void test_remove_copy_if_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_remove_copy_if_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_remove_copy_if_bad_alloc(execution::seq, IteratorTag());
-    test_remove_copy_if_bad_alloc(execution::par, IteratorTag());
+    test_remove_copy_if_bad_alloc(seq, IteratorTag());
+    test_remove_copy_if_bad_alloc(par, IteratorTag());
 
-    test_remove_copy_if_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_remove_copy_if_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_remove_copy_if_bad_alloc_async(seq(task), IteratorTag());
+    test_remove_copy_if_bad_alloc_async(par(task), IteratorTag());
 }
 
 void remove_copy_if_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_range.cpp
@@ -155,13 +155,13 @@ void test_remove_copy_outiter_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_remove_copy()
 {
-    using namespace hpx::parallel;
-    test_remove_copy(execution::seq, IteratorTag());
-    test_remove_copy(execution::par, IteratorTag());
-    test_remove_copy(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_remove_copy(seq, IteratorTag());
+    test_remove_copy(par, IteratorTag());
+    test_remove_copy(par_unseq, IteratorTag());
 
-    test_remove_copy_async(execution::seq(execution::task), IteratorTag());
-    test_remove_copy_async(execution::par(execution::task), IteratorTag());
+    test_remove_copy_async(seq(task), IteratorTag());
+    test_remove_copy_async(par(task), IteratorTag());
 }
 
 void remove_copy_test()
@@ -253,18 +253,16 @@ void test_remove_copy_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_remove_copy_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_remove_copy_exception(execution::seq, IteratorTag());
-    test_remove_copy_exception(execution::par, IteratorTag());
+    test_remove_copy_exception(seq, IteratorTag());
+    test_remove_copy_exception(par, IteratorTag());
 
-    test_remove_copy_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_remove_copy_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_remove_copy_exception_async(seq(task), IteratorTag());
+    test_remove_copy_exception_async(par(task), IteratorTag());
 }
 
 void remove_copy_exception_test()
@@ -354,18 +352,16 @@ void test_remove_copy_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_remove_copy_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_remove_copy_bad_alloc(execution::seq, IteratorTag());
-    test_remove_copy_bad_alloc(execution::par, IteratorTag());
+    test_remove_copy_bad_alloc(seq, IteratorTag());
+    test_remove_copy_bad_alloc(par, IteratorTag());
 
-    test_remove_copy_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_remove_copy_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_remove_copy_bad_alloc_async(seq(task), IteratorTag());
+    test_remove_copy_bad_alloc_async(par(task), IteratorTag());
 }
 
 void remove_copy_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_if_range.cpp
@@ -119,14 +119,14 @@ void test_remove_if_async(ExPolicy policy, DataType)
 template <typename DataType>
 void test_remove_if()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_remove_if(execution::seq, DataType());
-    test_remove_if(execution::par, DataType());
-    test_remove_if(execution::par_unseq, DataType());
+    test_remove_if(seq, DataType());
+    test_remove_if(par, DataType());
+    test_remove_if(par_unseq, DataType());
 
-    test_remove_if_async(execution::seq(execution::task), DataType());
-    test_remove_if_async(execution::par(execution::task), DataType());
+    test_remove_if_async(seq(task), DataType());
+    test_remove_if_async(par(task), DataType());
 }
 
 void test_remove_if()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_range.cpp
@@ -119,14 +119,14 @@ void test_remove_async(ExPolicy policy, DataType)
 template <typename DataType>
 void test_remove()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_remove(execution::seq, DataType());
-    test_remove(execution::par, DataType());
-    test_remove(execution::par_unseq, DataType());
+    test_remove(seq, DataType());
+    test_remove(par, DataType());
+    test_remove(par_unseq, DataType());
 
-    test_remove_async(execution::seq(execution::task), DataType());
-    test_remove_async(execution::par(execution::task), DataType());
+    test_remove_async(seq(task), DataType());
+    test_remove_async(par(task), DataType());
 }
 
 void test_remove()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_if_range.cpp
@@ -109,13 +109,13 @@ void test_replace_copy_if_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_copy_if()
 {
-    using namespace hpx::parallel;
-    test_replace_copy_if(execution::seq, IteratorTag());
-    test_replace_copy_if(execution::par, IteratorTag());
-    test_replace_copy_if(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_replace_copy_if(seq, IteratorTag());
+    test_replace_copy_if(par, IteratorTag());
+    test_replace_copy_if(par_unseq, IteratorTag());
 
-    test_replace_copy_if_async(execution::seq(execution::task), IteratorTag());
-    test_replace_copy_if_async(execution::par(execution::task), IteratorTag());
+    test_replace_copy_if_async(seq(task), IteratorTag());
+    test_replace_copy_if_async(par(task), IteratorTag());
 }
 
 void replace_copy_if_test()
@@ -207,18 +207,16 @@ void test_replace_copy_if_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_copy_if_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_replace_copy_if_exception(execution::seq, IteratorTag());
-    test_replace_copy_if_exception(execution::par, IteratorTag());
+    test_replace_copy_if_exception(seq, IteratorTag());
+    test_replace_copy_if_exception(par, IteratorTag());
 
-    test_replace_copy_if_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_replace_copy_if_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_replace_copy_if_exception_async(seq(task), IteratorTag());
+    test_replace_copy_if_exception_async(par(task), IteratorTag());
 }
 
 void replace_copy_if_exception_test()
@@ -308,18 +306,16 @@ void test_replace_copy_if_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_copy_if_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_replace_copy_if_bad_alloc(execution::seq, IteratorTag());
-    test_replace_copy_if_bad_alloc(execution::par, IteratorTag());
+    test_replace_copy_if_bad_alloc(seq, IteratorTag());
+    test_replace_copy_if_bad_alloc(par, IteratorTag());
 
-    test_replace_copy_if_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_replace_copy_if_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_replace_copy_if_bad_alloc_async(seq(task), IteratorTag());
+    test_replace_copy_if_bad_alloc_async(par(task), IteratorTag());
 }
 
 void replace_copy_if_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_range.cpp
@@ -93,13 +93,13 @@ void test_replace_copy_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_copy()
 {
-    using namespace hpx::parallel;
-    test_replace_copy(execution::seq, IteratorTag());
-    test_replace_copy(execution::par, IteratorTag());
-    test_replace_copy(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_replace_copy(seq, IteratorTag());
+    test_replace_copy(par, IteratorTag());
+    test_replace_copy(par_unseq, IteratorTag());
 
-    test_replace_copy_async(execution::seq(execution::task), IteratorTag());
-    test_replace_copy_async(execution::par(execution::task), IteratorTag());
+    test_replace_copy_async(seq(task), IteratorTag());
+    test_replace_copy_async(par(task), IteratorTag());
 }
 
 void replace_copy_test()
@@ -191,18 +191,16 @@ void test_replace_copy_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_copy_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_replace_copy_exception(execution::seq, IteratorTag());
-    test_replace_copy_exception(execution::par, IteratorTag());
+    test_replace_copy_exception(seq, IteratorTag());
+    test_replace_copy_exception(par, IteratorTag());
 
-    test_replace_copy_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_replace_copy_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_replace_copy_exception_async(seq(task), IteratorTag());
+    test_replace_copy_exception_async(par(task), IteratorTag());
 }
 
 void replace_copy_exception_test()
@@ -292,18 +290,16 @@ void test_replace_copy_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_copy_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_replace_copy_bad_alloc(execution::seq, IteratorTag());
-    test_replace_copy_bad_alloc(execution::par, IteratorTag());
+    test_replace_copy_bad_alloc(seq, IteratorTag());
+    test_replace_copy_bad_alloc(par, IteratorTag());
 
-    test_replace_copy_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_replace_copy_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_replace_copy_bad_alloc_async(seq(task), IteratorTag());
+    test_replace_copy_bad_alloc_async(par(task), IteratorTag());
 }
 
 void replace_copy_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_if_range.cpp
@@ -103,13 +103,13 @@ void test_replace_if_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_if()
 {
-    using namespace hpx::parallel;
-    test_replace_if(execution::seq, IteratorTag());
-    test_replace_if(execution::par, IteratorTag());
-    test_replace_if(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_replace_if(seq, IteratorTag());
+    test_replace_if(par, IteratorTag());
+    test_replace_if(par_unseq, IteratorTag());
 
-    test_replace_if_async(execution::seq(execution::task), IteratorTag());
-    test_replace_if_async(execution::par(execution::task), IteratorTag());
+    test_replace_if_async(seq(task), IteratorTag());
+    test_replace_if_async(par(task), IteratorTag());
 }
 
 void replace_if_test()
@@ -199,18 +199,16 @@ void test_replace_if_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_if_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_replace_if_exception(execution::seq, IteratorTag());
-    test_replace_if_exception(execution::par, IteratorTag());
+    test_replace_if_exception(seq, IteratorTag());
+    test_replace_if_exception(par, IteratorTag());
 
-    test_replace_if_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_replace_if_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_replace_if_exception_async(seq(task), IteratorTag());
+    test_replace_if_exception_async(par(task), IteratorTag());
 }
 
 void replace_if_exception_test()
@@ -298,18 +296,16 @@ void test_replace_if_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_if_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_replace_if_bad_alloc(execution::seq, IteratorTag());
-    test_replace_if_bad_alloc(execution::par, IteratorTag());
+    test_replace_if_bad_alloc(seq, IteratorTag());
+    test_replace_if_bad_alloc(par, IteratorTag());
 
-    test_replace_if_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_replace_if_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_replace_if_bad_alloc_async(seq(task), IteratorTag());
+    test_replace_if_bad_alloc_async(par(task), IteratorTag());
 }
 
 void replace_if_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_range.cpp
@@ -88,13 +88,13 @@ void test_replace_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace()
 {
-    using namespace hpx::parallel;
-    test_replace(execution::seq, IteratorTag());
-    test_replace(execution::par, IteratorTag());
-    test_replace(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_replace(seq, IteratorTag());
+    test_replace(par, IteratorTag());
+    test_replace(par_unseq, IteratorTag());
 
-    test_replace_async(execution::seq(execution::task), IteratorTag());
-    test_replace_async(execution::par(execution::task), IteratorTag());
+    test_replace_async(seq(task), IteratorTag());
+    test_replace_async(par(task), IteratorTag());
 }
 
 void replace_test()
@@ -184,18 +184,16 @@ void test_replace_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_replace_exception(execution::seq, IteratorTag());
-    test_replace_exception(execution::par, IteratorTag());
+    test_replace_exception(seq, IteratorTag());
+    test_replace_exception(par, IteratorTag());
 
-    test_replace_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_replace_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_replace_exception_async(seq(task), IteratorTag());
+    test_replace_exception_async(par(task), IteratorTag());
 }
 
 void replace_exception_test()
@@ -283,18 +281,16 @@ void test_replace_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_replace_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_replace_bad_alloc(execution::seq, IteratorTag());
-    test_replace_bad_alloc(execution::par, IteratorTag());
+    test_replace_bad_alloc(seq, IteratorTag());
+    test_replace_bad_alloc(par, IteratorTag());
 
-    test_replace_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_replace_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_replace_bad_alloc_async(seq(task), IteratorTag());
+    test_replace_bad_alloc_async(par(task), IteratorTag());
 }
 
 void replace_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/reverse_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/reverse_copy_range.cpp
@@ -86,13 +86,13 @@ void test_reverse_copy_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reverse_copy()
 {
-    using namespace hpx::parallel;
-    test_reverse_copy(execution::seq, IteratorTag());
-    test_reverse_copy(execution::par, IteratorTag());
-    test_reverse_copy(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_reverse_copy(seq, IteratorTag());
+    test_reverse_copy(par, IteratorTag());
+    test_reverse_copy(par_unseq, IteratorTag());
 
-    test_reverse_copy_async(execution::seq(execution::task), IteratorTag());
-    test_reverse_copy_async(execution::par(execution::task), IteratorTag());
+    test_reverse_copy_async(seq(task), IteratorTag());
+    test_reverse_copy_async(par(task), IteratorTag());
 }
 
 void reverse_copy_test()
@@ -182,18 +182,16 @@ void test_reverse_copy_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reverse_copy_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_reverse_copy_exception(execution::seq, IteratorTag());
-    test_reverse_copy_exception(execution::par, IteratorTag());
+    test_reverse_copy_exception(seq, IteratorTag());
+    test_reverse_copy_exception(par, IteratorTag());
 
-    test_reverse_copy_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_reverse_copy_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_reverse_copy_exception_async(seq(task), IteratorTag());
+    test_reverse_copy_exception_async(par(task), IteratorTag());
 }
 
 void reverse_copy_exception_test()
@@ -281,18 +279,16 @@ void test_reverse_copy_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reverse_copy_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_reverse_copy_bad_alloc(execution::seq, IteratorTag());
-    test_reverse_copy_bad_alloc(execution::par, IteratorTag());
+    test_reverse_copy_bad_alloc(seq, IteratorTag());
+    test_reverse_copy_bad_alloc(par, IteratorTag());
 
-    test_reverse_copy_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_reverse_copy_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_reverse_copy_bad_alloc_async(seq(task), IteratorTag());
+    test_reverse_copy_bad_alloc_async(par(task), IteratorTag());
 }
 
 void reverse_copy_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/reverse_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/reverse_range.cpp
@@ -86,13 +86,13 @@ void test_reverse_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reverse()
 {
-    using namespace hpx::parallel;
-    test_reverse(execution::seq, IteratorTag());
-    test_reverse(execution::par, IteratorTag());
-    test_reverse(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_reverse(seq, IteratorTag());
+    test_reverse(par, IteratorTag());
+    test_reverse(par_unseq, IteratorTag());
 
-    test_reverse_async(execution::seq(execution::task), IteratorTag());
-    test_reverse_async(execution::par(execution::task), IteratorTag());
+    test_reverse_async(seq(task), IteratorTag());
+    test_reverse_async(par(task), IteratorTag());
 }
 
 void reverse_test()
@@ -178,18 +178,16 @@ void test_reverse_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reverse_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_reverse_exception(execution::seq, IteratorTag());
-    test_reverse_exception(execution::par, IteratorTag());
+    test_reverse_exception(seq, IteratorTag());
+    test_reverse_exception(par, IteratorTag());
 
-    test_reverse_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_reverse_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_reverse_exception_async(seq(task), IteratorTag());
+    test_reverse_exception_async(par(task), IteratorTag());
 }
 
 void reverse_exception_test()
@@ -273,18 +271,16 @@ void test_reverse_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_reverse_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_reverse_bad_alloc(execution::seq, IteratorTag());
-    test_reverse_bad_alloc(execution::par, IteratorTag());
+    test_reverse_bad_alloc(seq, IteratorTag());
+    test_reverse_bad_alloc(par, IteratorTag());
 
-    test_reverse_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_reverse_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_reverse_bad_alloc_async(seq(task), IteratorTag());
+    test_reverse_bad_alloc_async(par(task), IteratorTag());
 }
 
 void reverse_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/rotate_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/rotate_copy_range.cpp
@@ -104,13 +104,13 @@ void test_rotate_copy_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_rotate_copy()
 {
-    using namespace hpx::parallel;
-    test_rotate_copy(execution::seq, IteratorTag());
-    test_rotate_copy(execution::par, IteratorTag());
-    test_rotate_copy(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_rotate_copy(seq, IteratorTag());
+    test_rotate_copy(par, IteratorTag());
+    test_rotate_copy(par_unseq, IteratorTag());
 
-    test_rotate_copy_async(execution::seq(execution::task), IteratorTag());
-    test_rotate_copy_async(execution::par(execution::task), IteratorTag());
+    test_rotate_copy_async(seq(task), IteratorTag());
+    test_rotate_copy_async(par(task), IteratorTag());
 }
 
 void rotate_copy_test()
@@ -216,18 +216,16 @@ void test_rotate_copy_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_rotate_copy_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_rotate_copy_exception(execution::seq, IteratorTag());
-    test_rotate_copy_exception(execution::par, IteratorTag());
+    test_rotate_copy_exception(seq, IteratorTag());
+    test_rotate_copy_exception(par, IteratorTag());
 
-    test_rotate_copy_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_rotate_copy_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_rotate_copy_exception_async(seq(task), IteratorTag());
+    test_rotate_copy_exception_async(par(task), IteratorTag());
 }
 
 void rotate_copy_exception_test()
@@ -331,18 +329,16 @@ void test_rotate_copy_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_rotate_copy_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_rotate_copy_bad_alloc(execution::seq, IteratorTag());
-    test_rotate_copy_bad_alloc(execution::par, IteratorTag());
+    test_rotate_copy_bad_alloc(seq, IteratorTag());
+    test_rotate_copy_bad_alloc(par, IteratorTag());
 
-    test_rotate_copy_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_rotate_copy_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_rotate_copy_bad_alloc_async(seq(task), IteratorTag());
+    test_rotate_copy_bad_alloc_async(par(task), IteratorTag());
 }
 
 void rotate_copy_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/rotate_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/rotate_range.cpp
@@ -99,13 +99,13 @@ void test_rotate_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_rotate()
 {
-    using namespace hpx::parallel;
-    test_rotate(execution::seq, IteratorTag());
-    test_rotate(execution::par, IteratorTag());
-    test_rotate(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_rotate(seq, IteratorTag());
+    test_rotate(par, IteratorTag());
+    test_rotate(par_unseq, IteratorTag());
 
-    test_rotate_async(execution::seq(execution::task), IteratorTag());
-    test_rotate_async(execution::par(execution::task), IteratorTag());
+    test_rotate_async(seq(task), IteratorTag());
+    test_rotate_async(par(task), IteratorTag());
 }
 
 void rotate_test()
@@ -209,16 +209,16 @@ void test_rotate_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_rotate_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_rotate_exception(execution::seq, IteratorTag());
-    test_rotate_exception(execution::par, IteratorTag());
+    test_rotate_exception(seq, IteratorTag());
+    test_rotate_exception(par, IteratorTag());
 
-    test_rotate_exception_async(execution::seq(execution::task), IteratorTag());
-    test_rotate_exception_async(execution::par(execution::task), IteratorTag());
+    test_rotate_exception_async(seq(task), IteratorTag());
+    test_rotate_exception_async(par(task), IteratorTag());
 }
 
 void rotate_exception_test()
@@ -320,16 +320,16 @@ void test_rotate_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_rotate_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_rotate_bad_alloc(execution::seq, IteratorTag());
-    test_rotate_bad_alloc(execution::par, IteratorTag());
+    test_rotate_bad_alloc(seq, IteratorTag());
+    test_rotate_bad_alloc(par, IteratorTag());
 
-    test_rotate_bad_alloc_async(execution::seq(execution::task), IteratorTag());
-    test_rotate_bad_alloc_async(execution::par(execution::task), IteratorTag());
+    test_rotate_bad_alloc_async(seq(task), IteratorTag());
+    test_rotate_bad_alloc_async(par(task), IteratorTag());
 }
 
 void rotate_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/search_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/search_range.cpp
@@ -85,13 +85,13 @@ void test_search1_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search1()
 {
-    using namespace hpx::parallel;
-    test_search1(execution::seq, IteratorTag());
-    test_search1(execution::par, IteratorTag());
-    test_search1(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_search1(seq, IteratorTag());
+    test_search1(par, IteratorTag());
+    test_search1(par_unseq, IteratorTag());
 
-    test_search1_async(execution::seq(execution::task), IteratorTag());
-    test_search1_async(execution::par(execution::task), IteratorTag());
+    test_search1_async(seq(task), IteratorTag());
+    test_search1_async(par(task), IteratorTag());
 }
 
 void search_test1()
@@ -154,13 +154,13 @@ void test_search2_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search2()
 {
-    using namespace hpx::parallel;
-    test_search2(execution::seq, IteratorTag());
-    test_search2(execution::par, IteratorTag());
-    test_search2(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_search2(seq, IteratorTag());
+    test_search2(par, IteratorTag());
+    test_search2(par_unseq, IteratorTag());
 
-    test_search2_async(execution::seq(execution::task), IteratorTag());
-    test_search2_async(execution::par(execution::task), IteratorTag());
+    test_search2_async(seq(task), IteratorTag());
+    test_search2_async(par(task), IteratorTag());
 }
 
 void search_test2()
@@ -218,13 +218,13 @@ void test_search3_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search3()
 {
-    using namespace hpx::parallel;
-    test_search3(execution::seq, IteratorTag());
-    test_search3(execution::par, IteratorTag());
-    test_search3(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_search3(seq, IteratorTag());
+    test_search3(par, IteratorTag());
+    test_search3(par_unseq, IteratorTag());
 
-    test_search3_async(execution::seq(execution::task), IteratorTag());
-    test_search3_async(execution::par(execution::task), IteratorTag());
+    test_search3_async(seq(task), IteratorTag());
+    test_search3_async(par(task), IteratorTag());
 }
 
 void search_test3()
@@ -285,13 +285,13 @@ void test_search4_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search4()
 {
-    using namespace hpx::parallel;
-    test_search4(execution::seq, IteratorTag());
-    test_search4(execution::par, IteratorTag());
-    test_search4(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_search4(seq, IteratorTag());
+    test_search4(par, IteratorTag());
+    test_search4(par_unseq, IteratorTag());
 
-    test_search4_async(execution::seq(execution::task), IteratorTag());
-    test_search4_async(execution::par(execution::task), IteratorTag());
+    test_search4_async(seq(task), IteratorTag());
+    test_search4_async(par(task), IteratorTag());
 }
 
 void search_test4()
@@ -363,13 +363,13 @@ void test_search5_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search5()
 {
-    using namespace hpx::parallel;
-    test_search5(execution::seq, IteratorTag());
-    test_search5(execution::par, IteratorTag());
-    test_search5(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_search5(seq, IteratorTag());
+    test_search5(par, IteratorTag());
+    test_search5(par_unseq, IteratorTag());
 
-    test_search5_async(execution::seq(execution::task), IteratorTag());
-    test_search5_async(execution::par(execution::task), IteratorTag());
+    test_search5_async(seq(task), IteratorTag());
+    test_search5_async(par(task), IteratorTag());
 }
 
 void search_test5()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/searchn_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/searchn_range.cpp
@@ -85,13 +85,13 @@ void test_search_n1_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search_n1()
 {
-    using namespace hpx::parallel;
-    test_search_n1(execution::seq, IteratorTag());
-    test_search_n1(execution::par, IteratorTag());
-    test_search_n1(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_search_n1(seq, IteratorTag());
+    test_search_n1(par, IteratorTag());
+    test_search_n1(par_unseq, IteratorTag());
 
-    test_search_n1_async(execution::seq(execution::task), IteratorTag());
-    test_search_n1_async(execution::par(execution::task), IteratorTag());
+    test_search_n1_async(seq(task), IteratorTag());
+    test_search_n1_async(par(task), IteratorTag());
 }
 
 void search_test_n1()
@@ -155,13 +155,13 @@ void test_search_n2_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search_n2()
 {
-    using namespace hpx::parallel;
-    test_search_n2(execution::seq, IteratorTag());
-    test_search_n2(execution::par, IteratorTag());
-    test_search_n2(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_search_n2(seq, IteratorTag());
+    test_search_n2(par, IteratorTag());
+    test_search_n2(par_unseq, IteratorTag());
 
-    test_search_n2_async(execution::seq(execution::task), IteratorTag());
-    test_search_n2_async(execution::par(execution::task), IteratorTag());
+    test_search_n2_async(seq(task), IteratorTag());
+    test_search_n2_async(par(task), IteratorTag());
 }
 
 void search_test_n2()
@@ -219,13 +219,13 @@ void test_search_n3_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search_n3()
 {
-    using namespace hpx::parallel;
-    test_search_n3(execution::seq, IteratorTag());
-    test_search_n3(execution::par, IteratorTag());
-    test_search_n3(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_search_n3(seq, IteratorTag());
+    test_search_n3(par, IteratorTag());
+    test_search_n3(par_unseq, IteratorTag());
 
-    test_search_n3_async(execution::seq(execution::task), IteratorTag());
-    test_search_n3_async(execution::par(execution::task), IteratorTag());
+    test_search_n3_async(seq(task), IteratorTag());
+    test_search_n3_async(par(task), IteratorTag());
 }
 
 void search_test_n3()
@@ -286,13 +286,13 @@ void test_search_n4_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search_n4()
 {
-    using namespace hpx::parallel;
-    test_search_n4(execution::seq, IteratorTag());
-    test_search_n4(execution::par, IteratorTag());
-    test_search_n4(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_search_n4(seq, IteratorTag());
+    test_search_n4(par, IteratorTag());
+    test_search_n4(par_unseq, IteratorTag());
 
-    test_search_n4_async(execution::seq(execution::task), IteratorTag());
-    test_search_n4_async(execution::par(execution::task), IteratorTag());
+    test_search_n4_async(seq(task), IteratorTag());
+    test_search_n4_async(par(task), IteratorTag());
 }
 
 void search_test_n4()
@@ -367,13 +367,13 @@ void test_search_n5_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_search_n5()
 {
-    using namespace hpx::parallel;
-    test_search_n5(execution::seq, IteratorTag());
-    test_search_n5(execution::par, IteratorTag());
-    test_search_n5(execution::par_unseq, IteratorTag());
+    using namespace hpx::execution;
+    test_search_n5(seq, IteratorTag());
+    test_search_n5(par, IteratorTag());
+    test_search_n5(par_unseq, IteratorTag());
 
-    test_search_n5_async(execution::seq(execution::task), IteratorTag());
-    test_search_n5_async(execution::par(execution::task), IteratorTag());
+    test_search_n5_async(seq(task), IteratorTag());
+    test_search_n5_async(par(task), IteratorTag());
 }
 
 void search_test_n5()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/sort_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/sort_range.cpp
@@ -23,103 +23,94 @@
 ////////////////////////////////////////////////////////////////////////////////
 void test_sort1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // default comparison operator (std::less)
-    test_sort1(execution::seq, int());
-    test_sort1(execution::par, int());
-    test_sort1(execution::par_unseq, int());
+    test_sort1(seq, int());
+    test_sort1(par, int());
+    test_sort1(par_unseq, int());
 
     // default comparison operator (std::less)
-    test_sort1(execution::seq, double());
-    test_sort1(execution::par, double());
-    test_sort1(execution::par_unseq, double());
+    test_sort1(seq, double());
+    test_sort1(par, double());
+    test_sort1(par_unseq, double());
 
     // default comparison operator (std::less)
-    test_sort1(execution::seq, std::string());
-    test_sort1(execution::par, std::string());
-    test_sort1(execution::par_unseq, std::string());
+    test_sort1(seq, std::string());
+    test_sort1(par, std::string());
+    test_sort1(par_unseq, std::string());
 
     // user supplied comparison operator (std::less)
-    test_sort1_comp(execution::seq, int(), std::less<std::size_t>());
-    test_sort1_comp(execution::par, int(), std::less<std::size_t>());
-    test_sort1_comp(execution::par_unseq, int(), std::less<std::size_t>());
+    test_sort1_comp(seq, int(), std::less<std::size_t>());
+    test_sort1_comp(par, int(), std::less<std::size_t>());
+    test_sort1_comp(par_unseq, int(), std::less<std::size_t>());
 
     // user supplied comparison operator (std::greater)
-    test_sort1_comp(execution::seq, double(), std::greater<double>());
-    test_sort1_comp(execution::par, double(), std::greater<double>());
-    test_sort1_comp(execution::par_unseq, double(), std::greater<double>());
+    test_sort1_comp(seq, double(), std::greater<double>());
+    test_sort1_comp(par, double(), std::greater<double>());
+    test_sort1_comp(par_unseq, double(), std::greater<double>());
 
     // default comparison operator (std::less)
-    test_sort1_comp(execution::seq, std::string(), std::greater<std::string>());
-    test_sort1_comp(execution::par, std::string(), std::greater<std::string>());
-    test_sort1_comp(
-        execution::par_unseq, std::string(), std::greater<std::string>());
+    test_sort1_comp(seq, std::string(), std::greater<std::string>());
+    test_sort1_comp(par, std::string(), std::greater<std::string>());
+    test_sort1_comp(par_unseq, std::string(), std::greater<std::string>());
 
     // Async execution, default comparison operator
-    test_sort1_async(execution::seq(execution::task), int());
-    test_sort1_async(execution::par(execution::task), char());
-    test_sort1_async(execution::seq(execution::task), double());
-    test_sort1_async(execution::par(execution::task), float());
-    test_sort1_async_string(execution::seq(execution::task), std::string());
-    test_sort1_async_string(execution::par(execution::task), std::string());
+    test_sort1_async(seq(task), int());
+    test_sort1_async(par(task), char());
+    test_sort1_async(seq(task), double());
+    test_sort1_async(par(task), float());
+    test_sort1_async_string(seq(task), std::string());
+    test_sort1_async_string(par(task), std::string());
 
     // Async execution, user comparison operator
-    test_sort1_async(
-        execution::seq(execution::task), int(), std::less<unsigned int>());
-    test_sort1_async(
-        execution::par(execution::task), char(), std::less<char>());
+    test_sort1_async(seq(task), int(), std::less<unsigned int>());
+    test_sort1_async(par(task), char(), std::less<char>());
     //
-    test_sort1_async(
-        execution::seq(execution::task), double(), std::greater<double>());
-    test_sort1_async(
-        execution::par(execution::task), float(), std::greater<float>());
+    test_sort1_async(seq(task), double(), std::greater<double>());
+    test_sort1_async(par(task), float(), std::greater<float>());
     //
-    test_sort1_async_string(execution::seq(execution::task), std::string(),
-        std::greater<std::string>());
-    test_sort1_async_string(execution::par(execution::task), std::string(),
-        std::greater<std::string>());
+    test_sort1_async_string(
+        seq(task), std::string(), std::greater<std::string>());
+    test_sort1_async_string(
+        par(task), std::string(), std::greater<std::string>());
 }
 
 void test_sort2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
     // default comparison operator (std::less)
-    test_sort2(execution::seq, int());
-    test_sort2(execution::par, int());
-    test_sort2(execution::par_unseq, int());
+    test_sort2(seq, int());
+    test_sort2(par, int());
+    test_sort2(par_unseq, int());
 
     // default comparison operator (std::less)
-    test_sort2(execution::seq, double());
-    test_sort2(execution::par, double());
-    test_sort2(execution::par_unseq, double());
+    test_sort2(seq, double());
+    test_sort2(par, double());
+    test_sort2(par_unseq, double());
 
     // user supplied comparison operator (std::less)
-    test_sort2_comp(execution::seq, int(), std::less<std::size_t>());
-    test_sort2_comp(execution::par, int(), std::less<std::size_t>());
-    test_sort2_comp(execution::par_unseq, int(), std::less<std::size_t>());
+    test_sort2_comp(seq, int(), std::less<std::size_t>());
+    test_sort2_comp(par, int(), std::less<std::size_t>());
+    test_sort2_comp(par_unseq, int(), std::less<std::size_t>());
 
     // user supplied comparison operator (std::greater)
-    test_sort2_comp(execution::seq, double(), std::greater<double>());
-    test_sort2_comp(execution::par, double(), std::greater<double>());
-    test_sort2_comp(execution::par_unseq, double(), std::greater<double>());
+    test_sort2_comp(seq, double(), std::greater<double>());
+    test_sort2_comp(par, double(), std::greater<double>());
+    test_sort2_comp(par_unseq, double(), std::greater<double>());
 
     // Async execution, default comparison operator
-    test_sort2_async(execution::seq(execution::task), int());
-    test_sort2_async(execution::par(execution::task), char());
-    test_sort2_async(execution::seq(execution::task), double());
-    test_sort2_async(execution::par(execution::task), float());
+    test_sort2_async(seq(task), int());
+    test_sort2_async(par(task), char());
+    test_sort2_async(seq(task), double());
+    test_sort2_async(par(task), float());
 
     // Async execution, user comparison operator
-    test_sort2_async(
-        execution::seq(execution::task), int(), std::less<unsigned int>());
-    test_sort2_async(
-        execution::par(execution::task), char(), std::less<char>());
+    test_sort2_async(seq(task), int(), std::less<unsigned int>());
+    test_sort2_async(par(task), char(), std::less<char>());
     //
-    test_sort2_async(
-        execution::seq(execution::task), double(), std::greater<double>());
-    test_sort2_async(
-        execution::par(execution::task), float(), std::greater<float>());
+    test_sort2_async(seq(task), double(), std::greater<double>());
+    test_sort2_async(par(task), float(), std::greater<float>());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/stable_sort_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/stable_sort_range.cpp
@@ -23,111 +23,95 @@
 ////////////////////////////////////////////////////////////////////////////////
 void test_stable_sort1()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // default comparison operator (std::less)
-    test_stable_sort1(execution::seq, int());
-    test_stable_sort1(execution::par, int());
-    test_stable_sort1(execution::par_unseq, int());
+    test_stable_sort1(seq, int());
+    test_stable_sort1(par, int());
+    test_stable_sort1(par_unseq, int());
 
     // default comparison operator (std::less)
-    test_stable_sort1(execution::seq, double());
-    test_stable_sort1(execution::par, double());
-    test_stable_sort1(execution::par_unseq, double());
+    test_stable_sort1(seq, double());
+    test_stable_sort1(par, double());
+    test_stable_sort1(par_unseq, double());
 
     // default comparison operator (std::less)
-    test_stable_sort1(execution::seq, std::string());
-    test_stable_sort1(execution::par, std::string());
-    test_stable_sort1(execution::par_unseq, std::string());
+    test_stable_sort1(seq, std::string());
+    test_stable_sort1(par, std::string());
+    test_stable_sort1(par_unseq, std::string());
 
     // user supplied comparison operator (std::less)
-    test_stable_sort1_comp(execution::seq, int(), std::less<std::size_t>());
-    test_stable_sort1_comp(execution::par, int(), std::less<std::size_t>());
-    test_stable_sort1_comp(
-        execution::par_unseq, int(), std::less<std::size_t>());
+    test_stable_sort1_comp(seq, int(), std::less<std::size_t>());
+    test_stable_sort1_comp(par, int(), std::less<std::size_t>());
+    test_stable_sort1_comp(par_unseq, int(), std::less<std::size_t>());
 
     // user supplied comparison operator (std::greater)
-    test_stable_sort1_comp(execution::seq, double(), std::greater<double>());
-    test_stable_sort1_comp(execution::par, double(), std::greater<double>());
-    test_stable_sort1_comp(
-        execution::par_unseq, double(), std::greater<double>());
+    test_stable_sort1_comp(seq, double(), std::greater<double>());
+    test_stable_sort1_comp(par, double(), std::greater<double>());
+    test_stable_sort1_comp(par_unseq, double(), std::greater<double>());
 
     // default comparison operator (std::less)
+    test_stable_sort1_comp(seq, std::string(), std::greater<std::string>());
+    test_stable_sort1_comp(par, std::string(), std::greater<std::string>());
     test_stable_sort1_comp(
-        execution::seq, std::string(), std::greater<std::string>());
-    test_stable_sort1_comp(
-        execution::par, std::string(), std::greater<std::string>());
-    test_stable_sort1_comp(
-        execution::par_unseq, std::string(), std::greater<std::string>());
+        par_unseq, std::string(), std::greater<std::string>());
 
     // Async execution, default comparison operator
-    test_stable_sort1_async(execution::seq(execution::task), int());
-    test_stable_sort1_async(execution::par(execution::task), char());
-    test_stable_sort1_async(execution::seq(execution::task), double());
-    test_stable_sort1_async(execution::par(execution::task), float());
-    test_stable_sort1_async_string(
-        execution::seq(execution::task), std::string());
-    test_stable_sort1_async_string(
-        execution::par(execution::task), std::string());
+    test_stable_sort1_async(seq(task), int());
+    test_stable_sort1_async(par(task), char());
+    test_stable_sort1_async(seq(task), double());
+    test_stable_sort1_async(par(task), float());
+    test_stable_sort1_async_string(seq(task), std::string());
+    test_stable_sort1_async_string(par(task), std::string());
 
     // Async execution, user comparison operator
-    test_stable_sort1_async(
-        execution::seq(execution::task), int(), std::less<unsigned int>());
-    test_stable_sort1_async(
-        execution::par(execution::task), char(), std::less<char>());
+    test_stable_sort1_async(seq(task), int(), std::less<unsigned int>());
+    test_stable_sort1_async(par(task), char(), std::less<char>());
     //
-    test_stable_sort1_async(
-        execution::seq(execution::task), double(), std::greater<double>());
-    test_stable_sort1_async(
-        execution::par(execution::task), float(), std::greater<float>());
+    test_stable_sort1_async(seq(task), double(), std::greater<double>());
+    test_stable_sort1_async(par(task), float(), std::greater<float>());
     //
-    test_stable_sort1_async_string(execution::seq(execution::task),
-        std::string(), std::greater<std::string>());
-    test_stable_sort1_async_string(execution::par(execution::task),
-        std::string(), std::greater<std::string>());
+    test_stable_sort1_async_string(
+        seq(task), std::string(), std::greater<std::string>());
+    test_stable_sort1_async_string(
+        par(task), std::string(), std::greater<std::string>());
 }
 
 void test_stable_sort2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
     // default comparison operator (std::less)
-    test_stable_sort2(execution::seq, int());
-    test_stable_sort2(execution::par, int());
-    test_stable_sort2(execution::par_unseq, int());
+    test_stable_sort2(seq, int());
+    test_stable_sort2(par, int());
+    test_stable_sort2(par_unseq, int());
 
     // default comparison operator (std::less)
-    test_stable_sort2(execution::seq, double());
-    test_stable_sort2(execution::par, double());
-    test_stable_sort2(execution::par_unseq, double());
+    test_stable_sort2(seq, double());
+    test_stable_sort2(par, double());
+    test_stable_sort2(par_unseq, double());
 
     // user supplied comparison operator (std::less)
-    test_stable_sort2_comp(execution::seq, int(), std::less<std::size_t>());
-    test_stable_sort2_comp(execution::par, int(), std::less<std::size_t>());
-    test_stable_sort2_comp(
-        execution::par_unseq, int(), std::less<std::size_t>());
+    test_stable_sort2_comp(seq, int(), std::less<std::size_t>());
+    test_stable_sort2_comp(par, int(), std::less<std::size_t>());
+    test_stable_sort2_comp(par_unseq, int(), std::less<std::size_t>());
 
     // user supplied comparison operator (std::greater)
-    test_stable_sort2_comp(execution::seq, double(), std::greater<double>());
-    test_stable_sort2_comp(execution::par, double(), std::greater<double>());
-    test_stable_sort2_comp(
-        execution::par_unseq, double(), std::greater<double>());
+    test_stable_sort2_comp(seq, double(), std::greater<double>());
+    test_stable_sort2_comp(par, double(), std::greater<double>());
+    test_stable_sort2_comp(par_unseq, double(), std::greater<double>());
 
     // Async execution, default comparison operator
-    test_stable_sort2_async(execution::seq(execution::task), int());
-    test_stable_sort2_async(execution::par(execution::task), char());
-    test_stable_sort2_async(execution::seq(execution::task), double());
-    test_stable_sort2_async(execution::par(execution::task), float());
+    test_stable_sort2_async(seq(task), int());
+    test_stable_sort2_async(par(task), char());
+    test_stable_sort2_async(seq(task), double());
+    test_stable_sort2_async(par(task), float());
 
     // Async execution, user comparison operator
-    test_stable_sort2_async(
-        execution::seq(execution::task), int(), std::less<unsigned int>());
-    test_stable_sort2_async(
-        execution::par(execution::task), char(), std::less<char>());
+    test_stable_sort2_async(seq(task), int(), std::less<unsigned int>());
+    test_stable_sort2_async(par(task), char(), std::less<char>());
     //
-    test_stable_sort2_async(
-        execution::seq(execution::task), double(), std::greater<double>());
-    test_stable_sort2_async(
-        execution::par(execution::task), float(), std::greater<float>());
+    test_stable_sort2_async(seq(task), double(), std::greater<double>());
+    test_stable_sort2_async(par(task), float(), std::greater<float>());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/test_utils.hpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/test_utils.hpp
@@ -204,10 +204,9 @@ namespace test {
     };
 
     template <typename IteratorTag>
-    struct test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-        IteratorTag>
+    struct test_num_exceptions<hpx::execution::sequenced_policy, IteratorTag>
     {
-        static void call(hpx::parallel::execution::sequenced_policy const&,
+        static void call(hpx::execution::sequenced_policy const&,
             hpx::exception_list const& e)
         {
             HPX_TEST_EQ(e.size(), 1u);
@@ -224,10 +223,10 @@ namespace test {
     };
 
     template <>
-    struct test_num_exceptions<hpx::parallel::execution::sequenced_policy,
+    struct test_num_exceptions<hpx::execution::sequenced_policy,
         std::input_iterator_tag>
     {
-        static void call(hpx::parallel::execution::sequenced_policy const&,
+        static void call(hpx::execution::sequenced_policy const&,
             hpx::exception_list const& e)
         {
             HPX_TEST_EQ(e.size(), 1u);

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range.cpp
@@ -88,14 +88,14 @@ void test_transform_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_transform()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_transform(execution::seq, IteratorTag());
-    test_transform(execution::par, IteratorTag());
-    test_transform(execution::par_unseq, IteratorTag());
+    test_transform(seq, IteratorTag());
+    test_transform(par, IteratorTag());
+    test_transform(par_unseq, IteratorTag());
 
-    test_transform_async(execution::seq(execution::task), IteratorTag());
-    test_transform_async(execution::par(execution::task), IteratorTag());
+    test_transform_async(seq(task), IteratorTag());
+    test_transform_async(par(task), IteratorTag());
 }
 
 void transform_test()
@@ -184,18 +184,16 @@ void test_transform_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_exception(execution::seq, IteratorTag());
-    test_transform_exception(execution::par, IteratorTag());
+    test_transform_exception(seq, IteratorTag());
+    test_transform_exception(par, IteratorTag());
 
-    test_transform_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_exception_async(seq(task), IteratorTag());
+    test_transform_exception_async(par(task), IteratorTag());
 }
 
 void transform_exception_test()
@@ -282,18 +280,16 @@ void test_transform_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_bad_alloc(execution::seq, IteratorTag());
-    test_transform_bad_alloc(execution::par, IteratorTag());
+    test_transform_bad_alloc(seq, IteratorTag());
+    test_transform_bad_alloc(par, IteratorTag());
 
-    test_transform_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_bad_alloc_async(seq(task), IteratorTag());
+    test_transform_bad_alloc_async(par(task), IteratorTag());
 }
 
 void transform_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary.cpp
@@ -105,14 +105,14 @@ void test_transform_binary_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_binary()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_transform_binary(execution::seq, IteratorTag());
-    test_transform_binary(execution::par, IteratorTag());
-    test_transform_binary(execution::par_unseq, IteratorTag());
+    test_transform_binary(seq, IteratorTag());
+    test_transform_binary(par, IteratorTag());
+    test_transform_binary(par_unseq, IteratorTag());
 
-    test_transform_binary_async(execution::seq(execution::task), IteratorTag());
-    test_transform_binary_async(execution::par(execution::task), IteratorTag());
+    test_transform_binary_async(seq(task), IteratorTag());
+    test_transform_binary_async(par(task), IteratorTag());
 }
 
 void transform_binary_test()
@@ -207,18 +207,16 @@ void test_transform_binary_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_binary_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_binary_exception(execution::seq, IteratorTag());
-    test_transform_binary_exception(execution::par, IteratorTag());
+    test_transform_binary_exception(seq, IteratorTag());
+    test_transform_binary_exception(par, IteratorTag());
 
-    test_transform_binary_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_binary_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_binary_exception_async(seq(task), IteratorTag());
+    test_transform_binary_exception_async(par(task), IteratorTag());
 }
 
 void transform_binary_exception_test()
@@ -311,18 +309,16 @@ void test_transform_binary_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_binary_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_binary_bad_alloc(execution::seq, IteratorTag());
-    test_transform_binary_bad_alloc(execution::par, IteratorTag());
+    test_transform_binary_bad_alloc(seq, IteratorTag());
+    test_transform_binary_bad_alloc(par, IteratorTag());
 
-    test_transform_binary_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_binary_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_binary_bad_alloc_async(seq(task), IteratorTag());
+    test_transform_binary_bad_alloc_async(par(task), IteratorTag());
 }
 
 void transform_binary_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary2.cpp
@@ -103,14 +103,14 @@ void test_transform_binary_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_binary()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_transform_binary(execution::seq, IteratorTag());
-    test_transform_binary(execution::par, IteratorTag());
-    test_transform_binary(execution::par_unseq, IteratorTag());
+    test_transform_binary(seq, IteratorTag());
+    test_transform_binary(par, IteratorTag());
+    test_transform_binary(par_unseq, IteratorTag());
 
-    test_transform_binary_async(execution::seq(execution::task), IteratorTag());
-    test_transform_binary_async(execution::par(execution::task), IteratorTag());
+    test_transform_binary_async(seq(task), IteratorTag());
+    test_transform_binary_async(par(task), IteratorTag());
 }
 
 void transform_binary_test()
@@ -207,18 +207,16 @@ void test_transform_binary_exception_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_binary_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_binary_exception(execution::seq, IteratorTag());
-    test_transform_binary_exception(execution::par, IteratorTag());
+    test_transform_binary_exception(seq, IteratorTag());
+    test_transform_binary_exception(par, IteratorTag());
 
-    test_transform_binary_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_binary_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_binary_exception_async(seq(task), IteratorTag());
+    test_transform_binary_exception_async(par(task), IteratorTag());
 }
 
 void transform_binary_exception_test()
@@ -313,18 +311,16 @@ void test_transform_binary_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_binary_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_binary_bad_alloc(execution::seq, IteratorTag());
-    test_transform_binary_bad_alloc(execution::par, IteratorTag());
+    test_transform_binary_bad_alloc(seq, IteratorTag());
+    test_transform_binary_bad_alloc(par, IteratorTag());
 
-    test_transform_binary_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_binary_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_binary_bad_alloc_async(seq(task), IteratorTag());
+    test_transform_binary_bad_alloc_async(par(task), IteratorTag());
 }
 
 void transform_binary_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_binary_bad_alloc_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_binary_bad_alloc_range.cpp
@@ -127,20 +127,18 @@ void test_transform_reduce_binary_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_reduce_binary_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_reduce_binary_bad_alloc(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_reduce_binary_bad_alloc(execution::seq, IteratorTag());
-    test_transform_reduce_binary_bad_alloc(execution::par, IteratorTag());
+    test_transform_reduce_binary_bad_alloc(seq, IteratorTag());
+    test_transform_reduce_binary_bad_alloc(par, IteratorTag());
 
-    test_transform_reduce_binary_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_reduce_binary_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_reduce_binary_bad_alloc_async(seq(task), IteratorTag());
+    test_transform_reduce_binary_bad_alloc_async(par(task), IteratorTag());
 }
 
 void transform_reduce_binary_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_binary_exception_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_binary_exception_range.cpp
@@ -130,18 +130,17 @@ void test_transform_reduce_binary_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_reduce_binary_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_reduce_binary_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_reduce_binary_exception(execution::seq, IteratorTag());
-    test_transform_reduce_binary_exception(execution::par, IteratorTag());
+    test_transform_reduce_binary_exception(seq, IteratorTag());
+    test_transform_reduce_binary_exception(par, IteratorTag());
 
-    test_transform_reduce_binary_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_reduce_binary_exception_async(par(task), IteratorTag());
 }
 
 void transform_reduce_binary_exception_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_binary_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_binary_range.cpp
@@ -18,18 +18,16 @@
 template <typename IteratorTag>
 void test_transform_reduce_binary()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_reduce_binary(IteratorTag());
 
-    test_transform_reduce_binary(execution::seq, IteratorTag());
-    test_transform_reduce_binary(execution::par, IteratorTag());
-    test_transform_reduce_binary(execution::par_unseq, IteratorTag());
+    test_transform_reduce_binary(seq, IteratorTag());
+    test_transform_reduce_binary(par, IteratorTag());
+    test_transform_reduce_binary(par_unseq, IteratorTag());
 
-    test_transform_reduce_binary_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_reduce_binary_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_reduce_binary_async(seq(task), IteratorTag());
+    test_transform_reduce_binary_async(par(task), IteratorTag());
 }
 
 void transform_reduce_binary_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_range.cpp
@@ -125,16 +125,16 @@ void test_transform_reduce_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_reduce()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_reduce(IteratorTag());
 
-    test_transform_reduce(execution::seq, IteratorTag());
-    test_transform_reduce(execution::par, IteratorTag());
-    test_transform_reduce(execution::par_unseq, IteratorTag());
+    test_transform_reduce(seq, IteratorTag());
+    test_transform_reduce(par, IteratorTag());
+    test_transform_reduce(par_unseq, IteratorTag());
 
-    test_transform_reduce_async(execution::seq(execution::task), IteratorTag());
-    test_transform_reduce_async(execution::par(execution::task), IteratorTag());
+    test_transform_reduce_async(seq(task), IteratorTag());
+    test_transform_reduce_async(par(task), IteratorTag());
 }
 
 void transform_reduce_test()
@@ -259,20 +259,18 @@ void test_transform_reduce_exception_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_reduce_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_reduce_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_reduce_exception(execution::seq, IteratorTag());
-    test_transform_reduce_exception(execution::par, IteratorTag());
+    test_transform_reduce_exception(seq, IteratorTag());
+    test_transform_reduce_exception(par, IteratorTag());
 
-    test_transform_reduce_exception_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_reduce_exception_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_reduce_exception_async(seq(task), IteratorTag());
+    test_transform_reduce_exception_async(par(task), IteratorTag());
 }
 
 void transform_reduce_exception_test()
@@ -393,20 +391,18 @@ void test_transform_reduce_bad_alloc_async(ExPolicy&& p, IteratorTag)
 template <typename IteratorTag>
 void test_transform_reduce_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_reduce_bad_alloc(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_transform_reduce_bad_alloc(execution::seq, IteratorTag());
-    test_transform_reduce_bad_alloc(execution::par, IteratorTag());
+    test_transform_reduce_bad_alloc(seq, IteratorTag());
+    test_transform_reduce_bad_alloc(par, IteratorTag());
 
-    test_transform_reduce_bad_alloc_async(
-        execution::seq(execution::task), IteratorTag());
-    test_transform_reduce_bad_alloc_async(
-        execution::par(execution::task), IteratorTag());
+    test_transform_reduce_bad_alloc_async(seq(task), IteratorTag());
+    test_transform_reduce_bad_alloc_async(par(task), IteratorTag());
 }
 
 void transform_reduce_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_copy_range.cpp
@@ -121,14 +121,14 @@ void test_unique_copy_async(ExPolicy policy, DataType)
 template <typename DataType>
 void test_unique_copy()
 {
-    using namespace hpx::parallel;
+    test_unique_copy(hpx::execution::seq, DataType());
+    test_unique_copy(hpx::execution::par, DataType());
+    test_unique_copy(hpx::execution::par_unseq, DataType());
 
-    test_unique_copy(execution::seq, DataType());
-    test_unique_copy(execution::par, DataType());
-    test_unique_copy(execution::par_unseq, DataType());
-
-    test_unique_copy_async(execution::seq(execution::task), DataType());
-    test_unique_copy_async(execution::par(execution::task), DataType());
+    test_unique_copy_async(
+        hpx::execution::seq(hpx::execution::task), DataType());
+    test_unique_copy_async(
+        hpx::execution::par(hpx::execution::task), DataType());
 }
 
 void test_unique_copy()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_range.cpp
@@ -115,14 +115,14 @@ void test_unique_async(ExPolicy policy, DataType)
 template <typename DataType>
 void test_unique()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
-    test_unique(execution::seq, DataType());
-    test_unique(execution::par, DataType());
-    test_unique(execution::par_unseq, DataType());
+    test_unique(seq, DataType());
+    test_unique(par, DataType());
+    test_unique(par_unseq, DataType());
 
-    test_unique_async(execution::seq(execution::task), DataType());
-    test_unique_async(execution::par(execution::task), DataType());
+    test_unique_async(seq(task), DataType());
+    test_unique_async(par(task), DataType());
 }
 
 void test_unique()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/count_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/count_datapar.cpp
@@ -18,12 +18,12 @@
 template <typename IteratorTag>
 void test_count()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
     test_count(execution::dataseq, IteratorTag());
     test_count(execution::datapar, IteratorTag());
 
-    test_count_async(execution::dataseq(execution::task), IteratorTag());
-    test_count_async(execution::datapar(execution::task), IteratorTag());
+    test_count_async(execution::dataseq(task), IteratorTag());
+    test_count_async(execution::datapar(task), IteratorTag());
 }
 
 void count_test()
@@ -36,15 +36,13 @@ void count_test()
 template <typename IteratorTag>
 void test_count_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_count_exception(execution::dataseq, IteratorTag());
     test_count_exception(execution::datapar, IteratorTag());
 
-    test_count_exception_async(
-        execution::dataseq(execution::task), IteratorTag());
-    test_count_exception_async(
-        execution::datapar(execution::task), IteratorTag());
+    test_count_exception_async(execution::dataseq(task), IteratorTag());
+    test_count_exception_async(execution::datapar(task), IteratorTag());
 }
 
 void count_exception_test()
@@ -57,15 +55,13 @@ void count_exception_test()
 template <typename IteratorTag>
 void test_count_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_count_bad_alloc(execution::dataseq, IteratorTag());
     test_count_bad_alloc(execution::datapar, IteratorTag());
 
-    test_count_bad_alloc_async(
-        execution::dataseq(execution::task), IteratorTag());
-    test_count_bad_alloc_async(
-        execution::datapar(execution::task), IteratorTag());
+    test_count_bad_alloc_async(execution::dataseq(task), IteratorTag());
+    test_count_bad_alloc_async(execution::datapar(task), IteratorTag());
 }
 
 void count_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/countif_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/countif_datapar.cpp
@@ -18,13 +18,13 @@
 template <typename IteratorTag>
 void test_count_if()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_count_if(execution::dataseq, IteratorTag());
     test_count_if(execution::datapar, IteratorTag());
 
-    test_count_if_async(execution::dataseq(execution::task), IteratorTag());
-    test_count_if_async(execution::datapar(execution::task), IteratorTag());
+    test_count_if_async(execution::dataseq(task), IteratorTag());
+    test_count_if_async(execution::datapar(task), IteratorTag());
 }
 
 void count_if_test()
@@ -37,15 +37,13 @@ void count_if_test()
 template <typename IteratorTag>
 void test_count_if_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_count_if_exception(execution::dataseq, IteratorTag());
     test_count_if_exception(execution::datapar, IteratorTag());
 
-    test_count_if_exception_async(
-        execution::dataseq(execution::task), IteratorTag());
-    test_count_if_exception_async(
-        execution::datapar(execution::task), IteratorTag());
+    test_count_if_exception_async(execution::dataseq(task), IteratorTag());
+    test_count_if_exception_async(execution::datapar(task), IteratorTag());
 }
 
 void count_if_exception_test()
@@ -58,15 +56,13 @@ void count_if_exception_test()
 template <typename IteratorTag>
 void test_count_if_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_count_if_bad_alloc(execution::dataseq, IteratorTag());
     test_count_if_bad_alloc(execution::datapar, IteratorTag());
 
-    test_count_if_bad_alloc_async(
-        execution::dataseq(execution::task), IteratorTag());
-    test_count_if_bad_alloc_async(
-        execution::datapar(execution::task), IteratorTag());
+    test_count_if_bad_alloc_async(execution::dataseq(task), IteratorTag());
+    test_count_if_bad_alloc_async(execution::datapar(task), IteratorTag());
 }
 
 void count_if_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_datapar.cpp
@@ -18,13 +18,13 @@
 template <typename IteratorTag>
 void test_for_each()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_for_each(execution::dataseq, IteratorTag());
     test_for_each(execution::datapar, IteratorTag());
 
-    test_for_each_async(execution::dataseq(execution::task), IteratorTag());
-    test_for_each_async(execution::datapar(execution::task), IteratorTag());
+    test_for_each_async(execution::dataseq(task), IteratorTag());
+    test_for_each_async(execution::datapar(task), IteratorTag());
 }
 
 void for_each_test()
@@ -37,15 +37,13 @@ void for_each_test()
 template <typename IteratorTag>
 void test_for_each_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_for_each_exception(execution::dataseq, IteratorTag());
     test_for_each_exception(execution::datapar, IteratorTag());
 
-    test_for_each_exception_async(
-        execution::dataseq(execution::task), IteratorTag());
-    test_for_each_exception_async(
-        execution::datapar(execution::task), IteratorTag());
+    test_for_each_exception_async(execution::dataseq(task), IteratorTag());
+    test_for_each_exception_async(execution::datapar(task), IteratorTag());
 }
 
 void for_each_exception_test()
@@ -58,15 +56,13 @@ void for_each_exception_test()
 template <typename IteratorTag>
 void test_for_each_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_for_each_bad_alloc(execution::dataseq, IteratorTag());
     test_for_each_bad_alloc(execution::datapar, IteratorTag());
 
-    test_for_each_bad_alloc_async(
-        execution::dataseq(execution::task), IteratorTag());
-    test_for_each_bad_alloc_async(
-        execution::datapar(execution::task), IteratorTag());
+    test_for_each_bad_alloc_async(execution::dataseq(task), IteratorTag());
+    test_for_each_bad_alloc_async(execution::datapar(task), IteratorTag());
 }
 
 void for_each_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_datapar_zipiter.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_datapar_zipiter.cpp
@@ -89,10 +89,10 @@ void for_each_zipiter_test(ExPolicy&& policy, IteratorTag)
 template <typename IteratorTag>
 void for_each_zipiter_test()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     for_each_zipiter_test(execution::datapar, IteratorTag());
-    //     test_for_each_async(execution::datapar(execution::task), IteratorTag());
+    //     test_for_each_async(execution::datapar(task), IteratorTag());
 }
 
 void for_each_zipiter_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreachn_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreachn_datapar.cpp
@@ -19,13 +19,13 @@
 template <typename IteratorTag>
 void test_for_each_n()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_for_each_n(execution::dataseq, IteratorTag());
     test_for_each_n(execution::datapar, IteratorTag());
 
-    test_for_each_n_async(execution::dataseq(execution::task), IteratorTag());
-    test_for_each_n_async(execution::datapar(execution::task), IteratorTag());
+    test_for_each_n_async(execution::dataseq(task), IteratorTag());
+    test_for_each_n_async(execution::datapar(task), IteratorTag());
 }
 
 void for_each_n_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_binary2_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_binary2_datapar.cpp
@@ -18,15 +18,13 @@
 template <typename IteratorTag>
 void test_transform_binary2()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_binary2(execution::dataseq, IteratorTag());
     test_transform_binary2(execution::datapar, IteratorTag());
 
-    test_transform_binary2_async(
-        execution::dataseq(execution::task), IteratorTag());
-    test_transform_binary2_async(
-        execution::datapar(execution::task), IteratorTag());
+    test_transform_binary2_async(execution::dataseq(task), IteratorTag());
+    test_transform_binary2_async(execution::datapar(task), IteratorTag());
 }
 
 void transform_binary2_test()
@@ -39,15 +37,15 @@ void transform_binary2_test()
 template <typename IteratorTag>
 void test_transform_binary2_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_binary2_exception(execution::dataseq, IteratorTag());
     test_transform_binary2_exception(execution::datapar, IteratorTag());
 
     test_transform_binary2_exception_async(
-        execution::dataseq(execution::task), IteratorTag());
+        execution::dataseq(task), IteratorTag());
     test_transform_binary2_exception_async(
-        execution::datapar(execution::task), IteratorTag());
+        execution::datapar(task), IteratorTag());
 }
 
 void transform_binary2_exception_test()
@@ -60,15 +58,15 @@ void transform_binary2_exception_test()
 template <typename IteratorTag>
 void test_transform_binary2_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_binary2_bad_alloc(execution::dataseq, IteratorTag());
     test_transform_binary2_bad_alloc(execution::datapar, IteratorTag());
 
     test_transform_binary2_bad_alloc_async(
-        execution::dataseq(execution::task), IteratorTag());
+        execution::dataseq(task), IteratorTag());
     test_transform_binary2_bad_alloc_async(
-        execution::datapar(execution::task), IteratorTag());
+        execution::datapar(task), IteratorTag());
 }
 
 void transform_binary2_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_binary_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_binary_datapar.cpp
@@ -18,15 +18,13 @@
 template <typename IteratorTag>
 void test_transform_binary()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_binary(execution::dataseq, IteratorTag());
     test_transform_binary(execution::datapar, IteratorTag());
 
-    test_transform_binary_async(
-        execution::dataseq(execution::task), IteratorTag());
-    test_transform_binary_async(
-        execution::datapar(execution::task), IteratorTag());
+    test_transform_binary_async(execution::dataseq(task), IteratorTag());
+    test_transform_binary_async(execution::datapar(task), IteratorTag());
 }
 
 void transform_binary_test()
@@ -39,15 +37,15 @@ void transform_binary_test()
 template <typename IteratorTag>
 void test_transform_binary_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_binary_exception(execution::dataseq, IteratorTag());
     test_transform_binary_exception(execution::datapar, IteratorTag());
 
     test_transform_binary_exception_async(
-        execution::dataseq(execution::task), IteratorTag());
+        execution::dataseq(task), IteratorTag());
     test_transform_binary_exception_async(
-        execution::datapar(execution::task), IteratorTag());
+        execution::datapar(task), IteratorTag());
 }
 
 void transform_binary_exception_test()
@@ -60,15 +58,15 @@ void transform_binary_exception_test()
 template <typename IteratorTag>
 void test_transform_binary_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_binary_bad_alloc(execution::dataseq, IteratorTag());
     test_transform_binary_bad_alloc(execution::datapar, IteratorTag());
 
     test_transform_binary_bad_alloc_async(
-        execution::dataseq(execution::task), IteratorTag());
+        execution::dataseq(task), IteratorTag());
     test_transform_binary_bad_alloc_async(
-        execution::datapar(execution::task), IteratorTag());
+        execution::datapar(task), IteratorTag());
 }
 
 void transform_binary_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_datapar.cpp
@@ -18,13 +18,13 @@
 template <typename IteratorTag>
 void test_transform()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform(execution::dataseq, IteratorTag());
     test_transform(execution::datapar, IteratorTag());
 
-    test_transform_async(execution::dataseq(execution::task), IteratorTag());
-    test_transform_async(execution::datapar(execution::task), IteratorTag());
+    test_transform_async(execution::dataseq(task), IteratorTag());
+    test_transform_async(execution::datapar(task), IteratorTag());
 }
 
 void transform_test()
@@ -36,15 +36,13 @@ void transform_test()
 template <typename IteratorTag>
 void test_transform_exception()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_exception(execution::dataseq, IteratorTag());
     test_transform_exception(execution::datapar, IteratorTag());
 
-    test_transform_exception_async(
-        execution::dataseq(execution::task), IteratorTag());
-    test_transform_exception_async(
-        execution::datapar(execution::task), IteratorTag());
+    test_transform_exception_async(execution::dataseq(task), IteratorTag());
+    test_transform_exception_async(execution::datapar(task), IteratorTag());
 }
 
 void transform_exception_test()
@@ -57,15 +55,13 @@ void transform_exception_test()
 template <typename IteratorTag>
 void test_transform_bad_alloc()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_bad_alloc(execution::dataseq, IteratorTag());
     test_transform_bad_alloc(execution::datapar, IteratorTag());
 
-    test_transform_bad_alloc_async(
-        execution::dataseq(execution::task), IteratorTag());
-    test_transform_bad_alloc_async(
-        execution::datapar(execution::task), IteratorTag());
+    test_transform_bad_alloc_async(execution::dataseq(task), IteratorTag());
+    test_transform_bad_alloc_async(execution::datapar(task), IteratorTag());
 }
 
 void transform_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_reduce_binary_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_reduce_binary_datapar.cpp
@@ -18,15 +18,13 @@
 template <typename IteratorTag>
 void test_transform_reduce_binary()
 {
-    using namespace hpx::parallel;
+    using namespace hpx::execution;
 
     test_transform_reduce_binary(execution::dataseq, IteratorTag());
     test_transform_reduce_binary(execution::datapar, IteratorTag());
 
-    test_transform_reduce_binary_async(
-        execution::dataseq(execution::task), IteratorTag());
-    test_transform_reduce_binary_async(
-        execution::datapar(execution::task), IteratorTag());
+    test_transform_reduce_binary_async(execution::dataseq(task), IteratorTag());
+    test_transform_reduce_binary_async(execution::datapar(task), IteratorTag());
 }
 
 void transform_reduce_binary_test()

--- a/libs/parallelism/execution/include/hpx/execution/executors/auto_chunk_size.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/executors/auto_chunk_size.hpp
@@ -22,7 +22,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx { namespace execution {
     ///////////////////////////////////////////////////////////////////////////
     /// Loop iterations are divided into pieces and then assigned to threads.
     /// The number of loop iterations combined is determined based on
@@ -78,8 +78,9 @@ namespace hpx { namespace parallel { namespace execution {
                 std::uint64_t t = high_resolution_clock::now();
 
                 // use executor to launch given function for measurements
-                std::size_t test_chunk_size = sync_execute(
-                    std::forward<Executor>(exec), f, num_iters_for_timing_);
+                std::size_t test_chunk_size =
+                    hpx::parallel::execution::sync_execute(
+                        std::forward<Executor>(exec), f, num_iters_for_timing_);
 
                 if (test_chunk_size != 0)
                 {
@@ -119,12 +120,19 @@ namespace hpx { namespace parallel { namespace execution {
         std::uint64_t num_iters_for_timing_;
         /// \endcond
     };
+}}    // namespace hpx::execution
+
+namespace hpx { namespace parallel { namespace execution {
+    using auto_chunk_size HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::auto_chunk_size is deprecated. Use "
+        "hpx::execution::auto_chunk_size instead.") =
+        hpx::execution::auto_chunk_size;
 }}}    // namespace hpx::parallel::execution
 
 namespace hpx { namespace parallel { namespace execution {
     /// \cond NOINTERNAL
     template <>
-    struct is_executor_parameters<parallel::execution::auto_chunk_size>
+    struct is_executor_parameters<hpx::execution::auto_chunk_size>
       : std::true_type
     {
     };

--- a/libs/parallelism/execution/include/hpx/execution/executors/dynamic_chunk_size.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/executors/dynamic_chunk_size.hpp
@@ -15,7 +15,7 @@
 #include <cstddef>
 #include <type_traits>
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx { namespace execution {
     ///////////////////////////////////////////////////////////////////////////
     /// Loop iterations are divided into pieces of size \a chunk_size and then
     /// dynamically scheduled among the threads; when a thread finishes one
@@ -63,12 +63,19 @@ namespace hpx { namespace parallel { namespace execution {
         std::size_t chunk_size_;
         /// \endcond
     };
+}}    // namespace hpx::execution
+
+namespace hpx { namespace parallel { namespace execution {
+    using dynamic_chunk_size HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::dynamic_chunk_size is deprecated. Use "
+        "hpx::execution::dynamic_chunk_size instead.") =
+        hpx::execution::dynamic_chunk_size;
 }}}    // namespace hpx::parallel::execution
 
 namespace hpx { namespace parallel { namespace execution {
     /// \cond NOINTERNAL
     template <>
-    struct is_executor_parameters<parallel::execution::dynamic_chunk_size>
+    struct is_executor_parameters<hpx::execution::dynamic_chunk_size>
       : std::true_type
     {
     };

--- a/libs/parallelism/execution/include/hpx/execution/executors/guided_chunk_size.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/executors/guided_chunk_size.hpp
@@ -16,7 +16,7 @@
 #include <cstddef>
 #include <type_traits>
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx { namespace execution {
     ///////////////////////////////////////////////////////////////////////////
     /// Iterations are dynamically assigned to threads in blocks as threads
     /// request them until no blocks remain to be assigned. Similar to
@@ -82,12 +82,19 @@ namespace hpx { namespace parallel { namespace execution {
         std::size_t min_chunk_size_;
         /// \endcond
     };
+}}    // namespace hpx::execution
+
+namespace hpx { namespace parallel { namespace execution {
+    using guided_chunk_size HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::guided_chunk_size is deprecated. Use "
+        "hpx::execution::guided_chunk_size instead.") =
+        hpx::execution::guided_chunk_size;
 }}}    // namespace hpx::parallel::execution
 
 namespace hpx { namespace parallel { namespace execution {
     /// \cond NOINTERNAL
     template <>
-    struct is_executor_parameters<parallel::execution::guided_chunk_size>
+    struct is_executor_parameters<hpx::execution::guided_chunk_size>
       : std::true_type
     {
     };

--- a/libs/parallelism/execution/include/hpx/execution/executors/persistent_auto_chunk_size.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/executors/persistent_auto_chunk_size.hpp
@@ -18,7 +18,7 @@
 #include <cstdint>
 #include <type_traits>
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx { namespace execution {
     ///////////////////////////////////////////////////////////////////////////
     /// Loop iterations are divided into pieces and then assigned to threads.
     /// The number of loop iterations combined is determined based on
@@ -140,13 +140,20 @@ namespace hpx { namespace parallel { namespace execution {
         std::uint64_t num_iters_for_timing_;
         /// \endcond
     };
+}}    // namespace hpx::execution
+
+namespace hpx { namespace parallel { namespace execution {
+    using persistent_auto_chunk_size HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::persistent_auto_chunk_size is deprecated. "
+        "Use hpx::execution::persistent_auto_chunk_size instead.") =
+        hpx::execution::persistent_auto_chunk_size;
 }}}    // namespace hpx::parallel::execution
 
 namespace hpx { namespace parallel { namespace execution {
     /// \cond NOINTERNAL
     template <>
-    struct is_executor_parameters<
-        parallel::execution::persistent_auto_chunk_size> : std::true_type
+    struct is_executor_parameters<hpx::execution::persistent_auto_chunk_size>
+      : std::true_type
     {
     };
     /// \endcond

--- a/libs/parallelism/execution/include/hpx/execution/executors/static_chunk_size.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/executors/static_chunk_size.hpp
@@ -17,7 +17,7 @@
 #include <cstddef>
 #include <type_traits>
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx { namespace execution {
     ///////////////////////////////////////////////////////////////////////////
     /// Loop iterations are divided into pieces of size \a chunk_size and then
     /// assigned to threads. If \a chunk_size is not specified, the iterations
@@ -57,7 +57,7 @@ namespace hpx { namespace parallel { namespace execution {
         {
             // Make sure the internal round robin counter of the executor is
             // reset
-            execution::reset_thread_distribution(*this, exec);
+            parallel::execution::reset_thread_distribution(*this, exec);
 
             // use the given chunk size if given
             if (chunk_size_ != 0)
@@ -98,12 +98,19 @@ namespace hpx { namespace parallel { namespace execution {
         std::size_t chunk_size_;
         /// \endcond
     };
+}}    // namespace hpx::execution
+
+namespace hpx { namespace parallel { namespace execution {
+    using static_chunk_size HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::static_chunk_size is deprecated. Use "
+        "hpx::execution::static_chunk_size instead.") =
+        hpx::execution::static_chunk_size;
 }}}    // namespace hpx::parallel::execution
 
 namespace hpx { namespace parallel { namespace execution {
     /// \cond NOINTERNAL
     template <>
-    struct is_executor_parameters<parallel::execution::static_chunk_size>
+    struct is_executor_parameters<hpx::execution::static_chunk_size>
       : std::true_type
     {
     };

--- a/libs/parallelism/execution/include/hpx/execution/traits/executor_traits.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/traits/executor_traits.hpp
@@ -22,7 +22,7 @@ namespace hpx { namespace lcos {
     class future;
 }}    // namespace hpx::lcos
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx { namespace execution {
     ///////////////////////////////////////////////////////////////////////////
     struct static_chunk_size;
 
@@ -30,7 +30,9 @@ namespace hpx { namespace parallel { namespace execution {
     struct sequenced_execution_tag;
     struct parallel_execution_tag;
     struct unsequenced_execution_tag;
+}}    // namespace hpx::execution
 
+namespace hpx { namespace parallel { namespace execution {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
         HPX_HAS_MEMBER_XXX_TRAIT_DEF(post)
@@ -135,8 +137,9 @@ namespace hpx { namespace parallel { namespace execution {
         using execution_category = typename T::execution_category;
 
     public:
-        using type = hpx::util::detected_or_t<unsequenced_execution_tag,
-            execution_category, Executor>;
+        using type =
+            hpx::util::detected_or_t<hpx::execution::unsequenced_execution_tag,
+                execution_category, Executor>;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -176,9 +179,8 @@ namespace hpx { namespace parallel { namespace execution {
         using parameters_type = typename T::parameters_type;
 
     public:
-        using type =
-            hpx::util::detected_or_t<parallel::execution::static_chunk_size,
-                parameters_type, Executor>;
+        using type = hpx::util::detected_or_t<hpx::execution::static_chunk_size,
+            parameters_type, Executor>;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -390,7 +392,7 @@ namespace hpx { namespace traits {
     struct executor_execution_category<Executor,
         typename std::enable_if<is_threads_executor<Executor>::value>::type>
     {
-        using type = parallel::execution::parallel_execution_tag;
+        using type = hpx::execution::parallel_execution_tag;
     };
 }}    // namespace hpx::traits
 #endif

--- a/libs/parallelism/execution/tests/regressions/annotated_minmax_2593.cpp
+++ b/libs/parallelism/execution/tests/regressions/annotated_minmax_2593.cpp
@@ -14,8 +14,8 @@
 
 double compute_minmax(const std::vector<double> v)
 {
-    hpx::parallel::execution::static_chunk_size param;
-    hpx::parallel::execution::parallel_task_policy par_policy;
+    hpx::execution::static_chunk_size param;
+    hpx::execution::parallel_task_policy par_policy;
     auto policy = par_policy.with(param);
 
     auto minmaxX_ = hpx::parallel::minmax_element(policy, v.begin(), v.end());

--- a/libs/parallelism/execution/tests/regressions/bulk_then_execute_3182.cpp
+++ b/libs/parallelism/execution/tests/regressions/bulk_then_execute_3182.cpp
@@ -68,7 +68,7 @@ int hpx_main(int argc, char* argv[])
         void_count.store(0);
         int_count.store(0);
 
-        hpx::parallel::execution::parallel_executor exec;
+        hpx::execution::parallel_executor exec;
         test_bulk_then_execute(exec);
     }
 

--- a/libs/parallelism/execution/tests/regressions/chunk_size_4118.cpp
+++ b/libs/parallelism/execution/tests/regressions/chunk_size_4118.cpp
@@ -23,7 +23,7 @@ int main(int argc, char* argv[])
     return hpx::util::report_errors();
 }
 
-struct test_async_executor : hpx::parallel::execution::parallel_executor
+struct test_async_executor : hpx::execution::parallel_executor
 {
     template <typename F, typename T>
     hpx::future<typename hpx::util::invoke_result<F, T, std::size_t>::type>
@@ -32,7 +32,7 @@ struct test_async_executor : hpx::parallel::execution::parallel_executor
         // make sure the chunk_size is equal to what was specified below
         HPX_TEST_EQ(chunk_size, std::size_t(50000));
 
-        using base_type = hpx::parallel::execution::parallel_executor;
+        using base_type = hpx::execution::parallel_executor;
         return this->base_type::async_execute(
             std::forward<F>(f), std::forward<T>(t), chunk_size);
     }
@@ -47,17 +47,16 @@ namespace hpx { namespace parallel { namespace execution {
 
 int hpx_main(int argc, char** argv)
 {
-    using namespace hpx::parallel;
     using namespace hpx::util;
 
     // create a fixed chunk size to be used in the algorithm
-    execution::static_chunk_size fixed(50000);
+    hpx::execution::static_chunk_size fixed(50000);
 
     // helper-executor to verify the used chunk-size
     test_async_executor exec;
 
     // this does not seem to be obeyed!
-    auto ex = execution::par.on(exec).with(fixed);
+    auto ex = hpx::execution::par.on(exec).with(fixed);
 
     // create and fill random vector of desired size
     std::random_device rnd_device;
@@ -72,7 +71,7 @@ int hpx_main(int argc, char** argv)
 
     std::vector<int> result(sz + 1);
 
-    exclusive_scan(ex, data.begin(), data.end(), result.begin(), 0);
+    hpx::exclusive_scan(ex, data.begin(), data.end(), result.begin(), 0);
 
     return hpx::finalize();
 }

--- a/libs/parallelism/execution/tests/regressions/future_then_async_executor.cpp
+++ b/libs/parallelism/execution/tests/regressions/future_then_async_executor.cpp
@@ -15,7 +15,7 @@
 
 struct test_async_executor
 {
-    using execution_category = hpx::parallel::execution::parallel_execution_tag;
+    using execution_category = hpx::execution::parallel_execution_tag;
 
     template <typename F, typename... Ts>
     static hpx::future<typename hpx::util::invoke_result<F, Ts...>::type>

--- a/libs/parallelism/execution/tests/regressions/is_executor_1691.cpp
+++ b/libs/parallelism/execution/tests/regressions/is_executor_1691.cpp
@@ -14,7 +14,7 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-struct my_executor : hpx::parallel::execution::parallel_executor
+struct my_executor : hpx::execution::parallel_executor
 {
 };
 
@@ -38,14 +38,11 @@ namespace hpx { namespace parallel { namespace execution {
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
-    using hpx::parallel::execution::par;
-    using hpx::ranges::for_each;
-
     my_executor exec;
 
     std::vector<int> v(100);
 
-    for_each(par.on(exec), v, [](int x) {});
+    hpx::ranges::for_each(hpx::execution::par.on(exec), v, [](int x) {});
 
     return hpx::finalize();
 }

--- a/libs/parallelism/execution/tests/regressions/lambda_arguments_2403.cpp
+++ b/libs/parallelism/execution/tests/regressions/lambda_arguments_2403.cpp
@@ -20,7 +20,7 @@ int hpx_main()
     auto zip_it_begin = hpx::util::make_zip_iterator(large.begin());
     auto zip_it_end = hpx::util::make_zip_iterator(large.end());
 
-    hpx::for_each(hpx::parallel::execution::datapar, zip_it_begin, zip_it_end,
+    hpx::for_each(hpx::execution::datapar, zip_it_begin, zip_it_end,
         [](auto& t) -> void { hpx::util::get<0>(t) = 10.0; });
 
     HPX_TEST_EQ(std::count(large.begin(), large.end(), 10.0),

--- a/libs/parallelism/execution/tests/regressions/lambda_return_type_2402.cpp
+++ b/libs/parallelism/execution/tests/regressions/lambda_return_type_2402.cpp
@@ -20,8 +20,8 @@ int hpx_main()
     auto zip_it_begin = hpx::util::make_zip_iterator(large.begin());
     auto zip_it_end = hpx::util::make_zip_iterator(large.end());
 
-    hpx::for_each(hpx::parallel::execution::datapar, zip_it_begin, zip_it_end,
-        [](auto t) {
+    hpx::for_each(
+        hpx::execution::datapar, zip_it_begin, zip_it_end, [](auto t) {
             using comp_type =
                 typename hpx::util::tuple_element<0, decltype(t)>::type;
             using var_type = typename hpx::util::decay<comp_type>::type;

--- a/libs/parallelism/execution/tests/regressions/parallel_executor_1781.cpp
+++ b/libs/parallelism/execution/tests/regressions/parallel_executor_1781.cpp
@@ -18,11 +18,10 @@ int hpx_main(int argc, char* argv[])
     std::vector<int> v(100);
 
     {
-        hpx::parallel::execution::static_chunk_size block(1);
-        hpx::parallel::execution::parallel_executor exec;
+        hpx::execution::static_chunk_size block(1);
+        hpx::execution::parallel_executor exec;
         hpx::ranges::for_each(
-            hpx::parallel::execution::par.on(exec).with(block), v,
-            [](int i) {});
+            hpx::execution::par.on(exec).with(block), v, [](int i) {});
     }
 
     return hpx::finalize();

--- a/libs/parallelism/execution/tests/unit/bulk_async.cpp
+++ b/libs/parallelism/execution/tests/unit/bulk_async.cpp
@@ -67,13 +67,11 @@ void test_bulk_async(Executor& exec)
 ////////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
-    using namespace hpx::parallel;
-
-    execution::sequenced_executor seq_exec;
+    hpx::execution::sequenced_executor seq_exec;
     test_bulk_sync(seq_exec);
 
-    execution::parallel_executor par_exec;
-    execution::parallel_executor par_fork_exec(hpx::launch::fork);
+    hpx::execution::parallel_executor par_exec;
+    hpx::execution::parallel_executor par_fork_exec(hpx::launch::fork);
     test_bulk_async(par_exec);
     test_bulk_async(par_fork_exec);
 

--- a/libs/parallelism/execution/tests/unit/created_executor.cpp
+++ b/libs/parallelism/execution/tests/unit/created_executor.cpp
@@ -28,9 +28,9 @@ typedef std::vector<int>::iterator iter;
 ////////////////////////////////////////////////////////////////////////////////
 // A parallel executor that returns void for bulk_execute and hpx::future<void>
 // for bulk_async_execute
-struct void_parallel_executor : hpx::parallel::execution::parallel_executor
+struct void_parallel_executor : hpx::execution::parallel_executor
 {
-    using base_type = hpx::parallel::execution::parallel_executor;
+    using base_type = hpx::execution::parallel_executor;
 
     template <typename F, typename Shape, typename... Ts>
     std::vector<hpx::future<void>> bulk_async_execute(
@@ -136,7 +136,7 @@ std::vector<hpx::util::iterator_range<iter>> split(
 // parallel sum using hpx's parallel executor
 int parallel_sum(iter first, iter last, int num_parts)
 {
-    hpx::parallel::execution::parallel_executor exec;
+    hpx::execution::parallel_executor exec;
 
     std::vector<hpx::util::iterator_range<iter>> input =
         split(first, last, num_parts);
@@ -192,7 +192,7 @@ void sum_test()
     int num_parts = std::rand() % 5 + 3;
 
     // Return futures holding results of parallel_sum and void_parallel_sum
-    hpx::parallel::execution::parallel_executor exec;
+    hpx::execution::parallel_executor exec;
 
     hpx::future<int> f_par = hpx::parallel::execution::async_execute(
         exec, &parallel_sum, std::begin(vec), std::end(vec), num_parts);

--- a/libs/parallelism/execution/tests/unit/executor_parameters.cpp
+++ b/libs/parallelism/execution/tests/unit/executor_parameters.cpp
@@ -27,26 +27,28 @@
 template <typename... Parameters>
 void parameters_test_impl(Parameters&&... params)
 {
-    using namespace hpx::parallel;
-
     typedef std::random_access_iterator_tag iterator_tag;
-    test_for_each(execution::seq.with(params...), iterator_tag());
-    test_for_each(execution::par.with(params...), iterator_tag());
+    test_for_each(hpx::execution::seq.with(params...), iterator_tag());
+    test_for_each(hpx::execution::par.with(params...), iterator_tag());
     test_for_each_async(
-        execution::seq(execution::task).with(params...), iterator_tag());
+        hpx::execution::seq(hpx::execution::task).with(params...),
+        iterator_tag());
     test_for_each_async(
-        execution::par(execution::task).with(params...), iterator_tag());
-
-    execution::sequenced_executor seq_exec;
-    test_for_each(execution::seq.on(seq_exec).with(params...), iterator_tag());
-    test_for_each_async(
-        execution::seq(execution::task).on(seq_exec).with(params...),
+        hpx::execution::par(hpx::execution::task).with(params...),
         iterator_tag());
 
-    execution::parallel_executor par_exec;
-    test_for_each(execution::par.on(par_exec).with(params...), iterator_tag());
+    hpx::execution::sequenced_executor seq_exec;
+    test_for_each(
+        hpx::execution::seq.on(seq_exec).with(params...), iterator_tag());
     test_for_each_async(
-        execution::par(execution::task).on(par_exec).with(params...),
+        hpx::execution::seq(hpx::execution::task).on(seq_exec).with(params...),
+        iterator_tag());
+
+    hpx::execution::parallel_executor par_exec;
+    test_for_each(
+        hpx::execution::par.on(par_exec).with(params...), iterator_tag());
+    test_for_each_async(
+        hpx::execution::par(hpx::execution::task).on(par_exec).with(params...),
         iterator_tag());
 }
 
@@ -60,12 +62,12 @@ void parameters_test(Parameters&&... params)
 void test_dynamic_chunk_size()
 {
     {
-        hpx::parallel::execution::dynamic_chunk_size dcs;
+        hpx::execution::dynamic_chunk_size dcs;
         parameters_test(dcs);
     }
 
     {
-        hpx::parallel::execution::dynamic_chunk_size dcs(100);
+        hpx::execution::dynamic_chunk_size dcs(100);
         parameters_test(dcs);
     }
 }
@@ -73,12 +75,12 @@ void test_dynamic_chunk_size()
 void test_static_chunk_size()
 {
     {
-        hpx::parallel::execution::static_chunk_size scs;
+        hpx::execution::static_chunk_size scs;
         parameters_test(scs);
     }
 
     {
-        hpx::parallel::execution::static_chunk_size scs(100);
+        hpx::execution::static_chunk_size scs(100);
         parameters_test(scs);
     }
 }
@@ -86,12 +88,12 @@ void test_static_chunk_size()
 void test_guided_chunk_size()
 {
     {
-        hpx::parallel::execution::guided_chunk_size gcs;
+        hpx::execution::guided_chunk_size gcs;
         parameters_test(gcs);
     }
 
     {
-        hpx::parallel::execution::guided_chunk_size gcs(100);
+        hpx::execution::guided_chunk_size gcs(100);
         parameters_test(gcs);
     }
 }
@@ -99,13 +101,12 @@ void test_guided_chunk_size()
 void test_auto_chunk_size()
 {
     {
-        hpx::parallel::execution::auto_chunk_size acs;
+        hpx::execution::auto_chunk_size acs;
         parameters_test(acs);
     }
 
     {
-        hpx::parallel::execution::auto_chunk_size acs(
-            std::chrono::milliseconds(1));
+        hpx::execution::auto_chunk_size acs(std::chrono::milliseconds(1));
         parameters_test(acs);
     }
 }
@@ -113,18 +114,18 @@ void test_auto_chunk_size()
 void test_persistent_auto_chunk_size()
 {
     {
-        hpx::parallel::execution::persistent_auto_chunk_size pacs;
+        hpx::execution::persistent_auto_chunk_size pacs;
         parameters_test(pacs);
     }
 
     {
-        hpx::parallel::execution::persistent_auto_chunk_size pacs(
+        hpx::execution::persistent_auto_chunk_size pacs(
             std::chrono::milliseconds(0), std::chrono::milliseconds(1));
         parameters_test(pacs);
     }
 
     {
-        hpx::parallel::execution::persistent_auto_chunk_size pacs(
+        hpx::execution::persistent_auto_chunk_size pacs(
             std::chrono::milliseconds(0));
         parameters_test(pacs);
     }
@@ -166,7 +167,7 @@ namespace hpx { namespace parallel { namespace execution {
 void test_combined_hooks()
 {
     timer_hooks_parameters pacs("time_hooks");
-    hpx::parallel::execution::auto_chunk_size acs;
+    hpx::execution::auto_chunk_size acs;
 
     parameters_test(acs, pacs);
     parameters_test(pacs, acs);

--- a/libs/parallelism/execution/tests/unit/executor_parameters_dispatching.cpp
+++ b/libs/parallelism/execution/tests/unit/executor_parameters_dispatching.cpp
@@ -26,11 +26,10 @@ std::atomic<std::size_t> exec_count(0);
 ///////////////////////////////////////////////////////////////////////////////
 // get_chunks_size
 
-struct test_executor_get_chunk_size
-  : hpx::parallel::execution::parallel_executor
+struct test_executor_get_chunk_size : hpx::execution::parallel_executor
 {
     test_executor_get_chunk_size()
-      : hpx::parallel::execution::parallel_executor()
+      : hpx::execution::parallel_executor()
     {
     }
 
@@ -78,7 +77,7 @@ void test_get_chunk_size()
         exec_count = 0;
 
         hpx::parallel::execution::get_chunk_size(
-            test_chunk_size{}, hpx::parallel::execution::par.executor(),
+            test_chunk_size{}, hpx::execution::par.executor(),
             [](std::size_t) { return 0; }, 1, 1);
 
         HPX_TEST_EQ(params_count, std::size_t(1));
@@ -102,10 +101,10 @@ void test_get_chunk_size()
 // maximal_number_of_chunks
 
 struct test_executor_maximal_number_of_chunks
-  : hpx::parallel::execution::parallel_executor
+  : hpx::execution::parallel_executor
 {
     test_executor_maximal_number_of_chunks()
-      : hpx::parallel::execution::parallel_executor()
+      : hpx::execution::parallel_executor()
     {
     }
 
@@ -152,8 +151,7 @@ void test_maximal_number_of_chunks()
         exec_count = 0;
 
         hpx::parallel::execution::maximal_number_of_chunks(
-            test_number_of_chunks{}, hpx::parallel::execution::par.executor(),
-            1, 1);
+            test_number_of_chunks{}, hpx::execution::par.executor(), 1, 1);
 
         HPX_TEST_EQ(params_count, std::size_t(1));
         HPX_TEST_EQ(exec_count, std::size_t(0));
@@ -176,10 +174,10 @@ void test_maximal_number_of_chunks()
 // reset_thread_distribution
 
 struct test_executor_reset_thread_distribution
-  : hpx::parallel::execution::parallel_executor
+  : hpx::execution::parallel_executor
 {
     test_executor_reset_thread_distribution()
-      : hpx::parallel::execution::parallel_executor()
+      : hpx::execution::parallel_executor()
     {
     }
 
@@ -221,8 +219,7 @@ void test_reset_thread_distribution()
         exec_count = 0;
 
         hpx::parallel::execution::reset_thread_distribution(
-            test_thread_distribution{},
-            hpx::parallel::execution::par.executor());
+            test_thread_distribution{}, hpx::execution::par.executor());
 
         HPX_TEST_EQ(params_count, std::size_t(1));
         HPX_TEST_EQ(exec_count, std::size_t(0));
@@ -244,11 +241,10 @@ void test_reset_thread_distribution()
 ///////////////////////////////////////////////////////////////////////////////
 // processing_units_count
 
-struct test_executor_processing_units_count
-  : hpx::parallel::execution::parallel_executor
+struct test_executor_processing_units_count : hpx::execution::parallel_executor
 {
     test_executor_processing_units_count()
-      : hpx::parallel::execution::parallel_executor()
+      : hpx::execution::parallel_executor()
     {
     }
 
@@ -292,7 +288,7 @@ void test_processing_units_count()
         exec_count = 0;
 
         hpx::parallel::execution::processing_units_count(
-            test_processing_units{}, hpx::parallel::execution::par.executor());
+            test_processing_units{}, hpx::execution::par.executor());
 
         HPX_TEST_EQ(params_count, std::size_t(1));
         HPX_TEST_EQ(exec_count, std::size_t(0));
@@ -313,10 +309,10 @@ void test_processing_units_count()
 ///////////////////////////////////////////////////////////////////////////////
 // mark_begin_execution, mark_end_of_scheduling, mark_end_execution
 
-struct test_executor_begin_end : hpx::parallel::execution::parallel_executor
+struct test_executor_begin_end : hpx::execution::parallel_executor
 {
     test_executor_begin_end()
-      : hpx::parallel::execution::parallel_executor()
+      : hpx::execution::parallel_executor()
     {
     }
 
@@ -382,7 +378,7 @@ void test_mark_begin_execution()
         exec_count = 0;
 
         hpx::parallel::execution::mark_begin_execution(
-            test_begin_end{}, hpx::parallel::execution::par.executor());
+            test_begin_end{}, hpx::execution::par.executor());
 
         HPX_TEST_EQ(params_count, std::size_t(1));
         HPX_TEST_EQ(exec_count, std::size_t(0));
@@ -407,7 +403,7 @@ void test_mark_end_of_scheduling()
         exec_count = 0;
 
         hpx::parallel::execution::mark_end_of_scheduling(
-            test_begin_end{}, hpx::parallel::execution::par.executor());
+            test_begin_end{}, hpx::execution::par.executor());
 
         HPX_TEST_EQ(params_count, std::size_t(1));
         HPX_TEST_EQ(exec_count, std::size_t(0));
@@ -432,7 +428,7 @@ void test_mark_end_execution()
         exec_count = 0;
 
         hpx::parallel::execution::mark_end_execution(
-            test_begin_end{}, hpx::parallel::execution::par.executor());
+            test_begin_end{}, hpx::execution::par.executor());
 
         HPX_TEST_EQ(params_count, std::size_t(1));
         HPX_TEST_EQ(exec_count, std::size_t(0));

--- a/libs/parallelism/execution/tests/unit/executor_parameters_timer_hooks.cpp
+++ b/libs/parallelism/execution/tests/unit/executor_parameters_timer_hooks.cpp
@@ -24,36 +24,36 @@
 template <typename Parameters>
 void chunk_size_test_seq(Parameters&& params)
 {
-    using namespace hpx::parallel;
-
     typedef std::random_access_iterator_tag iterator_tag;
-    test_for_each(execution::seq.with(std::ref(params)), iterator_tag());
+    test_for_each(hpx::execution::seq.with(std::ref(params)), iterator_tag());
     test_for_each_async(
-        execution::seq(execution::task).with(std::ref(params)), iterator_tag());
+        hpx::execution::seq(hpx::execution::task).with(std::ref(params)),
+        iterator_tag());
 
-    execution::sequenced_executor seq_exec;
-    test_for_each(
-        execution::seq.on(seq_exec).with(std::ref(params)), iterator_tag());
-    test_for_each_async(
-        execution::seq(execution::task).on(seq_exec).with(std::ref(params)),
+    hpx::execution::sequenced_executor seq_exec;
+    test_for_each(hpx::execution::seq.on(seq_exec).with(std::ref(params)),
+        iterator_tag());
+    test_for_each_async(hpx::execution::seq(hpx::execution::task)
+                            .on(seq_exec)
+                            .with(std::ref(params)),
         iterator_tag());
 }
 
 template <typename Parameters>
 void chunk_size_test_par(Parameters&& params)
 {
-    using namespace hpx::parallel;
-
     typedef std::random_access_iterator_tag iterator_tag;
-    test_for_each(execution::par.with(std::ref(params)), iterator_tag());
+    test_for_each(hpx::execution::par.with(std::ref(params)), iterator_tag());
     test_for_each_async(
-        execution::par(execution::task).with(std::ref(params)), iterator_tag());
+        hpx::execution::par(hpx::execution::task).with(std::ref(params)),
+        iterator_tag());
 
-    execution::parallel_executor par_exec;
-    test_for_each(
-        execution::par.on(par_exec).with(std::ref(params)), iterator_tag());
-    test_for_each_async(
-        execution::par(execution::task).on(par_exec).with(std::ref(params)),
+    hpx::execution::parallel_executor par_exec;
+    test_for_each(hpx::execution::par.on(par_exec).with(std::ref(params)),
+        iterator_tag());
+    test_for_each_async(hpx::execution::par(hpx::execution::task)
+                            .on(par_exec)
+                            .with(std::ref(params)),
         iterator_tag());
 }
 

--- a/libs/parallelism/execution/tests/unit/future_then_executor.cpp
+++ b/libs/parallelism/execution/tests/unit/future_then_executor.cpp
@@ -177,12 +177,12 @@ using hpx::program_options::variables_map;
 int hpx_main(variables_map&)
 {
     {
-        hpx::parallel::execution::sequenced_executor exec;
+        hpx::execution::sequenced_executor exec;
         test_then(exec);
     }
 
     {
-        hpx::parallel::execution::parallel_executor exec;
+        hpx::execution::parallel_executor exec;
         test_then(exec);
     }
 

--- a/libs/parallelism/execution/tests/unit/minimal_async_executor.cpp
+++ b/libs/parallelism/execution/tests/unit/minimal_async_executor.cpp
@@ -122,7 +122,7 @@ void test_executor(std::array<std::size_t, 5> expected)
     typedef typename hpx::traits::executor_execution_category<Executor>::type
         execution_category;
 
-    HPX_TEST((std::is_same<hpx::parallel::execution::parallel_execution_tag,
+    HPX_TEST((std::is_same<hpx::execution::parallel_execution_tag,
         execution_category>::value));
 
     count_apply.store(0);
@@ -149,7 +149,7 @@ void test_executor(std::array<std::size_t, 5> expected)
 ///////////////////////////////////////////////////////////////////////////////
 struct test_async_executor1
 {
-    typedef hpx::parallel::execution::parallel_execution_tag execution_category;
+    typedef hpx::execution::parallel_execution_tag execution_category;
 
     template <typename F, typename... Ts>
     static hpx::future<typename hpx::util::invoke_result<F, Ts...>::type>
@@ -170,7 +170,7 @@ namespace hpx { namespace parallel { namespace execution {
 
 struct test_async_executor2 : test_async_executor1
 {
-    typedef hpx::parallel::execution::parallel_execution_tag execution_category;
+    typedef hpx::execution::parallel_execution_tag execution_category;
 
     template <typename F, typename... Ts>
     static typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
@@ -192,7 +192,7 @@ namespace hpx { namespace parallel { namespace execution {
 
 struct test_async_executor3 : test_async_executor1
 {
-    typedef hpx::parallel::execution::parallel_execution_tag execution_category;
+    typedef hpx::execution::parallel_execution_tag execution_category;
 
     template <typename F, typename Shape, typename... Ts>
     static void bulk_sync_execute(F f, Shape const& shape, Ts&&... ts)
@@ -216,7 +216,7 @@ namespace hpx { namespace parallel { namespace execution {
 
 struct test_async_executor4 : test_async_executor1
 {
-    typedef hpx::parallel::execution::parallel_execution_tag execution_category;
+    typedef hpx::execution::parallel_execution_tag execution_category;
 
     template <typename F, typename Shape, typename... Ts>
     static std::vector<hpx::future<void>> bulk_async_execute(
@@ -246,7 +246,7 @@ namespace hpx { namespace parallel { namespace execution {
 
 struct test_async_executor5 : test_async_executor1
 {
-    typedef hpx::parallel::execution::parallel_execution_tag execution_category;
+    typedef hpx::execution::parallel_execution_tag execution_category;
 
     template <typename F, typename... Ts>
     static void post(F&& f, Ts&&... ts)

--- a/libs/parallelism/execution/tests/unit/minimal_sync_executor.cpp
+++ b/libs/parallelism/execution/tests/unit/minimal_sync_executor.cpp
@@ -217,7 +217,7 @@ void test_executor(std::array<std::size_t, 2> expected)
     typedef typename hpx::traits::executor_execution_category<Executor>::type
         execution_category;
 
-    HPX_TEST((std::is_same<hpx::parallel::execution::sequenced_execution_tag,
+    HPX_TEST((std::is_same<hpx::execution::sequenced_execution_tag,
         execution_category>::value));
 
     count_sync.store(0);
@@ -240,8 +240,7 @@ void test_executor(std::array<std::size_t, 2> expected)
 ///////////////////////////////////////////////////////////////////////////////
 struct test_sync_executor1
 {
-    typedef hpx::parallel::execution::sequenced_execution_tag
-        execution_category;
+    typedef hpx::execution::sequenced_execution_tag execution_category;
 
     template <typename F, typename... Ts>
     static typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
@@ -261,8 +260,7 @@ namespace hpx { namespace parallel { namespace execution {
 
 struct test_sync_executor2 : test_sync_executor1
 {
-    typedef hpx::parallel::execution::sequenced_execution_tag
-        execution_category;
+    typedef hpx::execution::sequenced_execution_tag execution_category;
 
     template <typename F, typename Shape, typename... Ts>
     static typename hpx::parallel::execution::detail::bulk_execute_result<F,

--- a/libs/parallelism/execution/tests/unit/parallel_executor.cpp
+++ b/libs/parallelism/execution/tests/unit/parallel_executor.cpp
@@ -25,7 +25,7 @@ hpx::thread::id test(int passed_through)
 
 void test_sync()
 {
-    typedef hpx::parallel::execution::parallel_executor executor;
+    typedef hpx::execution::parallel_executor executor;
 
     executor exec;
     HPX_TEST(hpx::parallel::execution::sync_execute(exec, &test, 42) ==
@@ -34,7 +34,7 @@ void test_sync()
 
 void test_async()
 {
-    typedef hpx::parallel::execution::parallel_executor executor;
+    typedef hpx::execution::parallel_executor executor;
 
     executor exec;
     HPX_TEST(hpx::parallel::execution::async_execute(exec, &test, 42).get() !=
@@ -54,7 +54,7 @@ hpx::thread::id test_f(hpx::future<void> f, int passed_through)
 
 void test_then()
 {
-    typedef hpx::parallel::execution::parallel_executor executor;
+    typedef hpx::execution::parallel_executor executor;
 
     hpx::future<void> f = hpx::make_ready_future();
 
@@ -73,7 +73,7 @@ void bulk_test(int value, hpx::thread::id tid, int passed_through)    //-V813
 
 void test_bulk_sync()
 {
-    typedef hpx::parallel::execution::parallel_executor executor;
+    typedef hpx::execution::parallel_executor executor;
 
     hpx::thread::id tid = hpx::this_thread::get_id();
 
@@ -92,7 +92,7 @@ void test_bulk_sync()
 ///////////////////////////////////////////////////////////////////////////////
 void test_bulk_async()
 {
-    typedef hpx::parallel::execution::parallel_executor executor;
+    typedef hpx::execution::parallel_executor executor;
 
     hpx::thread::id tid = hpx::this_thread::get_id();
 
@@ -125,7 +125,7 @@ void bulk_test_f(int value, hpx::shared_future<void> f, hpx::thread::id tid,
 
 void test_bulk_then()
 {
-    typedef hpx::parallel::execution::parallel_executor executor;
+    typedef hpx::execution::parallel_executor executor;
 
     hpx::thread::id tid = hpx::this_thread::get_id();
 
@@ -150,7 +150,7 @@ void test_bulk_then()
 void static_check_executor()
 {
     using namespace hpx::traits;
-    using executor = hpx::parallel::execution::parallel_executor;
+    using executor = hpx::execution::parallel_executor;
 
     static_assert(has_sync_execute_member<executor>::value,
         "has_sync_execute_member<executor>::value");

--- a/libs/parallelism/execution/tests/unit/parallel_fork_executor.cpp
+++ b/libs/parallelism/execution/tests/unit/parallel_fork_executor.cpp
@@ -25,7 +25,7 @@ hpx::thread::id test(int passed_through)
 
 void test_sync()
 {
-    typedef hpx::parallel::execution::parallel_executor executor;
+    typedef hpx::execution::parallel_executor executor;
 
     executor exec(hpx::launch::fork);
     HPX_TEST(hpx::parallel::execution::sync_execute(exec, &test, 42) ==
@@ -34,7 +34,7 @@ void test_sync()
 
 void test_async()
 {
-    typedef hpx::parallel::execution::parallel_executor executor;
+    typedef hpx::execution::parallel_executor executor;
 
     executor exec(hpx::launch::fork);
     HPX_TEST(hpx::parallel::execution::async_execute(exec, &test, 42).get() !=
@@ -54,7 +54,7 @@ hpx::thread::id test_f(hpx::future<void> f, int passed_through)
 
 void test_then()
 {
-    typedef hpx::parallel::execution::parallel_executor executor;
+    typedef hpx::execution::parallel_executor executor;
 
     hpx::future<void> f = hpx::make_ready_future();
 
@@ -73,7 +73,7 @@ void bulk_test(int value, hpx::thread::id tid, int passed_through)    //-V813
 
 void test_bulk_sync()
 {
-    typedef hpx::parallel::execution::parallel_executor executor;
+    typedef hpx::execution::parallel_executor executor;
 
     hpx::thread::id tid = hpx::this_thread::get_id();
 
@@ -91,7 +91,7 @@ void test_bulk_sync()
 
 void test_bulk_async()
 {
-    typedef hpx::parallel::execution::parallel_executor executor;
+    typedef hpx::execution::parallel_executor executor;
 
     hpx::thread::id tid = hpx::this_thread::get_id();
 
@@ -124,7 +124,7 @@ void bulk_test_f(int value, hpx::shared_future<void> f, hpx::thread::id tid,
 
 void test_bulk_then()
 {
-    typedef hpx::parallel::execution::parallel_executor executor;
+    typedef hpx::execution::parallel_executor executor;
 
     hpx::thread::id tid = hpx::this_thread::get_id();
 
@@ -149,7 +149,7 @@ void test_bulk_then()
 void static_check_executor()
 {
     using namespace hpx::traits;
-    using executor = hpx::parallel::execution::parallel_executor;
+    using executor = hpx::execution::parallel_executor;
 
     static_assert(has_sync_execute_member<executor>::value,
         "has_sync_execute_member<executor>::value");

--- a/libs/parallelism/execution/tests/unit/parallel_policy_executor.cpp
+++ b/libs/parallelism/execution/tests/unit/parallel_policy_executor.cpp
@@ -26,7 +26,7 @@ hpx::thread::id test(int passed_through)
 template <typename Policy>
 void test_sync()
 {
-    typedef hpx::parallel::execution::parallel_policy_executor<Policy> executor;
+    typedef hpx::execution::parallel_policy_executor<Policy> executor;
 
     executor exec;
     HPX_TEST(hpx::parallel::execution::sync_execute(exec, &test, 42) ==
@@ -36,7 +36,7 @@ void test_sync()
 template <typename Policy>
 void test_async(bool sync)
 {
-    typedef hpx::parallel::execution::parallel_policy_executor<Policy> executor;
+    typedef hpx::execution::parallel_policy_executor<Policy> executor;
 
     executor exec;
     bool result =
@@ -60,7 +60,7 @@ hpx::thread::id test_f(hpx::future<void> f, int passed_through)
 template <typename Policy>
 void test_then(bool sync)
 {
-    typedef hpx::parallel::execution::parallel_policy_executor<Policy> executor;
+    typedef hpx::execution::parallel_policy_executor<Policy> executor;
 
     hpx::future<void> f = hpx::make_ready_future();
 
@@ -88,7 +88,7 @@ void bulk_test_a(int value, hpx::thread::id tid, int passed_through)    //-V813
 template <typename Policy>
 void test_bulk_sync(bool sync)
 {
-    typedef hpx::parallel::execution::parallel_policy_executor<Policy> executor;
+    typedef hpx::execution::parallel_policy_executor<Policy> executor;
 
     hpx::thread::id tid = hpx::this_thread::get_id();
 
@@ -110,7 +110,7 @@ void test_bulk_sync(bool sync)
 template <typename Policy>
 void test_bulk_async(bool sync)
 {
-    typedef hpx::parallel::execution::parallel_policy_executor<Policy> executor;
+    typedef hpx::execution::parallel_policy_executor<Policy> executor;
 
     hpx::thread::id tid = hpx::this_thread::get_id();
 
@@ -157,7 +157,7 @@ void bulk_test_f_a(int value, hpx::shared_future<void> f, hpx::thread::id tid,
 template <typename Policy>
 void test_bulk_then(bool sync)
 {
-    typedef hpx::parallel::execution::parallel_policy_executor<Policy> executor;
+    typedef hpx::execution::parallel_policy_executor<Policy> executor;
 
     hpx::thread::id tid = hpx::this_thread::get_id();
 
@@ -185,7 +185,7 @@ template <typename Policy>
 void static_check_executor()
 {
     using namespace hpx::traits;
-    using executor = hpx::parallel::execution::parallel_policy_executor<Policy>;
+    using executor = hpx::execution::parallel_policy_executor<Policy>;
 
     static_assert(has_sync_execute_member<executor>::value,
         "has_sync_execute_member<executor>::value");

--- a/libs/parallelism/execution/tests/unit/persistent_executor_parameters.cpp
+++ b/libs/parallelism/execution/tests/unit/persistent_executor_parameters.cpp
@@ -24,32 +24,31 @@
 ///////////////////////////////////////////////////////////////////////////////
 void test_persistent_executitor_parameters()
 {
-    using namespace hpx::parallel;
-
     typedef std::random_access_iterator_tag iterator_tag;
     {
-        execution::persistent_auto_chunk_size p;
-        auto policy = execution::par.with(p);
+        hpx::execution::persistent_auto_chunk_size p;
+        auto policy = hpx::execution::par.with(p);
         test_for_each(policy, iterator_tag());
     }
 
     {
-        execution::persistent_auto_chunk_size p;
-        auto policy = execution::par(execution::task).with(p);
+        hpx::execution::persistent_auto_chunk_size p;
+        auto policy = hpx::execution::par(hpx::execution::task).with(p);
         test_for_each_async(policy, iterator_tag());
     }
 
-    execution::parallel_executor par_exec;
+    hpx::execution::parallel_executor par_exec;
 
     {
-        execution::persistent_auto_chunk_size p;
-        auto policy = execution::par.on(par_exec).with(p);
+        hpx::execution::persistent_auto_chunk_size p;
+        auto policy = hpx::execution::par.on(par_exec).with(p);
         test_for_each(policy, iterator_tag());
     }
 
     {
-        execution::persistent_auto_chunk_size p;
-        auto policy = execution::par(execution::task).on(par_exec).with(p);
+        hpx::execution::persistent_auto_chunk_size p;
+        auto policy =
+            hpx::execution::par(hpx::execution::task).on(par_exec).with(p);
         test_for_each_async(policy, iterator_tag());
     }
 }
@@ -61,28 +60,30 @@ void test_persistent_executitor_parameters_ref()
     typedef std::random_access_iterator_tag iterator_tag;
 
     {
-        execution::persistent_auto_chunk_size p;
-        test_for_each(execution::par.with(std::ref(p)), iterator_tag());
+        hpx::execution::persistent_auto_chunk_size p;
+        test_for_each(hpx::execution::par.with(std::ref(p)), iterator_tag());
     }
 
     {
-        execution::persistent_auto_chunk_size p;
+        hpx::execution::persistent_auto_chunk_size p;
         test_for_each_async(
-            execution::par(execution::task).with(std::ref(p)), iterator_tag());
+            hpx::execution::par(hpx::execution::task).with(std::ref(p)),
+            iterator_tag());
     }
 
-    execution::parallel_executor par_exec;
+    hpx::execution::parallel_executor par_exec;
 
     {
-        execution::persistent_auto_chunk_size p;
+        hpx::execution::persistent_auto_chunk_size p;
         test_for_each(
-            execution::par.on(par_exec).with(std::ref(p)), iterator_tag());
+            hpx::execution::par.on(par_exec).with(std::ref(p)), iterator_tag());
     }
 
     {
-        execution::persistent_auto_chunk_size p;
-        test_for_each_async(
-            execution::par(execution::task).on(par_exec).with(std::ref(p)),
+        hpx::execution::persistent_auto_chunk_size p;
+        test_for_each_async(hpx::execution::par(hpx::execution::task)
+                                .on(par_exec)
+                                .with(std::ref(p)),
             iterator_tag());
     }
 }

--- a/libs/parallelism/execution/tests/unit/polymorphic_executor.cpp
+++ b/libs/parallelism/execution/tests/unit/polymorphic_executor.cpp
@@ -182,10 +182,10 @@ int hpx_main(int argc, char* argv[])
 {
     static_check_executor();
 
-    hpx::parallel::execution::parallel_executor par_exec;
+    hpx::execution::parallel_executor par_exec;
     test_executor(executor(par_exec));
 
-    hpx::parallel::execution::sequenced_executor seq_exec;
+    hpx::execution::sequenced_executor seq_exec;
     test_executor(executor(seq_exec));
 
     return hpx::finalize();

--- a/libs/parallelism/execution/tests/unit/test_utils.hpp
+++ b/libs/parallelism/execution/tests/unit/test_utils.hpp
@@ -152,10 +152,9 @@ namespace test {
     };
 
     template <typename IteratorTag>
-    struct test_num_exceptions<hpx::parallel::execution::sequenced_policy,
-        IteratorTag>
+    struct test_num_exceptions<hpx::execution::sequenced_policy, IteratorTag>
     {
-        static void call(hpx::parallel::execution::sequenced_policy const&,
+        static void call(hpx::execution::sequenced_policy const&,
             hpx::exception_list const& e)
         {
             HPX_TEST_EQ(e.size(), 1u);
@@ -172,10 +171,10 @@ namespace test {
     };
 
     template <>
-    struct test_num_exceptions<hpx::parallel::execution::sequenced_policy,
+    struct test_num_exceptions<hpx::execution::sequenced_policy,
         std::input_iterator_tag>
     {
-        static void call(hpx::parallel::execution::sequenced_policy const&,
+        static void call(hpx::execution::sequenced_policy const&,
             hpx::exception_list const& e)
         {
             HPX_TEST_EQ(e.size(), 1u);

--- a/libs/parallelism/executors/docs/index.rst
+++ b/libs/parallelism/executors/docs/index.rst
@@ -14,17 +14,17 @@ executors
 The executors module exposes executors and execution policies. Most importantly,
 it exposes the following classes and constants:
 
-* :cpp:class:`hpx::parallel::execution::sequenced_executor`
-* :cpp:class:`hpx::parallel::execution::parallel_executor`
-* :cpp:class:`hpx::parallel::execution::sequenced_policy`
-* :cpp:class:`hpx::parallel::execution::parallel_policy`
-* :cpp:class:`hpx::parallel::execution::parallel_unsequenced_policy`
-* :cpp:class:`hpx::parallel::execution::sequenced_task_policy`
-* :cpp:class:`hpx::parallel::execution::parallel_task_policy`
-* :c:var:`hpx::parallel::execution::seq`
-* :c:var:`hpx::parallel::execution::par`
-* :c:var:`hpx::parallel::execution::par_unseq`
-* :c:var:`hpx::parallel::execution::task`
+* :cpp:class:`hpx::execution::sequenced_executor`
+* :cpp:class:`hpx::execution::parallel_executor`
+* :cpp:class:`hpx::execution::sequenced_policy`
+* :cpp:class:`hpx::execution::parallel_policy`
+* :cpp:class:`hpx::execution::parallel_unsequenced_policy`
+* :cpp:class:`hpx::execution::sequenced_task_policy`
+* :cpp:class:`hpx::execution::parallel_task_policy`
+* :cpp:var:`hpx::execution::seq`
+* :cpp:var:`hpx::execution::par`
+* :cpp:var:`hpx::execution::par_unseq`
+* :cpp:var:`hpx::execution::task`
 
 See the :ref:`API reference <modules_executors_api>` of this module for more
 details.

--- a/libs/parallelism/executors/include/hpx/executors/apply.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/apply.hpp
@@ -31,7 +31,7 @@ namespace hpx { namespace detail {
             traits::detail::is_deferred_invocable<F, Ts...>::value, bool>::type
         call(F&& f, Ts&&... ts)
         {
-            parallel::execution::parallel_executor exec;
+            execution::parallel_executor exec;
             exec.post(std::forward<F>(f), std::forward<Ts>(ts)...);
             return false;
         }

--- a/libs/parallelism/executors/include/hpx/executors/async.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/async.hpp
@@ -71,7 +71,7 @@ namespace hpx { namespace detail {
                 Ts...>::type>>::type
         call(F&& f, Ts&&... ts)
         {
-            parallel::execution::parallel_executor exec;
+            execution::parallel_executor exec;
             return exec.async_execute(
                 std::forward<F>(f), std::forward<Ts>(ts)...);
         }

--- a/libs/parallelism/executors/include/hpx/executors/datapar/execution_policy.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/datapar/execution_policy.hpp
@@ -23,7 +23,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace parallel { namespace execution { inline namespace v1 {
+namespace hpx { namespace execution { inline namespace v1 {
     ///////////////////////////////////////////////////////////////////////////
     /// Extension: The class dataseq_task_policy is an execution
     /// policy type used as a unique type to disambiguate parallel algorithm
@@ -1179,7 +1179,7 @@ namespace hpx { namespace parallel { namespace execution { inline namespace v1 {
         Parameters params_;
         /// \endcond
     };
-}}}}    // namespace hpx::parallel::execution::v1
+}}}    // namespace hpx::execution::v1
 
 namespace hpx { namespace parallel { namespace execution {
     ///////////////////////////////////////////////////////////////////////////
@@ -1187,46 +1187,54 @@ namespace hpx { namespace parallel { namespace execution {
     namespace detail {
         /// \cond NOINTERNAL
         template <>
-        struct is_execution_policy<dataseq_policy> : std::true_type
-        {
-        };
-
-        template <typename Executor, typename Parameters>
-        struct is_execution_policy<dataseq_policy_shim<Executor, Parameters>>
+        struct is_execution_policy<hpx::execution::dataseq_policy>
           : std::true_type
-        {
-        };
-
-        template <>
-        struct is_execution_policy<dataseq_task_policy> : std::true_type
         {
         };
 
         template <typename Executor, typename Parameters>
         struct is_execution_policy<
-            dataseq_task_policy_shim<Executor, Parameters>> : std::true_type
-        {
-        };
-
-        template <>
-        struct is_execution_policy<datapar_policy> : std::true_type
-        {
-        };
-
-        template <typename Executor, typename Parameters>
-        struct is_execution_policy<datapar_policy_shim<Executor, Parameters>>
+            hpx::execution::dataseq_policy_shim<Executor, Parameters>>
           : std::true_type
         {
         };
 
         template <>
-        struct is_execution_policy<datapar_task_policy> : std::true_type
+        struct is_execution_policy<hpx::execution::dataseq_task_policy>
+          : std::true_type
         {
         };
 
         template <typename Executor, typename Parameters>
         struct is_execution_policy<
-            datapar_task_policy_shim<Executor, Parameters>> : std::true_type
+            hpx::execution::dataseq_task_policy_shim<Executor, Parameters>>
+          : std::true_type
+        {
+        };
+
+        template <>
+        struct is_execution_policy<hpx::execution::datapar_policy>
+          : std::true_type
+        {
+        };
+
+        template <typename Executor, typename Parameters>
+        struct is_execution_policy<
+            hpx::execution::datapar_policy_shim<Executor, Parameters>>
+          : std::true_type
+        {
+        };
+
+        template <>
+        struct is_execution_policy<hpx::execution::datapar_task_policy>
+          : std::true_type
+        {
+        };
+
+        template <typename Executor, typename Parameters>
+        struct is_execution_policy<
+            hpx::execution::datapar_task_policy_shim<Executor, Parameters>>
+          : std::true_type
         {
         };
         /// \endcond
@@ -1236,25 +1244,28 @@ namespace hpx { namespace parallel { namespace execution {
     namespace detail {
         /// \cond NOINTERNAL
         template <>
-        struct is_sequenced_execution_policy<dataseq_policy> : std::true_type
+        struct is_sequenced_execution_policy<hpx::execution::dataseq_policy>
+          : std::true_type
         {
         };
 
         template <>
-        struct is_sequenced_execution_policy<dataseq_task_policy>
+        struct is_sequenced_execution_policy<
+            hpx::execution::dataseq_task_policy> : std::true_type
+        {
+        };
+
+        template <typename Executor, typename Parameters>
+        struct is_sequenced_execution_policy<
+            hpx::execution::dataseq_policy_shim<Executor, Parameters>>
           : std::true_type
         {
         };
 
         template <typename Executor, typename Parameters>
         struct is_sequenced_execution_policy<
-            dataseq_policy_shim<Executor, Parameters>> : std::true_type
-        {
-        };
-
-        template <typename Executor, typename Parameters>
-        struct is_sequenced_execution_policy<
-            dataseq_task_policy_shim<Executor, Parameters>> : std::true_type
+            hpx::execution::dataseq_task_policy_shim<Executor, Parameters>>
+          : std::true_type
         {
         };
         /// \endcond
@@ -1264,13 +1275,15 @@ namespace hpx { namespace parallel { namespace execution {
     namespace detail {
         /// \cond NOINTERNAL
         template <>
-        struct is_async_execution_policy<dataseq_task_policy> : std::true_type
+        struct is_async_execution_policy<hpx::execution::dataseq_task_policy>
+          : std::true_type
         {
         };
 
         template <typename Executor, typename Parameters>
         struct is_async_execution_policy<
-            dataseq_task_policy_shim<Executor, Parameters>> : std::true_type
+            hpx::execution::dataseq_task_policy_shim<Executor, Parameters>>
+          : std::true_type
         {
         };
 
@@ -1319,25 +1332,28 @@ namespace hpx { namespace parallel { namespace execution {
     namespace detail {
         /// \cond NOINTERNAL
         template <>
-        struct is_vectorpack_execution_policy<dataseq_policy> : std::true_type
+        struct is_vectorpack_execution_policy<hpx::execution::dataseq_policy>
+          : std::true_type
         {
         };
 
         template <>
-        struct is_vectorpack_execution_policy<dataseq_task_policy>
+        struct is_vectorpack_execution_policy<
+            hpx::execution::dataseq_task_policy> : std::true_type
+        {
+        };
+
+        template <typename Executor, typename Parameters>
+        struct is_vectorpack_execution_policy<
+            hpx::execution::dataseq_policy_shim<Executor, Parameters>>
           : std::true_type
         {
         };
 
         template <typename Executor, typename Parameters>
         struct is_vectorpack_execution_policy<
-            dataseq_policy_shim<Executor, Parameters>> : std::true_type
-        {
-        };
-
-        template <typename Executor, typename Parameters>
-        struct is_vectorpack_execution_policy<
-            dataseq_task_policy_shim<Executor, Parameters>> : std::true_type
+            hpx::execution::dataseq_task_policy_shim<Executor, Parameters>>
+          : std::true_type
         {
         };
 

--- a/libs/parallelism/executors/include/hpx/executors/datapar/execution_policy_fwd.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/datapar/execution_policy_fwd.hpp
@@ -8,8 +8,9 @@
 
 #include <hpx/config.hpp>
 
+// TODO: Should this be experimental?
 #if defined(HPX_HAVE_DATAPAR)
-namespace hpx { namespace parallel { namespace execution { inline namespace v1 {
+namespace hpx { namespace execution { inline namespace v1 {
     ///////////////////////////////////////////////////////////////////////////
     struct dataseq_policy;
 
@@ -31,6 +32,6 @@ namespace hpx { namespace parallel { namespace execution { inline namespace v1 {
 
     template <typename Executor, typename Parameters>
     struct datapar_task_policy_shim;
-}}}}    // namespace hpx::parallel::execution::v1
+}}}    // namespace hpx::execution::v1
 
 #endif

--- a/libs/parallelism/executors/include/hpx/executors/exception_list.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/exception_list.hpp
@@ -137,43 +137,43 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
         ///////////////////////////////////////////////////////////////////////
         template <typename Result>
-        struct handle_exception_impl<execution::sequenced_task_policy, Result>
-          : handle_exception_task_impl<Result>
+        struct handle_exception_impl<hpx::execution::sequenced_task_policy,
+            Result> : handle_exception_task_impl<Result>
         {
         };
 
         template <typename Executor, typename Parameters, typename Result>
         struct handle_exception_impl<
-            execution::sequenced_task_policy_shim<Executor, Parameters>, Result>
-          : handle_exception_task_impl<Result>
+            hpx::execution::sequenced_task_policy_shim<Executor, Parameters>,
+            Result> : handle_exception_task_impl<Result>
         {
         };
 
         ///////////////////////////////////////////////////////////////////////
         template <typename Result>
-        struct handle_exception_impl<execution::parallel_task_policy, Result>
-          : handle_exception_task_impl<Result>
+        struct handle_exception_impl<hpx::execution::parallel_task_policy,
+            Result> : handle_exception_task_impl<Result>
         {
         };
 
         template <typename Executor, typename Parameters, typename Result>
         struct handle_exception_impl<
-            execution::parallel_task_policy_shim<Executor, Parameters>, Result>
-          : handle_exception_task_impl<Result>
+            hpx::execution::parallel_task_policy_shim<Executor, Parameters>,
+            Result> : handle_exception_task_impl<Result>
         {
         };
 
 #if defined(HPX_HAVE_DATAPAR)
         ///////////////////////////////////////////////////////////////////////
         template <typename Result>
-        struct handle_exception_impl<execution::dataseq_task_policy, Result>
-          : handle_exception_task_impl<Result>
+        struct handle_exception_impl<hpx::execution::dataseq_task_policy,
+            Result> : handle_exception_task_impl<Result>
         {
         };
 
         template <typename Result>
-        struct handle_exception_impl<execution::datapar_task_policy, Result>
-          : handle_exception_task_impl<Result>
+        struct handle_exception_impl<hpx::execution::datapar_task_policy,
+            Result> : handle_exception_task_impl<Result>
         {
         };
 #endif
@@ -187,8 +187,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
         ///////////////////////////////////////////////////////////////////////
         template <typename Result>
-        struct handle_exception_impl<execution::parallel_unsequenced_policy,
-            Result>
+        struct handle_exception_impl<
+            hpx::execution::parallel_unsequenced_policy, Result>
         {
             typedef Result type;
 

--- a/libs/parallelism/executors/include/hpx/executors/execution_policy.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/execution_policy.hpp
@@ -29,7 +29,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx { namespace execution {
     ///////////////////////////////////////////////////////////////////////////
     /// Default sequential execution policy object.
     static constexpr task_policy_tag task;
@@ -50,8 +50,8 @@ namespace hpx { namespace parallel { namespace execution {
 
         /// The type of the associated executor parameters object which is
         /// associated with this execution policy
-        typedef execution::extract_executor_parameters<executor_type>::type
-            executor_parameters_type;
+        typedef parallel::execution::extract_executor_parameters<
+            executor_type>::type executor_parameters_type;
 
         /// The category of the execution agents created by this execution
         /// policy.
@@ -99,8 +99,8 @@ namespace hpx { namespace parallel { namespace execution {
         /// \returns The new sequenced_task_policy
         ///
         template <typename Executor>
-        typename rebind_executor<sequenced_task_policy, Executor,
-            executor_parameters_type>::type
+        typename parallel::execution::rebind_executor<sequenced_task_policy,
+            Executor, executor_parameters_type>::type
         on(Executor&& exec) const
         {
             typedef typename std::decay<Executor>::type executor_type;
@@ -111,8 +111,9 @@ namespace hpx { namespace parallel { namespace execution {
                 "hpx::traits::is_threads_executor<Executor>::value || "
                 "hpx::traits::is_executor_any<Executor>::value");
 
-            typedef typename rebind_executor<sequenced_task_policy, Executor,
-                executor_parameters_type>::type rebound_type;
+            typedef typename parallel::execution::rebind_executor<
+                sequenced_task_policy, Executor, executor_parameters_type>::type
+                rebound_type;
             return rebound_type(std::forward<Executor>(exec), parameters());
         }
 
@@ -132,16 +133,18 @@ namespace hpx { namespace parallel { namespace execution {
         /// \returns The new sequenced_task_policy
         ///
         template <typename... Parameters,
-            typename ParametersType =
-                typename executor_parameters_join<Parameters...>::type>
-        typename rebind_executor<sequenced_task_policy, executor_type,
-            ParametersType>::type
+            typename ParametersType = typename parallel::execution::
+                executor_parameters_join<Parameters...>::type>
+        typename parallel::execution::rebind_executor<sequenced_task_policy,
+            executor_type, ParametersType>::type
         with(Parameters&&... params) const
         {
-            typedef typename rebind_executor<sequenced_task_policy,
-                executor_type, ParametersType>::type rebound_type;
+            typedef typename parallel::execution::rebind_executor<
+                sequenced_task_policy, executor_type, ParametersType>::type
+                rebound_type;
             return rebound_type(executor(),
-                join_executor_parameters(std::forward<Parameters>(params)...));
+                parallel::execution::join_executor_parameters(
+                    std::forward<Parameters>(params)...));
         }
 
     public:
@@ -243,7 +246,8 @@ namespace hpx { namespace parallel { namespace execution {
         /// \returns The new sequenced_task_policy
         ///
         template <typename Executor_>
-        typename rebind_executor<sequenced_task_policy_shim, Executor_,
+        typename parallel::execution::rebind_executor<
+            sequenced_task_policy_shim, Executor_,
             executor_parameters_type>::type
         on(Executor_&& exec) const
         {
@@ -255,8 +259,9 @@ namespace hpx { namespace parallel { namespace execution {
                 "hpx::traits::is_threads_executor<Executor>::value || "
                 "hpx::traits::is_executor_any<Executor>::value");
 
-            typedef typename rebind_executor<sequenced_task_policy_shim,
-                Executor_, executor_parameters_type>::type rebound_type;
+            typedef typename parallel::execution::rebind_executor<
+                sequenced_task_policy_shim, Executor_,
+                executor_parameters_type>::type rebound_type;
             return rebound_type(std::forward<Executor_>(exec), params_);
         }
 
@@ -276,16 +281,18 @@ namespace hpx { namespace parallel { namespace execution {
         /// \returns The new sequenced_task_policy_shim
         ///
         template <typename... Parameters_,
-            typename ParametersType =
-                typename executor_parameters_join<Parameters_...>::type>
-        typename rebind_executor<sequenced_task_policy_shim, executor_type,
-            ParametersType>::type
+            typename ParametersType = typename parallel::execution::
+                executor_parameters_join<Parameters_...>::type>
+        typename parallel::execution::rebind_executor<
+            sequenced_task_policy_shim, executor_type, ParametersType>::type
         with(Parameters_&&... params) const
         {
-            typedef typename rebind_executor<sequenced_task_policy_shim,
-                executor_type, ParametersType>::type rebound_type;
+            typedef typename parallel::execution::rebind_executor<
+                sequenced_task_policy_shim, executor_type, ParametersType>::type
+                rebound_type;
             return rebound_type(exec_,
-                join_executor_parameters(std::forward<Parameters_>(params)...));
+                parallel::execution::join_executor_parameters(
+                    std::forward<Parameters_>(params)...));
         }
 
         /// Return the associated executor object.
@@ -354,8 +361,8 @@ namespace hpx { namespace parallel { namespace execution {
 
         /// The type of the associated executor parameters object which is
         /// associated with this execution policy
-        typedef execution::extract_executor_parameters<executor_type>::type
-            executor_parameters_type;
+        typedef parallel::execution::extract_executor_parameters<
+            executor_type>::type executor_parameters_type;
 
         /// The category of the execution agents created by this execution
         /// policy.
@@ -407,8 +414,8 @@ namespace hpx { namespace parallel { namespace execution {
         /// \returns The new sequenced_policy
         ///
         template <typename Executor>
-        typename rebind_executor<sequenced_policy, Executor,
-            executor_parameters_type>::type
+        typename parallel::execution::rebind_executor<sequenced_policy,
+            Executor, executor_parameters_type>::type
         on(Executor&& exec) const
         {
             typedef typename std::decay<Executor>::type executor_type;
@@ -419,8 +426,9 @@ namespace hpx { namespace parallel { namespace execution {
                 "hpx::traits::is_threads_executor<Executor>::value || "
                 "hpx::traits::is_executor_any<Executor>::value");
 
-            typedef typename rebind_executor<sequenced_policy, Executor,
-                executor_parameters_type>::type rebound_type;
+            typedef
+                typename parallel::execution::rebind_executor<sequenced_policy,
+                    Executor, executor_parameters_type>::type rebound_type;
             return rebound_type(std::forward<Executor>(exec), parameters());
         }
 
@@ -440,16 +448,18 @@ namespace hpx { namespace parallel { namespace execution {
         /// \returns The new sequenced_policy
         ///
         template <typename... Parameters,
-            typename ParametersType =
-                typename executor_parameters_join<Parameters...>::type>
-        typename rebind_executor<sequenced_policy, executor_type,
-            ParametersType>::type
+            typename ParametersType = typename parallel::execution::
+                executor_parameters_join<Parameters...>::type>
+        typename parallel::execution::rebind_executor<sequenced_policy,
+            executor_type, ParametersType>::type
         with(Parameters&&... params) const
         {
-            typedef typename rebind_executor<sequenced_policy, executor_type,
-                ParametersType>::type rebound_type;
+            typedef
+                typename parallel::execution::rebind_executor<sequenced_policy,
+                    executor_type, ParametersType>::type rebound_type;
             return rebound_type(executor(),
-                join_executor_parameters(std::forward<Parameters>(params)...));
+                parallel::execution::join_executor_parameters(
+                    std::forward<Parameters>(params)...));
         }
 
     public:
@@ -549,8 +559,8 @@ namespace hpx { namespace parallel { namespace execution {
         /// \returns The new sequenced_policy
         ///
         template <typename Executor_>
-        typename rebind_executor<sequenced_policy_shim, Executor_,
-            executor_parameters_type>::type
+        typename parallel::execution::rebind_executor<sequenced_policy_shim,
+            Executor_, executor_parameters_type>::type
         on(Executor_&& exec) const
         {
             typedef typename std::decay<Executor>::type executor_type;
@@ -561,7 +571,8 @@ namespace hpx { namespace parallel { namespace execution {
                 "hpx::traits::is_threads_executor<Executor>::value || "
                 "hpx::traits::is_executor_any<Executor>::value");
 
-            typedef typename rebind_executor<sequenced_policy_shim, Executor_,
+            typedef typename parallel::execution::rebind_executor<
+                sequenced_policy_shim, Executor_,
                 executor_parameters_type>::type rebound_type;
             return rebound_type(std::forward<Executor_>(exec), params_);
         }
@@ -582,16 +593,18 @@ namespace hpx { namespace parallel { namespace execution {
         /// \returns The new sequenced_policy_shim
         ///
         template <typename... Parameters_,
-            typename ParametersType =
-                typename executor_parameters_join<Parameters_...>::type>
-        typename rebind_executor<sequenced_policy_shim, executor_type,
-            ParametersType>::type
+            typename ParametersType = typename parallel::execution::
+                executor_parameters_join<Parameters_...>::type>
+        typename parallel::execution::rebind_executor<sequenced_policy_shim,
+            executor_type, ParametersType>::type
         with(Parameters_&&... params) const
         {
-            typedef typename rebind_executor<sequenced_policy_shim,
-                executor_type, ParametersType>::type rebound_type;
+            typedef typename parallel::execution::rebind_executor<
+                sequenced_policy_shim, executor_type, ParametersType>::type
+                rebound_type;
             return rebound_type(exec_,
-                join_executor_parameters(std::forward<Parameters_>(params)...));
+                parallel::execution::join_executor_parameters(
+                    std::forward<Parameters_>(params)...));
         }
 
         /// Return the associated executor object.
@@ -663,8 +676,8 @@ namespace hpx { namespace parallel { namespace execution {
 
         /// The type of the associated executor parameters object which is
         /// associated with this execution policy
-        typedef execution::extract_executor_parameters<executor_type>::type
-            executor_parameters_type;
+        typedef parallel::execution::extract_executor_parameters<
+            executor_type>::type executor_parameters_type;
 
         /// The category of the execution agents created by this execution
         /// policy.
@@ -710,8 +723,8 @@ namespace hpx { namespace parallel { namespace execution {
         /// \returns The new parallel_task_policy
         ///
         template <typename Executor>
-        typename rebind_executor<parallel_task_policy, Executor,
-            executor_parameters_type>::type
+        typename parallel::execution::rebind_executor<parallel_task_policy,
+            Executor, executor_parameters_type>::type
         on(Executor&& exec) const
         {
             typedef typename std::decay<Executor>::type executor_type;
@@ -722,8 +735,9 @@ namespace hpx { namespace parallel { namespace execution {
                 "hpx::traits::is_threads_executor<Executor>::value || "
                 "hpx::traits::is_executor_any<Executor>::value");
 
-            typedef typename rebind_executor<parallel_task_policy, Executor,
-                executor_parameters_type>::type rebound_type;
+            typedef typename parallel::execution::rebind_executor<
+                parallel_task_policy, Executor, executor_parameters_type>::type
+                rebound_type;
             return rebound_type(std::forward<Executor>(exec), parameters());
         }
 
@@ -743,16 +757,18 @@ namespace hpx { namespace parallel { namespace execution {
         /// \returns The new parallel_policy_shim
         ///
         template <typename... Parameters,
-            typename ParametersType =
-                typename executor_parameters_join<Parameters...>::type>
-        typename rebind_executor<parallel_task_policy, executor_type,
-            ParametersType>::type
+            typename ParametersType = typename parallel::execution::
+                executor_parameters_join<Parameters...>::type>
+        typename parallel::execution::rebind_executor<parallel_task_policy,
+            executor_type, ParametersType>::type
         with(Parameters&&... params) const
         {
-            typedef typename rebind_executor<parallel_task_policy,
-                executor_type, ParametersType>::type rebound_type;
+            typedef typename parallel::execution::rebind_executor<
+                parallel_task_policy, executor_type, ParametersType>::type
+                rebound_type;
             return rebound_type(executor(),
-                join_executor_parameters(std::forward<Parameters>(params)...));
+                parallel::execution::join_executor_parameters(
+                    std::forward<Parameters>(params)...));
         }
 
     public:
@@ -849,8 +865,8 @@ namespace hpx { namespace parallel { namespace execution {
         /// \returns The new parallel_task_policy
         ///
         template <typename Executor_>
-        typename rebind_executor<parallel_task_policy_shim, Executor_,
-            executor_parameters_type>::type
+        typename parallel::execution::rebind_executor<parallel_task_policy_shim,
+            Executor_, executor_parameters_type>::type
         on(Executor_&& exec) const
         {
             typedef typename std::decay<Executor>::type executor_type;
@@ -861,8 +877,9 @@ namespace hpx { namespace parallel { namespace execution {
                 "hpx::traits::is_threads_executor<Executor>::value || "
                 "hpx::traits::is_executor_any<Executor>::value");
 
-            typedef typename rebind_executor<parallel_task_policy_shim,
-                Executor_, executor_parameters_type>::type rebound_type;
+            typedef typename parallel::execution::rebind_executor<
+                parallel_task_policy_shim, Executor_,
+                executor_parameters_type>::type rebound_type;
             return rebound_type(std::forward<Executor_>(exec), params_);
         }
 
@@ -882,16 +899,18 @@ namespace hpx { namespace parallel { namespace execution {
         /// \returns The new parallel_policy_shim
         ///
         template <typename... Parameters_,
-            typename ParametersType =
-                typename executor_parameters_join<Parameters_...>::type>
-        typename rebind_executor<parallel_task_policy_shim, executor_type,
-            ParametersType>::type
+            typename ParametersType = typename parallel::execution::
+                executor_parameters_join<Parameters_...>::type>
+        typename parallel::execution::rebind_executor<parallel_task_policy_shim,
+            executor_type, ParametersType>::type
         with(Parameters_&&... params) const
         {
-            typedef typename rebind_executor<parallel_task_policy_shim,
-                executor_type, ParametersType>::type rebound_type;
+            typedef typename parallel::execution::rebind_executor<
+                parallel_task_policy_shim, executor_type, ParametersType>::type
+                rebound_type;
             return rebound_type(exec_,
-                join_executor_parameters(std::forward<Parameters_>(params)...));
+                parallel::execution::join_executor_parameters(
+                    std::forward<Parameters_>(params)...));
         }
 
         /// Return the associated executor object.
@@ -960,8 +979,8 @@ namespace hpx { namespace parallel { namespace execution {
 
         /// The type of the associated executor parameters object which is
         /// associated with this execution policy
-        typedef execution::extract_executor_parameters<executor_type>::type
-            executor_parameters_type;
+        typedef parallel::execution::extract_executor_parameters<
+            executor_type>::type executor_parameters_type;
 
         /// The category of the execution agents created by this execution
         /// policy.
@@ -1007,7 +1026,7 @@ namespace hpx { namespace parallel { namespace execution {
         /// \returns The new parallel_policy
         ///
         template <typename Executor>
-        typename rebind_executor<parallel_policy, Executor,
+        typename parallel::execution::rebind_executor<parallel_policy, Executor,
             executor_parameters_type>::type
         on(Executor&& exec) const
         {
@@ -1019,8 +1038,9 @@ namespace hpx { namespace parallel { namespace execution {
                 "hpx::traits::is_threads_executor<Executor>::value || "
                 "hpx::traits::is_executor_any<Executor>::value");
 
-            typedef typename rebind_executor<parallel_policy, Executor,
-                executor_parameters_type>::type rebound_type;
+            typedef
+                typename parallel::execution::rebind_executor<parallel_policy,
+                    Executor, executor_parameters_type>::type rebound_type;
             return rebound_type(std::forward<Executor>(exec), parameters());
         }
 
@@ -1039,16 +1059,18 @@ namespace hpx { namespace parallel { namespace execution {
         /// \returns The new parallel_policy
         ///
         template <typename... Parameters,
-            typename ParametersType =
-                typename executor_parameters_join<Parameters...>::type>
-        typename rebind_executor<parallel_policy, executor_type,
-            ParametersType>::type
+            typename ParametersType = typename parallel::execution::
+                executor_parameters_join<Parameters...>::type>
+        typename parallel::execution::rebind_executor<parallel_policy,
+            executor_type, ParametersType>::type
         with(Parameters&&... params) const
         {
-            typedef typename rebind_executor<parallel_policy, executor_type,
-                ParametersType>::type rebound_type;
+            typedef
+                typename parallel::execution::rebind_executor<parallel_policy,
+                    executor_type, ParametersType>::type rebound_type;
             return rebound_type(executor(),
-                join_executor_parameters(std::forward<Parameters>(params)...));
+                parallel::execution::join_executor_parameters(
+                    std::forward<Parameters>(params)...));
         }
 
     public:
@@ -1147,8 +1169,8 @@ namespace hpx { namespace parallel { namespace execution {
         /// \returns The new parallel_policy
         ///
         template <typename Executor_>
-        typename rebind_executor<parallel_policy_shim, Executor_,
-            executor_parameters_type>::type
+        typename parallel::execution::rebind_executor<parallel_policy_shim,
+            Executor_, executor_parameters_type>::type
         on(Executor_&& exec) const
         {
             typedef typename std::decay<Executor>::type executor_type;
@@ -1159,8 +1181,9 @@ namespace hpx { namespace parallel { namespace execution {
                 "hpx::traits::is_threads_executor<Executor>::value || "
                 "hpx::traits::is_executor_any<Executor>::value");
 
-            typedef typename rebind_executor<parallel_policy_shim, Executor_,
-                executor_parameters_type>::type rebound_type;
+            typedef typename parallel::execution::rebind_executor<
+                parallel_policy_shim, Executor_, executor_parameters_type>::type
+                rebound_type;
             return rebound_type(std::forward<Executor_>(exec), params_);
         }
 
@@ -1179,16 +1202,18 @@ namespace hpx { namespace parallel { namespace execution {
         /// \returns The new parallel_policy_shim
         ///
         template <typename... Parameters_,
-            typename ParametersType =
-                typename executor_parameters_join<Parameters_...>::type>
-        typename rebind_executor<parallel_policy_shim, executor_type,
-            ParametersType>::type
+            typename ParametersType = typename parallel::execution::
+                executor_parameters_join<Parameters_...>::type>
+        typename parallel::execution::rebind_executor<parallel_policy_shim,
+            executor_type, ParametersType>::type
         with(Parameters_&&... params) const
         {
-            typedef typename rebind_executor<parallel_policy_shim,
-                executor_type, ParametersType>::type rebound_type;
+            typedef typename parallel::execution::rebind_executor<
+                parallel_policy_shim, executor_type, ParametersType>::type
+                rebound_type;
             return rebound_type(exec_,
-                join_executor_parameters(std::forward<Parameters_>(params)...));
+                parallel::execution::join_executor_parameters(
+                    std::forward<Parameters_>(params)...));
         }
 
         /// Return the associated executor object.
@@ -1256,8 +1281,8 @@ namespace hpx { namespace parallel { namespace execution {
 
         /// The type of the associated executor parameters object which is
         /// associated with this execution policy
-        typedef execution::extract_executor_parameters<executor_type>::type
-            executor_parameters_type;
+        typedef parallel::execution::extract_executor_parameters<
+            executor_type>::type executor_parameters_type;
 
         /// The category of the execution agents created by this execution
         /// policy.
@@ -1321,7 +1346,76 @@ namespace hpx { namespace parallel { namespace execution {
 
     /// Default vector execution policy object.
     HPX_STATIC_CONSTEXPR parallel_unsequenced_policy par_unseq;
+}}    // namespace hpx::execution
 
+namespace hpx { namespace parallel { namespace execution {
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::par is deprecated. Please use "
+        "hpx::execution::par instead.")
+    static constexpr hpx::execution::parallel_policy par;
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::par_unseq is deprecated. Please use "
+        "hpx::execution::par_unseq instead.")
+    static constexpr hpx::execution::parallel_policy par_unseq;
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::seq is deprecated. Please use "
+        "hpx::execution::seq instead.")
+    static constexpr hpx::execution::sequenced_policy seq;
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::task is deprecated. Please use "
+        "hpx::execution::task instead.")
+    static constexpr hpx::execution::task_policy_tag task;
+    using parallel_executor HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::parallel_executor is deprecated. Please use "
+        "hpx::execution::parallel_executor instead.") =
+        hpx::execution::parallel_executor;
+    using parallel_policy HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::parallel_policy is deprecated. Please use "
+        "hpx::execution::parallel_policy instead.") =
+        hpx::execution::parallel_policy;
+    template <typename Executor, typename Parameters>
+    using parallel_policy_shim HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::parallel_policy_shim is deprecated. Please "
+        "use hpx::execution::parallel_policy_shim instead.") =
+        hpx::execution::parallel_policy_shim<Executor, Parameters>;
+    using parallel_task_policy HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::parallel_task_policy is deprecated. Please "
+        "use hpx::execution::parallel_task_policy instead.") =
+        hpx::execution::parallel_task_policy;
+    template <typename Executor, typename Parameters>
+    using parallel_task_policy_shim HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::parallel_task_policy_shim is deprecated. "
+        "Please use hpx::execution::parallel_task_policy_shim instead.") =
+        hpx::execution::parallel_task_policy_shim<Executor, Parameters>;
+    using parallel_unsequenced_policy HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::parallel_unsequenced_policy is deprecated. "
+        "Please use hpx::execution::parallel_unsequenced_policy instead.") =
+        hpx::execution::parallel_unsequenced_policy;
+    using sequenced_executor HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::sequenced_executor is deprecated. Please "
+        "use hpx::execution::sequenced_executor instead.") =
+        hpx::execution::sequenced_executor;
+    using sequenced_policy HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::sequenced_policy is deprecated. Please use "
+        "hpx::execution::sequenced_policy instead.") =
+        hpx::execution::sequenced_policy;
+    template <typename Executor, typename Parameters>
+    using sequenced_policy_shim HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::sequenced_policy_shim is deprecated. Please "
+        "use hpx::execution::sequenced_policy_shim instead.") =
+        hpx::execution::sequenced_policy_shim<Executor, Parameters>;
+    using sequenced_task_policy HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::sequenced_task_policy is deprecated. Please "
+        "use hpx::execution::sequenced_task_policy instead.") =
+        hpx::execution::sequenced_task_policy;
+    template <typename Executor, typename Parameters>
+    using sequenced_task_policy_shim HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::sequenced_task_policy_shim is deprecated. "
+        "Please use hpx::execution::sequenced_task_policy_shim instead.") =
+        hpx::execution::sequenced_task_policy_shim<Executor, Parameters>;
+}}}    // namespace hpx::parallel::execution
+
+namespace hpx { namespace parallel { namespace execution {
     ///////////////////////////////////////////////////////////////////////////
     // Allow to detect execution policies which were created as a result
     // of a rebind operation. This information can be used to inhibit the
@@ -1330,25 +1424,29 @@ namespace hpx { namespace parallel { namespace execution {
     namespace detail {
         template <typename Executor, typename Parameters>
         struct is_rebound_execution_policy<
-            sequenced_policy_shim<Executor, Parameters>> : std::true_type
+            hpx::execution::sequenced_policy_shim<Executor, Parameters>>
+          : std::true_type
         {
         };
 
         template <typename Executor, typename Parameters>
         struct is_rebound_execution_policy<
-            sequenced_task_policy_shim<Executor, Parameters>> : std::true_type
+            hpx::execution::sequenced_task_policy_shim<Executor, Parameters>>
+          : std::true_type
         {
         };
 
         template <typename Executor, typename Parameters>
         struct is_rebound_execution_policy<
-            parallel_policy_shim<Executor, Parameters>> : std::true_type
+            hpx::execution::parallel_policy_shim<Executor, Parameters>>
+          : std::true_type
         {
         };
 
         template <typename Executor, typename Parameters>
         struct is_rebound_execution_policy<
-            parallel_task_policy_shim<Executor, Parameters>> : std::true_type
+            hpx::execution::parallel_task_policy_shim<Executor, Parameters>>
+          : std::true_type
         {
         };
     }    // namespace detail
@@ -1357,52 +1455,61 @@ namespace hpx { namespace parallel { namespace execution {
     namespace detail {
         /// \cond NOINTERNAL
         template <>
-        struct is_execution_policy<parallel_policy> : std::true_type
+        struct is_execution_policy<hpx::execution::parallel_policy>
+          : std::true_type
         {
         };
 
         template <typename Executor, typename Parameters>
-        struct is_execution_policy<parallel_policy_shim<Executor, Parameters>>
+        struct is_execution_policy<
+            hpx::execution::parallel_policy_shim<Executor, Parameters>>
           : std::true_type
         {
         };
 
         template <>
-        struct is_execution_policy<parallel_unsequenced_policy> : std::true_type
+        struct is_execution_policy<hpx::execution::parallel_unsequenced_policy>
+          : std::true_type
         {
         };
 
         template <>
-        struct is_execution_policy<sequenced_policy> : std::true_type
+        struct is_execution_policy<hpx::execution::sequenced_policy>
+          : std::true_type
         {
         };
 
         template <typename Executor, typename Parameters>
-        struct is_execution_policy<sequenced_policy_shim<Executor, Parameters>>
+        struct is_execution_policy<
+            hpx::execution::sequenced_policy_shim<Executor, Parameters>>
           : std::true_type
         {
         };
 
         // extension
         template <>
-        struct is_execution_policy<sequenced_task_policy> : std::true_type
+        struct is_execution_policy<hpx::execution::sequenced_task_policy>
+          : std::true_type
         {
         };
 
         template <typename Executor, typename Parameters>
         struct is_execution_policy<
-            sequenced_task_policy_shim<Executor, Parameters>> : std::true_type
+            hpx::execution::sequenced_task_policy_shim<Executor, Parameters>>
+          : std::true_type
         {
         };
 
         template <>
-        struct is_execution_policy<parallel_task_policy> : std::true_type
+        struct is_execution_policy<hpx::execution::parallel_task_policy>
+          : std::true_type
         {
         };
 
         template <typename Executor, typename Parameters>
         struct is_execution_policy<
-            parallel_task_policy_shim<Executor, Parameters>> : std::true_type
+            hpx::execution::parallel_task_policy_shim<Executor, Parameters>>
+          : std::true_type
         {
         };
         /// \endcond
@@ -1412,31 +1519,34 @@ namespace hpx { namespace parallel { namespace execution {
     namespace detail {
         /// \cond NOINTERNAL
         template <>
-        struct is_parallel_execution_policy<parallel_policy> : std::true_type
-        {
-        };
-
-        template <typename Executor, typename Parameters>
-        struct is_parallel_execution_policy<
-            parallel_policy_shim<Executor, Parameters>> : std::true_type
-        {
-        };
-
-        template <>
-        struct is_parallel_execution_policy<parallel_unsequenced_policy>
-          : std::true_type
-        {
-        };
-
-        template <>
-        struct is_parallel_execution_policy<parallel_task_policy>
+        struct is_parallel_execution_policy<hpx::execution::parallel_policy>
           : std::true_type
         {
         };
 
         template <typename Executor, typename Parameters>
         struct is_parallel_execution_policy<
-            parallel_task_policy_shim<Executor, Parameters>> : std::true_type
+            hpx::execution::parallel_policy_shim<Executor, Parameters>>
+          : std::true_type
+        {
+        };
+
+        template <>
+        struct is_parallel_execution_policy<
+            hpx::execution::parallel_unsequenced_policy> : std::true_type
+        {
+        };
+
+        template <>
+        struct is_parallel_execution_policy<
+            hpx::execution::parallel_task_policy> : std::true_type
+        {
+        };
+
+        template <typename Executor, typename Parameters>
+        struct is_parallel_execution_policy<
+            hpx::execution::parallel_task_policy_shim<Executor, Parameters>>
+          : std::true_type
         {
         };
         /// \endcond
@@ -1446,25 +1556,28 @@ namespace hpx { namespace parallel { namespace execution {
     namespace detail {
         /// \cond NOINTERNAL
         template <>
-        struct is_sequenced_execution_policy<sequenced_task_policy>
+        struct is_sequenced_execution_policy<
+            hpx::execution::sequenced_task_policy> : std::true_type
+        {
+        };
+
+        template <typename Executor, typename Parameters>
+        struct is_sequenced_execution_policy<
+            hpx::execution::sequenced_task_policy_shim<Executor, Parameters>>
+          : std::true_type
+        {
+        };
+
+        template <>
+        struct is_sequenced_execution_policy<hpx::execution::sequenced_policy>
           : std::true_type
         {
         };
 
         template <typename Executor, typename Parameters>
         struct is_sequenced_execution_policy<
-            sequenced_task_policy_shim<Executor, Parameters>> : std::true_type
-        {
-        };
-
-        template <>
-        struct is_sequenced_execution_policy<sequenced_policy> : std::true_type
-        {
-        };
-
-        template <typename Executor, typename Parameters>
-        struct is_sequenced_execution_policy<
-            sequenced_policy_shim<Executor, Parameters>> : std::true_type
+            hpx::execution::sequenced_policy_shim<Executor, Parameters>>
+          : std::true_type
         {
         };
         /// \endcond
@@ -1474,24 +1587,28 @@ namespace hpx { namespace parallel { namespace execution {
     namespace detail {
         /// \cond NOINTERNAL
         template <>
-        struct is_async_execution_policy<sequenced_task_policy> : std::true_type
+        struct is_async_execution_policy<hpx::execution::sequenced_task_policy>
+          : std::true_type
         {
         };
 
         template <typename Executor, typename Parameters>
         struct is_async_execution_policy<
-            sequenced_task_policy_shim<Executor, Parameters>> : std::true_type
+            hpx::execution::sequenced_task_policy_shim<Executor, Parameters>>
+          : std::true_type
         {
         };
 
         template <>
-        struct is_async_execution_policy<parallel_task_policy> : std::true_type
+        struct is_async_execution_policy<hpx::execution::parallel_task_policy>
+          : std::true_type
         {
         };
 
         template <typename Executor, typename Parameters>
         struct is_async_execution_policy<
-            parallel_task_policy_shim<Executor, Parameters>> : std::true_type
+            hpx::execution::parallel_task_policy_shim<Executor, Parameters>>
+          : std::true_type
         {
         };
         /// \endcond

--- a/libs/parallelism/executors/include/hpx/executors/execution_policy_fwd.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/execution_policy_fwd.hpp
@@ -11,7 +11,7 @@
 #include <hpx/executors/datapar/execution_policy_fwd.hpp>
 #endif
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx { namespace execution {
     ///////////////////////////////////////////////////////////////////////////
     // forward declarations, see execution_policy.hpp
     struct sequenced_policy;
@@ -35,4 +35,4 @@ namespace hpx { namespace parallel { namespace execution {
     struct parallel_task_policy_shim;
 
     struct parallel_unsequenced_policy;
-}}}    // namespace hpx::parallel::execution
+}}    // namespace hpx::execution

--- a/libs/parallelism/executors/include/hpx/executors/guided_pool_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/guided_pool_executor.hpp
@@ -584,7 +584,7 @@ namespace hpx { namespace parallel { namespace execution {
     template <typename Hint>
     struct executor_execution_category<guided_pool_executor<Hint>>
     {
-        typedef parallel::execution::parallel_execution_tag type;
+        typedef hpx::execution::parallel_execution_tag type;
     };
 
     template <typename Hint>
@@ -596,7 +596,7 @@ namespace hpx { namespace parallel { namespace execution {
     template <typename Hint>
     struct executor_execution_category<guided_pool_executor_shim<Hint>>
     {
-        typedef parallel::execution::parallel_execution_tag type;
+        typedef hpx::execution::parallel_execution_tag type;
     };
 
     template <typename Hint>

--- a/libs/parallelism/executors/include/hpx/executors/parallel_executor_aggregated.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/parallel_executor_aggregated.hpp
@@ -47,11 +47,11 @@ namespace hpx { namespace parallel { namespace execution {
     {
         /// Associate the parallel_execution_tag executor tag type as a default
         /// with this executor.
-        using execution_category = parallel_execution_tag;
+        using execution_category = hpx::execution::parallel_execution_tag;
 
         /// Associate the static_chunk_size executor parameters type as a default
         /// with this executor.
-        using executor_parameters_type = static_chunk_size;
+        using executor_parameters_type = hpx::execution::static_chunk_size;
 
         /// Create a new parallel executor
         constexpr explicit parallel_policy_executor_aggregated(
@@ -257,11 +257,11 @@ namespace hpx { namespace parallel { namespace execution {
     {
         /// Associate the parallel_execution_tag executor tag type as a default
         /// with this executor.
-        using execution_category = parallel_execution_tag;
+        using execution_category = hpx::execution::parallel_execution_tag;
 
         /// Associate the static_chunk_size executor parameters type as a default
         /// with this executor.
-        using executor_parameters_type = static_chunk_size;
+        using executor_parameters_type = hpx::execution::static_chunk_size;
 
         /// Create a new parallel executor
         constexpr explicit parallel_policy_executor_aggregated(

--- a/libs/parallelism/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
@@ -29,11 +29,11 @@ namespace hpx { namespace parallel { namespace execution {
     public:
         /// Associate the parallel_execution_tag executor tag type as a default
         /// with this executor.
-        typedef parallel_execution_tag execution_category;
+        typedef hpx::execution::parallel_execution_tag execution_category;
 
         /// Associate the static_chunk_size executor parameters type as a default
         /// with this executor.
-        typedef static_chunk_size executor_parameters_type;
+        typedef hpx::execution::static_chunk_size executor_parameters_type;
 
         /// Create a new parallel executor
         restricted_thread_pool_executor(std::size_t first_thread = 0,

--- a/libs/parallelism/executors/include/hpx/executors/sequenced_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/sequenced_executor.hpp
@@ -25,7 +25,7 @@
 #include <utility>
 #include <vector>
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx { namespace execution {
     ///////////////////////////////////////////////////////////////////////////
     /// A \a sequential_executor creates groups of sequential execution agents
     /// which execute in the calling thread. The sequential order is given by
@@ -84,12 +84,13 @@ namespace hpx { namespace parallel { namespace execution {
 
         // BulkTwoWayExecutor interface
         template <typename F, typename S, typename... Ts>
-        static std::vector<hpx::future<
-            typename detail::bulk_function_result<F, S, Ts...>::type>>
+        static std::vector<hpx::future<typename parallel::execution::detail::
+                bulk_function_result<F, S, Ts...>::type>>
         bulk_async_execute(F&& f, S const& shape, Ts&&... ts)
         {
-            typedef typename detail::bulk_function_result<F, S, Ts...>::type
-                result_type;
+            typedef
+                typename parallel::execution::detail::bulk_function_result<F, S,
+                    Ts...>::type result_type;
             std::vector<hpx::future<result_type>> results;
 
             try
@@ -112,7 +113,8 @@ namespace hpx { namespace parallel { namespace execution {
         }
 
         template <typename F, typename S, typename... Ts>
-        static typename detail::bulk_execute_result<F, S, Ts...>::type
+        static typename parallel::execution::detail::bulk_execute_result<F, S,
+            Ts...>::type
         bulk_sync_execute(F&& f, S const& shape, Ts&&... ts)
         {
             return hpx::util::unwrap(bulk_async_execute(
@@ -133,30 +135,37 @@ namespace hpx { namespace parallel { namespace execution {
         }
         /// \endcond
     };
+}}    // namespace hpx::execution
+
+namespace hpx { namespace parallel { namespace execution {
+    using sequenced_executor HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::sequenced_executor is deprecated. Use "
+        "hpx::execution::sequenced_executor instead.") =
+        hpx::execution::sequenced_executor;
 }}}    // namespace hpx::parallel::execution
 
 namespace hpx { namespace parallel { namespace execution {
     /// \cond NOINTERNAL
     template <>
-    struct is_one_way_executor<parallel::execution::sequenced_executor>
+    struct is_one_way_executor<hpx::execution::sequenced_executor>
       : std::true_type
     {
     };
 
     template <>
-    struct is_bulk_one_way_executor<parallel::execution::sequenced_executor>
+    struct is_bulk_one_way_executor<hpx::execution::sequenced_executor>
       : std::true_type
     {
     };
 
     template <>
-    struct is_two_way_executor<parallel::execution::sequenced_executor>
+    struct is_two_way_executor<hpx::execution::sequenced_executor>
       : std::true_type
     {
     };
 
     template <>
-    struct is_bulk_two_way_executor<parallel::execution::sequenced_executor>
+    struct is_bulk_two_way_executor<hpx::execution::sequenced_executor>
       : std::true_type
     {
     };

--- a/libs/parallelism/executors/include/hpx/executors/service_executors.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/service_executors.hpp
@@ -38,11 +38,11 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
     public:
         /// Associate the parallel_execution_tag executor tag type as a default
         /// with this executor.
-        using execution_category = sequenced_execution_tag;
+        using execution_category = hpx::execution::sequenced_execution_tag;
 
         /// Associate the static_chunk_size executor parameters type as a default
         /// with this executor.
-        typedef static_chunk_size executor_parameters_type;
+        using executor_parameters_type = hpx::execution::static_chunk_size;
 
         service_executor(hpx::util::io_service_pool* pool)
           : pool_(pool)

--- a/libs/parallelism/executors/include/hpx/executors/sync.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/sync.hpp
@@ -66,7 +66,7 @@ namespace hpx { namespace detail {
             typename util::detail::invoke_deferred_result<F, Ts...>::type>::type
         call(F&& f, Ts&&... ts)
         {
-            parallel::execution::parallel_executor exec;
+            execution::parallel_executor exec;
             return parallel::execution::sync_execute(
                 exec, std::forward<F>(f), std::forward<Ts>(ts)...);
         }

--- a/libs/parallelism/executors/include/hpx/executors/thread_pool_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/thread_pool_executor.hpp
@@ -242,11 +242,11 @@ namespace hpx { namespace parallel { namespace execution {
     public:
         /// Associate the parallel_execution_tag executor tag type as a default
         /// with this executor.
-        typedef parallel_execution_tag execution_category;
+        typedef hpx::execution::parallel_execution_tag execution_category;
 
         /// Associate the static_chunk_size executor parameters type as a default
         /// with this executor.
-        typedef static_chunk_size executor_parameters_type;
+        typedef hpx::execution::static_chunk_size executor_parameters_type;
 
         /// Create a new parallel executor
         explicit thread_pool_executor(threads::thread_priority priority =

--- a/libs/parallelism/executors/tests/unit/limiting_executor.cpp
+++ b/libs/parallelism/executors/tests/unit/limiting_executor.cpp
@@ -58,8 +58,8 @@ void test_fn(atype& acnt, atype& atot, atype& amax)
 
 void test_limit()
 {
-    auto exec1 = hpx::parallel::execution::parallel_executor(
-        hpx::threads::thread_stacksize_small);
+    auto exec1 =
+        hpx::execution::parallel_executor(hpx::threads::thread_stacksize_small);
     //
     const bool block_on_exit = true;
     std::vector<hpx::future<void>> futures;

--- a/libs/parallelism/executors/tests/unit/sequenced_executor.cpp
+++ b/libs/parallelism/executors/tests/unit/sequenced_executor.cpp
@@ -25,14 +25,14 @@ hpx::thread::id test(int passed_through)
 
 void test_sync()
 {
-    hpx::parallel::execution::sequenced_executor exec;
+    hpx::execution::sequenced_executor exec;
     HPX_TEST(hpx::parallel::execution::sync_execute(exec, &test, 42) ==
         hpx::this_thread::get_id());
 }
 
 void test_async()
 {
-    typedef hpx::parallel::execution::parallel_executor executor;
+    typedef hpx::execution::parallel_executor executor;
 
     executor exec(hpx::launch::fork);
     HPX_TEST(hpx::parallel::execution::async_execute(exec, &test, 42).get() !=
@@ -52,7 +52,7 @@ hpx::thread::id test_f(hpx::future<void> f, int passed_through)
 
 void test_then()
 {
-    typedef hpx::parallel::execution::sequenced_executor executor;
+    typedef hpx::execution::sequenced_executor executor;
 
     hpx::future<void> f = hpx::make_ready_future();
 
@@ -79,7 +79,7 @@ void test_bulk_sync()
     using hpx::util::placeholders::_1;
     using hpx::util::placeholders::_2;
 
-    hpx::parallel::execution::sequenced_executor exec;
+    hpx::execution::sequenced_executor exec;
     hpx::parallel::execution::bulk_sync_execute(
         exec, hpx::util::bind(&bulk_test, _1, tid, _2), v, 42);
     hpx::parallel::execution::bulk_sync_execute(exec, &bulk_test, v, tid, 42);
@@ -99,7 +99,7 @@ void bulk_test_f(int value, hpx::shared_future<void> f, hpx::thread::id tid,
 
 void test_bulk_then()
 {
-    typedef hpx::parallel::execution::sequenced_executor executor;
+    typedef hpx::execution::sequenced_executor executor;
 
     hpx::thread::id tid = hpx::this_thread::get_id();
 
@@ -123,7 +123,7 @@ void test_bulk_then()
 
 void test_bulk_async()
 {
-    typedef hpx::parallel::execution::sequenced_executor executor;
+    typedef hpx::execution::sequenced_executor executor;
 
     hpx::thread::id tid = hpx::this_thread::get_id();
 
@@ -145,7 +145,7 @@ void test_bulk_async()
 void static_check_executor()
 {
     using namespace hpx::traits;
-    using executor = hpx::parallel::execution::sequenced_executor;
+    using executor = hpx::execution::sequenced_executor;
 
     static_assert(has_sync_execute_member<executor>::value,
         "has_sync_execute_member<executor>::value");

--- a/libs/parallelism/lcos_local/tests/unit/local_dataflow_executor.cpp
+++ b/libs/parallelism/lcos_local/tests/unit/local_dataflow_executor.cpp
@@ -325,7 +325,7 @@ void plain_deferred_arguments(Executor& exec)
 int hpx_main(variables_map&)
 {
     {
-        hpx::parallel::execution::sequenced_executor exec;
+        hpx::execution::sequenced_executor exec;
         function_pointers(exec);
         future_function_pointers(exec);
         plain_arguments(exec);
@@ -333,7 +333,7 @@ int hpx_main(variables_map&)
     }
 
     {
-        hpx::parallel::execution::parallel_executor exec;
+        hpx::execution::parallel_executor exec;
         function_pointers(exec);
         future_function_pointers(exec);
         plain_arguments(exec);

--- a/libs/parallelism/timed_execution/include/hpx/timed_execution/timed_executors.hpp
+++ b/libs/parallelism/timed_execution/include/hpx/timed_execution/timed_executors.hpp
@@ -88,7 +88,8 @@ namespace hpx { namespace parallel { namespace execution {
                         .get())
             {
                 auto predecessor = make_ready_future_at(abs_time);
-                return execution::then_execute(sequenced_executor(),
+                return execution::then_execute(
+                    hpx::execution::sequenced_executor(),
                     make_then_execute_helper<sync_execute_at_helper>(
                         std::forward<Executor>(exec),
                         hpx::util::deferred_call(
@@ -177,7 +178,8 @@ namespace hpx { namespace parallel { namespace execution {
                         std::forward<F>(f), std::forward<Ts>(ts)...))
             {
                 auto predecessor = make_ready_future_at(abs_time);
-                return execution::then_execute(sequenced_executor(),
+                return execution::then_execute(
+                    hpx::execution::sequenced_executor(),
                     make_then_execute_helper<async_execute_at_helper>(
                         std::forward<Executor>(exec),
                         hpx::util::deferred_call(
@@ -259,7 +261,7 @@ namespace hpx { namespace parallel { namespace execution {
                 Ts&&... ts)
             {
                 auto predecessor = make_ready_future_at(abs_time);
-                execution::then_execute(sequenced_executor(),
+                execution::then_execute(hpx::execution::sequenced_executor(),
                     make_then_execute_helper<post_at_helper>(
                         std::forward<Executor>(exec),
                         hpx::util::deferred_call(
@@ -407,10 +409,10 @@ namespace hpx { namespace parallel { namespace execution {
 
     ///////////////////////////////////////////////////////////////////////////
     using sequenced_timed_executor =
-        timed_executor<execution::sequenced_executor>;
+        timed_executor<hpx::execution::sequenced_executor>;
 
     using parallel_timed_executor =
-        timed_executor<execution::parallel_executor>;
+        timed_executor<hpx::execution::parallel_executor>;
 }}}    // namespace hpx::parallel::execution
 
 namespace hpx { namespace parallel { namespace execution {

--- a/libs/parallelism/timed_execution/tests/unit/minimal_timed_async_executor.cpp
+++ b/libs/parallelism/timed_execution/tests/unit/minimal_timed_async_executor.cpp
@@ -131,7 +131,7 @@ void test_timed_executor(std::array<std::size_t, 6> expected)
     typedef typename hpx::traits::executor_execution_category<Executor>::type
         execution_category;
 
-    HPX_TEST((std::is_same<hpx::parallel::execution::parallel_execution_tag,
+    HPX_TEST((std::is_same<hpx::execution::parallel_execution_tag,
         execution_category>::value));
 
     count_sync.store(0);
@@ -158,7 +158,7 @@ void test_timed_executor(std::array<std::size_t, 6> expected)
 ///////////////////////////////////////////////////////////////////////////////
 struct test_async_executor1
 {
-    typedef hpx::parallel::execution::parallel_execution_tag execution_category;
+    typedef hpx::execution::parallel_execution_tag execution_category;
 
     template <typename F, typename... Ts>
     static hpx::future<

--- a/libs/parallelism/timed_execution/tests/unit/minimal_timed_sync_executor.cpp
+++ b/libs/parallelism/timed_execution/tests/unit/minimal_timed_sync_executor.cpp
@@ -128,7 +128,7 @@ void test_timed_executor(std::array<std::size_t, 4> expected)
     typedef typename hpx::traits::executor_execution_category<Executor>::type
         execution_category;
 
-    HPX_TEST((std::is_same<hpx::parallel::execution::sequenced_execution_tag,
+    HPX_TEST((std::is_same<hpx::execution::sequenced_execution_tag,
         execution_category>::value));
 
     count_sync.store(0);
@@ -151,8 +151,7 @@ void test_timed_executor(std::array<std::size_t, 4> expected)
 ///////////////////////////////////////////////////////////////////////////////
 struct test_sync_executor1
 {
-    typedef hpx::parallel::execution::sequenced_execution_tag
-        execution_category;
+    typedef hpx::execution::sequenced_execution_tag execution_category;
 
     template <typename F, typename... Ts>
     typename hpx::util::detail::invoke_deferred_result<F,
@@ -165,8 +164,7 @@ struct test_sync_executor1
 
 struct test_timed_sync_executor1 : test_sync_executor1
 {
-    typedef hpx::parallel::execution::sequenced_execution_tag
-        execution_category;
+    typedef hpx::execution::sequenced_execution_tag execution_category;
 
     template <typename F, typename... Ts>
     typename hpx::util::detail::invoke_deferred_result<F,
@@ -194,8 +192,7 @@ namespace hpx { namespace parallel { namespace execution {
 
 struct test_sync_executor2 : test_sync_executor1
 {
-    typedef hpx::parallel::execution::sequenced_execution_tag
-        execution_category;
+    typedef hpx::execution::sequenced_execution_tag execution_category;
 
     template <typename F, typename... Ts>
     static void post(F&& f, Ts&&... ts)

--- a/libs/parallelism/timed_execution/tests/unit/timed_parallel_executor.cpp
+++ b/libs/parallelism/timed_execution/tests/unit/timed_parallel_executor.cpp
@@ -27,7 +27,7 @@ hpx::thread::id test(int passed_through)
 
 void test_timed_sync()
 {
-    typedef hpx::parallel::execution::parallel_executor executor;
+    typedef hpx::execution::parallel_executor executor;
 
     executor exec;
     HPX_TEST(hpx::parallel::execution::sync_execute_after(exec, milliseconds(1),
@@ -40,7 +40,7 @@ void test_timed_sync()
 
 void test_timed_async()
 {
-    typedef hpx::parallel::execution::parallel_executor executor;
+    typedef hpx::execution::parallel_executor executor;
 
     executor exec;
     HPX_TEST(hpx::parallel::execution::async_execute_after(
@@ -53,7 +53,7 @@ void test_timed_async()
 
 void test_timed_apply()
 {
-    typedef hpx::parallel::execution::parallel_executor executor;
+    typedef hpx::execution::parallel_executor executor;
 
     executor exec;
     hpx::parallel::execution::post_after(exec, milliseconds(1), &test, 42);

--- a/tests/performance/local/foreach_scaling.cpp
+++ b/tests/performance/local/foreach_scaling.cpp
@@ -77,13 +77,13 @@ void measure_sequential_foreach(
         disable_stealing_parameter dsp;
 
         // invoke sequential for_each
-        hpx::ranges::for_each(hpx::parallel::execution::seq.with(dsp),
+        hpx::ranges::for_each(hpx::execution::seq.with(dsp),
             data_representation, [](std::size_t) { worker_timed(delay); });
     }
     else
     {
         // invoke sequential for_each
-        hpx::ranges::for_each(hpx::parallel::execution::seq,
+        hpx::ranges::for_each(hpx::execution::seq,
             data_representation, [](std::size_t) { worker_timed(delay); });
     }
 }
@@ -93,7 +93,7 @@ void measure_parallel_foreach(
     std::vector<std::size_t> const& data_representation, Executor&& exec)
 {
     // create executor parameters object
-    hpx::parallel::execution::static_chunk_size cs(chunk_size);
+    hpx::execution::static_chunk_size cs(chunk_size);
 
     if (disable_stealing)
     {
@@ -102,13 +102,13 @@ void measure_parallel_foreach(
 
         // invoke parallel for_each
         hpx::ranges::for_each(
-            hpx::parallel::execution::par.with(cs, dsp).on(exec),
+            hpx::execution::par.with(cs, dsp).on(exec),
             data_representation, [](std::size_t) { worker_timed(delay); });
     }
     else
     {
         // invoke parallel for_each
-        hpx::ranges::for_each(hpx::parallel::execution::par.with(cs).on(exec),
+        hpx::ranges::for_each(hpx::execution::par.with(cs).on(exec),
             data_representation, [](std::size_t) { worker_timed(delay); });
     }
 }
@@ -119,7 +119,7 @@ hpx::future<void> measure_task_foreach(
     Executor&& exec)
 {
     // create executor parameters object
-    hpx::parallel::execution::static_chunk_size cs(chunk_size);
+    hpx::execution::static_chunk_size cs(chunk_size);
 
     if (disable_stealing)
     {
@@ -128,7 +128,7 @@ hpx::future<void> measure_task_foreach(
 
         // invoke parallel for_each
         return hpx::ranges::for_each(
-            hpx::parallel::execution::par(hpx::parallel::execution::task)
+            hpx::execution::par(hpx::execution::task)
                 .with(cs, dsp)
                 .on(exec),
             *data_representation, [](std::size_t) { worker_timed(delay); })
@@ -138,7 +138,7 @@ hpx::future<void> measure_task_foreach(
     {
         // invoke parallel for_each
         return hpx::ranges::for_each(
-            hpx::parallel::execution::par(hpx::parallel::execution::task)
+            hpx::execution::par(hpx::execution::task)
                 .with(cs)
                 .on(exec),
             *data_representation, [](std::size_t) { worker_timed(delay); })
@@ -158,14 +158,14 @@ void measure_sequential_forloop(
         disable_stealing_parameter dsp;
 
         // invoke sequential for_loop
-        hpx::for_loop(hpx::parallel::execution::seq.with(dsp),
+        hpx::for_loop(hpx::execution::seq.with(dsp),
             std::begin(data_representation), std::end(data_representation),
             [](iterator) { worker_timed(delay); });
     }
     else
     {
         // invoke sequential for_loop
-        hpx::for_loop(hpx::parallel::execution::seq,
+        hpx::for_loop(hpx::execution::seq,
             std::begin(data_representation), std::end(data_representation),
             [](iterator) { worker_timed(delay); });
     }
@@ -178,7 +178,7 @@ void measure_parallel_forloop(
     using iterator = typename std::vector<std::size_t>::const_iterator;
 
     // create executor parameters object
-    hpx::parallel::execution::static_chunk_size cs(chunk_size);
+    hpx::execution::static_chunk_size cs(chunk_size);
 
     if (disable_stealing)
     {
@@ -186,14 +186,14 @@ void measure_parallel_forloop(
         disable_stealing_parameter dsp;
 
         // invoke parallel for_loop
-        hpx::for_loop(hpx::parallel::execution::par.with(cs, dsp).on(exec),
+        hpx::for_loop(hpx::execution::par.with(cs, dsp).on(exec),
             std::begin(data_representation), std::end(data_representation),
             [](iterator) { worker_timed(delay); });
     }
     else
     {
         // invoke parallel for_loop
-        hpx::for_loop(hpx::parallel::execution::par.with(cs).on(exec),
+        hpx::for_loop(hpx::execution::par.with(cs).on(exec),
             std::begin(data_representation), std::end(data_representation),
             [](iterator) { worker_timed(delay); });
     }
@@ -207,7 +207,7 @@ hpx::future<void> measure_task_forloop(
     using iterator = typename std::vector<std::size_t>::const_iterator;
 
     // create executor parameters object
-    hpx::parallel::execution::static_chunk_size cs(chunk_size);
+    hpx::execution::static_chunk_size cs(chunk_size);
 
     if (disable_stealing)
     {
@@ -216,7 +216,7 @@ hpx::future<void> measure_task_forloop(
 
         // invoke parallel for_looph
         return hpx::for_loop(
-            hpx::parallel::execution::par(hpx::parallel::execution::task)
+            hpx::execution::par(hpx::execution::task)
                 .with(cs, dsp)
                 .on(exec),
             std::begin(*data_representation), std::end(*data_representation),
@@ -227,7 +227,7 @@ hpx::future<void> measure_task_forloop(
     {
         // invoke parallel for_looph
         return hpx::for_loop(
-            hpx::parallel::execution::par(hpx::parallel::execution::task)
+            hpx::execution::par(hpx::execution::task)
                 .with(cs)
                 .on(exec),
             std::begin(*data_representation), std::end(*data_representation),
@@ -434,7 +434,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         }
         else
         {
-            hpx::parallel::execution::parallel_executor par;
+            hpx::execution::parallel_executor par;
 
             par_time_foreach = averageout_parallel_foreach(vector_size, par);
             task_time_foreach = averageout_task_foreach(vector_size, par);

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -85,7 +85,7 @@ void print_stats(const char* title, const char* wait, const char* exec,
     //hpx::util::print_cdash_timing(title, duration);
 }
 
-const char* exec_name(hpx::parallel::execution::parallel_executor const& exec)
+const char* exec_name(hpx::execution::parallel_executor const& exec)
 {
     return "parallel_executor";
 }
@@ -252,7 +252,6 @@ template <typename Executor>
 void measure_function_futures_limiting_executor(
     std::uint64_t count, bool csv, Executor exec)
 {
-    using namespace hpx::parallel::execution;
     std::uint64_t const num_threads = hpx::get_num_worker_threads();
     std::uint64_t const tasks = num_threads * 2000;
     std::atomic<std::uint64_t> sanity_check(count);
@@ -276,14 +275,14 @@ void measure_function_futures_limiting_executor(
 
     // test a parallel algorithm on custom pool with high priority
     auto const chunk_size = count / (num_threads * 2);
-    hpx::parallel::execution::static_chunk_size fixed(chunk_size);
+    hpx::execution::static_chunk_size fixed(chunk_size);
 
     // start the clock
     high_resolution_timer walltime;
     {
         hpx::execution::experimental::limiting_executor<Executor> signal_exec(
             exec, tasks, tasks + 1000);
-        hpx::for_loop(hpx::parallel::execution::par.with(fixed), 0, count,
+        hpx::for_loop(hpx::execution::par.with(fixed), 0, count,
             [&](std::uint64_t) {
                 hpx::apply(signal_exec, [&]() {
                     null_function();
@@ -350,8 +349,8 @@ void measure_function_futures_for_loop(std::uint64_t count, bool csv,
 {
     // start the clock
     high_resolution_timer walltime;
-    hpx::for_loop(hpx::parallel::execution::par.on(exec).with(
-                      hpx::parallel::execution::static_chunk_size(1),
+    hpx::for_loop(hpx::execution::par.on(exec).with(
+                      hpx::execution::static_chunk_size(1),
                       unlimited_number_of_chunks()),
         0, count, [](std::uint64_t) { null_function(); });
 
@@ -503,7 +502,7 @@ void measure_function_futures_apply_hierarchical_placement(
         auto const hint =
             hpx::threads::thread_schedule_hint(static_cast<std::int16_t>(t));
         auto spawn_func = [&func, hint, t, count, num_threads]() {
-            auto exec = hpx::parallel::execution::parallel_executor(hint);
+            auto exec = hpx::execution::parallel_executor(hint);
             std::uint64_t const count_start = t * count / num_threads;
             std::uint64_t const count_end = (t + 1) * count / num_threads;
 
@@ -513,7 +512,7 @@ void measure_function_futures_apply_hierarchical_placement(
             }
         };
 
-        auto exec = hpx::parallel::execution::parallel_executor(hint);
+        auto exec = hpx::execution::parallel_executor(hint);
         hpx::apply(exec, spawn_func);
     }
     l.wait();
@@ -551,7 +550,7 @@ int hpx_main(variables_map& vm)
         if (HPX_UNLIKELY(0 == count))
             throw std::logic_error("error: count of 0 futures specified\n");
 
-        hpx::parallel::execution::parallel_executor par;
+        hpx::execution::parallel_executor par;
         hpx::parallel::execution::parallel_executor_aggregated par_agg;
         hpx::parallel::execution::thread_pool_executor tpe;
         hpx::parallel::execution::thread_pool_executor tpe_nostack(

--- a/tests/performance/local/libcds_hazard_pointer_overhead.cpp
+++ b/tests/performance/local/libcds_hazard_pointer_overhead.cpp
@@ -90,7 +90,7 @@ void print_stats(const char* title, const char* wait, const char* exec,
     //hpx::util::print_cdash_timing(title, duration);
 }
 
-const char* exec_name(hpx::parallel::execution::parallel_executor const& exec)
+const char* exec_name(hpx::execution::parallel_executor const& exec)
 {
     return "parallel_executor";
 }
@@ -311,7 +311,7 @@ int hpx_main(variables_map& vm)
 
         cds::gc::HP hpGC;
 
-        hpx::parallel::execution::parallel_executor par;
+        hpx::execution::parallel_executor par;
         hpx::parallel::execution::parallel_executor_aggregated par_agg;
         hpx::parallel::execution::thread_pool_executor tpe;
 

--- a/tests/performance/local/partitioned_vector_foreach.cpp
+++ b/tests/performance/local/partitioned_vector_foreach.cpp
@@ -81,26 +81,26 @@ int hpx_main(hpx::program_options::variables_map& vm)
     else
     {
         // create executor parameters object
-        hpx::parallel::execution::static_chunk_size cs(chunk_size);
+        hpx::execution::static_chunk_size cs(chunk_size);
 
         // retrieve reference time
         std::vector<int> ref(vector_size);
         std::uint64_t seq_ref =
-            foreach_vector(hpx::parallel::execution::seq, ref);
+            foreach_vector(hpx::execution::seq, ref);
         std::uint64_t par_ref = foreach_vector(
-            hpx::parallel::execution::par.with(cs), ref);    //-V106
+            hpx::execution::par.with(cs), ref);    //-V106
 
         // sequential hpx::partitioned_vector iteration
         {
             hpx::partitioned_vector<int> v(vector_size);
 
             hpx::cout << "hpx::partitioned_vector<int>(execution::seq): "
-                      << foreach_vector(hpx::parallel::execution::seq, v) /
+                      << foreach_vector(hpx::execution::seq, v) /
                     double(seq_ref)
                       << "\n";
             hpx::cout << "hpx::partitioned_vector<int>(execution::par): "
                       << foreach_vector(
-                             hpx::parallel::execution::par.with(cs), v) /
+                             hpx::execution::par.with(cs), v) /
                     double(par_ref)    //-V106
                       << "\n";
         }
@@ -111,13 +111,13 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
             hpx::cout << "hpx::partitioned_vector<int>(execution::seq, "
                          "container_layout(2)): "
-                      << foreach_vector(hpx::parallel::execution::seq, v) /
+                      << foreach_vector(hpx::execution::seq, v) /
                     double(seq_ref)
                       << "\n";
             hpx::cout << "hpx::partitioned_vector<int>(execution::par, "
                          "container_layout(2)): "
                       << foreach_vector(
-                             hpx::parallel::execution::par.with(cs), v) /
+                             hpx::execution::par.with(cs), v) /
                     double(par_ref)    //-V106
                       << "\n";
         }
@@ -128,13 +128,13 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
             hpx::cout << "hpx::partitioned_vector<int>(execution::seq, "
                          "container_layout(10)): "
-                      << foreach_vector(hpx::parallel::execution::seq, v) /
+                      << foreach_vector(hpx::execution::seq, v) /
                     double(seq_ref)
                       << "\n";
             hpx::cout << "hpx::partitioned_vector<int>(execution::par, "
                          "container_layout(10)): "
                       << foreach_vector(
-                             hpx::parallel::execution::par.with(cs), v) /
+                             hpx::execution::par.with(cs), v) /
                     double(par_ref)    //-V106
                       << "\n";
         }

--- a/tests/performance/local/stream.cpp
+++ b/tests/performance/local/stream.cpp
@@ -95,11 +95,11 @@ void check_results(std::size_t iterations, Vector const& a_res,
     std::vector<STREAM_TYPE> c(c_res.size());
 
     hpx::copy(
-        hpx::parallel::execution::par, a_res.begin(), a_res.end(), a.begin());
+        hpx::execution::par, a_res.begin(), a_res.end(), a.begin());
     hpx::copy(
-        hpx::parallel::execution::par, b_res.begin(), b_res.end(), b.begin());
+        hpx::execution::par, b_res.begin(), b_res.end(), b.begin());
     hpx::copy(
-        hpx::parallel::execution::par, c_res.begin(), c_res.end(), c.begin());
+        hpx::execution::par, c_res.begin(), c_res.end(), c.begin());
 
     STREAM_TYPE aj, bj, cj, scalar;
     STREAM_TYPE aSumErr, bSumErr, cSumErr;
@@ -460,7 +460,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
         allocator_type alloc(target);
         executor_type exec(target, host_targets);
-        auto policy = hpx::parallel::execution::par.on(exec);
+        auto policy = hpx::execution::par.on(exec);
 
 #else
 #error "The STREAM benchmark currently requires CUDA to run on an accelerator"
@@ -477,7 +477,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         {
             // Default parallel policy with serial allocator.
             timing = run_benchmark<>(iterations, vector_size,
-                std::allocator<STREAM_TYPE>{}, hpx::parallel::execution::par);
+                std::allocator<STREAM_TYPE>{}, hpx::execution::par);
         }
         else if (executor == 1)
         {
@@ -489,7 +489,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
             auto numa_nodes = hpx::compute::host::numa_domains();
             allocator_type alloc(numa_nodes);
             executor_type exec(numa_nodes);
-            auto policy = hpx::parallel::execution::par.on(exec);
+            auto policy = hpx::execution::par.on(exec);
 
             timing = run_benchmark<>(
                 iterations, vector_size, std::move(alloc), std::move(policy));
@@ -497,7 +497,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         else if (executor == 2)
         {
             // Default parallel policy and allocator with default parallel policy.
-            auto policy = hpx::parallel::execution::par;
+            auto policy = hpx::execution::par;
             hpx::compute::host::detail::policy_allocator<STREAM_TYPE,
                 decltype(policy)>
                 alloc(policy);
@@ -511,7 +511,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
             using executor_type =
                 hpx::parallel::execution::thread_pool_executor;
 
-            auto policy = hpx::parallel::execution::par.on(executor_type());
+            auto policy = hpx::execution::par.on(executor_type());
             hpx::compute::host::detail::policy_allocator<STREAM_TYPE,
                 decltype(policy)>
                 alloc(policy);

--- a/tests/performance/local/transform_reduce_binary_scaling.cpp
+++ b/tests/performance/local/transform_reduce_binary_scaling.cpp
@@ -91,13 +91,13 @@ int hpx_main(hpx::program_options::variables_map& vm)
     else
     {
         // warm up caches
-        measure_inner_product(hpx::parallel::execution::par, data1, data2);
+        measure_inner_product(hpx::execution::par, data1, data2);
 
         // do measurements
         std::uint64_t tr_time_datapar = measure_inner_product(
-            test_count, hpx::parallel::execution::datapar, data1, data2);
+            test_count, hpx::execution::datapar, data1, data2);
         std::uint64_t tr_time_par = measure_inner_product(
-            test_count, hpx::parallel::execution::par, data1, data2);
+            test_count, hpx::execution::par, data1, data2);
 
         if (csvoutput)
         {

--- a/tests/unit/apex/annotation_check.cpp
+++ b/tests/unit/apex/annotation_check.cpp
@@ -200,7 +200,7 @@ int hpx_main()
     hpx::parallel::execution::pool_executor NP_executor =
         hpx::parallel::execution::pool_executor(
             "default", hpx::threads::thread_priority_default);
-    hpx::parallel::execution::parallel_executor par_exec{};
+    hpx::execution::parallel_executor par_exec{};
 
     test_none();
     //


### PR DESCRIPTION
Also deprecates the names in `hpx::parallel::execution`.