### PR TITLE
Allow suspension on multiple localities

### DIFF
--- a/libs/full/runtime_local/src/runtime_local.cpp
+++ b/libs/full/runtime_local/src/runtime_local.cpp
@@ -1592,14 +1592,6 @@ namespace hpx {
 
     int runtime::resume()
     {
-        std::uint32_t initial_num_localities = get_initial_num_localities();
-        if (initial_num_localities > 1)
-        {
-            HPX_THROW_EXCEPTION(invalid_status, "runtime::resume",
-                "Can only suspend runtime when number of localities is 1");
-            return -1;
-        }
-
         LRT_(info) << "runtime_local: about to resume runtime";
 
         if (state_.load() == state_running)

--- a/src/runtime_distributed.cpp
+++ b/src/runtime_distributed.cpp
@@ -805,31 +805,11 @@ namespace hpx {
 
     int runtime_distributed::suspend()
     {
-#if defined(HPX_HAVE_NETWORKING)
-        std::uint32_t initial_num_localities = get_initial_num_localities();
-        if (initial_num_localities > 1)
-        {
-            HPX_THROW_EXCEPTION(invalid_status, "runtime_distributed::suspend",
-                "Can only suspend runtime when number of localities is 1");
-            return -1;
-        }
-#endif
-
         return runtime::suspend();
     }
 
     int runtime_distributed::resume()
     {
-#if defined(HPX_HAVE_NETWORKING)
-        std::uint32_t initial_num_localities = get_initial_num_localities();
-        if (initial_num_localities > 1)
-        {
-            HPX_THROW_EXCEPTION(invalid_status, "runtime_distributed::resume",
-                "Can only suspend runtime when number of localities is 1");
-            return -1;
-        }
-#endif
-
         return runtime::resume();
     }
 


### PR DESCRIPTION
The restriction of the suspend/resume mechanism of the runtime to a single locality seems unnecessary.

Fixes #4937

According to a short discussion with @msimberg it should be possible to suspend/resume the runtime also on multiple localities, so as a test I removed the corresponding checks and did some test runs on our cluster which showed no problems. Nevertheless, I would appreciate the input of someone with a deeper understanding of the code.