### PR TITLE
Deprecate tuple and timing functionality in hpx::util

### DIFF
--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -707,29 +707,28 @@ Header ``hpx/tuple.hpp``
 ========================
 
 Corresponds to the C++ standard library header :cppreference-header:`tuple`.
-:cpp:class:`hpx::util::tuple` can be used in CUDA device code, unlike
-``std::tuple``.
+:cpp:class:`hpx::tuple` can be used in CUDA device code, unlike ``std::tuple``.
 
 Constants
 ---------
 
-- :cpp:var:`hpx::util::ignore`
+- :cpp:var:`hpx::ignore`
 
 Classes
 -------
 
-- :cpp:struct:`hpx::util::tuple`
-- :cpp:struct:`hpx::util::tuple_size`
-- :cpp:struct:`hpx::util::tuple_element`
+- :cpp:struct:`hpx::tuple`
+- :cpp:struct:`hpx::tuple_size`
+- :cpp:struct:`hpx::tuple_element`
 
 Functions
 ---------
 
-- :cpp:func:`hpx::util::make_tuple`
-- :cpp:func:`hpx::util::tie`
-- :cpp:func:`hpx::util::forward_as_tuple`
-- :cpp:func:`hpx::util::tuple_cat`
-- :cpp:func:`hpx::util::get`
+- :cpp:func:`hpx::make_tuple`
+- :cpp:func:`hpx::tie`
+- :cpp:func:`hpx::forward_as_tuple`
+- :cpp:func:`hpx::tuple_cat`
+- :cpp:func:`hpx::get`
 
 Header ``hpx/type_traits.hpp``
 ==============================

--- a/examples/quickstart/fibonacci_futures.cpp
+++ b/examples/quickstart/fibonacci_futures.cpp
@@ -40,7 +40,7 @@ std::uint64_t add(
 ///////////////////////////////////////////////////////////////////////////////
 struct when_all_wrapper
 {
-    typedef hpx::util::tuple<
+    typedef hpx::tuple<
             hpx::future<std::uint64_t>
           , hpx::future<std::uint64_t> > data_type;
 
@@ -49,7 +49,7 @@ struct when_all_wrapper
     ) const
     {
         data_type v = data.get();
-        return hpx::util::get<0>(v).get() + hpx::util::get<1>(v).get();
+        return hpx::get<0>(v).get() + hpx::get<1>(v).get();
     }
 };
 

--- a/examples/quickstart/fibonacci_futures_distributed.cpp
+++ b/examples/quickstart/fibonacci_futures_distributed.cpp
@@ -38,7 +38,7 @@ hpx::id_type here;
 
 struct when_all_wrapper
 {
-    typedef hpx::util::tuple<
+    typedef hpx::tuple<
             hpx::lcos::future<std::uint64_t>
           , hpx::lcos::future<std::uint64_t> > data_type;
 
@@ -47,7 +47,7 @@ struct when_all_wrapper
     ) const
     {
         data_type v = data.get();
-        return hpx::util::get<0>(v).get() + hpx::util::get<1>(v).get();
+        return hpx::get<0>(v).get() + hpx::get<1>(v).get();
     }
 };
 

--- a/examples/quickstart/potpourri.cpp
+++ b/examples/quickstart/potpourri.cpp
@@ -14,7 +14,7 @@
 #include <vector>
 
 void final_task(
-    hpx::future<hpx::util::tuple<hpx::future<double>, hpx::future<void>>>)
+    hpx::future<hpx::tuple<hpx::future<double>, hpx::future<void>>>)
 {
     hpx::cout << "in final_task" << hpx::endl;
 }

--- a/examples/quickstart/vector_zip_dotproduct.cpp
+++ b/examples/quickstart/vector_zip_dotproduct.cpp
@@ -24,8 +24,8 @@ int hpx_main()
     std::fill(std::begin(yvalues), std::end(yvalues), 1.0);
 
     using hpx::util::make_zip_iterator;
-    using hpx::util::tuple;
-    using hpx::util::get;
+    using hpx::tuple;
+    using hpx::get;
 
     double result =
         hpx::transform_reduce(

--- a/examples/quickstart/wait_composition.cpp
+++ b/examples/quickstart/wait_composition.cpp
@@ -14,7 +14,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 struct cout_continuation
 {
-    typedef hpx::util::tuple<
+    typedef hpx::tuple<
             hpx::lcos::future<int>
           , hpx::lcos::future<int>
           , hpx::lcos::future<int> > data_type;
@@ -24,9 +24,9 @@ struct cout_continuation
     ) const
     {
         data_type v = data.get();
-        std::cout << hpx::util::get<0>(v).get() << "\n";
-        std::cout << hpx::util::get<1>(v).get() << "\n";
-        std::cout << hpx::util::get<2>(v).get() << "\n";
+        std::cout << hpx::get<0>(v).get() << "\n";
+        std::cout << hpx::get<1>(v).get() << "\n";
+        std::cout << hpx::get<2>(v).get() << "\n";
     }
 };
 ///////////////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/agas/primary_namespace.hpp
+++ b/hpx/runtime/agas/primary_namespace.hpp
@@ -28,7 +28,7 @@ namespace hpx { namespace agas
 
 struct HPX_EXPORT primary_namespace
 {
-    typedef hpx::util::tuple<naming::gid_type, gva, naming::gid_type>
+    typedef hpx::tuple<naming::gid_type, gva, naming::gid_type>
         resolved_type;
 
     static naming::gid_type get_service_instance(std::uint32_t service_locality_id);

--- a/hpx/runtime/agas/server/locality_namespace.hpp
+++ b/hpx/runtime/agas/server/locality_namespace.hpp
@@ -50,7 +50,7 @@ struct HPX_EXPORT locality_namespace
     typedef std::int32_t component_type;
 
     // stores the locality endpoints, and number of OS-threads running on this locality
-    typedef hpx::util::tuple<
+    typedef hpx::tuple<
         parcelset::endpoints_type, std::uint32_t>
     partition_type;
 

--- a/hpx/runtime/agas/server/primary_namespace.hpp
+++ b/hpx/runtime/agas/server/primary_namespace.hpp
@@ -126,7 +126,7 @@ struct HPX_EXPORT primary_namespace
     typedef std::map<naming::gid_type, gva_table_data_type> gva_table_type;
     typedef std::map<naming::gid_type, std::int64_t> refcnt_table_type;
 
-    typedef hpx::util::tuple<naming::gid_type, gva, naming::gid_type>
+    typedef hpx::tuple<naming::gid_type, gva, naming::gid_type>
         resolved_type;
     // }}}
 
@@ -139,7 +139,7 @@ struct HPX_EXPORT primary_namespace
     refcnt_table_type refcnts_;
     typedef std::map<
             naming::gid_type,
-            hpx::util::tuple<bool, std::size_t, lcos::local::detail::condition_variable>
+            hpx::tuple<bool, std::size_t, lcos::local::detail::condition_variable>
         > migration_table_type;
 
     std::string instance_name_;
@@ -299,7 +299,7 @@ public:
         );
 
     std::vector<std::int64_t> decrement_credit(
-        std::vector<hpx::util::tuple<std::int64_t, naming::gid_type,
+        std::vector<hpx::tuple<std::int64_t, naming::gid_type,
             naming::gid_type>> const& requests);
 
     std::pair<naming::gid_type, naming::gid_type> allocate(std::uint64_t count);
@@ -472,7 +472,7 @@ HPX_REGISTER_ACTION_DECLARATION(
 
 HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(
     hpx::naming::address, naming_address)
-typedef hpx::util::tuple<
+typedef hpx::tuple<
         hpx::naming::gid_type, hpx::agas::gva, hpx::naming::gid_type
     > gva_tuple_type;
 HPX_REGISTER_BASE_LCO_WITH_VALUE_DECLARATION(

--- a/hpx/runtime/components/server/console_logging.hpp
+++ b/hpx/runtime/components/server/console_logging.hpp
@@ -25,7 +25,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace components
 {
-    typedef hpx::util::tuple<
+    typedef hpx::tuple<
         logging_destination, std::size_t, std::string
     > message_type;
 

--- a/hpx/runtime/parcelset/parcelport.hpp
+++ b/hpx/runtime/parcelset/parcelport.hpp
@@ -336,7 +336,7 @@ namespace hpx { namespace parcelset
         hpx::applier::applier *applier_;
 
         /// The cache for pending parcels
-        typedef util::tuple<
+        typedef hpx::tuple<
             std::vector<parcel>
           , std::vector<write_handler_type>
         > map_second_type;

--- a/hpx/runtime/parcelset/parcelport_impl.hpp
+++ b/hpx/runtime/parcelset/parcelport_impl.hpp
@@ -628,8 +628,8 @@ namespace hpx { namespace parcelset
             > il(&l);
 
             mapped_type& e = pending_parcels_[locality_id];
-            util::get<0>(e).push_back(std::move(p));
-            util::get<1>(e).push_back(std::move(f));
+            hpx::get<0>(e).push_back(std::move(p));
+            hpx::get<1>(e).push_back(std::move(f));
 
             parcel_destinations_.insert(locality_id);
             ++num_parcel_destinations_;
@@ -652,23 +652,23 @@ namespace hpx { namespace parcelset
             HPX_ASSERT(parcels.size() == handlers.size());
 
             mapped_type& e = pending_parcels_[locality_id];
-            if (util::get<0>(e).empty())
+            if (hpx::get<0>(e).empty())
             {
-                HPX_ASSERT(util::get<1>(e).empty());
-                std::swap(util::get<0>(e), parcels);
-                std::swap(util::get<1>(e), handlers);
+                HPX_ASSERT(hpx::get<1>(e).empty());
+                std::swap(hpx::get<0>(e), parcels);
+                std::swap(hpx::get<1>(e), handlers);
             }
             else
             {
-                HPX_ASSERT(util::get<0>(e).size() == util::get<1>(e).size());
-                std::size_t new_size = util::get<0>(e).size() + parcels.size();
-                util::get<0>(e).reserve(new_size);
+                HPX_ASSERT(hpx::get<0>(e).size() == hpx::get<1>(e).size());
+                std::size_t new_size = hpx::get<0>(e).size() + parcels.size();
+                hpx::get<0>(e).reserve(new_size);
 
                 std::move(parcels.begin(), parcels.end(),
-                    std::back_inserter(util::get<0>(e)));
-                util::get<1>(e).reserve(new_size);
+                    std::back_inserter(hpx::get<0>(e)));
+                hpx::get<1>(e).reserve(new_size);
                 std::move(handlers.begin(), handlers.end(),
-                    std::back_inserter(util::get<1>(e)));
+                    std::back_inserter(hpx::get<1>(e)));
             }
 
             parcel_destinations_.insert(locality_id);
@@ -690,21 +690,21 @@ namespace hpx { namespace parcelset
 
                 // do nothing if parcels have already been picked up by
                 // another thread
-                if (it != pending_parcels_.end() && !util::get<0>(it->second).empty())
+                if (it != pending_parcels_.end() && !hpx::get<0>(it->second).empty())
                 {
                     HPX_ASSERT(it->first == locality_id);
                     HPX_ASSERT(handlers.size() == 0);
                     HPX_ASSERT(handlers.size() == parcels.size());
-                    std::swap(parcels, util::get<0>(it->second));
-                    HPX_ASSERT(util::get<0>(it->second).size() == 0);
-                    std::swap(handlers, util::get<1>(it->second));
+                    std::swap(parcels, hpx::get<0>(it->second));
+                    HPX_ASSERT(hpx::get<0>(it->second).size() == 0);
+                    std::swap(handlers, hpx::get<1>(it->second));
                     HPX_ASSERT(handlers.size() == parcels.size());
 
                     HPX_ASSERT(!handlers.empty());
                 }
                 else
                 {
-                    HPX_ASSERT(util::get<1>(it->second).empty());
+                    HPX_ASSERT(hpx::get<1>(it->second).empty());
                     return false;
                 }
 
@@ -727,10 +727,10 @@ namespace hpx { namespace parcelset
 
                 for (auto &pending: pending_parcels_)
                 {
-                    auto &parcels = util::get<0>(pending.second);
+                    auto &parcels = hpx::get<0>(pending.second);
                     if (!parcels.empty())
                     {
-                        auto& handlers = util::get<1>(pending.second);
+                        auto& handlers = hpx::get<1>(pending.second);
                         dest = pending.first;
                         p = std::move(parcels.back());
                         parcels.pop_back();
@@ -864,7 +864,7 @@ namespace hpx { namespace parcelset
 
 //                HPX_ASSERT(locality_id == sender_connection->destination());
                 pending_parcels_map::iterator it = pending_parcels_.find(locality_id);
-                if (it == pending_parcels_.end() || util::get<0>(it->second).empty())
+                if (it == pending_parcels_.end() || hpx::get<0>(it->second).empty())
                     return;
             }
 

--- a/hpx/util/connection_cache.hpp
+++ b/hpx/util/connection_cache.hpp
@@ -51,7 +51,7 @@ namespace hpx { namespace util
         typedef std::deque<connection_type> value_type;
         typedef Key key_type;
         typedef std::list<key_type> key_tracker_type;
-        typedef util::tuple<
+        typedef hpx::tuple<
             value_type,                 // cached (available) connections
             std::size_t,                // number of existing connections
             std::size_t,                // max number of cached connections
@@ -93,45 +93,45 @@ namespace hpx { namespace util
         static value_type&
         cached_connections(cache_value_type& entry)
         {
-            return util::get<0>(entry);
+            return hpx::get<0>(entry);
         }
         static value_type const&
         cached_connections(cache_value_type const& entry)
         {
-            return util::get<0>(entry);
+            return hpx::get<0>(entry);
         }
 
         static std::size_t&
         num_existing_connections(cache_value_type& entry)
         {
-            return util::get<1>(entry);
+            return hpx::get<1>(entry);
         }
         static std::size_t const&
         num_existing_connections(cache_value_type const& entry)
         {
-            return util::get<1>(entry);
+            return hpx::get<1>(entry);
         }
 
         static std::size_t&
         max_num_connections(cache_value_type& entry)
         {
-            return util::get<2>(entry);
+            return hpx::get<2>(entry);
         }
         static std::size_t const&
         max_num_connections(cache_value_type const& entry)
         {
-            return util::get<2>(entry);
+            return hpx::get<2>(entry);
         }
 
         static typename key_tracker_type::iterator&
         lru_reference(cache_value_type& entry)
         {
-            return util::get<3>(entry);
+            return hpx::get<3>(entry);
         }
         static typename key_tracker_type::iterator const&
         lru_reference(cache_value_type const& entry)
         {
-            return util::get<3>(entry);
+            return hpx::get<3>(entry);
         }
 
         ///////////////////////////////////////////////////////////////////////

--- a/libs/core/affinity/src/parse_affinity_options.cpp
+++ b/libs/core/affinity/src/parse_affinity_options.cpp
@@ -289,15 +289,15 @@ namespace hpx { namespace threads { namespace detail {
 
     ///////////////////////////////////////////////////////////////////////////
     //                  index,       mask
-    typedef util::tuple<std::size_t, mask_type> mask_info;
+    typedef hpx::tuple<std::size_t, mask_type> mask_info;
 
     inline std::size_t get_index(mask_info const& smi)
     {
-        return util::get<0>(smi);
+        return hpx::get<0>(smi);
     }
     inline mask_cref_type get_mask(mask_info const& smi)
     {
-        return util::get<1>(smi);
+        return hpx::get<1>(smi);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/core/datastructures/CMakeLists.txt
+++ b/libs/core/datastructures/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 # Compatibility with using Boost.FileSystem, introduced in V1.4.0
 hpx_option(
   HPX_DATASTRUCTURES_WITH_ADAPT_STD_TUPLE BOOL
-  "Enable compatibility of hpx::util::tuple with std::tuple. (default: ON)" ON
+  "Enable compatibility of hpx::tuple with std::tuple. (default: ON)" ON
   ADVANCED
   CATEGORY "Modules"
   MODULE DATASTRUCTURES

--- a/libs/core/datastructures/include/hpx/datastructures/tagged.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/tagged.hpp
@@ -179,18 +179,21 @@ namespace hpx { namespace util {
             x.swap(y);
         }
     };
+}}    // namespace hpx::util
 
+namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Base, typename... Tags>
-    struct tuple_size<tagged<Base, Tags...>> : tuple_size<Base>
+    struct tuple_size<util::tagged<Base, Tags...>> : tuple_size<Base>
     {
     };
 
     template <size_t N, typename Base, typename... Tags>
-    struct tuple_element<N, tagged<Base, Tags...>> : tuple_element<N, Base>
+    struct tuple_element<N, util::tagged<Base, Tags...>>
+      : tuple_element<N, Base>
     {
     };
-}}    // namespace hpx::util
+}    // namespace hpx
 
 // A tagged getter is an empty trivial class type that has a named member
 // function that returns a reference to a member of a tuple-like object that is
@@ -224,12 +227,11 @@ namespace hpx { namespace util {
             {                                                                  \
                 HPX_FORCEINLINE Type& NAME()                                   \
                 {                                                              \
-                    return hpx::util::get<I>(static_cast<Derived&>(*this));    \
+                    return hpx::get<I>(static_cast<Derived&>(*this));          \
                 }                                                              \
                 constexpr HPX_FORCEINLINE Type const& NAME() const             \
                 {                                                              \
-                    return hpx::util::get<I>(                                  \
-                        static_cast<Derived const&>(*this));                   \
+                    return hpx::get<I>(static_cast<Derived const&>(*this));    \
                 }                                                              \
                                                                                \
             private:                                                           \

--- a/libs/core/datastructures/include/hpx/datastructures/tagged_pair.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/tagged_pair.hpp
@@ -110,19 +110,21 @@ namespace hpx { namespace util {
 
         return result_type(std::forward<T1>(t1), std::forward<T2>(t2));
     }
+}}    // namespace hpx::util
 
+namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Tag1, typename Tag2>
-    struct tuple_size<tagged_pair<Tag1, Tag2>>
+    struct tuple_size<util::tagged_pair<Tag1, Tag2>>
       : std::integral_constant<std::size_t, 2>
     {
     };
 
     template <std::size_t N, typename Tag1, typename Tag2>
-    struct tuple_element<N, tagged_pair<Tag1, Tag2>>
+    struct tuple_element<N, util::tagged_pair<Tag1, Tag2>>
       : tuple_element<N,
-            std::pair<typename detail::tag_elem<Tag1>::type,
-                typename detail::tag_elem<Tag2>::type>>
+            std::pair<typename util::detail::tag_elem<Tag1>::type,
+                typename util::detail::tag_elem<Tag2>::type>>
     {
     };
-}}    // namespace hpx::util
+}    // namespace hpx

--- a/libs/core/datastructures/include/hpx/datastructures/tagged_tuple.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/tagged_tuple.hpp
@@ -92,17 +92,19 @@ namespace hpx { namespace util {
                 type;
         };
     }    // namespace detail
+}}       // namespace hpx::util
 
+namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     template <typename... Ts>
-    struct tuple_size<tagged_tuple<Ts...>>
-      : tuple_size<tuple<typename detail::tag_elem<Ts>::type...>>
+    struct tuple_size<util::tagged_tuple<Ts...>>
+      : tuple_size<tuple<typename util::detail::tag_elem<Ts>::type...>>
     {
     };
 
     template <std::size_t N, typename... Ts>
-    struct tuple_element<N, tagged_tuple<Ts...>>
-      : tuple_element<N, tuple<typename detail::tag_elem<Ts>::type...>>
+    struct tuple_element<N, util::tagged_tuple<Ts...>>
+      : tuple_element<N, tuple<typename util::detail::tag_elem<Ts>::type...>>
     {
     };
-}}    // namespace hpx::util
+}    // namespace hpx

--- a/libs/core/datastructures/include/hpx/datastructures/traits/is_tuple_like.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/traits/is_tuple_like.hpp
@@ -21,7 +21,7 @@ namespace hpx { namespace traits {
         template <typename T>
         struct is_tuple_like_impl<T,
             typename util::always_void<decltype(
-                util::tuple_size<T>::value)>::type> : std::true_type
+                hpx::tuple_size<T>::value)>::type> : std::true_type
         {
         };
     }    // namespace detail

--- a/libs/core/datastructures/include/hpx/datastructures/tuple.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/tuple.hpp
@@ -32,8 +32,7 @@
 #pragma clang diagnostic ignored "-Wmismatched-tags"
 #endif
 
-namespace hpx { namespace util {
-
+namespace hpx {
     template <typename... Ts>
     class tuple;
 
@@ -50,84 +49,83 @@ namespace hpx { namespace util {
 
         template <std::size_t I, typename Tuple,
             typename Enable = typename util::always_void<
-                typename util::tuple_element<I, Tuple>::type>::type>
+                typename tuple_element<I, Tuple>::type>::type>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::tuple_element<I, Tuple>::type&
+            typename tuple_element<I, Tuple>::type&
             get(Tuple& t) noexcept;
 
         template <std::size_t I, typename Tuple,
             typename Enable = typename util::always_void<
-                typename util::tuple_element<I, Tuple>::type>::type>
+                typename tuple_element<I, Tuple>::type>::type>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::tuple_element<I, Tuple>::type const&
+            typename tuple_element<I, Tuple>::type const&
             get(Tuple const& t) noexcept;
 
         template <std::size_t I, typename Tuple,
-            typename Enable =
-                typename util::always_void<typename util::tuple_element<I,
-                    typename std::decay<Tuple>::type>::type>::type>
+            typename Enable = typename util::always_void<typename tuple_element<
+                I, typename std::decay<Tuple>::type>::type>::type>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::tuple_element<I, Tuple>::type&&
+            typename tuple_element<I, Tuple>::type&&
             get(Tuple&& t) noexcept;
 
         template <std::size_t I, typename Tuple,
             typename Enable = typename util::always_void<
-                typename util::tuple_element<I, Tuple>::type>::type>
+                typename tuple_element<I, Tuple>::type>::type>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::tuple_element<I, Tuple>::type const&&
+            typename tuple_element<I, Tuple>::type const&&
             get(Tuple const&& t) noexcept;
     }    // namespace adl_barrier
 
-    // we separate the implementation of util::get for our tuple type so that
+    // we separate the implementation of get for our tuple type so that
     // it can be injected into the std:: namespace
     namespace std_adl_barrier {
 
         template <std::size_t I, typename... Ts>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::tuple_element<I, util::tuple<Ts...>>::type&
-            get(util::tuple<Ts...>& t) noexcept;
+            typename tuple_element<I, tuple<Ts...>>::type&
+            get(tuple<Ts...>& t) noexcept;
 
         template <std::size_t I, typename... Ts>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::tuple_element<I, util::tuple<Ts...>>::type const&
-            get(util::tuple<Ts...> const& t) noexcept;
+            typename tuple_element<I, tuple<Ts...>>::type const&
+            get(tuple<Ts...> const& t) noexcept;
 
         template <std::size_t I, typename... Ts>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::tuple_element<I, util::tuple<Ts...>>::type&&
-            get(util::tuple<Ts...>&& t) noexcept;
+            typename tuple_element<I, tuple<Ts...>>::type&&
+            get(tuple<Ts...>&& t) noexcept;
 
         template <std::size_t I, typename... Ts>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::tuple_element<I, util::tuple<Ts...>>::type const&&
-            get(util::tuple<Ts...> const&& t) noexcept;
+            typename tuple_element<I, tuple<Ts...>>::type const&&
+            get(tuple<Ts...> const&& t) noexcept;
     }    // namespace std_adl_barrier
 
-    using hpx::util::adl_barrier::get;
-    using hpx::util::std_adl_barrier::get;
-}}    // namespace hpx::util
+    using hpx::adl_barrier::get;
+    using hpx::std_adl_barrier::get;
+}    // namespace hpx
 
 #if defined(HPX_DATASTRUCTURES_HAVE_ADAPT_STD_TUPLE)
-// Adapt hpx::util::tuple to be usable with std::tuple
+// Adapt hpx::tuple to be usable with std::tuple
 namespace std {
 
     template <typename... Ts>
-    struct tuple_size<hpx::util::tuple<Ts...>>
-      : public hpx::util::tuple_size<hpx::util::tuple<Ts...>>
+    struct tuple_size<hpx::tuple<Ts...>>
+      : public hpx::tuple_size<hpx::tuple<Ts...>>
     {
     };
 
     template <std::size_t I, typename... Ts>
-    struct tuple_element<I, hpx::util::tuple<Ts...>>
-      : public hpx::util::tuple_element<I, hpx::util::tuple<Ts...>>
+    struct tuple_element<I, hpx::tuple<Ts...>>
+      : public hpx::tuple_element<I, hpx::tuple<Ts...>>
     {
     };
 
-    using hpx::util::std_adl_barrier::get;
+    using hpx::std_adl_barrier::get;
 }    // namespace std
 #endif
 
-namespace hpx { namespace util {
+namespace hpx {
 
     namespace detail {
 
@@ -145,7 +143,7 @@ namespace hpx { namespace util {
                                         UTuple>::type>::value ==
                 util::pack<Ts...>::size>::type>
           : util::all_of<std::is_convertible<
-                decltype(util::get<Is>(std::declval<UTuple>())), Ts>...>
+                decltype(get<Is>(std::declval<UTuple>())), Ts>...>
         {
         };
 
@@ -300,7 +298,7 @@ namespace hpx { namespace util {
         template <std::size_t... Is, typename UTuple>
         constexpr HPX_HOST_DEVICE tuple(util::index_pack<Is...>, UTuple&& other)
           : _members(std::piecewise_construct,
-                util::get<Is>(std::forward<UTuple>(other))...)
+                hpx::get<Is>(std::forward<UTuple>(other))...)
         {
         }
 
@@ -350,7 +348,7 @@ namespace hpx { namespace util {
         {
             int const _sequencer[] = {
                 ((_members.template get<Is>() =
-                         util::get<Is>(std::forward<UTuple>(other))),
+                         hpx::get<Is>(std::forward<UTuple>(other))),
                     0)...};
             (void) _sequencer;
         }
@@ -421,7 +419,7 @@ namespace hpx { namespace util {
         template <std::size_t... Is, typename UTuple>
         std::tuple<Ts...> make_tuple_(util::index_pack<Is...>, UTuple&& t)
         {
-            return std::make_tuple(util::get<Is>(std::forward<UTuple>(t))...);
+            return std::make_tuple(hpx::get<Is>(std::forward<UTuple>(t))...);
         }
 
     public:
@@ -640,10 +638,10 @@ namespace hpx { namespace util {
         // get(tuple<Types...>& t) noexcept;
         template <std::size_t I, typename Tuple, typename Enable>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::tuple_element<I, Tuple>::type&
+            typename tuple_element<I, Tuple>::type&
             get(Tuple& t) noexcept
         {
-            return util::tuple_element<I, Tuple>::get(t);
+            return tuple_element<I, Tuple>::get(t);
         }
 
         // template <size_t I, class... Types>
@@ -651,10 +649,10 @@ namespace hpx { namespace util {
         // get(const tuple<Types...>& t) noexcept;
         template <std::size_t I, typename Tuple, typename Enable>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::tuple_element<I, Tuple>::type const&
+            typename tuple_element<I, Tuple>::type const&
             get(Tuple const& t) noexcept
         {
-            return util::tuple_element<I, Tuple>::get(t);
+            return tuple_element<I, Tuple>::get(t);
         }
 
         // template <size_t I, class... Types>
@@ -662,11 +660,11 @@ namespace hpx { namespace util {
         // get(tuple<Types...>&& t) noexcept;
         template <std::size_t I, typename Tuple, typename Enable>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::tuple_element<I, Tuple>::type&&
+            typename tuple_element<I, Tuple>::type&&
             get(Tuple&& t) noexcept
         {
-            return std::forward<typename util::tuple_element<I, Tuple>::type>(
-                util::get<I>(t));
+            return std::forward<typename tuple_element<I, Tuple>::type>(
+                get<I>(t));
         }
 
         // template <size_t I, class... Types>
@@ -674,12 +672,11 @@ namespace hpx { namespace util {
         // get(const tuple<Types...>&& t) noexcept;
         template <std::size_t I, typename Tuple, typename Enable>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::tuple_element<I, Tuple>::type const&&
+            typename tuple_element<I, Tuple>::type const&&
             get(Tuple const&& t) noexcept
         {
-            return std::forward<
-                typename util::tuple_element<I, Tuple>::type const>(
-                util::get<I>(t));
+            return std::forward<typename tuple_element<I, Tuple>::type const>(
+                get<I>(t));
         }
     }    // namespace adl_barrier
 
@@ -687,37 +684,36 @@ namespace hpx { namespace util {
 
         template <std::size_t I, typename... Ts>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::tuple_element<I, util::tuple<Ts...>>::type&
-            get(util::tuple<Ts...>& t) noexcept
+            typename tuple_element<I, tuple<Ts...>>::type&
+            get(tuple<Ts...>& t) noexcept
         {
-            return util::tuple_element<I, util::tuple<Ts...>>::get(t);
+            return tuple_element<I, tuple<Ts...>>::get(t);
         }
 
         template <std::size_t I, typename... Ts>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::tuple_element<I, util::tuple<Ts...>>::type const&
-            get(util::tuple<Ts...> const& t) noexcept
+            typename tuple_element<I, tuple<Ts...>>::type const&
+            get(tuple<Ts...> const& t) noexcept
         {
-            return util::tuple_element<I, util::tuple<Ts...>>::get(t);
+            return tuple_element<I, tuple<Ts...>>::get(t);
         }
 
         template <std::size_t I, typename... Ts>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::tuple_element<I, util::tuple<Ts...>>::type&&
-            get(util::tuple<Ts...>&& t) noexcept
+            typename tuple_element<I, tuple<Ts...>>::type&&
+            get(tuple<Ts...>&& t) noexcept
+        {
+            return std::forward<typename tuple_element<I, tuple<Ts...>>::type>(
+                get<I>(t));
+        }
+
+        template <std::size_t I, typename... Ts>
+        constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
+            typename tuple_element<I, tuple<Ts...>>::type const&&
+            get(tuple<Ts...> const&& t) noexcept
         {
             return std::forward<
-                typename util::tuple_element<I, util::tuple<Ts...>>::type>(
-                util::get<I>(t));
-        }
-
-        template <std::size_t I, typename... Ts>
-        constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-            typename util::tuple_element<I, util::tuple<Ts...>>::type const&&
-            get(util::tuple<Ts...> const&& t) noexcept
-        {
-            return std::forward<typename util::tuple_element<I,
-                util::tuple<Ts...>>::type const>(util::get<I>(t));
+                typename tuple_element<I, tuple<Ts...>>::type const>(get<I>(t));
         }
     }    // namespace std_adl_barrier
 
@@ -728,10 +724,10 @@ namespace hpx { namespace util {
     // constexpr tuple<VTypes...> make_tuple(Types&&... t);
     template <typename... Ts>
     constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-        tuple<typename decay_unwrap<Ts>::type...>
+        tuple<typename util::decay_unwrap<Ts>::type...>
         make_tuple(Ts&&... vs)
     {
-        return tuple<typename decay_unwrap<Ts>::type...>(
+        return tuple<typename util::decay_unwrap<Ts>::type...>(
             std::forward<Ts>(vs)...);
     }
 
@@ -794,9 +790,9 @@ namespace hpx { namespace util {
             template <typename THead, typename... TTail>
             static constexpr HPX_HOST_DEVICE HPX_FORCEINLINE auto get(
                 THead&& head, TTail&&... /*tail*/) noexcept
-                -> decltype(hpx::util::get<I>(std::forward<THead>(head)))
+                -> decltype(hpx::get<I>(std::forward<THead>(head)))
             {
-                return hpx::util::get<I>(std::forward<THead>(head));
+                return hpx::get<I>(std::forward<THead>(head));
             }
         };
 
@@ -822,10 +818,11 @@ namespace hpx { namespace util {
         struct tuple_cat_result_impl;
 
         template <std::size_t... Is, typename... Tuples>
-        struct tuple_cat_result_impl<index_pack<Is...>, pack<Tuples...>>
+        struct tuple_cat_result_impl<util::index_pack<Is...>,
+            util::pack<Tuples...>>
         {
-            using type =
-                tuple<typename tuple_cat_element<Is, pack<Tuples...>>::type...>;
+            using type = tuple<
+                typename tuple_cat_element<Is, util::pack<Tuples...>>::type...>;
         };
 
         template <typename Indices, typename Tuples>
@@ -834,13 +831,13 @@ namespace hpx { namespace util {
 
         template <std::size_t... Is, typename... Tuples, typename... Tuples_>
         constexpr HPX_HOST_DEVICE HPX_FORCEINLINE auto tuple_cat_impl(
-            index_pack<Is...> is_pack, pack<Tuples...> tuple_pack,
+            util::index_pack<Is...> is_pack, util::pack<Tuples...> tuple_pack,
             Tuples_&&... tuples)
             -> tuple_cat_result_of_t<decltype(is_pack), decltype(tuple_pack)>
         {
             return tuple_cat_result_of_t<decltype(is_pack),
                 decltype(tuple_pack)>{
-                tuple_cat_element<Is, pack<Tuples...>>::get(
+                tuple_cat_element<Is, util::pack<Tuples...>>::get(
                     std::forward<Tuples_>(tuples)...)...};
         }
     }    // namespace detail
@@ -876,7 +873,7 @@ namespace hpx { namespace util {
             static constexpr HPX_HOST_DEVICE HPX_FORCEINLINE bool call(
                 TTuple const& t, UTuple const& u)
             {
-                return util::get<I>(t) == util::get<I>(u) &&
+                return get<I>(t) == get<I>(u) &&
                     tuple_equal_to<I + 1, Size>::call(t, u);
             }
         };
@@ -927,8 +924,8 @@ namespace hpx { namespace util {
             static constexpr HPX_HOST_DEVICE HPX_FORCEINLINE bool call(
                 TTuple const& t, UTuple const& u)
             {
-                return util::get<I>(t) < util::get<I>(u) ||
-                    (!(util::get<I>(u) < util::get<I>(t)) &&
+                return get<I>(t) < get<I>(u) ||
+                    (!(get<I>(u) < get<I>(t)) &&
                         tuple_less_than<I + 1, Size>::call(t, u));
             }
         };
@@ -1014,6 +1011,68 @@ namespace hpx { namespace util {
         x.swap(y);
     }
 #endif
+}    // namespace hpx
+
+namespace hpx { namespace util {
+    HPX_DEPRECATED_V(
+        1, 6, "hpx::util::ignore is deprecated. Use hpx::ignore instead.")
+    hpx::detail::ignore_type const ignore = {};
+
+    template <typename... Ts>
+    using tuple HPX_DEPRECATED_V(
+        1, 6, "hpx::util::tuple is deprecated. Use hpx::tuple instead.") =
+        hpx::tuple<Ts...>;
+    template <typename T>
+    using tuple_size HPX_DEPRECATED_V(1, 6,
+        "hpx::util::tuple_size is deprecated. Use hpx::tuple_size instead.") =
+        hpx::tuple_size<T>;
+    template <std::size_t I, typename T>
+    using tuple_element HPX_DEPRECATED_V(1, 6,
+        "hpx::util::tuple_element is deprecated. Use hpx::tuple_size "
+        "instead.") = hpx::tuple_element<I, T>;
+
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::util::make_tuple is deprecated. Use hpx::make_tuple instead.")
+    template <typename... Ts>
+    constexpr HPX_HOST_DEVICE HPX_FORCEINLINE auto make_tuple(Ts&&... vs)
+    {
+        return hpx::make_tuple(std::forward<Ts>(vs)...);
+    }
+
+    HPX_DEPRECATED_V(
+        1, 6, "hpx::util::tie is deprecated. Use hpx::tie instead.")
+    template <typename... Ts>
+    constexpr HPX_HOST_DEVICE HPX_FORCEINLINE auto tie(Ts&&... vs)
+    {
+        return hpx::tie(std::forward<Ts>(vs)...);
+    }
+
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::util::forward_as_tuple is deprecated. Use hpx::forward_as_tuple "
+        "instead.")
+    template <typename... Ts>
+    constexpr HPX_HOST_DEVICE HPX_FORCEINLINE auto forward_as_tuple(Ts&&... vs)
+    {
+        return hpx::forward_as_tuple(std::forward<Ts>(vs)...);
+    }
+
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::util::tuple_cat is deprecated. Use hpx::tuple_cat "
+        "instead.")
+    template <typename... Ts>
+    constexpr HPX_HOST_DEVICE HPX_FORCEINLINE auto tuple_cat(Ts&&... vs)
+    {
+        return hpx::tuple_cat(std::forward<Ts>(vs)...);
+    }
+
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::util::get is deprecated. Use hpx::get "
+        "instead.")
+    template <typename... Ts>
+    constexpr HPX_HOST_DEVICE HPX_FORCEINLINE auto get(Ts&&... vs)
+    {
+        return hpx::get(std::forward<Ts>(vs)...);
+    }
 }}    // namespace hpx::util
 
 #if defined(HPX_MSVC_WARNING_PRAGMA)

--- a/libs/core/datastructures/tests/regressions/tuple_serialization_803.cpp
+++ b/libs/core/datastructures/tests/regressions/tuple_serialization_803.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 // This test verifies that issue #803 is resolved (Create proper serialization
-// support functions for util::tuple).
+// support functions for hpx::tuple).
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/actions.hpp>
@@ -16,38 +16,38 @@
 
 #include <string>
 
-typedef hpx::util::tuple<int, double, std::string> tuple_type;
-typedef hpx::util::tuple<int, double, std::string> tuple_base_type;
+typedef hpx::tuple<int, double, std::string> tuple_type;
+typedef hpx::tuple<int, double, std::string> tuple_base_type;
 
 void worker1(tuple_type t)
 {
-    HPX_TEST_EQ(hpx::util::get<0>(t), 42);
-    HPX_TEST_EQ(hpx::util::get<1>(t), 3.14);
-    HPX_TEST_EQ(hpx::util::get<2>(t), "test");
+    HPX_TEST_EQ(hpx::get<0>(t), 42);
+    HPX_TEST_EQ(hpx::get<1>(t), 3.14);
+    HPX_TEST_EQ(hpx::get<2>(t), "test");
 }
 HPX_PLAIN_ACTION(worker1);
 
 void worker2(tuple_base_type t)
 {
-    HPX_TEST_EQ(hpx::util::get<0>(t), 42);
-    HPX_TEST_EQ(hpx::util::get<1>(t), 3.14);
-    HPX_TEST_EQ(hpx::util::get<2>(t), "test");
+    HPX_TEST_EQ(hpx::get<0>(t), 42);
+    HPX_TEST_EQ(hpx::get<1>(t), 3.14);
+    HPX_TEST_EQ(hpx::get<2>(t), "test");
 }
 HPX_PLAIN_ACTION(worker2);
 
 void worker1_ref(tuple_type const& t)
 {
-    HPX_TEST_EQ(hpx::util::get<0>(t), 42);
-    HPX_TEST_EQ(hpx::util::get<1>(t), 3.14);
-    HPX_TEST_EQ(hpx::util::get<2>(t), "test");
+    HPX_TEST_EQ(hpx::get<0>(t), 42);
+    HPX_TEST_EQ(hpx::get<1>(t), 3.14);
+    HPX_TEST_EQ(hpx::get<2>(t), "test");
 }
 HPX_PLAIN_ACTION(worker1_ref);
 
 void worker2_ref(tuple_base_type const& t)
 {
-    HPX_TEST_EQ(hpx::util::get<0>(t), 42);
-    HPX_TEST_EQ(hpx::util::get<1>(t), 3.14);
-    HPX_TEST_EQ(hpx::util::get<2>(t), "test");
+    HPX_TEST_EQ(hpx::get<0>(t), 42);
+    HPX_TEST_EQ(hpx::get<1>(t), 3.14);
+    HPX_TEST_EQ(hpx::get<2>(t), "test");
 }
 HPX_PLAIN_ACTION(worker2_ref);
 

--- a/libs/core/datastructures/tests/unit/is_tuple_like.cpp
+++ b/libs/core/datastructures/tests/unit/is_tuple_like.cpp
@@ -17,7 +17,7 @@ void tuple_like_true()
 {
     using hpx::traits::is_tuple_like;
 
-    HPX_TEST_EQ((is_tuple_like<hpx::util::tuple<int, int, int>>::value), true);
+    HPX_TEST_EQ((is_tuple_like<hpx::tuple<int, int, int>>::value), true);
     HPX_TEST_EQ((is_tuple_like<std::pair<int, int>>::value), true);
     HPX_TEST_EQ((is_tuple_like<std::array<int, 4>>::value), true);
 }

--- a/libs/core/datastructures/tests/unit/tagged.cpp
+++ b/libs/core/datastructures/tests/unit/tagged.cpp
@@ -76,8 +76,8 @@ void tagged_pair_test()
     {
         pair p(42, 43);
 
-        HPX_TEST_EQ(hpx::util::get<0>(p).value_, 42);
-        HPX_TEST_EQ(hpx::util::get<1>(p).value_, 43);
+        HPX_TEST_EQ(hpx::get<0>(p).value_, 42);
+        HPX_TEST_EQ(hpx::get<1>(p).value_, 43);
     }
 
     {
@@ -105,16 +105,13 @@ void tagged_tuple_test()
         tuple t;
 
         static_assert(
-            std::is_same<typename hpx::util::tuple_element<0, tuple>::type,
-                A>::value,
+            std::is_same<typename hpx::tuple_element<0, tuple>::type, A>::value,
             "");
         static_assert(
-            std::is_same<typename hpx::util::tuple_element<1, tuple>::type,
-                B>::value,
+            std::is_same<typename hpx::tuple_element<1, tuple>::type, B>::value,
             "");
         static_assert(
-            std::is_same<typename hpx::util::tuple_element<2, tuple>::type,
-                C>::value,
+            std::is_same<typename hpx::tuple_element<2, tuple>::type, C>::value,
             "");
 
         static_assert(
@@ -142,9 +139,9 @@ void tagged_tuple_test()
     {
         tuple t(42, 43, 44);
 
-        HPX_TEST_EQ(hpx::util::get<0>(t).value_, 42);
-        HPX_TEST_EQ(hpx::util::get<1>(t).value_, 43);
-        HPX_TEST_EQ(hpx::util::get<2>(t).value_, 44);
+        HPX_TEST_EQ(hpx::get<0>(t).value_, 42);
+        HPX_TEST_EQ(hpx::get<1>(t).value_, 43);
+        HPX_TEST_EQ(hpx::get<2>(t).value_, 44);
     }
 
     {
@@ -160,7 +157,7 @@ void tagged_tuple_test()
     {
         using hpx::util::make_tagged_tuple;
         tuple t = make_tagged_tuple<tag::tag1, tag::tag2, tag::tag3>(
-            hpx::util::make_tuple(42, 43, 44));
+            hpx::make_tuple(42, 43, 44));
 
         HPX_TEST_EQ(t.tag1().value_, 42);
         HPX_TEST_EQ(t.tag2().value_, 43);

--- a/libs/core/datastructures/tests/unit/tuple.cpp
+++ b/libs/core/datastructures/tests/unit/tuple.cpp
@@ -121,76 +121,73 @@ public:
 // Testing different element types --------------------------------------------
 // ----------------------------------------------------------------------------
 
-typedef hpx::util::tuple<int> t1;
-typedef hpx::util::tuple<double&, const double&, const double, double*,
-    const double*>
+typedef hpx::tuple<int> t1;
+typedef hpx::tuple<double&, const double&, const double, double*, const double*>
     t2;
-typedef hpx::util::tuple<A, int (*)(char, int), C> t3;
-typedef hpx::util::tuple<std::string, std::pair<A, B>> t4;
-typedef hpx::util::tuple<A*, hpx::util::tuple<const A*, const B&, C>, bool,
-    void*>
-    t5;
-typedef hpx::util::tuple<volatile int, const volatile char&, int (&)(float)> t6;
-typedef hpx::util::tuple<B (A::*)(C&), A&> t7;
+typedef hpx::tuple<A, int (*)(char, int), C> t3;
+typedef hpx::tuple<std::string, std::pair<A, B>> t4;
+typedef hpx::tuple<A*, hpx::tuple<const A*, const B&, C>, bool, void*> t5;
+typedef hpx::tuple<volatile int, const volatile char&, int (&)(float)> t6;
+typedef hpx::tuple<B (A::*)(C&), A&> t7;
 
 // -----------------------------------------------------------------------
 // -tuple construction tests ---------------------------------------------
 // -----------------------------------------------------------------------
 
 no_copy y;
-hpx::util::tuple<no_copy&> x = hpx::util::tuple<no_copy&>(y);    // ok
+hpx::tuple<no_copy&> x = hpx::tuple<no_copy&>(y);    // ok
 
 char cs[10];
-hpx::util::tuple<char (&)[10]> v2(cs);    // ok
+hpx::tuple<char (&)[10]> v2(cs);    // ok
 
 void construction_test()
 {
-    hpx::util::tuple<int> t1;
-    HPX_TEST_EQ(hpx::util::get<0>(t1), int());
+    hpx::tuple<int> t1;
+    HPX_TEST_EQ(hpx::get<0>(t1), int());
 
-    hpx::util::tuple<float> t2(5.5f);
-    HPX_TEST_RANGE(hpx::util::get<0>(t2), 5.4f, 5.6f);
+    hpx::tuple<float> t2(5.5f);
+    HPX_TEST_RANGE(hpx::get<0>(t2), 5.4f, 5.6f);
 
-    hpx::util::tuple<foo> t3(foo(12));
-    HPX_TEST(hpx::util::get<0>(t3) == foo(12));
+    hpx::tuple<foo> t3(foo(12));
+    HPX_TEST(hpx::get<0>(t3) == foo(12));
 
-    hpx::util::tuple<double> t4(t2);
-    HPX_TEST_RANGE(hpx::util::get<0>(t4), 5.4f, 5.6f);
+    hpx::tuple<double> t4(t2);
+    HPX_TEST_RANGE(hpx::get<0>(t4), 5.4f, 5.6f);
 
-    hpx::util::tuple<int, float> t5;
-    HPX_TEST_EQ(hpx::util::get<0>(t5), int());
-    HPX_TEST_EQ(hpx::util::get<1>(t5), float());
+    hpx::tuple<int, float> t5;
+    HPX_TEST_EQ(hpx::get<0>(t5), int());
+    HPX_TEST_EQ(hpx::get<1>(t5), float());
 
-    hpx::util::tuple<int, float> t6(12, 5.5f);
-    HPX_TEST_EQ(hpx::util::get<0>(t6), 12);
-    HPX_TEST_RANGE(hpx::util::get<1>(t6), 5.4f, 5.6f);
+    hpx::tuple<int, float> t6(12, 5.5f);
+    HPX_TEST_EQ(hpx::get<0>(t6), 12);
+    HPX_TEST_RANGE(hpx::get<1>(t6), 5.4f, 5.6f);
 
-    hpx::util::tuple<int, float> t7(t6);
-    HPX_TEST_EQ(hpx::util::get<0>(t7), 12);
-    HPX_TEST_RANGE(hpx::util::get<1>(t7), 5.4f, 5.6f);
+    hpx::tuple<int, float> t7(t6);
+    HPX_TEST_EQ(hpx::get<0>(t7), 12);
+    HPX_TEST_RANGE(hpx::get<1>(t7), 5.4f, 5.6f);
 
-    hpx::util::tuple<long, double> t8(t6);
-    HPX_TEST_EQ(hpx::util::get<0>(t8), 12);
-    HPX_TEST_RANGE(hpx::util::get<1>(t8), 5.4f, 5.6f);
+    hpx::tuple<long, double> t8(t6);
+    HPX_TEST_EQ(hpx::get<0>(t8), 12);
+    HPX_TEST_RANGE(hpx::get<1>(t8), 5.4f, 5.6f);
 
-    dummy(hpx::util::tuple<no_def_constructor, no_def_constructor,
+    dummy(hpx::tuple<no_def_constructor, no_def_constructor,
         no_def_constructor>(std::string("Jaba"),    // ok, since the default
         std::string("Daba"),                        // constructor is not used
         std::string("Doo")));
 
     // testing default values
-    dummy(hpx::util::tuple<int, double>());
-    dummy(hpx::util::tuple<int, double>(1, 3.14));
+    dummy(hpx::tuple<int, double>());
+    dummy(hpx::tuple<int, double>(1, 3.14));
 
-    //dummy(hpx::util::tuple<double&>()); // should fail, not defaults for references
-    //dummy(hpx::util::tuple<const double&>()); // likewise
+    //dummy(hpx::tuple<double&>()); // should fail, not defaults for references
+    //dummy(hpx::tuple<const double&>()); // likewise
 
     double dd = 5;
-    dummy(hpx::util::tuple<double&>(dd));    // ok
+    dummy(hpx::tuple<double&>(dd));    // ok
 
-    dummy(hpx::util::tuple<const double&>(dd + 3.14));    // ok, but dangerous
+    dummy(hpx::tuple<const double&>(dd + 3.14));    // ok, but dangerous
 
-    //dummy(hpx::util::tuple<double&>(dd+3.14)); // should fail,
+    //dummy(hpx::tuple<double&>(dd+3.14)); // should fail,
     // temporary to non-const reference
 }
 
@@ -202,46 +199,47 @@ void element_access_test()
 {
     double d = 2.7;
     A a;
-    hpx::util::tuple<int, double&, const A&, int> t(1, d, a, 2);
-    const hpx::util::tuple<int, double&, const A, int> ct = t;
+    hpx::tuple<int, double&, const A&, int> t(1, d, a, 2);
+    const hpx::tuple<int, double&, const A, int> ct = t;
 
-    int i = hpx::util::get<0>(t);
-    int i2 = hpx::util::get<3>(t);
+    int i = hpx::get<0>(t);
+    int i2 = hpx::get<3>(t);
 
     HPX_TEST(i == 1 && i2 == 2);
 
-    int j = hpx::util::get<0>(ct);
+    int j = hpx::get<0>(ct);
     HPX_TEST_EQ(j, 1);
 
-    HPX_TEST(hpx::util::get<0>(t) = 5);
+    HPX_TEST(hpx::get<0>(t) = 5);
 
-    //hpx::util::get<0>(ct) = 5; // can't assign to const
+    //hpx::get<0>(ct) = 5; // can't assign to const
 
-    double e = hpx::util::get<1>(t);
+    double e = hpx::get<1>(t);
     HPX_TEST_RANGE(e, 2.69, 2.71);
 
-    hpx::util::get<1>(t) = 3.14 + i;
-    HPX_TEST_RANGE(hpx::util::get<1>(t), 4.13, 4.15);
+    hpx::get<1>(t) = 3.14 + i;
+    HPX_TEST_RANGE(hpx::get<1>(t), 4.13, 4.15);
 
-    //hpx::util::get<2>(t) = A(); // can't assign to const
-    //dummy(hpx::util::get<4>(ct)); // illegal index
+    //hpx::get<2>(t) = A(); // can't assign to const
+    //dummy(hpx::get<4>(ct)); // illegal index
 
-    ++hpx::util::get<0>(t);
-    HPX_TEST_EQ(hpx::util::get<0>(t), 6);
+    ++hpx::get<0>(t);
+    HPX_TEST_EQ(hpx::get<0>(t), 6);
 
-    HPX_TEST((std::is_const<hpx::util::tuple_element<0,
-                  hpx::util::tuple<int, float>>::type>::value != true));
-    HPX_TEST((std::is_const<hpx::util::tuple_element<0,
-            const hpx::util::tuple<int, float>>::type>::value));
+    HPX_TEST((std::is_const<
+                  hpx::tuple_element<0, hpx::tuple<int, float>>::type>::value !=
+        true));
+    HPX_TEST((std::is_const<
+        hpx::tuple_element<0, const hpx::tuple<int, float>>::type>::value));
 
-    HPX_TEST((std::is_const<hpx::util::tuple_element<1,
-                  hpx::util::tuple<int, float>>::type>::value != true));
-    HPX_TEST((std::is_const<hpx::util::tuple_element<1,
-            const hpx::util::tuple<int, float>>::type>::value));
+    HPX_TEST((std::is_const<
+                  hpx::tuple_element<1, hpx::tuple<int, float>>::type>::value !=
+        true));
+    HPX_TEST((std::is_const<
+        hpx::tuple_element<1, const hpx::tuple<int, float>>::type>::value));
 
-    HPX_TEST(
-        (std::is_same<hpx::util::tuple_element<1, std::array<float, 4>>::type,
-            float>::value));
+    HPX_TEST((std::is_same<hpx::tuple_element<1, std::array<float, 4>>::type,
+        float>::value));
 
     dummy(i);
     dummy(i2);
@@ -255,28 +253,28 @@ void element_access_test()
 
 void copy_test()
 {
-    hpx::util::tuple<int, char> t1(4, 'a');
-    hpx::util::tuple<int, char> t2(5, 'b');
+    hpx::tuple<int, char> t1(4, 'a');
+    hpx::tuple<int, char> t2(5, 'b');
     t2 = t1;
-    HPX_TEST_EQ(hpx::util::get<0>(t1), hpx::util::get<0>(t2));
-    HPX_TEST_EQ(hpx::util::get<1>(t1), hpx::util::get<1>(t2));
+    HPX_TEST_EQ(hpx::get<0>(t1), hpx::get<0>(t2));
+    HPX_TEST_EQ(hpx::get<1>(t1), hpx::get<1>(t2));
 
-    hpx::util::tuple<long, std::string> t3(2, "a");
+    hpx::tuple<long, std::string> t3(2, "a");
     t3 = t1;
-    HPX_TEST_EQ((double) hpx::util::get<0>(t1), hpx::util::get<0>(t3));
-    HPX_TEST_EQ(hpx::util::get<1>(t1), hpx::util::get<1>(t3)[0]);
+    HPX_TEST_EQ((double) hpx::get<0>(t1), hpx::get<0>(t3));
+    HPX_TEST_EQ(hpx::get<1>(t1), hpx::get<1>(t3)[0]);
 
     // testing copy and assignment with implicit conversions between elements
     // testing tie
 
-    hpx::util::tuple<char, BB*, BB, DD> t;
-    hpx::util::tuple<int, AA*, CC, CC> a(t);
+    hpx::tuple<char, BB*, BB, DD> t;
+    hpx::tuple<int, AA*, CC, CC> a(t);
     a = t;
 
     int i;
     char c;
     double d;
-    hpx::util::tie(i, c, d) = hpx::util::make_tuple(1, 'a', 5.5);
+    hpx::util::tie(i, c, d) = hpx::make_tuple(1, 'a', 5.5);
 
     HPX_TEST_EQ(i, 1);
     HPX_TEST_EQ(c, 'a');
@@ -285,16 +283,16 @@ void copy_test()
 
 void mutate_test()
 {
-    hpx::util::tuple<int, float, bool, foo> t1(5, 12.2f, true, foo(4));
-    hpx::util::get<0>(t1) = 6;
-    hpx::util::get<1>(t1) = 2.2f;
-    hpx::util::get<2>(t1) = false;
-    hpx::util::get<3>(t1) = foo(5);
+    hpx::tuple<int, float, bool, foo> t1(5, 12.2f, true, foo(4));
+    hpx::get<0>(t1) = 6;
+    hpx::get<1>(t1) = 2.2f;
+    hpx::get<2>(t1) = false;
+    hpx::get<3>(t1) = foo(5);
 
-    HPX_TEST_EQ(hpx::util::get<0>(t1), 6);
-    HPX_TEST_RANGE(hpx::util::get<1>(t1), 2.1f, 2.3f);
-    HPX_TEST_EQ(hpx::util::get<2>(t1), false);
-    HPX_TEST(hpx::util::get<3>(t1) == foo(5));
+    HPX_TEST_EQ(hpx::get<0>(t1), 6);
+    HPX_TEST_RANGE(hpx::get<1>(t1), 2.1f, 2.3f);
+    HPX_TEST_EQ(hpx::get<2>(t1), false);
+    HPX_TEST(hpx::get<3>(t1) == foo(5));
 }
 
 // ----------------------------------------------------------------------------
@@ -303,47 +301,47 @@ void mutate_test()
 
 void make_tuple_test()
 {
-    hpx::util::tuple<int, char> t1 = hpx::util::make_tuple(5, 'a');
-    HPX_TEST_EQ(hpx::util::get<0>(t1), 5);
-    HPX_TEST_EQ(hpx::util::get<1>(t1), 'a');
+    hpx::tuple<int, char> t1 = hpx::make_tuple(5, 'a');
+    HPX_TEST_EQ(hpx::get<0>(t1), 5);
+    HPX_TEST_EQ(hpx::get<1>(t1), 'a');
 
-    hpx::util::tuple<int, std::string> t2;
-    t2 = hpx::util::make_tuple((short int) 2, std::string("Hi"));
-    HPX_TEST_EQ(hpx::util::get<0>(t2), 2);
-    HPX_TEST_EQ(hpx::util::get<1>(t2), "Hi");
+    hpx::tuple<int, std::string> t2;
+    t2 = hpx::make_tuple((short int) 2, std::string("Hi"));
+    HPX_TEST_EQ(hpx::get<0>(t2), 2);
+    HPX_TEST_EQ(hpx::get<1>(t2), "Hi");
 
     A a = A();
     B b;
     const A ca = a;
-    hpx::util::make_tuple(std::cref(a), b);
-    hpx::util::make_tuple(std::ref(a), b);
-    hpx::util::make_tuple(std::ref(a), std::cref(b));
+    hpx::make_tuple(std::cref(a), b);
+    hpx::make_tuple(std::ref(a), b);
+    hpx::make_tuple(std::ref(a), std::cref(b));
 
-    hpx::util::make_tuple(std::ref(ca));
+    hpx::make_tuple(std::ref(ca));
 
     // the result of make_tuple is assignable:
-    HPX_TEST(hpx::util::make_tuple(2, 4, 6) ==
-        (hpx::util::make_tuple(1, 2, 3) = hpx::util::make_tuple(2, 4, 6)));
+    HPX_TEST(hpx::make_tuple(2, 4, 6) ==
+        (hpx::make_tuple(1, 2, 3) = hpx::make_tuple(2, 4, 6)));
 
-    hpx::util::make_tuple("Donald", "Daisy");    // should work;
+    hpx::make_tuple("Donald", "Daisy");    // should work;
 
     // You can store a reference to a function in a tuple
-    hpx::util::tuple<void (&)()> adf(make_tuple_test);
+    hpx::tuple<void (&)()> adf(make_tuple_test);
 
     dummy(adf);    // avoid warning for unused variable
 
     // But make_tuple doesn't work (in C++03)
     // with function references, since it creates a const qualified function type
 
-    hpx::util::make_tuple(make_tuple_test);
+    hpx::make_tuple(make_tuple_test);
 
     // With function pointers, make_tuple works just fine
 
-    hpx::util::make_tuple(&make_tuple_test);
+    hpx::make_tuple(&make_tuple_test);
 
     // wrapping it the function reference with ref
 
-    // hpx::util::make_tuple(ref(foo3));
+    // hpx::make_tuple(ref(foo3));
 }
 
 void tie_test()
@@ -352,13 +350,13 @@ void tie_test()
     char b;
     foo c(5);
 
-    hpx::util::tie(a, b, c) = hpx::util::make_tuple(2, 'a', foo(3));
+    hpx::util::tie(a, b, c) = hpx::make_tuple(2, 'a', foo(3));
     HPX_TEST_EQ(a, 2);
     HPX_TEST_EQ(b, 'a');
     HPX_TEST(c == foo(3));
 
-    hpx::util::tie(a, hpx::util::ignore, c) =
-        hpx::util::make_tuple((short int) 5, false, foo(5));
+    hpx::util::tie(a, hpx::ignore, c) =
+        hpx::make_tuple((short int) 5, false, foo(5));
     HPX_TEST_EQ(a, 5);
     HPX_TEST_EQ(b, 'a');
     HPX_TEST(c == foo(5));
@@ -368,7 +366,7 @@ void tie_test()
     hpx::util::tie(i, j) = std::make_pair(1, 2);
     HPX_TEST(i == 1 && j == 2);
 
-    hpx::util::tuple<int, int, float> ta;
+    hpx::tuple<int, int, float> ta;
     //ta = std::make_pair(1, 2); // should fail, tuple is of length 3, not 2
 
     dummy(ta);
@@ -379,42 +377,41 @@ void tie_test()
 // ----------------------------------------------------------------------------
 void tuple_cat_test()
 {
-    hpx::util::tuple<int, float> two = hpx::util::make_tuple(1, 2.f);
+    hpx::tuple<int, float> two = hpx::make_tuple(1, 2.f);
 
     // Cat two tuples
     {
-        hpx::util::tuple<int, float, int, float> res =
-            hpx::util::tuple_cat(two, two);
+        hpx::tuple<int, float, int, float> res = hpx::tuple_cat(two, two);
 
-        auto expected = hpx::util::make_tuple(1, 2.f, 1, 2.f);
+        auto expected = hpx::make_tuple(1, 2.f, 1, 2.f);
 
         HPX_TEST(res == expected);
     }
 
     // Cat multiple tuples
     {
-        hpx::util::tuple<int, float, int, float, int, float> res =
-            hpx::util::tuple_cat(two, two, two);
+        hpx::tuple<int, float, int, float, int, float> res =
+            hpx::tuple_cat(two, two, two);
 
-        auto expected = hpx::util::make_tuple(1, 2.f, 1, 2.f, 1, 2.f);
+        auto expected = hpx::make_tuple(1, 2.f, 1, 2.f, 1, 2.f);
 
         HPX_TEST(res == expected);
     }
 
     // Cat move only types
     {
-        auto t0 = hpx::util::make_tuple(std::unique_ptr<int>(new int(0)));
-        auto t1 = hpx::util::make_tuple(std::unique_ptr<int>(new int(1)));
-        auto t2 = hpx::util::make_tuple(std::unique_ptr<int>(new int(2)));
+        auto t0 = hpx::make_tuple(std::unique_ptr<int>(new int(0)));
+        auto t1 = hpx::make_tuple(std::unique_ptr<int>(new int(1)));
+        auto t2 = hpx::make_tuple(std::unique_ptr<int>(new int(2)));
 
-        hpx::util::tuple<std::unique_ptr<int>, std::unique_ptr<int>,
+        hpx::tuple<std::unique_ptr<int>, std::unique_ptr<int>,
             std::unique_ptr<int>>
-            result = hpx::util::tuple_cat(
-                std::move(t0), std::move(t1), std::move(t2));
+            result =
+                hpx::tuple_cat(std::move(t0), std::move(t1), std::move(t2));
 
-        HPX_TEST_EQ((*hpx::util::get<0>(result)), 0);
-        HPX_TEST_EQ((*hpx::util::get<1>(result)), 1);
-        HPX_TEST_EQ((*hpx::util::get<2>(result)), 2);
+        HPX_TEST_EQ((*hpx::get<0>(result)), 0);
+        HPX_TEST_EQ((*hpx::get<1>(result)), 1);
+        HPX_TEST_EQ((*hpx::get<2>(result)), 2);
     }
 
     // Don't move references unconditionally (copyable types)
@@ -422,14 +419,14 @@ void tuple_cat_test()
         int i1 = 11;
         int i2 = 22;
 
-        hpx::util::tuple<int&> f1 = hpx::util::forward_as_tuple(i1);
-        hpx::util::tuple<int&&> f2 = hpx::util::forward_as_tuple(std::move(i2));
+        hpx::tuple<int&> f1 = hpx::forward_as_tuple(i1);
+        hpx::tuple<int&&> f2 = hpx::forward_as_tuple(std::move(i2));
 
-        hpx::util::tuple<int&, int&&> result =
-            hpx::util::tuple_cat(std::move(f1), std::move(f2));
+        hpx::tuple<int&, int&&> result =
+            hpx::tuple_cat(std::move(f1), std::move(f2));
 
-        HPX_TEST_EQ((hpx::util::get<0>(result)), 11);
-        HPX_TEST_EQ((hpx::util::get<1>(result)), 22);
+        HPX_TEST_EQ((hpx::get<0>(result)), 11);
+        HPX_TEST_EQ((hpx::get<1>(result)), 22);
     }
 
     // Don't move references unconditionally (move only types)
@@ -437,16 +434,15 @@ void tuple_cat_test()
         std::unique_ptr<int> i1(new int(11));
         std::unique_ptr<int> i2(new int(22));
 
-        hpx::util::tuple<std::unique_ptr<int>&> f1 =
-            hpx::util::forward_as_tuple(i1);
-        hpx::util::tuple<std::unique_ptr<int>&&> f2 =
-            hpx::util::forward_as_tuple(std::move(i2));
+        hpx::tuple<std::unique_ptr<int>&> f1 = hpx::forward_as_tuple(i1);
+        hpx::tuple<std::unique_ptr<int>&&> f2 =
+            hpx::forward_as_tuple(std::move(i2));
 
-        hpx::util::tuple<std::unique_ptr<int>&, std::unique_ptr<int>&&> result =
-            hpx::util::tuple_cat(std::move(f1), std::move(f2));
+        hpx::tuple<std::unique_ptr<int>&, std::unique_ptr<int>&&> result =
+            hpx::tuple_cat(std::move(f1), std::move(f2));
 
-        HPX_TEST_EQ((*hpx::util::get<0>(result)), 11);
-        HPX_TEST_EQ((*hpx::util::get<1>(result)), 22);
+        HPX_TEST_EQ((*hpx::get<0>(result)), 11);
+        HPX_TEST_EQ((*hpx::get<1>(result)), 22);
     }
 }
 
@@ -456,12 +452,12 @@ void tuple_cat_test()
 
 void equality_test()
 {
-    hpx::util::tuple<int, char> t1(5, 'a');
-    hpx::util::tuple<int, char> t2(5, 'a');
+    hpx::tuple<int, char> t1(5, 'a');
+    hpx::tuple<int, char> t2(5, 'a');
     HPX_TEST(t1 == t2);
 
-    hpx::util::tuple<int, char> t3(5, 'b');
-    hpx::util::tuple<int, char> t4(2, 'a');
+    hpx::tuple<int, char> t3(5, 'b');
+    hpx::tuple<int, char> t4(2, 'a');
     HPX_TEST(t1 != t3);
     HPX_TEST(t1 != t4);
     HPX_TEST(!(t1 != t2));
@@ -473,9 +469,9 @@ void equality_test()
 
 void ordering_test()
 {
-    hpx::util::tuple<int, float> t1(4, 3.3f);
-    hpx::util::tuple<short, float> t2(5, 3.3f);
-    hpx::util::tuple<long, double> t3(5, 4.4);
+    hpx::tuple<int, float> t1(4, 3.3f);
+    hpx::tuple<short, float> t2(5, 3.3f);
+    hpx::tuple<long, double> t3(5, 4.4);
     HPX_TEST(t1 < t2);
     HPX_TEST(t1 <= t2);
     HPX_TEST(t2 > t1);
@@ -491,9 +487,9 @@ void ordering_test()
 // ----------------------------------------------------------------------------
 void const_tuple_test()
 {
-    const hpx::util::tuple<int, float> t1(5, 3.3f);
-    HPX_TEST_EQ(hpx::util::get<0>(t1), 5);
-    HPX_TEST_EQ(hpx::util::get<1>(t1), 3.3f);
+    const hpx::tuple<int, float> t1(5, 3.3f);
+    HPX_TEST_EQ(hpx::get<0>(t1), 5);
+    HPX_TEST_EQ(hpx::get<1>(t1), 3.3f);
 }
 
 // ----------------------------------------------------------------------------
@@ -501,15 +497,15 @@ void const_tuple_test()
 // ----------------------------------------------------------------------------
 void tuple_length_test()
 {
-    typedef hpx::util::tuple<int, float, double> t1;
-    typedef hpx::util::tuple<> t2;
+    typedef hpx::tuple<int, float, double> t1;
+    typedef hpx::tuple<> t2;
 
-    HPX_TEST_EQ(hpx::util::tuple_size<t1>::value, std::size_t(3));
-    HPX_TEST_EQ(hpx::util::tuple_size<t2>::value, std::size_t(0));
+    HPX_TEST_EQ(hpx::tuple_size<t1>::value, std::size_t(3));
+    HPX_TEST_EQ(hpx::tuple_size<t2>::value, std::size_t(0));
 
     {
         using t3 = std::array<int, 4>;
-        HPX_TEST_EQ(hpx::util::tuple_size<t3>::value, std::size_t(4));
+        HPX_TEST_EQ(hpx::tuple_size<t3>::value, std::size_t(4));
     }
 }
 
@@ -520,21 +516,21 @@ void tuple_swap_test()
 {
     using std::swap;
 
-    hpx::util::tuple<int, float, double> t1(1, 2.0f, 3.0), t2(4, 5.0f, 6.0);
+    hpx::tuple<int, float, double> t1(1, 2.0f, 3.0), t2(4, 5.0f, 6.0);
     swap(t1, t2);
-    HPX_TEST_EQ(hpx::util::get<0>(t1), 4);
-    HPX_TEST_EQ(hpx::util::get<1>(t1), 5.0f);
-    HPX_TEST_EQ(hpx::util::get<2>(t1), 6.0);
-    HPX_TEST_EQ(hpx::util::get<0>(t2), 1);
-    HPX_TEST_EQ(hpx::util::get<1>(t2), 2.0f);
-    HPX_TEST_EQ(hpx::util::get<2>(t2), 3.0);
+    HPX_TEST_EQ(hpx::get<0>(t1), 4);
+    HPX_TEST_EQ(hpx::get<1>(t1), 5.0f);
+    HPX_TEST_EQ(hpx::get<2>(t1), 6.0);
+    HPX_TEST_EQ(hpx::get<0>(t2), 1);
+    HPX_TEST_EQ(hpx::get<1>(t2), 2.0f);
+    HPX_TEST_EQ(hpx::get<2>(t2), 3.0);
 
     int i = 1, j = 2;
 
-    hpx::util::tuple<int&> t3(i), t4(j);
+    hpx::tuple<int&> t3(i), t4(j);
     swap(t3, t4);
-    HPX_TEST_EQ(hpx::util::get<0>(t3), 2);
-    HPX_TEST_EQ(hpx::util::get<0>(t4), 1);
+    HPX_TEST_EQ(hpx::get<0>(t3), 2);
+    HPX_TEST_EQ(hpx::get<0>(t4), 1);
     HPX_TEST_EQ(i, 2);
     HPX_TEST_EQ(j, 1);
 }
@@ -542,39 +538,39 @@ void tuple_swap_test()
 void tuple_std_test()
 {
 #if defined(HPX_DATASTRUCTURES_HAVE_ADAPT_STD_TUPLE)
-    hpx::util::tuple<int, float, double> t1(1, 2.0f, 3.0);
+    hpx::tuple<int, float, double> t1(1, 2.0f, 3.0);
     std::tuple<int, float, double> t2 = t1;
-    hpx::util::tuple<int, float, double> t3 = t2;
+    hpx::tuple<int, float, double> t3 = t2;
     HPX_TEST_EQ(std::get<0>(t1), 1);
     HPX_TEST_EQ(std::get<0>(t2), 1);
     HPX_TEST_EQ(std::get<0>(t3), 1);
 
-    HPX_TEST_EQ(hpx::util::get<0>(t1), 1);
-    HPX_TEST_EQ(hpx::util::get<0>(t2), 1);
-    HPX_TEST_EQ(hpx::util::get<0>(t3), 1);
+    HPX_TEST_EQ(hpx::get<0>(t1), 1);
+    HPX_TEST_EQ(hpx::get<0>(t2), 1);
+    HPX_TEST_EQ(hpx::get<0>(t3), 1);
 
     HPX_TEST_EQ(std::get<1>(t1), 2.0f);
     HPX_TEST_EQ(std::get<1>(t2), 2.0f);
     HPX_TEST_EQ(std::get<1>(t3), 2.0f);
 
-    HPX_TEST_EQ(hpx::util::get<1>(t1), 2.0f);
-    HPX_TEST_EQ(hpx::util::get<1>(t2), 2.0f);
-    HPX_TEST_EQ(hpx::util::get<1>(t3), 2.0f);
+    HPX_TEST_EQ(hpx::get<1>(t1), 2.0f);
+    HPX_TEST_EQ(hpx::get<1>(t2), 2.0f);
+    HPX_TEST_EQ(hpx::get<1>(t3), 2.0f);
 
     HPX_TEST_EQ(std::get<2>(t1), 3.0);
     HPX_TEST_EQ(std::get<2>(t2), 3.0);
     HPX_TEST_EQ(std::get<2>(t3), 3.0);
 
-    HPX_TEST_EQ(hpx::util::get<2>(t1), 3.0);
-    HPX_TEST_EQ(hpx::util::get<2>(t2), 3.0);
-    HPX_TEST_EQ(hpx::util::get<2>(t3), 3.0);
+    HPX_TEST_EQ(hpx::get<2>(t1), 3.0);
+    HPX_TEST_EQ(hpx::get<2>(t2), 3.0);
+    HPX_TEST_EQ(hpx::get<2>(t3), 3.0);
 #endif
 }
 
 void tuple_structured_binding_test()
 {
 #if defined(HPX_HAVE_CXX17_STRUCTURED_BINDINGS)
-    auto [a1, a2] = hpx::util::make_tuple(1, '2');
+    auto [a1, a2] = hpx::make_tuple(1, '2');
 
     HPX_TEST_EQ(a1, 1);
     HPX_TEST_EQ(a2, '2');

--- a/libs/core/functional/include/hpx/functional/first_argument.hpp
+++ b/libs/core/functional/include/hpx/functional/first_argument.hpp
@@ -18,13 +18,13 @@ namespace hpx { namespace util {
         struct tuple_first_argument;
 
         template <>
-        struct tuple_first_argument<hpx::util::tuple<>>
+        struct tuple_first_argument<hpx::tuple<>>
         {
             using type = std::false_type;
         };
 
         template <typename Arg0, typename... Args>
-        struct tuple_first_argument<hpx::util::tuple<Arg0, Args...>>
+        struct tuple_first_argument<hpx::tuple<Arg0, Args...>>
         {
             using type = typename std::decay<Arg0>::type;
         };

--- a/libs/core/functional/include/hpx/functional/invoke_fused.hpp
+++ b/libs/core/functional/include/hpx/functional/invoke_fused.hpp
@@ -23,7 +23,7 @@ namespace hpx { namespace util {
         template <typename Tuple>
         struct fused_index_pack
           : make_index_pack<
-                util::tuple_size<typename std::decay<Tuple>::type>::value>
+                hpx::tuple_size<typename std::decay<Tuple>::type>::value>
         {
         };
 
@@ -34,14 +34,14 @@ namespace hpx { namespace util {
         template <typename F, typename Tuple, std::size_t... Is>
         struct invoke_fused_result_impl<F, Tuple&, index_pack<Is...>>
           : util::invoke_result<F,
-                typename util::tuple_element<Is, Tuple>::type&...>
+                typename hpx::tuple_element<Is, Tuple>::type&...>
         {
         };
 
         template <typename F, typename Tuple, std::size_t... Is>
         struct invoke_fused_result_impl<F, Tuple&&, index_pack<Is...>>
           : util::invoke_result<F,
-                typename util::tuple_element<Is, Tuple>::type&&...>
+                typename hpx::tuple_element<Is, Tuple>::type&&...>
         {
         };
 
@@ -77,7 +77,7 @@ namespace hpx { namespace util {
         invoke_fused_impl(index_pack<Is...>, F&& f, Tuple&& t)
         {
             return HPX_INVOKE(
-                std::forward<F>(f), util::get<Is>(std::forward<Tuple>(t))...);
+                std::forward<F>(f), hpx::get<Is>(std::forward<Tuple>(t))...);
         }
     }    // namespace detail
 

--- a/libs/core/iterator_support/include/hpx/iterator_support/zip_iterator.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/zip_iterator.hpp
@@ -213,7 +213,7 @@ namespace hpx { namespace util {
                 typename zip_iterator_reference<tuple<Ts...>>::type
                 call(util::index_pack<Is...>, tuple<Ts...> const& iterators)
             {
-                return util::forward_as_tuple(*util::get<Is>(iterators)...);
+                return util::forward_as_tuple(*hpx::get<Is>(iterators)...);
             }
         };
 
@@ -299,7 +299,7 @@ namespace hpx { namespace util {
             {
                 return dereference_iterator<IteratorTuple>::call(
                     typename util::make_index_pack<
-                        util::tuple_size<IteratorTuple>::value>::type(),
+                        hpx::tuple_size<IteratorTuple>::value>::type(),
                     iterators_);
             }
 
@@ -321,8 +321,7 @@ namespace hpx { namespace util {
             HPX_HOST_DEVICE
             std::ptrdiff_t distance_to(zip_iterator_base const& other) const
             {
-                return util::get<0>(other.iterators_) -
-                    util::get<0>(iterators_);
+                return hpx::get<0>(other.iterators_) - hpx::get<0>(iterators_);
             }
 
         private:
@@ -330,7 +329,7 @@ namespace hpx { namespace util {
             HPX_HOST_DEVICE void apply(F&& f, util::index_pack<Is...>)
             {
                 int const _sequencer[] = {
-                    ((f(util::get<Is>(iterators_))), 0)...};
+                    ((f(hpx::get<Is>(iterators_))), 0)...};
                 (void) _sequencer;
             }
 
@@ -339,7 +338,7 @@ namespace hpx { namespace util {
             {
                 return apply(std::forward<F>(f),
                     util::make_index_pack<
-                        util::tuple_size<IteratorTuple>::value>());
+                        hpx::tuple_size<IteratorTuple>::value>());
             }
 
         private:
@@ -534,16 +533,16 @@ namespace hpx { namespace traits {
         {
             typedef typename util::zip_iterator<Ts...>::iterator_tuple_type
                 tuple_type;
-            typedef util::tuple<typename element_result_of<
+            typedef hpx::tuple<typename element_result_of<
                 typename F::template apply<Ts>, Ts>::type...>
                 result_type;
 
             template <std::size_t... Is, typename... Ts_>
             static result_type call(
-                util::index_pack<Is...>, util::tuple<Ts_...> const& t)
+                util::index_pack<Is...>, hpx::tuple<Ts_...> const& t)
             {
                 return util::make_tuple(
-                    typename F::template apply<Ts>()(util::get<Is>(t))...);
+                    typename F::template apply<Ts>()(hpx::get<Is>(t))...);
             }
 
             template <typename... Ts_>

--- a/libs/core/iterator_support/tests/performance/stencil3_iterators.cpp
+++ b/libs/core/iterator_support/tests/performance/stencil3_iterators.cpp
@@ -163,7 +163,7 @@ namespace hpx { namespace experimental {
                 right_iterator;
 
             typedef util::detail::zip_iterator_base<
-                util::tuple<left_iterator, Iterator, right_iterator>,
+                hpx::tuple<left_iterator, Iterator, right_iterator>,
                 stencil3_iterator_full<Iterator, IterBegin, IterValueBegin,
                     IterEnd, IterValueEnd>>
                 type;
@@ -222,8 +222,8 @@ namespace hpx { namespace experimental {
 
         bool equal(stencil3_iterator_full const& other) const
         {
-            return util::get<1>(this->get_iterator_tuple()) ==
-                util::get<1>(other.get_iterator_tuple());
+            return hpx::get<1>(this->get_iterator_tuple()) ==
+                hpx::get<1>(other.get_iterator_tuple());
         }
     };
 
@@ -276,7 +276,7 @@ std::uint64_t bench_stencil3_iterator_full()
     int result = 0;
 
     std::for_each(r.first, r.second, [&result](reference val) {
-        using hpx::util::get;
+        using hpx::get;
         result += get<0>(val) + get<1>(val) + get<2>(val);
     });
 
@@ -289,12 +289,12 @@ namespace hpx { namespace experimental {
     template <typename Iterator>
     class stencil3_iterator_v1
       : public util::detail::zip_iterator_base<
-            util::tuple<Iterator, Iterator, Iterator>,
+            hpx::tuple<Iterator, Iterator, Iterator>,
             stencil3_iterator_v1<Iterator>>
     {
     private:
         typedef util::detail::zip_iterator_base<
-            util::tuple<Iterator, Iterator, Iterator>,
+            hpx::tuple<Iterator, Iterator, Iterator>,
             stencil3_iterator_v1<Iterator>>
             base_type;
 
@@ -312,8 +312,8 @@ namespace hpx { namespace experimental {
 
         bool equal(stencil3_iterator_v1 const& other) const
         {
-            return util::get<1>(this->get_iterator_tuple()) ==
-                util::get<1>(other.get_iterator_tuple());
+            return hpx::get<1>(this->get_iterator_tuple()) ==
+                hpx::get<1>(other.get_iterator_tuple());
         }
     };
 
@@ -350,7 +350,7 @@ std::uint64_t bench_stencil3_iterator_v1()
     int result = values.back() + values.front() + values[1];
 
     std::for_each(r.first, r.second, [&result](reference val) {
-        using hpx::util::get;
+        using hpx::get;
         result += get<0>(val) + get<1>(val) + get<2>(val);
     });
 
@@ -371,8 +371,7 @@ namespace hpx { namespace experimental {
             {
                 typedef typename std::iterator_traits<Iterator>::reference
                     element_type;
-                typedef hpx::util::tuple<element_type, element_type,
-                    element_type>
+                typedef hpx::tuple<element_type, element_type, element_type>
                     type;
             };
 
@@ -460,7 +459,7 @@ std::uint64_t bench_stencil3_iterator_v2()
     int result = values.back() + values.front() + values[1];
 
     std::for_each(r.first, r.second, [&result](reference val) {
-        using hpx::util::get;
+        using hpx::get;
         result += get<0>(val) + get<1>(val) + get<2>(val);
     });
 

--- a/libs/core/iterator_support/tests/unit/stencil3_iterator.cpp
+++ b/libs/core/iterator_support/tests/unit/stencil3_iterator.cpp
@@ -39,8 +39,7 @@ namespace test {
             {
                 typedef typename std::iterator_traits<Iterator>::reference
                     element_type;
-                typedef hpx::util::tuple<element_type, element_type,
-                    element_type>
+                typedef hpx::tuple<element_type, element_type, element_type>
                     type;
             };
 
@@ -124,7 +123,7 @@ void test_stencil3_iterator()
     std::ostringstream str;
 
     std::for_each(r.first, r.second, [&str](reference val) {
-        using hpx::util::get;
+        using hpx::get;
         str << get<0>(val) << get<1>(val) << get<2>(val) << " ";
     });
 
@@ -144,7 +143,7 @@ namespace test {
             typedef typename hpx::util::invoke_result<F, element_type>::type
                 value_type;
 
-            typedef hpx::util::tuple<value_type, element_type, value_type> type;
+            typedef hpx::tuple<value_type, element_type, value_type> type;
         };
 
         custom_stencil_transformer(F f)
@@ -187,7 +186,7 @@ void test_stencil3_iterator_custom()
     std::ostringstream str;
 
     std::for_each(r.first, r.second, [&str](reference val) {
-        using hpx::util::get;
+        using hpx::get;
         str << get<0>(val) << get<1>(val) << get<2>(val) << " ";
     });
 

--- a/libs/core/iterator_support/tests/unit/zip_iterator.cpp
+++ b/libs/core/iterator_support/tests/unit/zip_iterator.cpp
@@ -32,7 +32,7 @@ void category_test()
     std::list<int> rng1;
     std::string rng2;
 
-    hpx::util::make_zip_iterator(hpx::util::make_tuple(
+    hpx::util::make_zip_iterator(hpx::make_tuple(
         // BidirectionalInput
         hpx::util::make_transform_iterator(rng1.begin(), &to_value),
         rng2.begin()    // RandomAccess
@@ -43,8 +43,7 @@ void category_test()
 /// Deduces to the result of tuple_cat when it's invoked with the given
 /// parameters Ts.
 template <typename... Ts>
-using tuple_cat_result_of_t =
-    decltype(hpx::util::tuple_cat(std::declval<Ts>()...));
+using tuple_cat_result_of_t = decltype(hpx::tuple_cat(std::declval<Ts>()...));
 
 int main(void)
 {
@@ -75,22 +74,21 @@ int main(void)
         zit_mixed;
 
     zit_mixed zip_it_mixed =
-        zit_mixed(hpx::util::make_tuple(intset.begin(), vect1.begin()));
+        zit_mixed(hpx::make_tuple(intset.begin(), vect1.begin()));
 
-    hpx::util::tuple<int, double> val_tuple(*zip_it_mixed);
+    hpx::tuple<int, double> val_tuple(*zip_it_mixed);
 
-    hpx::util::tuple<const int&, double&> ref_tuple(*zip_it_mixed);
+    hpx::tuple<const int&, double&> ref_tuple(*zip_it_mixed);
 
-    double dblOldVal = hpx::util::get<1>(ref_tuple);
-    hpx::util::get<1>(ref_tuple) -= 41.;
+    double dblOldVal = hpx::get<1>(ref_tuple);
+    hpx::get<1>(ref_tuple) -= 41.;
 
-    HPX_TEST(52 == hpx::util::get<0>(val_tuple) &&
-        42. == hpx::util::get<1>(val_tuple) &&
-        52 == hpx::util::get<0>(ref_tuple) &&
-        1. == hpx::util::get<1>(ref_tuple) && 1. == *vect1.begin());
+    HPX_TEST(52 == hpx::get<0>(val_tuple) && 42. == hpx::get<1>(val_tuple) &&
+        52 == hpx::get<0>(ref_tuple) && 1. == hpx::get<1>(ref_tuple) &&
+        1. == *vect1.begin());
 
     // Undo change to vect1
-    hpx::util::get<1>(ref_tuple) = dblOldVal;
+    hpx::get<1>(ref_tuple) = dblOldVal;
 
     /////////////////////////////////////////////////////////////////////////////
     //
@@ -129,27 +127,26 @@ int main(void)
     ve4.push_back(12);
 
     // typedefs for cons lists of iterators.
-    typedef tuple_cat_result_of_t<hpx::util::tuple<std::set<int>::iterator>,
-        hpx::util::tuple<std::vector<int>::iterator, std::list<int>::iterator,
+    typedef tuple_cat_result_of_t<hpx::tuple<std::set<int>::iterator>,
+        hpx::tuple<std::vector<int>::iterator, std::list<int>::iterator,
             std::set<int>::iterator, std::vector<int>::iterator,
             std::list<int>::iterator, std::set<int>::iterator,
             std::vector<int>::iterator, std::list<int>::iterator,
             std::set<int>::iterator, std::vector<int>::const_iterator>>
         cons_11_its_type;
     //
-    typedef tuple_cat_result_of_t<
-        hpx::util::tuple<std::list<int>::const_iterator>, cons_11_its_type>
+    typedef tuple_cat_result_of_t<hpx::tuple<std::list<int>::const_iterator>,
+        cons_11_its_type>
         cons_12_its_type;
 
     // typedefs for cons lists for dereferencing the zip iterator
     // made from the cons list above.
-    typedef tuple_cat_result_of_t<hpx::util::tuple<const int&>,
-        hpx::util::tuple<int&, int&, const int&, int&, int&, const int&, int&,
-            int&, const int&, const int&>>
+    typedef tuple_cat_result_of_t<hpx::tuple<const int&>,
+        hpx::tuple<int&, int&, const int&, int&, int&, const int&, int&, int&,
+            const int&, const int&>>
         cons_11_refs_type;
     //
-    typedef tuple_cat_result_of_t<hpx::util::tuple<const int&>,
-        cons_11_refs_type>
+    typedef tuple_cat_result_of_t<hpx::tuple<const int&>, cons_11_refs_type>
         cons_12_refs_type;
 
     // typedef for zip iterator with 12 elements
@@ -162,18 +159,16 @@ int main(void)
 
     // Dereference, mess with the result a little.
     cons_12_refs_type zip_it_12_dereferenced(*zip_it_12);
-    hpx::util::get<9>(zip_it_12_dereferenced) = 42;
+    hpx::get<9>(zip_it_12_dereferenced) = 42;
 
     // Make a copy and move it a little to force some instantiations.
     zip_it_12_type zip_it_12_copy(zip_it_12);
     ++zip_it_12_copy;
 
-    HPX_TEST(
-        hpx::util::get<11>(zip_it_12.get_iterator_tuple()) == ve4.begin() &&
-        hpx::util::get<11>(zip_it_12_copy.get_iterator_tuple()) == ve4.end() &&
-        1 == hpx::util::get<0>(zip_it_12_dereferenced) &&
-        12 == hpx::util::get<11>(zip_it_12_dereferenced) &&
-        42 == *(li4.begin()));
+    HPX_TEST(hpx::get<11>(zip_it_12.get_iterator_tuple()) == ve4.begin() &&
+        hpx::get<11>(zip_it_12_copy.get_iterator_tuple()) == ve4.end() &&
+        1 == hpx::get<0>(zip_it_12_dereferenced) &&
+        12 == hpx::get<11>(zip_it_12_dereferenced) && 42 == *(li4.begin()));
 
     /////////////////////////////////////////////////////////////////////////////
     //
@@ -186,28 +181,24 @@ int main(void)
     vect2[1] = 3.3;
     vect2[2] = 4.4;
 
-    hpx::util::zip_iterator<
-        hpx::util::tuple<std::vector<double>::const_iterator,
-            std::vector<double>::const_iterator>>
-        zip_it_begin(hpx::util::make_tuple(vect1.begin(), vect2.begin()));
+    hpx::util::zip_iterator<hpx::tuple<std::vector<double>::const_iterator,
+        std::vector<double>::const_iterator>>
+        zip_it_begin(hpx::make_tuple(vect1.begin(), vect2.begin()));
 
-    hpx::util::zip_iterator<
-        hpx::util::tuple<std::vector<double>::const_iterator,
-            std::vector<double>::const_iterator>>
-        zip_it_run(hpx::util::make_tuple(vect1.begin(), vect2.begin()));
+    hpx::util::zip_iterator<hpx::tuple<std::vector<double>::const_iterator,
+        std::vector<double>::const_iterator>>
+        zip_it_run(hpx::make_tuple(vect1.begin(), vect2.begin()));
 
-    hpx::util::zip_iterator<
-        hpx::util::tuple<std::vector<double>::const_iterator,
-            std::vector<double>::const_iterator>>
-        zip_it_end(hpx::util::make_tuple(vect1.end(), vect2.end()));
+    hpx::util::zip_iterator<hpx::tuple<std::vector<double>::const_iterator,
+        std::vector<double>::const_iterator>>
+        zip_it_end(hpx::make_tuple(vect1.end(), vect2.end()));
 
-    HPX_TEST(zip_it_run == zip_it_begin &&
-        42. == hpx::util::get<0>(*zip_it_run) &&
-        2.2 == hpx::util::get<1>(*zip_it_run) &&
-        43. == hpx::util::get<0>(*(++zip_it_run)) &&
-        3.3 == hpx::util::get<1>(*zip_it_run) &&
-        44. == hpx::util::get<0>(*(++zip_it_run)) &&
-        4.4 == hpx::util::get<1>(*zip_it_run) && zip_it_end == ++zip_it_run);
+    HPX_TEST(zip_it_run == zip_it_begin && 42. == hpx::get<0>(*zip_it_run) &&
+        2.2 == hpx::get<1>(*zip_it_run) &&
+        43. == hpx::get<0>(*(++zip_it_run)) &&
+        3.3 == hpx::get<1>(*zip_it_run) &&
+        44. == hpx::get<0>(*(++zip_it_run)) &&
+        4.4 == hpx::get<1>(*zip_it_run) && zip_it_end == ++zip_it_run);
 
     /////////////////////////////////////////////////////////////////////////////
     //
@@ -216,12 +207,11 @@ int main(void)
     /////////////////////////////////////////////////////////////////////////////
 
     HPX_TEST(zip_it_run == zip_it_end && zip_it_end == zip_it_run-- &&
-        44. == hpx::util::get<0>(*zip_it_run) &&
-        4.4 == hpx::util::get<1>(*zip_it_run) &&
-        43. == hpx::util::get<0>(*(--zip_it_run)) &&
-        3.3 == hpx::util::get<1>(*zip_it_run) &&
-        42. == hpx::util::get<0>(*(--zip_it_run)) &&
-        2.2 == hpx::util::get<1>(*zip_it_run) && zip_it_begin == zip_it_run);
+        44. == hpx::get<0>(*zip_it_run) && 4.4 == hpx::get<1>(*zip_it_run) &&
+        43. == hpx::get<0>(*(--zip_it_run)) &&
+        3.3 == hpx::get<1>(*zip_it_run) &&
+        42. == hpx::get<0>(*(--zip_it_run)) &&
+        2.2 == hpx::get<1>(*zip_it_run) && zip_it_begin == zip_it_run);
 
     /////////////////////////////////////////////////////////////////////////////
     //
@@ -229,9 +219,8 @@ int main(void)
     //
     /////////////////////////////////////////////////////////////////////////////
 
-    hpx::util::zip_iterator<
-        hpx::util::tuple<std::vector<double>::const_iterator,
-            std::vector<double>::const_iterator>>
+    hpx::util::zip_iterator<hpx::tuple<std::vector<double>::const_iterator,
+        std::vector<double>::const_iterator>>
         zip_it_run_copy(zip_it_run);
 
     HPX_TEST(zip_it_run == zip_it_run && zip_it_run == zip_it_run_copy);
@@ -353,10 +342,9 @@ int main(void)
     // Note: zip_it_run and zip_it_run_copy are both at
     // begin plus one.
     //
-    HPX_TEST(hpx::util::get<0>(zip_it_run.get_iterator_tuple()) ==
-            vect1.begin() + 1 &&
-        hpx::util::get<1>(zip_it_run.get_iterator_tuple()) ==
-            vect2.begin() + 1);
+    HPX_TEST(
+        hpx::get<0>(zip_it_run.get_iterator_tuple()) == vect1.begin() + 1 &&
+        hpx::get<1>(zip_it_run.get_iterator_tuple()) == vect2.begin() + 1);
 
     /////////////////////////////////////////////////////////////////////////////
     //
@@ -364,20 +352,19 @@ int main(void)
     //
     /////////////////////////////////////////////////////////////////////////////
 
-    std::vector<hpx::util::tuple<double, double>> vect_of_tuples(3);
+    std::vector<hpx::tuple<double, double>> vect_of_tuples(3);
 
     std::copy(hpx::util::make_zip_iterator(
-                  hpx::util::make_tuple(vect1.begin(), vect2.begin())),
-        hpx::util::make_zip_iterator(
-            hpx::util::make_tuple(vect1.end(), vect2.end())),
+                  hpx::make_tuple(vect1.begin(), vect2.begin())),
+        hpx::util::make_zip_iterator(hpx::make_tuple(vect1.end(), vect2.end())),
         vect_of_tuples.begin());
 
-    HPX_TEST(42. == hpx::util::get<0>(*vect_of_tuples.begin()) &&
-        2.2 == hpx::util::get<1>(*vect_of_tuples.begin()) &&
-        43. == hpx::util::get<0>(*(vect_of_tuples.begin() + 1)) &&
-        3.3 == hpx::util::get<1>(*(vect_of_tuples.begin() + 1)) &&
-        44. == hpx::util::get<0>(*(vect_of_tuples.begin() + 2)) &&
-        4.4 == hpx::util::get<1>(*(vect_of_tuples.begin() + 2)));
+    HPX_TEST(42. == hpx::get<0>(*vect_of_tuples.begin()) &&
+        2.2 == hpx::get<1>(*vect_of_tuples.begin()) &&
+        43. == hpx::get<0>(*(vect_of_tuples.begin() + 1)) &&
+        3.3 == hpx::get<1>(*(vect_of_tuples.begin() + 1)) &&
+        44. == hpx::get<0>(*(vect_of_tuples.begin() + 2)) &&
+        4.4 == hpx::get<1>(*(vect_of_tuples.begin() + 2)));
 
     /////////////////////////////////////////////////////////////////////////////
     //
@@ -385,17 +372,17 @@ int main(void)
     //
     /////////////////////////////////////////////////////////////////////////////
 
-    hpx::util::zip_iterator<hpx::util::tuple<std::set<int>::const_iterator,
+    hpx::util::zip_iterator<hpx::tuple<std::set<int>::const_iterator,
         std::vector<double>::const_iterator>>
-        zip_it_const(hpx::util::make_tuple(intset.begin(), vect2.begin()));
+        zip_it_const(hpx::make_tuple(intset.begin(), vect2.begin()));
     //
-    hpx::util::zip_iterator<hpx::util::tuple<std::set<int>::iterator,
+    hpx::util::zip_iterator<hpx::tuple<std::set<int>::iterator,
         std::vector<double>::const_iterator>>
-        zip_it_half_const(hpx::util::make_tuple(intset.begin(), vect2.begin()));
+        zip_it_half_const(hpx::make_tuple(intset.begin(), vect2.begin()));
     //
-    hpx::util::zip_iterator<hpx::util::tuple<std::set<int>::iterator,
-        std::vector<double>::iterator>>
-        zip_it_non_const(hpx::util::make_tuple(intset.begin(), vect2.begin()));
+    hpx::util::zip_iterator<
+        hpx::tuple<std::set<int>::iterator, std::vector<double>::iterator>>
+        zip_it_non_const(hpx::make_tuple(intset.begin(), vect2.begin()));
 
     zip_it_half_const = ++zip_it_non_const;
     zip_it_const = zip_it_half_const;
@@ -404,10 +391,10 @@ int main(void)
     // Error: can't convert from const to non-const
     //  zip_it_non_const = ++zip_it_const;
 
-    HPX_TEST(54 == hpx::util::get<0>(*zip_it_const) &&
-        4.4 == hpx::util::get<1>(*zip_it_const) &&
-        53 == hpx::util::get<0>(*zip_it_half_const) &&
-        3.3 == hpx::util::get<1>(*zip_it_half_const));
+    HPX_TEST(54 == hpx::get<0>(*zip_it_const) &&
+        4.4 == hpx::get<1>(*zip_it_const) &&
+        53 == hpx::get<0>(*zip_it_half_const) &&
+        3.3 == hpx::get<1>(*zip_it_half_const));
 
     /////////////////////////////////////////////////////////////////////////////
     //
@@ -429,7 +416,7 @@ int main(void)
     // traversal.
     //
     typedef hpx::util::zip_iterator<
-        hpx::util::tuple<std::vector<double>::const_iterator,
+        hpx::tuple<std::vector<double>::const_iterator,
             std::vector<double>::const_iterator>>
         all_vects_type;
 

--- a/libs/core/serialization/include/hpx/serialization/brace_initializable.hpp
+++ b/libs/core/serialization/include/hpx/serialization/brace_initializable.hpp
@@ -31,7 +31,7 @@ namespace hpx { namespace serialization {
         hpx::traits::detail::size<1>)
     {
         auto& [p1] = t;
-        auto&& data = hpx::util::forward_as_tuple(p1);
+        auto&& data = hpx::forward_as_tuple(p1);
         serialize(archive, data, version);
     }
 
@@ -40,7 +40,7 @@ namespace hpx { namespace serialization {
         hpx::traits::detail::size<2>)
     {
         auto& [p1, p2] = t;
-        auto&& data = hpx::util::forward_as_tuple(p1, p2);
+        auto&& data = hpx::forward_as_tuple(p1, p2);
         serialize(archive, data, version);
     }
 
@@ -49,7 +49,7 @@ namespace hpx { namespace serialization {
         hpx::traits::detail::size<3>)
     {
         auto& [p1, p2, p3] = t;
-        auto&& data = hpx::util::forward_as_tuple(p1, p2, p3);
+        auto&& data = hpx::forward_as_tuple(p1, p2, p3);
         serialize(archive, data, version);
     }
 
@@ -58,7 +58,7 @@ namespace hpx { namespace serialization {
         hpx::traits::detail::size<4>)
     {
         auto& [p1, p2, p3, p4] = t;
-        auto&& data = hpx::util::forward_as_tuple(p1, p2, p3, p4);
+        auto&& data = hpx::forward_as_tuple(p1, p2, p3, p4);
         serialize(archive, data, version);
     }
 
@@ -67,7 +67,7 @@ namespace hpx { namespace serialization {
         hpx::traits::detail::size<5>)
     {
         auto& [p1, p2, p3, p4, p5] = t;
-        auto&& data = hpx::util::forward_as_tuple(p1, p2, p3, p4, p5);
+        auto&& data = hpx::forward_as_tuple(p1, p2, p3, p4, p5);
         serialize(archive, data, version);
     }
 
@@ -76,7 +76,7 @@ namespace hpx { namespace serialization {
         hpx::traits::detail::size<6>)
     {
         auto& [p1, p2, p3, p4, p5, p6] = t;
-        auto&& data = hpx::util::forward_as_tuple(p1, p2, p3, p4, p5, p6);
+        auto&& data = hpx::forward_as_tuple(p1, p2, p3, p4, p5, p6);
         serialize(archive, data, version);
     }
 
@@ -85,7 +85,7 @@ namespace hpx { namespace serialization {
         hpx::traits::detail::size<7>)
     {
         auto& [p1, p2, p3, p4, p5, p6, p7] = t;
-        auto&& data = hpx::util::forward_as_tuple(p1, p2, p3, p4, p5, p6, p7);
+        auto&& data = hpx::forward_as_tuple(p1, p2, p3, p4, p5, p6, p7);
         serialize(archive, data, version);
     }
 
@@ -94,8 +94,7 @@ namespace hpx { namespace serialization {
         hpx::traits::detail::size<8>)
     {
         auto& [p1, p2, p3, p4, p5, p6, p7, p8] = t;
-        auto&& data =
-            hpx::util::forward_as_tuple(p1, p2, p3, p4, p5, p6, p7, p8);
+        auto&& data = hpx::forward_as_tuple(p1, p2, p3, p4, p5, p6, p7, p8);
         serialize(archive, data, version);
     }
 
@@ -104,8 +103,7 @@ namespace hpx { namespace serialization {
         hpx::traits::detail::size<9>)
     {
         auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9] = t;
-        auto&& data =
-            hpx::util::forward_as_tuple(p1, p2, p3, p4, p5, p6, p7, p8, p9);
+        auto&& data = hpx::forward_as_tuple(p1, p2, p3, p4, p5, p6, p7, p8, p9);
         serialize(archive, data, version);
     }
 
@@ -114,8 +112,8 @@ namespace hpx { namespace serialization {
         hpx::traits::detail::size<10>)
     {
         auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10] = t;
-        auto&& data = hpx::util::forward_as_tuple(
-            p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);
+        auto&& data =
+            hpx::forward_as_tuple(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);
         serialize(archive, data, version);
     }
 
@@ -124,8 +122,8 @@ namespace hpx { namespace serialization {
         hpx::traits::detail::size<11>)
     {
         auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11] = t;
-        auto&& data = hpx::util::forward_as_tuple(
-            p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11);
+        auto&& data =
+            hpx::forward_as_tuple(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11);
         serialize(archive, data, version);
     }
 
@@ -134,7 +132,7 @@ namespace hpx { namespace serialization {
         hpx::traits::detail::size<12>)
     {
         auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12] = t;
-        auto&& data = hpx::util::forward_as_tuple(
+        auto&& data = hpx::forward_as_tuple(
             p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12);
         serialize(archive, data, version);
     }
@@ -144,7 +142,7 @@ namespace hpx { namespace serialization {
         hpx::traits::detail::size<13>)
     {
         auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13] = t;
-        auto&& data = hpx::util::forward_as_tuple(
+        auto&& data = hpx::forward_as_tuple(
             p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13);
         serialize(archive, data, version);
     }
@@ -154,7 +152,7 @@ namespace hpx { namespace serialization {
         hpx::traits::detail::size<14>)
     {
         auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14] = t;
-        auto&& data = hpx::util::forward_as_tuple(
+        auto&& data = hpx::forward_as_tuple(
             p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14);
         serialize(archive, data, version);
     }
@@ -165,7 +163,7 @@ namespace hpx { namespace serialization {
     {
         auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14,
             p15] = t;
-        auto&& data = hpx::util::forward_as_tuple(
+        auto&& data = hpx::forward_as_tuple(
             p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15);
         serialize(archive, data, version);
     }

--- a/libs/core/serialization/include/hpx/serialization/tuple.hpp
+++ b/libs/core/serialization/include/hpx/serialization/tuple.hpp
@@ -21,7 +21,7 @@
 namespace hpx { namespace traits {
 
     template <typename... Ts>
-    struct is_bitwise_serializable<::hpx::util::tuple<Ts...>>
+    struct is_bitwise_serializable<::hpx::tuple<Ts...>>
       : ::hpx::util::all_of<hpx::traits::is_bitwise_serializable<
             typename std::remove_const<Ts>::type>...>
     {
@@ -43,9 +43,9 @@ namespace hpx { namespace util { namespace detail {
     struct serialize_with_index_pack<Archive, hpx::util::index_pack<Is...>,
         Ts...>
     {
-        static void call(Archive& ar, hpx::util::tuple<Ts...>& t, unsigned int)
+        static void call(Archive& ar, hpx::tuple<Ts...>& t, unsigned int)
         {
-            int const _sequencer[] = {((ar & hpx::util::get<Is>(t)), 0)...};
+            int const _sequencer[] = {((ar & hpx::get<Is>(t)), 0)...};
             (void) _sequencer;
         }
     };
@@ -55,12 +55,11 @@ namespace hpx { namespace util { namespace detail {
         hpx::util::index_pack<Is...>, Ts...>
     {
         static void call(
-            Archive& ar, hpx::util::tuple<Ts...>& t, unsigned int version)
+            Archive& ar, hpx::tuple<Ts...>& t, unsigned int version)
         {
             using serialization::detail::load_construct_data;
             int const _sequencer[] = {
-                (load_construct_data(ar, &hpx::util::get<Is>(t), version),
-                    0)...};
+                (load_construct_data(ar, &hpx::get<Is>(t), version), 0)...};
             (void) _sequencer;
         }
     };
@@ -70,12 +69,11 @@ namespace hpx { namespace util { namespace detail {
         hpx::util::index_pack<Is...>, Ts...>
     {
         static void call(
-            Archive& ar, hpx::util::tuple<Ts...> const& t, unsigned int version)
+            Archive& ar, hpx::tuple<Ts...> const& t, unsigned int version)
         {
             using serialization::detail::save_construct_data;
             int const _sequencer[] = {
-                (save_construct_data(ar, &hpx::util::get<Is>(t), version),
-                    0)...};
+                (save_construct_data(ar, &hpx::get<Is>(t), version), 0)...};
             (void) _sequencer;
         }
     };
@@ -84,8 +82,7 @@ namespace hpx { namespace util { namespace detail {
 namespace hpx { namespace serialization {
 
     template <typename Archive, typename... Ts>
-    void serialize(
-        Archive& ar, hpx::util::tuple<Ts...>& t, unsigned int version)
+    void serialize(Archive& ar, hpx::tuple<Ts...>& t, unsigned int version)
     {
         using Is = typename hpx::util::make_index_pack<sizeof...(Ts)>::type;
         hpx::util::detail::serialize_with_index_pack<Archive, Is, Ts...>::call(
@@ -93,13 +90,13 @@ namespace hpx { namespace serialization {
     }
 
     template <typename Archive>
-    void serialize(Archive& ar, hpx::util::tuple<>&, unsigned)
+    void serialize(Archive& ar, hpx::tuple<>&, unsigned)
     {
     }
 
     template <typename Archive, typename... Ts>
     void load_construct_data(
-        Archive& ar, hpx::util::tuple<Ts...>* t, unsigned int version)
+        Archive& ar, hpx::tuple<Ts...>* t, unsigned int version)
     {
         using Is = typename hpx::util::make_index_pack<sizeof...(Ts)>::type;
         hpx::util::detail::load_construct_data_with_index_pack<Archive, Is,
@@ -108,7 +105,7 @@ namespace hpx { namespace serialization {
 
     template <typename Archive, typename... Ts>
     void save_construct_data(
-        Archive& ar, hpx::util::tuple<Ts...> const* t, unsigned int version)
+        Archive& ar, hpx::tuple<Ts...> const* t, unsigned int version)
     {
         using Is = typename hpx::util::make_index_pack<sizeof...(Ts)>::type;
         hpx::util::detail::save_construct_data_with_index_pack<Archive, Is,

--- a/libs/core/serialization/tests/unit/serialization_tuple.cpp
+++ b/libs/core/serialization/tests/unit/serialization_tuple.cpp
@@ -51,7 +51,7 @@ struct A
 void test()
 {
     {
-        hpx::util::tuple<int, double, std::string, A<int>> ot{
+        hpx::tuple<int, double, std::string, A<int>> ot{
             42, 42.0, "42.0", A<int>{0}};
 
         std::vector<char> buffer;
@@ -61,12 +61,12 @@ void test()
         std::size_t size = oarchive.bytes_written();
 
         hpx::serialization::input_archive iarchive(buffer, size, &chunks);
-        hpx::util::tuple<int, double, std::string, A<int>> it;
+        hpx::tuple<int, double, std::string, A<int>> it;
         iarchive >> it;
         HPX_TEST(ot == it);
     }
     {
-        hpx::util::tuple<> ot{};
+        hpx::tuple<> ot{};
 
         std::vector<char> buffer;
         std::vector<hpx::serialization::serialization_chunk> chunks;
@@ -75,7 +75,7 @@ void test()
         std::size_t size = oarchive.bytes_written();
 
         hpx::serialization::input_archive iarchive(buffer, size, &chunks);
-        hpx::util::tuple<> it;
+        hpx::tuple<> it;
         iarchive >> it;
         HPX_TEST(ot == it);
     }

--- a/libs/core/threading_base/include/hpx/threading_base/set_thread_state.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/set_thread_state.hpp
@@ -18,7 +18,6 @@
 #include <hpx/threading_base/create_work.hpp>
 #include <hpx/threading_base/register_thread.hpp>
 #include <hpx/threading_base/thread_data.hpp>
-#include <hpx/timing/steady_clock.hpp>
 
 #include <boost/asio/basic_waitable_timer.hpp>
 #include <boost/asio/io_service.hpp>
@@ -332,10 +331,10 @@ namespace hpx { namespace threads { namespace detail {
     /// behalf of one of the threads#detail#set_thread_state functions).
     template <typename SchedulingPolicy>
     thread_result_type at_timer(SchedulingPolicy& scheduler,
-        util::steady_clock::time_point& abs_time, thread_id_type const& thrd,
-        thread_state_enum newstate, thread_state_ex_enum newstate_ex,
-        thread_priority priority, std::atomic<bool>* started,
-        bool retry_on_active)
+        std::chrono::steady_clock::time_point& abs_time,
+        thread_id_type const& thrd, thread_state_enum newstate,
+        thread_state_ex_enum newstate_ex, thread_priority priority,
+        std::atomic<bool>* started, bool retry_on_active)
     {
         if (HPX_UNLIKELY(!thrd))
         {
@@ -363,7 +362,7 @@ namespace hpx { namespace threads { namespace detail {
 
         // create timer firing in correspondence with given time
         using deadline_timer =
-            boost::asio::basic_waitable_timer<util::steady_clock>;
+            boost::asio::basic_waitable_timer<std::chrono::steady_clock>;
 
         boost::asio::io_service* s = get_default_timer_service();
         HPX_ASSERT(s);

--- a/libs/core/threading_base/src/execution_agent.cpp
+++ b/libs/core/threading_base/src/execution_agent.cpp
@@ -103,13 +103,13 @@ namespace hpx { namespace threads {
     void execution_agent::sleep_until(
         hpx::util::steady_time_point const& sleep_time, const char* desc)
     {
-        auto now = hpx::util::steady_clock::now();
+        auto now = std::chrono::steady_clock::now();
 
         // Just yield until time has passed by...
         for (std::size_t k = 0; now < sleep_time.value(); ++k)
         {
             yield_k(k, desc);
-            now = hpx::util::steady_clock::now();
+            now = std::chrono::steady_clock::now();
         }
     }
 

--- a/libs/core/timing/CMakeLists.txt
+++ b/libs/core/timing/CMakeLists.txt
@@ -36,6 +36,6 @@ add_hpx_module(
   SOURCES ${timing_sources}
   HEADERS ${timing_headers}
   COMPAT_HEADERS ${timing_compat_headers}
-  MODULE_DEPENDENCIES hpx_config hpx_hardware
+  MODULE_DEPENDENCIES hpx_config hpx_hardware hpx_type_support
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/timing/include/hpx/timing/high_resolution_clock.hpp
+++ b/libs/core/timing/include/hpx/timing/high_resolution_clock.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/modules/type_support.hpp>
 
 #if defined(__bgq__)
 #include <hwi/include/bqc/A2_inlines.h>
@@ -15,7 +16,7 @@
 #include <chrono>
 #include <cstdint>
 
-namespace hpx { namespace util {
+namespace hpx { namespace chrono {
     struct high_resolution_clock
     {
         // This function returns a tick count with a resolution (not
@@ -49,4 +50,11 @@ namespace hpx { namespace util {
             return (duration_values::max)().count();
         }
     };
+}}    // namespace hpx::chrono
+
+namespace hpx { namespace util {
+    using high_resolution_clock HPX_DEPRECATED_V(1, 6,
+        "hpx::util::high_resolution_clock is deprecated. Use "
+        "hpx::chrono::high_resolution_clock instead.") =
+        hpx::chrono::high_resolution_clock;
 }}    // namespace hpx::util

--- a/libs/core/timing/include/hpx/timing/high_resolution_timer.hpp
+++ b/libs/core/timing/include/hpx/timing/high_resolution_timer.hpp
@@ -11,7 +11,7 @@
 
 #include <cstdint>
 
-namespace hpx { namespace util {
+namespace hpx { namespace chrono {
     ///////////////////////////////////////////////////////////////////////////
     //
     //  high_resolution_timer
@@ -75,4 +75,11 @@ namespace hpx { namespace util {
     private:
         std::uint64_t start_time_;
     };
+}}    // namespace hpx::chrono
+
+namespace hpx { namespace util {
+    using high_resolution_timer HPX_DEPRECATED_V(1, 6,
+        "hpx::util::high_resolution_timer is deprecated. Use "
+        "hpx::chrono::high_resolution_timer instead.") =
+        hpx::chrono::high_resolution_timer;
 }}    // namespace hpx::util

--- a/libs/core/timing/include/hpx/timing/steady_clock.hpp
+++ b/libs/core/timing/include/hpx/timing/steady_clock.hpp
@@ -14,7 +14,7 @@
 
 #include <chrono>
 
-namespace hpx { namespace util {
+namespace hpx { namespace chrono {
     using std::chrono::steady_clock;
 
     class steady_time_point
@@ -75,4 +75,14 @@ namespace hpx { namespace util {
     private:
         value_type _rel_time;
     };
+}}    // namespace hpx::chrono
+
+namespace hpx { namespace util {
+    using steady_time_point HPX_DEPRECATED_V(1, 6,
+        "hpx::util::steady_time_point is deprecated. Use "
+        "hpx::chrono::steady_time_point instead.") =
+        hpx::chrono::steady_time_point;
+    using steady_duration HPX_DEPRECATED_V(1, 6,
+        "hpx::util::steady_duration is deprecated. Use "
+        "hpx::chrono::steady_duration instead.") = hpx::chrono::steady_duration;
 }}    // namespace hpx::util

--- a/libs/full/actions/include/hpx/actions/transfer_action.hpp
+++ b/libs/full/actions/include/hpx/actions/transfer_action.hpp
@@ -135,7 +135,7 @@ namespace hpx { namespace actions {
     {
         return base_type::derived_type::construct_thread_function(
             std::move(target), lva, comptype,
-            util::get<Is>(std::move(this->arguments_))...);
+            hpx::get<Is>(std::move(this->arguments_))...);
     }
 
     template <typename Action>
@@ -174,7 +174,7 @@ namespace hpx { namespace actions {
 #endif
         applier::detail::apply_helper<typename base_type::derived_type>::call(
             std::move(data), target, lva, comptype, this->priority_,
-            std::move(util::get<Is>(this->arguments_))...);
+            std::move(hpx::get<Is>(this->arguments_))...);
     }
 
     template <typename Action>

--- a/libs/full/actions/include/hpx/actions/transfer_base_action.hpp
+++ b/libs/full/actions/include/hpx/actions/transfer_base_action.hpp
@@ -100,41 +100,41 @@ namespace hpx { namespace actions {
     }    // namespace detail
 }}       // namespace hpx::actions
 
-namespace hpx { namespace util {
+namespace hpx {
     template <std::size_t I, typename Args>
     constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-        typename util::tuple_element<I, Args>::type&
+        typename hpx::tuple_element<I, Args>::type&
         get(hpx::actions::detail::argument_holder<Args>& t)
     {
-        return util::tuple_element<I, Args>::get(t.data());
+        return hpx::tuple_element<I, Args>::get(t.data());
     }
 
     template <std::size_t I, typename Args>
     constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-        typename util::tuple_element<I, Args>::type const&
+        typename hpx::tuple_element<I, Args>::type const&
         get(hpx::actions::detail::argument_holder<Args> const& t)
     {
-        return util::tuple_element<I, Args>::get(t.data());
+        return hpx::tuple_element<I, Args>::get(t.data());
     }
 
     template <std::size_t I, typename Args>
     constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-        typename util::tuple_element<I, Args>::type&&
+        typename hpx::tuple_element<I, Args>::type&&
         get(hpx::actions::detail::argument_holder<Args>&& t)
     {
-        return std::forward<typename util::tuple_element<I, Args>::type>(
-            util::get<I>(t.data()));
+        return std::forward<typename hpx::tuple_element<I, Args>::type>(
+            hpx::get<I>(t.data()));
     }
 
     template <std::size_t I, typename Args>
     constexpr HPX_HOST_DEVICE HPX_FORCEINLINE
-        typename util::tuple_element<I, Args>::type const&&
+        typename hpx::tuple_element<I, Args>::type const&&
         get(hpx::actions::detail::argument_holder<Args> const&& t)
     {
-        return std::forward<typename util::tuple_element<I, Args>::type const>(
-            util::get<I>(t.data()));
+        return std::forward<typename hpx::tuple_element<I, Args>::type const>(
+            hpx::get<I>(t.data()));
     }
-}}    // namespace hpx::util
+}    // namespace hpx
 
 namespace hpx { namespace actions {
     ///////////////////////////////////////////////////////////////////////////
@@ -276,10 +276,10 @@ namespace hpx { namespace actions {
         /// retrieve the N's argument
         template <std::size_t N>
         constexpr inline
-            typename util::tuple_element<N, arguments_type>::type const&
+            typename hpx::tuple_element<N, arguments_type>::type const&
             get() const
         {
-            return util::get<N>(arguments_);
+            return hpx::get<N>(arguments_);
         }
 
         /// Extract the current invocation count for this action
@@ -333,7 +333,7 @@ namespace hpx { namespace actions {
 
     ///////////////////////////////////////////////////////////////////////////
     template <std::size_t N, typename Action>
-    constexpr inline typename util::tuple_element<N,
+    constexpr inline typename hpx::tuple_element<N,
         typename transfer_action<Action>::arguments_type>::type const&
     get(transfer_base_action<Action> const& args)
     {

--- a/libs/full/actions/include/hpx/actions/transfer_continuation_action.hpp
+++ b/libs/full/actions/include/hpx/actions/transfer_continuation_action.hpp
@@ -16,6 +16,7 @@
 #include <hpx/actions/transfer_base_action.hpp>
 #include <hpx/actions_base/actions_base_support.hpp>
 #include <hpx/async_distributed/applier/apply_helper.hpp>
+#include <hpx/modules/datastructures.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/serialization/input_archive.hpp>
 #include <hpx/serialization/output_archive.hpp>
@@ -147,7 +148,7 @@ namespace hpx { namespace actions {
     {
         return base_type::derived_type::construct_thread_function(
             std::move(target), std::move(cont_), lva, comptype,
-            util::get<Is>(std::move(this->arguments_))...);
+            hpx::get<Is>(std::move(this->arguments_))...);
     }
 
     template <typename Action>
@@ -188,7 +189,7 @@ namespace hpx { namespace actions {
 #endif
         applier::detail::apply_helper<typename base_type::derived_type>::call(
             std::move(data), std::move(cont_), target, lva, comptype,
-            this->priority_, std::move(util::get<Is>(this->arguments_))...);
+            this->priority_, std::move(hpx::get<Is>(this->arguments_))...);
     }
 
     template <typename Action>

--- a/libs/full/actions_base/include/hpx/actions_base/basic_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/basic_action.hpp
@@ -250,7 +250,7 @@ namespace hpx { namespace actions {
         static constexpr std::size_t arity = sizeof...(Args);
 
         using internal_result_type = R;
-        using arguments_type = util::tuple<typename std::decay<Args>::type...>;
+        using arguments_type = hpx::tuple<typename std::decay<Args>::type...>;
 
         using action_tag = void;
 

--- a/libs/full/async_distributed/include/hpx/async_distributed/applier/apply_callback.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/applier/apply_callback.hpp
@@ -366,7 +366,7 @@ namespace hpx {
         struct apply_c_p_cb_impl
         {
         public:
-            typedef util::tuple<Ts...> tuple_type;
+            typedef hpx::tuple<Ts...> tuple_type;
 
             template <typename... Ts_>
             apply_c_p_cb_impl(naming::id_type const& contid,
@@ -416,12 +416,12 @@ namespace hpx {
                 {
                     hpx::apply_c_p_cb<Action>(contid_, std::move(addr_), id_,
                         p_, std::move(cb_),
-                        util::get<Is>(std::forward<tuple_type>(args_))...);
+                        hpx::get<Is>(std::forward<tuple_type>(args_))...);
                 }
                 else
                 {
                     hpx::apply_c_p_cb<Action>(contid_, id_, p_, std::move(cb_),
-                        util::get<Is>(std::forward<tuple_type>(args_))...);
+                        hpx::get<Is>(std::forward<tuple_type>(args_))...);
                 }
             }
 

--- a/libs/full/async_distributed/include/hpx/async_distributed/applier/register_apply_colocated.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/applier/register_apply_colocated.hpp
@@ -21,7 +21,7 @@ namespace hpx { namespace detail {
     struct apply_colocated_bound_action;
 
     template <typename Action, typename... Ts>
-    struct apply_colocated_bound_action<Action, hpx::util::tuple<Ts...>>
+    struct apply_colocated_bound_action<Action, hpx::tuple<Ts...>>
     {
         typedef hpx::util::detail::bound_action<Action,
             hpx::util::make_index_pack<1 + sizeof...(Ts)>,

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/async_colocated.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/async_colocated.hpp
@@ -34,7 +34,7 @@ namespace hpx { namespace detail {
     struct async_colocated_bound_action;
 
     template <typename Action, typename... Ts>
-    struct async_colocated_bound_action<Action, hpx::util::tuple<Ts...>>
+    struct async_colocated_bound_action<Action, hpx::tuple<Ts...>>
     {
         typedef hpx::util::detail::bound_action<Action,
             hpx::util::make_index_pack<1 + sizeof...(Ts)>,

--- a/libs/full/collectives/include/hpx/collectives/broadcast_direct.hpp
+++ b/libs/full/collectives/include/hpx/collectives/broadcast_direct.hpp
@@ -288,7 +288,7 @@ namespace hpx { namespace lcos {
 
             typedef detail::broadcast_invoker<Action,
                 typename std::is_void<action_result>::type,
-                typename util::tuple_element<Is,
+                typename hpx::tuple_element<Is,
                     typename Action::arguments_type>::type...>
                 broadcast_invoker_type;
 
@@ -320,7 +320,7 @@ namespace hpx { namespace lcos {
                 typename broadcast_result<Action>::action_result action_result;
 
             typedef detail::broadcast_apply_invoker<Action,
-                typename util::tuple_element<Is,
+                typename hpx::tuple_element<Is,
                     typename Action::arguments_type>::type...>
                 broadcast_invoker_type;
 

--- a/libs/full/collectives/include/hpx/collectives/fold.hpp
+++ b/libs/full/collectives/include/hpx/collectives/fold.hpp
@@ -258,7 +258,7 @@ namespace hpx { namespace lcos {
                 typedef typename util::decay<FoldOp>::type fold_op_type;
 
                 typedef detail::fold_invoker<Action, fold_op_type,
-                    typename util::tuple_element<Is,
+                    typename hpx::tuple_element<Is,
                         typename Action::arguments_type>::type...>
                     fold_invoker_type;
 

--- a/libs/full/collectives/include/hpx/collectives/reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/reduce.hpp
@@ -175,7 +175,7 @@ namespace hpx { namespace lcos {
                 typedef typename util::decay<ReduceOp>::type reduce_op_type;
 
                 typedef detail::reduce_invoker<Action, reduce_op_type,
-                    typename util::tuple_element<Is,
+                    typename hpx::tuple_element<Is,
                         typename Action::arguments_type>::type...>
                     reduce_invoker_type;
 

--- a/libs/full/compute/include/hpx/compute/host/block_allocator.hpp
+++ b/libs/full/compute/include/hpx/compute/host/block_allocator.hpp
@@ -143,7 +143,7 @@ namespace hpx { namespace compute { namespace host {
                     parallel::util::detail::no_data>;
 
                 auto&& arguments =
-                    hpx::util::forward_as_tuple(std::forward<Args>(args)...);
+                    hpx::forward_as_tuple(std::forward<Args>(args)...);
 
                 cancellation_token tok;
                 partitioner::call(

--- a/libs/full/compute_cuda/include/hpx/compute/cuda/default_executor.hpp
+++ b/libs/full/compute_cuda/include/hpx/compute/cuda/default_executor.hpp
@@ -84,7 +84,7 @@ namespace hpx { namespace cuda { namespace experimental {
         // specialization used by partitioner implementations
         template <typename Iterator>
         struct bulk_launch_helper<
-            hpx::util::tuple<Iterator, std::size_t, std::size_t>,
+            hpx::tuple<Iterator, std::size_t, std::size_t>,
             typename std::enable_if<
                 hpx::traits::is_iterator<Iterator>::value>::type>
         {
@@ -98,8 +98,8 @@ namespace hpx { namespace cuda { namespace experimental {
 
                 for (auto const& s : shape)
                 {
-                    auto begin = hpx::util::get<0>(s);
-                    std::size_t chunk_size = hpx::util::get<1>(s);
+                    auto begin = hpx::get<0>(s);
+                    std::size_t chunk_size = hpx::get<1>(s);
 
                     // FIXME: make the 1024 to be configurable...
                     int threads_per_block =

--- a/libs/full/compute_cuda/include/hpx/compute/cuda/detail/launch.hpp
+++ b/libs/full/compute_cuda/include/hpx/compute/cuda/detail/launch.hpp
@@ -37,7 +37,7 @@ namespace hpx { namespace cuda { namespace experimental { namespace detail {
     template <typename F, typename... Ts>
     struct closure
     {
-        typedef hpx::util::tuple<typename util::decay<Ts>::type...> args_type;
+        typedef hpx::tuple<typename util::decay<Ts>::type...> args_type;
         typedef typename util::decay<F>::type fun_type;
 
         fun_type f_;

--- a/libs/full/include/include/hpx/chrono.hpp
+++ b/libs/full/include/include/hpx/chrono.hpp
@@ -9,9 +9,3 @@
 #include <hpx/timing/high_resolution_clock.hpp>
 #include <hpx/timing/high_resolution_timer.hpp>
 #include <hpx/timing/steady_clock.hpp>
-
-namespace hpx { namespace chrono {
-    using hpx::util::high_resolution_clock;
-    using hpx::util::high_resolution_timer;
-    using hpx::util::steady_time_point;
-}}    // namespace hpx::chrono

--- a/libs/full/include/include/hpx/tuple.hpp
+++ b/libs/full/include/include/hpx/tuple.hpp
@@ -7,15 +7,3 @@
 #pragma once
 
 #include <hpx/datastructures/tuple.hpp>
-
-namespace hpx {
-    using hpx::util::forward_as_tuple;
-    using hpx::util::get;
-    using hpx::util::ignore;
-    using hpx::util::make_tuple;
-    using hpx::util::tie;
-    using hpx::util::tuple;
-    using hpx::util::tuple_cat;
-    using hpx::util::tuple_element;
-    using hpx::util::tuple_size;
-}    // namespace hpx

--- a/libs/full/resiliency/include/hpx/resiliency/async_replicate_executor.hpp
+++ b/libs/full/resiliency/include/hpx/resiliency/async_replicate_executor.hpp
@@ -48,10 +48,9 @@ namespace hpx { namespace resiliency { namespace experimental {
                         result_type>::type;
 
                 // launch given function n times
-                auto func =
-                    [f = std::forward<F>(f),
-                        t = hpx::util::make_tuple(std::forward<Ts>(ts)...)](
-                        std::size_t) mutable -> result_type {
+                auto func = [f = std::forward<F>(f),
+                                t = hpx::make_tuple(std::forward<Ts>(ts)...)](
+                                std::size_t) mutable -> result_type {
                     // ignore argument (invocation count of bulk_execute)
                     return hpx::util::invoke_fused(f, t);
                 };
@@ -126,8 +125,8 @@ namespace hpx { namespace resiliency { namespace experimental {
 
                 // launch given function n times
                 auto func = [f = std::forward<F>(f),
-                                t = hpx::util::make_tuple(std::forward<Ts>(
-                                    ts)...)](std::size_t) mutable {
+                                t = hpx::make_tuple(std::forward<Ts>(ts)...)](
+                                std::size_t) mutable {
                     // ignore argument (invocation count of bulk_execute)
                     hpx::util::invoke_fused(f, t);
                 };

--- a/libs/full/resource_partitioner/examples/async_customization.cpp
+++ b/libs/full/resource_partitioner/examples/async_customization.cpp
@@ -56,7 +56,7 @@ struct test_async_executor
     struct is_tuple_of_futures;
 
     template <typename... Futures>
-    struct is_tuple_of_futures<util::tuple<Futures...>>
+    struct is_tuple_of_futures<hpx::tuple<Futures...>>
       : util::all_of<
             traits::is_future<typename std::remove_reference<Futures>::type>...>
     {
@@ -160,16 +160,16 @@ struct test_async_executor
     template <typename F, template <typename> class OuterFuture,
         typename... InnerFutures, typename... Ts,
         typename = enable_if_t<is_future_of_tuple_of_futures<
-            OuterFuture<util::tuple<InnerFutures...>>>::value>,
+            OuterFuture<hpx::tuple<InnerFutures...>>>::value>,
         typename = enable_if_t<
-            is_tuple_of_futures<util::tuple<InnerFutures...>>::value>>
+            is_tuple_of_futures<hpx::tuple<InnerFutures...>>::value>>
     auto then_execute(F&& f,
-        OuterFuture<util::tuple<InnerFutures...>>&& predecessor, Ts&&... ts)
+        OuterFuture<hpx::tuple<InnerFutures...>>&& predecessor, Ts&&... ts)
         -> future<typename util::detail::invoke_deferred_result<F,
-            OuterFuture<util::tuple<InnerFutures...>>, Ts...>::type>
+            OuterFuture<hpx::tuple<InnerFutures...>>, Ts...>::type>
     {
         typedef typename util::detail::invoke_deferred_result<F,
-            OuterFuture<util::tuple<InnerFutures...>>, Ts...>::type result_type;
+            OuterFuture<hpx::tuple<InnerFutures...>>, Ts...>::type result_type;
 
         // get the tuple of futures from the predecessor future <tuple of futures>
         const auto& predecessor_value =
@@ -181,7 +181,7 @@ struct test_async_executor
 
         using namespace hpx::util::debug;
         std::cout << "when_all(fut) : Predecessor : "
-                  << print_type<OuterFuture<util::tuple<InnerFutures...>>>()
+                  << print_type<OuterFuture<hpx::tuple<InnerFutures...>>>()
                   << "\n";
         std::cout << "when_all(fut) : unwrapped   : "
                   << print_type<decltype(unwrapped_futures_tuple)>(" | ")
@@ -203,8 +203,7 @@ struct test_async_executor
         // forward the task execution on to the real internal executor
         return hpx::parallel::execution::then_execute(executor_,
             util::annotated_function(std::forward<F>(f), "custom then"),
-            std::forward<OuterFuture<util::tuple<InnerFutures...>>>(
-                predecessor),
+            std::forward<OuterFuture<hpx::tuple<InnerFutures...>>>(predecessor),
             std::forward<Ts>(ts)...);
     }
 
@@ -215,20 +214,20 @@ struct test_async_executor
     // --------------------------------------------------------------------
     template <typename F, typename... InnerFutures,
         typename = enable_if_t<
-            traits::is_future_tuple<util::tuple<InnerFutures...>>::value>>
-    auto async_execute(F&& f, util::tuple<InnerFutures...>&& predecessor)
+            traits::is_future_tuple<hpx::tuple<InnerFutures...>>::value>>
+    auto async_execute(F&& f, hpx::tuple<InnerFutures...>&& predecessor)
         -> future<typename util::detail::invoke_deferred_result<F,
-            util::tuple<InnerFutures...>>::type>
+            hpx::tuple<InnerFutures...>>::type>
     {
         typedef typename util::detail::invoke_deferred_result<F,
-            util::tuple<InnerFutures...>>::type result_type;
+            hpx::tuple<InnerFutures...>>::type result_type;
 
         auto unwrapped_futures_tuple =
             util::map_pack(future_extract_value{}, predecessor);
 
         using namespace hpx::util::debug;
         std::cout << "dataflow      : Predecessor : "
-                  << print_type<util::tuple<InnerFutures...>>() << "\n";
+                  << print_type<hpx::tuple<InnerFutures...>>() << "\n";
         std::cout << "dataflow      : unwrapped   : "
                   << print_type<decltype(unwrapped_futures_tuple)>(" | ")
                   << "\n";
@@ -247,7 +246,7 @@ struct test_async_executor
         // forward the task execution on to the real internal executor
         return hpx::parallel::execution::async_execute(executor_,
             util::annotated_function(std::forward<F>(f), "custom async"),
-            std::forward<util::tuple<InnerFutures...>>(predecessor));
+            std::forward<hpx::tuple<InnerFutures...>>(predecessor));
     }
 
 private:
@@ -339,13 +338,13 @@ int test(const std::string& message, Executor& exec)
     //
     auto fw = when_all(fw1, fw2).then(exec,
         [testval2, testval3](
-            future<util::tuple<future<int>, future<double>>>&& f) {
+            future<hpx::tuple<future<int>, future<double>>>&& f) {
             std::cout << "Inside when_all : " << std::endl;
             HPX_TEST_EQ_MSG(
                 f.is_ready(), true, "Continuation run before future ready");
             auto tup = f.get();
             auto cmplx = std::complex<double>(
-                double(util::get<0>(tup).get()), util::get<1>(tup).get());
+                double(hpx::get<0>(tup).get()), hpx::get<1>(tup).get());
             auto cmplxe = std::complex<double>(double(testval2), testval3);
             std::cout << "expected " << cmplxe << " got " << cmplx << std::endl;
             HPX_TEST_EQ(cmplx, cmplxe);
@@ -365,15 +364,15 @@ int test(const std::string& message, Executor& exec)
     auto fws =
         when_all(fws1, fws2)
             .then(exec,
-                [testval4, testval5](future<util::tuple<future<std::uint64_t>,
+                [testval4, testval5](future<hpx::tuple<future<std::uint64_t>,
                         shared_future<float>>>&& f) {
                     std::cout << "Inside when_all(shared) : " << std::endl;
                     HPX_TEST_EQ_MSG(f.is_ready(), true,
                         "Continuation run before future ready");
                     auto tup = f.get();
                     auto cmplx =
-                        std::complex<double>(double(util::get<0>(tup).get()),
-                            double(util::get<1>(tup).get()));
+                        std::complex<double>(double(hpx::get<0>(tup).get()),
+                            double(hpx::get<1>(tup).get()));
                     auto cmplxe = std::complex<double>(
                         double(testval4), double(testval5));
                     std::cout << "expected " << cmplxe << " got " << cmplx
@@ -465,13 +464,13 @@ namespace hpx { namespace parallel { namespace execution {
             std::cout << "Hint 2 \n";
             return 2;
         }
-        int operator()(const util::tuple<future<int>, future<double>>&) const
+        int operator()(const hpx::tuple<future<int>, future<double>>&) const
         {
             std::cout << "Hint 3(a) \n";
             return 3;
         }
         int operator()(
-            const util::tuple<future<std::uint64_t>, shared_future<float>>&)
+            const hpx::tuple<future<std::uint64_t>, shared_future<float>>&)
             const
         {
             std::cout << "Hint 3(b) \n";

--- a/libs/full/resource_partitioner/include/hpx/resource_partitioner/detail/partitioner.hpp
+++ b/libs/full/resource_partitioner/include/hpx/resource_partitioner/detail/partitioner.hpp
@@ -66,7 +66,7 @@ namespace hpx { namespace resource { namespace detail {
         std::vector<threads::mask_type> assigned_pus_;    // mask
 
         // pu index/exclusive/assigned
-        std::vector<util::tuple<std::size_t, bool, bool>> assigned_pu_nums_;
+        std::vector<hpx::tuple<std::size_t, bool, bool>> assigned_pu_nums_;
 
         // counter for number of threads bound to this pool
         std::size_t num_threads_;

--- a/libs/full/resource_partitioner/src/detail_partitioner.cpp
+++ b/libs/full/resource_partitioner/src/detail_partitioner.cpp
@@ -161,33 +161,33 @@ namespace hpx { namespace resource { namespace detail {
     void init_pool_data::assign_pu(std::size_t virt_core)
     {
         HPX_ASSERT(virt_core <= assigned_pu_nums_.size());
-        HPX_ASSERT(!util::get<2>(assigned_pu_nums_[virt_core]));
+        HPX_ASSERT(!hpx::get<2>(assigned_pu_nums_[virt_core]));
 
-        util::get<2>(assigned_pu_nums_[virt_core]) = true;    // -V601
+        hpx::get<2>(assigned_pu_nums_[virt_core]) = true;    // -V601
     }
 
     void init_pool_data::unassign_pu(std::size_t virt_core)
     {
         HPX_ASSERT(virt_core <= assigned_pu_nums_.size());
-        HPX_ASSERT(util::get<2>(assigned_pu_nums_[virt_core]));
+        HPX_ASSERT(hpx::get<2>(assigned_pu_nums_[virt_core]));
 
-        util::get<2>(assigned_pu_nums_[virt_core]) = false;    // -V601
+        hpx::get<2>(assigned_pu_nums_[virt_core]) = false;    // -V601
     }
 
     bool init_pool_data::pu_is_exclusive(std::size_t virt_core) const
     {
         HPX_ASSERT(virt_core <= assigned_pu_nums_.size());
-        HPX_ASSERT(util::get<2>(assigned_pu_nums_[virt_core]));
+        HPX_ASSERT(hpx::get<2>(assigned_pu_nums_[virt_core]));
 
-        return util::get<1>(assigned_pu_nums_[virt_core]);
+        return hpx::get<1>(assigned_pu_nums_[virt_core]);
     }
 
     bool init_pool_data::pu_is_assigned(std::size_t virt_core) const
     {
         HPX_ASSERT(virt_core <= assigned_pu_nums_.size());
-        HPX_ASSERT(util::get<2>(assigned_pu_nums_[virt_core]));
+        HPX_ASSERT(hpx::get<2>(assigned_pu_nums_[virt_core]));
 
-        return util::get<2>(assigned_pu_nums_[virt_core]);
+        return hpx::get<2>(assigned_pu_nums_[virt_core]);
     }
 
     // 'shift' all thread assignments up by the first_core offset
@@ -195,7 +195,7 @@ namespace hpx { namespace resource { namespace detail {
     {
         for (std::size_t i = 0; i != num_threads_; ++i)
         {
-            std::size_t& pu_num = util::get<0>(assigned_pu_nums_[i]);
+            std::size_t& pu_num = hpx::get<0>(assigned_pu_nums_[i]);
             pu_num = (pu_num + first_core) % threads::hardware_concurrency();
 
             threads::reset(assigned_pus_[i]);
@@ -520,7 +520,7 @@ namespace hpx { namespace resource { namespace detail {
                 }
                 for (auto const& pu_num : itp.assigned_pu_nums_)
                 {
-                    new_pu_nums.push_back(util::get<0>(pu_num));
+                    new_pu_nums.push_back(hpx::get<0>(pu_num));
                 }
             }
         }

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
@@ -103,8 +103,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     };
 
     template <typename Iterator1, typename Iterator2, typename Iterator3>
-    struct algorithm_result_helper<
-        hpx::util::tuple<Iterator1, Iterator2, Iterator3>,
+    struct algorithm_result_helper<hpx::tuple<Iterator1, Iterator2, Iterator3>,
         typename std::enable_if<
             hpx::traits::is_segmented_local_iterator<Iterator1>::value ||
             hpx::traits::is_segmented_local_iterator<Iterator2>::value ||
@@ -114,17 +113,15 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         typedef hpx::traits::segmented_local_iterator_traits<Iterator2> traits2;
         typedef hpx::traits::segmented_local_iterator_traits<Iterator3> traits3;
 
-        static HPX_FORCEINLINE hpx::util::tuple<
-            typename traits1::local_iterator, typename traits2::local_iterator,
-            typename traits3::local_iterator>
-        call(hpx::util::tuple<typename traits1::local_raw_iterator,
+        static HPX_FORCEINLINE hpx::tuple<typename traits1::local_iterator,
+            typename traits2::local_iterator, typename traits3::local_iterator>
+        call(hpx::tuple<typename traits1::local_raw_iterator,
             typename traits2::local_raw_iterator,
             typename traits3::local_raw_iterator>&& p)
         {
-            return hpx::util::make_tuple(
-                traits1::remote(std::move(hpx::util::get<0>(p))),
-                traits2::remote(std::move(hpx::util::get<1>(p))),
-                traits3::remote(std::move(hpx::util::get<2>(p))));
+            return hpx::make_tuple(traits1::remote(std::move(hpx::get<0>(p))),
+                traits2::remote(std::move(hpx::get<1>(p))),
+                traits3::remote(std::move(hpx::get<2>(p))));
         }
     };
 
@@ -211,7 +208,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
     template <typename Iterator1, typename Iterator2, typename Iterator3>
     struct algorithm_result_helper<
-        future<hpx::util::tuple<Iterator1, Iterator2, Iterator3>>,
+        future<hpx::tuple<Iterator1, Iterator2, Iterator3>>,
         typename std::enable_if<
             hpx::traits::is_segmented_local_iterator<Iterator1>::value ||
             hpx::traits::is_segmented_local_iterator<Iterator2>::value ||
@@ -221,12 +218,12 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         typedef hpx::traits::segmented_local_iterator_traits<Iterator2> traits2;
         typedef hpx::traits::segmented_local_iterator_traits<Iterator3> traits3;
 
-        typedef hpx::util::tuple<typename traits1::local_raw_iterator,
+        typedef hpx::tuple<typename traits1::local_raw_iterator,
             typename traits2::local_raw_iterator,
             typename traits3::local_raw_iterator>
             arg_type;
 
-        static HPX_FORCEINLINE future<hpx::util::tuple<
+        static HPX_FORCEINLINE future<hpx::tuple<
             typename traits1::local_iterator, typename traits2::local_iterator,
             typename traits3::local_iterator>>
         call(future<arg_type>&& f)
@@ -235,14 +232,14 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             // clang-format off
             return f.then(hpx::launch::sync,
                 [](future<arg_type>&& f)
-                    -> hpx::util::tuple<typename traits1::local_iterator,
+                    -> hpx::tuple<typename traits1::local_iterator,
                         typename traits2::local_iterator,
                         typename traits3::local_iterator> {
                     auto&& p = f.get();
-                    return hpx::util::make_tuple(
-                        traits1::remote(std::move(hpx::util::get<0>(p))),
-                        traits2::remote(std::move(hpx::util::get<1>(p))),
-                        traits3::remote(std::move(hpx::util::get<2>(p))));
+                    return hpx::make_tuple(
+                        traits1::remote(std::move(hpx::get<0>(p))),
+                        traits2::remote(std::move(hpx::get<1>(p))),
+                        traits3::remote(std::move(hpx::get<2>(p))));
                 });
             // clang-format on
         }

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/reduce.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/reduce.hpp
@@ -148,8 +148,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                 [&r, &conv](
                     zip_iterator part_begin, std::size_t part_size) -> T {
                     auto iters = part_begin.get_iterator_tuple();
-                    FwdIter1 it1 = hpx::util::get<0>(iters);
-                    FwdIter2 it2 = hpx::util::get<1>(iters);
+                    FwdIter1 it1 = hpx::get<0>(iters);
+                    FwdIter2 it2 = hpx::get<1>(iters);
                     FwdIter1 last1 = it1;
                     std::advance(last1, part_size);
                     return util::accumulate<T>(it1, last1, it2,

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/scan.hpp
@@ -327,7 +327,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef typename traits_out::segment_iterator segment_iterator_out;
             typedef typename traits_out::local_iterator local_iterator_type_out;
 
-            typedef typename hpx::util::tuple<local_iterator_type_in,
+            typedef typename hpx::tuple<local_iterator_type_in,
                 local_iterator_type_in>
                 local_iterator_in_tuple;
 
@@ -351,7 +351,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     results.push_back(dispatch(traits_in::get_id(sit_in),
                         segmented_scan_T<T>(), policy, std::true_type(), beg,
                         end, op, conv));
-                    in_iters.push_back(hpx::util::make_tuple(beg, end));
+                    in_iters.push_back(hpx::make_tuple(beg, end));
                     out_iters.push_back(sit_out);
                 }
             }
@@ -366,7 +366,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     results.push_back(dispatch(traits_in::get_id(sit_in),
                         segmented_scan_T<T>(), policy, std::true_type(), beg,
                         end, op, conv));
-                    in_iters.push_back(hpx::util::make_tuple(beg, end));
+                    in_iters.push_back(hpx::make_tuple(beg, end));
                     out_iters.push_back(sit_out);
                 }
 
@@ -381,7 +381,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         results.push_back(dispatch(traits_in::get_id(sit_in),
                             segmented_scan_T<T>(), policy, std::true_type(),
                             beg, end, op, conv));
-                        in_iters.push_back(hpx::util::make_tuple(beg, end));
+                        in_iters.push_back(hpx::make_tuple(beg, end));
                         out_iters.push_back(sit_out);
                     }
                 }
@@ -394,7 +394,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     results.push_back(dispatch(traits_in::get_id(sit_in),
                         segmented_scan_T<T>(), policy, std::true_type(), beg,
                         end, op, conv));
-                    in_iters.push_back(hpx::util::make_tuple(beg, end));
+                    in_iters.push_back(hpx::make_tuple(beg, end));
                     out_iters.push_back(sit_out);
                 }
             }
@@ -403,7 +403,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             T last_value = init;
             for (std::size_t i = 0; i < results.size(); ++i)
             {
-                using hpx::util::get;
+                using hpx::get;
                 local_iterator_type_out out = traits_out::begin(out_iters[i]);
 
                 // 2. Step: use the init values to dispatch final scan for each
@@ -534,7 +534,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 !hpx::traits::is_forward_iterator<SegIter>::value>
                 forced_seq;
 
-            typedef typename hpx::util::tuple<local_iterator_type_in,
+            typedef typename hpx::tuple<local_iterator_type_in,
                 local_iterator_type_in>
                 local_iterator_in_tuple;
 
@@ -561,7 +561,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type_in end = traits_in::end(sit_in);
                 if (beg != end)
                 {
-                    in_iters.push_back(hpx::util::make_tuple(beg, end));
+                    in_iters.push_back(hpx::make_tuple(beg, end));
                     out_iters.push_back(sit_out);
                     results.push_back(dispatch_async(traits_in::get_id(sit_in),
                         segmented_scan_T<T>(), policy, forced_seq(), beg, end,
@@ -576,7 +576,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 if (beg != end)
                 {
-                    in_iters.push_back(hpx::util::make_tuple(beg, end));
+                    in_iters.push_back(hpx::make_tuple(beg, end));
                     out_iters.push_back(sit_out);
                     results.push_back(dispatch_async(traits_in::get_id(sit_in),
                         segmented_scan_T<T>(), policy, forced_seq(), beg, end,
@@ -591,7 +591,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     end = traits_in::end(sit_in);
                     if (beg != end)
                     {
-                        in_iters.push_back(hpx::util::make_tuple(beg, end));
+                        in_iters.push_back(hpx::make_tuple(beg, end));
                         out_iters.push_back(sit_out);
                         results.push_back(dispatch_async(
                             traits_in::get_id(sit_in), segmented_scan_T<T>(),
@@ -604,7 +604,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 end = traits_in::local(last);
                 if (beg != end)
                 {
-                    in_iters.push_back(hpx::util::make_tuple(beg, end));
+                    in_iters.push_back(hpx::make_tuple(beg, end));
                     out_iters.push_back(sit_out);
                     results.push_back(dispatch_async(traits_in::get_id(sit_in),
                         segmented_scan_T<T>(), policy, forced_seq(), beg, end,
@@ -625,7 +625,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             for (auto const& res : results)
             {
-                using hpx::util::get;
+                using hpx::get;
                 segment_iterator_out out_it = out_iters[i];
                 local_iterator_type_out out = traits_out::begin(out_it);
                 local_iterator_in_tuple in_tuple = in_iters[i];

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/traits/zip_iterator.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/traits/zip_iterator.hpp
@@ -138,12 +138,12 @@ namespace hpx { namespace traits {
         // iterator.
         static naming::id_type get_id(segment_iterator const& iter)
         {
-            typedef typename util::tuple_element<0,
+            typedef typename hpx::tuple_element<0,
                 typename iterator::iterator_tuple_type>::type
                 first_base_iterator;
             typedef segmented_iterator_traits<first_base_iterator> traits;
 
-            return traits::get_id(util::get<0>(iter.get_iterator_tuple()));
+            return traits::get_id(hpx::get<0>(iter.get_iterator_tuple()));
         }
     };
 

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform.hpp
@@ -261,7 +261,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typename InIter2, typename OutIter, typename F, typename Proj1,
             typename Proj2>
         static typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tuple<InIter1, InIter2, OutIter>>::type
+            hpx::tuple<InIter1, InIter2, OutIter>>::type
         segmented_transform(Algo&& algo, ExPolicy&& policy, InIter1 first1,
             InIter1 last1, InIter2 first2, OutIter dest, F&& f, Proj1&& proj1,
             Proj2&& proj2, std::true_type)
@@ -277,7 +277,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef typename traits3::local_iterator local_iterator_type3;
 
             typedef util::detail::algorithm_result<ExPolicy,
-                hpx::util::tuple<InIter1, InIter2, OutIter>>
+                hpx::tuple<InIter1, InIter2, OutIter>>
                 result;
 
             auto last2 = first2;
@@ -297,14 +297,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type3 ldest = traits3::begin(sdest);
                 if (beg1 != end1)
                 {
-                    hpx::util::tuple<local_iterator_type1, local_iterator_type2,
+                    hpx::tuple<local_iterator_type1, local_iterator_type2,
                         local_iterator_type3>
                         out = dispatch(traits1::get_id(sit1), algo, policy,
                             std::true_type(), beg1, end1, beg2, ldest, f, proj1,
                             proj2);
-                    last1 = traits1::compose(send1, hpx::util::get<0>(out));
-                    last2 = traits2::compose(send2, hpx::util::get<1>(out));
-                    dest = traits3::compose(sdest, hpx::util::get<2>(out));
+                    last1 = traits1::compose(send1, hpx::get<0>(out));
+                    last2 = traits2::compose(send2, hpx::get<1>(out));
+                    dest = traits3::compose(sdest, hpx::get<2>(out));
                 }
             }
             else
@@ -314,7 +314,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type1 end1 = traits1::end(sit1);
                 local_iterator_type2 beg2 = traits2::local(first2);
                 local_iterator_type3 ldest = traits3::begin(sdest);
-                hpx::util::tuple<local_iterator_type1, local_iterator_type2,
+                hpx::tuple<local_iterator_type1, local_iterator_type2,
                     local_iterator_type3>
                     out;
                 if (beg1 != end1)
@@ -351,11 +351,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         std::true_type(), beg1, end1, beg2, ldest, f, proj1,
                         proj2);
                 }
-                last1 = traits1::compose(send1, hpx::util::get<0>(out));
-                last2 = traits2::compose(send2, hpx::util::get<1>(out));
-                dest = traits3::compose(sdest, hpx::util::get<2>(out));
+                last1 = traits1::compose(send1, hpx::get<0>(out));
+                last2 = traits2::compose(send2, hpx::get<1>(out));
+                dest = traits3::compose(sdest, hpx::get<2>(out));
             }
-            return result::get(hpx::util::make_tuple<InIter1, InIter2, OutIter>(
+            return result::get(hpx::make_tuple<InIter1, InIter2, OutIter>(
                 std::move(last1), std::move(last2), std::move(dest)));
         }
 
@@ -364,7 +364,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typename InIter2, typename OutIter, typename F, typename Proj1,
             typename Proj2>
         static typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tuple<InIter1, InIter2, OutIter>>::type
+            hpx::tuple<InIter1, InIter2, OutIter>>::type
         segmented_transform(Algo&& algo, ExPolicy&& policy, InIter1 first1,
             InIter1 last1, InIter2 first2, OutIter dest, F&& f, Proj1&& proj1,
             Proj2&& proj2, std::false_type)
@@ -380,7 +380,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef typename traits3::local_iterator local_iterator_type3;
 
             typedef util::detail::algorithm_result<ExPolicy,
-                hpx::util::tuple<InIter1, InIter2, OutIter>>
+                hpx::tuple<InIter1, InIter2, OutIter>>
                 result;
 
             typedef std::integral_constant<bool,
@@ -397,7 +397,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             segment_iterator2 send2 = traits2::segment(last2);
             segment_iterator3 sdest = traits3::segment(dest);
 
-            typedef std::vector<future<hpx::util::tuple<local_iterator_type1,
+            typedef std::vector<future<hpx::tuple<local_iterator_type1,
                 local_iterator_type2, local_iterator_type3>>>
                 segment_type;
             segment_type segments;
@@ -461,19 +461,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
             }
 
             return result::get(dataflow(
-                [=](segment_type&& r)
-                    -> hpx::util::tuple<InIter1, InIter2, OutIter> {
+                [=](segment_type&& r) -> hpx::tuple<InIter1, InIter2, OutIter> {
                     // handle any remote exceptions, will throw on error
                     std::list<std::exception_ptr> errors;
                     parallel::util::detail::handle_remote_exceptions<
                         ExPolicy>::call(r, errors);
                     auto rl = r.back().get();
-                    auto olast1 =
-                        traits1::compose(send1, hpx::util::get<0>(rl));
-                    auto olast2 =
-                        traits2::compose(send2, hpx::util::get<1>(rl));
-                    auto odest = traits3::compose(sdest, hpx::util::get<2>(rl));
-                    return hpx::util::make_tuple(olast1, olast2, odest);
+                    auto olast1 = traits1::compose(send1, hpx::get<0>(rl));
+                    auto olast2 = traits2::compose(send2, hpx::get<1>(rl));
+                    auto odest = traits3::compose(sdest, hpx::get<2>(rl));
+                    return hpx::make_tuple(olast1, olast2, odest);
                 },
                 std::move(segments)));
         }
@@ -501,9 +498,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             if (first1 == last1)
             {
-                return result::get(
-                    hpx::util::make_tuple<InIter1, InIter2, OutIter>(
-                        std::move(last1), std::move(last2), std::move(dest)));
+                return result::get(hpx::make_tuple<InIter1, InIter2, OutIter>(
+                    std::move(last1), std::move(last2), std::move(dest)));
             }
 
             typedef hpx::traits::segmented_iterator_traits<InIter1>
@@ -512,15 +508,15 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 iterator2_traits;
             typedef hpx::traits::segmented_iterator_traits<OutIter>
                 iterator3_traits;
-            return hpx::util::make_tagged_tuple<tag::in1, tag::in2,
-                tag::out>(segmented_transform(
-                transform_binary<
-                    hpx::util::tuple<typename iterator1_traits::local_iterator,
-                        typename iterator2_traits::local_iterator,
-                        typename iterator3_traits::local_iterator>>(),
-                std::forward<ExPolicy>(policy), first1, last1, first2, dest,
-                std::forward<F>(f), std::forward<Proj1>(proj1),
-                std::forward<Proj2>(proj2), is_seq()));
+            return hpx::util::make_tagged_tuple<tag::in1, tag::in2, tag::out>(
+                segmented_transform(
+                    transform_binary<
+                        hpx::tuple<typename iterator1_traits::local_iterator,
+                            typename iterator2_traits::local_iterator,
+                            typename iterator3_traits::local_iterator>>(),
+                    std::forward<ExPolicy>(policy), first1, last1, first2, dest,
+                    std::forward<F>(f), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2), is_seq()));
         }
 
         // forward declare the non-segmented version of this algorithm
@@ -540,7 +536,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typename InIter2, typename OutIter, typename F, typename Proj1,
             typename Proj2>
         static typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tuple<InIter1, InIter2, OutIter>>::type
+            hpx::tuple<InIter1, InIter2, OutIter>>::type
         segmented_transform(Algo&& algo, ExPolicy&& policy, InIter1 first1,
             InIter1 last1, InIter2 first2, InIter2 last2, OutIter dest, F&& f,
             Proj1&& proj1, Proj2&& proj2, std::true_type)
@@ -556,7 +552,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef typename traits3::local_iterator local_iterator_type3;
 
             typedef util::detail::algorithm_result<ExPolicy,
-                hpx::util::tuple<InIter1, InIter2, OutIter>>
+                hpx::tuple<InIter1, InIter2, OutIter>>
                 result;
 
             segment_iterator1 sit1 = traits1::segment(first1);
@@ -575,14 +571,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type3 ldest = traits3::begin(sdest);
                 if (beg1 != end1 && beg2 != end2)
                 {
-                    hpx::util::tuple<local_iterator_type1, local_iterator_type2,
+                    hpx::tuple<local_iterator_type1, local_iterator_type2,
                         local_iterator_type3>
                         out = dispatch(traits1::get_id(sit1), algo, policy,
                             std::true_type(), beg1, end1, beg2, end2, ldest, f,
                             proj1, proj2);
-                    last1 = traits1::compose(send1, hpx::util::get<0>(out));
-                    last2 = traits2::compose(send2, hpx::util::get<1>(out));
-                    dest = traits3::compose(sdest, hpx::util::get<2>(out));
+                    last1 = traits1::compose(send1, hpx::get<0>(out));
+                    last2 = traits2::compose(send2, hpx::get<1>(out));
+                    dest = traits3::compose(sdest, hpx::get<2>(out));
                 }
             }
             else
@@ -593,7 +589,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type2 beg2 = traits2::local(first2);
                 local_iterator_type2 end2 = traits2::end(sit2);
                 local_iterator_type3 ldest = traits3::begin(sdest);
-                hpx::util::tuple<local_iterator_type1, local_iterator_type2,
+                hpx::tuple<local_iterator_type1, local_iterator_type2,
                     local_iterator_type3>
                     out;
                 if (beg1 != end1 && beg2 != end2)
@@ -632,11 +628,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         std::true_type(), beg1, end1, beg2, end2, ldest, f,
                         proj1, proj2);
                 }
-                last1 = traits1::compose(send1, hpx::util::get<0>(out));
-                last2 = traits2::compose(send2, hpx::util::get<1>(out));
-                dest = traits3::compose(sdest, hpx::util::get<2>(out));
+                last1 = traits1::compose(send1, hpx::get<0>(out));
+                last2 = traits2::compose(send2, hpx::get<1>(out));
+                dest = traits3::compose(sdest, hpx::get<2>(out));
             }
-            return result::get(hpx::util::make_tuple<InIter1, InIter2, OutIter>(
+            return result::get(hpx::make_tuple<InIter1, InIter2, OutIter>(
                 std::move(last1), std::move(last2), std::move(dest)));
         }
 
@@ -645,7 +641,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typename InIter2, typename OutIter, typename F, typename Proj1,
             typename Proj2>
         static typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tuple<InIter1, InIter2, OutIter>>::type
+            hpx::tuple<InIter1, InIter2, OutIter>>::type
         segmented_transform(Algo&& algo, ExPolicy&& policy, InIter1 first1,
             InIter1 last1, InIter2 first2, InIter2 last2, OutIter dest, F&& f,
             Proj1&& proj1, Proj2&& proj2, std::false_type)
@@ -661,7 +657,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef typename traits3::local_iterator local_iterator_type3;
 
             typedef util::detail::algorithm_result<ExPolicy,
-                hpx::util::tuple<InIter1, InIter2, OutIter>>
+                hpx::tuple<InIter1, InIter2, OutIter>>
                 result;
 
             typedef std::integral_constant<bool,
@@ -675,7 +671,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             segment_iterator2 send2 = traits2::segment(last2);
             segment_iterator3 sdest = traits3::segment(dest);
 
-            typedef std::vector<future<hpx::util::tuple<local_iterator_type1,
+            typedef std::vector<future<hpx::tuple<local_iterator_type1,
                 local_iterator_type2, local_iterator_type3>>>
                 segment_type;
             segment_type segments;
@@ -743,19 +739,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
             }
 
             return result::get(dataflow(
-                [=](segment_type&& r)
-                    -> hpx::util::tuple<InIter1, InIter2, OutIter> {
+                [=](segment_type&& r) -> hpx::tuple<InIter1, InIter2, OutIter> {
                     // handle any remote exceptions, will throw on error
                     std::list<std::exception_ptr> errors;
                     parallel::util::detail::handle_remote_exceptions<
                         ExPolicy>::call(r, errors);
                     auto rl = r.back().get();
-                    auto olast1 =
-                        traits1::compose(send1, hpx::util::get<0>(rl));
-                    auto olast2 =
-                        traits2::compose(send2, hpx::util::get<1>(rl));
-                    auto odest = traits3::compose(sdest, hpx::util::get<2>(rl));
-                    return hpx::util::make_tuple(olast1, olast2, odest);
+                    auto olast1 = traits1::compose(send1, hpx::get<0>(rl));
+                    auto olast2 = traits2::compose(send2, hpx::get<1>(rl));
+                    auto odest = traits3::compose(sdest, hpx::get<2>(rl));
+                    return hpx::make_tuple(olast1, olast2, odest);
                 },
                 std::move(segments)));
         }
@@ -780,9 +773,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             if (first1 == last1)
             {
-                return result::get(
-                    hpx::util::make_tuple<InIter1, InIter2, OutIter>(
-                        std::move(last1), std::move(last2), std::move(dest)));
+                return result::get(hpx::make_tuple<InIter1, InIter2, OutIter>(
+                    std::move(last1), std::move(last2), std::move(dest)));
             }
 
             typedef hpx::traits::segmented_iterator_traits<InIter1>
@@ -792,15 +784,15 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef hpx::traits::segmented_iterator_traits<OutIter>
                 iterator3_traits;
 
-            return hpx::util::make_tagged_tuple<tag::in1, tag::in2,
-                tag::out>(segmented_transform(
-                transform_binary2<
-                    hpx::util::tuple<typename iterator1_traits::local_iterator,
-                        typename iterator2_traits::local_iterator,
-                        typename iterator3_traits::local_iterator>>(),
-                std::forward<ExPolicy>(policy), first1, last1, first2, last2,
-                dest, std::forward<F>(f), std::forward<Proj1>(proj1),
-                std::forward<Proj2>(proj2), is_seq()));
+            return hpx::util::make_tagged_tuple<tag::in1, tag::in2, tag::out>(
+                segmented_transform(
+                    transform_binary2<
+                        hpx::tuple<typename iterator1_traits::local_iterator,
+                            typename iterator2_traits::local_iterator,
+                            typename iterator3_traits::local_iterator>>(),
+                    std::forward<ExPolicy>(policy), first1, last1, first2,
+                    last2, dest, std::forward<F>(f), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2), is_seq()));
         }
 
         // forward declare the non-segmented version of this algorithm

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce1.cpp
@@ -23,9 +23,9 @@ struct multiply
 {
     template <typename T>
     typename hpx::util::decay<T>::type operator()(
-        hpx::util::tuple<T, T> const& r) const
+        hpx::tuple<T, T> const& r) const
     {
-        using hpx::util::get;
+        using hpx::get;
         return get<0>(r) * get<1>(r);
     }
 };

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce2.cpp
@@ -23,9 +23,9 @@ struct multiply
 {
     template <typename T>
     typename hpx::util::decay<T>::type operator()(
-        hpx::util::tuple<T, T> const& r) const
+        hpx::tuple<T, T> const& r) const
     {
-        using hpx::util::get;
+        using hpx::get;
         return get<0>(r) * get<1>(r);
     }
 };

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce_binary1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce_binary1.cpp
@@ -22,9 +22,9 @@ struct multiply
 {
     template <typename T>
     typename hpx::util::decay<T>::type operator()(
-        hpx::util::tuple<T, T> const& r) const
+        hpx::tuple<T, T> const& r) const
     {
-        using hpx::util::get;
+        using hpx::get;
         return get<0>(r) * get<1>(r);
     }
 };

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce_binary2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce_binary2.cpp
@@ -22,9 +22,9 @@ struct multiply
 {
     template <typename T>
     typename hpx::util::decay<T>::type operator()(
-        hpx::util::tuple<T, T> const& r) const
+        hpx::tuple<T, T> const& r) const
     {
-        using hpx::util::get;
+        using hpx::get;
         return get<0>(r) * get<1>(r);
     }
 };

--- a/libs/full/thread_executors/include/hpx/thread_executors/embedded_thread_pool_executors.hpp
+++ b/libs/full/thread_executors/include/hpx/thread_executors/embedded_thread_pool_executors.hpp
@@ -17,7 +17,6 @@
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/thread_executors/thread_executor.hpp>
 #include <hpx/threading_base/thread_description.hpp>
-#include <hpx/timing/steady_clock.hpp>
 
 #include <atomic>
 #include <chrono>
@@ -59,14 +58,14 @@ namespace hpx { namespace threads { namespace executors {
             // Schedule given function for execution in this executor no sooner
             // than time abs_time. This call never blocks, and may violate
             // bounds on the executor's queue size.
-            void add_at(util::steady_clock::time_point const& abs_time,
+            void add_at(std::chrono::steady_clock::time_point const& abs_time,
                 closure_type&& f, util::thread_description const& description,
                 threads::thread_stacksize stacksize, error_code& ec) override;
 
             // Schedule given function for execution in this executor no sooner
             // than time rel_time from now. This call never blocks, and may
             // violate bounds on the executor's queue size.
-            void add_after(util::steady_clock::duration const& rel_time,
+            void add_after(std::chrono::steady_clock::duration const& rel_time,
                 closure_type&& f, util::thread_description const& description,
                 threads::thread_stacksize stacksize, error_code& ec) override;
 

--- a/libs/full/thread_executors/include/hpx/thread_executors/this_thread_executors.hpp
+++ b/libs/full/thread_executors/include/hpx/thread_executors/this_thread_executors.hpp
@@ -21,7 +21,6 @@
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/thread_executors/thread_executor.hpp>
 #include <hpx/threading_base/thread_description.hpp>
-#include <hpx/timing/steady_clock.hpp>
 
 #include <atomic>
 #include <chrono>
@@ -61,14 +60,14 @@ namespace hpx { namespace threads { namespace executors {
             // Schedule given function for execution in this executor no sooner
             // than time abs_time. This call never blocks, and may violate
             // bounds on the executor's queue size.
-            void add_at(util::steady_clock::time_point const& abs_time,
+            void add_at(std::chrono::steady_clock::time_point const& abs_time,
                 closure_type&& f, util::thread_description const& description,
                 threads::thread_stacksize stacksize, error_code& ec) override;
 
             // Schedule given function for execution in this executor no sooner
             // than time rel_time from now. This call never blocks, and may
             // violate bounds on the executor's queue size.
-            void add_after(util::steady_clock::duration const& rel_time,
+            void add_after(std::chrono::steady_clock::duration const& rel_time,
                 closure_type&& f, util::thread_description const& description,
                 threads::thread_stacksize stacksize, error_code& ec) override;
 

--- a/libs/full/thread_executors/include/hpx/thread_executors/thread_execution.hpp
+++ b/libs/full/thread_executors/include/hpx/thread_executors/thread_execution.hpp
@@ -194,7 +194,7 @@ namespace hpx { namespace threads {
         auto func =
             parallel::execution::detail::make_fused_bulk_async_execute_helper<
                 result_type>(exec, std::forward<F>(f), shape,
-                hpx::util::make_tuple(std::forward<Ts>(ts)...));
+                hpx::make_tuple(std::forward<Ts>(ts)...));
 
         // void or std::vector<func_result_type>
         typedef

--- a/libs/full/thread_executors/include/hpx/thread_executors/thread_executor.hpp
+++ b/libs/full/thread_executors/include/hpx/thread_executors/thread_executor.hpp
@@ -16,7 +16,6 @@
 #include <hpx/threading_base/scheduler_mode.hpp>
 #include <hpx/threading_base/thread_description.hpp>
 #include <hpx/threading_base/thread_pool_base.hpp>
-#include <hpx/timing/steady_clock.hpp>
 #include <hpx/topology/cpu_mask.hpp>
 #include <hpx/topology/topology.hpp>
 
@@ -229,7 +228,8 @@ namespace hpx { namespace threads {
             // Schedule given function for execution in this executor no sooner
             // than time abs_time. This call never blocks, and may violate
             // bounds on the executor's queue size.
-            virtual void add_at(util::steady_clock::time_point const& abs_time,
+            virtual void add_at(
+                std::chrono::steady_clock::time_point const& abs_time,
                 closure_type&& f, util::thread_description const& desc,
                 threads::thread_stacksize stacksize, error_code& ec) = 0;
 
@@ -244,7 +244,8 @@ namespace hpx { namespace threads {
             // Schedule given function for execution in this executor no sooner
             // than time rel_time from now. This call never blocks, and may
             // violate bounds on the executor's queue size.
-            virtual void add_after(util::steady_clock::duration const& rel_time,
+            virtual void add_after(
+                std::chrono::steady_clock::duration const& rel_time,
                 closure_type&& f, util::thread_description const& desc,
                 threads::thread_stacksize stacksize, error_code& ec) = 0;
 
@@ -375,9 +376,9 @@ namespace hpx { namespace threads {
     //      class scheduled_executor : public executor
     //      {
     //      public:
-    //          virtual void add_at(chrono::steady_clock::time_point abs_time,
+    //          virtual void add_at(chstd::chrono::steady_clock::time_point abs_time,
     //              function<void()> closure) = 0;
-    //          virtual void add_after(chrono::steady_clock::duration rel_time,
+    //          virtual void add_after(chstd::chrono::steady_clock::duration rel_time,
     //              function<void()> closure) = 0;
     //      };
     //
@@ -407,7 +408,7 @@ namespace hpx { namespace threads {
         /// variables.
         /// Error conditions: If invoking closure throws an exception, the
         /// executor shall call terminate.
-        void add_at(util::steady_clock::time_point const& abs_time,
+        void add_at(std::chrono::steady_clock::time_point const& abs_time,
             closure_type f, char const* desc = "",
             threads::thread_stacksize stacksize =
                 threads::thread_stacksize_default,
@@ -435,7 +436,7 @@ namespace hpx { namespace threads {
         /// variables.
         /// Error conditions: If invoking closure throws an exception, the
         /// executor shall call terminate.
-        void add_after(util::steady_clock::duration const& rel_time,
+        void add_after(std::chrono::steady_clock::duration const& rel_time,
             closure_type f, char const* desc = "",
             threads::thread_stacksize stacksize =
                 threads::thread_stacksize_default,

--- a/libs/full/thread_executors/include/hpx/thread_executors/thread_pool_os_executors.hpp
+++ b/libs/full/thread_executors/include/hpx/thread_executors/thread_pool_os_executors.hpp
@@ -20,7 +20,6 @@
 #include <hpx/thread_pools/scheduled_thread_pool.hpp>
 #include <hpx/threading_base/callback_notifier.hpp>
 #include <hpx/threading_base/thread_description.hpp>
-#include <hpx/timing/steady_clock.hpp>
 
 #include <atomic>
 #include <chrono>
@@ -59,14 +58,14 @@ namespace hpx { namespace threads { namespace executors {
             // Schedule given function for execution in this executor no sooner
             // than time abs_time. This call never blocks, and may violate
             // bounds on the executor's queue size.
-            void add_at(util::steady_clock::time_point const& abs_time,
+            void add_at(std::chrono::steady_clock::time_point const& abs_time,
                 closure_type&& f, util::thread_description const& description,
                 threads::thread_stacksize stacksize, error_code& ec) override;
 
             // Schedule given function for execution in this executor no sooner
             // than time rel_time from now. This call never blocks, and may
             // violate bounds on the executor's queue size.
-            void add_after(util::steady_clock::duration const& rel_time,
+            void add_after(std::chrono::steady_clock::duration const& rel_time,
                 closure_type&& f, util::thread_description const& description,
                 threads::thread_stacksize stacksize, error_code& ec) override;
 

--- a/libs/full/thread_executors/src/embedded_thread_pool_executors.cpp
+++ b/libs/full/thread_executors/src/embedded_thread_pool_executors.cpp
@@ -33,7 +33,6 @@
 #include <hpx/threading_base/create_thread.hpp>
 #include <hpx/threading_base/set_thread_state.hpp>
 #include <hpx/threading_base/thread_description.hpp>
-#include <hpx/timing/steady_clock.hpp>
 
 #include <atomic>
 #include <chrono>
@@ -198,7 +197,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail {
     // bounds on the executor's queue size.
     template <typename Scheduler>
     void embedded_thread_pool_executor<Scheduler>::add_at(
-        util::steady_clock::time_point const& abs_time, closure_type&& f,
+        std::chrono::steady_clock::time_point const& abs_time, closure_type&& f,
         util::thread_description const& desc,
         threads::thread_stacksize stacksize, error_code& ec)
     {
@@ -238,12 +237,12 @@ namespace hpx { namespace threads { namespace executors { namespace detail {
     // violate bounds on the executor's queue size.
     template <typename Scheduler>
     void embedded_thread_pool_executor<Scheduler>::add_after(
-        util::steady_clock::duration const& rel_time, closure_type&& f,
+        std::chrono::steady_clock::duration const& rel_time, closure_type&& f,
         util::thread_description const& desc,
         threads::thread_stacksize stacksize, error_code& ec)
     {
-        return add_at(util::steady_clock::now() + rel_time, std::move(f), desc,
-            stacksize, ec);
+        return add_at(std::chrono::steady_clock::now() + rel_time, std::move(f),
+            desc, stacksize, ec);
     }
 
     // Return an estimate of the number of waiting tasks.

--- a/libs/full/thread_executors/src/this_thread_executors.cpp
+++ b/libs/full/thread_executors/src/this_thread_executors.cpp
@@ -32,7 +32,6 @@
 #include <hpx/threading_base/set_thread_state.hpp>
 #include <hpx/threading_base/thread_description.hpp>
 #include <hpx/threading_base/thread_num_tss.hpp>
-#include <hpx/timing/steady_clock.hpp>
 
 #include <atomic>
 #include <chrono>
@@ -175,7 +174,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail {
     // bounds on the executor's queue size.
     template <typename Scheduler>
     void this_thread_executor<Scheduler>::add_at(
-        util::steady_clock::time_point const& abs_time, closure_type&& f,
+        std::chrono::steady_clock::time_point const& abs_time, closure_type&& f,
         util::thread_description const& desc,
         threads::thread_stacksize stacksize, error_code& ec)
     {
@@ -225,12 +224,12 @@ namespace hpx { namespace threads { namespace executors { namespace detail {
     // violate bounds on the executor's queue size.
     template <typename Scheduler>
     void this_thread_executor<Scheduler>::add_after(
-        util::steady_clock::duration const& rel_time, closure_type&& f,
+        std::chrono::steady_clock::duration const& rel_time, closure_type&& f,
         util::thread_description const& desc,
         threads::thread_stacksize stacksize, error_code& ec)
     {
-        return add_at(util::steady_clock::now() + rel_time, std::move(f), desc,
-            stacksize, ec);
+        return add_at(std::chrono::steady_clock::now() + rel_time, std::move(f),
+            desc, stacksize, ec);
     }
 
     // Return an estimate of the number of waiting tasks.

--- a/libs/full/thread_executors/src/thread_pool_os_executors.cpp
+++ b/libs/full/thread_executors/src/thread_pool_os_executors.cpp
@@ -27,7 +27,6 @@
 #include <hpx/functional/bind.hpp>
 #include <hpx/functional/unique_function.hpp>
 #include <hpx/threading_base/thread_description.hpp>
-#include <hpx/timing/steady_clock.hpp>
 
 #include <atomic>
 #include <chrono>
@@ -197,7 +196,7 @@ namespace hpx { namespace threads { namespace executors { namespace detail {
     // bounds on the executor's queue size.
     template <typename Scheduler>
     void thread_pool_os_executor<Scheduler>::add_at(
-        util::steady_clock::time_point const& abs_time, closure_type&& f,
+        std::chrono::steady_clock::time_point const& abs_time, closure_type&& f,
         util::thread_description const& desc,
         threads::thread_stacksize stacksize, error_code& ec)
     {
@@ -231,12 +230,12 @@ namespace hpx { namespace threads { namespace executors { namespace detail {
     // violate bounds on the executor's queue size.
     template <typename Scheduler>
     void thread_pool_os_executor<Scheduler>::add_after(
-        util::steady_clock::duration const& rel_time, closure_type&& f,
+        std::chrono::steady_clock::duration const& rel_time, closure_type&& f,
         util::thread_description const& desc,
         threads::thread_stacksize stacksize, error_code& ec)
     {
-        return add_at(util::steady_clock::now() + rel_time, std::move(f), desc,
-            stacksize, ec);
+        return add_at(std::chrono::steady_clock::now() + rel_time, std::move(f),
+            desc, stacksize, ec);
     }
 
     // Return an estimate of the number of waiting tasks.

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
@@ -80,7 +80,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 auto f1 = [op = std::forward<Op>(op)](zip_iterator part_begin,
                               std::size_t part_size) mutable {
                     // VS2015RC bails out when op is captured by ref
-                    using hpx::util::get;
+                    using hpx::get;
                     util::loop_n<ExPolicy>(
                         part_begin, part_size, [op](zip_iterator it) {
                             get<2>(*it) =

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_find.hpp
@@ -74,7 +74,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               std::size_t base_idx) mutable {
                     util::loop_idx_n(base_idx, it, part_size, tok,
                         [&op, &tok](reference t, std::size_t i) {
-                            using hpx::util::get;
+                            using hpx::get;
                             if (op(get<0>(t), get<1>(t)))
                                 tok.cancel(i);
                         });

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -249,7 +249,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             HPX_HOST_DEVICE HPX_FORCEINLINE void operator()(
                 Iter part_begin, std::size_t part_size, std::size_t)
             {
-                using hpx::util::get;
+                using hpx::get;
                 auto iters = part_begin.get_iterator_tuple();
                 util::copy_n(get<0>(iters), part_size, get<1>(iters));
             }
@@ -297,7 +297,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         hpx::util::make_zip_iterator(first, dest),
                         detail::distance(first, last), copy_iteration(),
                         [](zip_iterator&& last) -> zip_iterator {
-                            using hpx::util::get;
+                            using hpx::get;
                             auto iters = last.get_iterator_tuple();
                             util::copy_synchronize(
                                 get<0>(iters), get<1>(iters));
@@ -406,14 +406,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         hpx::util::make_zip_iterator(first, dest), count,
                         [](zip_iterator part_begin, std::size_t part_size,
                             std::size_t) {
-                            using hpx::util::get;
+                            using hpx::get;
 
                             auto iters = part_begin.get_iterator_tuple();
                             util::copy_n(
                                 get<0>(iters), part_size, get<1>(iters));
                         },
                         [](zip_iterator&& last) -> zip_iterator {
-                            using hpx::util::get;
+                            using hpx::get;
                             auto iters = last.get_iterator_tuple();
                             util::copy_synchronize(
                                 get<0>(iters), get<1>(iters));
@@ -526,7 +526,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #endif
                 std::size_t init = 0;
 
-                using hpx::util::get;
+                using hpx::get;
                 using hpx::util::make_zip_iterator;
                 typedef util::scan_partitioner<ExPolicy,
                     util::in_out_result<FwdIter1, FwdIter3>, std::size_t>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -57,7 +57,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     };
 
     template <typename Result1, typename Result2, typename Result3>
-    struct local_algorithm_result<hpx::util::tuple<Result1, Result2, Result3>>
+    struct local_algorithm_result<hpx::tuple<Result1, Result2, Result3>>
     {
         typedef typename hpx::traits::segmented_local_iterator_traits<
             Result1>::local_raw_iterator type1;
@@ -66,7 +66,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         typedef typename hpx::traits::segmented_local_iterator_traits<
             Result3>::local_raw_iterator type3;
 
-        typedef hpx::util::tuple<type1, type2, type3> type;
+        typedef hpx::tuple<type1, type2, type3> type;
     };
 
     template <>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/equal.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/equal.hpp
@@ -288,10 +288,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         [&f, &proj1, &proj2, &tok](zip_iterator const& curr) {
                             reference t = *curr;
                             if (!hpx::util::invoke(f,
-                                    hpx::util::invoke(
-                                        proj1, hpx::util::get<0>(t)),
-                                    hpx::util::invoke(
-                                        proj2, hpx::util::get<1>(t))))
+                                    hpx::util::invoke(proj1, hpx::get<0>(t)),
+                                    hpx::util::invoke(proj2, hpx::get<1>(t))))
                             {
                                 tok.cancel();
                             }
@@ -389,8 +387,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     util::loop_n<ExPolicy>(it, part_count, tok,
                         [&f, &tok](zip_iterator const& curr) {
                             reference t = *curr;
-                            if (!hpx::util::invoke(f, hpx::util::get<0>(t),
-                                    hpx::util::get<1>(t)))
+                            if (!hpx::util::invoke(
+                                    f, hpx::get<0>(t), hpx::get<1>(t)))
                             {
                                 tok.cancel();
                             }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -116,7 +116,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 // right to be used by the third step--which operates on the
                 // same partitions the first step operated on.
 
-                using hpx::util::get;
+                using hpx::get;
                 using hpx::util::make_zip_iterator;
 
                 auto f3 = [op](zip_iterator part_begin, std::size_t part_size,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -765,42 +765,40 @@ namespace hpx {
             ///////////////////////////////////////////////////////////////////////
             template <typename... Ts, std::size_t... Is>
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void init_iteration(
-                hpx::util::tuple<Ts...>& args, hpx::util::index_pack<Is...>,
+                hpx::tuple<Ts...>& args, hpx::util::index_pack<Is...>,
                 std::size_t part_index)
             {
-                int const _sequencer[] = {0,
-                    (hpx::util::get<Is>(args).init_iteration(part_index),
-                        0)...};
+                int const _sequencer[] = {
+                    0, (hpx::get<Is>(args).init_iteration(part_index), 0)...};
                 (void) _sequencer;
             }
 
             template <typename... Ts, std::size_t... Is, typename F, typename B>
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void invoke_iteration(
-                hpx::util::tuple<Ts...>& args, hpx::util::index_pack<Is...>,
-                F&& f, B part_begin)
+                hpx::tuple<Ts...>& args, hpx::util::index_pack<Is...>, F&& f,
+                B part_begin)
             {
                 hpx::util::invoke(std::forward<F>(f), part_begin,
-                    hpx::util::get<Is>(args).iteration_value()...);
+                    hpx::get<Is>(args).iteration_value()...);
             }
 
             template <typename... Ts, std::size_t... Is>
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void next_iteration(
-                hpx::util::tuple<Ts...>& args, hpx::util::index_pack<Is...>,
+                hpx::tuple<Ts...>& args, hpx::util::index_pack<Is...>,
                 std::size_t part_index)
             {
-                int const _sequencer[] = {0,
-                    (hpx::util::get<Is>(args).next_iteration(part_index),
-                        0)...};
+                int const _sequencer[] = {
+                    0, (hpx::get<Is>(args).next_iteration(part_index), 0)...};
                 (void) _sequencer;
             }
 
             template <typename... Ts, std::size_t... Is>
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void exit_iteration(
-                hpx::util::tuple<Ts...>& args, hpx::util::index_pack<Is...>,
+                hpx::tuple<Ts...>& args, hpx::util::index_pack<Is...>,
                 std::size_t size)
             {
                 int const _sequencer[] = {
-                    0, (hpx::util::get<Is>(args).exit_iteration(size), 0)...};
+                    0, (hpx::get<Is>(args).exit_iteration(size), 0)...};
                 (void) _sequencer;
             }
 
@@ -809,13 +807,13 @@ namespace hpx {
             struct part_iterations;
 
             template <typename F, typename S, typename... Ts>
-            struct part_iterations<F, S, hpx::util::tuple<Ts...>>
+            struct part_iterations<F, S, hpx::tuple<Ts...>>
             {
                 typedef typename hpx::util::decay<F>::type fun_type;
 
                 fun_type f_;
                 S stride_;
-                hpx::util::tuple<Ts...> args_;
+                hpx::tuple<Ts...> args_;
 
                 template <typename F_, typename S_, typename Args>
                 part_iterations(F_&& f, S_&& stride, Args&& args)
@@ -861,7 +859,7 @@ namespace hpx {
             };
 
             template <typename F, typename S>
-            struct part_iterations<F, S, hpx::util::tuple<>>
+            struct part_iterations<F, S, hpx::tuple<>>
             {
                 typedef typename hpx::util::decay<F>::type fun_type;
 
@@ -972,12 +970,11 @@ namespace hpx {
 
                     // we need to decay copy here to properly transport everything
                     // to a GPU device
-                    typedef hpx::util::tuple<
-                        typename hpx::util::decay<Ts>::type...>
+                    typedef hpx::tuple<typename hpx::util::decay<Ts>::type...>
                         args_type;
 
                     args_type args =
-                        hpx::util::forward_as_tuple(std::forward<Ts>(ts)...);
+                        hpx::forward_as_tuple(std::forward<Ts>(ts)...);
 
                     return util::partitioner<ExPolicy>::call_with_index(policy,
                         first, size, stride,
@@ -1024,13 +1021,11 @@ namespace hpx {
                     is_seq;
 
                 std::size_t size = parallel::v1::detail::distance(first, last);
-                auto&& t =
-                    hpx::util::forward_as_tuple(std::forward<Args>(args)...);
+                auto&& t = hpx::forward_as_tuple(std::forward<Args>(args)...);
 
                 return for_loop_algo().call(std::forward<ExPolicy>(policy),
                     is_seq(), first, size, stride,
-                    hpx::util::get<sizeof...(Args) - 1>(t),
-                    hpx::util::get<Is>(t)...);
+                    hpx::get<sizeof...(Args) - 1>(t), hpx::get<Is>(t)...);
             }
 
             // reshuffle arguments, last argument is function object, will go first
@@ -1062,13 +1057,11 @@ namespace hpx {
                 typedef execution::is_sequenced_execution_policy<ExPolicy>
                     is_seq;
 
-                auto&& t =
-                    hpx::util::forward_as_tuple(std::forward<Args>(args)...);
+                auto&& t = hpx::forward_as_tuple(std::forward<Args>(args)...);
 
                 return for_loop_algo().call(std::forward<ExPolicy>(policy),
                     is_seq(), first, size, stride,
-                    hpx::util::get<sizeof...(Args) - 1>(t),
-                    hpx::util::get<Is>(t)...);
+                    hpx::get<sizeof...(Args) - 1>(t), hpx::get<Is>(t)...);
             }
             /// \endcond
         }    // namespace detail

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -134,7 +134,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 // right to be used by the third step--which operates on the
                 // same partitions the first step operated on.
 
-                using hpx::util::get;
+                using hpx::get;
                 using hpx::util::make_zip_iterator;
 
                 auto f3 = [op, policy](zip_iterator part_begin,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
@@ -86,7 +86,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               std::size_t base_idx) mutable -> void {
                     util::loop_idx_n(base_idx, it, part_count, tok,
                         [&pred, &tok](reference t, std::size_t i) -> void {
-                            using hpx::util::get;
+                            using hpx::get;
                             using hpx::util::invoke;
                             if (invoke(pred, get<0>(t), get<1>(t)) ||
                                 invoke(pred, get<1>(t), get<0>(t)))

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/merge.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/merge.hpp
@@ -46,9 +46,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         // sequential merge with projection function.
         template <typename InIter1, typename InIter2, typename OutIter,
             typename Comp, typename Proj1, typename Proj2>
-        hpx::util::tuple<InIter1, InIter2, OutIter> sequential_merge(
-            InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
-            OutIter dest, Comp&& comp, Proj1&& proj1, Proj2&& proj2)
+        hpx::tuple<InIter1, InIter2, OutIter> sequential_merge(InIter1 first1,
+            InIter1 last1, InIter2 first2, InIter2 last2, OutIter dest,
+            Comp&& comp, Proj1&& proj1, Proj2&& proj2)
         {
             if (first1 != last1 && first2 != last2)
             {
@@ -73,7 +73,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             dest = std::copy(first1, last1, dest);
             dest = std::copy(first2, last2, dest);
 
-            return hpx::util::make_tuple(last1, last2, dest);
+            return hpx::make_tuple(last1, last2, dest);
         }
 
         struct upper_bound_helper
@@ -237,13 +237,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
         template <typename ExPolicy, typename RandIter1, typename RandIter2,
             typename RandIter3, typename Comp, typename Proj1, typename Proj2>
-        hpx::future<hpx::util::tuple<RandIter1, RandIter2, RandIter3>>
-        parallel_merge(ExPolicy&& policy, RandIter1 first1, RandIter1 last1,
+        hpx::future<hpx::tuple<RandIter1, RandIter2, RandIter3>> parallel_merge(
+            ExPolicy&& policy, RandIter1 first1, RandIter1 last1,
             RandIter2 first2, RandIter2 last2, RandIter3 dest, Comp&& comp,
             Proj1&& proj1, Proj2&& proj2)
         {
-            typedef hpx::util::tuple<RandIter1, RandIter2, RandIter3>
-                result_type;
+            typedef hpx::tuple<RandIter1, RandIter2, RandIter3> result_type;
 
             typedef typename std::remove_reference<ExPolicy>::type ExPolicy_;
             typedef typename std::remove_reference<Comp>::type Comp_;
@@ -263,7 +262,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                 std::move(proj1), std::move(proj2), false,
                                 lower_bound_helper());
 
-                            return hpx::util::make_tuple(last1, last2,
+                            return hpx::make_tuple(last1, last2,
                                 dest + (last1 - first1) + (last2 - first2));
                         }
                         catch (...)
@@ -291,10 +290,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename ExPolicy, typename InIter1, typename InIter2,
                 typename OutIter, typename Comp, typename Proj1, typename Proj2>
-            static hpx::util::tuple<InIter1, InIter2, OutIter> sequential(
-                ExPolicy, InIter1 first1, InIter1 last1, InIter2 first2,
-                InIter2 last2, OutIter dest, Comp&& comp, Proj1&& proj1,
-                Proj2&& proj2)
+            static hpx::tuple<InIter1, InIter2, OutIter> sequential(ExPolicy,
+                InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
+                OutIter dest, Comp&& comp, Proj1&& proj1, Proj2&& proj2)
             {
                 return sequential_merge(first1, last1, first2, last2, dest,
                     std::forward<Comp>(comp), std::forward<Proj1>(proj1),
@@ -305,13 +303,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 typename RandIter3, typename Comp, typename Proj1,
                 typename Proj2>
             static typename util::detail::algorithm_result<ExPolicy,
-                hpx::util::tuple<RandIter1, RandIter2, RandIter3>>::type
+                hpx::tuple<RandIter1, RandIter2, RandIter3>>::type
             parallel(ExPolicy&& policy, RandIter1 first1, RandIter1 last1,
                 RandIter2 first2, RandIter2 last2, RandIter3 dest, Comp&& comp,
                 Proj1&& proj1, Proj2&& proj2)
             {
-                typedef hpx::util::tuple<RandIter1, RandIter2, RandIter3>
-                    result_type;
+                typedef hpx::tuple<RandIter1, RandIter2, RandIter3> result_type;
                 typedef util::detail::algorithm_result<ExPolicy, result_type>
                     algorithm_result;
 
@@ -461,7 +458,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             "Requires at least random access iterator.");
 
         typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
-        typedef hpx::util::tuple<RandIter1, RandIter2, RandIter3> result_type;
+        typedef hpx::tuple<RandIter1, RandIter2, RandIter3> result_type;
 
         return hpx::util::make_tagged_tuple<tag::in1, tag::in2, tag::out>(
             detail::merge<result_type>().call(std::forward<ExPolicy>(policy),

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
@@ -285,10 +285,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     util::loop_idx_n(base_idx, it, part_count, tok,
                         [&f, &proj1, &proj2, &tok](reference t, std::size_t i) {
                             if (!hpx::util::invoke(f,
-                                    hpx::util::invoke(
-                                        proj1, hpx::util::get<0>(t)),
-                                    hpx::util::invoke(
-                                        proj2, hpx::util::get<1>(t))))
+                                    hpx::util::invoke(proj1, hpx::get<0>(t)),
+                                    hpx::util::invoke(proj2, hpx::get<1>(t))))
                             {
                                 tok.cancel(i);
                             }
@@ -419,8 +417,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               std::size_t base_idx) mutable -> void {
                     util::loop_idx_n(base_idx, it, part_count, tok,
                         [&f, &tok](reference t, std::size_t i) {
-                            if (!hpx::util::invoke(f, hpx::util::get<0>(t),
-                                    hpx::util::get<1>(t)))
+                            if (!hpx::util::invoke(
+                                    f, hpx::get<0>(t), hpx::get<1>(t)))
                             {
                                 tok.cancel(i);
                             }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/move.hpp
@@ -130,7 +130,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         detail::distance(first, last),
                         [](zip_iterator part_begin, std::size_t part_size,
                             std::size_t) {
-                            using hpx::util::get;
+                            using hpx::get;
 
                             auto iters = part_begin.get_iterator_tuple();
                             util::move_n(

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partition.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partition.hpp
@@ -1081,7 +1081,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         // sequential partition_copy with projection function
         template <typename InIter, typename OutIter1, typename OutIter2,
             typename Pred, typename Proj>
-        hpx::util::tuple<InIter, OutIter1, OutIter2> sequential_partition_copy(
+        hpx::tuple<InIter, OutIter1, OutIter2> sequential_partition_copy(
             InIter first, InIter last, OutIter1 dest_true, OutIter2 dest_false,
             Pred&& pred, Proj&& proj)
         {
@@ -1093,7 +1093,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     *dest_false++ = *first;
                 first++;
             }
-            return hpx::util::make_tuple(
+            return hpx::make_tuple(
                 std::move(last), std::move(dest_true), std::move(dest_false));
         }
 
@@ -1109,8 +1109,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             template <typename ExPolicy, typename InIter, typename OutIter1,
                 typename OutIter2, typename Pred,
                 typename Proj = util::projection_identity>
-            static hpx::util::tuple<InIter, OutIter1, OutIter2> sequential(
-                ExPolicy, InIter first, InIter last, OutIter1 dest_true,
+            static hpx::tuple<InIter, OutIter1, OutIter2> sequential(ExPolicy,
+                InIter first, InIter last, OutIter1 dest_true,
                 OutIter2 dest_false, Pred&& pred, Proj&& proj)
             {
                 return sequential_partition_copy(first, last, dest_true,
@@ -1122,14 +1122,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 typename FwdIter3, typename Pred,
                 typename Proj = util::projection_identity>
             static typename util::detail::algorithm_result<ExPolicy,
-                hpx::util::tuple<FwdIter1, FwdIter2, FwdIter3>>::type
+                hpx::tuple<FwdIter1, FwdIter2, FwdIter3>>::type
             parallel(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
                 FwdIter2 dest_true, FwdIter3 dest_false, Pred&& pred,
                 Proj&& proj)
             {
                 using zip_iterator = hpx::util::zip_iterator<FwdIter1, bool*>;
                 using result = util::detail::algorithm_result<ExPolicy,
-                    hpx::util::tuple<FwdIter1, FwdIter2, FwdIter3>>;
+                    hpx::tuple<FwdIter1, FwdIter2, FwdIter3>>;
                 using difference_type =
                     typename std::iterator_traits<FwdIter1>::difference_type;
                 using output_iterator_offset =
@@ -1137,7 +1137,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 if (first == last)
                     return result::get(
-                        hpx::util::make_tuple(last, dest_true, dest_false));
+                        hpx::make_tuple(last, dest_true, dest_false));
 
                 difference_type count = std::distance(first, last);
 
@@ -1148,10 +1148,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #endif
                 output_iterator_offset init = {0, 0};
 
-                using hpx::util::get;
+                using hpx::get;
                 using hpx::util::make_zip_iterator;
                 using scan_partitioner_type = util::scan_partitioner<ExPolicy,
-                    hpx::util::tuple<FwdIter1, FwdIter2, FwdIter3>,
+                    hpx::tuple<FwdIter1, FwdIter2, FwdIter3>,
                     output_iterator_offset>;
 
                 auto f1 = [pred = std::forward<Pred>(pred),
@@ -1212,7 +1212,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         std::vector<
                             hpx::shared_future<output_iterator_offset>>&& items,
                         std::vector<hpx::future<void>>&&) mutable
-                    -> hpx::util::tuple<FwdIter1, FwdIter2, FwdIter3> {
+                    -> hpx::tuple<FwdIter1, FwdIter2, FwdIter3> {
                     HPX_UNUSED(flags);
 
                     output_iterator_offset count_pair = items.back().get();
@@ -1221,7 +1221,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::advance(dest_true, count_true);
                     std::advance(dest_false, count_false);
 
-                    return hpx::util::make_tuple(last, dest_true, dest_false);
+                    return hpx::make_tuple(last, dest_true, dest_false);
                 };
 
                 return scan_partitioner_type::call(
@@ -1350,7 +1350,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             "Requires at least forward iterator.");
 
         using is_seq = execution::is_sequenced_execution_policy<ExPolicy>;
-        using result_type = hpx::util::tuple<FwdIter1, FwdIter2, FwdIter3>;
+        using result_type = hpx::tuple<FwdIter1, FwdIter2, FwdIter3>;
 
         return hpx::util::make_tagged_tuple<tag::in, tag::out1, tag::out2>(
             detail::partition_copy<result_type>().call(

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce_by_key.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce_by_key.hpp
@@ -57,8 +57,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
                 typedef typename std::iterator_traits<Iterator>::reference
                     element_type;
-                typedef hpx::util::tuple<element_type, element_type,
-                    element_type>
+                typedef hpx::tuple<element_type, element_type, element_type>
                     type;
             };
 
@@ -143,9 +142,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
                 // resolves to a tuple of values for *(it-1), *it, *(it+1)
 
-                element_type left = hpx::util::get<0>(value);
-                element_type mid = hpx::util::get<1>(value);
-                element_type right = hpx::util::get<2>(value);
+                element_type left = hpx::get<0>(value);
+                element_type mid = hpx::get<1>(value);
+                element_type right = hpx::get<2>(value);
 
                 // we need to determine which of three states this
                 // index is. It can be:
@@ -174,7 +173,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             // the iterator we want is 'second' part of tagged_pair type (from copy_if)
             auto t = zipiter.out.get_iterator_tuple();
-            iKey key_end = hpx::util::get<0>(t);
+            iKey key_end = hpx::get<0>(t);
             return util::in_out_result<iKey, iVal>{key_end,
                 std::next(val_start, std::distance(key_start, key_end))};
         }
@@ -189,7 +188,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             return lcos::make_future<result_type>(
                 std::move(ziter), [=](ZIter zipiter) {
                     auto t = zipiter.second.get_iterator_tuple();
-                    iKey key_end = hpx::util::get<0>(t);
+                    iKey key_end = hpx::get<0>(t);
                     return result_type{key_end,
                         std::next(
                             val_start, std::distance(key_start, key_end))};
@@ -352,7 +351,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 zip_type_in initial;
                 //
-                typedef hpx::util::tuple<value_type, reduce_key_series_states>
+                typedef hpx::tuple<value_type, reduce_key_series_states>
                     lambda_type;
                 hpx::parallel::inclusive_scan(
                     sync_policy, states_begin, states_end, states_out_begin,
@@ -369,7 +368,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         if (b_state.start)
                         {
                             debug_reduce_by_key(" = " << b_val << std::endl);
-                            return make_tuple(b_val,
+                            return hpx::make_tuple(b_val,
                                 reduce_key_series_states(
                                     a_state.start || b_state.start,
                                     b_state.end));
@@ -380,7 +379,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             debug_reduce_by_key(
                                 " = " << func(a_val, b_val) << std::endl);
                             value_type temp = func(a_val, b_val);
-                            return make_tuple(temp,
+                            return hpx::make_tuple(temp,
                                 reduce_key_series_states(
                                     a_state.start || b_state.start,
                                     b_state.end));

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
@@ -100,7 +100,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #endif
                 std::size_t init = 0u;
 
-                using hpx::util::get;
+                using hpx::get;
                 using hpx::util::make_zip_iterator;
                 typedef util::scan_partitioner<ExPolicy, FwdIter, std::size_t,
                     void, util::scan_partitioner_sequential_f3_tag>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/replace.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/replace.hpp
@@ -376,7 +376,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::distance(first, last),
                     [old_value, new_value, proj = std::forward<Proj>(proj)](
                         reference t) -> void {
-                        using hpx::util::get;
+                        using hpx::get;
                         if (hpx::util::invoke(proj, get<0>(t)) == old_value)
                             get<1>(t) = new_value;
                         else
@@ -539,7 +539,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::distance(first, last),
                     [new_value, f = std::forward<F>(f),
                         proj = std::forward<Proj>(proj)](reference t) -> void {
-                        using hpx::util::get;
+                        using hpx::get;
                         using hpx::util::invoke;
                         if (invoke(f, invoke(proj, get<0>(t))))
                             get<1>(t) = new_value;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reverse.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reverse.hpp
@@ -66,7 +66,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             first, destination_iterator(last)),
                         std::distance(first, last) / 2,
                         [](reference t) -> void {
-                            using hpx::util::get;
+                            using hpx::get;
                             std::swap(get<0>(t), get<1>(t));
                         },
                         util::projection_identity()),

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/sort_by_key.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/sort_by_key.hpp
@@ -29,9 +29,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             template <typename Tuple>
             auto operator()(Tuple&& t) const
-                -> decltype(hpx::util::get<0>(std::forward<Tuple>(t)))
+                -> decltype(hpx::get<0>(std::forward<Tuple>(t)))
             {
-                return hpx::util::get<0>(std::forward<Tuple>(t));
+                return hpx::get<0>(std::forward<Tuple>(t));
             }
         };
         /// \endcond

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/swap_ranges.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/swap_ranges.hpp
@@ -61,7 +61,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     hpx::util::make_zip_iterator(first1, first2),
                     std::distance(first1, last1),
                     [](reference t) -> void {
-                        using hpx::util::get;
+                        using hpx::get;
                         std::swap(get<0>(t), get<1>(t));
                     },
                     util::projection_identity()));

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
@@ -101,24 +101,23 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename Iter>
             HPX_HOST_DEVICE HPX_FORCEINLINE
-                std::pair<typename hpx::util::tuple_element<0,
+                std::pair<typename hpx::tuple_element<0,
                               typename Iter::iterator_tuple_type>::type,
-                    typename hpx::util::tuple_element<1,
+                    typename hpx::tuple_element<1,
                         typename Iter::iterator_tuple_type>::type>
                 execute(Iter part_begin, std::size_t part_size)
             {
                 auto iters = part_begin.get_iterator_tuple();
                 return util::transform_loop_n<execution_policy_type>(
-                    hpx::util::get<0>(iters), part_size,
-                    hpx::util::get<1>(iters),
+                    hpx::get<0>(iters), part_size, hpx::get<1>(iters),
                     transform_projected<F, Proj>{f_, proj_});
             }
 
             template <typename Iter>
             HPX_HOST_DEVICE HPX_FORCEINLINE
-                std::pair<typename hpx::util::tuple_element<0,
+                std::pair<typename hpx::tuple_element<0,
                               typename Iter::iterator_tuple_type>::type,
-                    typename hpx::util::tuple_element<1,
+                    typename hpx::tuple_element<1,
                         typename Iter::iterator_tuple_type>::type>
                 operator()(Iter part_begin, std::size_t part_size,
                     std::size_t /*part_index*/)
@@ -366,19 +365,19 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename Iter>
             HPX_HOST_DEVICE HPX_FORCEINLINE
-                hpx::util::tuple<typename hpx::util::tuple_element<0,
-                                     typename Iter::iterator_tuple_type>::type,
-                    typename hpx::util::tuple_element<1,
+                hpx::tuple<typename hpx::tuple_element<0,
+                               typename Iter::iterator_tuple_type>::type,
+                    typename hpx::tuple_element<1,
                         typename Iter::iterator_tuple_type>::type,
-                    typename hpx::util::tuple_element<2,
+                    typename hpx::tuple_element<2,
                         typename Iter::iterator_tuple_type>::type>
                 operator()(Iter part_begin, std::size_t part_size,
                     std::size_t /*part_index*/)
             {
                 auto iters = part_begin.get_iterator_tuple();
                 return util::transform_binary_loop_n<execution_policy_type>(
-                    hpx::util::get<0>(iters), part_size,
-                    hpx::util::get<1>(iters), hpx::util::get<2>(iters),
+                    hpx::get<0>(iters), part_size, hpx::get<1>(iters),
+                    hpx::get<2>(iters),
                     transform_binary_projected<F, Proj1, Proj2>{
                         f_, proj1_, proj2_});
             }
@@ -396,7 +395,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename ExPolicy, typename InIter1, typename InIter2,
                 typename OutIter, typename F, typename Proj1, typename Proj2>
-            static hpx::util::tuple<InIter1, InIter2, OutIter> sequential(
+            static hpx::tuple<InIter1, InIter2, OutIter> sequential(
                 ExPolicy&& policy, InIter1 first1, InIter1 last1,
                 InIter2 first2, OutIter dest, F&& f, Proj1&& proj1,
                 Proj2&& proj2)
@@ -410,7 +409,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
                 typename FwdIter3, typename F, typename Proj1, typename Proj2>
             static typename util::detail::algorithm_result<ExPolicy,
-                hpx::util::tuple<FwdIter1, FwdIter2, FwdIter3>>::type
+                hpx::tuple<FwdIter1, FwdIter2, FwdIter3>>::type
             parallel(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
                 FwdIter2 first2, FwdIter3 dest, F&& f, Proj1&& proj1,
                 Proj2&& proj2)
@@ -431,8 +430,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 }
 
                 return util::detail::algorithm_result<ExPolicy,
-                    hpx::util::tuple<FwdIter1, FwdIter2,
-                        FwdIter3>>::get(hpx::util::make_tuple(std::move(first1),
+                    hpx::tuple<FwdIter1, FwdIter2,
+                        FwdIter3>>::get(hpx::make_tuple(std::move(first1),
                     std::move(first2), std::move(dest)));
             }
         };
@@ -454,7 +453,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 "Requires at least forward iterator.");
 
             typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
-            typedef hpx::util::tuple<FwdIter1, FwdIter2, FwdIter3> result_type;
+            typedef hpx::tuple<FwdIter1, FwdIter2, FwdIter3> result_type;
 
             return hpx::util::make_tagged_tuple<tag::in1, tag::in2, tag::out>(
                 detail::transform_binary<result_type>().call(
@@ -606,7 +605,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename ExPolicy, typename InIter1, typename InIter2,
                 typename OutIter, typename F, typename Proj1, typename Proj2>
-            static hpx::util::tuple<InIter1, InIter2, OutIter> sequential(
+            static hpx::tuple<InIter1, InIter2, OutIter> sequential(
                 ExPolicy&& policy, InIter1 first1, InIter1 last1,
                 InIter2 first2, InIter2 last2, OutIter dest, F&& f,
                 Proj1&& proj1, Proj2&& proj2)
@@ -620,7 +619,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
                 typename FwdIter3, typename F, typename Proj1, typename Proj2>
             static typename util::detail::algorithm_result<ExPolicy,
-                hpx::util::tuple<FwdIter1, FwdIter2, FwdIter3>>::type
+                hpx::tuple<FwdIter1, FwdIter2, FwdIter3>>::type
             parallel(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
                 FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, F&& f,
                 Proj1&& proj1, Proj2&& proj2)
@@ -642,8 +641,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 }
 
                 return util::detail::algorithm_result<ExPolicy,
-                    hpx::util::tuple<FwdIter1, FwdIter2,
-                        FwdIter3>>::get(hpx::util::make_tuple(std::move(first1),
+                    hpx::tuple<FwdIter1, FwdIter2,
+                        FwdIter3>>::get(hpx::make_tuple(std::move(first1),
                     std::move(first2), std::move(dest)));
             }
         };
@@ -665,7 +664,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 "Requires at least forward iterator.");
 
             typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
-            typedef hpx::util::tuple<FwdIter1, FwdIter2, FwdIter3> result_type;
+            typedef hpx::tuple<FwdIter1, FwdIter2, FwdIter3> result_type;
 
             return hpx::util::make_tagged_tuple<tag::in1, tag::in2, tag::out>(
                 detail::transform_binary2<result_type>().call(

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -119,7 +119,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 // results for each partition and the second produces the
                 // overall result
 
-                using hpx::util::get;
+                using hpx::get;
                 using hpx::util::make_zip_iterator;
 
                 auto f3 = [op](zip_iterator part_begin, std::size_t part_size,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -141,7 +141,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 // results for each partition and the second produces the
                 // overall result
 
-                using hpx::util::get;
+                using hpx::get;
                 using hpx::util::make_zip_iterator;
 
                 auto f3 = [op](zip_iterator part_begin, std::size_t part_size,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
@@ -526,8 +526,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               zip_iterator part_begin,
                               std::size_t part_size) mutable -> T {
                     auto iters = part_begin.get_iterator_tuple();
-                    Iter it1 = hpx::util::get<0>(iters);
-                    Iter2 it2 = hpx::util::get<1>(iters);
+                    Iter it1 = hpx::get<0>(iters);
+                    Iter2 it2 = hpx::get<1>(iters);
 
                     Iter last1 = it1;
                     std::advance(last1, part_size);

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
@@ -103,7 +103,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     hpx::util::make_zip_iterator(first, dest), count,
                     [tok](zip_iterator t, std::size_t part_size) mutable
                     -> partition_result_type {
-                        using hpx::util::get;
+                        using hpx::get;
                         auto iters = t.get_iterator_tuple();
                         FwdIter2 dest = get<1>(iters);
                         return std::make_pair(dest,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_move.hpp
@@ -109,7 +109,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     hpx::util::make_zip_iterator(first, dest), count,
                     [tok](zip_iterator t, std::size_t part_size) mutable
                     -> partition_result_type {
-                        using hpx::util::get;
+                        using hpx::get;
                         auto iters = t.get_iterator_tuple();
                         FwdIter2 dest = get<1>(iters);
                         return std::make_pair(dest,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -102,7 +102,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 flags[0] = false;
 
-                using hpx::util::get;
+                using hpx::get;
                 using hpx::util::make_zip_iterator;
                 typedef util::scan_partitioner<ExPolicy, FwdIter, std::size_t,
                     void, util::scan_partitioner_sequential_f3_tag>
@@ -411,7 +411,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #endif
                 std::size_t init = 0;
 
-                using hpx::util::get;
+                using hpx::get;
                 using hpx::util::make_zip_iterator;
                 typedef util::scan_partitioner<ExPolicy,
                     std::pair<FwdIter1, FwdIter2>, std::size_t>

--- a/libs/parallelism/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
@@ -139,7 +139,7 @@ namespace hpx { namespace parallel { namespace util {
                     iterator_datapar_compatible<InIter1>::value &&
                     iterator_datapar_compatible<InIter2>::value &&
                     iterator_datapar_compatible<OutIter>::value,
-                hpx::util::tuple<InIter1, InIter2, OutIter>>::type
+                hpx::tuple<InIter1, InIter2, OutIter>>::type
             call(InIter1 first1, std::size_t count, InIter2 first2,
                 OutIter dest, F&& f)
             {
@@ -164,7 +164,7 @@ namespace hpx { namespace parallel { namespace util {
                     datapar_transform_loop_step::call1(f, first1, first2, dest);
                 }
 
-                return hpx::util::make_tuple(
+                return hpx::make_tuple(
                     std::move(first1), std::move(first2), std::move(dest));
             }
 
@@ -176,7 +176,7 @@ namespace hpx { namespace parallel { namespace util {
                     !iterator_datapar_compatible<InIter1>::value ||
                     !iterator_datapar_compatible<InIter2>::value ||
                     !iterator_datapar_compatible<OutIter>::value,
-                hpx::util::tuple<InIter1, InIter2, OutIter>>::type
+                hpx::tuple<InIter1, InIter2, OutIter>>::type
             call(InIter1 first1, std::size_t count, InIter2 first2,
                 OutIter dest, F&& f)
             {
@@ -211,7 +211,7 @@ namespace hpx { namespace parallel { namespace util {
                     iterator_datapar_compatible<InIter1>::value &&
                     iterator_datapar_compatible<InIter2>::value &&
                     iterator_datapar_compatible<OutIter>::value,
-                hpx::util::tuple<InIter1, InIter2, OutIter>>::type
+                hpx::tuple<InIter1, InIter2, OutIter>>::type
             call(InIter1 first1, InIter1 last1, InIter2 first2, OutIter dest,
                 F&& f)
             {
@@ -229,7 +229,7 @@ namespace hpx { namespace parallel { namespace util {
                     !iterator_datapar_compatible<InIter1>::value ||
                     !iterator_datapar_compatible<InIter2>::value ||
                     !iterator_datapar_compatible<OutIter>::value,
-                hpx::util::tuple<InIter1, InIter2, OutIter>>::type
+                hpx::tuple<InIter1, InIter2, OutIter>>::type
             call(InIter1 first1, InIter1 last1, InIter2 first2, OutIter dest,
                 F&& f)
             {
@@ -245,7 +245,7 @@ namespace hpx { namespace parallel { namespace util {
                     iterator_datapar_compatible<InIter1>::value &&
                     iterator_datapar_compatible<InIter2>::value &&
                     iterator_datapar_compatible<OutIter>::value,
-                hpx::util::tuple<InIter1, InIter2, OutIter>>::type
+                hpx::tuple<InIter1, InIter2, OutIter>>::type
             call(InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
                 OutIter dest, F&& f)
             {
@@ -265,7 +265,7 @@ namespace hpx { namespace parallel { namespace util {
                     !iterator_datapar_compatible<InIter1>::value ||
                     !iterator_datapar_compatible<InIter2>::value ||
                     !iterator_datapar_compatible<OutIter>::value,
-                hpx::util::tuple<InIter1, InIter2, OutIter>>::type
+                hpx::tuple<InIter1, InIter2, OutIter>>::type
             call(InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
                 OutIter dest, F&& f)
             {
@@ -310,7 +310,7 @@ namespace hpx { namespace parallel { namespace util {
         typename OutIter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
         execution::is_vectorpack_execution_policy<ExPolicy>::value,
-        hpx::util::tuple<InIter1, InIter2, OutIter>>::type
+        hpx::tuple<InIter1, InIter2, OutIter>>::type
     transform_binary_loop_n(
         InIter1 first1, std::size_t count, InIter2 first2, OutIter dest, F&& f)
     {
@@ -324,7 +324,7 @@ namespace hpx { namespace parallel { namespace util {
         typename OutIter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
         execution::is_vectorpack_execution_policy<ExPolicy>::value,
-        hpx::util::tuple<InIter1, InIter2, OutIter>>::type
+        hpx::tuple<InIter1, InIter2, OutIter>>::type
     transform_binary_loop(
         InIter1 first1, InIter1 last1, InIter2 first2, OutIter dest, F&& f)
     {
@@ -336,7 +336,7 @@ namespace hpx { namespace parallel { namespace util {
         typename OutIter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
         execution::is_vectorpack_execution_policy<ExPolicy>::value,
-        hpx::util::tuple<InIter1, InIter2, OutIter>>::type
+        hpx::tuple<InIter1, InIter2, OutIter>>::type
     transform_binary_loop(InIter1 first1, InIter1 last1, InIter2 first2,
         InIter2 last2, OutIter dest, F&& f)
     {

--- a/libs/parallelism/algorithms/include/hpx/parallel/datapar/zip_iterator.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/datapar/zip_iterator.hpp
@@ -39,7 +39,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         {
             auto const& t = it.get_iterator_tuple();
             bool const sequencer[] = {
-                false, is_data_aligned(hpx::util::get<Is>(t))...};
+                false, is_data_aligned(hpx::get<Is>(t))...};
             return std::any_of(&sequencer[1], &sequencer[sizeof...(Is) + 1],
                 [](bool val) { return val; });
         }
@@ -70,10 +70,10 @@ namespace hpx { namespace parallel { namespace traits {
             hpx::util::index_pack<Is...>)
         {
             auto const& t = iter.get_iterator_tuple();
-            return hpx::util::make_tuple(vector_pack_load<
-                typename hpx::util::tuple_element<Is, Tuple>::type,
-                typename std::iterator_traits<Iter>::value_type>::
-                    aligned(hpx::util::get<Is>(t))...);
+            return hpx::make_tuple(
+                vector_pack_load<typename hpx::tuple_element<Is, Tuple>::type,
+                    typename std::iterator_traits<Iter>::value_type>::
+                    aligned(hpx::get<Is>(t))...);
         }
 
         template <typename Tuple, typename... Iter, std::size_t... Is>
@@ -81,17 +81,17 @@ namespace hpx { namespace parallel { namespace traits {
             hpx::util::index_pack<Is...>)
         {
             auto const& t = iter.get_iterator_tuple();
-            return hpx::util::make_tuple(vector_pack_load<
-                typename hpx::util::tuple_element<Is, Tuple>::type,
-                typename std::iterator_traits<Iter>::value_type>::
-                    unaligned(hpx::util::get<Is>(t))...);
+            return hpx::make_tuple(
+                vector_pack_load<typename hpx::tuple_element<Is, Tuple>::type,
+                    typename std::iterator_traits<Iter>::value_type>::
+                    unaligned(hpx::get<Is>(t))...);
         }
     }    // namespace detail
 
     template <typename... Vector, typename ValueType>
-    struct vector_pack_load<hpx::util::tuple<Vector...>, ValueType>
+    struct vector_pack_load<hpx::tuple<Vector...>, ValueType>
     {
-        typedef hpx::util::tuple<Vector...> value_type;
+        typedef hpx::tuple<Vector...> value_type;
 
         template <typename... Iter>
         static value_type aligned(hpx::util::zip_iterator<Iter...> const& iter)
@@ -118,11 +118,9 @@ namespace hpx { namespace parallel { namespace traits {
         {
             auto const& t = iter.get_iterator_tuple();
             int const sequencer[] = {0,
-                (vector_pack_store<
-                     typename hpx::util::tuple_element<Is, Tuple>::type,
+                (vector_pack_store<typename hpx::tuple_element<Is, Tuple>::type,
                      typename std::iterator_traits<Iter>::value_type>::
-                        aligned(
-                            hpx::util::get<Is>(value), hpx::util::get<Is>(t)),
+                        aligned(hpx::get<Is>(value), hpx::get<Is>(t)),
                     0)...};
             (void) sequencer;
         }
@@ -134,18 +132,16 @@ namespace hpx { namespace parallel { namespace traits {
         {
             auto const& t = iter.get_iterator_tuple();
             int const sequencer[] = {0,
-                (vector_pack_store<
-                     typename hpx::util::tuple_element<Is, Tuple>::type,
+                (vector_pack_store<typename hpx::tuple_element<Is, Tuple>::type,
                      typename std::iterator_traits<Iter>::value_type>::
-                        unaligned(
-                            hpx::util::get<Is>(value), hpx::util::get<Is>(t)),
+                        unaligned(hpx::get<Is>(value), hpx::get<Is>(t)),
                     0)...};
             (void) sequencer;
         }
     }    // namespace detail
 
     template <typename... Vector, typename ValueType>
-    struct vector_pack_store<hpx::util::tuple<Vector...>, ValueType>
+    struct vector_pack_store<hpx::tuple<Vector...>, ValueType>
     {
         template <typename V, typename... Iter>
         static void aligned(

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -169,12 +169,12 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     template <typename ExPolicy, typename Future, typename F1, typename FwdIter,
         typename Stride>
     // requires traits::is_future<Future>
-    std::vector<hpx::util::tuple<FwdIter, std::size_t>>
-    get_bulk_iteration_shape(std::true_type /*has_variable_chunk_size*/,
-        ExPolicy&& policy, std::vector<Future>& /*workitems*/, F1&& /*f1*/,
-        FwdIter& first, std::size_t& count, Stride s)
+    std::vector<hpx::tuple<FwdIter, std::size_t>> get_bulk_iteration_shape(
+        std::true_type /*has_variable_chunk_size*/, ExPolicy&& policy,
+        std::vector<Future>& /*workitems*/, F1&& /*f1*/, FwdIter& first,
+        std::size_t& count, Stride s)
     {
-        using tuple_type = hpx::util::tuple<FwdIter, std::size_t>;
+        using tuple_type = hpx::tuple<FwdIter, std::size_t>;
 
         std::size_t const cores = execution::processing_units_count(
             policy.parameters(), policy.executor());
@@ -211,7 +211,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             // in last chunk, consider only remaining number of elements
             std::size_t chunk = (std::min)(chunk_size, count);
 
-            shape.push_back(hpx::util::make_tuple(first, chunk));
+            shape.push_back(hpx::make_tuple(first, chunk));
 
             // modifies 'chunk'
             first = parallel::v1::detail::next(first, count, chunk);
@@ -311,12 +311,12 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     template <typename ExPolicy, typename Future, typename F1, typename FwdIter,
         typename Stride>
     // requires traits::is_future<Future>
-    std::vector<hpx::util::tuple<FwdIter, std::size_t, std::size_t>>
+    std::vector<hpx::tuple<FwdIter, std::size_t, std::size_t>>
     get_bulk_iteration_shape_idx(std::true_type /*has_variable_chunk_size*/,
         ExPolicy&& policy, std::vector<Future>& workitems, F1&& f1,
         FwdIter first, std::size_t count, Stride s)
     {
-        using tuple_type = hpx::util::tuple<FwdIter, std::size_t, std::size_t>;
+        using tuple_type = hpx::tuple<FwdIter, std::size_t, std::size_t>;
 
         std::size_t const cores = execution::processing_units_count(
             policy.parameters(), policy.executor());
@@ -353,7 +353,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             // in last chunk, consider only remaining number of elements
             std::size_t chunk = (std::min)(chunk_size, count);
 
-            shape.push_back(hpx::util::make_tuple(first, chunk, base_idx));
+            shape.push_back(hpx::make_tuple(first, chunk, base_idx));
 
             // modifies 'chunk'
             first = parallel::v1::detail::next(first, count, chunk);

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/chunk_size_iterator.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/chunk_size_iterator.hpp
@@ -23,13 +23,11 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     template <typename Iterator>
     struct chunk_size_iterator
       : public hpx::util::iterator_facade<chunk_size_iterator<Iterator>,
-            hpx::util::tuple<Iterator, std::size_t> const,
-            std::input_iterator_tag>
+            hpx::tuple<Iterator, std::size_t> const, std::input_iterator_tag>
     {
     private:
         typedef hpx::util::iterator_facade<chunk_size_iterator<Iterator>,
-            hpx::util::tuple<Iterator, std::size_t> const,
-            std::input_iterator_tag>
+            hpx::tuple<Iterator, std::size_t> const, std::input_iterator_tag>
             base_type;
 
     public:
@@ -46,23 +44,23 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         HPX_HOST_DEVICE
         Iterator& iterator()
         {
-            return hpx::util::get<0>(data_);
+            return hpx::get<0>(data_);
         }
         HPX_HOST_DEVICE
         Iterator iterator() const
         {
-            return hpx::util::get<0>(data_);
+            return hpx::get<0>(data_);
         }
 
         HPX_HOST_DEVICE
         std::size_t& chunk()
         {
-            return hpx::util::get<1>(data_);
+            return hpx::get<1>(data_);
         }
         HPX_HOST_DEVICE
         std::size_t chunk() const
         {
-            return hpx::util::get<1>(data_);
+            return hpx::get<1>(data_);
         }
 
     protected:
@@ -89,7 +87,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         }
 
     private:
-        hpx::util::tuple<Iterator, std::size_t> data_;
+        hpx::tuple<Iterator, std::size_t> data_;
         std::size_t chunk_size_;
         std::size_t count_;
     };
@@ -98,12 +96,12 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     template <typename Iterator>
     struct chunk_size_idx_iterator
       : public hpx::util::iterator_facade<chunk_size_idx_iterator<Iterator>,
-            hpx::util::tuple<Iterator, std::size_t, std::size_t> const,
+            hpx::tuple<Iterator, std::size_t, std::size_t> const,
             std::input_iterator_tag>
     {
     private:
         typedef hpx::util::iterator_facade<chunk_size_idx_iterator<Iterator>,
-            hpx::util::tuple<Iterator, std::size_t, std::size_t> const,
+            hpx::tuple<Iterator, std::size_t, std::size_t> const,
             std::input_iterator_tag>
             base_type;
 
@@ -121,29 +119,29 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         HPX_HOST_DEVICE
         Iterator& iterator()
         {
-            return hpx::util::get<0>(data_);
+            return hpx::get<0>(data_);
         }
         HPX_HOST_DEVICE
         Iterator iterator() const
         {
-            return hpx::util::get<0>(data_);
+            return hpx::get<0>(data_);
         }
 
         HPX_HOST_DEVICE
         std::size_t& chunk()
         {
-            return hpx::util::get<1>(data_);
+            return hpx::get<1>(data_);
         }
         HPX_HOST_DEVICE
         std::size_t chunk() const
         {
-            return hpx::util::get<1>(data_);
+            return hpx::get<1>(data_);
         }
 
         HPX_HOST_DEVICE
         std::size_t& base_index()
         {
-            return hpx::util::get<2>(data_);
+            return hpx::get<2>(data_);
         }
 
     protected:
@@ -171,7 +169,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         }
 
     private:
-        hpx::util::tuple<Iterator, std::size_t, std::size_t> data_;
+        hpx::tuple<Iterator, std::size_t, std::size_t> data_;
         std::size_t count_;
         std::size_t chunk_size_;
     };

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/partitioner.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/partitioner.hpp
@@ -118,8 +118,8 @@ namespace hpx { namespace parallel { namespace util {
             typename std::vector<std::size_t>::const_iterator chunk_size_it =
                 hpx::util::begin(chunk_sizes);
 
-            typedef typename hpx::util::tuple<typename data_type::value_type,
-                FwdIter, std::size_t>
+            typedef typename hpx::tuple<typename data_type::value_type, FwdIter,
+                std::size_t>
                 tuple_type;
 
             // schedule every chunk on a separate thread
@@ -131,7 +131,7 @@ namespace hpx { namespace parallel { namespace util {
                 std::size_t chunk = (std::min)(count, *chunk_size_it);
                 HPX_ASSERT(chunk != 0);
 
-                shape.push_back(hpx::util::make_tuple(*data_it, first, chunk));
+                shape.push_back(hpx::make_tuple(*data_it, first, chunk));
 
                 count -= chunk;
                 std::advance(first, chunk);

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/prefetching.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/prefetching.hpp
@@ -47,7 +47,7 @@ namespace hpx { namespace parallel { namespace util {
             typedef value_type& reference;
 
         private:
-            typedef hpx::util::tuple<std::reference_wrapper<Ts>...> ranges_type;
+            typedef hpx::tuple<std::reference_wrapper<Ts>...> ranges_type;
 
             ranges_type rngs_;
             base_iterator base_;
@@ -213,7 +213,7 @@ namespace hpx { namespace parallel { namespace util {
         struct prefetcher_context
         {
         private:
-            typedef hpx::util::tuple<std::reference_wrapper<Ts>...> ranges_type;
+            typedef hpx::tuple<std::reference_wrapper<Ts>...> ranges_type;
 
             Itr it_begin_;
             Itr it_end_;
@@ -221,8 +221,8 @@ namespace hpx { namespace parallel { namespace util {
             std::size_t chunk_size_;
             std::size_t range_size_;
 
-            static constexpr std::size_t sizeof_first_value_type = sizeof(
-                typename hpx::util::tuple_element<0, ranges_type>::type::type);
+            static constexpr std::size_t sizeof_first_value_type =
+                sizeof(typename hpx::tuple_element<0, ranges_type>::type::type);
 
         public:
             prefetcher_context(Itr begin, Itr end, ranges_type const& rngs,
@@ -263,20 +263,17 @@ namespace hpx { namespace parallel { namespace util {
         }
 
         template <typename... Ts, std::size_t... Is>
-        HPX_FORCEINLINE void prefetch_containers(
-            hpx::util::tuple<Ts...> const& t, hpx::util::index_pack<Is...>,
-            std::size_t idx)
+        HPX_FORCEINLINE void prefetch_containers(hpx::tuple<Ts...> const& t,
+            hpx::util::index_pack<Is...>, std::size_t idx)
         {
-            prefetch_addresses((hpx::util::get<Is>(t).get())[idx]...);
+            prefetch_addresses((hpx::get<Is>(t).get())[idx]...);
         }
 #else
         template <typename... Ts, std::size_t... Is>
-        HPX_FORCEINLINE void prefetch_containers(
-            hpx::util::tuple<Ts...> const& t, hpx::util::index_pack<Is...>,
-            std::size_t idx)
+        HPX_FORCEINLINE void prefetch_containers(hpx::tuple<Ts...> const& t,
+            hpx::util::index_pack<Is...>, std::size_t idx)
         {
-            int const sequencer[] = {
-                (hpx::util::get<Is>(t).get()[idx], 0)..., 0};
+            int const sequencer[] = {(hpx::get<Is>(t).get()[idx], 0)..., 0};
             (void) sequencer;
         }
 #endif
@@ -402,8 +399,7 @@ namespace hpx { namespace parallel { namespace util {
         static_assert(hpx::util::all_of<hpx::traits::is_range<Ts>...>::value,
             "All variadic parameters have to represent ranges");
 
-        typedef hpx::util::tuple<std::reference_wrapper<Ts const>...>
-            ranges_type;
+        typedef hpx::tuple<std::reference_wrapper<Ts const>...> ranges_type;
 
         auto&& ranges = ranges_type(std::cref(rngs)...);
         return detail::prefetcher_context<Itr, Ts const...>(

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -122,37 +122,35 @@ namespace hpx { namespace parallel { namespace util {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
         template <typename ZipIter>
-        in_out_result<typename hpx::util::tuple_element<0,
+        in_out_result<typename hpx::tuple_element<0,
                           typename ZipIter::iterator_tuple_type>::type,
-            typename hpx::util::tuple_element<1,
+            typename hpx::tuple_element<1,
                 typename ZipIter::iterator_tuple_type>::type>
         get_in_out_result(ZipIter&& zipiter)
         {
             using iterator_tuple_type = typename ZipIter::iterator_tuple_type;
 
             using result_type = in_out_result<
-                typename hpx::util::tuple_element<0, iterator_tuple_type>::type,
-                typename hpx::util::tuple_element<1,
-                    iterator_tuple_type>::type>;
+                typename hpx::tuple_element<0, iterator_tuple_type>::type,
+                typename hpx::tuple_element<1, iterator_tuple_type>::type>;
 
             iterator_tuple_type t = zipiter.get_iterator_tuple();
-            return result_type{hpx::util::get<0>(t), hpx::util::get<1>(t)};
+            return result_type{hpx::get<0>(t), hpx::get<1>(t)};
         }
 
         template <typename ZipIter>
         hpx::future<
-            in_out_result<typename hpx::util::tuple_element<0,
+            in_out_result<typename hpx::tuple_element<0,
                               typename ZipIter::iterator_tuple_type>::type,
-                typename hpx::util::tuple_element<1,
+                typename hpx::tuple_element<1,
                     typename ZipIter::iterator_tuple_type>::type>>
         get_in_out_result(hpx::future<ZipIter>&& zipiter)
         {
             using iterator_tuple_type = typename ZipIter::iterator_tuple_type;
 
             using result_type = in_out_result<
-                typename hpx::util::tuple_element<0, iterator_tuple_type>::type,
-                typename hpx::util::tuple_element<1,
-                    iterator_tuple_type>::type>;
+                typename hpx::tuple_element<0, iterator_tuple_type>::type,
+                typename hpx::tuple_element<1, iterator_tuple_type>::type>;
 
             return lcos::make_future<result_type>(
                 std::move(zipiter), [](ZipIter zipiter) {

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/scan_partitioner.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/scan_partitioner.hpp
@@ -128,8 +128,8 @@ namespace hpx { namespace parallel { namespace util {
                     // partition to the left is ready.
                     for (auto const& elem : shape)
                     {
-                        FwdIter it = hpx::util::get<0>(elem);
-                        std::size_t size = hpx::util::get<1>(elem);
+                        FwdIter it = hpx::get<0>(elem);
+                        std::size_t size = hpx::get<1>(elem);
 
                         hpx::shared_future<Result1> prev = workitems.back();
                         auto curr = execution::async_execute(
@@ -217,8 +217,8 @@ namespace hpx { namespace parallel { namespace util {
                     // partition to the left is ready.
                     for (auto const& elem : shape)
                     {
-                        FwdIter it = hpx::util::get<0>(elem);
-                        std::size_t size = hpx::util::get<1>(elem);
+                        FwdIter it = hpx::get<0>(elem);
+                        std::size_t size = hpx::get<1>(elem);
 
                         hpx::shared_future<Result1> prev = workitems.back();
                         auto curr = execution::async_execute(
@@ -244,8 +244,8 @@ namespace hpx { namespace parallel { namespace util {
                     else
                     {
                         auto elem = *shape_iter++;
-                        FwdIter it = hpx::util::get<0>(elem);
-                        std::size_t size = hpx::util::get<1>(elem);
+                        FwdIter it = hpx::get<0>(elem);
+                        std::size_t size = hpx::get<1>(elem);
 
                         finalitems.push_back(dataflow(hpx::launch::sync, f3, it,
                             size, workitems[0], workitems[1]));
@@ -259,8 +259,8 @@ namespace hpx { namespace parallel { namespace util {
                          ++shape_iter, ++widx)
                     {
                         auto elem = *shape_iter;
-                        FwdIter it = hpx::util::get<0>(elem);
-                        std::size_t size = hpx::util::get<1>(elem);
+                        FwdIter it = hpx::get<0>(elem);
+                        std::size_t size = hpx::get<1>(elem);
 
                         // Wait the completion of f3 on previous partition.
                         finalitems.back().wait();

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/transform_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/transform_loop.hpp
@@ -52,26 +52,26 @@ namespace hpx { namespace parallel { namespace util {
         {
             template <typename InIter1, typename InIter2, typename OutIter,
                 typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static hpx::util::tuple<InIter1,
-                InIter2, OutIter>
-            call(InIter1 first1, InIter1 last1, InIter2 first2, OutIter dest,
-                F&& f)
+            HPX_HOST_DEVICE
+                HPX_FORCEINLINE static hpx::tuple<InIter1, InIter2, OutIter>
+                call(InIter1 first1, InIter1 last1, InIter2 first2,
+                    OutIter dest, F&& f)
             {
                 for (/* */; first1 != last1; (void) ++first1, ++first2, ++dest)
                 {
                     *dest =
                         hpx::util::invoke(std::forward<F>(f), first1, first2);
                 }
-                return hpx::util::make_tuple(
+                return hpx::make_tuple(
                     std::move(first1), std::move(first2), std::move(dest));
             }
 
             template <typename InIter1, typename InIter2, typename OutIter,
                 typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static hpx::util::tuple<InIter1,
-                InIter2, OutIter>
-            call(InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
-                OutIter dest, F&& f)
+            HPX_HOST_DEVICE
+                HPX_FORCEINLINE static hpx::tuple<InIter1, InIter2, OutIter>
+                call(InIter1 first1, InIter1 last1, InIter2 first2,
+                    InIter2 last2, OutIter dest, F&& f)
             {
                 for (/* */; first1 != last1 && first2 != last2;
                      (void) ++first1, ++first2, ++dest)
@@ -79,7 +79,7 @@ namespace hpx { namespace parallel { namespace util {
                     *dest =
                         hpx::util::invoke(std::forward<F>(f), first1, first2);
                 }
-                return hpx::util::make_tuple(first1, first2, dest);
+                return hpx::make_tuple(first1, first2, dest);
             }
         };
     }    // namespace detail
@@ -88,7 +88,7 @@ namespace hpx { namespace parallel { namespace util {
         typename OutIter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
         !execution::is_vectorpack_execution_policy<ExPolicy>::value,
-        hpx::util::tuple<InIter1, InIter2, OutIter>>::type
+        hpx::tuple<InIter1, InIter2, OutIter>>::type
     transform_binary_loop(
         InIter1 first1, InIter1 last1, InIter2 first2, OutIter dest, F&& f)
     {
@@ -100,7 +100,7 @@ namespace hpx { namespace parallel { namespace util {
         typename OutIter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
         !execution::is_vectorpack_execution_policy<ExPolicy>::value,
-        hpx::util::tuple<InIter1, InIter2, OutIter>>::type
+        hpx::tuple<InIter1, InIter2, OutIter>>::type
     transform_binary_loop(InIter1 first1, InIter1 last1, InIter2 first2,
         InIter2 last2, OutIter dest, F&& f)
     {
@@ -142,17 +142,17 @@ namespace hpx { namespace parallel { namespace util {
         {
             template <typename InIter1, typename InIter2, typename OutIter,
                 typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static hpx::util::tuple<InIter1,
-                InIter2, OutIter>
-            call(InIter1 first1, std::size_t count, InIter2 first2,
-                OutIter dest, F&& f)
+            HPX_HOST_DEVICE
+                HPX_FORCEINLINE static hpx::tuple<InIter1, InIter2, OutIter>
+                call(InIter1 first1, std::size_t count, InIter2 first2,
+                    OutIter dest, F&& f)
             {
                 for (/* */; count != 0;
                      (void) --count, ++first1, first2++, ++dest)
                 {
                     *dest = hpx::util::invoke(f, first1, first2);
                 }
-                return hpx::util::make_tuple(
+                return hpx::make_tuple(
                     std::move(first1), std::move(first2), std::move(dest));
             }
         };
@@ -162,7 +162,7 @@ namespace hpx { namespace parallel { namespace util {
         typename OutIter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
         !execution::is_vectorpack_execution_policy<ExPolicy>::value,
-        hpx::util::tuple<InIter1, InIter2, OutIter>>::type
+        hpx::tuple<InIter1, InIter2, OutIter>>::type
     transform_binary_loop_n(
         InIter1 first1, std::size_t count, InIter2 first2, OutIter dest, F&& f)
     {

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/zip_iterator.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/zip_iterator.hpp
@@ -21,13 +21,13 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     template <int N, typename R, typename ZipIter>
     R get_iter(ZipIter&& zipiter)
     {
-        return hpx::util::get<N>(zipiter.get_iterator_tuple());
+        return hpx::get<N>(zipiter.get_iterator_tuple());
     }
 
     template <int N, typename R, typename ZipIter>
     R get_iter(hpx::future<ZipIter>&& zipiter)
     {
-        typedef typename hpx::util::tuple_element<N,
+        typedef typename hpx::tuple_element<N,
             typename ZipIter::iterator_tuple_type>::type result_type;
 
         return lcos::make_future<result_type>(
@@ -54,30 +54,30 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename ZipIter>
-    std::pair<typename hpx::util::tuple_element<0,
+    std::pair<typename hpx::tuple_element<0,
                   typename ZipIter::iterator_tuple_type>::type,
-        typename hpx::util::tuple_element<1,
+        typename hpx::tuple_element<1,
             typename ZipIter::iterator_tuple_type>::type>
     get_iter_pair(ZipIter&& zipiter)
     {
         typedef typename ZipIter::iterator_tuple_type iterator_tuple_type;
 
         iterator_tuple_type t = zipiter.get_iterator_tuple();
-        return std::make_pair(hpx::util::get<0>(t), hpx::util::get<1>(t));
+        return std::make_pair(hpx::get<0>(t), hpx::get<1>(t));
     }
 
     template <typename ZipIter>
-    hpx::future<std::pair<typename hpx::util::tuple_element<0,
+    hpx::future<std::pair<typename hpx::tuple_element<0,
                               typename ZipIter::iterator_tuple_type>::type,
-        typename hpx::util::tuple_element<1,
+        typename hpx::tuple_element<1,
             typename ZipIter::iterator_tuple_type>::type>>
     get_iter_pair(hpx::future<ZipIter>&& zipiter)
     {
         typedef typename ZipIter::iterator_tuple_type iterator_tuple_type;
 
         typedef std::pair<
-            typename hpx::util::tuple_element<0, iterator_tuple_type>::type,
-            typename hpx::util::tuple_element<1, iterator_tuple_type>::type>
+            typename hpx::tuple_element<0, iterator_tuple_type>::type,
+            typename hpx::tuple_element<1, iterator_tuple_type>::type>
             result_type;
 
         return lcos::make_future<result_type>(std::move(zipiter),
@@ -86,9 +86,9 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Tag1, typename Tag2, typename ZipIter>
-    hpx::util::tagged_pair<Tag1(typename hpx::util::tuple_element<0,
+    hpx::util::tagged_pair<Tag1(typename hpx::tuple_element<0,
                                typename ZipIter::iterator_tuple_type>::type),
-        Tag2(typename hpx::util::tuple_element<1,
+        Tag2(typename hpx::tuple_element<1,
             typename ZipIter::iterator_tuple_type>::type)>
     get_iter_tagged_pair(ZipIter&& zipiter)
     {
@@ -98,18 +98,17 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
     template <typename Tag1, typename Tag2, typename ZipIter>
     hpx::future<hpx::util::tagged_pair<
-        Tag1(typename hpx::util::tuple_element<0,
+        Tag1(typename hpx::tuple_element<0,
             typename ZipIter::iterator_tuple_type>::type),
-        Tag2(typename hpx::util::tuple_element<1,
+        Tag2(typename hpx::tuple_element<1,
             typename ZipIter::iterator_tuple_type>::type)>>
     get_iter_tagged_pair(hpx::future<ZipIter>&& zipiter)
     {
         typedef typename ZipIter::iterator_tuple_type iterator_tuple_type;
 
-        typedef hpx::util::tagged_pair<Tag1(typename hpx::util::tuple_element<0,
-                                           iterator_tuple_type>::type),
-            Tag2(typename hpx::util::tuple_element<1,
-                iterator_tuple_type>::type)>
+        typedef hpx::util::tagged_pair<
+            Tag1(typename hpx::tuple_element<0, iterator_tuple_type>::type),
+            Tag2(typename hpx::tuple_element<1, iterator_tuple_type>::type)>
             result_type;
 
         return lcos::make_future<result_type>(

--- a/libs/parallelism/algorithms/tests/regressions/stable_merge_2964.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/stable_merge_2964.cpp
@@ -52,7 +52,7 @@ void test_merge_stable(ExPolicy policy, DataType, int rand_base)
 
     typedef typename std::pair<DataType, int> ElemType;
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size1 = 1000007, size2 = 960202;
     std::vector<ElemType> src1(size1), src2(size2), dest(size1 + size2);

--- a/libs/parallelism/algorithms/tests/unit/algorithms/inplace_merge_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/inplace_merge_tests.hpp
@@ -127,7 +127,7 @@ void test_inplace_merge(
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const left_size = 300007, right_size = 123456;
     std::vector<DataType> res(left_size + right_size), sol;
@@ -167,7 +167,7 @@ void test_inplace_merge_async(
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const left_size = 300007, right_size = 123456;
     std::vector<DataType> res(left_size + right_size), sol;
@@ -381,7 +381,7 @@ void test_inplace_merge_etc(
 
     typedef typename std::vector<DataType>::iterator base_iterator;
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const left_size = 300007, right_size = 123456;
     std::vector<DataType> res(left_size + right_size), sol, org;
@@ -454,7 +454,7 @@ void test_inplace_merge_stable(
     typedef typename std::vector<ElemType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const left_size = 300007, right_size = 123456;
     std::vector<ElemType> res(left_size + right_size);

--- a/libs/parallelism/algorithms/tests/unit/algorithms/merge_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/merge_tests.hpp
@@ -126,7 +126,7 @@ void test_merge(
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size1 = 300007, size2 = 123456;
     std::vector<DataType> src1(size1), src2(size2), dest_res(size1 + size2),
@@ -161,7 +161,7 @@ void test_merge_async(
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size1 = 300007, size2 = 123456;
     std::vector<DataType> src1(size1), src2(size2), dest_res(size1 + size2),
@@ -361,7 +361,7 @@ void test_merge_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
 
     typedef typename std::vector<DataType>::iterator base_iterator;
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size1 = 300007, size2 = 123456;
     std::vector<DataType> src1(size1), src2(size2), dest_res(size1 + size2),
@@ -452,7 +452,7 @@ void test_merge_stable(ExPolicy policy, IteratorTag, DataType, int rand_base)
     typedef typename std::vector<ElemType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size1 = 300007, size2 = 123456;
     std::vector<ElemType> src1(size1), src2(size2), dest(size1 + size2);

--- a/libs/parallelism/algorithms/tests/unit/algorithms/partition_copy_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/partition_copy_tests.hpp
@@ -108,7 +108,7 @@ void test_partition_copy(
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), d_true_res(size), d_false_res(size),
@@ -145,7 +145,7 @@ void test_partition_copy_async(
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), d_true_res(size), d_false_res(size),

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary2_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary2_tests.hpp
@@ -68,9 +68,9 @@ void test_transform_binary2(ExPolicy policy, IteratorTag)
         iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(d1),
         add());
 
-    HPX_TEST(hpx::util::get<0>(result) == iterator(std::end(c1)));
-    HPX_TEST(hpx::util::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::util::get<2>(result) == std::end(d1));
+    HPX_TEST(hpx::get<0>(result) == iterator(std::end(c1)));
+    HPX_TEST(hpx::get<1>(result) == std::end(c2));
+    HPX_TEST(hpx::get<2>(result) == std::end(d1));
 
     // verify values
     std::vector<int> d2(c1.size());
@@ -106,10 +106,10 @@ void test_transform_binary2_async(ExPolicy p, IteratorTag)
         add());
     f.wait();
 
-    hpx::util::tuple<iterator, base_iterator, base_iterator> result = f.get();
-    HPX_TEST(hpx::util::get<0>(result) == iterator(std::end(c1)));
-    HPX_TEST(hpx::util::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::util::get<2>(result) == std::end(d1));
+    hpx::tuple<iterator, base_iterator, base_iterator> result = f.get();
+    HPX_TEST(hpx::get<0>(result) == iterator(std::end(c1)));
+    HPX_TEST(hpx::get<1>(result) == std::end(c2));
+    HPX_TEST(hpx::get<2>(result) == std::end(d1));
 
     // verify values
     std::vector<int> d2(c1.size());

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary_tests.hpp
@@ -67,9 +67,9 @@ void test_transform_binary(ExPolicy policy, IteratorTag)
     auto result = hpx::parallel::transform(policy, iterator(std::begin(c1)),
         iterator(std::end(c1)), std::begin(c2), std::begin(d1), add());
 
-    HPX_TEST(hpx::util::get<0>(result) == iterator(std::end(c1)));
-    HPX_TEST(hpx::util::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::util::get<2>(result) == std::end(d1));
+    HPX_TEST(hpx::get<0>(result) == iterator(std::end(c1)));
+    HPX_TEST(hpx::get<1>(result) == std::end(c2));
+    HPX_TEST(hpx::get<2>(result) == std::end(d1));
 
     // verify values
     std::vector<int> d2(c1.size());
@@ -104,10 +104,10 @@ void test_transform_binary_async(ExPolicy p, IteratorTag)
         iterator(std::end(c1)), std::begin(c2), std::begin(d1), add());
     f.wait();
 
-    hpx::util::tuple<iterator, base_iterator, base_iterator> result = f.get();
-    HPX_TEST(hpx::util::get<0>(result) == iterator(std::end(c1)));
-    HPX_TEST(hpx::util::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::util::get<2>(result) == std::end(d1));
+    hpx::tuple<iterator, base_iterator, base_iterator> result = f.get();
+    HPX_TEST(hpx::get<0>(result) == iterator(std::end(c1)));
+    HPX_TEST(hpx::get<1>(result) == std::end(c2));
+    HPX_TEST(hpx::get<2>(result) == std::end(d1));
 
     // verify values
     std::vector<int> d2(c1.size());

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce.cpp
@@ -29,10 +29,10 @@ void test_transform_reduce(IteratorTag)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
 
-    typedef hpx::util::tuple<std::size_t, std::size_t> result_type;
+    typedef hpx::tuple<std::size_t, std::size_t> result_type;
 
-    using hpx::util::get;
-    using hpx::util::make_tuple;
+    using hpx::get;
+    using hpx::make_tuple;
 
     auto reduce_op = [](result_type v1, result_type v2) -> result_type {
         return make_tuple(get<0>(v1) * get<0>(v2), get<1>(v1) * get<1>(v2));
@@ -70,10 +70,10 @@ void test_transform_reduce(ExPolicy&& policy, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
 
-    typedef hpx::util::tuple<std::size_t, std::size_t> result_type;
+    typedef hpx::tuple<std::size_t, std::size_t> result_type;
 
-    using hpx::util::get;
-    using hpx::util::make_tuple;
+    using hpx::get;
+    using hpx::make_tuple;
 
     auto reduce_op = [](result_type v1, result_type v2) -> result_type {
         return make_tuple(get<0>(v1) * get<0>(v2), get<1>(v1) * get<1>(v2));

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_tests.hpp
@@ -63,8 +63,8 @@ void test_transform(ExPolicy policy, IteratorTag)
     auto result = hpx::parallel::transform(policy, iterator(std::begin(c)),
         iterator(std::end(c)), std::begin(d), add_one());
 
-    HPX_TEST(hpx::util::get<0>(result) == iterator(std::end(c)));
-    HPX_TEST(hpx::util::get<1>(result) == std::end(d));
+    HPX_TEST(hpx::get<0>(result) == iterator(std::end(c)));
+    HPX_TEST(hpx::get<1>(result) == std::end(d));
 
     // verify values
     std::size_t count = 0;
@@ -91,9 +91,9 @@ void test_transform_async(ExPolicy p, IteratorTag)
         iterator(std::end(c)), std::begin(d), add_one());
     f.wait();
 
-    hpx::util::tuple<iterator, base_iterator> result = f.get();
-    HPX_TEST(hpx::util::get<0>(result) == iterator(std::end(c)));
-    HPX_TEST(hpx::util::get<1>(result) == std::end(d));
+    hpx::tuple<iterator, base_iterator> result = f.get();
+    HPX_TEST(hpx::get<0>(result) == iterator(std::end(c)));
+    HPX_TEST(hpx::get<1>(result) == std::end(d));
 
     // verify values
     std::size_t count = 0;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/unique_copy_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/unique_copy_tests.hpp
@@ -130,7 +130,7 @@ void test_unique_copy(
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), dest_res(size), dest_sol(size);
@@ -159,7 +159,7 @@ void test_unique_copy_async(
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), dest_res(size), dest_sol(size);
@@ -332,7 +332,7 @@ void test_unique_copy_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
 
     typedef typename std::vector<DataType>::iterator base_iterator;
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), dest_res(size), dest_sol(size);

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/is_heap_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/is_heap_range.cpp
@@ -59,7 +59,7 @@ void test_is_heap(ExPolicy policy, DataType)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size);
@@ -81,7 +81,7 @@ void test_is_heap_async(ExPolicy policy, DataType)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size);

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/is_heap_until_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/is_heap_until_range.cpp
@@ -59,7 +59,7 @@ void test_is_heap_until(ExPolicy policy, DataType)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size);
@@ -81,7 +81,7 @@ void test_is_heap_until_async(ExPolicy policy, DataType)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size);

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/merge_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/merge_range.cpp
@@ -96,7 +96,7 @@ void test_merge(ExPolicy policy, DataType)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size1 = 300007, size2 = 123456;
     std::vector<DataType> src1(size1), src2(size2), dest_res(size1 + size2),
@@ -128,7 +128,7 @@ void test_merge_async(ExPolicy policy, DataType)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size1 = 300007, size2 = 123456;
     std::vector<DataType> src1(size1), src2(size2), dest_res(size1 + size2),

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/partition_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/partition_copy_range.cpp
@@ -87,7 +87,7 @@ void test_partition_copy(ExPolicy policy, DataType)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    using hpx::util::get;
+    using hpx::get;
 
     int rand_base = std::rand();
     auto pred = [rand_base](
@@ -123,7 +123,7 @@ void test_partition_copy_async(ExPolicy policy, DataType)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    using hpx::util::get;
+    using hpx::get;
 
     int rand_base = std::rand();
     auto pred = [rand_base](

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/partition_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/partition_range.cpp
@@ -93,7 +93,7 @@ void test_partition(ExPolicy policy, DataType)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    using hpx::util::get;
+    using hpx::get;
 
     int rand_base = std::rand();
     auto pred = [rand_base](
@@ -131,7 +131,7 @@ void test_partition_async(ExPolicy policy, DataType)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    using hpx::util::get;
+    using hpx::get;
 
     int rand_base = std::rand();
     auto pred = [rand_base](

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_if_range.cpp
@@ -74,7 +74,7 @@ void test_remove_if(ExPolicy policy, DataType)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), d;
@@ -98,7 +98,7 @@ void test_remove_if_async(ExPolicy policy, DataType)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), d;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_range.cpp
@@ -74,7 +74,7 @@ void test_remove(ExPolicy policy, DataType)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), d;
@@ -98,7 +98,7 @@ void test_remove_async(ExPolicy policy, DataType)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), d;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range.cpp
@@ -39,8 +39,8 @@ void test_transform(ExPolicy policy, IteratorTag)
     auto result = hpx::parallel::transform(
         policy, c, std::begin(d), [](std::size_t v) { return v + 1; });
 
-    HPX_TEST(hpx::util::get<0>(result) == std::end(c));
-    HPX_TEST(hpx::util::get<1>(result) == std::end(d));
+    HPX_TEST(hpx::get<0>(result) == std::end(c));
+    HPX_TEST(hpx::get<1>(result) == std::end(d));
 
     // verify values
     std::size_t count = 0;
@@ -71,8 +71,8 @@ void test_transform_async(ExPolicy p, IteratorTag)
     f.wait();
 
     auto result = f.get();
-    HPX_TEST(hpx::util::get<0>(result) == std::end(c));
-    HPX_TEST(hpx::util::get<1>(result) == std::end(d));
+    HPX_TEST(hpx::get<0>(result) == std::end(c));
+    HPX_TEST(hpx::get<1>(result) == std::end(d));
 
     // verify values
     std::size_t count = 0;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary.cpp
@@ -83,9 +83,9 @@ void test_transform_binary_async(ExPolicy p, IteratorTag)
     f.wait();
 
     auto result = f.get();
-    HPX_TEST(hpx::util::get<0>(result) == std::end(c1));
-    HPX_TEST(hpx::util::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::util::get<2>(result) == std::end(d1));
+    HPX_TEST(hpx::get<0>(result) == std::end(c1));
+    HPX_TEST(hpx::get<1>(result) == std::end(c2));
+    HPX_TEST(hpx::get<2>(result) == std::end(d1));
 
     // verify values
     std::vector<std::size_t> d2(c1.size());

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary2.cpp
@@ -42,9 +42,9 @@ void test_transform_binary(ExPolicy policy, IteratorTag)
 
     auto result = hpx::parallel::transform(policy, c1, c2, std::begin(d1), add);
 
-    HPX_TEST(hpx::util::get<0>(result) == std::end(c1));
-    HPX_TEST(hpx::util::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::util::get<2>(result) == std::end(d1));
+    HPX_TEST(hpx::get<0>(result) == std::end(c1));
+    HPX_TEST(hpx::get<1>(result) == std::end(c2));
+    HPX_TEST(hpx::get<2>(result) == std::end(d1));
 
     // verify values
     std::vector<std::size_t> d2(c1.size());
@@ -81,9 +81,9 @@ void test_transform_binary_async(ExPolicy p, IteratorTag)
     f.wait();
 
     auto result = f.get();
-    HPX_TEST(hpx::util::get<0>(result) == std::end(c1));
-    HPX_TEST(hpx::util::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::util::get<2>(result) == std::end(d1));
+    HPX_TEST(hpx::get<0>(result) == std::end(c1));
+    HPX_TEST(hpx::get<1>(result) == std::end(c2));
+    HPX_TEST(hpx::get<2>(result) == std::end(d1));
 
     // verify values
     std::vector<std::size_t> d2(c1.size());

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_range.cpp
@@ -30,10 +30,10 @@ void test_transform_reduce(IteratorTag)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
 
-    typedef hpx::util::tuple<std::size_t, std::size_t> result_type;
+    typedef hpx::tuple<std::size_t, std::size_t> result_type;
 
-    using hpx::util::get;
-    using hpx::util::make_tuple;
+    using hpx::get;
+    using hpx::make_tuple;
 
     auto reduce_op = [](result_type v1, result_type v2) -> result_type {
         return make_tuple(get<0>(v1) * get<0>(v2), get<1>(v1) * get<1>(v2));
@@ -71,10 +71,10 @@ void test_transform_reduce(ExPolicy&& policy, IteratorTag)
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());
 
-    typedef hpx::util::tuple<std::size_t, std::size_t> result_type;
+    typedef hpx::tuple<std::size_t, std::size_t> result_type;
 
-    using hpx::util::get;
-    using hpx::util::make_tuple;
+    using hpx::get;
+    using hpx::make_tuple;
 
     auto reduce_op = [](result_type v1, result_type v2) -> result_type {
         return make_tuple(get<0>(v1) * get<0>(v2), get<1>(v1) * get<1>(v2));

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_copy_range.cpp
@@ -74,7 +74,7 @@ void test_unique_copy(ExPolicy policy, DataType)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), dest_res(size), dest_sol(size);
@@ -99,7 +99,7 @@ void test_unique_copy_async(ExPolicy policy, DataType)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), dest_res(size), dest_sol(size);

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_range.cpp
@@ -74,7 +74,7 @@ void test_unique(ExPolicy policy, DataType)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), d;
@@ -96,7 +96,7 @@ void test_unique_async(ExPolicy policy, DataType)
         hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
         "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::size_t const size = 10007;
     std::vector<DataType> c(size), d;

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_datapar_zipiter.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_datapar_zipiter.cpp
@@ -27,8 +27,8 @@ struct set_42
     template <typename Tuple>
     void operator()(Tuple&& t)
     {
-        hpx::util::get<0>(t) = 42;
-        hpx::util::get<1>(t) = 42;
+        hpx::get<0>(t) = 42;
+        hpx::get<1>(t) = 42;
     }
 };
 

--- a/libs/parallelism/async_combinators/include/hpx/async_combinators/split_future.hpp
+++ b/libs/parallelism/async_combinators/include/hpx/async_combinators/split_future.hpp
@@ -18,7 +18,7 @@ namespace hpx {
     ///
     /// \param f    [in] A future holding an arbitrary sequence of values stored
     ///             in a tuple-like container. This facility supports
-    ///             \a hpx::util::tuple<>, \a std::pair<T1, T2>, and
+    ///             \a hpx::tuple<>, \a std::pair<T1, T2>, and
     ///             \a std::array<T, N>
     ///
     /// \return     Returns an equivalent container (same container type as
@@ -108,8 +108,7 @@ namespace hpx { namespace lcos {
                 {
                     typedef typename traits::future_traits<T>::type result_type;
                     result_type* result = state->get_result();
-                    this->base_type::set_value(
-                        std::move(hpx::util::get<I>(*result)));
+                    this->base_type::set_value(std::move(hpx::get<I>(*result)));
                     return;
                 }
                 catch (...)
@@ -150,7 +149,7 @@ namespace hpx { namespace lcos {
         template <typename Result, typename Tuple, std::size_t I,
             typename Future>
         inline typename hpx::traits::detail::shared_state_ptr<
-            typename hpx::util::tuple_element<I, Tuple>::type>::type
+            typename hpx::tuple_element<I, Tuple>::type>::type
         extract_nth_continuation(Future& future)
         {
             typedef split_nth_continuation<Result> shared_state;
@@ -164,24 +163,20 @@ namespace hpx { namespace lcos {
 
         ///////////////////////////////////////////////////////////////////////
         template <std::size_t I, typename Tuple>
-        HPX_FORCEINLINE
-            hpx::future<typename hpx::util::tuple_element<I, Tuple>::type>
-            extract_nth_future(hpx::future<Tuple>& future)
+        HPX_FORCEINLINE hpx::future<typename hpx::tuple_element<I, Tuple>::type>
+        extract_nth_future(hpx::future<Tuple>& future)
         {
-            typedef
-                typename hpx::util::tuple_element<I, Tuple>::type result_type;
+            typedef typename hpx::tuple_element<I, Tuple>::type result_type;
 
             return hpx::traits::future_access<hpx::future<result_type>>::create(
                 extract_nth_continuation<result_type, Tuple, I>(future));
         }
 
         template <std::size_t I, typename Tuple>
-        HPX_FORCEINLINE
-            hpx::future<typename hpx::util::tuple_element<I, Tuple>::type>
-            extract_nth_future(hpx::shared_future<Tuple>& future)
+        HPX_FORCEINLINE hpx::future<typename hpx::tuple_element<I, Tuple>::type>
+        extract_nth_future(hpx::shared_future<Tuple>& future)
         {
-            typedef
-                typename hpx::util::tuple_element<I, Tuple>::type result_type;
+            typedef typename hpx::tuple_element<I, Tuple>::type result_type;
 
             return hpx::traits::future_access<hpx::future<result_type>>::create(
                 extract_nth_continuation<result_type, Tuple, I>(future));
@@ -189,19 +184,18 @@ namespace hpx { namespace lcos {
 
         ///////////////////////////////////////////////////////////////////////
         template <typename... Ts, std::size_t... Is>
-        HPX_FORCEINLINE hpx::util::tuple<hpx::future<Ts>...>
-        split_future_helper(hpx::future<hpx::util::tuple<Ts...>>&& f,
-            hpx::util::index_pack<Is...>)
+        HPX_FORCEINLINE hpx::tuple<hpx::future<Ts>...> split_future_helper(
+            hpx::future<hpx::tuple<Ts...>>&& f, hpx::util::index_pack<Is...>)
         {
-            return hpx::util::make_tuple(extract_nth_future<Is>(f)...);
+            return hpx::make_tuple(extract_nth_future<Is>(f)...);
         }
 
         template <typename... Ts, std::size_t... Is>
-        HPX_FORCEINLINE hpx::util::tuple<hpx::future<Ts>...>
-        split_future_helper(hpx::shared_future<hpx::util::tuple<Ts...>>&& f,
+        HPX_FORCEINLINE hpx::tuple<hpx::future<Ts>...> split_future_helper(
+            hpx::shared_future<hpx::tuple<Ts...>>&& f,
             hpx::util::index_pack<Is...>)
         {
-            return hpx::util::make_tuple(extract_nth_future<Is>(f)...);
+            return hpx::make_tuple(extract_nth_future<Is>(f)...);
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -323,31 +317,31 @@ namespace hpx { namespace lcos {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename... Ts>
-    HPX_FORCEINLINE hpx::util::tuple<hpx::future<Ts>...> split_future(
-        hpx::future<hpx::util::tuple<Ts...>>&& f)
+    HPX_FORCEINLINE hpx::tuple<hpx::future<Ts>...> split_future(
+        hpx::future<hpx::tuple<Ts...>>&& f)
     {
         return detail::split_future_helper(std::move(f),
             typename hpx::util::make_index_pack<sizeof...(Ts)>::type());
     }
 
-    HPX_FORCEINLINE hpx::util::tuple<hpx::future<void>> split_future(
-        hpx::future<hpx::util::tuple<>>&& f)
+    HPX_FORCEINLINE hpx::tuple<hpx::future<void>> split_future(
+        hpx::future<hpx::tuple<>>&& f)
     {
-        return hpx::util::make_tuple(hpx::future<void>(std::move(f)));
+        return hpx::make_tuple(hpx::future<void>(std::move(f)));
     }
 
     template <typename... Ts>
-    HPX_FORCEINLINE hpx::util::tuple<hpx::future<Ts>...> split_future(
-        hpx::shared_future<hpx::util::tuple<Ts...>>&& f)
+    HPX_FORCEINLINE hpx::tuple<hpx::future<Ts>...> split_future(
+        hpx::shared_future<hpx::tuple<Ts...>>&& f)
     {
         return detail::split_future_helper(std::move(f),
             typename hpx::util::make_index_pack<sizeof...(Ts)>::type());
     }
 
-    HPX_FORCEINLINE hpx::util::tuple<hpx::future<void>> split_future(
-        hpx::shared_future<hpx::util::tuple<>>&& f)
+    HPX_FORCEINLINE hpx::tuple<hpx::future<void>> split_future(
+        hpx::shared_future<hpx::tuple<>>&& f)
     {
-        return hpx::util::make_tuple(hpx::make_future<void>(std::move(f)));
+        return hpx::make_tuple(hpx::make_future<void>(std::move(f)));
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/async_combinators/include/hpx/async_combinators/wait_all.hpp
+++ b/libs/parallelism/async_combinators/include/hpx/async_combinators/wait_all.hpp
@@ -196,8 +196,7 @@ namespace hpx { namespace lcos {
 
             template <std::size_t I>
             struct is_end
-              : std::integral_constant<bool,
-                    util::tuple_size<Tuple>::value == I>
+              : std::integral_constant<bool, hpx::tuple_size<Tuple>::value == I>
             {
             };
 
@@ -268,8 +267,8 @@ namespace hpx { namespace lcos {
             template <std::size_t I>
             HPX_FORCEINLINE void await_next(std::false_type, std::true_type)
             {
-                await_range<I>(util::begin(util::unwrap_ref(util::get<I>(t_))),
-                    util::end(util::unwrap_ref(util::get<I>(t_))));
+                await_range<I>(util::begin(util::unwrap_ref(hpx::get<I>(t_))),
+                    util::end(util::unwrap_ref(hpx::get<I>(t_))));
             }
 
             // Current element is a simple future
@@ -277,7 +276,7 @@ namespace hpx { namespace lcos {
             HPX_FORCEINLINE void await_next(std::true_type, std::false_type)
             {
                 typedef
-                    typename util::decay_unwrap<typename util::tuple_element<I,
+                    typename util::decay_unwrap<typename hpx::tuple_element<I,
                         Tuple>::type>::type future_type;
 
                 typedef typename detail::future_or_shared_state_result<
@@ -285,7 +284,7 @@ namespace hpx { namespace lcos {
 
                 typename traits::detail::shared_state_ptr<
                     future_result_type>::type next_future_data =
-                    traits::detail::get_shared_state(util::get<I>(t_));
+                    traits::detail::get_shared_state(hpx::get<I>(t_));
 
                 if (next_future_data.get() != nullptr &&
                     !next_future_data->is_ready())
@@ -314,7 +313,7 @@ namespace hpx { namespace lcos {
             HPX_FORCEINLINE void do_await(std::false_type)
             {
                 typedef
-                    typename util::decay_unwrap<typename util::tuple_element<I,
+                    typename util::decay_unwrap<typename hpx::tuple_element<I,
                         Tuple>::type>::type future_type;
 
                 typedef typename detail::is_future_or_shared_state<
@@ -345,7 +344,7 @@ namespace hpx { namespace lcos {
     template <typename Future>
     void wait_all(std::vector<Future> const& values)
     {
-        typedef util::tuple<std::vector<Future> const&> result_type;
+        typedef hpx::tuple<std::vector<Future> const&> result_type;
         typedef detail::wait_all_frame<result_type> frame_type;
         typedef typename frame_type::init_no_addref init_no_addref;
 
@@ -370,7 +369,7 @@ namespace hpx { namespace lcos {
     template <typename Future, std::size_t N>
     void wait_all(std::array<Future, N> const& values)
     {
-        typedef util::tuple<std::array<Future, N> const&> result_type;
+        typedef hpx::tuple<std::array<Future, N> const&> result_type;
         typedef detail::wait_all_frame<result_type> frame_type;
         typedef typename frame_type::init_no_addref init_no_addref;
 
@@ -437,7 +436,7 @@ namespace hpx { namespace lcos {
     template <typename... Ts>
     void wait_all(Ts&&... ts)
     {
-        typedef util::tuple<
+        typedef hpx::tuple<
             typename traits::detail::shared_state_ptr_for<Ts>::type...>
             result_type;
         typedef detail::wait_all_frame<result_type> frame_type;

--- a/libs/parallelism/async_combinators/include/hpx/async_combinators/wait_some.hpp
+++ b/libs/parallelism/async_combinators/include/hpx/async_combinators/wait_some.hpp
@@ -260,12 +260,12 @@ namespace hpx { namespace lcos {
                 Tuple& tuple, util::index_pack<Is...>) const
             {
                 int const _sequencer[] = {
-                    (((*this)(util::get<Is>(tuple))), 0)...};
+                    (((*this)(hpx::get<Is>(tuple))), 0)...};
                 (void) _sequencer;
             }
 
             template <typename... Ts>
-            HPX_FORCEINLINE void apply(util::tuple<Ts...>& sequence) const
+            HPX_FORCEINLINE void apply(hpx::tuple<Ts...>& sequence) const
             {
                 apply(sequence,
                     typename util::make_index_pack<sizeof...(Ts)>::type());
@@ -543,7 +543,7 @@ namespace hpx { namespace lcos {
     template <typename... Ts>
     void wait_some(std::size_t n, error_code& ec, Ts&&... ts)
     {
-        typedef util::tuple<
+        typedef hpx::tuple<
             typename traits::detail::shared_state_ptr_for<Ts>::type...>
             result_type;
 
@@ -572,7 +572,7 @@ namespace hpx { namespace lcos {
     template <typename... Ts>
     void wait_some(std::size_t n, Ts&&... ts)
     {
-        typedef util::tuple<
+        typedef hpx::tuple<
             typename traits::detail::shared_state_ptr_for<Ts>::type...>
             result_type;
 

--- a/libs/parallelism/async_combinators/include/hpx/async_combinators/when_all.hpp
+++ b/libs/parallelism/async_combinators/include/hpx/async_combinators/when_all.hpp
@@ -167,14 +167,14 @@ namespace hpx { namespace lcos {
         };
 
         template <typename T>
-        struct when_all_result<util::tuple<T>,
+        struct when_all_result<hpx::tuple<T>,
             typename std::enable_if<traits::is_future_range<T>::value>::type>
         {
             typedef T type;
 
-            static type call(util::tuple<T>&& t)
+            static type call(hpx::tuple<T>&& t)
             {
-                return std::move(util::get<0>(t));
+                return std::move(hpx::get<0>(t));
             }
         };
 
@@ -220,10 +220,10 @@ namespace hpx { namespace lcos {
 
         template <typename... T>
         typename detail::async_when_all_frame<
-            util::tuple<typename traits::acquire_future<T>::type...>>::type
+            hpx::tuple<typename traits::acquire_future<T>::type...>>::type
         when_all_impl(T&&... args)
         {
-            typedef util::tuple<typename traits::acquire_future<T>::type...>
+            typedef hpx::tuple<typename traits::acquire_future<T>::type...>
                 result_type;
             typedef detail::async_when_all_frame<result_type> frame_type;
 
@@ -259,10 +259,10 @@ namespace hpx { namespace lcos {
             detail::acquire_future_iterators<Iterator, Container>(begin, end));
     }
 
-    inline lcos::future<util::tuple<>>    //-V524
+    inline lcos::future<hpx::tuple<>>    //-V524
     when_all()
     {
-        typedef util::tuple<> result_type;
+        typedef hpx::tuple<> result_type;
         return lcos::make_ready_future(result_type());
     }
 

--- a/libs/parallelism/async_combinators/include/hpx/async_combinators/when_any.hpp
+++ b/libs/parallelism/async_combinators/include/hpx/async_combinators/when_any.hpp
@@ -277,12 +277,12 @@ namespace hpx { namespace lcos {
                 Tuple& tuple, util::index_pack<Is...>) const
             {
                 int const _sequencer[] = {
-                    (((*this)(util::get<Is>(tuple))), 0)...};
+                    (((*this)(hpx::get<Is>(tuple))), 0)...};
                 (void) _sequencer;
             }
 
             template <typename... Ts>
-            HPX_FORCEINLINE void apply(util::tuple<Ts...>& sequence) const
+            HPX_FORCEINLINE void apply(hpx::tuple<Ts...>& sequence) const
             {
                 apply(sequence,
                     typename util::make_index_pack<sizeof...(Ts)>::type());
@@ -414,10 +414,10 @@ namespace hpx { namespace lcos {
         return lcos::when_any(std::move(lazy_values_));
     }
 
-    inline lcos::future<when_any_result<util::tuple<>>>    //-V524
+    inline lcos::future<when_any_result<hpx::tuple<>>>    //-V524
     when_any()
     {
-        typedef when_any_result<util::tuple<>> result_type;
+        typedef when_any_result<hpx::tuple<>> result_type;
 
         return lcos::make_ready_future(result_type());
     }
@@ -443,12 +443,12 @@ namespace hpx { namespace lcos {
     template <typename T, typename... Ts>
     typename std::enable_if<!(traits::is_future_range<T>::value &&
                                 sizeof...(Ts) == 0),
-        lcos::future<when_any_result<
-            util::tuple<typename traits::acquire_future<T>::type,
+        lcos::future<
+            when_any_result<hpx::tuple<typename traits::acquire_future<T>::type,
                 typename traits::acquire_future<Ts>::type...>>>>::type
     when_any(T&& t, Ts&&... ts)
     {
-        typedef util::tuple<typename traits::acquire_future<T>::type,
+        typedef hpx::tuple<typename traits::acquire_future<T>::type,
             typename traits::acquire_future<Ts>::type...>
             result_type;
 

--- a/libs/parallelism/async_combinators/include/hpx/async_combinators/when_each.hpp
+++ b/libs/parallelism/async_combinators/include/hpx/async_combinators/when_each.hpp
@@ -185,8 +185,7 @@ namespace hpx { namespace lcos {
 
             template <std::size_t I>
             struct is_end
-              : std::integral_constant<bool,
-                    util::tuple_size<Tuple>::value == I>
+              : std::integral_constant<bool, hpx::tuple_size<Tuple>::value == I>
             {
             };
 
@@ -263,8 +262,8 @@ namespace hpx { namespace lcos {
             template <std::size_t I>
             HPX_FORCEINLINE void await_next(std::false_type, std::true_type)
             {
-                await_range<I>(util::begin(util::unwrap_ref(util::get<I>(t_))),
-                    util::end(util::unwrap_ref(util::get<I>(t_))));
+                await_range<I>(util::begin(util::unwrap_ref(hpx::get<I>(t_))),
+                    util::end(util::unwrap_ref(hpx::get<I>(t_))));
             }
 
             // Current element is a simple future
@@ -272,13 +271,13 @@ namespace hpx { namespace lcos {
             HPX_FORCEINLINE void await_next(std::true_type, std::false_type)
             {
                 typedef
-                    typename util::decay_unwrap<typename util::tuple_element<I,
+                    typename util::decay_unwrap<typename hpx::tuple_element<I,
                         Tuple>::type>::type future_type;
 
                 typedef typename traits::future_traits<future_type>::type
                     future_result_type;
 
-                future_type& fut = util::get<I>(t_);
+                future_type& fut = hpx::get<I>(t_);
 
                 typename traits::detail::shared_state_ptr<
                     future_result_type>::type next_future_data =
@@ -322,7 +321,7 @@ namespace hpx { namespace lcos {
             HPX_FORCEINLINE void do_await(std::false_type)
             {
                 typedef
-                    typename util::decay_unwrap<typename util::tuple_element<I,
+                    typename util::decay_unwrap<typename hpx::tuple_element<I,
                         Tuple>::type>::type future_type;
 
                 typedef util::any_of<traits::is_future<future_type>,
@@ -357,7 +356,7 @@ namespace hpx { namespace lcos {
         static_assert(
             traits::is_future<Future>::value, "invalid use of when_each");
 
-        typedef util::tuple<std::vector<Future>> argument_type;
+        typedef hpx::tuple<std::vector<Future>> argument_type;
         typedef typename std::decay<F>::type func_type;
         typedef detail::when_each_frame<argument_type, func_type> frame_type;
 
@@ -440,7 +439,7 @@ namespace hpx { namespace lcos {
         lcos::future<void>>::type
     when_each(F&& f, Ts&&... ts)
     {
-        typedef util::tuple<typename traits::acquire_future<Ts>::type...>
+        typedef hpx::tuple<typename traits::acquire_future<Ts>::type...>
             argument_type;
 
         typedef typename std::decay<F>::type func_type;

--- a/libs/parallelism/async_combinators/include/hpx/async_combinators/when_some.hpp
+++ b/libs/parallelism/async_combinators/include/hpx/async_combinators/when_some.hpp
@@ -376,12 +376,12 @@ namespace hpx { namespace lcos {
                 Tuple& tuple, util::index_pack<Is...>) const
             {
                 int const _sequencer[] = {
-                    (((*this)(util::get<Is>(tuple))), 0)...};
+                    (((*this)(hpx::get<Is>(tuple))), 0)...};
                 (void) _sequencer;
             }
 
             template <typename... Ts>
-            HPX_FORCEINLINE void apply(util::tuple<Ts...>& sequence) const
+            HPX_FORCEINLINE void apply(hpx::tuple<Ts...>& sequence) const
             {
                 apply(sequence,
                     typename util::make_index_pack<sizeof...(Ts)>::type());
@@ -556,10 +556,10 @@ namespace hpx { namespace lcos {
         return lcos::when_some(n, lazy_values_, ec);
     }
 
-    inline lcos::future<when_some_result<util::tuple<>>> when_some(
+    inline lcos::future<when_some_result<hpx::tuple<>>> when_some(
         std::size_t n, error_code& ec = throws)
     {
-        typedef util::tuple<> result_type;
+        typedef hpx::tuple<> result_type;
 
         result_type lazy_values;
 
@@ -579,11 +579,11 @@ namespace hpx { namespace lcos {
     typename std::enable_if<!(traits::is_future_range<T>::value &&
                                 sizeof...(Ts) == 0),
         lcos::future<when_some_result<
-            util::tuple<typename traits::acquire_future<T>::type,
+            hpx::tuple<typename traits::acquire_future<T>::type,
                 typename traits::acquire_future<Ts>::type...>>>>::type
     when_some(std::size_t n, T&& t, Ts&&... ts)
     {
-        typedef util::tuple<typename traits::acquire_future<T>::type,
+        typedef hpx::tuple<typename traits::acquire_future<T>::type,
             typename traits::acquire_future<Ts>::type...>
             result_type;
 
@@ -621,11 +621,11 @@ namespace hpx { namespace lcos {
     typename std::enable_if<!(traits::is_future_range<T>::value &&
                                 sizeof...(Ts) == 0),
         lcos::future<when_some_result<
-            util::tuple<typename traits::acquire_future<T>::type,
+            hpx::tuple<typename traits::acquire_future<T>::type,
                 typename traits::acquire_future<Ts>::type...>>>>::type
     when_some(std::size_t n, error_code& ec, T&& t, Ts&&... ts)
     {
-        typedef util::tuple<typename traits::acquire_future<T>::type,
+        typedef hpx::tuple<typename traits::acquire_future<T>::type,
             typename traits::acquire_future<Ts>::type...>
             result_type;
 

--- a/libs/parallelism/async_combinators/tests/unit/split_shared_future.cpp
+++ b/libs/parallelism/async_combinators/tests/unit/split_shared_future.cpp
@@ -15,85 +15,81 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::util::tuple<> make_tuple0_slowly()
+hpx::tuple<> make_tuple0_slowly()
 {
     hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
-    return hpx::util::make_tuple();
+    return hpx::make_tuple();
 }
 
 void test_split_future0()
 {
-    hpx::lcos::local::futures_factory<hpx::util::tuple<>()> pt(
-        make_tuple0_slowly);
+    hpx::lcos::local::futures_factory<hpx::tuple<>()> pt(make_tuple0_slowly);
     pt.apply();
 
-    hpx::util::tuple<hpx::future<void>> result = hpx::split_future(
-        hpx::shared_future<hpx::util::tuple<>>(pt.get_future()));
+    hpx::tuple<hpx::future<void>> result =
+        hpx::split_future(hpx::shared_future<hpx::tuple<>>(pt.get_future()));
 
-    hpx::util::get<0>(result).get();
+    hpx::get<0>(result).get();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::util::tuple<int> make_tuple1_slowly()
+hpx::tuple<int> make_tuple1_slowly()
 {
     hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
-    return hpx::util::make_tuple(42);
+    return hpx::make_tuple(42);
 }
 
 void test_split_future1()
 {
-    hpx::lcos::local::futures_factory<hpx::util::tuple<int>()> pt(
-        make_tuple1_slowly);
+    hpx::lcos::local::futures_factory<hpx::tuple<int>()> pt(make_tuple1_slowly);
     pt.apply();
 
-    hpx::util::tuple<hpx::future<int>> result = hpx::split_future(
-        hpx::shared_future<hpx::util::tuple<int>>(pt.get_future()));
+    hpx::tuple<hpx::future<int>> result =
+        hpx::split_future(hpx::shared_future<hpx::tuple<int>>(pt.get_future()));
 
-    HPX_TEST_EQ(hpx::util::get<0>(result).get(), 42);
+    HPX_TEST_EQ(hpx::get<0>(result).get(), 42);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::util::tuple<int, int> make_tuple2_slowly()
+hpx::tuple<int, int> make_tuple2_slowly()
 {
     hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
-    return hpx::util::make_tuple(42, 43);
+    return hpx::make_tuple(42, 43);
 }
 
 void test_split_future2()
 {
-    hpx::lcos::local::futures_factory<hpx::util::tuple<int, int>()> pt(
+    hpx::lcos::local::futures_factory<hpx::tuple<int, int>()> pt(
         make_tuple2_slowly);
     pt.apply();
 
-    hpx::util::tuple<hpx::future<int>, hpx::future<int>> result =
-        hpx::split_future(
-            hpx::shared_future<hpx::util::tuple<int, int>>(pt.get_future()));
+    hpx::tuple<hpx::future<int>, hpx::future<int>> result = hpx::split_future(
+        hpx::shared_future<hpx::tuple<int, int>>(pt.get_future()));
 
-    HPX_TEST_EQ(hpx::util::get<0>(result).get(), 42);
-    HPX_TEST_EQ(hpx::util::get<1>(result).get(), 43);
+    HPX_TEST_EQ(hpx::get<0>(result).get(), 42);
+    HPX_TEST_EQ(hpx::get<1>(result).get(), 43);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::util::tuple<int, int, int> make_tuple3_slowly()
+hpx::tuple<int, int, int> make_tuple3_slowly()
 {
     hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
-    return hpx::util::make_tuple(42, 43, 44);
+    return hpx::make_tuple(42, 43, 44);
 }
 
 void test_split_future3()
 {
-    hpx::lcos::local::futures_factory<hpx::util::tuple<int, int, int>()> pt(
+    hpx::lcos::local::futures_factory<hpx::tuple<int, int, int>()> pt(
         make_tuple3_slowly);
     pt.apply();
 
-    hpx::util::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>>
-        result = hpx::split_future(
-            hpx::shared_future<hpx::util::tuple<int, int, int>>(
-                pt.get_future()));
+    hpx::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>> result =
+        hpx::split_future(
+            hpx::shared_future<hpx::tuple<int, int, int>>(pt.get_future()));
 
-    HPX_TEST_EQ(hpx::util::get<0>(result).get(), 42);
-    HPX_TEST_EQ(hpx::util::get<1>(result).get(), 43);
-    HPX_TEST_EQ(hpx::util::get<2>(result).get(), 44);
+    HPX_TEST_EQ(hpx::get<0>(result).get(), 42);
+    HPX_TEST_EQ(hpx::get<1>(result).get(), 43);
+    HPX_TEST_EQ(hpx::get<2>(result).get(), 44);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/async_combinators/tests/unit/when_all.cpp
+++ b/libs/parallelism/async_combinators/tests/unit/when_all.cpp
@@ -81,14 +81,14 @@ void test_wait_for_all_one_future()
     hpx::lcos::future<int> f1 = pt1.get_future();
     pt1.apply();
 
-    typedef hpx::util::tuple<hpx::lcos::future<int>> result_type;
+    typedef hpx::tuple<hpx::lcos::future<int>> result_type;
     hpx::lcos::future<result_type> r = hpx::when_all(f1);
 
     result_type result = r.get();
 
     HPX_TEST(!f1.valid());
 
-    HPX_TEST(hpx::util::get<0>(result).is_ready());
+    HPX_TEST(hpx::get<0>(result).is_ready());
 }
 
 void test_wait_for_all_two_futures()
@@ -100,7 +100,7 @@ void test_wait_for_all_two_futures()
     hpx::lcos::future<int> f2 = pt2.get_future();
     pt2.apply();
 
-    typedef hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>
+    typedef hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>
         result_type;
     hpx::lcos::future<result_type> r = hpx::when_all(f1, f2);
 
@@ -109,8 +109,8 @@ void test_wait_for_all_two_futures()
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
 
-    HPX_TEST(hpx::util::get<0>(result).is_ready());
-    HPX_TEST(hpx::util::get<1>(result).is_ready());
+    HPX_TEST(hpx::get<0>(result).is_ready());
+    HPX_TEST(hpx::get<1>(result).is_ready());
 }
 
 void test_wait_for_all_three_futures()
@@ -125,7 +125,7 @@ void test_wait_for_all_three_futures()
     hpx::lcos::future<int> f3 = pt3.get_future();
     pt3.apply();
 
-    typedef hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
+    typedef hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
         hpx::lcos::future<int>>
         result_type;
     hpx::lcos::future<result_type> r = hpx::when_all(f1, f2, f3);
@@ -136,9 +136,9 @@ void test_wait_for_all_three_futures()
     HPX_TEST(!f2.valid());
     HPX_TEST(!f3.valid());
 
-    HPX_TEST(hpx::util::get<0>(result).is_ready());
-    HPX_TEST(hpx::util::get<1>(result).is_ready());
-    HPX_TEST(hpx::util::get<2>(result).is_ready());
+    HPX_TEST(hpx::get<0>(result).is_ready());
+    HPX_TEST(hpx::get<1>(result).is_ready());
+    HPX_TEST(hpx::get<2>(result).is_ready());
 }
 
 void test_wait_for_all_four_futures()
@@ -156,7 +156,7 @@ void test_wait_for_all_four_futures()
     hpx::lcos::future<int> f4 = pt4.get_future();
     pt4.apply();
 
-    typedef hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
+    typedef hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
         hpx::lcos::future<int>, hpx::lcos::future<int>>
         result_type;
     hpx::lcos::future<result_type> r = hpx::when_all(f1, f2, f3, f4);
@@ -168,10 +168,10 @@ void test_wait_for_all_four_futures()
     HPX_TEST(!f3.valid());
     HPX_TEST(!f4.valid());
 
-    HPX_TEST(hpx::util::get<0>(result).is_ready());
-    HPX_TEST(hpx::util::get<1>(result).is_ready());
-    HPX_TEST(hpx::util::get<2>(result).is_ready());
-    HPX_TEST(hpx::util::get<3>(result).is_ready());
+    HPX_TEST(hpx::get<0>(result).is_ready());
+    HPX_TEST(hpx::get<1>(result).is_ready());
+    HPX_TEST(hpx::get<2>(result).is_ready());
+    HPX_TEST(hpx::get<3>(result).is_ready());
 }
 
 void test_wait_for_all_five_futures()
@@ -192,7 +192,7 @@ void test_wait_for_all_five_futures()
     hpx::lcos::future<int> f5 = pt5.get_future();
     pt5.apply();
 
-    typedef hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
+    typedef hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
         hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>>
         result_type;
     hpx::lcos::future<result_type> r = hpx::when_all(f1, f2, f3, f4, f5);
@@ -205,11 +205,11 @@ void test_wait_for_all_five_futures()
     HPX_TEST(!f4.valid());
     HPX_TEST(!f5.valid());
 
-    HPX_TEST(hpx::util::get<0>(result).is_ready());
-    HPX_TEST(hpx::util::get<1>(result).is_ready());
-    HPX_TEST(hpx::util::get<2>(result).is_ready());
-    HPX_TEST(hpx::util::get<3>(result).is_ready());
-    HPX_TEST(hpx::util::get<4>(result).is_ready());
+    HPX_TEST(hpx::get<0>(result).is_ready());
+    HPX_TEST(hpx::get<1>(result).is_ready());
+    HPX_TEST(hpx::get<2>(result).is_ready());
+    HPX_TEST(hpx::get<3>(result).is_ready());
+    HPX_TEST(hpx::get<4>(result).is_ready());
 }
 
 void test_wait_for_all_late_futures()
@@ -220,7 +220,7 @@ void test_wait_for_all_late_futures()
     hpx::lcos::local::futures_factory<int()> pt2(make_int_slowly);
     hpx::lcos::future<int> f2 = pt2.get_future();
 
-    typedef hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>
+    typedef hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>
         result_type;
     hpx::lcos::future<result_type> r = hpx::when_all(f1, f2);
 
@@ -231,8 +231,8 @@ void test_wait_for_all_late_futures()
 
     result_type result = r.get();
 
-    HPX_TEST(hpx::util::get<0>(result).is_ready());
-    HPX_TEST(hpx::util::get<1>(result).is_ready());
+    HPX_TEST(hpx::get<0>(result).is_ready());
+    HPX_TEST(hpx::get<1>(result).is_ready());
 }
 
 void test_wait_for_all_deferred_futures()
@@ -242,7 +242,7 @@ void test_wait_for_all_deferred_futures()
     hpx::lcos::future<int> f2 =
         hpx::async(hpx::launch::deferred, &make_int_slowly);
 
-    typedef hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>
+    typedef hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>
         result_type;
     hpx::lcos::future<result_type> r = hpx::when_all(f1, f2);
 
@@ -251,8 +251,8 @@ void test_wait_for_all_deferred_futures()
 
     result_type result = r.get();
 
-    HPX_TEST(hpx::util::get<0>(result).is_ready());
-    HPX_TEST(hpx::util::get<1>(result).is_ready());
+    HPX_TEST(hpx::get<0>(result).is_ready());
+    HPX_TEST(hpx::get<1>(result).is_ready());
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/async_combinators/tests/unit/when_any.cpp
+++ b/libs/parallelism/async_combinators/tests/unit/when_any.cpp
@@ -36,16 +36,16 @@ void test_wait_for_either_of_two_futures_1()
     pt1();
 
     hpx::lcos::future<hpx::when_any_result<
-        hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+        hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>>>
         r = hpx::when_any(f1, f2);
-    hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>> t =
+    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>> t =
         r.get().futures;
 
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
 
-    HPX_TEST(hpx::util::get<0>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<0>(t).get(), 42);
+    HPX_TEST(hpx::get<0>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<0>(t).get(), 42);
 }
 
 void test_wait_for_either_of_two_futures_2()
@@ -58,16 +58,16 @@ void test_wait_for_either_of_two_futures_2()
     pt2();
 
     hpx::lcos::future<hpx::when_any_result<
-        hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+        hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>>>
         r = hpx::when_any(f1, f2);
-    hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>> t =
+    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>> t =
         r.get().futures;
 
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
 
-    HPX_TEST(hpx::util::get<1>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<1>(t).get(), 42);
+    HPX_TEST(hpx::get<1>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<1>(t).get(), 42);
 }
 
 template <class Container>
@@ -133,11 +133,10 @@ void test_wait_for_either_of_three_futures_1()
 
     pt1();
 
-    hpx::lcos::future<
-        hpx::when_any_result<hpx::util::tuple<hpx::lcos::future<int>,
-            hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+    hpx::lcos::future<hpx::when_any_result<hpx::tuple<hpx::lcos::future<int>,
+        hpx::lcos::future<int>, hpx::lcos::future<int>>>>
         r = hpx::when_any(f1, f2, f3);
-    hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
+    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
         hpx::lcos::future<int>>
         t = r.get().futures;
 
@@ -145,8 +144,8 @@ void test_wait_for_either_of_three_futures_1()
     HPX_TEST(!f2.valid());
     HPX_TEST(!f3.valid());
 
-    HPX_TEST(hpx::util::get<0>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<0>(t).get(), 42);
+    HPX_TEST(hpx::get<0>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<0>(t).get(), 42);
 }
 
 void test_wait_for_either_of_three_futures_2()
@@ -160,11 +159,10 @@ void test_wait_for_either_of_three_futures_2()
 
     pt2();
 
-    hpx::lcos::future<
-        hpx::when_any_result<hpx::util::tuple<hpx::lcos::future<int>,
-            hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+    hpx::lcos::future<hpx::when_any_result<hpx::tuple<hpx::lcos::future<int>,
+        hpx::lcos::future<int>, hpx::lcos::future<int>>>>
         r = hpx::when_any(f1, f2, f3);
-    hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
+    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
         hpx::lcos::future<int>>
         t = r.get().futures;
 
@@ -172,8 +170,8 @@ void test_wait_for_either_of_three_futures_2()
     HPX_TEST(!f2.valid());
     HPX_TEST(!f3.valid());
 
-    HPX_TEST(hpx::util::get<1>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<1>(t).get(), 42);
+    HPX_TEST(hpx::get<1>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<1>(t).get(), 42);
 }
 
 void test_wait_for_either_of_three_futures_3()
@@ -187,11 +185,10 @@ void test_wait_for_either_of_three_futures_3()
 
     pt3();
 
-    hpx::lcos::future<
-        hpx::when_any_result<hpx::util::tuple<hpx::lcos::future<int>,
-            hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+    hpx::lcos::future<hpx::when_any_result<hpx::tuple<hpx::lcos::future<int>,
+        hpx::lcos::future<int>, hpx::lcos::future<int>>>>
         r = hpx::when_any(f1, f2, f3);
-    hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
+    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
         hpx::lcos::future<int>>
         t = r.get().futures;
 
@@ -199,8 +196,8 @@ void test_wait_for_either_of_three_futures_3()
     HPX_TEST(!f2.valid());
     HPX_TEST(!f3.valid());
 
-    HPX_TEST(hpx::util::get<2>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<2>(t).get(), 42);
+    HPX_TEST(hpx::get<2>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<2>(t).get(), 42);
 }
 
 void test_wait_for_either_of_four_futures_1()
@@ -217,10 +214,10 @@ void test_wait_for_either_of_four_futures_1()
     pt1();
 
     hpx::lcos::future<hpx::when_any_result<
-        hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
+        hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
             hpx::lcos::future<int>, hpx::lcos::future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4);
-    hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
+    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
         hpx::lcos::future<int>, hpx::lcos::future<int>>
         t = r.get().futures;
 
@@ -229,8 +226,8 @@ void test_wait_for_either_of_four_futures_1()
     HPX_TEST(!f3.valid());
     HPX_TEST(!f4.valid());
 
-    HPX_TEST(hpx::util::get<0>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<0>(t).get(), 42);
+    HPX_TEST(hpx::get<0>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<0>(t).get(), 42);
 }
 
 void test_wait_for_either_of_four_futures_2()
@@ -247,10 +244,10 @@ void test_wait_for_either_of_four_futures_2()
     pt2();
 
     hpx::lcos::future<hpx::when_any_result<
-        hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
+        hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
             hpx::lcos::future<int>, hpx::lcos::future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4);
-    hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
+    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
         hpx::lcos::future<int>, hpx::lcos::future<int>>
         t = r.get().futures;
 
@@ -259,8 +256,8 @@ void test_wait_for_either_of_four_futures_2()
     HPX_TEST(!f3.valid());
     HPX_TEST(!f4.valid());
 
-    HPX_TEST(hpx::util::get<1>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<1>(t).get(), 42);
+    HPX_TEST(hpx::get<1>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<1>(t).get(), 42);
 }
 
 void test_wait_for_either_of_four_futures_3()
@@ -277,10 +274,10 @@ void test_wait_for_either_of_four_futures_3()
     pt3();
 
     hpx::lcos::future<hpx::when_any_result<
-        hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
+        hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
             hpx::lcos::future<int>, hpx::lcos::future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4);
-    hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
+    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
         hpx::lcos::future<int>, hpx::lcos::future<int>>
         t = r.get().futures;
 
@@ -289,8 +286,8 @@ void test_wait_for_either_of_four_futures_3()
     HPX_TEST(!f3.valid());
     HPX_TEST(!f4.valid());
 
-    HPX_TEST(hpx::util::get<2>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<2>(t).get(), 42);
+    HPX_TEST(hpx::get<2>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<2>(t).get(), 42);
 }
 
 void test_wait_for_either_of_four_futures_4()
@@ -307,10 +304,10 @@ void test_wait_for_either_of_four_futures_4()
     pt4();
 
     hpx::lcos::future<hpx::when_any_result<
-        hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
+        hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
             hpx::lcos::future<int>, hpx::lcos::future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4);
-    hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
+    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
         hpx::lcos::future<int>, hpx::lcos::future<int>>
         t = r.get().futures;
 
@@ -319,8 +316,8 @@ void test_wait_for_either_of_four_futures_4()
     HPX_TEST(!f3.valid());
     HPX_TEST(!f4.valid());
 
-    HPX_TEST(hpx::util::get<3>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<3>(t).get(), 42);
+    HPX_TEST(hpx::get<3>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<3>(t).get(), 42);
 }
 
 template <class Container>
@@ -422,11 +419,11 @@ void test_wait_for_either_of_five_futures_1()
 
     pt1();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::util::tuple<
+    hpx::lcos::future<hpx::when_any_result<hpx::tuple<hpx::lcos::future<int>,
         hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+        hpx::lcos::future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4, f5);
-    hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
+    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
         hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>>
         t = r.get().futures;
 
@@ -436,8 +433,8 @@ void test_wait_for_either_of_five_futures_1()
     HPX_TEST(!f4.valid());
     HPX_TEST(!f5.valid());
 
-    HPX_TEST(hpx::util::get<0>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<0>(t).get(), 42);
+    HPX_TEST(hpx::get<0>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<0>(t).get(), 42);
 }
 
 void test_wait_for_either_of_five_futures_2()
@@ -455,11 +452,11 @@ void test_wait_for_either_of_five_futures_2()
 
     pt2();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::util::tuple<
+    hpx::lcos::future<hpx::when_any_result<hpx::tuple<hpx::lcos::future<int>,
         hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+        hpx::lcos::future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4, f5);
-    hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
+    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
         hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>>
         t = r.get().futures;
 
@@ -469,8 +466,8 @@ void test_wait_for_either_of_five_futures_2()
     HPX_TEST(!f4.valid());
     HPX_TEST(!f5.valid());
 
-    HPX_TEST(hpx::util::get<1>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<1>(t).get(), 42);
+    HPX_TEST(hpx::get<1>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<1>(t).get(), 42);
 }
 
 void test_wait_for_either_of_five_futures_3()
@@ -488,11 +485,11 @@ void test_wait_for_either_of_five_futures_3()
 
     pt3();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::util::tuple<
+    hpx::lcos::future<hpx::when_any_result<hpx::tuple<hpx::lcos::future<int>,
         hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+        hpx::lcos::future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4, f5);
-    hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
+    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
         hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>>
         t = r.get().futures;
 
@@ -502,8 +499,8 @@ void test_wait_for_either_of_five_futures_3()
     HPX_TEST(!f4.valid());
     HPX_TEST(!f5.valid());
 
-    HPX_TEST(hpx::util::get<2>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<2>(t).get(), 42);
+    HPX_TEST(hpx::get<2>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<2>(t).get(), 42);
 }
 
 void test_wait_for_either_of_five_futures_4()
@@ -521,11 +518,11 @@ void test_wait_for_either_of_five_futures_4()
 
     pt4();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::util::tuple<
+    hpx::lcos::future<hpx::when_any_result<hpx::tuple<hpx::lcos::future<int>,
         hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+        hpx::lcos::future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4, f5);
-    hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
+    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
         hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>>
         t = r.get().futures;
 
@@ -535,8 +532,8 @@ void test_wait_for_either_of_five_futures_4()
     HPX_TEST(!f4.valid());
     HPX_TEST(!f5.valid());
 
-    HPX_TEST(hpx::util::get<3>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<3>(t).get(), 42);
+    HPX_TEST(hpx::get<3>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<3>(t).get(), 42);
 }
 
 void test_wait_for_either_of_five_futures_5()
@@ -554,11 +551,11 @@ void test_wait_for_either_of_five_futures_5()
 
     pt5();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::util::tuple<
+    hpx::lcos::future<hpx::when_any_result<hpx::tuple<hpx::lcos::future<int>,
         hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>,
-        hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+        hpx::lcos::future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4, f5);
-    hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
+    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>,
         hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>>
         t = r.get().futures;
 
@@ -568,8 +565,8 @@ void test_wait_for_either_of_five_futures_5()
     HPX_TEST(!f4.valid());
     HPX_TEST(!f5.valid());
 
-    HPX_TEST(hpx::util::get<4>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<4>(t).get(), 42);
+    HPX_TEST(hpx::get<4>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<4>(t).get(), 42);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -633,7 +630,7 @@ void test_wait_for_either_of_two_late_futures()
     hpx::lcos::future<int> f2(pt2.get_future());
 
     hpx::lcos::future<hpx::when_any_result<
-        hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+        hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>>>
         r = hpx::when_any(f1, f2);
 
     HPX_TEST(!f1.valid());
@@ -642,11 +639,11 @@ void test_wait_for_either_of_two_late_futures()
     pt2();
     pt1();
 
-    hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>> t =
+    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>> t =
         r.get().futures;
 
-    HPX_TEST(hpx::util::get<1>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<1>(t).get(), 42);
+    HPX_TEST(hpx::get<1>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<1>(t).get(), 42);
 }
 
 void test_wait_for_either_of_two_deferred_futures()
@@ -657,17 +654,17 @@ void test_wait_for_either_of_two_deferred_futures()
         hpx::async(hpx::launch::deferred, &make_int_slowly);
 
     hpx::lcos::future<hpx::when_any_result<
-        hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>>>
+        hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>>>>
         r = hpx::when_any(f1, f2);
 
     HPX_TEST(!f1.valid());
     HPX_TEST(!f2.valid());
 
-    hpx::util::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>> t =
+    hpx::tuple<hpx::lcos::future<int>, hpx::lcos::future<int>> t =
         r.get().futures;
 
-    HPX_TEST(hpx::util::get<0>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<0>(t).get(), 42);
+    HPX_TEST(hpx::get<0>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<0>(t).get(), 42);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/async_combinators/tests/unit/when_some.cpp
+++ b/libs/parallelism/async_combinators/tests/unit/when_some.cpp
@@ -42,7 +42,7 @@ void test_wait_for_two_out_of_five_futures()
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
     hpx::lcos::future<int> f5 = pt5.get_future();
 
-    typedef hpx::when_some_result<hpx::util::tuple<hpx::lcos::future<int>,
+    typedef hpx::when_some_result<hpx::tuple<hpx::lcos::future<int>,
         hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>,
         hpx::lcos::future<int>>>
         result_type;
@@ -58,11 +58,11 @@ void test_wait_for_two_out_of_five_futures()
     HPX_TEST(!f5.valid());
 
     HPX_TEST_EQ(result.indices.size(), count);
-    HPX_TEST(!hpx::util::get<0>(result.futures).is_ready());
-    HPX_TEST(hpx::util::get<1>(result.futures).is_ready());
-    HPX_TEST(!hpx::util::get<2>(result.futures).is_ready());
-    HPX_TEST(hpx::util::get<3>(result.futures).is_ready());
-    HPX_TEST(!hpx::util::get<4>(result.futures).is_ready());
+    HPX_TEST(!hpx::get<0>(result.futures).is_ready());
+    HPX_TEST(hpx::get<1>(result.futures).is_ready());
+    HPX_TEST(!hpx::get<2>(result.futures).is_ready());
+    HPX_TEST(hpx::get<3>(result.futures).is_ready());
+    HPX_TEST(!hpx::get<4>(result.futures).is_ready());
 }
 
 void test_wait_for_three_out_of_five_futures()
@@ -83,7 +83,7 @@ void test_wait_for_three_out_of_five_futures()
     hpx::lcos::future<int> f5 = pt5.get_future();
     pt5();
 
-    typedef hpx::when_some_result<hpx::util::tuple<hpx::lcos::future<int>,
+    typedef hpx::when_some_result<hpx::tuple<hpx::lcos::future<int>,
         hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>,
         hpx::lcos::future<int>>>
         result_type;
@@ -99,11 +99,11 @@ void test_wait_for_three_out_of_five_futures()
     HPX_TEST(!f5.valid());
 
     HPX_TEST_EQ(result.indices.size(), count);
-    HPX_TEST(hpx::util::get<0>(result.futures).is_ready());
-    HPX_TEST(!hpx::util::get<1>(result.futures).is_ready());
-    HPX_TEST(hpx::util::get<2>(result.futures).is_ready());
-    HPX_TEST(!hpx::util::get<3>(result.futures).is_ready());
-    HPX_TEST(hpx::util::get<4>(result.futures).is_ready());
+    HPX_TEST(hpx::get<0>(result.futures).is_ready());
+    HPX_TEST(!hpx::get<1>(result.futures).is_ready());
+    HPX_TEST(hpx::get<2>(result.futures).is_ready());
+    HPX_TEST(!hpx::get<3>(result.futures).is_ready());
+    HPX_TEST(hpx::get<4>(result.futures).is_ready());
 }
 
 void test_wait_for_two_out_of_five_late_futures()
@@ -121,7 +121,7 @@ void test_wait_for_two_out_of_five_late_futures()
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
     hpx::lcos::future<int> f5 = pt5.get_future();
 
-    typedef hpx::when_some_result<hpx::util::tuple<hpx::lcos::future<int>,
+    typedef hpx::when_some_result<hpx::tuple<hpx::lcos::future<int>,
         hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>,
         hpx::lcos::future<int>>>
         result_type;
@@ -140,11 +140,11 @@ void test_wait_for_two_out_of_five_late_futures()
     result_type result = r.get();
 
     HPX_TEST_EQ(result.indices.size(), count);
-    HPX_TEST(!hpx::util::get<0>(result.futures).is_ready());
-    HPX_TEST(hpx::util::get<1>(result.futures).is_ready());
-    HPX_TEST(!hpx::util::get<2>(result.futures).is_ready());
-    HPX_TEST(hpx::util::get<3>(result.futures).is_ready());
-    HPX_TEST(!hpx::util::get<4>(result.futures).is_ready());
+    HPX_TEST(!hpx::get<0>(result.futures).is_ready());
+    HPX_TEST(hpx::get<1>(result.futures).is_ready());
+    HPX_TEST(!hpx::get<2>(result.futures).is_ready());
+    HPX_TEST(hpx::get<3>(result.futures).is_ready());
+    HPX_TEST(!hpx::get<4>(result.futures).is_ready());
 }
 
 void test_wait_for_two_out_of_five_deferred_futures()
@@ -162,7 +162,7 @@ void test_wait_for_two_out_of_five_deferred_futures()
     hpx::lcos::future<int> f5 =
         hpx::async(hpx::launch::deferred, &make_int_slowly);
 
-    typedef hpx::when_some_result<hpx::util::tuple<hpx::lcos::future<int>,
+    typedef hpx::when_some_result<hpx::tuple<hpx::lcos::future<int>,
         hpx::lcos::future<int>, hpx::lcos::future<int>, hpx::lcos::future<int>,
         hpx::lcos::future<int>>>
         result_type;
@@ -178,11 +178,11 @@ void test_wait_for_two_out_of_five_deferred_futures()
     result_type result = r.get();
 
     HPX_TEST_EQ(result.indices.size(), count);
-    HPX_TEST(hpx::util::get<0>(result.futures).is_ready());
-    HPX_TEST(hpx::util::get<1>(result.futures).is_ready());
-    HPX_TEST(!hpx::util::get<2>(result.futures).is_ready());
-    HPX_TEST(!hpx::util::get<3>(result.futures).is_ready());
-    HPX_TEST(!hpx::util::get<4>(result.futures).is_ready());
+    HPX_TEST(hpx::get<0>(result.futures).is_ready());
+    HPX_TEST(hpx::get<1>(result.futures).is_ready());
+    HPX_TEST(!hpx::get<2>(result.futures).is_ready());
+    HPX_TEST(!hpx::get<3>(result.futures).is_ready());
+    HPX_TEST(!hpx::get<4>(result.futures).is_ready());
 }
 
 template <class Container>

--- a/libs/parallelism/execution/include/hpx/execution/executors/execution.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/executors/execution.hpp
@@ -1003,7 +1003,7 @@ namespace hpx { namespace parallel { namespace execution {
 
                 auto func = make_fused_bulk_sync_execute_helper<result_type>(
                     exec, std::forward<F>(f), shape,
-                    hpx::util::make_tuple(std::forward<Ts>(ts)...));
+                    hpx::make_tuple(std::forward<Ts>(ts)...));
 
                 shared_state_type p =
                     lcos::detail::make_continuation_exec<result_type>(
@@ -1022,7 +1022,7 @@ namespace hpx { namespace parallel { namespace execution {
             {
                 auto func = make_fused_bulk_sync_execute_helper<void>(exec,
                     std::forward<F>(f), shape,
-                    hpx::util::make_tuple(std::forward<Ts>(ts)...));
+                    hpx::make_tuple(std::forward<Ts>(ts)...));
 
                 typename hpx::traits::detail::shared_state_ptr<void>::type p =
                     lcos::detail::make_continuation_exec<void>(
@@ -1118,7 +1118,7 @@ namespace hpx { namespace parallel { namespace execution {
 
                 auto func = make_fused_bulk_async_execute_helper<result_type>(
                     exec, std::forward<F>(f), shape,
-                    hpx::util::make_tuple(std::forward<Ts>(ts)...));
+                    hpx::make_tuple(std::forward<Ts>(ts)...));
 
                 // void or std::vector<func_result_type>
                 typedef typename bulk_then_execute_result<F, Shape, Future,

--- a/libs/parallelism/execution/include/hpx/execution/executors/fused_bulk_execute.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/executors/fused_bulk_execute.hpp
@@ -62,14 +62,14 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
         std::size_t... Is, typename... Ts>
     HPX_FORCEINLINE auto fused_bulk_sync_execute(Executor&& exec, F&& f,
         Shape const& shape, Future&& predecessor, hpx::util::index_pack<Is...>,
-        hpx::util::tuple<Ts...> const& args)
+        hpx::tuple<Ts...> const& args)
         -> decltype(execution::bulk_sync_execute(std::forward<Executor>(exec),
             std::forward<F>(f), shape, std::forward<Future>(predecessor),
-            hpx::util::get<Is>(args)...))
+            hpx::get<Is>(args)...))
     {
         return execution::bulk_sync_execute(std::forward<Executor>(exec),
             std::forward<F>(f), shape, std::forward<Future>(predecessor),
-            hpx::util::get<Is>(args)...);
+            hpx::get<Is>(args)...);
     }
 
     template <typename Result, typename Executor, typename F, typename Shape,
@@ -79,12 +79,12 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
     template <typename Result, typename Executor, typename F, typename Shape,
         typename... Ts>
     struct fused_bulk_sync_execute_helper<Result, Executor, F, Shape,
-        hpx::util::tuple<Ts...>>
+        hpx::tuple<Ts...>>
     {
         Executor exec_;
         F f_;
         Shape shape_;
-        hpx::util::tuple<Ts...> args_;
+        hpx::tuple<Ts...> args_;
 
         template <typename Future>
         Result operator()(Future&& predecessor)
@@ -115,14 +115,14 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
         std::size_t... Is, typename... Ts>
     HPX_FORCEINLINE auto fused_bulk_async_execute(Executor&& exec, F&& f,
         Shape const& shape, Future&& predecessor, hpx::util::index_pack<Is...>,
-        hpx::util::tuple<Ts...> const& args)
+        hpx::tuple<Ts...> const& args)
         -> decltype(execution::bulk_async_execute(std::forward<Executor>(exec),
             std::forward<F>(f), shape, std::forward<Future>(predecessor),
-            hpx::util::get<Is>(args)...))
+            hpx::get<Is>(args)...))
     {
         return execution::bulk_async_execute(std::forward<Executor>(exec),
             std::forward<F>(f), shape, std::forward<Future>(predecessor),
-            hpx::util::get<Is>(args)...);
+            hpx::get<Is>(args)...);
     }
 
     template <typename Result, typename Executor, typename F, typename Shape,
@@ -132,12 +132,12 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
     template <typename Result, typename Executor, typename F, typename Shape,
         typename... Ts>
     struct fused_bulk_async_execute_helper<Result, Executor, F, Shape,
-        hpx::util::tuple<Ts...>>
+        hpx::tuple<Ts...>>
     {
         Executor exec_;
         F f_;
         Shape shape_;
-        hpx::util::tuple<Ts...> args_;
+        hpx::tuple<Ts...> args_;
 
         template <typename Future>
         Result operator()(Future&& predecessor)

--- a/libs/parallelism/execution/include/hpx/execution/traits/vector_pack_alignment_size.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/traits/vector_pack_alignment_size.hpp
@@ -41,12 +41,12 @@ namespace hpx { namespace parallel { namespace traits {
     struct vector_pack_alignment;
 
     template <typename... Vector>
-    struct vector_pack_alignment<hpx::util::tuple<Vector...>,
+    struct vector_pack_alignment<hpx::tuple<Vector...>,
         typename std::enable_if<
             hpx::util::all_of<is_vector_pack<Vector>...>::value>::type>
     {
-        typedef typename hpx::util::tuple_element<0,
-            hpx::util::tuple<Vector...>>::type pack_type;
+        typedef typename hpx::tuple_element<0, hpx::tuple<Vector...>>::type
+            pack_type;
 
         static std::size_t const value =
             vector_pack_alignment<pack_type>::value;
@@ -57,12 +57,12 @@ namespace hpx { namespace parallel { namespace traits {
     struct vector_pack_size;
 
     template <typename... Vector>
-    struct vector_pack_size<hpx::util::tuple<Vector...>,
+    struct vector_pack_size<hpx::tuple<Vector...>,
         typename std::enable_if<
             hpx::util::all_of<is_vector_pack<Vector>...>::value>::type>
     {
-        typedef typename hpx::util::tuple_element<0,
-            hpx::util::tuple<Vector...>>::type pack_type;
+        typedef typename hpx::tuple_element<0, hpx::tuple<Vector...>>::type
+            pack_type;
 
         static std::size_t const value = vector_pack_size<pack_type>::value;
     };

--- a/libs/parallelism/execution/include/hpx/execution/traits/vector_pack_type.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/traits/vector_pack_type.hpp
@@ -22,10 +22,9 @@ namespace hpx { namespace parallel { namespace traits {
 
     // handle tuple<> transformations
     template <typename... T, std::size_t N, typename Abi>
-    struct vector_pack_type<hpx::util::tuple<T...>, N, Abi>
+    struct vector_pack_type<hpx::tuple<T...>, N, Abi>
     {
-        typedef hpx::util::tuple<typename vector_pack_type<T, N, Abi>::type...>
-            type;
+        typedef hpx::tuple<typename vector_pack_type<T, N, Abi>::type...> type;
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/execution/tests/regressions/lambda_arguments_2403.cpp
+++ b/libs/parallelism/execution/tests/regressions/lambda_arguments_2403.cpp
@@ -21,7 +21,7 @@ int hpx_main()
     auto zip_it_end = hpx::util::make_zip_iterator(large.end());
 
     hpx::for_each(hpx::execution::datapar, zip_it_begin, zip_it_end,
-        [](auto& t) -> void { hpx::util::get<0>(t) = 10.0; });
+        [](auto& t) -> void { hpx::get<0>(t) = 10.0; });
 
     HPX_TEST_EQ(std::count(large.begin(), large.end(), 10.0),
         std::ptrdiff_t(large.size()));

--- a/libs/parallelism/execution/tests/regressions/lambda_return_type_2402.cpp
+++ b/libs/parallelism/execution/tests/regressions/lambda_return_type_2402.cpp
@@ -22,8 +22,7 @@ int hpx_main()
 
     hpx::for_each(
         hpx::execution::datapar, zip_it_begin, zip_it_end, [](auto t) {
-            using comp_type =
-                typename hpx::util::tuple_element<0, decltype(t)>::type;
+            using comp_type = typename hpx::tuple_element<0, decltype(t)>::type;
             using var_type = typename hpx::util::decay<comp_type>::type;
 
             var_type mass_density = 0.0;

--- a/libs/parallelism/executors/include/hpx/executors/dataflow.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/dataflow.hpp
@@ -358,7 +358,7 @@ namespace hpx { namespace lcos { namespace detail {
     template <typename Policy, typename Func, typename... Ts,
         typename Frame = dataflow_frame<typename std::decay<Policy>::type,
             typename std::decay<Func>::type,
-            util::tuple<typename std::decay<Ts>::type...>>>
+            hpx::tuple<typename std::decay<Ts>::type...>>>
     typename Frame::type create_dataflow(
         Policy&& policy, Func&& func, Ts&&... ts)
     {
@@ -381,7 +381,7 @@ namespace hpx { namespace lcos { namespace detail {
         typename... Ts,
         typename Frame = dataflow_frame<typename std::decay<Policy>::type,
             typename std::decay<Func>::type,
-            util::tuple<typename std::decay<Ts>::type...>>>
+            hpx::tuple<typename std::decay<Ts>::type...>>>
     typename Frame::type create_dataflow_alloc(
         Allocator const& alloc, Policy&& policy, Func&& func, Ts&&... ts)
     {
@@ -414,7 +414,7 @@ namespace hpx { namespace lcos { namespace detail {
             !traits::is_action<typename std::decay<F>::type>::value,
             lcos::future<
                 typename detail::dataflow_return<typename std::decay<F>::type,
-                    util::tuple<typename traits::acquire_future<Ts>::type...>>::
+                    hpx::tuple<typename traits::acquire_future<Ts>::type...>>::
                     type>>::type
         call(Allocator const& alloc, Policy_&& policy, F&& f, Ts&&... ts)
         {
@@ -469,7 +469,7 @@ namespace hpx { namespace lcos { namespace detail {
             !traits::is_action<typename std::decay<F>::type>::value,
             lcos::future<
                 typename detail::dataflow_return<typename std::decay<F>::type,
-                    util::tuple<typename traits::acquire_future<Ts>::type...>>::
+                    hpx::tuple<typename traits::acquire_future<Ts>::type...>>::
                     type>>::type
         call(Allocator const& alloc, Executor_&& exec, F&& f, Ts&&... ts)
         {

--- a/libs/parallelism/executors/include/hpx/executors/guided_pool_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/guided_pool_executor.hpp
@@ -346,14 +346,13 @@ namespace hpx { namespace parallel { namespace execution {
             typename... InnerFutures, typename... Ts,
             typename =
                 detail::enable_if_t<detail::is_future_of_tuple_of_futures<
-                    OuterFuture<hpx::util::tuple<InnerFutures...>>>::value>,
+                    OuterFuture<hpx::tuple<InnerFutures...>>>::value>,
             typename = detail::enable_if_t<hpx::traits::is_future_tuple<
-                hpx::util::tuple<InnerFutures...>>::value>>
+                hpx::tuple<InnerFutures...>>::value>>
         auto then_execute(F&& f,
-            OuterFuture<hpx::util::tuple<InnerFutures...>>&& predecessor,
-            Ts&&... ts)
+            OuterFuture<hpx::tuple<InnerFutures...>>&& predecessor, Ts&&... ts)
             -> future<typename hpx::util::detail::invoke_deferred_result<F,
-                OuterFuture<hpx::util::tuple<InnerFutures...>>, Ts...>::type>
+                OuterFuture<hpx::tuple<InnerFutures...>>, Ts...>::type>
         {
 #ifdef GUIDED_EXECUTOR_DEBUG
             // get the tuple of futures from the predecessor future <tuple of futures>
@@ -365,13 +364,13 @@ namespace hpx { namespace parallel { namespace execution {
                 detail::future_extract_value{}, predecessor_value);
 
             typedef typename hpx::util::detail::invoke_deferred_result<F,
-                OuterFuture<hpx::util::tuple<InnerFutures...>>, Ts...>::type
+                OuterFuture<hpx::tuple<InnerFutures...>>, Ts...>::type
                 result_type;
 
             // clang-format off
             gpx_deb.debug(debug::str<>("when_all(fut) : Predecessor")
                 , hpx::util::debug::print_type<
-                       OuterFuture<hpx::util::tuple<InnerFutures...>>>()
+                       OuterFuture<hpx::tuple<InnerFutures...>>>()
                 , "\n"
                 , "when_all(fut) : unwrapped   : "
                 , hpx::util::debug::print_type<decltype(unwrapped_futures_tuple)>(
@@ -389,8 +388,7 @@ namespace hpx { namespace parallel { namespace execution {
             return dataflow(
                 launch::sync,
                 [f = std::forward<F>(f), this](
-                    OuterFuture<hpx::util::tuple<InnerFutures...>>&&
-                        predecessor,
+                    OuterFuture<hpx::tuple<InnerFutures...>>&& predecessor,
                     Ts&&... ts) {
                     detail::pre_execution_then_domain_schedule<
                         typename std::decay<typename std::remove_pointer<
@@ -399,11 +397,10 @@ namespace hpx { namespace parallel { namespace execution {
                         pre_exec{*this, hint_, hp_sync_};
 
                     return pre_exec(std::move(f),
-                        std::forward<
-                            OuterFuture<hpx::util::tuple<InnerFutures...>>>(
+                        std::forward<OuterFuture<hpx::tuple<InnerFutures...>>>(
                             predecessor));
                 },
-                std::forward<OuterFuture<hpx::util::tuple<InnerFutures...>>>(
+                std::forward<OuterFuture<hpx::tuple<InnerFutures...>>>(
                     predecessor),
                 std::forward<Ts>(ts)...);
         }
@@ -415,14 +412,13 @@ namespace hpx { namespace parallel { namespace execution {
         // --------------------------------------------------------------------
         template <typename F, typename... InnerFutures,
             typename = detail::enable_if_t<hpx::traits::is_future_tuple<
-                hpx::util::tuple<InnerFutures...>>::value>>
-        auto async_execute(
-            F&& f, hpx::util::tuple<InnerFutures...>&& predecessor)
+                hpx::tuple<InnerFutures...>>::value>>
+        auto async_execute(F&& f, hpx::tuple<InnerFutures...>&& predecessor)
             -> future<typename hpx::util::detail::invoke_deferred_result<F,
-                hpx::util::tuple<InnerFutures...>>::type>
+                hpx::tuple<InnerFutures...>>::type>
         {
             typedef typename hpx::util::detail::invoke_deferred_result<F,
-                hpx::util::tuple<InnerFutures...>>::type result_type;
+                hpx::tuple<InnerFutures...>>::type result_type;
 
             // invoke the hint function with the unwrapped tuple futures
 #ifdef GUIDED_POOL_EXECUTOR_FAKE_NOOP
@@ -438,7 +434,7 @@ namespace hpx { namespace parallel { namespace execution {
 #ifndef GUIDED_EXECUTOR_DEBUG
             // clang-format off
             gpx_deb.debug(debug::str<>("dataflow      : Predecessor")
-                      , hpx::util::debug::print_type<hpx::util::tuple<InnerFutures...>>()
+                      , hpx::util::debug::print_type<hpx::tuple<InnerFutures...>>()
                       , "\n"
                       , "dataflow      : unwrapped   : "
                       , hpx::util::debug::print_type<
@@ -456,8 +452,7 @@ namespace hpx { namespace parallel { namespace execution {
             // forward the task execution on to the real internal executor
             lcos::local::futures_factory<result_type()> p(
                 hpx::util::deferred_call(std::forward<F>(f),
-                    std::forward<hpx::util::tuple<InnerFutures...>>(
-                        predecessor)));
+                    std::forward<hpx::tuple<InnerFutures...>>(predecessor)));
 
             if (hp_sync_ && priority_ == hpx::threads::thread_priority_high)
             {

--- a/libs/parallelism/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/parallel_executor.hpp
@@ -280,7 +280,7 @@ namespace hpx { namespace execution {
             auto&& func = parallel::execution::detail::
                 make_fused_bulk_async_execute_helper<result_type>(*this,
                     std::forward<F>(f), shape,
-                    hpx::util::make_tuple(std::forward<Ts>(ts)...));
+                    hpx::make_tuple(std::forward<Ts>(ts)...));
 
             // void or std::vector<func_result_type>
             using vector_result_type =

--- a/libs/parallelism/executors/include/hpx/executors/service_executors.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/service_executors.hpp
@@ -128,7 +128,7 @@ namespace hpx { namespace parallel { namespace execution { namespace detail {
             auto func = parallel::execution::detail::
                 make_fused_bulk_async_execute_helper<result_type>(*this,
                     std::forward<F>(f), shape,
-                    hpx::util::make_tuple(std::forward<Ts>(ts)...));
+                    hpx::make_tuple(std::forward<Ts>(ts)...));
             using vector_result_type =
                 typename parallel::execution::detail::bulk_then_execute_result<
                     F, Shape, Future, Ts...>::type;

--- a/libs/parallelism/executors/include/hpx/executors/thread_pool_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/thread_pool_executor.hpp
@@ -195,7 +195,7 @@ namespace hpx { namespace parallel { namespace execution {
             auto&& func =
                 detail::make_fused_bulk_async_execute_helper<result_type>(
                     executor, std::forward<F>(f), shape,
-                    hpx::util::make_tuple(std::forward<Ts>(ts)...));
+                    hpx::make_tuple(std::forward<Ts>(ts)...));
 
             // void or std::vector<func_result_type>
             using vector_result_type =

--- a/libs/parallelism/futures/include/hpx/futures/detail/future_data.hpp
+++ b/libs/parallelism/futures/include/hpx/futures/detail/future_data.hpp
@@ -22,7 +22,6 @@
 #include <hpx/thread_support/atomic_count.hpp>
 #include <hpx/threading_base/annotated_function.hpp>
 #include <hpx/threading_base/thread_helpers.hpp>
-#include <hpx/timing/steady_clock.hpp>
 #include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/unused.hpp>
 
@@ -283,7 +282,7 @@ namespace hpx { namespace lcos { namespace detail {
         virtual state wait(error_code& ec = throws);
 
         virtual future_status wait_until(
-            util::steady_clock::time_point const& abs_time,
+            std::chrono::steady_clock::time_point const& abs_time,
             error_code& ec = throws);
 
         virtual std::exception_ptr get_exception_ptr() const = 0;
@@ -764,8 +763,8 @@ namespace hpx { namespace lcos { namespace detail {
         timed_future_data() {}
 
         template <typename Result_>
-        timed_future_data(
-            util::steady_clock::time_point const& abs_time, Result_&& init)
+        timed_future_data(std::chrono::steady_clock::time_point const& abs_time,
+            Result_&& init)
         {
             hpx::intrusive_ptr<timed_future_data> this_(this);
 
@@ -846,7 +845,7 @@ namespace hpx { namespace lcos { namespace detail {
         }
 
         virtual future_status wait_until(
-            util::steady_clock::time_point const& abs_time,
+            std::chrono::steady_clock::time_point const& abs_time,
             error_code& ec = throws)
         {
             if (!started_test())

--- a/libs/parallelism/futures/include/hpx/futures/traits/is_future_tuple.hpp
+++ b/libs/parallelism/futures/include/hpx/futures/traits/is_future_tuple.hpp
@@ -19,7 +19,7 @@ namespace hpx { namespace traits {
     };
 
     template <typename... Ts>
-    struct is_future_tuple<util::tuple<Ts...>> : util::all_of<is_future<Ts>...>
+    struct is_future_tuple<hpx::tuple<Ts...>> : util::all_of<is_future<Ts>...>
     {
     };
 }}    // namespace hpx::traits

--- a/libs/parallelism/futures/src/future_data.cpp
+++ b/libs/parallelism/futures/src/future_data.cpp
@@ -289,7 +289,7 @@ namespace hpx { namespace lcos { namespace detail {
 
     future_status
     future_data_base<traits::detail::future_data_void>::wait_until(
-        util::steady_clock::time_point const& abs_time, error_code& ec)
+        std::chrono::steady_clock::time_point const& abs_time, error_code& ec)
     {
         // block if this entry is empty
         if (state_.load(std::memory_order_acquire) == empty)

--- a/libs/parallelism/futures/tests/unit/shared_future.cpp
+++ b/libs/parallelism/futures/tests/unit/shared_future.cpp
@@ -637,19 +637,18 @@ void test_wait_for_either_of_two_futures_1()
 
     pt1();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::util::tuple<
+    hpx::lcos::future<hpx::when_any_result<hpx::tuple<
         hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
         r = hpx::when_any(f1, f2);
-    hpx::util::tuple<hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>>
-        t = r.get().futures;
+    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>> t =
+        r.get().futures;
 
     HPX_TEST(f1.is_ready());
     HPX_TEST(!f2.is_ready());
     HPX_TEST_EQ(f1.get(), 42);
 
-    HPX_TEST(hpx::util::get<0>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<0>(t).get(), 42);
+    HPX_TEST(hpx::get<0>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<0>(t).get(), 42);
 }
 
 void test_wait_for_either_of_two_futures_2()
@@ -661,19 +660,18 @@ void test_wait_for_either_of_two_futures_2()
 
     pt2();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::util::tuple<
+    hpx::lcos::future<hpx::when_any_result<hpx::tuple<
         hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
         r = hpx::when_any(f1, f2);
-    hpx::util::tuple<hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>>
-        t = r.get().futures;
+    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>> t =
+        r.get().futures;
 
     HPX_TEST(!f1.is_ready());
     HPX_TEST(f2.is_ready());
     HPX_TEST_EQ(f2.get(), 42);
 
-    HPX_TEST(hpx::util::get<1>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<1>(t).get(), 42);
+    HPX_TEST(hpx::get<1>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<1>(t).get(), 42);
 }
 
 void test_wait_for_either_of_two_futures_list_1()
@@ -744,11 +742,11 @@ void test_wait_for_either_of_three_futures_1()
     pt1();
 
     hpx::lcos::future<
-        hpx::when_any_result<hpx::util::tuple<hpx::lcos::shared_future<int>,
+        hpx::when_any_result<hpx::tuple<hpx::lcos::shared_future<int>,
             hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3);
-    hpx::util::tuple<hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>
+    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
+        hpx::lcos::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(f1.is_ready());
@@ -756,8 +754,8 @@ void test_wait_for_either_of_three_futures_1()
     HPX_TEST(!f3.is_ready());
     HPX_TEST_EQ(f1.get(), 42);
 
-    HPX_TEST(hpx::util::get<0>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<0>(t).get(), 42);
+    HPX_TEST(hpx::get<0>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<0>(t).get(), 42);
 }
 
 void test_wait_for_either_of_three_futures_2()
@@ -772,11 +770,11 @@ void test_wait_for_either_of_three_futures_2()
     pt2();
 
     hpx::lcos::future<
-        hpx::when_any_result<hpx::util::tuple<hpx::lcos::shared_future<int>,
+        hpx::when_any_result<hpx::tuple<hpx::lcos::shared_future<int>,
             hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3);
-    hpx::util::tuple<hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>
+    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
+        hpx::lcos::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.is_ready());
@@ -784,8 +782,8 @@ void test_wait_for_either_of_three_futures_2()
     HPX_TEST(!f3.is_ready());
     HPX_TEST_EQ(f2.get(), 42);
 
-    HPX_TEST(hpx::util::get<1>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<1>(t).get(), 42);
+    HPX_TEST(hpx::get<1>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<1>(t).get(), 42);
 }
 
 void test_wait_for_either_of_three_futures_3()
@@ -800,11 +798,11 @@ void test_wait_for_either_of_three_futures_3()
     pt3();
 
     hpx::lcos::future<
-        hpx::when_any_result<hpx::util::tuple<hpx::lcos::shared_future<int>,
+        hpx::when_any_result<hpx::tuple<hpx::lcos::shared_future<int>,
             hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3);
-    hpx::util::tuple<hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>
+    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
+        hpx::lcos::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.is_ready());
@@ -812,8 +810,8 @@ void test_wait_for_either_of_three_futures_3()
     HPX_TEST(f3.is_ready());
     HPX_TEST_EQ(f3.get(), 42);
 
-    HPX_TEST(hpx::util::get<2>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<2>(t).get(), 42);
+    HPX_TEST(hpx::get<2>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<2>(t).get(), 42);
 }
 
 void test_wait_for_either_of_four_futures_1()
@@ -829,13 +827,12 @@ void test_wait_for_either_of_four_futures_1()
 
     pt1();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::util::tuple<
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
+    hpx::lcos::future<hpx::when_any_result<
+        hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
+            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4);
-    hpx::util::tuple<hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>>
+    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
+        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(f1.is_ready());
@@ -844,8 +841,8 @@ void test_wait_for_either_of_four_futures_1()
     HPX_TEST(!f4.is_ready());
     HPX_TEST_EQ(f1.get(), 42);
 
-    HPX_TEST(hpx::util::get<0>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<0>(t).get(), 42);
+    HPX_TEST(hpx::get<0>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<0>(t).get(), 42);
 }
 
 void test_wait_for_either_of_four_futures_2()
@@ -861,13 +858,12 @@ void test_wait_for_either_of_four_futures_2()
 
     pt2();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::util::tuple<
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
+    hpx::lcos::future<hpx::when_any_result<
+        hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
+            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4);
-    hpx::util::tuple<hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>>
+    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
+        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.is_ready());
@@ -876,8 +872,8 @@ void test_wait_for_either_of_four_futures_2()
     HPX_TEST(!f4.is_ready());
     HPX_TEST_EQ(f2.get(), 42);
 
-    HPX_TEST(hpx::util::get<1>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<1>(t).get(), 42);
+    HPX_TEST(hpx::get<1>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<1>(t).get(), 42);
 }
 
 void test_wait_for_either_of_four_futures_3()
@@ -893,13 +889,12 @@ void test_wait_for_either_of_four_futures_3()
 
     pt3();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::util::tuple<
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
+    hpx::lcos::future<hpx::when_any_result<
+        hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
+            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4);
-    hpx::util::tuple<hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>>
+    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
+        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.is_ready());
@@ -908,8 +903,8 @@ void test_wait_for_either_of_four_futures_3()
     HPX_TEST(!f4.is_ready());
     HPX_TEST_EQ(f3.get(), 42);
 
-    HPX_TEST(hpx::util::get<2>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<2>(t).get(), 42);
+    HPX_TEST(hpx::get<2>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<2>(t).get(), 42);
 }
 
 void test_wait_for_either_of_four_futures_4()
@@ -925,13 +920,12 @@ void test_wait_for_either_of_four_futures_4()
 
     pt4();
 
-    hpx::lcos::future<hpx::when_any_result<hpx::util::tuple<
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
+    hpx::lcos::future<hpx::when_any_result<
+        hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
+            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4);
-    hpx::util::tuple<hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>>
+    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
+        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.is_ready());
@@ -940,8 +934,8 @@ void test_wait_for_either_of_four_futures_4()
     HPX_TEST(f4.is_ready());
     HPX_TEST_EQ(f4.get(), 42);
 
-    HPX_TEST(hpx::util::get<3>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<3>(t).get(), 42);
+    HPX_TEST(hpx::get<3>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<3>(t).get(), 42);
 }
 
 void test_wait_for_either_of_five_futures_1_from_list()
@@ -1046,13 +1040,13 @@ void test_wait_for_either_of_five_futures_1()
     pt1();
 
     hpx::lcos::future<
-        hpx::when_any_result<hpx::util::tuple<hpx::lcos::shared_future<int>,
+        hpx::when_any_result<hpx::tuple<hpx::lcos::shared_future<int>,
             hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
             hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4, f5);
-    hpx::util::tuple<hpx::lcos::shared_future<int>,
+    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
         hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>
+        hpx::lcos::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(f1.is_ready());
@@ -1062,8 +1056,8 @@ void test_wait_for_either_of_five_futures_1()
     HPX_TEST(!f5.is_ready());
     HPX_TEST_EQ(f1.get(), 42);
 
-    HPX_TEST(hpx::util::get<0>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<0>(t).get(), 42);
+    HPX_TEST(hpx::get<0>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<0>(t).get(), 42);
 }
 
 void test_wait_for_either_of_five_futures_2()
@@ -1082,13 +1076,13 @@ void test_wait_for_either_of_five_futures_2()
     pt2();
 
     hpx::lcos::future<
-        hpx::when_any_result<hpx::util::tuple<hpx::lcos::shared_future<int>,
+        hpx::when_any_result<hpx::tuple<hpx::lcos::shared_future<int>,
             hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
             hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4, f5);
-    hpx::util::tuple<hpx::lcos::shared_future<int>,
+    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
         hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>
+        hpx::lcos::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.is_ready());
@@ -1098,8 +1092,8 @@ void test_wait_for_either_of_five_futures_2()
     HPX_TEST(!f5.is_ready());
     HPX_TEST_EQ(f2.get(), 42);
 
-    HPX_TEST(hpx::util::get<1>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<1>(t).get(), 42);
+    HPX_TEST(hpx::get<1>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<1>(t).get(), 42);
 }
 
 void test_wait_for_either_of_five_futures_3()
@@ -1118,13 +1112,13 @@ void test_wait_for_either_of_five_futures_3()
     pt3();
 
     hpx::lcos::future<
-        hpx::when_any_result<hpx::util::tuple<hpx::lcos::shared_future<int>,
+        hpx::when_any_result<hpx::tuple<hpx::lcos::shared_future<int>,
             hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
             hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4, f5);
-    hpx::util::tuple<hpx::lcos::shared_future<int>,
+    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
         hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>
+        hpx::lcos::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.is_ready());
@@ -1134,8 +1128,8 @@ void test_wait_for_either_of_five_futures_3()
     HPX_TEST(!f5.is_ready());
     HPX_TEST_EQ(f3.get(), 42);
 
-    HPX_TEST(hpx::util::get<2>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<2>(t).get(), 42);
+    HPX_TEST(hpx::get<2>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<2>(t).get(), 42);
 }
 
 void test_wait_for_either_of_five_futures_4()
@@ -1154,13 +1148,13 @@ void test_wait_for_either_of_five_futures_4()
     pt4();
 
     hpx::lcos::future<
-        hpx::when_any_result<hpx::util::tuple<hpx::lcos::shared_future<int>,
+        hpx::when_any_result<hpx::tuple<hpx::lcos::shared_future<int>,
             hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
             hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4, f5);
-    hpx::util::tuple<hpx::lcos::shared_future<int>,
+    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
         hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>
+        hpx::lcos::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.is_ready());
@@ -1170,8 +1164,8 @@ void test_wait_for_either_of_five_futures_4()
     HPX_TEST(!f5.is_ready());
     HPX_TEST_EQ(f4.get(), 42);
 
-    HPX_TEST(hpx::util::get<3>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<3>(t).get(), 42);
+    HPX_TEST(hpx::get<3>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<3>(t).get(), 42);
 }
 
 void test_wait_for_either_of_five_futures_5()
@@ -1190,13 +1184,13 @@ void test_wait_for_either_of_five_futures_5()
     pt5();
 
     hpx::lcos::future<
-        hpx::when_any_result<hpx::util::tuple<hpx::lcos::shared_future<int>,
+        hpx::when_any_result<hpx::tuple<hpx::lcos::shared_future<int>,
             hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
             hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>>
         r = hpx::when_any(f1, f2, f3, f4, f5);
-    hpx::util::tuple<hpx::lcos::shared_future<int>,
+    hpx::tuple<hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
         hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>
+        hpx::lcos::shared_future<int>>
         t = r.get().futures;
 
     HPX_TEST(!f1.is_ready());
@@ -1206,8 +1200,8 @@ void test_wait_for_either_of_five_futures_5()
     HPX_TEST(f5.is_ready());
     HPX_TEST_EQ(f5.get(), 42);
 
-    HPX_TEST(hpx::util::get<4>(t).is_ready());
-    HPX_TEST_EQ(hpx::util::get<4>(t).get(), 42);
+    HPX_TEST(hpx::get<4>(t).is_ready());
+    HPX_TEST_EQ(hpx::get<4>(t).get(), 42);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1320,15 +1314,15 @@ void test_wait_for_all_two_futures()
     hpx::lcos::shared_future<int> f2 = pt2.get_future();
     pt2.apply();
 
-    typedef hpx::util::tuple<hpx::lcos::shared_future<int>,
+    typedef hpx::tuple<hpx::lcos::shared_future<int>,
         hpx::lcos::shared_future<int>>
         result_type;
     hpx::lcos::future<result_type> r = hpx::when_all(f1, f2);
 
     result_type result = r.get();
 
-    HPX_TEST(hpx::util::get<0>(result).is_ready());
-    HPX_TEST(hpx::util::get<1>(result).is_ready());
+    HPX_TEST(hpx::get<0>(result).is_ready());
+    HPX_TEST(hpx::get<1>(result).is_ready());
     HPX_TEST(f1.is_ready());
     HPX_TEST(f2.is_ready());
 }
@@ -1345,16 +1339,16 @@ void test_wait_for_all_three_futures()
     hpx::lcos::shared_future<int> f3 = pt3.get_future();
     pt3.apply();
 
-    typedef hpx::util::tuple<hpx::lcos::shared_future<int>,
+    typedef hpx::tuple<hpx::lcos::shared_future<int>,
         hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>
         result_type;
     hpx::lcos::future<result_type> r = hpx::when_all(f1, f2, f3);
 
     result_type result = r.get();
 
-    HPX_TEST(hpx::util::get<0>(result).is_ready());
-    HPX_TEST(hpx::util::get<1>(result).is_ready());
-    HPX_TEST(hpx::util::get<2>(result).is_ready());
+    HPX_TEST(hpx::get<0>(result).is_ready());
+    HPX_TEST(hpx::get<1>(result).is_ready());
+    HPX_TEST(hpx::get<2>(result).is_ready());
     HPX_TEST(f1.is_ready());
     HPX_TEST(f2.is_ready());
     HPX_TEST(f3.is_ready());
@@ -1375,7 +1369,7 @@ void test_wait_for_all_four_futures()
     hpx::lcos::shared_future<int> f4 = pt4.get_future();
     pt4.apply();
 
-    typedef hpx::util::tuple<hpx::lcos::shared_future<int>,
+    typedef hpx::tuple<hpx::lcos::shared_future<int>,
         hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
         hpx::lcos::shared_future<int>>
         result_type;
@@ -1383,10 +1377,10 @@ void test_wait_for_all_four_futures()
 
     result_type result = r.get();
 
-    HPX_TEST(hpx::util::get<0>(result).is_ready());
-    HPX_TEST(hpx::util::get<1>(result).is_ready());
-    HPX_TEST(hpx::util::get<2>(result).is_ready());
-    HPX_TEST(hpx::util::get<3>(result).is_ready());
+    HPX_TEST(hpx::get<0>(result).is_ready());
+    HPX_TEST(hpx::get<1>(result).is_ready());
+    HPX_TEST(hpx::get<2>(result).is_ready());
+    HPX_TEST(hpx::get<3>(result).is_ready());
     HPX_TEST(f1.is_ready());
     HPX_TEST(f2.is_ready());
     HPX_TEST(f3.is_ready());
@@ -1411,7 +1405,7 @@ void test_wait_for_all_five_futures()
     hpx::lcos::shared_future<int> f5 = pt5.get_future();
     pt5.apply();
 
-    typedef hpx::util::tuple<hpx::lcos::shared_future<int>,
+    typedef hpx::tuple<hpx::lcos::shared_future<int>,
         hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
         hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>
         result_type;
@@ -1419,11 +1413,11 @@ void test_wait_for_all_five_futures()
 
     result_type result = r.get();
 
-    HPX_TEST(hpx::util::get<0>(result).is_ready());
-    HPX_TEST(hpx::util::get<1>(result).is_ready());
-    HPX_TEST(hpx::util::get<2>(result).is_ready());
-    HPX_TEST(hpx::util::get<3>(result).is_ready());
-    HPX_TEST(hpx::util::get<4>(result).is_ready());
+    HPX_TEST(hpx::get<0>(result).is_ready());
+    HPX_TEST(hpx::get<1>(result).is_ready());
+    HPX_TEST(hpx::get<2>(result).is_ready());
+    HPX_TEST(hpx::get<3>(result).is_ready());
+    HPX_TEST(hpx::get<4>(result).is_ready());
     HPX_TEST(f1.is_ready());
     HPX_TEST(f2.is_ready());
     HPX_TEST(f3.is_ready());
@@ -1448,10 +1442,9 @@ void test_wait_for_two_out_of_five_futures()
     hpx::lcos::local::packaged_task<int()> pt5(make_int_slowly);
     hpx::lcos::shared_future<int> f5 = pt5.get_future();
 
-    typedef hpx::when_some_result<
-        hpx::util::tuple<hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>
+    typedef hpx::when_some_result<hpx::tuple<hpx::lcos::shared_future<int>,
+        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
+        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>
         result_type;
     hpx::lcos::future<result_type> r =
         hpx::when_some(count, f1, f2, f3, f4, f5);
@@ -1465,11 +1458,11 @@ void test_wait_for_two_out_of_five_futures()
     HPX_TEST(!f5.is_ready());
 
     HPX_TEST_EQ(result.indices.size(), count);
-    HPX_TEST(!hpx::util::get<0>(result.futures).is_ready());
-    HPX_TEST(hpx::util::get<1>(result.futures).is_ready());
-    HPX_TEST(!hpx::util::get<2>(result.futures).is_ready());
-    HPX_TEST(hpx::util::get<3>(result.futures).is_ready());
-    HPX_TEST(!hpx::util::get<4>(result.futures).is_ready());
+    HPX_TEST(!hpx::get<0>(result.futures).is_ready());
+    HPX_TEST(hpx::get<1>(result.futures).is_ready());
+    HPX_TEST(!hpx::get<2>(result.futures).is_ready());
+    HPX_TEST(hpx::get<3>(result.futures).is_ready());
+    HPX_TEST(!hpx::get<4>(result.futures).is_ready());
 }
 
 void test_wait_for_three_out_of_five_futures()
@@ -1490,10 +1483,9 @@ void test_wait_for_three_out_of_five_futures()
     hpx::lcos::shared_future<int> f5 = pt5.get_future();
     pt5();
 
-    typedef hpx::when_some_result<
-        hpx::util::tuple<hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
-            hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>
+    typedef hpx::when_some_result<hpx::tuple<hpx::lcos::shared_future<int>,
+        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>,
+        hpx::lcos::shared_future<int>, hpx::lcos::shared_future<int>>>
         result_type;
     hpx::lcos::future<result_type> r =
         hpx::when_some(count, f1, f2, f3, f4, f5);
@@ -1507,11 +1499,11 @@ void test_wait_for_three_out_of_five_futures()
     HPX_TEST(f5.is_ready());
 
     HPX_TEST_EQ(result.indices.size(), count);
-    HPX_TEST(hpx::util::get<0>(result.futures).is_ready());
-    HPX_TEST(!hpx::util::get<1>(result.futures).is_ready());
-    HPX_TEST(hpx::util::get<2>(result.futures).is_ready());
-    HPX_TEST(!hpx::util::get<3>(result.futures).is_ready());
-    HPX_TEST(hpx::util::get<4>(result.futures).is_ready());
+    HPX_TEST(hpx::get<0>(result.futures).is_ready());
+    HPX_TEST(!hpx::get<1>(result.futures).is_ready());
+    HPX_TEST(hpx::get<2>(result.futures).is_ready());
+    HPX_TEST(!hpx::get<3>(result.futures).is_ready());
+    HPX_TEST(hpx::get<4>(result.futures).is_ready());
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/lcos_local/tests/unit/split_future.cpp
+++ b/libs/parallelism/lcos_local/tests/unit/split_future.cpp
@@ -15,82 +15,78 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::util::tuple<> make_tuple0_slowly()
+hpx::tuple<> make_tuple0_slowly()
 {
     hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
-    return hpx::util::make_tuple();
+    return hpx::make_tuple();
 }
 
 void test_split_future0()
 {
-    hpx::lcos::local::futures_factory<hpx::util::tuple<>()> pt(
-        make_tuple0_slowly);
+    hpx::lcos::local::futures_factory<hpx::tuple<>()> pt(make_tuple0_slowly);
     pt.apply();
 
-    hpx::util::tuple<hpx::future<void>> result =
-        hpx::split_future(pt.get_future());
+    hpx::tuple<hpx::future<void>> result = hpx::split_future(pt.get_future());
 
-    hpx::util::get<0>(result).get();
+    hpx::get<0>(result).get();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::util::tuple<int> make_tuple1_slowly()
+hpx::tuple<int> make_tuple1_slowly()
 {
     hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
-    return hpx::util::make_tuple(42);
+    return hpx::make_tuple(42);
 }
 
 void test_split_future1()
 {
-    hpx::lcos::local::futures_factory<hpx::util::tuple<int>()> pt(
-        make_tuple1_slowly);
+    hpx::lcos::local::futures_factory<hpx::tuple<int>()> pt(make_tuple1_slowly);
     pt.apply();
 
-    hpx::util::tuple<hpx::future<int>> result =
-        hpx::split_future(pt.get_future());
+    hpx::tuple<hpx::future<int>> result = hpx::split_future(pt.get_future());
 
-    HPX_TEST_EQ(hpx::util::get<0>(result).get(), 42);
+    HPX_TEST_EQ(hpx::get<0>(result).get(), 42);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::util::tuple<int, int> make_tuple2_slowly()
+hpx::tuple<int, int> make_tuple2_slowly()
 {
     hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
-    return hpx::util::make_tuple(42, 43);
+    return hpx::make_tuple(42, 43);
 }
 
 void test_split_future2()
 {
-    hpx::lcos::local::futures_factory<hpx::util::tuple<int, int>()> pt(
+    hpx::lcos::local::futures_factory<hpx::tuple<int, int>()> pt(
         make_tuple2_slowly);
     pt.apply();
 
-    hpx::util::tuple<hpx::future<int>, hpx::future<int>> result =
+    hpx::tuple<hpx::future<int>, hpx::future<int>> result =
         hpx::split_future(pt.get_future());
 
-    HPX_TEST_EQ(hpx::util::get<0>(result).get(), 42);
-    HPX_TEST_EQ(hpx::util::get<1>(result).get(), 43);
+    HPX_TEST_EQ(hpx::get<0>(result).get(), 42);
+    HPX_TEST_EQ(hpx::get<1>(result).get(), 43);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-hpx::util::tuple<int, int, int> make_tuple3_slowly()
+hpx::tuple<int, int, int> make_tuple3_slowly()
 {
     hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
-    return hpx::util::make_tuple(42, 43, 44);
+    return hpx::make_tuple(42, 43, 44);
 }
 
 void test_split_future3()
 {
-    hpx::lcos::local::futures_factory<hpx::util::tuple<int, int, int>()> pt(
+    hpx::lcos::local::futures_factory<hpx::tuple<int, int, int>()> pt(
         make_tuple3_slowly);
     pt.apply();
 
-    hpx::util::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>>
-        result = hpx::split_future(pt.get_future());
+    hpx::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>> result =
+        hpx::split_future(pt.get_future());
 
-    HPX_TEST_EQ(hpx::util::get<0>(result).get(), 42);
-    HPX_TEST_EQ(hpx::util::get<1>(result).get(), 43);
-    HPX_TEST_EQ(hpx::util::get<2>(result).get(), 44);
+    HPX_TEST_EQ(hpx::get<0>(result).get(), 42);
+    HPX_TEST_EQ(hpx::get<1>(result).get(), 43);
+    HPX_TEST_EQ(hpx::get<2>(result).get(), 44);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
+++ b/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
@@ -120,7 +120,7 @@ namespace hpx {
         public:
             explicit async_traversal_frame(Visitor visitor, Args... args)
               : Visitor(std::move(visitor))
-              , args_(util::make_tuple(std::move(args)...))
+              , args_(hpx::make_tuple(std::move(args)...))
               , finished_(false)
             {
             }
@@ -135,7 +135,7 @@ namespace hpx {
             explicit async_traversal_frame(async_traverse_in_place_tag<Visitor>,
                 MapperArg&& mapper_arg, Args... args)
               : Visitor(std::forward<MapperArg>(mapper_arg))
-              , args_(util::make_tuple(std::move(args)...))
+              , args_(hpx::make_tuple(std::move(args)...))
               , finished_(false)
             {
             }
@@ -274,9 +274,9 @@ namespace hpx {
             }
 
             constexpr auto operator*() const noexcept
-                -> decltype(util::get<Begin>(*target_))
+                -> decltype(hpx::get<Begin>(*target_))
             {
-                return util::get<Begin>(*target_);
+                return hpx::get<Begin>(*target_);
             }
 
             template <std::size_t Position>
@@ -314,7 +314,7 @@ namespace hpx {
         /// Returns a static range for the given type
         template <typename T,
             typename Range = static_async_range<typename std::decay<T>::type,
-                0U, util::tuple_size<typename std::decay<T>::type>::value>>
+                0U, hpx::tuple_size<typename std::decay<T>::type>::value>>
         Range make_static_range(T&& element)
         {
             auto pointer = std::addressof(element);
@@ -408,8 +408,8 @@ namespace hpx {
             {
                 // Create a new hierarchy which contains the
                 // the parent (the last traversed element).
-                auto hierarchy = util::tuple_cat(
-                    util::make_tuple(std::forward<Parent>(parent)), hierarchy_);
+                auto hierarchy = hpx::tuple_cat(
+                    hpx::make_tuple(std::forward<Parent>(parent)), hierarchy_);
 
                 return async_traversal_point<Frame,
                     typename std::decay<Parent>::type, Hierarchy...>(
@@ -452,8 +452,8 @@ namespace hpx {
                 {
                     // Store the current call hierarchy into a tuple for
                     // later re-entrance.
-                    auto hierarchy = util::tuple_cat(
-                        util::make_tuple(current.next()), hierarchy_);
+                    auto hierarchy = hpx::tuple_cat(
+                        hpx::make_tuple(current.next()), hierarchy_);
 
                     // First detach the current execution context
                     detach();
@@ -573,7 +573,7 @@ namespace hpx {
                 if (!current.is_finished())
                 {
                     traversal_point_of_t<Frame> point(
-                        frame, util::make_tuple(), detached);
+                        frame, hpx::make_tuple(), detached);
 
                     point.async_traverse(std::forward<Current>(current));
 
@@ -601,8 +601,7 @@ namespace hpx {
                     // Don't forward the arguments here, since we still need
                     // the objects in a valid state later.
                     traversal_point_of_t<Frame, Parent, Hierarchy...> point(
-                        frame, util::make_tuple(parent, hierarchy...),
-                        detached);
+                        frame, hpx::make_tuple(parent, hierarchy...), detached);
 
                     point.async_traverse(std::forward<Current>(current));
 
@@ -624,7 +623,7 @@ namespace hpx {
         template <typename Frame, typename State>
         void resume_traversal_callable<Frame, State>::operator()()
         {
-            auto hierarchy = util::tuple_cat(util::make_tuple(frame_), state_);
+            auto hierarchy = hpx::tuple_cat(hpx::make_tuple(frame_), state_);
             util::invoke_fused(resume_state_callable{}, std::move(hierarchy));
         }
 
@@ -671,7 +670,7 @@ namespace hpx {
             auto range = make_static_range(frame->head());
 
             auto resumer = make_resume_traversal_callable(
-                frame, util::make_tuple(std::move(range)));
+                frame, hpx::make_tuple(std::move(range)));
 
             // Start the asynchronous traversal
             resumer();
@@ -714,7 +713,7 @@ namespace hpx {
             auto range = make_static_range(frame->head());
 
             auto resumer = make_resume_traversal_callable(
-                frame, util::make_tuple(std::move(range)));
+                frame, hpx::make_tuple(std::move(range)));
 
             // Start the asynchronous traversal
             resumer();

--- a/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_impl.hpp
+++ b/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_impl.hpp
@@ -198,10 +198,10 @@ namespace hpx { namespace util { namespace detail {
         template <typename C, typename... T>
         constexpr auto apply_spread_impl(std::true_type, C&& callable,
             T&&... args) -> decltype(invoke_fused(std::forward<C>(callable),
-            util::tuple_cat(undecorate(std::forward<T>(args))...)))
+            hpx::tuple_cat(undecorate(std::forward<T>(args))...)))
         {
             return invoke_fused(std::forward<C>(callable),
-                util::tuple_cat(undecorate(std::forward<T>(args))...));
+                hpx::tuple_cat(undecorate(std::forward<T>(args))...));
         }
 
         /// Use the linear instantiation for variadic packs which don't

--- a/libs/parallelism/pack_traversal/include/hpx/pack_traversal/pack_traversal.hpp
+++ b/libs/parallelism/pack_traversal/include/hpx/pack_traversal/pack_traversal.hpp
@@ -30,7 +30,7 @@ namespace hpx { namespace util {
     ///    map_pack([](int value) {
     ///        return float(value);
     ///    },
-    ///    1, hpx::util::make_tuple(2, std::vector<int>{3, 4}), 5);
+    ///    1, hpx::make_tuple(2, std::vector<int>{3, 4}), 5);
     ///    ```
     ///
     /// \throws       std::exception like objects which are thrown by an

--- a/libs/parallelism/pack_traversal/include/hpx/pack_traversal/unwrap.hpp
+++ b/libs/parallelism/pack_traversal/include/hpx/pack_traversal/unwrap.hpp
@@ -51,7 +51,7 @@ namespace hpx { namespace util {
     ///          arbitrary future or non future type.
     ///
     /// \returns Depending on the count of arguments this function returns
-    ///          a hpx::util::tuple containing the unwrapped arguments
+    ///          a hpx::tuple containing the unwrapped arguments
     ///          if multiple arguments are given.
     ///          In case the function is called with a single argument,
     ///          the argument is unwrapped and returned.

--- a/libs/parallelism/pack_traversal/tests/unit/pack_traversal.cpp
+++ b/libs/parallelism/pack_traversal/tests/unit/pack_traversal.cpp
@@ -19,16 +19,16 @@
 #include <utility>
 #include <vector>
 
+using hpx::get;
+using hpx::make_tuple;
+using hpx::tuple;
 using hpx::lcos::future;
 using hpx::lcos::make_ready_future;
 using hpx::traits::future_traits;
 using hpx::traits::is_future;
-using hpx::util::get;
-using hpx::util::make_tuple;
 using hpx::util::map_pack;
 using hpx::util::spread_this;
 using hpx::util::traverse_pack;
-using hpx::util::tuple;
 
 struct all_map_float
 {
@@ -61,13 +61,12 @@ struct all_map
 static void test_mixed_traversal()
 {
     {
-        auto res =
-            map_pack(all_map_float{}, 0, 1.f, hpx::util::make_tuple(1.f, 3),
-                std::vector<std::vector<int>>{{1, 2}, {4, 5}},
-                std::vector<std::vector<float>>{{1.f, 2.f}, {4.f, 5.f}}, 2);
+        auto res = map_pack(all_map_float{}, 0, 1.f, hpx::make_tuple(1.f, 3),
+            std::vector<std::vector<int>>{{1, 2}, {4, 5}},
+            std::vector<std::vector<float>>{{1.f, 2.f}, {4.f, 5.f}}, 2);
 
-        auto expected = hpx::util::make_tuple(    // ...
-            1.f, 2.f, hpx::util::make_tuple(2.f, 4.f),
+        auto expected = hpx::make_tuple(    // ...
+            1.f, 2.f, hpx::make_tuple(2.f, 4.f),
             std::vector<std::vector<float>>{{2.f, 3.f}, {5.f, 6.f}},
             std::vector<std::vector<float>>{{2.f, 3.f}, {5.f, 6.f}}, 3.f);
 
@@ -90,14 +89,14 @@ static void test_mixed_traversal()
 
     {
         auto res = map_pack(my_mapper{}, 0, 1.f,
-            hpx::util::make_tuple(1.f, 3,
+            hpx::make_tuple(1.f, 3,
                 std::vector<std::vector<int>>{{1, 2}, {4, 5}},
                 std::vector<std::vector<float>>{{1.f, 2.f}, {4.f, 5.f}}),
             2);
 
-        auto expected = hpx::util::make_tuple(    // ...
+        auto expected = hpx::make_tuple(    // ...
             1.f, 1.f,
-            hpx::util::make_tuple(1.f, 4.f,
+            hpx::make_tuple(1.f, 4.f,
                 std::vector<std::vector<float>>{{2.f, 3.f}, {5.f, 6.f}},
                 std::vector<std::vector<float>>{{1.f, 2.f}, {4.f, 5.f}}),
             3.f);
@@ -115,7 +114,7 @@ static void test_mixed_traversal()
                 count = el;
             },
             1,
-            hpx::util::make_tuple(
+            hpx::make_tuple(
                 2, 3, std::vector<std::vector<int>>{{4, 5}, {6, 7}}));
 
         HPX_TEST_EQ(count, 7);
@@ -141,8 +140,7 @@ static void test_mixed_early_unwrapping()
             0, 1, make_ready_future(3),
             make_tuple(make_ready_future(4), make_ready_future(5)));
 
-        auto expected =
-            hpx::util::make_tuple(0, 1, 3, hpx::util::make_tuple(4, 5));
+        auto expected = hpx::make_tuple(0, 1, 3, hpx::make_tuple(4, 5));
 
         static_assert(std::is_same<decltype(res), decltype(expected)>::value,
             "Type mismatch!");
@@ -274,17 +272,14 @@ struct my_int_mapper
 static void test_mixed_fall_through()
 {
     traverse_pack(my_int_mapper{}, int(0),
-        std::vector<hpx::util::tuple<float, float>>{
-            hpx::util::make_tuple(1.f, 2.f)},
-        hpx::util::make_tuple(std::vector<float>{1.f, 2.f}));
+        std::vector<hpx::tuple<float, float>>{hpx::make_tuple(1.f, 2.f)},
+        hpx::make_tuple(std::vector<float>{1.f, 2.f}));
 
     traverse_pack(my_int_mapper{}, int(0),
-        std::vector<std::vector<float>>{{1.f, 2.f}},
-        hpx::util::make_tuple(1.f, 2.f));
+        std::vector<std::vector<float>>{{1.f, 2.f}}, hpx::make_tuple(1.f, 2.f));
 
     auto res1 = map_pack(my_int_mapper{}, int(0),
-        std::vector<std::vector<float>>{{1.f, 2.f}},
-        hpx::util::make_tuple(77.f, 2));
+        std::vector<std::vector<float>>{{1.f, 2.f}}, hpx::make_tuple(77.f, 2));
 
     auto res2 = map_pack(
         [](int) {
@@ -506,8 +501,7 @@ static void test_strategic_traverse()
         std::unique_ptr<int> ptr1(new int(6));
         std::unique_ptr<int> ptr2(new int(7));
 
-        hpx::util::tuple<std::unique_ptr<int> const&,
-            std::unique_ptr<int> const&>
+        hpx::tuple<std::unique_ptr<int> const&, std::unique_ptr<int> const&>
             ref = map_pack(
                 [](std::unique_ptr<int> const& ref)
                     -> std::unique_ptr<int> const& {
@@ -716,11 +710,10 @@ static void test_strategic_tuple_like_traverse()
     // Make it possible to pass tuples containing move only objects
     // in as reference, while returning those as reference.
     {
-        auto value = hpx::util::make_tuple(
+        auto value = hpx::make_tuple(
             std::unique_ptr<int>(new int(6)), std::unique_ptr<int>(new int(7)));
 
-        hpx::util::tuple<std::unique_ptr<int> const&,
-            std::unique_ptr<int> const&>
+        hpx::tuple<std::unique_ptr<int> const&, std::unique_ptr<int> const&>
             ref = map_pack(
                 [](std::unique_ptr<int> const& ref)
                     -> std::unique_ptr<int> const& {

--- a/libs/parallelism/pack_traversal/tests/unit/pack_traversal_async.cpp
+++ b/libs/parallelism/pack_traversal/tests/unit/pack_traversal_async.cpp
@@ -22,12 +22,12 @@
 #include <utility>
 #include <vector>
 
+using hpx::make_tuple;
+using hpx::tuple;
 using hpx::util::async_traverse_complete_tag;
 using hpx::util::async_traverse_detach_tag;
 using hpx::util::async_traverse_visit_tag;
-using hpx::util::make_tuple;
 using hpx::util::traverse_pack_async;
-using hpx::util::tuple;
 
 /// A tag which isn't accepted by any mapper
 struct not_accepted_tag
@@ -303,11 +303,10 @@ static void test_async_mixed_traversal()
     using container_t = std::vector<std::size_t>;
 
     // Test hierarchies where container and tuple like types are mixed
-    test_async_traversal_base<4U>(
-        0U, hpx::util::make_tuple(container_t{1U, 2U}), 3U);
+    test_async_traversal_base<4U>(0U, hpx::make_tuple(container_t{1U, 2U}), 3U);
 
     test_async_traversal_base<4U>(
-        hpx::util::make_tuple(
+        hpx::make_tuple(
             0U, vector_of(not_accepted_tag{}), vector_of(vector_of(1U))),
         make_tuple(2U, 3U));
 

--- a/libs/parallelism/pack_traversal/tests/unit/unwrap.cpp
+++ b/libs/parallelism/pack_traversal/tests/unit/unwrap.cpp
@@ -23,9 +23,9 @@
 #include <utility>
 #include <vector>
 
-using hpx::util::get;
-using hpx::util::make_tuple;
-using hpx::util::tuple;
+using hpx::get;
+using hpx::make_tuple;
+using hpx::tuple;
 using hpx::util::unwrap;
 using hpx::util::unwrap_all;
 using hpx::util::unwrap_n;

--- a/libs/parallelism/timed_execution/include/hpx/timed_execution/timed_execution_fwd.hpp
+++ b/libs/parallelism/timed_execution/include/hpx/timed_execution/timed_execution_fwd.hpp
@@ -12,15 +12,11 @@
 #include <hpx/config.hpp>
 #include <hpx/execution/traits/executor_traits.hpp>
 #include <hpx/execution_base/execution.hpp>
+#include <hpx/modules/timing.hpp>
 #include <hpx/timed_execution/timed_executors.hpp>
 
 #include <type_traits>
 #include <utility>
-
-namespace hpx { namespace util {
-    class steady_time_point;
-    class steady_duration;
-}}    // namespace hpx::util
 
 namespace hpx { namespace parallel { namespace execution {
     ///////////////////////////////////////////////////////////////////////////
@@ -52,7 +48,8 @@ namespace hpx { namespace parallel { namespace execution {
         {
             template <typename TwoWayExecutor, typename F, typename... Ts>
             HPX_FORCEINLINE static auto call(TwoWayExecutor&& exec,
-                hpx::util::steady_time_point const& abs_time, F&& f, Ts&&... ts)
+                hpx::chrono::steady_time_point const& abs_time, F&& f,
+                Ts&&... ts)
                 -> decltype(execution::async_execute(
                     timed_executor<TwoWayExecutor&>(exec, abs_time),
                     std::forward<F>(f), std::forward<Ts>(ts)...))
@@ -78,7 +75,7 @@ namespace hpx { namespace parallel { namespace execution {
             struct result
             {
                 using type = decltype(call(std::declval<TwoWayExecutor>(),
-                    std::declval<hpx::util::steady_time_point const&>(),
+                    std::declval<hpx::chrono::steady_time_point const&>(),
                     std::declval<F>(), std::declval<Ts>()...));
             };
         };
@@ -110,8 +107,8 @@ namespace hpx { namespace parallel { namespace execution {
         // async_execute_at dispatch point
         template <typename Executor, typename F, typename... Ts>
         HPX_FORCEINLINE auto async_execute_at(Executor&& exec,
-            hpx::util::steady_time_point const& abs_time, F&& f, Ts&&... ts) ->
-            typename timed_async_execute_fn_helper<typename std::decay<
+            hpx::chrono::steady_time_point const& abs_time, F&& f, Ts&&... ts)
+            -> typename timed_async_execute_fn_helper<typename std::decay<
                 Executor>::type>::template result<Executor, F, Ts...>::type
         {
             return timed_async_execute_fn_helper<typename std::decay<
@@ -134,8 +131,8 @@ namespace hpx { namespace parallel { namespace execution {
         // sync_execute_at dispatch point
         template <typename Executor, typename F, typename... Ts>
         HPX_FORCEINLINE auto sync_execute_at(Executor&& exec,
-            hpx::util::steady_time_point const& abs_time, F&& f, Ts&&... ts) ->
-            typename timed_sync_execute_fn_helper<typename std::decay<
+            hpx::chrono::steady_time_point const& abs_time, F&& f, Ts&&... ts)
+            -> typename timed_sync_execute_fn_helper<typename std::decay<
                 Executor>::type>::template result<Executor, F, Ts...>::type
         {
             return timed_sync_execute_fn_helper<typename std::decay<
@@ -158,7 +155,8 @@ namespace hpx { namespace parallel { namespace execution {
         // post_at dispatch point
         template <typename Executor, typename F, typename... Ts>
         HPX_FORCEINLINE auto post_at(Executor&& exec,
-            hpx::util::steady_time_point const& abs_time, F&& f, Ts&&... ts) ->
+            hpx::chrono::steady_time_point const& abs_time, F&& f, Ts&&... ts)
+            ->
             typename timed_post_fn_helper<typename std::decay<Executor>::type>::
                 template result<Executor, F, Ts...>::type
         {
@@ -199,7 +197,7 @@ namespace hpx { namespace parallel { namespace execution {
         {
             template <typename Executor, typename F, typename... Ts>
             HPX_FORCEINLINE auto operator()(Executor&& exec,
-                hpx::util::steady_time_point const& abs_time, F&& f,
+                hpx::chrono::steady_time_point const& abs_time, F&& f,
                 Ts&&... ts) const
                 -> decltype(post_at(std::forward<Executor>(exec), abs_time,
                     std::forward<F>(f), std::forward<Ts>(ts)...))
@@ -229,7 +227,7 @@ namespace hpx { namespace parallel { namespace execution {
         {
             template <typename Executor, typename F, typename... Ts>
             HPX_FORCEINLINE auto operator()(Executor&& exec,
-                hpx::util::steady_time_point const& abs_time, F&& f,
+                hpx::chrono::steady_time_point const& abs_time, F&& f,
                 Ts&&... ts) const
                 -> decltype(sync_execute_at(std::forward<Executor>(exec),
                     abs_time, std::forward<F>(f), std::forward<Ts>(ts)...))
@@ -244,7 +242,7 @@ namespace hpx { namespace parallel { namespace execution {
         {
             template <typename Executor, typename F, typename... Ts>
             HPX_FORCEINLINE auto operator()(Executor&& exec,
-                hpx::util::steady_time_point const& abs_time, F&& f,
+                hpx::chrono::steady_time_point const& abs_time, F&& f,
                 Ts&&... ts) const
                 -> decltype(async_execute_at(std::forward<Executor>(exec),
                     abs_time, std::forward<F>(f), std::forward<Ts>(ts)...))

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -1136,7 +1136,7 @@ bool addressing_service::resolve_full_local(
     try {
         auto rep = primary_ns_.resolve_gid(id);
 
-        using hpx::util::get;
+        using hpx::get;
 
         if (get<0>(rep) == naming::invalid_gid || get<2>(rep) == naming::invalid_gid)
             return false;
@@ -1322,7 +1322,7 @@ naming::address addressing_service::resolve_full_postproc(
     naming::gid_type const& id, future<primary_namespace::resolved_type> f
     )
 {
-    using hpx::util::get;
+    using hpx::get;
 
     naming::address addr;
 
@@ -1399,7 +1399,7 @@ bool addressing_service::resolve_full_local(
     locals.resize(count);
 
     try {
-        using hpx::util::get;
+        using hpx::get;
 
         // special cases
         for (std::size_t i = 0; i != count; ++i)
@@ -2613,7 +2613,7 @@ void addressing_service::send_refcnt_requests_non_blocking(
             std::map<
                 naming::id_type,
                 std::vector<
-                    hpx::util::tuple<std::int64_t, naming::gid_type, naming::gid_type>
+                    hpx::tuple<std::int64_t, naming::gid_type, naming::gid_type>
                 >
             >
             requests_type;
@@ -2629,7 +2629,7 @@ void addressing_service::send_refcnt_requests_non_blocking(
                 primary_namespace::get_service_instance(raw)
               , naming::id_type::unmanaged);
 
-            requests[target].push_back(hpx::util::make_tuple(e.second, raw, raw));
+            requests[target].push_back(hpx::make_tuple(e.second, raw, raw));
         }
 
         // send requests to all locality
@@ -2686,7 +2686,7 @@ addressing_service::send_refcnt_requests_async(
         std::map<
             naming::id_type,
             std::vector<
-                hpx::util::tuple<std::int64_t, naming::gid_type, naming::gid_type>
+                hpx::tuple<std::int64_t, naming::gid_type, naming::gid_type>
             >
         >
         requests_type;
@@ -2703,7 +2703,7 @@ addressing_service::send_refcnt_requests_async(
             primary_namespace::get_service_instance(raw)
           , naming::id_type::unmanaged);
 
-        requests[target].push_back(hpx::util::make_tuple(e.second, raw, raw));
+        requests[target].push_back(hpx::make_tuple(e.second, raw, raw));
     }
 
     // send requests to all locality

--- a/src/runtime/agas/server/locality_namespace_server.cpp
+++ b/src/runtime/agas/server/locality_namespace_server.cpp
@@ -188,7 +188,7 @@ std::uint32_t locality_namespace::allocate(
     );
     counter_data_.increment_allocate_count();
 
-    using hpx::util::get;
+    using hpx::get;
 
     std::unique_lock<mutex_type> l(mutex_);
 
@@ -292,7 +292,7 @@ parcelset::endpoints_type locality_namespace::resolve_locality(
     );
     counter_data_.increment_resolve_locality_count();
 
-    using hpx::util::get;
+    using hpx::get;
     std::uint32_t prefix = naming::get_locality_id_from_gid(locality);
 
     std::lock_guard<mutex_type> l(mutex_);
@@ -314,7 +314,7 @@ void locality_namespace::free(naming::gid_type const& locality)
     );
     counter_data_.increment_free_count();
 
-    using hpx::util::get;
+    using hpx::get;
 
     // parameters
     std::uint32_t prefix = naming::get_locality_id_from_gid(locality);
@@ -433,7 +433,7 @@ std::vector<std::uint32_t> locality_namespace::get_num_threads()
     for (partition_table_type::iterator it = partitions_.begin();
          it != end; ++it)
     {
-        using hpx::util::get;
+        using hpx::get;
         num_threads.push_back(get<1>(it->second));
     }
 
@@ -454,7 +454,7 @@ std::uint32_t locality_namespace::get_num_overall_threads()
     for (partition_table_type::iterator it = partitions_.begin();
          it != end; ++it)
     {
-        using hpx::util::get;
+        using hpx::get;
         num_threads += get<1>(it->second);
     }
 

--- a/src/runtime/agas/server/primary_namespace_server.cpp
+++ b/src/runtime/agas/server/primary_namespace_server.cpp
@@ -244,7 +244,7 @@ primary_namespace::begin_migration(naming::gid_type id)
         counter_data_.begin_migration_.enabled_
     );
     counter_data_.increment_begin_migration_count();
-    using hpx::util::get;
+    using hpx::get;
 
     std::unique_lock<mutex_type> l(mutex_);
 
@@ -272,15 +272,15 @@ primary_namespace::begin_migration(naming::gid_type id)
     }
     else
     {
-        HPX_ASSERT(hpx::util::get<0>(it->second) == false);
+        HPX_ASSERT(hpx::get<0>(it->second) == false);
     }
 
     // flag this id as being migrated
-    hpx::util::get<0>(it->second) = true; //-V601
+    hpx::get<0>(it->second) = true; //-V601
 
-    gva const& g(hpx::util::get<1>(r));
+    gva const& g(hpx::get<1>(r));
     naming::address addr(g.prefix, g.type, g.lva());
-    naming::id_type loc(hpx::util::get<2>(r), id_type::unmanaged);
+    naming::id_type loc(hpx::get<2>(r), id_type::unmanaged);
     return std::make_pair(loc, addr);
 }
 
@@ -295,7 +295,7 @@ bool primary_namespace::end_migration(naming::gid_type const& id)
 
     std::unique_lock<mutex_type> l(mutex_);
 
-    using hpx::util::get;
+    using hpx::get;
 
     migration_table_type::iterator it = migrating_objects_.find(id);
     if (it != migrating_objects_.end())
@@ -321,7 +321,7 @@ void primary_namespace::wait_for_migration_locked(
 {
     HPX_ASSERT_OWNS_LOCK(l);
 
-    using hpx::util::get;
+    using hpx::get;
 
     migration_table_type::iterator it = migrating_objects_.find(id);
     if (it != migrating_objects_.end())
@@ -356,7 +356,7 @@ bool primary_namespace::bind_gid(
         counter_data_.bind_gid_.enabled_
     );
     counter_data_.increment_bind_gid_count();
-    using hpx::util::get;
+    using hpx::get;
 
     naming::gid_type gid = id;
     naming::detail::strip_internal_bits_from_gid(id);
@@ -541,7 +541,7 @@ primary_namespace::resolved_type primary_namespace::resolve_gid(
         counter_data_.resolve_gid_.enabled_
     );
     counter_data_.increment_resolve_gid_count();
-    using hpx::util::get;
+    using hpx::get;
 
     resolved_type r;
 
@@ -578,7 +578,7 @@ primary_namespace::resolved_type primary_namespace::resolve_gid(
 naming::id_type primary_namespace::colocate(naming::gid_type const& id)
 {
     return naming::id_type(
-        hpx::util::get<2>(resolve_gid(id)), naming::id_type::unmanaged);
+        hpx::get<2>(resolve_gid(id)), naming::id_type::unmanaged);
 }
 
 naming::address primary_namespace::unbind_gid(
@@ -685,7 +685,7 @@ std::int64_t primary_namespace::increment_credit(
 }
 
 std::vector<std::int64_t> primary_namespace::decrement_credit(
-    std::vector<hpx::util::tuple<std::int64_t, naming::gid_type,
+    std::vector<hpx::tuple<std::int64_t, naming::gid_type,
         naming::gid_type>> const& requests)
 { // decrement_credit implementation
     util::scoped_timer<std::atomic<std::int64_t> > update(
@@ -699,9 +699,9 @@ std::vector<std::int64_t> primary_namespace::decrement_credit(
 
     for(auto& req: requests)
     {
-        std::int64_t credits = hpx::util::get<0>(req);
-        naming::gid_type lower = hpx::util::get<1>(req);
-        naming::gid_type upper = hpx::util::get<1>(req);
+        std::int64_t credits = hpx::get<0>(req);
+        naming::gid_type lower = hpx::get<1>(req);
+        naming::gid_type upper = hpx::get<1>(req);
 
         naming::detail::strip_internal_bits_from_gid(lower);
         naming::detail::strip_internal_bits_from_gid(upper);
@@ -923,7 +923,7 @@ void primary_namespace::resolve_free_list(
 {
     HPX_ASSERT_OWNS_LOCK(l);
 
-    using hpx::util::get;
+    using hpx::get;
 
     typedef refcnt_table_type::iterator iterator;
 
@@ -1136,7 +1136,7 @@ void primary_namespace::free_components_sync(
   , error_code& ec
     )
 { // {{{ free_components_sync implementation
-    using hpx::util::get;
+    using hpx::get;
 
     ///////////////////////////////////////////////////////////////////////////
     // Delete the objects on the free list.

--- a/src/runtime/agas/server/route.cpp
+++ b/src/runtime/agas/server/route.cpp
@@ -72,7 +72,7 @@ namespace hpx { namespace agas { namespace server
 
             cache_address = resolve_gid_locked(l, gid, ec);
 
-            if (ec || hpx::util::get<0>(cache_address) == naming::invalid_gid)
+            if (ec || hpx::get<0>(cache_address) == naming::invalid_gid)
             {
                 l.unlock();
 
@@ -89,11 +89,11 @@ namespace hpx { namespace agas { namespace server
             if (!naming::detail::store_in_cache(gid))
             {
                 naming::detail::set_dont_store_in_cache(
-                    hpx::util::get<0>(cache_address));
+                    hpx::get<0>(cache_address));
             }
 
-            gva const g = hpx::util::get<1>(cache_address).resolve(
-                gid, hpx::util::get<0>(cache_address));
+            gva const g = hpx::get<1>(cache_address).resolve(
+                gid, hpx::get<0>(cache_address));
 
             addr.locality_ = g.prefix;
             addr.type_ = g.type;
@@ -118,10 +118,10 @@ namespace hpx { namespace agas { namespace server
         {
             // asynchronously update cache on source locality
             // update remote cache if the id is not flagged otherwise
-            naming::gid_type const& id = hpx::util::get<0>(cache_address);
+            naming::gid_type const& id = hpx::get<0>(cache_address);
             if (id && naming::detail::store_in_cache(id))
             {
-                gva const& g = hpx::util::get<1>(cache_address);
+                gva const& g = hpx::get<1>(cache_address);
                 naming::address addr(g.prefix, g.type, g.lva());
 
                 HPX_ASSERT(naming::is_locality(source));

--- a/src/runtime/components/console_logging.cpp
+++ b/src/runtime/components/console_logging.cpp
@@ -29,7 +29,7 @@ namespace hpx { namespace components
     void fallback_console_logging_locked(messages_type const& msgs,
         std::string fail_msg = "")
     {
-        using hpx::util::get;
+        using hpx::get;
 
         if (!fail_msg.empty())
             fail_msg = "Logging failed due to: " + fail_msg + "\n";

--- a/src/runtime/components/server/console_logging_server.cpp
+++ b/src/runtime/components/server/console_logging_server.cpp
@@ -53,7 +53,7 @@ namespace hpx { namespace components { namespace server
     {
         std::lock_guard<util::spinlock> l(util::detail::get_log_lock());
 
-        using hpx::util::get;
+        using hpx::get;
 
         for (message_type const& msg : msgs)
         {

--- a/src/runtime/parcelset/parcelport.cpp
+++ b/src/runtime/parcelset/parcelport.cpp
@@ -192,10 +192,10 @@ namespace hpx { namespace parcelset
         std::int64_t count = 0;
         for (auto && p : pending_parcels_)
         {
-            count += hpx::util::get<0>(p.second).size();
+            count += hpx::get<0>(p.second).size();
             HPX_ASSERT(
-                hpx::util::get<0>(p.second).size() ==
-                hpx::util::get<1>(p.second).size());
+                hpx::get<0>(p.second).size() ==
+                hpx::get<1>(p.second).size());
         }
         return count;
     }

--- a/src/runtime_distributed.cpp
+++ b/src/runtime_distributed.cpp
@@ -126,10 +126,10 @@ namespace hpx {
 #if defined(HPX_HAVE_NETWORKING)
     // There is no need to protect these global from thread concurrent access
     // as they are access during early startup only.
-    std::vector<hpx::util::tuple<char const*, char const*>>&
+    std::vector<hpx::tuple<char const*, char const*>>&
     get_message_handler_registrations()
     {
-        static std::vector<hpx::util::tuple<char const*, char const*>>
+        static std::vector<hpx::tuple<char const*, char const*>>
             message_handler_registrations;
         return message_handler_registrations;
     }
@@ -140,7 +140,7 @@ namespace hpx {
         for (auto const& t : get_message_handler_registrations())
         {
             error_code ec(lightweight);
-            rtd.register_message_handler(util::get<0>(t), util::get<1>(t), ec);
+            rtd.register_message_handler(hpx::get<0>(t), hpx::get<1>(t), ec);
         }
         lbt_ << "(3rd stage) pre_main: registered message handlers";
     }
@@ -1765,7 +1765,7 @@ namespace hpx {
 
         // store the request for later
         get_message_handler_registrations().push_back(
-            hpx::util::make_tuple(message_handler_type, action));
+            hpx::make_tuple(message_handler_type, action));
     }
 
     parcelset::policies::message_handler* create_message_handler(

--- a/src/util/pool_timer.cpp
+++ b/src/util/pool_timer.cpp
@@ -13,7 +13,6 @@
 #include <hpx/runtime_local/runtime_local.hpp>
 #include <hpx/runtime_local/shutdown_function.hpp>
 #include <hpx/thread_support/unlock_guard.hpp>
-#include <hpx/timing/steady_clock.hpp>
 #include <hpx/functional/deferred_call.hpp>
 #include <hpx/io_service/io_service_pool.hpp>
 #include <hpx/util/pool_timer.hpp>
@@ -59,7 +58,7 @@ namespace hpx { namespace util { namespace detail
 
     private:
         typedef boost::asio::basic_waitable_timer<
-            util::steady_clock> deadline_timer;
+            std::chrono::steady_clock> deadline_timer;
 
         mutable mutex_type mtx_;
         util::function_nonser<bool()> f_; ///< function to call


### PR DESCRIPTION
Continuation of #4943. Properly moves the functionality to `namespace hpx`.