### PR TITLE
Fix typos reported by fossies codespell report

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -7,7 +7,7 @@
 # This cmake-format configuration file is a suggested configuration file for
 # formatting CMake files for the HPX project.
 
-# PLEASE NOTE: This file has been created and tested withs cmake-format V0.6.10
+# PLEASE NOTE: This file has been created and tested with cmake-format V0.6.10
 
 # -----------------------------
 # Options affecting formatting.
@@ -77,7 +77,7 @@ with section("format"):
   max_rows_cmdline = 2
 
   # By default, if cmake-format cannot successfully fit everything into the
-  # desired linewidth it will apply the last, most agressive attempt that it
+  # desired linewidth it will apply the last, most aggressive attempt that it
   # made.  If this flag is True, however, cmake-format will print error, exit
   # with non-zero status code, and write-out nothing
   require_valid_layout = False
@@ -116,7 +116,7 @@ with section("markup"):
   canonicalize_hashrulers = True
 
   # If a comment line matches starts with this pattern then it is explicitly a
-  # trailing comment for the preceeding argument.  Default is '#<'
+  # trailing comment for the preceding argument.  Default is '#<'
   explicit_trailing_pattern = u'#<'
 
   # If comment markup is enabled, don't reflow the first comment block in each

--- a/docs/sphinx/releases/whats_new_0_9_6.rst
+++ b/docs/sphinx/releases/whats_new_0_9_6.rst
@@ -17,7 +17,7 @@ roughly 140 tickets (bugs, feature requests, etc.).
 General changes
 ===============
 
-The major new fetures in this release are:
+The major new features in this release are:
 
 * We further consolidated the API exposed by |hpx|. We aligned our APIs as much
   as possible with the existing |cpp11|_ and related proposals to the C++

--- a/docs/sphinx/releases/whats_new_1_5_0.rst
+++ b/docs/sphinx/releases/whats_new_1_5_0.rst
@@ -30,7 +30,7 @@ and many bug fixes.
   ``hpx::stop_token``.
 * We have added ``hpx::stable_sort`` based on Francisco Tapia's
   implementation.
-* We have adapted existing sychronization primitives to be fully conformant
+* We have adapted existing synchronization primitives to be fully conformant
   C++20: ``hpx::barrier``, ``hpx::latch``, ``hpx::counting_semaphore``, and
   ``hpx::binary_semaphore``.
 * We have started using customization point objects (CPOs) to make the

--- a/examples/quickstart/1d_wave_equation.cpp
+++ b/examples/quickstart/1d_wave_equation.cpp
@@ -84,7 +84,7 @@ struct data
     }
 
     // Copy constructor: data d1; data d2(d1);
-    // We can't copy the mutex, because mutexs are noncopyable.
+    // We can't copy the mutex, because mutexes are noncopyable.
     data(data const& other)
       : mtx()
       , u_value(other.u_value)

--- a/hpx/util/connection_cache.hpp
+++ b/hpx/util/connection_cache.hpp
@@ -80,7 +80,7 @@ namespace hpx { namespace util
                 HPX_THROW_EXCEPTION(bad_parameter,
                     "connection_cache::connection_cache",
                     "the maximum number of connections per locality cannot "
-                    "excede the overall maximum number of connections");
+                    "exceed the overall maximum number of connections");
             }
         }
 

