### PR TITLE
Use object libraries for modules

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -350,6 +350,7 @@ with section("parse"):
                                     'EXCLUDE_FROM_GLOBAL_HEADER': '+',
                                     'GLOBAL_HEADER_GEN': 1,
                                     'HEADERS': '+',
+                                    'OBJECTS': '+',
                                     'MODULE_DEPENDENCIES': '+',
                                     'SOURCES': '+'},
                         'pargs': { 'flags': ['FORCE_LINKING_GEN',

--- a/cmake/HPX_AddCompileTest.cmake
+++ b/cmake/HPX_AddCompileTest.cmake
@@ -5,7 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 function(add_hpx_compile_test category name)
-  set(options FAILURE_EXPECTED NOLIBS)
+  set(options FAILURE_EXPECTED NOLIBS OBJECT)
   set(one_value_args SOURCE_ROOT FOLDER)
   set(multi_value_args SOURCES COMPONENT_DEPENDENCIES DEPENDENCIES)
 
@@ -17,18 +17,33 @@ function(add_hpx_compile_test category name)
   if(${name}_NOLIBS)
     set(_additional_flags ${_additional_flags} NOLIBS)
   endif()
+  if(${name}_OBJECT)
+    set(_additional_flags ${_additional_flags} OBJECT)
+  endif()
 
   string(REGEX REPLACE "\\." "_" test_name "${category}.${name}")
 
-  add_hpx_executable(
-    ${test_name}
-    SOURCE_ROOT ${${name}_SOURCE_ROOT}
-    SOURCES ${${name}_SOURCES}
-    EXCLUDE_FROM_ALL EXCLUDE_FROM_DEFAULT_BUILD
-    FOLDER ${${name}_FOLDER}
-    COMPONENT_DEPENDENCIES ${${name}_COMPONENT_DEPENDENCIES}
-    DEPENDENCIES ${${name}_DEPENDENCIES} ${_additional_flags}
-  )
+  if(${name}_OBJECT)
+    add_hpx_library(
+      ${test_name}
+      SOURCE_ROOT ${${name}_SOURCE_ROOT}
+      SOURCES ${${name}_SOURCES}
+      EXCLUDE_FROM_ALL EXCLUDE_FROM_DEFAULT_BUILD
+      FOLDER ${${name}_FOLDER}
+      COMPONENT_DEPENDENCIES ${${name}_COMPONENT_DEPENDENCIES}
+      DEPENDENCIES ${${name}_DEPENDENCIES} ${_additional_flags}
+    )
+  else()
+    add_hpx_executable(
+      ${test_name}
+      SOURCE_ROOT ${${name}_SOURCE_ROOT}
+      SOURCES ${${name}_SOURCES}
+      EXCLUDE_FROM_ALL EXCLUDE_FROM_DEFAULT_BUILD
+      FOLDER ${${name}_FOLDER}
+      COMPONENT_DEPENDENCIES ${${name}_COMPONENT_DEPENDENCIES}
+      DEPENDENCIES ${${name}_DEPENDENCIES} ${_additional_flags}
+    )
+  endif()
 
   add_test(
     NAME "${category}.${name}"
@@ -42,7 +57,6 @@ function(add_hpx_compile_test category name)
   endif()
 
   set_tests_properties("${category}.${name}" PROPERTIES RUN_SERIAL TRUE)
-
 endfunction(add_hpx_compile_test)
 
 function(add_hpx_compile_test_target_dependencies category name)
@@ -75,7 +89,9 @@ endfunction(add_hpx_regression_compile_test)
 function(add_hpx_headers_compile_test subcategory name)
   # Important to keep the double quotes around subcategory otherwise don't
   # consider empty argument but just remove it
-  add_test_and_deps_compile_test("headers" "${subcategory}" ${name} ${ARGN})
+  add_test_and_deps_compile_test(
+    "headers" "${subcategory}" ${name} ${ARGN} OBJECT
+  )
 endfunction(add_hpx_headers_compile_test)
 
 function(add_hpx_header_tests category)

--- a/cmake/HPX_AddLibrary.cmake
+++ b/cmake/HPX_AddLibrary.cmake
@@ -14,6 +14,7 @@ function(add_hpx_library name)
       NOEXPORT
       AUTOGLOB
       STATIC
+      OBJECT
       PLUGIN
       NONAMEPREFIX
       UNITY_BUILD
@@ -39,6 +40,11 @@ function(add_hpx_library name)
   cmake_parse_arguments(
     ${name} "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN}
   )
+
+  if(${name}_OBJECT AND ${name}_STATIC)
+    hpx_error("Trying to create ${name} library with both STATIC and OBJECT.\
+ Only one can be used at the same time.")
+  endif()
 
   if(NOT ${name}_SOURCE_ROOT)
     set(${name}_SOURCE_ROOT ".")
@@ -195,6 +201,8 @@ function(add_hpx_library name)
 
   if(${name}_STATIC)
     set(${name}_linktype STATIC)
+  elseif(${name}_OBJECT)
+    set(${name}_linktype OBJECT)
   else()
     if(HPX_WITH_STATIC_LINKING)
       set(${name}_linktype STATIC)

--- a/cmake/HPX_AddLibrary.cmake
+++ b/cmake/HPX_AddLibrary.cmake
@@ -43,7 +43,8 @@ function(add_hpx_library name)
 
   if(${name}_OBJECT AND ${name}_STATIC)
     hpx_error("Trying to create ${name} library with both STATIC and OBJECT.\
- Only one can be used at the same time.")
+ Only one can be used at the same time."
+    )
   endif()
 
   if(NOT ${name}_SOURCE_ROOT)

--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -280,7 +280,9 @@ function(add_hpx_module libname modulename)
 
   # This is a temporary solution until all of HPX has been modularized as it
   # enables using header files from HPX for compiling this module.
-  target_include_directories(hpx_${modulename} PRIVATE ${HPX_SOURCE_DIR})
+  if("${libname}" STREQUAL "full")
+    target_include_directories(hpx_${modulename} PRIVATE ${HPX_SOURCE_DIR})
+  endif()
 
   add_hpx_source_group(
     NAME hpx_${modulename}

--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -189,6 +189,14 @@ function(add_hpx_module libname modulename)
     hpx_debug(${header_file})
   endforeach(header_file)
 
+  # NOTE: the modules belonging to libhpx still have cyclic dependencies. We
+  # keep those as static libraries.
+  if("${libname}" STREQUAL "full")
+    set(module_library_type STATIC)
+  else()
+    set(module_library_type OBJECT)
+  endif()
+
   # create library modules
   if(${name}_CUDA
      AND HPX_WITH_CUDA
@@ -196,7 +204,7 @@ function(add_hpx_module libname modulename)
   )
     # cmake-format: off
     cuda_add_library(
-      hpx_${modulename} OBJECT
+      hpx_${modulename} ${module_library_type}
       ${sources} ${config_entries_source} ${${modulename}_OBJECTS}
       ${headers} ${generated_headers} ${compat_headers}
     )
@@ -204,7 +212,7 @@ function(add_hpx_module libname modulename)
   else()
     # cmake-format: off
     add_library(
-      hpx_${modulename} OBJECT
+      hpx_${modulename} ${module_library_type}
       ${sources} ${config_entries_source} ${${modulename}_OBJECTS}
       ${headers} ${generated_headers} ${compat_headers}
     )
@@ -385,7 +393,34 @@ function(add_hpx_module libname modulename)
   endif()
 
   # Link modules to their higher-level libraries
-  target_link_libraries(hpx_${libname} PUBLIC hpx_${modulename})
+  if("${libname}" STREQUAL "full")
+    set(_module_target hpx_${modulename})
+    if(UNIX)
+      if(APPLE)
+        set(_module_target "-Wl,-all_load" "hpx_${modulename}")
+      else(APPLE) # not apple, regular linux
+        set(_module_target "-Wl,--whole-archive" "hpx_${modulename}"
+                           "-Wl,--no-whole-archive"
+        )
+      endif(APPLE)
+    elseif(MSVC)
+      target_link_libraries(
+        hpx_${libname} PRIVATE -WHOLEARCHIVE:$<TARGET_FILE:hpx_${modulename}>
+      )
+    endif()
+
+    target_link_libraries(hpx_${libname} PRIVATE ${_module_target})
+
+    get_target_property(
+      _module_interface_include_directories hpx_${modulename}
+      INTERFACE_INCLUDE_DIRECTORIES
+    )
+    target_include_directories(
+      hpx_${libname} INTERFACE ${_module_interface_include_directories}
+    )
+  else()
+    target_link_libraries(hpx_${libname} PUBLIC hpx_${modulename})
+  endif()
 
   foreach(dir ${${modulename}_CMAKE_SUBDIRS})
     add_subdirectory(${dir})

--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -196,7 +196,7 @@ function(add_hpx_module libname modulename)
   )
     # cmake-format: off
     cuda_add_library(
-      hpx_${modulename} STATIC
+      hpx_${modulename} OBJECT
       ${sources} ${config_entries_source} ${${modulename}_OBJECTS}
       ${headers} ${generated_headers} ${compat_headers}
     )
@@ -204,7 +204,7 @@ function(add_hpx_module libname modulename)
   else()
     # cmake-format: off
     add_library(
-      hpx_${modulename} STATIC
+      hpx_${modulename} OBJECT
       ${sources} ${config_entries_source} ${${modulename}_OBJECTS}
       ${headers} ${generated_headers} ${compat_headers}
     )
@@ -385,30 +385,7 @@ function(add_hpx_module libname modulename)
   endif()
 
   # Link modules to their higher-level libraries
-  set(_module_target hpx_${modulename})
-  if(UNIX)
-    if(APPLE)
-      set(_module_target "-Wl,-all_load" "hpx_${modulename}")
-    else(APPLE) # not apple, regular linux
-      set(_module_target "-Wl,--whole-archive" "hpx_${modulename}"
-                         "-Wl,--no-whole-archive"
-      )
-    endif(APPLE)
-  elseif(MSVC)
-    target_link_libraries(
-      hpx_${libname} PRIVATE -WHOLEARCHIVE:$<TARGET_FILE:hpx_${modulename}>
-    )
-  endif()
-
-  target_link_libraries(hpx_${libname} PRIVATE ${_module_target})
-
-  get_target_property(
-    _module_interface_include_directories hpx_${modulename}
-    INTERFACE_INCLUDE_DIRECTORIES
-  )
-  target_include_directories(
-    hpx_${libname} INTERFACE ${_module_interface_include_directories}
-  )
+  target_link_libraries(hpx_${libname} PUBLIC hpx_${modulename})
 
   foreach(dir ${${modulename}_CMAKE_SUBDIRS})
     add_subdirectory(${dir})

--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -422,6 +422,7 @@ function(add_hpx_module libname modulename)
     )
   else()
     target_link_libraries(hpx_${libname} PUBLIC hpx_${modulename})
+    target_link_libraries(hpx_${libname} PRIVATE ${${modulename}_OBJECTS})
   endif()
 
   foreach(dir ${${modulename}_CMAKE_SUBDIRS})

--- a/cmake/HPX_GeneratePackageUtils.cmake
+++ b/cmake/HPX_GeneratePackageUtils.cmake
@@ -259,7 +259,7 @@ function(
   # NOTE: This uses -I and not -isystem in lack of a good way to filter out
   # compiler search paths.
   set(_cflag_list
-      "${_cflag_list} $<$<BOOL:${${sys_include_dirs}}>:-I$<JOIN:${${sys_include_dirs}}, -isystem>>"
+      "${_cflag_list} $<$<BOOL:${${sys_include_dirs}}>:-I$<JOIN:${${sys_include_dirs}}, -I>>"
   )
   set(${cflag_list}
       ${_cflag_list}

--- a/cmake/HPX_GeneratePackageUtils.cmake
+++ b/cmake/HPX_GeneratePackageUtils.cmake
@@ -142,6 +142,9 @@ function(
           endif()
         endif()
 
+      elseif(${dep} MATCHES "::@")
+        # Skip targets beginning with ::@ as they come from object libraries
+        # which do not need to be linked.
       elseif(${dep} MATCHES "\\$<TARGET_NAME_IF_EXISTS:")
         # Skip conditional targets like $<TARGET_NAME_IF_EXISTS:hpx> as they are
         # not useful for pkgconfig file generation.

--- a/cmake/templates/HPXConfig.cmake.in
+++ b/cmake/templates/HPXConfig.cmake.in
@@ -105,6 +105,8 @@ include(HPX_SetupPapi)
 # CUDA
 include(HPX_SetupCUDA)
 
+include(HPX_SetupMPI)
+
 # APEX
 set(APEX_WITH_MSR "@APEX_WITH_MSR@")
 set(MSR_ROOT "@MSR_ROOT@")

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -98,19 +98,6 @@ configure_file(
   @ONLY
 )
 
-# FIXME : temporary add public dependencies to the boost libraries which are
-# only linked in the modules (which are themselves privately linked to hpx), it
-# should be removed when we make the modules object libraries that we publicly
-# link to hpx
-target_link_libraries(hpx_core PUBLIC hpx_dependencies_boost)
-target_link_libraries(hpx_core PUBLIC hpx_dependencies_allocator)
-target_link_libraries(hpx_core PUBLIC Hwloc::hwloc)
-target_link_libraries(hpx_core PUBLIC ASIO::standalone_asio)
-
-if(HPX_FILESYSTEM_WITH_BOOST_FILESYSTEM_COMPATIBILITY)
-  target_link_libraries(hpx_core PUBLIC Boost::filesystem)
-endif()
-
 if(MSVC AND HPX_COROUTINES_WITH_SWAP_CONTEXT_EMULATION)
   target_link_options(hpx_core PRIVATE "/EXPORT:switch_to_fiber")
 endif()

--- a/libs/core/assertion/tests/unit/CMakeLists.txt
+++ b/libs/core/assertion/tests/unit/CMakeLists.txt
@@ -15,7 +15,7 @@ foreach(test ${tests})
     ${test}_test INTERNAL_FLAGS
     SOURCES ${sources}
     NOLIBS
-    DEPENDENCIES hpx_assertion
+    DEPENDENCIES hpx_core
     EXCLUDE_FROM_ALL
     FOLDER "Tests/Unit/Modules/Core/Assertion/"
   )

--- a/libs/core/coroutines/CMakeLists.txt
+++ b/libs/core/coroutines/CMakeLists.txt
@@ -111,7 +111,8 @@ add_hpx_module(
   core coroutines
   GLOBAL_HEADER_GEN ON
   SOURCES ${coroutines_sources}
-  HEADERS ${coroutines_headers} OBJECTS "${switch_to_fiber_object}"
+  HEADERS ${coroutines_headers}
+  OBJECTS "${switch_to_fiber_object}"
   COMPAT_HEADERS ${coroutines_compat_headers}
   MODULE_DEPENDENCIES
     hpx_assertion

--- a/libs/core/debugging/tests/unit/CMakeLists.txt
+++ b/libs/core/debugging/tests/unit/CMakeLists.txt
@@ -19,6 +19,8 @@ foreach(test ${tests})
     SOURCES ${sources} ${${test}_FLAGS} ${${test}_LIBS}
     EXCLUDE_FROM_ALL
     FOLDER ${folder_name}
+    NOLIBS
+    DEPENDENCIES hpx_core
   )
 
   add_hpx_unit_test("modules.debugging" ${test} ${${test}_PARAMETERS})

--- a/libs/core/errors/tests/unit/CMakeLists.txt
+++ b/libs/core/errors/tests/unit/CMakeLists.txt
@@ -11,7 +11,7 @@ if(HPX_WITH_DISTRIBUTED_RUNTIME)
   set(tests ${tests} handled_exception unhandled_exception)
 endif()
 
-set(exception_LIBS NOLIBS DEPENDENCIES hpx_errors hpx_testing)
+set(exception_LIBS NOLIBS DEPENDENCIES hpx_core)
 set(unhandled_exception_PARAMETERS FAILURE_EXPECTED)
 
 foreach(test ${tests})

--- a/libs/core/format/tests/unit/CMakeLists.txt
+++ b/libs/core/format/tests/unit/CMakeLists.txt
@@ -12,7 +12,7 @@ foreach(test ${tests})
   source_group("Source Files" FILES ${sources})
 
   add_executable(${test}_test EXCLUDE_FROM_ALL ${sources})
-  target_link_libraries(${test}_test hpx_format hpx_testing)
+  target_link_libraries(${test}_test PRIVATE hpx_core)
   set_target_properties(
     ${test}_test PROPERTIES FOLDER "Tests/Unit/Modules/Core/Format"
   )

--- a/libs/core/functional/CMakeLists.txt
+++ b/libs/core/functional/CMakeLists.txt
@@ -91,7 +91,6 @@ add_hpx_module(
   COMPAT_HEADERS ${functional_compat_headers}
   MODULE_DEPENDENCIES
     hpx_assertion
-    hpx_concurrency
     hpx_config
     hpx_datastructures
     hpx_debugging

--- a/libs/core/functional/tests/unit/CMakeLists.txt
+++ b/libs/core/functional/tests/unit/CMakeLists.txt
@@ -48,7 +48,7 @@ foreach(test ${function_tests})
     ${test}_test INTERNAL_FLAGS
     SOURCES ${sources}
     NOLIBS
-    DEPENDENCIES hpx_functional hpx_testing
+    DEPENDENCIES hpx_core
     EXCLUDE_FROM_ALL
     FOLDER "Tests/Unit/Modules/Core/Functional"
   )

--- a/libs/core/iterator_support/tests/unit/CMakeLists.txt
+++ b/libs/core/iterator_support/tests/unit/CMakeLists.txt
@@ -26,10 +26,10 @@ if(HPX_WITH_DISTRIBUTED_RUNTIME)
 endif()
 
 set(is_range_FLAGS NOLIBS)
-set(is_range_LIBS DEPENDENCIES hpx_config hpx_iterator_support hpx_testing)
+set(is_range_LIBS DEPENDENCIES hpx_core)
 
 set(range_FLAGS NOLIBS)
-set(range_LIBS DEPENDENCIES hpx_config hpx_iterator_support hpx_testing)
+set(range_LIBS DEPENDENCIES hpx_core)
 
 # Add the tests
 foreach(test ${tests})

--- a/libs/core/itt_notify/CMakeLists.txt
+++ b/libs/core/itt_notify/CMakeLists.txt
@@ -20,8 +20,8 @@ set(itt_notify_compat_headers
 
 set(itt_notify_sources itt_notify.cpp thread_name.cpp)
 
-if(HPX_WITH_ITTNOTIFY)
-  set(itt_notify_dependencies Amplifier::amplifier)
+if(TARGET Amplifier::amplifier)
+  set(itt_notify_optional_dependencies Amplifier::amplifier)
 endif()
 
 include(HPX_AddModule)
@@ -31,7 +31,7 @@ add_hpx_module(
   SOURCES ${itt_notify_sources}
   HEADERS ${itt_notify_headers}
   COMPAT_HEADERS ${itt_notify_compat_headers}
-  DEPENDENCIES ${itt_notify_dependencies}
+  DEPENDENCIES ${itt_notify_optional_dependencies}
   MODULE_DEPENDENCIES hpx_config
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/memory/tests/unit/CMakeLists.txt
+++ b/libs/core/memory/tests/unit/CMakeLists.txt
@@ -24,7 +24,7 @@ foreach(test ${tests})
     ${test}_test INTERNAL_FLAGS
     SOURCES ${sources} ${${test}_FLAGS}
     EXCLUDE_FROM_ALL NOLIBS
-    DEPENDENCIES hpx_memory hpx_testing
+    DEPENDENCIES hpx_core
     FOLDER "Tests/Unit/Modules/Core/Memory"
   )
 

--- a/libs/core/serialization/tests/unit/CMakeLists.txt
+++ b/libs/core/serialization/tests/unit/CMakeLists.txt
@@ -57,7 +57,7 @@ foreach(test ${tests})
     ${test}_test INTERNAL_FLAGS
     SOURCES ${sources} ${${test}_FLAGS}
     EXCLUDE_FROM_ALL NOLIBS
-    DEPENDENCIES hpx_serialization hpx_testing
+    DEPENDENCIES hpx_core
     FOLDER ${folder_name}
   )
 

--- a/libs/core/serialization/tests/unit/polymorphic/CMakeLists.txt
+++ b/libs/core/serialization/tests/unit/polymorphic/CMakeLists.txt
@@ -25,7 +25,7 @@ foreach(test ${tests})
     ${test}_test INTERNAL_FLAGS
     SOURCES ${sources} ${${test}_FLAGS}
     EXCLUDE_FROM_ALL NOLIBS
-    DEPENDENCIES hpx_serialization hpx_testing
+    DEPENDENCIES hpx_core
     FOLDER "Tests/Unit/Modules/Core/Serialization/Polymorphic"
   )
 

--- a/libs/core/string_util/tests/CMakeLists.txt
+++ b/libs/core/string_util/tests/CMakeLists.txt
@@ -42,7 +42,7 @@ if(HPX_WITH_TESTS)
       HEADERS ${string_util_headers}
       HEADER_ROOT ${PROJECT_SOURCE_DIR}/include
       NOLIBS
-      DEPENDENCIES hpx_string_util
+      DEPENDENCIES hpx_core
     )
   endif()
 endif()

--- a/libs/core/string_util/tests/unit/CMakeLists.txt
+++ b/libs/core/string_util/tests/unit/CMakeLists.txt
@@ -17,7 +17,7 @@ foreach(test ${tests})
     ${test}_test INTERNAL_FLAGS
     SOURCES ${sources} ${${test}_FLAGS}
     EXCLUDE_FROM_ALL NOLIBS
-    DEPENDENCIES hpx_string_util hpx_testing
+    DEPENDENCIES hpx_core
     FOLDER ${folder_name}
   )
 

