### PR TITLE
Adding communications set

### DIFF
--- a/libs/full/collectives/CMakeLists.txt
+++ b/libs/full/collectives/CMakeLists.txt
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 if(NOT HPX_WITH_DISTRIBUTED_RUNTIME)
@@ -19,6 +20,8 @@ set(collectives_headers
     hpx/collectives/barrier.hpp
     hpx/collectives/broadcast.hpp
     hpx/collectives/broadcast_direct.hpp
+    hpx/collectives/communication_set.hpp
+    hpx/collectives/detail/communication_set_node.hpp
     hpx/collectives/detail/communicator.hpp
     hpx/collectives/fold.hpp
     hpx/collectives/gather.hpp
@@ -44,8 +47,9 @@ set(collectives_compat_headers
 )
 
 # Default location is $HPX_ROOT/libs/collectives/src
-set(collectives_sources barrier.cpp latch.cpp detail/barrier_node.cpp
-                        detail/communicator.cpp
+set(collectives_sources
+    barrier.cpp create_communication_set.cpp latch.cpp detail/barrier_node.cpp
+    detail/communication_set_node.cpp detail/communicator.cpp
 )
 
 include(HPX_AddModule)

--- a/libs/full/collectives/include/hpx/collectives/communication_set.hpp
+++ b/libs/full/collectives/include/hpx/collectives/communication_set.hpp
@@ -1,0 +1,55 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#if defined(DOXYGEN)
+
+// clang-format off
+namespace hpx { namespace lcos {
+
+    /// The function \a create_communication_set sets up a (distributed)
+    /// tree-like communication structure that can be used with any of the
+    /// collective APIs (such like \a all_to_all and similar).
+    ///
+    /// \param  basename    The base name identifying the all_to_all operation
+    /// \param  num_sites   The number of participating sites (default: all
+    ///                     localities).
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
+    /// \param arity        The number of children each of the communication
+    ///                     nodes is connected to (default: picked based on
+    ///                     num_sites)
+    ///
+    /// \returns    This function returns a future holding an id_type of the
+    ///             communicator object to be used on the current locality.
+    ///
+    hpx::future<hpx::id_type> create_communication_set(char const* basename,
+        std::size_t num_sites = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1),
+        std::size_t arity = std::size_t(-1));
+}}
+// clang-format on
+
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/modules/futures.hpp>
+#include <hpx/runtime/naming/id_type.hpp>
+
+#include <cstddef>
+
+namespace hpx { namespace lcos {
+
+    HPX_EXPORT hpx::future<hpx::id_type> create_communication_set(
+        char const* name, std::size_t num_sites = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1),
+        std::size_t arity = std::size_t(-1));
+
+}}    // namespace hpx::lcos
+
+#endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/detail/communication_set_node.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/communication_set_node.hpp
@@ -1,0 +1,172 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+
+#include <hpx/actions_base/component_action.hpp>
+#include <hpx/assert.hpp>
+#include <hpx/datastructures/any.hpp>
+#include <hpx/lcos_local/and_gate.hpp>
+#include <hpx/modules/futures.hpp>
+#include <hpx/runtime/components/server/component_base.hpp>
+#include <hpx/runtime/naming/id_type.hpp>
+#include <hpx/synchronization/spinlock.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace traits {
+
+    // This type will be specialized for a particular collective operation
+    template <typename Communicator, typename Operation>
+    struct communication_operation;
+
+}}    // namespace hpx::traits
+
+namespace hpx { namespace lcos { namespace detail {
+
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_EXPORT std::size_t calculate_connected_node(
+        std::size_t site, std::size_t arity);
+    HPX_EXPORT std::size_t calculate_num_connected(
+        std::size_t num_sites, std::size_t site, std::size_t arity);
+
+    ///////////////////////////////////////////////////////////////////////////
+    constexpr std::size_t next_power_of_two(std::uint64_t v)
+    {
+        --v;
+        v |= v >> 1;
+        v |= v >> 2;
+        v |= v >> 4;
+        v |= v >> 8;
+        v |= v >> 16;
+        v |= v >> 32;
+        return static_cast<std::size_t>(++v);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    class communication_set_node
+      : public hpx::components::component_base<communication_set_node>
+    {
+        using mutex_type = lcos::local::spinlock;
+
+    public:
+        HPX_EXPORT communication_set_node();
+
+        HPX_EXPORT communication_set_node(std::size_t num_sites,
+            std::string name, std::size_t site, std::size_t arity);
+
+        ///////////////////////////////////////////////////////////////////////
+        // generic get action, dispatches to proper operation
+        template <typename Operation, typename Result, typename... Args>
+        Result get_result(std::size_t which, Args... args)
+        {
+            return std::make_shared<traits::communication_operation<
+                communication_set_node, Operation>>(*this)
+                ->template get<Result>(which, std::move(args)...);
+        }
+
+        template <typename Operation, typename Result, typename... Args>
+        struct get_action
+          : hpx::actions::make_action<Result (communication_set_node::*)(
+                                          std::size_t, Args...),
+                &communication_set_node::template get_result<Operation, Result,
+                    Args...>,
+                get_action<Operation, Result, Args...>>::type
+        {
+        };
+
+        template <typename Operation, typename Result, typename... Args>
+        Result set_result(std::size_t which, Args... args)
+        {
+            return std::make_shared<traits::communication_operation<
+                communication_set_node, Operation>>(*this)
+                ->template set<Result>(which, std::move(args)...);
+        }
+
+        template <typename Operation, typename Result, typename... Args>
+        struct set_action
+          : hpx::actions::make_action<Result (communication_set_node::*)(
+                                          std::size_t, Args...),
+                &communication_set_node::template set_result<Operation, Result,
+                    Args...>,
+                set_action<Operation, Result, Args...>>::type
+        {
+        };
+
+    private:
+        // re-initialize data
+        template <typename T, typename Lock>
+        void reinitialize_data(Lock& l)
+        {
+            HPX_ASSERT_OWNS_LOCK(l);
+            if (needs_initialization_)
+            {
+                needs_initialization_ = false;
+                data_ = std::vector<T>(num_sites_);
+            }
+        }
+
+        template <typename T, typename Lock>
+        std::vector<T>& access_data(Lock& l)
+        {
+            HPX_ASSERT_OWNS_LOCK(l);
+            reinitialize_data<T>(l);
+            return hpx::util::any_cast<std::vector<T>&>(data_);
+        }
+
+        template <typename Lock>
+        void invalidate_data(Lock& l)
+        {
+            HPX_ASSERT_OWNS_LOCK(l);
+            if (!needs_initialization_)
+            {
+                needs_initialization_ = true;
+                data_.reset();
+            }
+        }
+
+    private:
+        template <typename Communicator, typename Operation>
+        friend struct hpx::traits::communication_operation;
+
+    private:
+        mutex_type mtx_;
+        std::string name_;
+        std::size_t const arity_;
+        std::size_t const num_connected_;    // number of connecting nodes
+        std::size_t const num_sites_;        // number of participants
+        std::size_t const site_;
+        std::size_t const connect_to_;
+        std::size_t which_;
+        bool needs_initialization_;
+        hpx::util::unique_any_nonser data_;
+        lcos::local::and_gate gate_;
+
+        // valid if site_ != connect_to_
+        hpx::shared_future<id_type> connected_node_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_EXPORT hpx::future<hpx::id_type> register_communication_set_name(
+        hpx::future<hpx::id_type>&& f, std::string basename, std::size_t site);
+
+    HPX_EXPORT hpx::future<hpx::id_type> create_communication_set_node(
+        char const* basename, std::size_t num_sites, std::size_t this_site,
+        std::size_t arity);
+}}}    // namespace hpx::lcos::detail
+
+#endif    // COMPUTE_HOST_CODE

--- a/libs/full/collectives/src/create_communication_set.cpp
+++ b/libs/full/collectives/src/create_communication_set.cpp
@@ -1,0 +1,88 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/assert.hpp>
+#include <hpx/collectives/communication_set.hpp>
+#include <hpx/collectives/detail/communication_set_node.hpp>
+#include <hpx/collectives/detail/communicator.hpp>
+#include <hpx/modules/futures.hpp>
+#include <hpx/runtime/naming/id_type.hpp>
+#include <hpx/runtime_local/config_entry.hpp>
+
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace hpx { namespace lcos {
+
+    // This function creates P/A communicator objects, (where P is the number
+    // of participating sites, and A is the arity). Each invocation of the
+    // function returns the communication node closest to the caller.
+    //
+    //               /                     \
+    //              0                       8
+    //             / \                     / \
+    //            /   \                   /   \
+    //           /     \                 /     \
+    //          /       \               /       \
+    //         /         \             /         \
+    //        0           4           8           2
+    //       / \         / \         / \         / \
+    //      /   \       /   \       /   \       /   \
+    //     0     2     4     6     8     0     2     4    <-- communicator nodes
+    //    / \   / \   / \   / \   / \   / \   / \   / \
+    //   0   1 2   3 4   5 6   7 8   9 0   1 2   3 4   5  <-- participants
+    //
+    // As can be seen from the graph, every evenly numbered participant should
+    // create an communication node, while every odd numbered participant should
+    // connect to its left neighbor (similar for other arities).
+    //
+    // The number of participants that will depend on a communication node is
+    // calculated by counting the nodes that have a given node as its parent.
+    //
+    // The node some other node connects to is calculated by clearing the lowest
+    // significant bit set (for arities == 2, simular for other arities).
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<hpx::id_type> create_communication_set(char const* name,
+        std::size_t num_sites, std::size_t this_site, std::size_t arity)
+    {
+        // set defaults for arguments
+        if (num_sites == std::size_t(-1))
+        {
+            num_sites = static_cast<std::size_t>(
+                hpx::get_num_localities(hpx::launch::sync));
+        }
+        if (this_site == std::size_t(-1))
+        {
+            this_site = static_cast<std::size_t>(hpx::get_locality_id());
+        }
+        if (arity == std::size_t(-1))
+        {
+            arity = std::stoull(
+                get_config_entry("hpx.lcos.collectives.arity", "32"));
+        }
+
+        // the arity has to be a power of two but not equal to zero
+        HPX_ASSERT(arity != 0 && detail::next_power_of_two(arity) == arity);
+
+        hpx::future<hpx::id_type> node_id;
+        if ((this_site % arity) == 0)
+        {
+            node_id = detail::create_communication_set_node(
+                name, num_sites, this_site, arity);
+        }
+        else
+        {
+            node_id =
+                hpx::find_from_basename(name, (this_site / arity) * arity);
+        }
+
+        return node_id;
+    }
+}}    // namespace hpx::lcos

--- a/libs/full/collectives/src/detail/communication_set_node.cpp
+++ b/libs/full/collectives/src/detail/communication_set_node.cpp
@@ -1,0 +1,202 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+
+#include <hpx/assert.hpp>
+#include <hpx/collectives/detail/communication_set_node.hpp>
+#include <hpx/exception.hpp>
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/futures.hpp>
+#include <hpx/modules/iterator_support.hpp>
+#include <hpx/parallel/container_algorithms/count.hpp>
+#include <hpx/runtime/basename_registration.hpp>
+#include <hpx/runtime/components/component_factory.hpp>
+#include <hpx/runtime/components/new.hpp>
+#include <hpx/runtime/components/server/component.hpp>
+#include <hpx/runtime/naming/id_type.hpp>
+#include <hpx/runtime_local/get_num_localities.hpp>
+
+#include <climits>
+#include <cmath>
+#include <cstddef>
+#include <cstdlib>
+#include <string>
+#include <utility>
+
+///////////////////////////////////////////////////////////////////////////////
+using communication_set_node_component =
+    hpx::components::component<hpx::lcos::detail::communication_set_node>;
+
+HPX_REGISTER_COMPONENT(communication_set_node_component);
+
+namespace hpx { namespace lcos { namespace detail {
+
+    constexpr int count_trailing_zeros(std::size_t x)
+    {
+        int count = 0;
+        while ((x & 0x1) == 0)
+        {
+            x >>= 1;
+            ++count;
+        }
+        return count;
+    }
+
+    constexpr std::size_t create_digit_mask(int bits)
+    {
+        constexpr std::size_t masks[] = {0x01, 0x03, 0x07, 0x0f, 0x1f, 0x3f};
+        return masks[bits - 1];
+    }
+
+    constexpr int max_number_of_digits(int bits)
+    {
+        constexpr int num_digits[] = {64, 32, 22, 16, 13, 11, 10};
+        return num_digits[bits - 1];
+    }
+
+    // We calculate the number of the connected node (the parent) by clearing
+    // out the lowest non-zero digit in the base-arity representation of the
+    // given node number (site).
+    std::size_t calculate_connected_node(std::size_t site, std::size_t arity)
+    {
+        // avoid executing the loop below for a maximal number of iterations
+        if (site == 0)
+        {
+            return 0;
+        }
+
+        // pure leaf nodes can be handled directly
+        auto quot_rem = site % arity;
+        if (quot_rem != 0)
+        {
+            return site - quot_rem;
+        }
+
+        // arity of two is trivial and special
+        if (arity == 2)
+        {
+            return site &
+                ~(static_cast<std::ptrdiff_t>(site) &
+                    -static_cast<std::ptrdiff_t>(site));
+        }
+
+        // the arity has to be a power of two but not equal to zero
+        HPX_ASSERT(arity != 0 && next_power_of_two(arity) == arity);
+
+        int trailing_zeros = count_trailing_zeros(arity);
+        std::size_t mask = create_digit_mask(trailing_zeros);
+        int count = max_number_of_digits(trailing_zeros);
+
+        while ((site & mask) == 0 && --count != 0)
+        {
+            mask <<= trailing_zeros;
+        }
+
+        return site & ~mask;
+    }
+
+    std::size_t calculate_num_connected(
+        std::size_t num_sites, std::size_t site, std::size_t arity)
+    {
+        std::size_t num_children =
+            hpx::ranges::count(hpx::parallel::execution::par,
+                hpx::util::make_counting_iterator(site + 1),
+                hpx::util::make_counting_iterator(num_sites), site,
+                [&](std::size_t node) {
+                    return calculate_connected_node(node, arity);
+                });
+        return num_children + 1;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    communication_set_node::communication_set_node()    //-V730
+      : arity_(0)
+      , num_connected_(0)
+      , num_sites_(0)
+      , site_(0)
+      , connect_to_(0)
+      , which_(0)
+      , needs_initialization_(false)
+    {
+        HPX_ASSERT(false);    // shouldn't ever be called
+    }
+
+    communication_set_node::communication_set_node(std::size_t num_sites,
+        std::string name, std::size_t site, std::size_t arity)
+      : name_(name)
+      , arity_(arity)
+      , num_connected_(calculate_num_connected(num_sites, site, arity))
+      , num_sites_(num_sites)
+      , site_(site)
+      , connect_to_(calculate_connected_node(site, arity))
+      , which_(0)
+      , needs_initialization_(true)
+      , gate_(num_connected_)
+    {
+        HPX_ASSERT(num_connected_ != 0);
+        HPX_ASSERT(num_sites_ != 0);
+
+        // node zero does not connect to any other node (it's the only one that
+        // is connected to itself)
+        HPX_ASSERT(site_ == 0 || connect_to_ != site_);
+        if (connect_to_ != site_)
+        {
+            connected_node_ =
+                hpx::find_from_basename(std::move(name), connect_to_);
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<hpx::id_type> register_communication_set_name(
+        hpx::future<hpx::id_type>&& f, std::string basename, std::size_t site)
+    {
+        hpx::id_type target = f.get();
+
+        hpx::future<bool> result =
+            hpx::register_with_basename(basename, target, site);
+
+        return result.then(hpx::launch::sync,
+            [target = std::move(target), basename = std::move(basename)](
+                hpx::future<bool>&& f) -> hpx::id_type {
+                bool result = f.get();
+                if (!result)
+                {
+                    HPX_THROW_EXCEPTION(bad_parameter,
+                        "hpx::lcos::detail::register_communication_set_name",
+                        "the given base name for the communication_set_node "
+                        "operation was already registered: " +
+                            basename);
+                }
+                return target;
+            });
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<hpx::id_type> create_communication_set_node(
+        char const* basename, std::size_t num_sites, std::size_t this_site,
+        std::size_t arity)
+    {
+        // we create communication nodes for base participants only
+        HPX_ASSERT((this_site % arity) == 0);
+
+        std::string name(basename);
+
+        // create a new communication_set_node
+        hpx::future<hpx::id_type> id =
+            hpx::local_new<detail::communication_set_node>(
+                num_sites, name, this_site, arity);
+
+        // register the communicator's id using the given basename
+        return id.then(hpx::launch::sync,
+            util::bind_back(&detail::register_communication_set_name,
+                std::move(name), this_site));
+    }
+}}}    // namespace hpx::lcos::detail
+
+#endif

--- a/libs/full/collectives/tests/unit/CMakeLists.txt
+++ b/libs/full/collectives/tests/unit/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Hartmut Kaiser
+# Copyright (c) 2019-2020 Hartmut Kaiser
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,6 +12,7 @@ set(tests
     broadcast_direct
     broadcast_apply
     broadcast_component
+    communication_set
     fold
     gather
     reduce

--- a/libs/full/collectives/tests/unit/communication_set.cpp
+++ b/libs/full/collectives/tests/unit/communication_set.cpp
@@ -1,0 +1,278 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/async_distributed.hpp>
+#include <hpx/modules/collectives.hpp>
+#include <hpx/modules/format.hpp>
+#include <hpx/modules/pack_traversal.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <hpx/collectives/detail/communication_set_node.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace test {
+
+    ///////////////////////////////////////////////////////////////////////////
+    struct communication_set_tag
+    {
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    // tag used to extract node the given node of the communicating set is
+    // connected to
+    struct get_connected_to
+    {
+    };
+
+    // tag used to extract the number of the given node of the communication set
+    struct get_site_number
+    {
+    };
+
+    // tag used to verify all nodes are connected
+    struct get_connected_to_zero
+    {
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    using get_connected_to_action =
+        typename hpx::lcos::detail::communication_set_node::template get_action<
+            communication_set_tag, std::size_t, get_connected_to>;
+
+    using get_site_number_action =
+        typename hpx::lcos::detail::communication_set_node::template get_action<
+            communication_set_tag, std::size_t, get_site_number>;
+
+    using get_connected_to_zero_action =
+        typename hpx::lcos::detail::communication_set_node::template get_action<
+            communication_set_tag, hpx::future<void>, get_connected_to_zero>;
+}    // namespace test
+
+namespace hpx { namespace traits {
+
+    template <typename Communicator>
+    struct communication_operation<Communicator, test::communication_set_tag>
+      : std::enable_shared_from_this<
+            communication_operation<Communicator, test::communication_set_tag>>
+    {
+        communication_operation(Communicator& comm)
+          : communicator_(comm)
+        {
+        }
+
+        template <typename Result>
+        Result get(std::size_t which, test::get_connected_to)
+        {
+            return communicator_.connect_to_;
+        }
+
+        template <typename Result>
+        Result get(std::size_t which, test::get_site_number)
+        {
+            return communicator_.site_;
+        }
+
+        template <typename Result>
+        Result get(std::size_t, test::get_connected_to_zero)
+        {
+            // first forward request to parent
+            if (communicator_.connect_to_ != communicator_.site_)
+            {
+                hpx::sync(test::get_connected_to_zero_action{},
+                    communicator_.connected_node_.get(), communicator_.site_,
+                    test::get_connected_to_zero{});
+            }
+
+            // now, handle request ourselves
+            using mutex_type = typename Communicator::mutex_type;
+
+            auto this_ = this->shared_from_this();
+            auto on_ready = [this_ = std::move(this_)](
+                                shared_future<void>&& f) {
+                f.get();    // propagate any exceptions
+
+                auto& communicator = this_->communicator_;
+
+                std::unique_lock<mutex_type> l(communicator.mtx_);
+                communicator.which_ = 0;
+            };
+
+            std::unique_lock<mutex_type> l(communicator_.mtx_);
+            util::ignore_while_checking<std::unique_lock<mutex_type>> il(&l);
+
+            hpx::future<void> f = communicator_.gate_.get_shared_future(l).then(
+                hpx::launch::sync, on_ready);
+
+            communicator_.gate_.synchronize(1, l);
+
+            if (communicator_.gate_.set(communicator_.which_++, l))
+            {
+                HPX_ASSERT_DOESNT_OWN_LOCK(l);
+            }
+            return f;
+        }
+
+        Communicator& communicator_;
+    };
+}}    // namespace hpx::traits
+
+///////////////////////////////////////////////////////////////////////////////
+// Every node is connected to another one
+//
+//               /                     \
+//              0                       8
+//             / \                     / \
+//            /   \                   /   \
+//           /     \                 /     \
+//          /       \               /       \
+//         /         \             /         \
+//        0           4           8           2
+//       / \         / \         / \         / \
+//      /   \       /   \       /   \       /   \
+//     0     2     4     6     8     0     2     4    <-- communicator nodes
+//    / \   / \   / \   / \   / \   / \   / \   / \
+//   0   1 2   3 4   5 6   7 8   9 0   1 2   3 4   5  <-- participants
+//
+// clang-format off
+std::size_t connected_nodes_2[] = {
+    0,  0,  0,  4,  0,  8,  8, 12,
+    0, 16, 16, 20, 16, 24, 24, 28,
+    0, 32, 32, 36, 32, 40, 40, 44,
+   32, 48, 48, 52, 48, 56, 56, 60,
+};
+
+std::size_t connected_nodes_4[] = {
+    0,  0,  0,  0,  0, 16, 16, 16,
+    0, 32, 32, 32,  0, 48, 48, 48,
+};
+
+std::size_t connected_nodes_8[] = {
+    0,  0,  0,  0,  0,  0,  0,  0,
+};
+
+std::size_t connected_nodes_16[] = {
+    0,  0,  0,  0,
+};
+
+std::size_t connected_nodes_32[] = {
+    0,  0,
+};
+
+std::size_t connected_nodes_64[] = {
+    0,
+};
+// clang-format on
+
+///////////////////////////////////////////////////////////////////////////////
+constexpr char const* communication_set_basename = "/test/communication_set";
+
+void test_communication_set(std::size_t size, std::size_t arity)
+{
+    // create nodes of communication set
+    std::string basename =
+        hpx::util::format("{}_{}_{}", communication_set_basename, size, arity);
+
+    std::vector<hpx::future<hpx::id_type>> nodes;
+    nodes.reserve(size);
+    for (std::size_t i = 0; i != size; ++i)
+    {
+        nodes.push_back(hpx::lcos::create_communication_set(
+            basename.c_str(), size, i, arity));
+    }
+
+    // verify that all leaf-nodes are connected to the proper parent
+    std::vector<hpx::id_type> node_ids = hpx::util::unwrap(nodes);
+    for (std::size_t i = 0; i < size; i += arity)
+    {
+        for (std::size_t j = 1; j != arity && i + j < size; ++j)
+        {
+            HPX_TEST(node_ids[i] == node_ids[i + j]);
+        }
+    }
+
+    // verify the number of the connected node for this endpoint
+    for (std::size_t i = 0; i != size; ++i)
+    {
+        hpx::future<std::size_t> f = hpx::async(test::get_site_number_action{},
+            node_ids[i], i, test::get_site_number{});
+        HPX_TEST_EQ(f.get(), (i / arity) * arity);
+    }
+
+    // verify how created nodes are connected
+    for (std::size_t i = 0; i != size; ++i)
+    {
+        hpx::future<std::size_t> f = hpx::async(test::get_connected_to_action{},
+            node_ids[i], i, test::get_connected_to{});
+
+        switch (arity)
+        {
+        case 2:
+            HPX_TEST_EQ(f.get(), connected_nodes_2[i / 2]);
+            break;
+
+        case 4:
+            HPX_TEST_EQ(f.get(), connected_nodes_4[i / 4]);
+            break;
+
+        case 8:
+            HPX_TEST_EQ(f.get(), connected_nodes_8[i / 8]);
+            break;
+
+        case 16:
+            HPX_TEST_EQ(f.get(), connected_nodes_16[i / 16]);
+            break;
+
+        case 32:
+            HPX_TEST_EQ(f.get(), connected_nodes_32[i / 32]);
+            break;
+
+        case 64:
+            HPX_TEST_EQ(f.get(), connected_nodes_64[i / 64]);
+            break;
+        }
+    }
+
+    // verify the number of the connected node for this endpoint
+    std::vector<hpx::future<void>> futures;
+    futures.reserve(size);
+    for (std::size_t i = 0; i != size; ++i)
+    {
+        futures.push_back(hpx::async(test::get_connected_to_zero_action{},
+            node_ids[i], i, test::get_connected_to_zero{}));
+    }
+
+    // rethrow exceptions
+    hpx::util::unwrap(futures);
+}
+
+int hpx_main(int argc, char* argv[])
+{
+    for (std::size_t size = 0; size != 64; ++size)
+    {
+        test_communication_set(size + 1, 2);
+        test_communication_set(size + 1, 4);
+        test_communication_set(size + 1, 8);
+        test_communication_set(size + 1, 16);
+        test_communication_set(size + 1, 32);
+        test_communication_set(size + 1, 64);
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
A `communication_set` is a set of connected `communicator_node` objects that are connected using a binomial communication pattern. A `communication_set` can be created once and reused with any of the collective operations. This not only removes the overhead of establishing the connections for each instance of a collective operation, it also switches from the linear communication model to a tree based one.

Note that this PR does not change the collective operations (yet). These will be changed separately. Eventually all existing collective operations will be adapted to use the new `communication_set` mechanism.