--- a/libs/algorithms/include/hpx/parallel/util/low_level.hpp
+++ b/libs/algorithms/include/hpx/parallel/util/low_level.hpp
@@ -73,7 +73,7 @@ namespace hpx { namespace parallel { namespace util {
         (::new (static_cast<void*>(ptr)) Value(std::forward<Args>(args)...));
     }
 
-    /// \brief Move objets
+    /// \brief Move objects
     /// \tparam Iter : iterator to the elements
     /// \tparam Value : typename of the object to create
     /// \param [in] itdest : iterator to the final place of the objects
@@ -88,7 +88,7 @@ namespace hpx { namespace parallel { namespace util {
         return it_dest;
     }
 
-    /// \brief Move objets to uninitialized memory
+    /// \brief Move objects to uninitialized memory
     /// \tparam Iter : iterator to the elements
     /// \tparam Value : typename of the object to construct
     /// \param [in] ptr : pointer to the memory where to create the object

--- a/libs/algorithms/tests/unit/algorithms/parallel_sort.cpp
+++ b/libs/algorithms/tests/unit/algorithms/parallel_sort.cpp
@@ -357,7 +357,7 @@ void test6()
         }
         else
         {
-            throw std::ios_base::failure("Insuficient lenght of the vector\n");
+            throw std::ios_base::failure("Insufficient length of the vector\n");
         }
     }
 

--- a/libs/checkpoint_base/docs/index.rst
+++ b/libs/checkpoint_base/docs/index.rst
@@ -19,7 +19,7 @@ a given container.
 This module exposes the ``hpx::util::save_checkpoint_data``,
 ``hpx::util::restore_checkpoint_data``, and ``hpx::util::prepare_checkpoint_data``
 APIs. These functions encapsulate the basic serialization functionalities
-necessary to save/resore a variadic list of arguments to/from a given data
+necessary to save/restore a variadic list of arguments to/from a given data
 container.
 
 See the :ref:`API reference <libs_checkpoint_base_api>` of this module for more

--- a/libs/debugging/include/hpx/debugging/print.hpp
+++ b/libs/debugging/include/hpx/debugging/print.hpp
@@ -255,7 +255,7 @@ namespace hpx { namespace debug {
     };
 
     // ------------------------------------------------------------------
-    // helper fuction for printing CRC32
+    // helper function for printing CRC32
     // ------------------------------------------------------------------
     inline uint32_t crc32(const void* /*address*/, size_t /*length*/)
     {
@@ -266,7 +266,7 @@ namespace hpx { namespace debug {
     }
 
     // ------------------------------------------------------------------
-    // helper fuction for printing short memory dump and crc32
+    // helper function for printing short memory dump and crc32
     // useful for debugging corruptions in buffers during
     // rma or other transfers
     // ------------------------------------------------------------------

--- a/libs/executors/include/hpx/executors/limiting_executor.hpp
+++ b/libs/executors/include/hpx/executors/limiting_executor.hpp
@@ -114,7 +114,7 @@ namespace hpx { namespace execution { namespace experimental {
         // and uses the underlying executor to get a count of tasks
         // 'in flight' for the throttling.
         // The dummy B template param must match BaseExecutor and helps
-        // deduction rules complete this type so that the default implementaiton
+        // deduction rules complete this type so that the default implementation
         // (above) still works
         template <typename F, typename B>
         struct throttling_wrapper<F, B,

--- a/libs/runtime_configuration/src/ini.cpp
+++ b/libs/runtime_configuration/src/ini.cpp
@@ -261,7 +261,7 @@ namespace hpx { namespace util {
                     current = current->add_section_if_new(
                         sec_key.substr(pos, dot_pos - pos));
                 }
-                // if we don't have section qualifiers, restor current...
+                // if we don't have section qualifiers, restore current...
                 if (current == this)
                 {
                     current = s;

--- a/libs/serialization/docs/index.rst
+++ b/libs/serialization/docs/index.rst
@@ -14,7 +14,7 @@ serialization
 This module provides serialization primitives and support for all built-in
 types as well as all C++ Standard Library collection and utility types. This
 list is extended by |hpx| vocabulary types with proper support for global
-reference counting. |hpx|'s mode of serialization is dervied from `Boost's
+reference counting. |hpx|'s mode of serialization is derived from `Boost's
 serialization model
 <https://www.boost.org/doc/libs/1_72_0/libs/serialization/doc/index.html>`_
 and, as such, is mostly interface compatible with

--- a/plugins/parcelport/libfabric/rma_receiver.cpp
+++ b/plugins/parcelport/libfabric/rma_receiver.cpp
@@ -278,7 +278,7 @@ namespace libfabric
 
                 // overwrite the serialization chunk data pointer because the chunk
                 // info sent contains the pointer to the remote data and when we
-                // deocde the parcel we want the chunk to point to the local copy of it
+                // decode the parcel we want the chunk to point to the local copy of it
                 const void *remoteAddr = c.data_.cpos_;
                 c.data_.cpos_ = get_region->get_address();
                 // call the rma read function for the chunk

--- a/tests/performance/local/nonconcurrent_fifo_overhead.cpp
+++ b/tests/performance/local/nonconcurrent_fifo_overhead.cpp
@@ -299,7 +299,7 @@ int main(
 
     if (iterations % blocksize)
         throw std::invalid_argument(
-            "iterations must be cleanly divisable by blocksize\n");
+            "iterations must be cleanly divisible by blocksize\n");
 
     if (vm.count("no-header"))
         header = false;

--- a/tests/performance/local/nonconcurrent_lifo_overhead.cpp
+++ b/tests/performance/local/nonconcurrent_lifo_overhead.cpp
@@ -299,7 +299,7 @@ int main(
 
     if (iterations % blocksize)
         throw std::invalid_argument(
-            "iterations must be cleanly divisable by blocksize\n");
+            "iterations must be cleanly divisible by blocksize\n");
 
     if (vm.count("no-header"))
         header = false;


### PR DESCRIPTION
Fixes #4940. I've left typos that come from an external source (mainly PR titles).