### PR TITLE
Clean up old artifacts better and more aggressively on Jenkins

### DIFF
--- a/.jenkins/cscs/Jenkinsfile
+++ b/.jenkins/cscs/Jenkinsfile
@@ -12,6 +12,16 @@ pipeline {
             label 'ssl_daintvm1'
         }
     }
+    options {
+        buildDiscarder(
+            logRotator(
+                daysToKeepStr: "14",
+                numToKeepStr: "50",
+                artifactDaysToKeepStr: "14",
+                artifactNumToKeepStr: "50"
+            )
+        )
+    }
     environment {
         SPACK_ROOT = '/apps/daint/SSL/HPX/spack'
         GITHUB_TOKEN = credentials('97b30156-2f6f-47fc-94eb-68044d95ec50')

--- a/.jenkins/cscs/entry.sh
+++ b/.jenkins/cscs/entry.sh
@@ -9,8 +9,8 @@
 # Make undefined variables errors, print each command
 set -eux
 
-# Clean up directory
-rm -f jenkins-hpx*
+# Clean up old artifacts
+rm -f ./jenkins-hpx* ./*-Testing
 
 source .jenkins/cscs/slurm-constraint-${configuration_name}.sh
 

--- a/.jenkins/lsu/Jenkinsfile
+++ b/.jenkins/lsu/Jenkinsfile
@@ -8,6 +8,16 @@
 
 pipeline {
     agent any
+    options {
+        buildDiscarder(
+            logRotator(
+                daysToKeepStr: "14",
+                numToKeepStr: "50",
+                artifactDaysToKeepStr: "14",
+                artifactNumToKeepStr: "50"
+            )
+        )
+    }
     environment {
         GITHUB_TOKEN = credentials('GITHUB_TOKEN')
     }

--- a/.jenkins/lsu/entry.sh
+++ b/.jenkins/lsu/entry.sh
@@ -9,8 +9,8 @@
 # Make undefined variables errors, print each command
 set -eux
 
-# Clean up directory
-rm -f jenkins-hpx*
+# Clean up old artifacts
+rm -f ./jenkins-hpx* ./*-Testing
 
 export configuration_name_with_build_type="${configuration_name}-${build_type,,}"
 


### PR DESCRIPTION
Set a limit on days and number of artifacts to keep. Also make sure that artifacts from previous builds are deleted at the beginning of a build.