--- a/libs/full/actions/CMakeLists.txt
+++ b/libs/full/actions/CMakeLists.txt
@@ -46,7 +46,8 @@ add_hpx_module(
   SOURCES ${actions_sources}
   HEADERS ${actions_headers}
   COMPAT_HEADERS ${actions_compat_headers}
-  MODULE_DEPENDENCIES hpx_actions_base hpx_naming hpx_runtime_local
+  MODULE_DEPENDENCIES hpx_actions_base hpx_agas hpx_async_distributed hpx_naming
+                      hpx_runtime_local
   DEPENDENCIES hpx_core
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/full/init_runtime/CMakeLists.txt
+++ b/libs/full/init_runtime/CMakeLists.txt
@@ -31,8 +31,8 @@ if(HPX_WITH_DISTRIBUTED_RUNTIME)
   set(init_runtime_sources ${init_runtime_sources} pre_main.cpp)
 
   set(init_runtime_optional_module_dependencies
-      hpx_async_distributed hpx_runtime_distributed hpx_naming
-      hpx_performance_counters hpx_runtime_components hpx_runtime_distributed
+      hpx_async_distributed hpx_naming hpx_performance_counters
+      hpx_runtime_components hpx_runtime_distributed
   )
 endif()
 
@@ -47,8 +47,7 @@ add_hpx_module(
   HEADERS ${init_runtime_headers}
   SOURCES ${init_runtime_sources}
   DEPENDENCIES hpx_core hpx_parallelism
-  MODULE_DEPENDENCIES
-    hpx_program_options hpx:runtime_distributed hpx_runtime_local
-    hpx_threadmanager ${init_runtime_optional_module_dependencies}
+  MODULE_DEPENDENCIES hpx_program_options hpx_runtime_local hpx_threadmanager
+                      ${init_runtime_optional_module_dependencies}
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/full/init_runtime/CMakeLists.txt
+++ b/libs/full/init_runtime/CMakeLists.txt
@@ -47,7 +47,8 @@ add_hpx_module(
   HEADERS ${init_runtime_headers}
   SOURCES ${init_runtime_sources}
   DEPENDENCIES hpx_core hpx_parallelism
-  MODULE_DEPENDENCIES hpx_program_options hpx_runtime_local hpx_threadmanager
-                      ${init_runtime_optional_module_dependencies}
+  MODULE_DEPENDENCIES
+    hpx_program_options hpx:runtime_distributed hpx_runtime_local
+    hpx_threadmanager ${init_runtime_optional_module_dependencies}
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/full/init_runtime/CMakeLists.txt
+++ b/libs/full/init_runtime/CMakeLists.txt
@@ -32,7 +32,7 @@ if(HPX_WITH_DISTRIBUTED_RUNTIME)
 
   set(init_runtime_optional_module_dependencies
       hpx_async_distributed hpx_naming hpx_performance_counters
-      hpx_runtime_components hpx_runtime_distributed
+      hpx_runtime_distributed
   )
 endif()
 
@@ -47,8 +47,7 @@ add_hpx_module(
   HEADERS ${init_runtime_headers}
   SOURCES ${init_runtime_sources}
   DEPENDENCIES hpx_core hpx_parallelism
-  MODULE_DEPENDENCIES
-    hpx_program_options hpx:runtime_distributed hpx_runtime_local
-    hpx_threadmanager ${init_runtime_optional_module_dependencies}
+  MODULE_DEPENDENCIES hpx_program_options hpx_runtime_local hpx_threadmanager
+                      ${init_runtime_optional_module_dependencies}
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/parallelism/async_combinators/CMakeLists.txt
+++ b/libs/parallelism/async_combinators/CMakeLists.txt
@@ -41,6 +41,6 @@ add_hpx_module(
   HEADERS ${async_combinators_headers}
   COMPAT_HEADERS ${async_combinators_compat_headers}
   DEPENDENCIES hpx_core
-  MODULE_DEPENDENCIES hpx_async_base hpx_threading
+  MODULE_DEPENDENCIES hpx_async_base
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/parallelism/async_combinators/include/hpx/async_combinators/wait_any.hpp
+++ b/libs/parallelism/async_combinators/include/hpx/async_combinators/wait_any.hpp
@@ -165,7 +165,6 @@ namespace hpx {
 #include <hpx/async_combinators/wait_some.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/modules/threading.hpp>
 #include <hpx/preprocessor/strip_parens.hpp>
 #include <hpx/type_support/always_void.hpp>
 

--- a/libs/parallelism/async_combinators/include/hpx/async_combinators/wait_some.hpp
+++ b/libs/parallelism/async_combinators/include/hpx/async_combinators/wait_some.hpp
@@ -184,7 +184,6 @@ namespace hpx {
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/futures/traits/is_future.hpp>
 #include <hpx/modules/errors.hpp>
-#include <hpx/modules/threading.hpp>
 #include <hpx/preprocessor/strip_parens.hpp>
 #include <hpx/type_support/always_void.hpp>
 #include <hpx/type_support/pack.hpp>

--- a/libs/parallelism/async_combinators/include/hpx/async_combinators/when_any.hpp
+++ b/libs/parallelism/async_combinators/include/hpx/async_combinators/when_any.hpp
@@ -133,7 +133,6 @@ namespace hpx {
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/futures/traits/is_future.hpp>
 #include <hpx/futures/traits/is_future_range.hpp>
-#include <hpx/modules/threading.hpp>
 #include <hpx/type_support/pack.hpp>
 #include <hpx/util/detail/reserve.hpp>
 

--- a/libs/parallelism/async_combinators/include/hpx/async_combinators/when_some.hpp
+++ b/libs/parallelism/async_combinators/include/hpx/async_combinators/when_some.hpp
@@ -236,7 +236,6 @@ namespace hpx {
 #include <hpx/futures/traits/is_future.hpp>
 #include <hpx/futures/traits/is_future_range.hpp>
 #include <hpx/modules/errors.hpp>
-#include <hpx/modules/threading.hpp>
 #include <hpx/type_support/pack.hpp>
 #include <hpx/util/detail/reserve.hpp>
 

--- a/libs/parallelism/async_combinators/tests/unit/split_shared_future.cpp
+++ b/libs/parallelism/async_combinators/tests/unit/split_shared_future.cpp
@@ -4,9 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/hpx_init.hpp>
-#include <hpx/include/lcos.hpp>
+#include <hpx/future.hpp>
+#include <hpx/init.hpp>
 #include <hpx/modules/testing.hpp>
+#include <hpx/thread.hpp>
 
 #include <array>
 #include <chrono>

--- a/libs/parallelism/execution/CMakeLists.txt
+++ b/libs/parallelism/execution/CMakeLists.txt
@@ -80,13 +80,17 @@ set(execution_compat_headers
 )
 # cmake-format: on
 
+if(TARGET Vc::vc)
+  set(execution_optional_dependencies Vc::vc)
+endif()
+
 include(HPX_AddModule)
 add_hpx_module(
   parallelism execution
   SOURCES ${execution_sources}
   HEADERS ${execution_headers}
   COMPAT_HEADERS ${execution_compat_headers}
-  DEPENDENCIES hpx_core
+  DEPENDENCIES hpx_core ${execution_optional_dependencies}
   MODULE_DEPENDENCIES hpx_async_base hpx_async_combinators hpx_threading
                       hpx_pack_traversal
   CMAKE_SUBDIRS examples tests

--- a/libs/parallelism/lcos_local/tests/unit/split_future.cpp
+++ b/libs/parallelism/lcos_local/tests/unit/split_future.cpp
@@ -4,10 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/init.hpp>
 #include <hpx/future.hpp>
-#include <hpx/thread.hpp>
+#include <hpx/init.hpp>
 #include <hpx/modules/testing.hpp>
+#include <hpx/thread.hpp>
 
 #include <array>
 #include <chrono>

--- a/libs/parallelism/lcos_local/tests/unit/split_future.cpp
+++ b/libs/parallelism/lcos_local/tests/unit/split_future.cpp
@@ -4,8 +4,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/hpx_init.hpp>
-#include <hpx/include/lcos.hpp>
+#include <hpx/init.hpp>
+#include <hpx/future.hpp>
+#include <hpx/thread.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <array>

--- a/libs/parallelism/threading/CMakeLists.txt
+++ b/libs/parallelism/threading/CMakeLists.txt
@@ -26,6 +26,6 @@ add_hpx_module(
   HEADERS ${threading_headers}
   COMPAT_HEADERS ${threading_compat_headers}
   DEPENDENCIES hpx_core
-  MODULE_DEPENDENCIES hpx_execution hpx_futures
+  MODULE_DEPENDENCIES hpx_futures
   CMAKE_SUBDIRS examples tests
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -197,6 +197,14 @@ target_include_directories(
          $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> $<INSTALL_INTERFACE:include>
 )
 
+# FIXME : temporary add public dependencies to the boost libraries which are
+# only linked in the modules (which are themselves privately linked to hpx), it
+# should be removed when we make the modules object libraries that we publicly
+# link to hpx
+if(HPX_PROGRAM_OPTIONS_WITH_BOOST_PROGRAM_OPTIONS_COMPATIBILITY)
+  target_link_libraries(hpx_full PUBLIC Boost::program_options)
+endif()
+
 if(TARGET APEX::apex)
   # APEX won't get explicitly pulled into libhpx.so any more.  HOWEVER, we do
   # want to add the APEX link commands to all executables, so we use the

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -197,14 +197,6 @@ target_include_directories(
          $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> $<INSTALL_INTERFACE:include>
 )
 
-# FIXME : temporary add public dependencies to the boost libraries which are
-# only linked in the modules (which are themselves privately linked to hpx), it
-# should be removed when we make the modules object libraries that we publicly
-# link to hpx
-if(HPX_PROGRAM_OPTIONS_WITH_BOOST_PROGRAM_OPTIONS_COMPATIBILITY)
-  target_link_libraries(hpx_full PUBLIC Boost::program_options)
-endif()
-
 if(TARGET APEX::apex)
   # APEX won't get explicitly pulled into libhpx.so any more.  HOWEVER, we do
   # want to add the APEX link commands to all executables, so we use the

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -197,23 +197,6 @@ target_include_directories(
          $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> $<INSTALL_INTERFACE:include>
 )
 
-# FIXME : temporary add public dependencies to the boost libraries which are
-# only linked in the modules (which are themselves privately linked to hpx), it
-# should be removed when we make the modules object libraries that we publicly
-# link to hpx
-if(HPX_PROGRAM_OPTIONS_WITH_BOOST_PROGRAM_OPTIONS_COMPATIBILITY)
-  target_link_libraries(hpx_full PUBLIC Boost::program_options)
-endif()
-
-# Enable SIMD via VC if it is available
-if(TARGET Vc::vc)
-  target_link_libraries(hpx_full PUBLIC Vc::vc)
-endif()
-
-if(TARGET Amplifier::amplifier)
-  target_link_libraries(hpx_full PRIVATE Amplifier::amplifier)
-endif()
-
 if(TARGET APEX::apex)
   # APEX won't get explicitly pulled into libhpx.so any more.  HOWEVER, we do
   # want to add the APEX link commands to all executables, so we use the

--- a/tests/performance/local/CMakeLists.txt
+++ b/tests/performance/local/CMakeLists.txt
@@ -30,7 +30,6 @@ endif()
 
 if(NOT HPX_WITH_SANITIZERS)
   list(APPEND benchmarks start_stop)
-  set(start_stop_FLAGS DEPENDENCIES hpx_timing)
 endif()
 
 if(HPX_WITH_LIBCDS)
@@ -42,9 +41,7 @@ if(HPX_WITH_DISTRIBUTED_RUNTIME AND (HPX_WITH_DATAPAR_VC
                                      OR HPX_WITH_DATAPAR_BOOST_SIMD)
 )
   list(APPEND benchmarks transform_reduce_binary_scaling)
-  set(transform_reduce_binary_scaling_FLAGS DEPENDENCIES iostreams_component
-                                            hpx_timing
-  )
+  set(transform_reduce_binary_scaling_FLAGS DEPENDENCIES iostreams_component)
 endif()
 
 if(HPX_WITH_EXAMPLES_OPENMP)
@@ -53,16 +50,10 @@ if(HPX_WITH_EXAMPLES_OPENMP)
   )
 
   set(openmp_homogeneous_timed_task_spawn_FLAGS
-      NOLIBS
-      DEPENDENCIES
-      ${boost_library_dependencies}
-      hpx_assertion
-      hpx_config
-      hpx_format
-      hpx_timing
+      NOLIBS DEPENDENCIES ${boost_library_dependencies} hpx_core
   )
-  set(openmp_parallel_region_FLAGS
-      NOLIBS DEPENDENCIES ${boost_library_dependencies} hpx_format hpx_timing
+  set(openmp_parallel_region_FLAGS NOLIBS DEPENDENCIES
+                                   ${boost_library_dependencies} hpx_core
   )
 endif()
 
@@ -72,24 +63,13 @@ if(HPX_WITH_EXAMPLES_QTHREADS)
   )
 
   set(qthreads_homogeneous_timed_task_spawn_FLAGS
-      NOLIBS
-      DEPENDENCIES
-      ${boost_library_dependencies}
-      ${QTHREADS_LIBRARIES}
-      hpx_config
-      hpx_format
-      hpx_preprocessor
-      hpx_timing
+      NOLIBS DEPENDENCIES ${boost_library_dependencies} ${QTHREADS_LIBRARIES}
+      hpx_core
   )
 
   set(qthreads_heterogeneous_timed_task_spawn_FLAGS
-      NOLIBS
-      DEPENDENCIES
-      ${boost_library_dependencies}
-      ${QTHREADS_LIBRARIES}
-      hpx_assertion
-      hpx_format
-      hpx_timing
+      NOLIBS DEPENDENCIES ${boost_library_dependencies} ${QTHREADS_LIBRARIES}
+      hpx_core
   )
 
   set(qthreads_heterogeneous_timed_task_spawn_INCLUDE_DIRECTORIES
@@ -101,14 +81,8 @@ if(HPX_WITH_EXAMPLES_TBB)
   list(APPEND benchmarks tbb_homogeneous_timed_task_spawn)
 
   set(tbb_homogeneous_timed_task_spawn_FLAGS
-      NOLIBS
-      DEPENDENCIES
-      ${boost_library_dependencies}
-      ${TBB_LIBRARIES}
-      hpx_config
-      hpx_format
-      hpx_preprocessor
-      hpx_timing
+      NOLIBS DEPENDENCIES ${boost_library_dependencies} ${TBB_LIBRARIES}
+      hpx_core
   )
 
   set(tbb_homogeneous_timed_task_spawn_INCLUDE_DIRECTORIES ${TBB_INCLUDE_DIR})
@@ -133,15 +107,15 @@ if(HPX_WITH_DISTRIBUTED_RUNTIME)
 endif()
 
 set(delay_baseline_FLAGS NOLIBS DEPENDENCIES ${boost_library_dependencies}
-                         hpx_config hpx_format hpx_timing
+                         hpx_core
 )
 
 set(delay_baseline_threaded_FLAGS DEPENDENCIES ${boost_library_dependencies}
-                                  hpx_format hpx_timing
+                                  hpx_core
 )
 
-set(print_heterogeneous_payloads_FLAGS
-    NOLIBS DEPENDENCIES ${boost_library_dependencies} hpx_config hpx_format
+set(print_heterogeneous_payloads_FLAGS NOLIBS DEPENDENCIES
+                                       ${boost_library_dependencies} hpx_core
 )
 set(resume_suspend_FLAGS DEPENDENCIES hpx_timing)
 
@@ -153,24 +127,18 @@ set(hpx_homogeneous_timed_task_spawn_executors_FLAGS DEPENDENCIES
 set(hpx_heterogeneous_timed_task_spawn_FLAGS DEPENDENCIES iostreams_component
                                              hpx_timing
 )
-set(parent_vs_child_stealing_FLAGS DEPENDENCIES iostreams_component hpx_timing)
+set(parent_vs_child_stealing_FLAGS DEPENDENCIES iostreams_component)
 set(skynet_FLAGS DEPENDENCIES iostreams_component)
-set(wait_all_timings_FLAGS DEPENDENCIES iostreams_component hpx_timing)
-set(future_overhead_FLAGS DEPENDENCIES hpx_timing)
+set(wait_all_timings_FLAGS DEPENDENCIES iostreams_component)
+set(future_overhead_FLAGS DEPENDENCIES)
 set(sizeof_FLAGS DEPENDENCIES iostreams_component)
-set(foreach_scaling_FLAGS DEPENDENCIES iostreams_component hpx_timing)
-set(spinlock_overhead1_FLAGS DEPENDENCIES iostreams_component hpx_timing)
-set(spinlock_overhead2_FLAGS DEPENDENCIES iostreams_component hpx_timing)
+set(foreach_scaling_FLAGS DEPENDENCIES iostreams_component)
+set(spinlock_overhead1_FLAGS DEPENDENCIES iostreams_component)
+set(spinlock_overhead2_FLAGS DEPENDENCIES iostreams_component)
 set(partitioned_vector_foreach_FLAGS DEPENDENCIES iostreams_component
-                                     partitioned_vector_component hpx_timing
+                                     partitioned_vector_component
 )
 
-set(function_object_wrapper_overhead_FLAGS DEPENDENCIES hpx_timing)
-set(hpx_tls_overhead_FLAGS DEPENDENCIES hpx_timing)
-set(native_tls_overhead_FLAGS DEPENDENCIES hpx_timing)
-set(nonconcurrent_fifo_overhead_FLAGS DEPENDENCIES hpx_timing)
-set(nonconcurrent_lifo_overhead_FLAGS DEPENDENCIES hpx_timing)
-set(transform_reduce_scaling_FLAGS DEPENDENCIES hpx_timing)
 set(future_overhead_PARAMETERS THREADS_PER_LOCALITY 4)
 
 # These tests do not run on hpx threads, so we don't want to pass hpx params

--- a/tests/unit/build/CMakeLists.txt
+++ b/tests/unit/build/CMakeLists.txt
@@ -176,25 +176,15 @@ foreach(build_type ${build_types})
   endif()
 endforeach()
 
-# PkgConfig
-if(NOT MSVC
-   AND NOT APPLE
-   AND NOT HPX_WITH_HIP
-)
-  # Disabling test for hipcc since the workaround for one of its bug resulted in
-  # breaking clang-7 CI (with -DHPX_WITH_DYNAMIC_MAIN=OFF)
-  # https://github.com/ROCm-Developer-Tools/HIP/issues/2167#issuecomment-712286173
-  find_package(PkgConfig)
-  if(PKGCONFIG_FOUND)
-    create_pkgconfig_test(
-      pkgconfig_build_dir_test "${PROJECT_BINARY_DIR}/lib/pkgconfig"
-    )
-
-    create_pkgconfig_test(
-      pkgconfig_install_dir_test "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig"
-    )
-  endif()
-endif()
+# TODO: Support pkgconfig? PkgConfig if(NOT MSVC AND NOT APPLE AND NOT
+# HPX_WITH_HIP ) # Disabling test for hipcc since the workaround for one of its
+# bug resulted in # breaking clang-7 CI (with -DHPX_WITH_DYNAMIC_MAIN=OFF) #
+# https://github.com/ROCm-Developer-Tools/HIP/issues/2167#issuecomment-712286173
+# find_package(PkgConfig) if(PKGCONFIG_FOUND) create_pkgconfig_test(
+# pkgconfig_build_dir_test "${PROJECT_BINARY_DIR}/lib/pkgconfig" )
+#
+# create_pkgconfig_test( pkgconfig_install_dir_test
+# "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig" ) endif() endif()
 
 set(build_systems cmake)
 set(cmake_tests build_dir_targets install_dir_targets build_dir_macros
@@ -203,15 +193,9 @@ set(cmake_tests build_dir_targets install_dir_targets build_dir_macros
 if(HPX_WITH_DYNAMIC_HPX_MAIN)
   list(APPEND cmake_tests build_dir_gtest_emulation install_dir_gtest_emulation)
 endif()
-if(NOT CMAKE_TOOLCHAIN_FILE
-   AND PKGCONFIG_FOUND
-   AND NOT MSVC
-   AND NOT APPLE
-   AND NOT HPX_WITH_HIP
-)
-  set(build_systems ${build_systems} pkgconfig)
-  set(pkgconfig_tests build_dir install_dir)
-endif()
+# if(NOT CMAKE_TOOLCHAIN_FILE AND PKGCONFIG_FOUND AND NOT MSVC AND NOT APPLE AND
+# NOT HPX_WITH_HIP ) set(build_systems ${build_systems} pkgconfig)
+# set(pkgconfig_tests build_dir install_dir) endif()
 
 set(system cmake)
 add_hpx_pseudo_target(tests.unit.build.${system})

--- a/tests/unit/build/CMakeLists.txt
+++ b/tests/unit/build/CMakeLists.txt
@@ -68,7 +68,7 @@ function(
     VERBATIM
   )
   add_dependencies(
-    ${name}.make_configure ${name}.make_build_dir hpx hpx_init
+    ${name}.make_configure ${name}.make_build_dir hpx hpx_init hpx_wrap
     iostreams_component
   )
   add_custom_target(


### PR DESCRIPTION
Fixes #4135. Still a draft as I think this will have the same problems as in #4649 (i.e. long configuration times). At least I have not done anything about them. Profiling on Linux gives little useful information and the configuration times are mostly unchanged, so I'll first see what the GitHub actions builders say. @hkaiser at some point I'd need you to test this on Windows, but this is not urgent at all. I'm just opening this up to get this started again.