### PR TITLE
Moving is_execution_policy and friends into namespace hpx

### DIFF
--- a/libs/full/compute/include/hpx/compute/host/block_allocator.hpp
+++ b/libs/full/compute/include/hpx/compute/host/block_allocator.hpp
@@ -39,8 +39,8 @@ namespace hpx { namespace compute { namespace host {
         /// The policy_allocator allocates blocks of memory touched according to
         /// the distribution policy of the given executor.
         template <typename T, typename Policy,
-            typename Enable = typename std::enable_if<hpx::parallel::execution::
-                    is_execution_policy<Policy>::value>::type>
+            typename Enable = typename std::enable_if<
+                hpx::is_execution_policy<Policy>::value>::type>
         struct policy_allocator
         {
             using policy_type = Policy;

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/adjacent_difference.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/adjacent_difference.hpp
@@ -240,8 +240,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         adjacent_difference_(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
             FwdIter2 dest, Op&& op, std::true_type)
         {
-            typedef parallel::execution::is_sequenced_execution_policy<ExPolicy>
-                is_seq;
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
             typedef util::detail::algorithm_result<ExPolicy, FwdIter2> result;
 
             if (first == last)

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/adjacent_find.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/adjacent_find.hpp
@@ -272,8 +272,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         adjacent_find_(ExPolicy&& policy, FwdIter first, FwdIter last,
             Pred&& op, std::true_type)
         {
-            typedef parallel::execution::is_sequenced_execution_policy<ExPolicy>
-                is_seq;
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
             typedef util::detail::algorithm_result<ExPolicy, FwdIter> result;
 
             if (first == last)

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/transfer.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/transfer.hpp
@@ -250,8 +250,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     result_type>::get(result_type{last, dest});
             }
 
-            typedef parallel::execution::is_sequenced_execution_policy<ExPolicy>
-                is_seq;
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
             return segmented_transfer(Algo(), std::forward<ExPolicy>(policy),
                 is_seq(), first, last, dest);
         }

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/exclusive_scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/exclusive_scan.hpp
@@ -258,8 +258,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         exclusive_scan_(ExPolicy&& policy, InIter first, InIter last,
             OutIter dest, T&& init, Op&& op, std::true_type, Conv&& conv)
         {
-            typedef parallel::execution::is_sequenced_execution_policy<ExPolicy>
-                is_seq;
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
             if (first == last)
                 return util::detail::algorithm_result<ExPolicy, OutIter>::get(

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/find.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/find.hpp
@@ -231,8 +231,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         find_(ExPolicy&& policy, FwdIter first, FwdIter last, T const& val,
             Proj&& proj, std::true_type)
         {
-            typedef parallel::execution::is_sequenced_execution_policy<ExPolicy>
-                is_seq;
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
             if (first == last)
             {
@@ -259,8 +258,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         find_if_(ExPolicy&& policy, FwdIter first, FwdIter last, F&& f,
             Proj&& proj, std::true_type)
         {
-            typedef parallel::execution::is_sequenced_execution_policy<ExPolicy>
-                is_seq;
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
             if (first == last)
             {
@@ -288,8 +286,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         find_if_not_(ExPolicy&& policy, FwdIter first, FwdIter last, F&& f,
             Proj&& proj, std::true_type)
         {
-            typedef parallel::execution::is_sequenced_execution_policy<ExPolicy>
-                is_seq;
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
             if (first == last)
             {

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/for_each.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/for_each.hpp
@@ -186,8 +186,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         for_each_(ExPolicy&& policy, SegIterB first, SegIterE last, F&& f,
             Proj&& proj, std::true_type)
         {
-            typedef parallel::execution::is_sequenced_execution_policy<ExPolicy>
-                is_seq;
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
             if (first == last)
             {

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/generate.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/generate.hpp
@@ -183,8 +183,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         generate_(ExPolicy&& policy, FwdIter first, FwdIter last, F&& f,
             std::true_type)
         {
-            typedef parallel::execution::is_sequenced_execution_policy<ExPolicy>
-                is_seq;
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
             if (first == last)
             {

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/inclusive_scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/inclusive_scan.hpp
@@ -259,8 +259,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         inclusive_scan_(ExPolicy&& policy, InIter first, InIter last,
             OutIter dest, T&& init, Op&& op, std::true_type, Conv&& conv)
         {
-            typedef parallel::execution::is_sequenced_execution_policy<ExPolicy>
-                is_seq;
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
             if (first == last)
             {
@@ -279,8 +278,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         inclusive_scan_(ExPolicy&& policy, InIter first, InIter last,
             OutIter dest, Op&& op, std::true_type, Conv&& conv)
         {
-            typedef parallel::execution::is_sequenced_execution_policy<ExPolicy>
-                is_seq;
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
             typedef
                 typename std::iterator_traits<InIter>::value_type value_type;
 

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/reduce.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/reduce.hpp
@@ -195,8 +195,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             ExPolicy&& policy, InIterB first, InIterE last, T init, F&& f,
             std::true_type)
         {
-            typedef parallel::execution::is_sequenced_execution_policy<ExPolicy>
-                is_seq;
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
             typedef typename hpx::util::decay<T>::type init_type;
 
             if (first == last)

--- a/libs/parallelism/algorithms/include/hpx/algorithms/traits/projected.hpp
+++ b/libs/parallelism/algorithms/include/hpx/algorithms/traits/projected.hpp
@@ -192,8 +192,7 @@ namespace hpx { namespace parallel { namespace traits {
         struct is_indirect_callable<ExPolicy, F, hpx::util::pack<Projected...>,
             typename std::enable_if<
                 hpx::util::all_of<is_projected_indirect<Projected>...>::value &&
-                (!hpx::parallel::execution::is_vectorpack_execution_policy<
-                     ExPolicy>::value ||
+                (!hpx::is_vectorpack_execution_policy<ExPolicy>::value ||
                     !hpx::util::all_of<
                         is_projected_zip_iterator<Projected>...>::value)>::type>
           : is_indirect_callable_impl<F,
@@ -209,8 +208,7 @@ namespace hpx { namespace parallel { namespace traits {
         struct is_indirect_callable<ExPolicy, F, hpx::util::pack<Projected...>,
             typename std::enable_if<
                 hpx::util::all_of<is_projected_indirect<Projected>...>::value &&
-                hpx::parallel::execution::is_vectorpack_execution_policy<
-                    ExPolicy>::value &&
+                hpx::is_vectorpack_execution_policy<ExPolicy>::value &&
                 hpx::util::all_of<
                     is_projected_zip_iterator<Projected>...>::value>::type>
           : is_indirect_callable_impl<F,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
@@ -113,7 +113,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
             return detail::adjacent_difference<FwdIter2>().call(
                 std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
@@ -181,8 +181,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
 
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2>
-    inline typename std::enable_if<
-        execution::is_execution_policy<ExPolicy>::value,
+    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type>::type
     adjacent_difference(
         ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest)
@@ -260,8 +259,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Op>
-    inline typename std::enable_if<
-        execution::is_execution_policy<ExPolicy>::value,
+    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type>::type
     adjacent_difference(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
         FwdIter2 dest, Op&& op)

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_find.hpp
@@ -106,7 +106,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Requires at least a forward iterator");
 
-            typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
             return detail::adjacent_find<FwdIter>().call(
                 std::forward<ExPolicy>(policy), is_seq(), first, last,
@@ -184,8 +184,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter,
         typename Pred = detail::equal_to>
-    inline typename std::enable_if<
-        execution::is_execution_policy<ExPolicy>::value,
+    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter>::type>::type
     adjacent_find(
         ExPolicy&& policy, FwdIter first, FwdIter last, Pred&& op = Pred())

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/destroy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/destroy.hpp
@@ -203,7 +203,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename FwdIter,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter>::value
         )>
     // clang-format on
@@ -215,7 +215,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
-        using is_seq = execution::is_sequenced_execution_policy<ExPolicy>;
+        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 
         return detail::destroy<FwdIter>().call(
             std::forward<ExPolicy>(policy), is_seq{}, first, last);
@@ -270,7 +270,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename FwdIter, typename Size,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter>::value
         )>
     // clang-format on
@@ -289,7 +289,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 std::move(first));
         }
 
-        using is_seq = execution::is_sequenced_execution_policy<ExPolicy>;
+        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 
         return detail::destroy_n<FwdIter>().call(std::forward<ExPolicy>(policy),
             is_seq{}, first, std::size_t(count));
@@ -307,7 +307,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
@@ -318,9 +318,7 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Required at least forward iterator.");
 
-            using is_seq =
-                hpx::parallel::execution::is_sequenced_execution_policy<
-                    ExPolicy>;
+            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 
             return hpx::parallel::util::detail::algorithm_result<ExPolicy>::get(
                 hpx::parallel::v1::detail::destroy<FwdIter>().call(
@@ -352,7 +350,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename Size,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
@@ -370,9 +368,7 @@ namespace hpx {
                     FwdIter>::get(std::move(first));
             }
 
-            using is_seq =
-                hpx::parallel::execution::is_sequenced_execution_policy<
-                    ExPolicy>;
+            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 
             return hpx::parallel::v1::detail::destroy_n<FwdIter>().call(
                 std::forward<ExPolicy>(policy), is_seq{}, first,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
@@ -52,11 +52,14 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                 return *this;
             }
 
+            // different versions of clang-format produce different results
+            // clang-format off
             operator T const&() const
             {
                 HPX_ASSERT(item_ != 0);
                 return *item_;
             }
+            // clang-format on
 
         private:
             T const* item_;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/transfer.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/transfer.hpp
@@ -57,8 +57,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         transfer_(ExPolicy&& policy, FwdIter1 first, Sent1 last, FwdIter2 dest,
             std::false_type)
         {
-            typedef parallel::execution::is_sequenced_execution_policy<ExPolicy>
-                is_seq;
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
             return Algo().call(
                 std::forward<ExPolicy>(policy), is_seq(), first, last, dest);
@@ -116,7 +115,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename Algo, typename ExPolicy, typename FwdIter1,
             typename Sent1, typename FwdIter2,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/includes.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/includes.hpp
@@ -277,18 +277,17 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Pred = detail::less>
-    inline
-        typename std::enable_if<execution::is_execution_policy<ExPolicy>::value,
-            typename util::detail::algorithm_result<ExPolicy, bool>::type>::type
-        includes(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
-            FwdIter2 first2, FwdIter2 last2, Pred&& op = Pred())
+    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
+        typename util::detail::algorithm_result<ExPolicy, bool>::type>::type
+    includes(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+        FwdIter2 first2, FwdIter2 last2, Pred&& op = Pred())
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
             "Requires at least forward iterator.");
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
         return detail::includes().call(std::forward<ExPolicy>(policy), is_seq(),
             first1, last1, first2, last2, std::forward<Pred>(op));

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_partitioned.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_partitioned.hpp
@@ -175,16 +175,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           elements, the function is always true.
     ///
     template <typename ExPolicy, typename FwdIter, typename Pred>
-    inline
-        typename std::enable_if<execution::is_execution_policy<ExPolicy>::value,
-            typename util::detail::algorithm_result<ExPolicy, bool>::type>::type
-        is_partitioned(
-            ExPolicy&& policy, FwdIter first, FwdIter last, Pred&& pred)
+    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
+        typename util::detail::algorithm_result<ExPolicy, bool>::type>::type
+    is_partitioned(ExPolicy&& policy, FwdIter first, FwdIter last, Pred&& pred)
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
         return detail::is_partitioned<FwdIter>().call(
             std::forward<ExPolicy>(policy), is_seq(), first, last,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
@@ -161,16 +161,15 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           the function always returns true.
     ///
     template <typename ExPolicy, typename FwdIter, typename Pred = detail::less>
-    inline
-        typename std::enable_if<execution::is_execution_policy<ExPolicy>::value,
-            typename util::detail::algorithm_result<ExPolicy, bool>::type>::type
-        is_sorted(ExPolicy&& policy, FwdIter first, FwdIter last,
-            Pred&& pred = Pred())
+    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
+        typename util::detail::algorithm_result<ExPolicy, bool>::type>::type
+    is_sorted(
+        ExPolicy&& policy, FwdIter first, FwdIter last, Pred&& pred = Pred())
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
         return detail::is_sorted<FwdIter>().call(std::forward<ExPolicy>(policy),
             is_seq(), first, last, std::forward<Pred>(pred));
@@ -315,8 +314,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           sequence is sorted, last is returned.
     ///
     template <typename ExPolicy, typename FwdIter, typename Pred = detail::less>
-    inline typename std::enable_if<
-        execution::is_execution_policy<ExPolicy>::value,
+    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter>::type>::type
     is_sorted_until(
         ExPolicy&& policy, FwdIter first, FwdIter last, Pred&& pred = Pred())
@@ -324,7 +322,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
         return detail::is_sorted_until<FwdIter>().call(
             std::forward<ExPolicy>(policy), is_seq(), first, last,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
@@ -197,19 +197,17 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Pred = detail::less>
-    inline
-        typename std::enable_if<execution::is_execution_policy<ExPolicy>::value,
-            typename util::detail::algorithm_result<ExPolicy, bool>::type>::type
-        lexicographical_compare(ExPolicy&& policy, FwdIter1 first1,
-            FwdIter1 last1, FwdIter2 first2, FwdIter2 last2,
-            Pred&& pred = Pred())
+    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
+        typename util::detail::algorithm_result<ExPolicy, bool>::type>::type
+    lexicographical_compare(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+        FwdIter2 first2, FwdIter2 last2, Pred&& pred = Pred())
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
             "Requires at least forward iterator.");
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
         return detail::lexicographical_compare().call(
             std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/move.hpp
@@ -171,7 +171,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value)>
     // clang-format on
@@ -197,7 +197,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value)>
         // clang-format on

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce_by_key.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce_by_key.hpp
@@ -563,7 +563,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             std::equal_to<typename std::iterator_traits<RanIter>::value_type>,
         typename Func =
             std::plus<typename std::iterator_traits<RanIter2>::value_type>,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<RanIter>::value&&
                     hpx::traits::is_iterator<RanIter2>::value&&
                         hpx::traits::is_iterator<FwdIter1>::value&&
@@ -595,7 +595,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 keys_output, values_output});
         }
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
         return detail::reduce_by_key<FwdIter1, FwdIter2>().call(
             std::forward<ExPolicy>(policy), is_seq(), key_first, key_last,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reverse.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reverse.hpp
@@ -115,7 +115,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           It returns \a last.
     ///
     template <typename ExPolicy, typename BidirIter,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<BidirIter>::value)>
     typename util::detail::algorithm_result<ExPolicy, BidirIter>::type reverse(
         ExPolicy&& policy, BidirIter first, BidirIter last)
@@ -124,7 +124,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             (hpx::traits::is_bidirectional_iterator<BidirIter>::value),
             "Requires at least bidirectional iterator.");
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
         return detail::reverse<BidirIter>().call(
             std::forward<ExPolicy>(policy), is_seq(), first, last);
@@ -243,7 +243,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename BidirIter, typename FwdIter,
         HPX_CONCEPT_REQUIRES_(hpx::traits::is_iterator<BidirIter>::value&&
-                execution::is_execution_policy<ExPolicy>::value&&
+                hpx::is_execution_policy<ExPolicy>::value&&
                     hpx::traits::is_iterator<FwdIter>::value)>
     typename util::detail::algorithm_result<ExPolicy,
         util::in_out_result<BidirIter, FwdIter>>::type
@@ -256,7 +256,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
         return detail::reverse_copy<util::in_out_result<BidirIter, FwdIter>>()
             .call(std::forward<ExPolicy>(policy), is_seq(), first, last,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/rotate.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/rotate.hpp
@@ -173,7 +173,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           pair(first + (last - new_first), last).
     ///
     template <typename ExPolicy, typename FwdIter,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value)>
     typename util::detail::algorithm_result<ExPolicy,
         util::in_out_result<FwdIter, FwdIter>>::type
@@ -183,7 +183,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             "Requires at least forward iterator.");
 
         typedef std::integral_constant<bool,
-            execution::is_sequenced_execution_policy<ExPolicy>::value ||
+            hpx::is_sequenced_execution_policy<ExPolicy>::value ||
                 !hpx::traits::is_bidirectional_iterator<FwdIter>::value>
             is_seq;
 
@@ -315,7 +315,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         HPX_CONCEPT_REQUIRES_(hpx::traits::is_iterator<FwdIter1>::value&&
-                execution::is_execution_policy<ExPolicy>::value&&
+                hpx::is_execution_policy<ExPolicy>::value&&
                     hpx::traits::is_iterator<FwdIter2>::value)>
     typename util::detail::algorithm_result<ExPolicy,
         util::in_out_result<FwdIter1, FwdIter2>>::type
@@ -328,7 +328,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             "Requires at least forward iterator.");
 
         typedef std::integral_constant<bool,
-            execution::is_sequenced_execution_policy<ExPolicy>::value ||
+            hpx::is_sequenced_execution_policy<ExPolicy>::value ||
                 !hpx::traits::is_bidirectional_iterator<FwdIter1>::value>
             is_seq;
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
@@ -186,8 +186,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename FwdIter3, typename Pred = detail::less>
-    inline typename std::enable_if<
-        execution::is_execution_policy<ExPolicy>::value,
+    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter3>::type>::type
     set_difference(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
         FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, Pred&& op = Pred())
@@ -200,7 +199,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             "Requires at least forward iterator.");
 
         typedef std::integral_constant<bool,
-            execution::is_sequenced_execution_policy<ExPolicy>::value ||
+            hpx::is_sequenced_execution_policy<ExPolicy>::value ||
                 !hpx::traits::is_random_access_iterator<FwdIter1>::value ||
                 !hpx::traits::is_random_access_iterator<FwdIter2>::value>
             is_seq;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_intersection.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_intersection.hpp
@@ -175,8 +175,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename FwdIter3, typename Pred = detail::less>
-    inline typename std::enable_if<
-        execution::is_execution_policy<ExPolicy>::value,
+    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter3>::type>::type
     set_intersection(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
         FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, Pred&& op = Pred())
@@ -189,7 +188,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             "Requires at least forward iterator.");
 
         typedef std::integral_constant<bool,
-            execution::is_sequenced_execution_policy<ExPolicy>::value ||
+            hpx::is_sequenced_execution_policy<ExPolicy>::value ||
                 !hpx::traits::is_random_access_iterator<FwdIter1>::value ||
                 !hpx::traits::is_random_access_iterator<FwdIter2>::value>
             is_seq;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
@@ -194,8 +194,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename FwdIter3, typename Pred = detail::less>
-    inline typename std::enable_if<
-        execution::is_execution_policy<ExPolicy>::value,
+    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter3>::type>::type
     set_symmetric_difference(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
         FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, Pred&& op = Pred())
@@ -208,7 +207,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             "Requires at least forward iterator.");
 
         typedef std::integral_constant<bool,
-            execution::is_sequenced_execution_policy<ExPolicy>::value ||
+            hpx::is_sequenced_execution_policy<ExPolicy>::value ||
                 !hpx::traits::is_random_access_iterator<FwdIter1>::value ||
                 !hpx::traits::is_random_access_iterator<FwdIter2>::value>
             is_seq;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_union.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_union.hpp
@@ -192,8 +192,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename FwdIter3, typename Pred = detail::less>
-    inline typename std::enable_if<
-        execution::is_execution_policy<ExPolicy>::value,
+    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter3>::type>::type
     set_union(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
         FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, Pred&& op = Pred())
@@ -206,7 +205,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             "Requires at least forward iterator.");
 
         typedef std::integral_constant<bool,
-            execution::is_sequenced_execution_policy<ExPolicy>::value ||
+            hpx::is_sequenced_execution_policy<ExPolicy>::value ||
                 !hpx::traits::is_random_access_iterator<FwdIter1>::value ||
                 !hpx::traits::is_random_access_iterator<FwdIter2>::value>
             is_seq;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/stable_sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/stable_sort.hpp
@@ -202,7 +202,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         typename Proj = util::projection_identity,
         typename Compare = detail::less,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<RandomIt>::value &&
             hpx::traits::is_sentinel_for<Sentinel, RandomIt>::value &&
             traits::is_projected<Proj, RandomIt>::value &&
@@ -219,7 +219,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_random_access_iterator<RandomIt>::value),
             "Requires a random access iterator.");
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
         return detail::stable_sort<RandomIt>().call(
             std::forward<ExPolicy>(policy), is_seq(), first, last,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/swap_ranges.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/swap_ranges.hpp
@@ -117,8 +117,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           \a first2.
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2>
-    inline typename std::enable_if<
-        execution::is_execution_policy<ExPolicy>::value,
+    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type>::type
     swap_ranges(
         ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1, FwdIter2 first2)
@@ -128,7 +127,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
         return detail::swap_ranges<FwdIter2>().call(
             std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2);

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -176,7 +176,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
             return detail::transform_exclusive_scan<FwdIter2>().call(
                 std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
@@ -295,7 +295,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename T, typename Op, typename Conv,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value &&
             hpx::traits::is_invocable<Conv,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
@@ -204,8 +204,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           the last element copied.
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2>
-    inline typename std::enable_if<
-        execution::is_execution_policy<ExPolicy>::value,
+    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type>::type
     uninitialized_copy(
         ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest)
@@ -215,7 +214,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
         return detail::uninitialized_copy<FwdIter2>().call(
             std::forward<ExPolicy>(policy), is_seq(), first, last, dest);
@@ -307,8 +306,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename Size,
         typename FwdIter2>
-    inline typename std::enable_if<
-        execution::is_execution_policy<ExPolicy>::value,
+    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type>::type
     uninitialized_copy_n(
         ExPolicy&& policy, FwdIter1 first, Size count, FwdIter2 dest)
@@ -318,7 +316,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
         // if count is representing a negative value, we do nothing
         if (detail::is_negative(count))

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_default_construct.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_default_construct.hpp
@@ -192,7 +192,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           \a parallel_task_policy and returns \a void otherwise.
     ///
     template <typename ExPolicy, typename FwdIter,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value)>
     typename util::detail::algorithm_result<ExPolicy>::type
     uninitialized_default_construct(
@@ -201,7 +201,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
         return detail::uninitialized_default_construct<FwdIter>().call(
             std::forward<ExPolicy>(policy), is_seq(), first, last);
@@ -316,7 +316,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           the last element constructed.
     ///
     template <typename ExPolicy, typename FwdIter, typename Size,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value)>
     typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
     uninitialized_default_construct_n(
@@ -332,7 +332,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 std::move(first));
         }
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
         return detail::uninitialized_default_construct_n<FwdIter>().call(
             std::forward<ExPolicy>(policy), is_seq(), first,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_fill.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_fill.hpp
@@ -184,16 +184,15 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           otherwise.
     ///
     template <typename ExPolicy, typename FwdIter, typename T>
-    inline
-        typename std::enable_if<execution::is_execution_policy<ExPolicy>::value,
-            typename util::detail::algorithm_result<ExPolicy>::type>::type
-        uninitialized_fill(
-            ExPolicy&& policy, FwdIter first, FwdIter last, T const& value)
+    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
+        typename util::detail::algorithm_result<ExPolicy>::type>::type
+    uninitialized_fill(
+        ExPolicy&& policy, FwdIter first, FwdIter last, T const& value)
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
         return detail::uninitialized_fill().call(
             std::forward<ExPolicy>(policy), is_seq(), first, last, value);
@@ -305,11 +304,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           otherwise.
     ///
     template <typename ExPolicy, typename FwdIter, typename Size, typename T>
-    inline
-        typename std::enable_if<execution::is_execution_policy<ExPolicy>::value,
-            typename util::detail::algorithm_result<ExPolicy>::type>::type
-        uninitialized_fill_n(
-            ExPolicy&& policy, FwdIter first, Size count, T const& value)
+    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
+        typename util::detail::algorithm_result<ExPolicy>::type>::type
+    uninitialized_fill_n(
+        ExPolicy&& policy, FwdIter first, Size count, T const& value)
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
@@ -320,7 +318,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             return util::detail::algorithm_result<ExPolicy>::get();
         }
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
         return detail::uninitialized_fill_n().call(
             std::forward<ExPolicy>(policy), is_seq(), first, std::size_t(count),

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_move.hpp
@@ -216,7 +216,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           the last element moved.
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter1>::value&&
                     hpx::traits::is_iterator<FwdIter2>::value)>
     typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type
@@ -228,7 +228,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
         return detail::uninitialized_move<FwdIter2>().call(
             std::forward<ExPolicy>(policy), is_seq(), first, last, dest);
@@ -352,7 +352,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename Size,
         typename FwdIter2,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter1>::value&&
                     hpx::traits::is_iterator<FwdIter2>::value)>
     typename util::detail::algorithm_result<ExPolicy,
@@ -365,7 +365,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
         // if count is representing a negative value, we do nothing
         if (detail::is_negative(count))

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_value_construct.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_value_construct.hpp
@@ -193,7 +193,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           \a parallel_task_policy and returns \a void otherwise.
     ///
     template <typename ExPolicy, typename FwdIter,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value)>
     typename util::detail::algorithm_result<ExPolicy>::type
     uninitialized_value_construct(
@@ -202,7 +202,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
         return detail::uninitialized_value_construct<FwdIter>().call(
             std::forward<ExPolicy>(policy), is_seq(), first, last);
@@ -318,7 +318,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           the last element constructed.
     ///
     template <typename ExPolicy, typename FwdIter, typename Size,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value)>
     typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
     uninitialized_value_construct_n(
@@ -334,7 +334,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 std::move(first));
         }
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
         return detail::uninitialized_value_construct_n<FwdIter>().call(
             std::forward<ExPolicy>(policy), is_seq(), first,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/destroy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/destroy.hpp
@@ -137,7 +137,7 @@ namespace hpx { namespace ranges {
         // clang-format off
         template <typename ExPolicy, typename Rng,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value
             )>
         // clang-format on
@@ -152,9 +152,7 @@ namespace hpx { namespace ranges {
                 (hpx::traits::is_forward_iterator<iterator_type>::value),
                 "Required at least forward iterator.");
 
-            using is_seq =
-                hpx::parallel::execution::is_sequenced_execution_policy<
-                    ExPolicy>;
+            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 
             return hpx::parallel::v1::detail::destroy<iterator_type>().call(
                 std::forward<ExPolicy>(policy), is_seq{}, hpx::util::begin(rng),
@@ -164,7 +162,7 @@ namespace hpx { namespace ranges {
         // clang-format off
         template <typename ExPolicy, typename Iter, typename Sent,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent, Iter>::value
             )>
         // clang-format on
@@ -175,9 +173,7 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_forward_iterator<Iter>::value),
                 "Required at least forward iterator.");
 
-            using is_seq =
-                hpx::parallel::execution::is_sequenced_execution_policy<
-                    ExPolicy>;
+            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 
             return hpx::parallel::v1::detail::destroy<Iter>().call(
                 std::forward<ExPolicy>(policy), is_seq{}, first, last);
@@ -229,7 +225,7 @@ namespace hpx { namespace ranges {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename Size,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
@@ -247,9 +243,7 @@ namespace hpx { namespace ranges {
                     FwdIter>::get(std::move(first));
             }
 
-            using is_seq =
-                hpx::parallel::execution::is_sequenced_execution_policy<
-                    ExPolicy>;
+            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 
             return hpx::parallel::v1::detail::destroy_n<FwdIter>().call(
                 std::forward<ExPolicy>(policy), is_seq{}, first,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/fill.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/fill.hpp
@@ -121,7 +121,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename Rng, typename T,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_range<Rng>::value
         )>
     // clang-format on
@@ -137,7 +137,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename Rng, typename Size, typename T,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_range<Rng>::value
         )>
     // clang-format on
@@ -164,7 +164,7 @@ namespace hpx { namespace ranges {
         // clang-format off
         template <typename ExPolicy, typename Rng, typename T,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value
             )>
         // clang-format on
@@ -190,7 +190,7 @@ namespace hpx { namespace ranges {
         // clang-format off
         template <typename ExPolicy, typename Iter, typename Sent, typename T,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent, Iter>::value
             )>
         // clang-format on
@@ -260,7 +260,7 @@ namespace hpx { namespace ranges {
         // clang-format off
         template <typename ExPolicy, typename Rng, typename T,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value
             )>
         // clang-format on
@@ -275,9 +275,7 @@ namespace hpx { namespace ranges {
                 (hpx::traits::is_forward_iterator<iterator_type>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq =
-                hpx::parallel::execution::is_sequenced_execution_policy<
-                    ExPolicy>;
+            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 
             // if count is representing a negative value, we do nothing
             if (hpx::parallel::v1::detail::is_negative(hpx::util::size(rng)))
@@ -295,7 +293,7 @@ namespace hpx { namespace ranges {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename Size, typename T,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
@@ -307,9 +305,7 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq =
-                hpx::parallel::execution::is_sequenced_execution_policy<
-                    ExPolicy>;
+            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 
             // if count is representing a negative value, we do nothing
             if (hpx::parallel::v1::detail::is_negative(count))

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/merge.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/merge.hpp
@@ -118,7 +118,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         typename RandIter3, typename Comp = detail::less,
         typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng1>::value&& hpx::traits::is_range<
                     Rng2>::value&& hpx::traits::is_iterator<RandIter3>::value&&
                     traits::is_projected_range<Proj1, Rng1>::value&&
@@ -213,7 +213,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename Rng, typename RandIter,
         typename Comp = detail::less, typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
                     RandIter>::value&& traits::is_projected_range<Proj,
                     Rng>::value&& traits::is_projected<Proj, RandIter>::value&&

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/minmax.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/minmax.hpp
@@ -89,7 +89,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename Rng,
         typename Proj = util::projection_identity, typename F = detail::less,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
                     Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
                     F, traits::projected_range<Proj, Rng>,
@@ -169,7 +169,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename Rng,
         typename Proj = util::projection_identity, typename F = detail::less,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
                     Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
                     F, traits::projected_range<Proj, Rng>,
@@ -262,7 +262,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
     template <typename ExPolicy, typename Rng,
         typename Proj = util::projection_identity, typename F = detail::less,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
                     Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
                     F, traits::projected_range<Proj, Rng>,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/move.hpp
@@ -155,7 +155,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Iter1, typename Sent1,
             typename Iter2,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
                 hpx::traits::is_iterator<Iter2>::value
             )>
@@ -173,7 +173,7 @@ namespace hpx { namespace ranges {
         // clang-format off
         template <typename ExPolicy, typename Rng, typename Iter2,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value &&
                 hpx::traits::is_iterator<Iter2>::value
             )>
@@ -236,7 +236,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename Sent1,
         typename FwdIter,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter>::value
@@ -256,7 +256,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename Rng, typename FwdIter,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_range<Rng>::value &&
             hpx::traits::is_iterator<FwdIter>::value
         )>

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/partition.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/partition.hpp
@@ -87,7 +87,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename Rng, typename Pred,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
                     Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
                     Pred, traits::projected_range<Proj, Rng>>::value)>
@@ -185,10 +185,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename Rng, typename FwdIter2,
         typename FwdIter3, typename Pred,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
-                    FwdIter2>::value&& hpx::traits::is_iterator<FwdIter3>::
-                    value&& traits::is_projected_range<Proj, Rng>::value&&
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value&& hpx::traits::is_range<
+                Rng>::value&& hpx::traits::is_iterator<FwdIter2>::value&&
+                hpx::traits::is_iterator<FwdIter3>::value&&
+                    traits::is_projected_range<Proj, Rng>::value&&
                         traits::is_indirect_callable<ExPolicy, Pred,
                             traits::projected_range<Proj, Rng>>::value)>
     typename util::detail::algorithm_result<ExPolicy,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove.hpp
@@ -73,9 +73,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename Rng, typename T,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&&
-                    traits::is_projected_range<Proj, Rng>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value&& hpx::traits::is_range<
+                Rng>::value&& traits::is_projected_range<Proj, Rng>::value)>
     typename util::detail::algorithm_result<ExPolicy,
         typename hpx::traits::range_iterator<Rng>::type>::type
     remove(ExPolicy&& policy, Rng&& rng, T const& value, Proj&& proj = Proj())
@@ -149,7 +149,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename Rng, typename Pred,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
                     Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
                     Pred, traits::projected_range<Proj, Rng>>::value)>

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove_copy.hpp
@@ -91,7 +91,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename Rng, typename OutIter, typename T,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
                     OutIter>::value&& traits::is_projected_range<Proj,
                     Rng>::value&& traits::is_indirect_callable<ExPolicy,
@@ -191,7 +191,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename Rng, typename OutIter, typename F,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
                     OutIter>::value&& traits::is_projected_range<Proj,
                     Rng>::value&& traits::is_indirect_callable<ExPolicy, F,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/replace.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/replace.hpp
@@ -73,7 +73,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename Rng, typename T1, typename T2,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
                     Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
                     std::equal_to<T1>, traits::projected_range<Proj, Rng>,
@@ -158,7 +158,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename Rng, typename F, typename T,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
                     Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
                     F, traits::projected_range<Proj, Rng>>::value)>
@@ -237,7 +237,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename Rng, typename OutIter, typename T1,
         typename T2, typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
                     Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
                     std::equal_to<T1>, traits::projected_range<Proj, Rng>,
@@ -337,7 +337,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename Rng, typename OutIter, typename F,
         typename T, typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
                     Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
                     F, traits::projected_range<Proj, Rng>>::value)>

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/reverse.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/reverse.hpp
@@ -61,7 +61,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           It returns \a last.
     ///
     template <typename ExPolicy, typename Rng,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value)>
     typename util::detail::algorithm_result<ExPolicy,
         typename hpx::traits::range_iterator<Rng>::type>::type
@@ -126,9 +126,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           copied.
     ///
     template <typename ExPolicy, typename Rng, typename OutIter,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&&
-                    hpx::traits::is_iterator<OutIter>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value&& hpx::traits::is_range<
+                Rng>::value&& hpx::traits::is_iterator<OutIter>::value)>
     typename util::detail::algorithm_result<ExPolicy,
         util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
             OutIter>>::type

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/rotate.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/rotate.hpp
@@ -71,7 +71,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           pair(first + (last - new_first), last).
     ///
     template <typename ExPolicy, typename Rng,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value)>
     typename util::detail::algorithm_result<ExPolicy,
         util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
@@ -131,9 +131,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           element past the last element copied.
     ///
     template <typename ExPolicy, typename Rng, typename OutIter,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&&
-                    hpx::traits::is_iterator<OutIter>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value&& hpx::traits::is_range<
+                Rng>::value&& hpx::traits::is_iterator<OutIter>::value)>
     typename util::detail::algorithm_result<ExPolicy,
         util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
             OutIter>>::type

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/search.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/search.hpp
@@ -102,13 +102,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
         typename Pred = detail::equal_to,
         typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng1>::value&& traits::is_projected_range<
-                    Proj1, Rng1>::value&& hpx::traits::is_range<Rng2>::value&&
-                    traits::is_projected_range<Proj2, Rng2>::value&&
-                        traits::is_indirect_callable<ExPolicy, Pred,
-                            traits::projected_range<Proj1, Rng1>,
-                            traits::projected_range<Proj2, Rng2>>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value&& hpx::traits::is_range<
+                Rng1>::value&& traits::is_projected_range<Proj1, Rng1>::value&&
+                hpx::traits::is_range<Rng2>::value&& traits::is_projected_range<
+                    Proj2, Rng2>::value&& traits::is_indirect_callable<ExPolicy,
+                    Pred, traits::projected_range<Proj1, Rng1>,
+                    traits::projected_range<Proj2, Rng2>>::value)>
     typename util::detail::algorithm_result<ExPolicy,
         typename hpx::traits::range_iterator<Rng1>::type>::type
     search(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2, Pred&& op = Pred(),
@@ -201,13 +201,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
         typename Pred = detail::equal_to,
         typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng1>::value&& traits::is_projected_range<
-                    Proj1, Rng1>::value&& hpx::traits::is_range<Rng2>::value&&
-                    traits::is_projected_range<Proj2, Rng2>::value&&
-                        traits::is_indirect_callable<ExPolicy, Pred,
-                            traits::projected_range<Proj1, Rng1>,
-                            traits::projected_range<Proj2, Rng2>>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value&& hpx::traits::is_range<
+                Rng1>::value&& traits::is_projected_range<Proj1, Rng1>::value&&
+                hpx::traits::is_range<Rng2>::value&& traits::is_projected_range<
+                    Proj2, Rng2>::value&& traits::is_indirect_callable<ExPolicy,
+                    Pred, traits::projected_range<Proj1, Rng1>,
+                    traits::projected_range<Proj2, Rng2>>::value)>
     typename util::detail::algorithm_result<ExPolicy,
         typename hpx::traits::range_iterator<Rng1>::type>::type
     search_n(ExPolicy&& policy, Rng1&& rng1, std::size_t count, Rng2&& rng2,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/sort.hpp
@@ -88,7 +88,7 @@ namespace hpx { namespace parallel { inline namespace rangev1 {
         typename Compare = v1::detail::less,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_range<Rng>::value &&
             traits::is_projected_range<Proj, Rng>::value &&
             traits::is_indirect_callable<ExPolicy, Compare,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/stable_sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/stable_sort.hpp
@@ -91,7 +91,7 @@ namespace hpx { namespace parallel { inline namespace rangev1 {
         typename Compare = v1::detail::less,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_range<Rng>::value&&
             traits::is_projected_range<Proj, Rng>::value&&
             traits::is_indirect_callable<ExPolicy, Compare,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
@@ -96,7 +96,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename Rng, typename OutIter, typename F,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
                     OutIter>::value&& traits::is_projected_range<Proj,
                     Rng>::value&& traits::is_indirect_callable<ExPolicy, F,
@@ -204,7 +204,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         typename OutIter, typename F,
         typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
                     InIter2>::value&& hpx::traits::is_iterator<OutIter>::value&&
                     traits::is_projected_range<Proj1, Rng>::value&&
@@ -318,7 +318,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename Rng1, typename Rng2, typename OutIter,
         typename F, typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng1>::value&& hpx::traits::is_range<
                     Rng2>::value&& hpx::traits::is_iterator<OutIter>::value&&
                     traits::is_projected_range<Proj1, Rng1>::value&&

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_reduce.hpp
@@ -284,7 +284,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Iter, typename Sent, typename T,
             typename Reduce, typename Convert,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent, Iter>::value &&
                 hpx::traits::is_invocable<Convert,
                     typename std::iterator_traits<Iter>::value_type
@@ -351,7 +351,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Iter, typename Sent,
             typename Iter2, typename T,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent, Iter>::value &&
                 hpx::traits::is_iterator<Iter2>::value
             )>
@@ -391,7 +391,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Iter, typename Sent,
             typename Iter2, typename T, typename Reduce, typename Convert,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent, Iter>::value &&
                 hpx::traits::is_iterator<Iter2>::value &&
                 hpx::traits::is_invocable<Convert,
@@ -461,7 +461,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Rng, typename T, typename Reduce,
             typename Convert,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value &&
                 hpx::traits::is_invocable<Convert,
                     typename hpx::traits::range_iterator<Rng>::type
@@ -536,7 +536,7 @@ namespace hpx { namespace ranges {
         // clang-format off
         template <typename ExPolicy, typename Rng, typename Iter2, typename T,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value &&
                 hpx::traits::is_iterator<Iter2>::value
             )>
@@ -582,7 +582,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Rng, typename Iter2,
             typename T, typename Reduce, typename Convert,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value &&
                 hpx::traits::is_iterator<Iter2>::value &&
                 hpx::traits::is_invocable<Convert,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/unique.hpp
@@ -90,7 +90,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename Rng, typename Pred = detail::equal_to,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
                     Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
                     Pred, traits::projected_range<Proj, Rng>,
@@ -181,7 +181,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename Rng, typename FwdIter2,
         typename Pred = detail::equal_to,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
                     FwdIter2>::value&& traits::is_projected_range<Proj,
                     Rng>::value&& traits::is_indirect_callable<ExPolicy, Pred,

--- a/libs/parallelism/algorithms/include/hpx/parallel/datapar/loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/datapar/loop.hpp
@@ -34,7 +34,7 @@ namespace hpx { namespace parallel { namespace util {
         ///////////////////////////////////////////////////////////////////////
         template <typename ExPolicy, typename Vector>
         HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
-            execution::is_vectorpack_execution_policy<ExPolicy>::value,
+            hpx::is_vectorpack_execution_policy<ExPolicy>::value,
             typename Vector::value_type>::type
         extract_value(Vector const& value)
         {
@@ -46,7 +46,7 @@ namespace hpx { namespace parallel { namespace util {
         ///////////////////////////////////////////////////////////////////////
         template <typename ExPolicy, typename F, typename Vector>
         HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
-            execution::is_vectorpack_execution_policy<ExPolicy>::value,
+            hpx::is_vectorpack_execution_policy<ExPolicy>::value,
             typename traits::vector_pack_type<
                 typename hpx::util::decay<Vector>::type::value_type,
                 1>::type>::type
@@ -68,7 +68,7 @@ namespace hpx { namespace parallel { namespace util {
         ///////////////////////////////////////////////////////////////////////
         template <typename ExPolicy, typename F, typename Vector, typename T>
         HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
-            execution::is_vectorpack_execution_policy<ExPolicy>::value,
+            hpx::is_vectorpack_execution_policy<ExPolicy>::value,
             typename traits::vector_pack_type<T, 1>::type>::type
         accumulate_values(F&& f, Vector const& value, T accum)
         {
@@ -285,7 +285,7 @@ namespace hpx { namespace parallel { namespace util {
     ///////////////////////////////////////////////////////////////////////////
     template <typename ExPolicy, typename F, typename Iter1, typename Iter2,
         typename U = typename std::enable_if<
-            execution::is_vectorpack_execution_policy<ExPolicy>::value>::type>
+            hpx::is_vectorpack_execution_policy<ExPolicy>::value>::type>
     HPX_HOST_DEVICE HPX_FORCEINLINE auto loop_step(
         std::false_type, F&& f, Iter1& it1, Iter2& it2)
         -> decltype(detail::datapar_loop_step2<Iter1, Iter2>::call1(
@@ -297,7 +297,7 @@ namespace hpx { namespace parallel { namespace util {
 
     template <typename ExPolicy, typename F, typename Iter1, typename Iter2,
         typename U = typename std::enable_if<
-            execution::is_vectorpack_execution_policy<ExPolicy>::value>::type>
+            hpx::is_vectorpack_execution_policy<ExPolicy>::value>::type>
     HPX_HOST_DEVICE HPX_FORCEINLINE auto loop_step(
         std::true_type, F&& f, Iter1& it1, Iter2& it2)
         -> decltype(detail::datapar_loop_step2<Iter1, Iter2>::callv(
@@ -310,7 +310,7 @@ namespace hpx { namespace parallel { namespace util {
     ///////////////////////////////////////////////////////////////////////////
     template <typename ExPolicy, typename Iter, typename Sent>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
-        execution::is_vectorpack_execution_policy<ExPolicy>::value, bool>::type
+        hpx::is_vectorpack_execution_policy<ExPolicy>::value, bool>::type
     loop_optimization(Iter first1, Sent last1)
     {
         return detail::loop_optimization<Iter>::call(first1, last1);
@@ -337,7 +337,7 @@ namespace hpx { namespace parallel { namespace util {
     template <typename ExPolicy, typename VecOnly, typename Iter1,
         typename Iter2, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
-        execution::is_vectorpack_execution_policy<ExPolicy>::value,
+        hpx::is_vectorpack_execution_policy<ExPolicy>::value,
         std::pair<Iter1, Iter2>>::type
     loop2(VecOnly, Iter1 first1, Iter1 last1, Iter2 first2, F&& f)
     {
@@ -348,7 +348,7 @@ namespace hpx { namespace parallel { namespace util {
     ///////////////////////////////////////////////////////////////////////////
     template <typename ExPolicy, typename Iter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
-        execution::is_vectorpack_execution_policy<ExPolicy>::value, Iter>::type
+        hpx::is_vectorpack_execution_policy<ExPolicy>::value, Iter>::type
     loop_n(Iter it, std::size_t count, F&& f)
     {
         return detail::datapar_loop_n<Iter>::call(

--- a/libs/parallelism/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
@@ -278,7 +278,7 @@ namespace hpx { namespace parallel { namespace util {
     ///////////////////////////////////////////////////////////////////////////
     template <typename ExPolicy, typename Iter, typename OutIter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
-        execution::is_vectorpack_execution_policy<ExPolicy>::value,
+        hpx::is_vectorpack_execution_policy<ExPolicy>::value,
         std::pair<Iter, OutIter>>::type
     transform_loop_n(Iter it, std::size_t count, OutIter dest, F&& f)
     {
@@ -309,7 +309,7 @@ namespace hpx { namespace parallel { namespace util {
     template <typename ExPolicy, typename InIter1, typename InIter2,
         typename OutIter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
-        execution::is_vectorpack_execution_policy<ExPolicy>::value,
+        hpx::is_vectorpack_execution_policy<ExPolicy>::value,
         hpx::tuple<InIter1, InIter2, OutIter>>::type
     transform_binary_loop_n(
         InIter1 first1, std::size_t count, InIter2 first2, OutIter dest, F&& f)
@@ -323,7 +323,7 @@ namespace hpx { namespace parallel { namespace util {
     template <typename ExPolicy, typename InIter1, typename InIter2,
         typename OutIter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
-        execution::is_vectorpack_execution_policy<ExPolicy>::value,
+        hpx::is_vectorpack_execution_policy<ExPolicy>::value,
         hpx::tuple<InIter1, InIter2, OutIter>>::type
     transform_binary_loop(
         InIter1 first1, InIter1 last1, InIter2 first2, OutIter dest, F&& f)
@@ -335,7 +335,7 @@ namespace hpx { namespace parallel { namespace util {
     template <typename ExPolicy, typename InIter1, typename InIter2,
         typename OutIter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
-        execution::is_vectorpack_execution_policy<ExPolicy>::value,
+        hpx::is_vectorpack_execution_policy<ExPolicy>::value,
         hpx::tuple<InIter1, InIter2, OutIter>>::type
     transform_binary_loop(InIter1 first1, InIter1 last1, InIter2 first2,
         InIter2 last2, OutIter dest, F&& f)

--- a/libs/parallelism/algorithms/include/hpx/parallel/spmd_block.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/spmd_block.hpp
@@ -175,9 +175,8 @@ namespace hpx { namespace lcos { namespace local {
     std::vector<hpx::future<void>> define_spmd_block(
         ExPolicy&& policy, std::size_t num_images, F&& f, Args&&... args)
     {
-        static_assert(
-            parallel::execution::is_async_execution_policy<ExPolicy>::value,
-            "parallel::execution::is_async_execution_policy<ExPolicy>::value");
+        static_assert(hpx::is_async_execution_policy<ExPolicy>::value,
+            "hpx::is_async_execution_policy<ExPolicy>::value");
 
         using ftype = typename std::decay<F>::type;
         using first_type = typename hpx::util::first_argument<ftype>::type;
@@ -208,13 +207,12 @@ namespace hpx { namespace lcos { namespace local {
     // Synchronous version
     template <typename ExPolicy, typename F, typename... Args,
         typename = typename std::enable_if<
-            !hpx::parallel::execution::is_async_execution_policy<
-                ExPolicy>::value>::type>
+            !hpx::is_async_execution_policy<ExPolicy>::value>::type>
     void define_spmd_block(
         ExPolicy&& policy, std::size_t num_images, F&& f, Args&&... args)
     {
-        static_assert(parallel::execution::is_execution_policy<ExPolicy>::value,
-            "parallel::execution::is_execution_policy<ExPolicy>::value");
+        static_assert(hpx::is_execution_policy<ExPolicy>::value,
+            "hpx::is_execution_policy<ExPolicy>::value");
 
         using ftype = typename std::decay<F>::type;
         using first_type = typename hpx::util::first_argument<ftype>::type;
@@ -277,8 +275,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
     // Synchronous version
     template <typename ExPolicy, typename F, typename... Args,
         typename = typename std::enable_if<
-            !hpx::parallel::execution::is_async_execution_policy<
-                ExPolicy>::value>::type>
+            !hpx::is_async_execution_policy<ExPolicy>::value>::type>
     void define_spmd_block(
         ExPolicy&& policy, std::size_t num_images, F&& f, Args&&... args)
     {

--- a/libs/parallelism/algorithms/include/hpx/parallel/task_block.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/task_block.hpp
@@ -405,8 +405,8 @@ namespace hpx { namespace parallel { inline namespace v2 {
     typename util::detail::algorithm_result<ExPolicy>::type define_task_block(
         ExPolicy&& policy, F&& f)
     {
-        static_assert(parallel::execution::is_execution_policy<ExPolicy>::value,
-            "parallel::execution::is_execution_policy<ExPolicy>::value");
+        static_assert(hpx::is_execution_policy<ExPolicy>::value,
+            "hpx::is_execution_policy<ExPolicy>::value");
 
         typedef typename hpx::util::decay<ExPolicy>::type policy_type;
         task_block<policy_type> trh(std::forward<ExPolicy>(policy));
@@ -481,8 +481,8 @@ namespace hpx { namespace parallel { inline namespace v2 {
     typename util::detail::algorithm_result<ExPolicy>::type
     define_task_block_restore_thread(ExPolicy&& policy, F&& f)
     {
-        static_assert(parallel::execution::is_execution_policy<ExPolicy>::value,
-            "parallel::execution::is_execution_policy<ExPolicy>::value");
+        static_assert(hpx::is_execution_policy<ExPolicy>::value,
+            "hpx::is_execution_policy<ExPolicy>::value");
 
         // By design we always return on the same (HPX-) thread as we started
         // executing define_task_block_restore_thread.

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/loop.hpp
@@ -31,7 +31,7 @@ namespace hpx { namespace parallel { namespace util {
     template <typename ExPolicy, typename VecOnly, typename F,
         typename... Iters>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
-        !execution::is_vectorpack_execution_policy<ExPolicy>::value,
+        !hpx::is_vectorpack_execution_policy<ExPolicy>::value,
         typename hpx::util::invoke_result<F, Iters...>::type>::type
     loop_step(VecOnly, F&& f, Iters&... its)
     {
@@ -40,7 +40,7 @@ namespace hpx { namespace parallel { namespace util {
 
     template <typename ExPolicy, typename Iter>
     HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
-        !execution::is_vectorpack_execution_policy<ExPolicy>::value, bool>::type
+        !hpx::is_vectorpack_execution_policy<ExPolicy>::value, bool>::type
         loop_optimization(Iter, Iter)
     {
         return false;
@@ -124,7 +124,7 @@ namespace hpx { namespace parallel { namespace util {
     template <typename ExPolicy, typename VecOnly, typename Begin1,
         typename End1, typename Begin2, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
-        !execution::is_vectorpack_execution_policy<ExPolicy>::value,
+        !hpx::is_vectorpack_execution_policy<ExPolicy>::value,
         std::pair<Begin1, Begin2>>::type
     loop2(VecOnly, Begin1 begin1, End1 end1, Begin2 begin2, F&& f)
     {
@@ -271,7 +271,7 @@ namespace hpx { namespace parallel { namespace util {
         ///////////////////////////////////////////////////////////////////////
         template <typename ExPolicy, typename T>
         HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
-            !execution::is_vectorpack_execution_policy<ExPolicy>::value,
+            !hpx::is_vectorpack_execution_policy<ExPolicy>::value,
             T const&>::type
         extract_value(T const& v)
         {
@@ -280,7 +280,7 @@ namespace hpx { namespace parallel { namespace util {
 
         template <typename ExPolicy, typename F, typename T>
         HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
-            !execution::is_vectorpack_execution_policy<ExPolicy>::value,
+            !hpx::is_vectorpack_execution_policy<ExPolicy>::value,
             T const&>::type
         accumulate_values(F&&, T const& v)
         {
@@ -289,8 +289,7 @@ namespace hpx { namespace parallel { namespace util {
 
         template <typename ExPolicy, typename F, typename T, typename T1>
         HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
-            !execution::is_vectorpack_execution_policy<ExPolicy>::value,
-            T>::type
+            !hpx::is_vectorpack_execution_policy<ExPolicy>::value, T>::type
         accumulate_values(F&& f, T&& v, T1&& init)
         {
             return hpx::util::invoke(
@@ -300,7 +299,7 @@ namespace hpx { namespace parallel { namespace util {
 
     template <typename ExPolicy, typename Iter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
-        !execution::is_vectorpack_execution_policy<ExPolicy>::value, Iter>::type
+        !hpx::is_vectorpack_execution_policy<ExPolicy>::value, Iter>::type
     loop_n(Iter it, std::size_t count, F&& f)
     {
         using pred = std::integral_constant<bool,
@@ -314,7 +313,7 @@ namespace hpx { namespace parallel { namespace util {
     template <typename ExPolicy, typename Iter, typename CancelToken,
         typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
-        !execution::is_vectorpack_execution_policy<ExPolicy>::value, Iter>::type
+        !hpx::is_vectorpack_execution_policy<ExPolicy>::value, Iter>::type
     loop_n(Iter it, std::size_t count, CancelToken& tok, F&& f)
     {
         using pred = std::integral_constant<bool,

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/transform_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/transform_loop.hpp
@@ -87,7 +87,7 @@ namespace hpx { namespace parallel { namespace util {
     template <typename ExPolicy, typename InIter1, typename InIter2,
         typename OutIter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
-        !execution::is_vectorpack_execution_policy<ExPolicy>::value,
+        !hpx::is_vectorpack_execution_policy<ExPolicy>::value,
         hpx::tuple<InIter1, InIter2, OutIter>>::type
     transform_binary_loop(
         InIter1 first1, InIter1 last1, InIter2 first2, OutIter dest, F&& f)
@@ -99,7 +99,7 @@ namespace hpx { namespace parallel { namespace util {
     template <typename ExPolicy, typename InIter1, typename InIter2,
         typename OutIter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
-        !execution::is_vectorpack_execution_policy<ExPolicy>::value,
+        !hpx::is_vectorpack_execution_policy<ExPolicy>::value,
         hpx::tuple<InIter1, InIter2, OutIter>>::type
     transform_binary_loop(InIter1 first1, InIter1 last1, InIter2 first2,
         InIter2 last2, OutIter dest, F&& f)
@@ -127,7 +127,7 @@ namespace hpx { namespace parallel { namespace util {
 
     template <typename ExPolicy, typename Iter, typename OutIter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
-        !execution::is_vectorpack_execution_policy<ExPolicy>::value,
+        !hpx::is_vectorpack_execution_policy<ExPolicy>::value,
         std::pair<Iter, OutIter>>::type
     transform_loop_n(Iter it, std::size_t count, OutIter dest, F&& f)
     {
@@ -161,7 +161,7 @@ namespace hpx { namespace parallel { namespace util {
     template <typename ExPolicy, typename InIter1, typename InIter2,
         typename OutIter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
-        !execution::is_vectorpack_execution_policy<ExPolicy>::value,
+        !hpx::is_vectorpack_execution_policy<ExPolicy>::value,
         hpx::tuple<InIter1, InIter2, OutIter>>::type
     transform_binary_loop_n(
         InIter1 first1, std::size_t count, InIter2 first2, OutIter dest, F&& f)

--- a/libs/parallelism/algorithms/include_compatibility/hpx/parallel/traits/projected.hpp
+++ b/libs/parallelism/algorithms/include_compatibility/hpx/parallel/traits/projected.hpp
@@ -10,12 +10,16 @@
 #include <hpx/algorithms/config/defines.hpp>
 #include <hpx/algorithm.hpp>
 
+// different versions of clang-format produce different results
+// clang-format off
 #if HPX_ALGORITHMS_HAVE_DEPRECATION_WARNINGS
 #if defined(HPX_MSVC)
-#pragma message("The header hpx/parallel/traits/projected.hpp is deprecated, \
+#pragma message(                                                               \
+    "The header hpx/parallel/traits/projected.hpp is deprecated, \
     please include hpx/algorithms/traits/projected.hpp")
 #else
 #warning "The header hpx/parallel/traits/projected.hpp is deprecated, \
     please include hpx/algorithms/traits/projected.hpp"
 #endif
 #endif
+// clang-format on

--- a/libs/parallelism/algorithms/include_compatibility/hpx/traits/segmented_iterator_traits.hpp
+++ b/libs/parallelism/algorithms/include_compatibility/hpx/traits/segmented_iterator_traits.hpp
@@ -10,13 +10,17 @@
 #include <hpx/algorithms/config/defines.hpp>
 #include <hpx/algorithm.hpp>
 
+// different versions of clang-format produce different results
+// clang-format off
 #if HPX_ALGORITHMS_HAVE_DEPRECATION_WARNINGS
 #if defined(HPX_MSVC)
 #pragma message(                                                               \
     "The header hpx/traits/segmented_iterator_traits.hpp is deprecated, \
     please include hpx/algorithms/traits/segmented_iterator_traits.hpp")
 #else
-#warning "The header hpx/traits/segmented_iterator_traits.hpp is deprecated, \
+#warning                                                                       \
+    "The header hpx/traits/segmented_iterator_traits.hpp is deprecated, \
     please include hpx/algorithms/traits/segmented_iterator_traits.hpp"
 #endif
 #endif
+// clang-format on

--- a/libs/parallelism/algorithms/tests/regressions/stable_merge_2964.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/stable_merge_2964.cpp
@@ -46,9 +46,8 @@ struct random_fill
 template <typename ExPolicy, typename DataType>
 void test_merge_stable(ExPolicy policy, DataType, int rand_base)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::pair<DataType, int> ElemType;
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentdifference.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentdifference.cpp
@@ -22,9 +22,8 @@
 template <typename ExPolicy>
 void test_adjacent_difference(ExPolicy policy)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c = test::random_iota(10007);
     std::vector<std::size_t> d(10007);
@@ -43,9 +42,8 @@ void test_adjacent_difference(ExPolicy policy)
 template <typename ExPolicy>
 void test_adjacent_difference_async(ExPolicy p)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c = test::random_iota(10007);
     std::vector<std::size_t> d(10007);

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentdifference_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentdifference_bad_alloc.cpp
@@ -21,9 +21,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_difference_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentdifference_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentdifference_exception.cpp
@@ -21,9 +21,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_difference_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind.cpp
@@ -27,9 +27,8 @@ std::uniform_int_distribution<> dist(2, 10005);
 template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_find(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_bad_alloc.cpp
@@ -26,9 +26,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_find_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_binary.cpp
@@ -28,9 +28,8 @@ std::uniform_int_distribution<> dist(2, 10005);
 template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_find(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_binary_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_binary_bad_alloc.cpp
@@ -26,9 +26,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_find_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_binary_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_binary_exception.cpp
@@ -26,9 +26,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_find_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_exception.cpp
@@ -26,9 +26,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag>
 void test_adjacent_find_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/all_of.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/all_of.cpp
@@ -45,9 +45,8 @@ void test_all_of(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_all_of(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -98,9 +97,8 @@ template <typename ExPolicy, typename IteratorTag,
     typename Proj = hpx::parallel::util::projection_identity>
 void test_all_of_ranges(ExPolicy&& policy, IteratorTag, Proj proj = Proj())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -239,9 +237,8 @@ void all_of_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_all_of_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -380,9 +377,8 @@ void all_of_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_all_of_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/any_of.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/any_of.cpp
@@ -45,9 +45,8 @@ void test_any_of(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_any_of(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -98,9 +97,8 @@ template <typename ExPolicy, typename IteratorTag,
     typename Proj = hpx::parallel::util::projection_identity>
 void test_any_of_ranges(ExPolicy&& policy, IteratorTag, Proj proj = Proj())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -276,9 +274,8 @@ void test_any_of_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_any_of_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -380,9 +377,8 @@ void any_of_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_any_of_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/copy.cpp
@@ -47,9 +47,8 @@ void test_copy(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_copy(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -152,9 +151,8 @@ void test_copy_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_copy_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -251,9 +249,8 @@ void copy_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_copy_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/copyif_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/copyif_bad_alloc.cpp
@@ -26,9 +26,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag>
 void test_copy_if_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/copyif_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/copyif_exception.cpp
@@ -59,9 +59,8 @@ void test_copy_if_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_copy_if_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/copyif_forward.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/copyif_forward.cpp
@@ -59,9 +59,8 @@ void test_copy_if_seq()
 template <typename ExPolicy>
 void test_copy_if(ExPolicy&& policy)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, std::forward_iterator_tag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/copyif_random.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/copyif_random.cpp
@@ -60,9 +60,8 @@ void test_copy_if_seq()
 template <typename ExPolicy>
 void test_copy_if(ExPolicy&& policy)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, std::random_access_iterator_tag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/copyn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/copyn.cpp
@@ -48,9 +48,8 @@ void test_copy_n(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_copy_n(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -150,9 +149,8 @@ void test_copy_n_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_copy_n_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -250,9 +248,8 @@ void copy_n_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_copy_n_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/count_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/count_tests.hpp
@@ -49,9 +49,8 @@ void test_count(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_count(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -129,9 +128,8 @@ void test_count_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_count_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -203,9 +201,8 @@ void test_count_exception_async(ExPolicy&& p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_count_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/countif_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/countif_tests.hpp
@@ -63,9 +63,8 @@ void test_count_if(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_count_if(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef std::vector<int>::difference_type diff_type;
@@ -135,9 +134,8 @@ void test_count_if_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_count_if_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -211,9 +209,8 @@ void test_count_if_exception_async(ExPolicy&& p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_count_if_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/destroy_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/destroy_tests.hpp
@@ -73,9 +73,8 @@ void test_destroy(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_destroy(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef destructable* base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -180,9 +179,8 @@ void test_destroy_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_destroy_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef test::count_instances_v<destructable> data_type;
     typedef data_type* base_iterator;
@@ -297,9 +295,8 @@ void test_destroy_exception_async(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_destroy_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef test::count_instances_v<destructable> data_type;
     typedef data_type* base_iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/destroyn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/destroyn.cpp
@@ -71,9 +71,8 @@ void test_destroy_n(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_destroy_n(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef destructable* base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -198,9 +197,8 @@ void test_destroy_n_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_destroy_n_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef test::count_instances_v<destructable> data_type;
     typedef data_type* base_iterator;
@@ -338,9 +336,8 @@ void destroy_n_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_destroy_n_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef test::count_instances_v<destructable> data_type;
     typedef data_type* base_iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/equal.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/equal.cpp
@@ -64,9 +64,8 @@ void test_equal1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_equal1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -209,9 +208,8 @@ void test_equal2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_equal2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -355,9 +353,8 @@ void test_equal_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_equal_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -460,9 +457,8 @@ void equal_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_equal_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/equal_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/equal_binary.cpp
@@ -64,9 +64,8 @@ void test_equal_binary1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_equal_binary1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -209,9 +208,8 @@ void test_equal_binary2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_equal_binary2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -355,9 +353,8 @@ void test_equal_binary_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_equal_binary_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -460,9 +457,8 @@ void equal_binary_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_equal_binary_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan.cpp
@@ -62,9 +62,8 @@ void exclusive_scan_benchmark()
 template <typename ExPolicy, typename IteratorTag>
 void test_exclusive_scan1(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan2.cpp
@@ -21,9 +21,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_exclusive_scan2(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_bad_alloc.cpp
@@ -21,9 +21,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_exclusive_scan_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_exception.cpp
@@ -21,9 +21,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_exclusive_scan_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/fill.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/fill.cpp
@@ -47,9 +47,8 @@ void test_fill(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_fill(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -145,9 +144,8 @@ void test_fill_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_fill_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -241,9 +239,8 @@ void fill_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_fill_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/filln.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/filln.cpp
@@ -47,9 +47,8 @@ void test_fill_n(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_fill_n(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -145,9 +144,8 @@ void test_fill_n_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_fill_n_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -241,9 +239,8 @@ void fill_n_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_fill_n_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/find.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/find.cpp
@@ -46,9 +46,8 @@ void test_find(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -144,9 +143,8 @@ void test_find_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -242,9 +240,8 @@ void find_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findend.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findend.cpp
@@ -52,9 +52,8 @@ void test_find_end1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -150,9 +149,8 @@ void test_find_end2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -253,9 +251,8 @@ void test_find_end3(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end3(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -357,9 +354,8 @@ void test_find_end4(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end4(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -434,9 +430,8 @@ void find_end_test4()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -584,9 +579,8 @@ void find_end_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findfirstof.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findfirstof.cpp
@@ -50,9 +50,8 @@ void test_find_first_of(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -156,9 +155,8 @@ void test_find_first_of_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -258,9 +256,8 @@ void find_first_of_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findfirstof_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findfirstof_binary.cpp
@@ -53,9 +53,8 @@ void test_find_first_of(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -165,9 +164,8 @@ void test_find_first_of_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -271,9 +269,8 @@ void find_first_of_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findif.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findif.cpp
@@ -47,9 +47,8 @@ void test_find_if(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_if(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -147,9 +146,8 @@ void test_find_if_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_if_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -245,9 +243,8 @@ void find_if_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_if_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findifnot.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findifnot.cpp
@@ -46,9 +46,8 @@ void test_find_if_not(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_if_not(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findifnot_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findifnot_bad_alloc.cpp
@@ -26,9 +26,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag>
 void test_find_if_not_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findifnot_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findifnot_exception.cpp
@@ -58,9 +58,8 @@ void test_find_if_not_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_if_not_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop.cpp
@@ -27,9 +27,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -94,9 +93,8 @@ void for_loop_test()
 template <typename ExPolicy>
 void test_for_loop_idx(ExPolicy&& policy)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_exception.cpp
@@ -67,9 +67,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -141,9 +140,8 @@ void test_for_loop_exception_async(ExPolicy&& p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -241,9 +239,8 @@ void for_loop_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_idx_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
@@ -310,9 +307,8 @@ void test_for_loop_idx_exception_async(ExPolicy&& p, IteratorTag)
 template <typename ExPolicy>
 void test_for_loop_idx_bad_alloc(ExPolicy&& policy)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_induction.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_induction.cpp
@@ -27,9 +27,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_induction(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -59,9 +58,8 @@ void test_for_loop_induction(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_induction_stride(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -93,9 +91,8 @@ void test_for_loop_induction_stride(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_induction_life_out(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -128,9 +125,8 @@ void test_for_loop_induction_life_out(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_induction_stride_life_out(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -197,9 +193,8 @@ void for_loop_induction_test()
 template <typename ExPolicy>
 void test_for_loop_induction_idx(ExPolicy&& policy)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
@@ -222,9 +217,8 @@ void test_for_loop_induction_idx(ExPolicy&& policy)
 template <typename ExPolicy>
 void test_for_loop_induction_stride_idx(ExPolicy&& policy)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_induction_async.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_induction_async.cpp
@@ -27,9 +27,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_induction(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -60,9 +59,8 @@ void test_for_loop_induction(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_induction_stride(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -95,9 +93,8 @@ void test_for_loop_induction_stride(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_induction_life_out(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -131,9 +128,8 @@ void test_for_loop_induction_life_out(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_induction_stride_life_out(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -197,9 +193,8 @@ void for_loop_induction_test()
 template <typename ExPolicy>
 void test_for_loop_induction_idx(ExPolicy&& policy)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
@@ -223,9 +218,8 @@ void test_for_loop_induction_idx(ExPolicy&& policy)
 template <typename ExPolicy>
 void test_for_loop_induction_stride_idx(ExPolicy&& policy)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_n.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_n.cpp
@@ -27,9 +27,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_n(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -94,9 +93,8 @@ void for_loop_n_test()
 template <typename ExPolicy>
 void test_for_loop_n_idx(ExPolicy&& policy)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_n_strided.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_n_strided.cpp
@@ -28,9 +28,8 @@ std::uniform_int_distribution<> dis(1, 10006);
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_n_strided(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -127,9 +126,8 @@ void for_loop_n_strided_test()
 template <typename ExPolicy>
 void test_for_loop_n_strided_idx(ExPolicy&& policy)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_reduction.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_reduction.cpp
@@ -27,9 +27,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_reduction_plus(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -51,9 +50,8 @@ void test_for_loop_reduction_plus(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_reduction_multiplies(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -75,9 +73,8 @@ void test_for_loop_reduction_multiplies(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_reduction_min(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -128,9 +125,8 @@ void for_loop_reduction_test()
 template <typename ExPolicy>
 void test_for_loop_reduction_bit_and_idx(ExPolicy&& policy)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
@@ -149,9 +145,8 @@ void test_for_loop_reduction_bit_and_idx(ExPolicy&& policy)
 template <typename ExPolicy>
 void test_for_loop_reduction_bit_or_idx(ExPolicy&& policy)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_reduction_async.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_reduction_async.cpp
@@ -27,9 +27,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_reduction_plus(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -53,9 +52,8 @@ void test_for_loop_reduction_plus(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_reduction_multiplies(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -79,9 +77,8 @@ void test_for_loop_reduction_multiplies(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_reduction_min(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -131,9 +128,8 @@ void for_loop_reduction_test()
 template <typename ExPolicy>
 void test_for_loop_reduction_bit_and_idx(ExPolicy&& policy)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
@@ -153,9 +149,8 @@ void test_for_loop_reduction_bit_and_idx(ExPolicy&& policy)
 template <typename ExPolicy>
 void test_for_loop_reduction_bit_or_idx(ExPolicy&& policy)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_strided.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_strided.cpp
@@ -28,9 +28,8 @@ std::uniform_int_distribution<> dis(1, 10006);
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_strided(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -127,9 +126,8 @@ void for_loop_strided_test()
 template <typename ExPolicy>
 void test_for_loop_strided_idx(ExPolicy&& policy)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreach_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreach_tests.hpp
@@ -82,9 +82,8 @@ void test_for_each_seq(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -160,9 +159,8 @@ void test_for_each_exception_seq(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -258,9 +256,8 @@ void test_for_each_bad_alloc_seq(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -348,9 +345,8 @@ void test_for_each_n_seq(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_n(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreach_tests_prefetching.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreach_tests_prefetching.hpp
@@ -24,9 +24,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_prefetching(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::size_t prefetch_distance_factor = 2;
     std::vector<double> c(10007, 1.0);
@@ -82,9 +81,8 @@ void test_for_each_prefetching_async(ExPolicy&& p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_prefetching_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename hpx::parallel::util::detail::prefetching_iterator<
         std::vector<double>::iterator, double>
@@ -165,9 +163,8 @@ void test_for_each_prefetching_exception_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_prefetching_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename hpx::parallel::util::detail::prefetching_iterator<
         std::vector<double>::iterator, double>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreach_tests_projection.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreach_tests_projection.hpp
@@ -21,9 +21,8 @@
 template <typename ExPolicy, typename IteratorTag, typename Proj>
 void test_for_each(ExPolicy&& policy, IteratorTag, Proj&& proj)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -75,9 +74,8 @@ void test_for_each_async(ExPolicy&& p, IteratorTag, Proj&& proj)
 template <typename ExPolicy, typename IteratorTag, typename Proj>
 void test_for_each_exception(ExPolicy policy, IteratorTag, Proj&& proj)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -146,9 +144,8 @@ void test_for_each_exception_async(ExPolicy p, IteratorTag, Proj&& proj)
 template <typename ExPolicy, typename IteratorTag, typename Proj>
 void test_for_each_bad_alloc(ExPolicy policy, IteratorTag, Proj&& proj)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_bad_alloc.cpp
@@ -55,9 +55,8 @@ void test_for_each_n_bad_alloc_seq(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_n_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_exception.cpp
@@ -55,9 +55,8 @@ void test_for_each_n_exception_seq(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_n_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_projection.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_projection.cpp
@@ -22,9 +22,8 @@
 template <typename ExPolicy, typename IteratorTag, typename Proj>
 void test_for_each_n(ExPolicy policy, IteratorTag, Proj&& proj)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_projection_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_projection_bad_alloc.cpp
@@ -26,9 +26,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag, typename Proj>
 void test_for_each_n_bad_alloc(ExPolicy policy, IteratorTag, Proj&& proj)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_projection_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_projection_exception.cpp
@@ -26,9 +26,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag, typename Proj>
 void test_for_each_n_exception(ExPolicy policy, IteratorTag, Proj&& proj)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/generate.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/generate.cpp
@@ -46,9 +46,8 @@ void test_generate(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_generate(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -147,9 +146,8 @@ void test_generate_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_generate_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -245,9 +243,8 @@ void generate_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_generate_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/generaten.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/generaten.cpp
@@ -43,9 +43,8 @@ void test_generate_n(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_generate_n(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -144,9 +143,8 @@ void test_generate_n_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_generate_n_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -242,9 +240,8 @@ void generate_n_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_generate_n_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/includes.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/includes.cpp
@@ -29,9 +29,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag>
 void test_includes1(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -160,9 +159,8 @@ void includes_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_includes2(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -293,9 +291,8 @@ void includes_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_includes_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -421,9 +418,8 @@ void includes_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_includes_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/inclusive_scan_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/inclusive_scan_tests.hpp
@@ -66,9 +66,8 @@ void inclusive_scan_benchmark()
 template <typename ExPolicy, typename IteratorTag>
 void test_inclusive_scan1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -133,9 +132,8 @@ void test_inclusive_scan1_async(ExPolicy&& p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_inclusive_scan2(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -197,9 +195,8 @@ void test_inclusive_scan2_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_inclusive_scan3(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -257,9 +254,8 @@ void test_inclusive_scan3_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_inclusive_scan_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -338,9 +334,8 @@ void test_inclusive_scan_exception_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_inclusive_scan_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/inplace_merge_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/inplace_merge_tests.hpp
@@ -120,9 +120,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType,
 void test_inplace_merge(
     ExPolicy policy, IteratorTag, DataType, Comp comp, int rand_base)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -160,9 +159,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType,
 void test_inplace_merge_async(
     ExPolicy policy, IteratorTag, DataType, Comp comp, int rand_base)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -200,9 +198,8 @@ void test_inplace_merge_async(
 template <typename ExPolicy, typename IteratorTag>
 void test_inplace_merge_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -288,9 +285,8 @@ void test_inplace_merge_exception_async(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_inplace_merge_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -375,9 +371,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType>
 void test_inplace_merge_etc(
     ExPolicy policy, IteratorTag, DataType, int rand_base)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
 
@@ -446,9 +441,8 @@ void test_inplace_merge_stable(
     ExPolicy policy, IteratorTag, DataType, int rand_base)
 {
 #if defined(HPX_HAVE_STABLE_INPLACE_MERGE)
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::pair<DataType, int> ElemType;
     typedef typename std::vector<ElemType>::iterator base_iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/is_heap_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/is_heap_tests.hpp
@@ -110,9 +110,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType>
 void test_is_heap(
     ExPolicy&& policy, IteratorTag, DataType, bool test_for_is_heap = true)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -177,9 +176,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType,
 void test_is_heap_with_pred(ExPolicy&& policy, IteratorTag, DataType, Pred pred,
     bool test_for_is_heap = true)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -212,9 +210,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType>
 void test_is_heap_async(
     ExPolicy&& policy, IteratorTag, DataType, bool test_for_is_heap = true)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -290,9 +287,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_is_heap_exception(
     ExPolicy&& policy, IteratorTag, bool test_for_is_heap = true)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -419,9 +415,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_is_heap_bad_alloc(
     ExPolicy&& policy, IteratorTag, bool test_for_is_heap = true)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/is_partitioned.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/is_partitioned.cpp
@@ -26,9 +26,8 @@ std::uniform_int_distribution<> dis(0, 99);
 template <typename ExPolicy, typename IteratorTag>
 void test_partitioned1(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -87,9 +86,8 @@ void partitioned_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_partitioned2(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -160,9 +158,8 @@ void partitioned_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_partitioned3(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -194,9 +191,8 @@ void test_partitioned3(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_partitioned3_async(ExPolicy p, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -252,9 +248,8 @@ void partitioned_test3()
 template <typename ExPolicy, typename IteratorTag>
 void test_partitioned_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -352,9 +347,8 @@ void partitioned_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_partitioned_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/is_sorted_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/is_sorted_tests.hpp
@@ -28,9 +28,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -66,9 +65,8 @@ void test_sorted1_async(ExPolicy&& p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted2(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -120,9 +118,8 @@ void test_sorted2_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted3(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -148,9 +145,8 @@ void test_sorted3(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted3_async(ExPolicy p, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -178,9 +174,8 @@ void test_sorted3_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -249,9 +244,8 @@ void test_sorted_exception_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/is_sorted_until.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/is_sorted_until.cpp
@@ -27,9 +27,8 @@ std::uniform_int_distribution<> dis(0, 99);
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted_until1(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -48,9 +47,8 @@ void test_sorted_until1(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted_until1_async(ExPolicy p, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -93,9 +91,8 @@ void sorted_until_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted_until2(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -123,9 +120,8 @@ void test_sorted_until2(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted_until2_async(ExPolicy p, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -172,9 +168,8 @@ void sorted_until_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted_until3(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -206,9 +201,8 @@ void test_sorted_until3(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted_until3_async(ExPolicy p, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -261,9 +255,8 @@ void sorted_until_test3()
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted_until_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -355,9 +348,8 @@ void sorted_until_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_sorted_until_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/lexicographical_compare.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/lexicographical_compare.cpp
@@ -26,9 +26,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag>
 void test_lexicographical_compare1(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -93,9 +92,8 @@ void lexicographical_compare_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_lexicographical_compare2(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -158,9 +156,8 @@ void lexicographical_compare_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_lexicographical_compare3(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -227,9 +224,8 @@ void lexicographical_compare_test3()
 template <typename ExPolicy, typename IteratorTag>
 void test_lexicographical_compare_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -331,9 +327,8 @@ void lexicographical_compare_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_lexicographical_compare_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/max_element.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/max_element.cpp
@@ -21,9 +21,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_max_element(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -105,9 +104,8 @@ void max_element_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_max_element_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -259,9 +257,8 @@ void max_element_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_max_element_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/merge_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/merge_tests.hpp
@@ -119,9 +119,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType,
 void test_merge(
     ExPolicy policy, IteratorTag, DataType, Comp comp, int rand_base)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -154,9 +153,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType,
 void test_merge_async(
     ExPolicy policy, IteratorTag, DataType, Comp comp, int rand_base)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -189,9 +187,8 @@ void test_merge_async(
 template <typename ExPolicy, typename IteratorTag>
 void test_merge_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -273,9 +270,8 @@ void test_merge_exception_async(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_merge_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -355,9 +351,8 @@ void test_merge_bad_alloc_async(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag, typename DataType>
 void test_merge_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
 
@@ -444,9 +439,8 @@ void test_merge_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
 template <typename ExPolicy, typename IteratorTag, typename DataType>
 void test_merge_stable(ExPolicy policy, IteratorTag, DataType, int rand_base)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::pair<DataType, int> ElemType;
     typedef typename std::vector<ElemType>::iterator base_iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/min_element.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/min_element.cpp
@@ -22,9 +22,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_min_element(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -106,9 +105,8 @@ void min_element_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_min_element_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -260,9 +258,8 @@ void min_element_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_min_element_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/minmax_element.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/minmax_element.cpp
@@ -23,9 +23,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_minmax_element(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -115,9 +114,8 @@ void minmax_element_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_minmax_element_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -269,9 +267,8 @@ void minmax_element_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_minmax_element_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/mismatch.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/mismatch.cpp
@@ -68,9 +68,8 @@ void test_mismatch1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -220,9 +219,8 @@ void test_mismatch2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -371,9 +369,8 @@ void test_mismatch_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -474,9 +471,8 @@ void mismatch_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/mismatch_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/mismatch_binary.cpp
@@ -68,9 +68,8 @@ void test_mismatch_binary1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_binary1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -222,9 +221,8 @@ void test_mismatch_binary2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_binary2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -373,9 +371,8 @@ void test_mismatch_binary_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_binary_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -478,9 +475,8 @@ void mismatch_binary_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_binary_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/move.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/move.cpp
@@ -50,9 +50,8 @@ void test_move(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_move(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -130,9 +129,8 @@ void move_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_move_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -229,9 +227,8 @@ void move_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_move_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/none_of.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/none_of.cpp
@@ -44,9 +44,8 @@ void test_none_of(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_none_of(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -95,9 +94,8 @@ template <typename ExPolicy, typename IteratorTag,
     typename Proj = hpx::parallel::util::projection_identity>
 void test_none_of_ranges(ExPolicy&& policy, IteratorTag, Proj proj = Proj())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -272,9 +270,8 @@ void test_none_of_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_none_of_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -376,9 +373,8 @@ void none_of_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_none_of_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/partition_copy_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/partition_copy_tests.hpp
@@ -101,9 +101,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType,
 void test_partition_copy(
     ExPolicy policy, IteratorTag, DataType, Pred pred, int rand_base)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -138,9 +137,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType,
 void test_partition_copy_async(
     ExPolicy policy, IteratorTag, DataType, Pred pred, int rand_base)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -175,9 +173,8 @@ void test_partition_copy_async(
 template <typename ExPolicy, typename IteratorTag>
 void test_partition_copy_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -250,9 +247,8 @@ void test_partition_copy_exception_async(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_partition_copy_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/partition_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/partition_tests.hpp
@@ -107,9 +107,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType,
 void test_partition(ExPolicy policy, IteratorTag, DataType, Pred pred,
     std::size_t size, random_fill gen_functor)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -143,9 +142,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType,
 void test_partition_async(ExPolicy policy, IteratorTag, DataType, Pred pred,
     std::size_t size, random_fill gen_functor)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -179,9 +177,8 @@ void test_partition_async(ExPolicy policy, IteratorTag, DataType, Pred pred,
 template <typename ExPolicy, typename IteratorTag>
 void test_partition_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -251,9 +248,8 @@ void test_partition_exception_async(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_partition_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/reduce_.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/reduce_.cpp
@@ -26,9 +26,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce1(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -91,9 +90,8 @@ void reduce_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce2(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -152,9 +150,8 @@ void reduce_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce3(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -213,9 +210,8 @@ void reduce_test3()
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -308,9 +304,8 @@ void reduce_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/reduce_by_key.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/reduce_by_key.cpp
@@ -109,9 +109,8 @@ template <typename ExPolicy, typename Tkey, typename Tval, typename Op,
 void test_reduce_by_key1(ExPolicy&& policy, Tkey, Tval, bool benchmark,
     const Op& op, const HelperOp& ho)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(Tval).name(), typeid(Op).name(), sync);
     std::cout << "\n";
 
@@ -208,9 +207,8 @@ template <typename ExPolicy, typename Tkey, typename Tval, typename Op,
 void test_reduce_by_key_const(ExPolicy&& policy, Tkey, Tval, bool benchmark,
     const Op& op, const HelperOp& ho)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(Tval).name(), typeid(Op).name(), sync);
     std::cout << "\n";
 
@@ -310,9 +308,8 @@ template <typename ExPolicy, typename Tkey, typename Tval, typename Op,
 void test_reduce_by_key_async(
     ExPolicy&& policy, Tkey, Tval, const Op& op, const HelperOp& ho)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(Tval).name(), typeid(Op).name(), async);
     std::cout << "\n";
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy.cpp
@@ -26,9 +26,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -88,9 +87,8 @@ void test_remove_copy_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_outiter(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -170,9 +168,8 @@ void remove_copy_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -267,9 +264,8 @@ void remove_copy_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy_if.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy_if.cpp
@@ -26,9 +26,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_if(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -105,9 +104,8 @@ void test_remove_copy_if_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_if_outiter(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -188,9 +186,8 @@ void remove_copy_if_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_if_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -284,9 +281,8 @@ void remove_copy_if_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_if_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove_tests.hpp
@@ -116,9 +116,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType,
 void test_remove(
     ExPolicy policy, IteratorTag, DataType, ValueType value, int rand_base)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -143,9 +142,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType,
 void test_remove_async(
     ExPolicy policy, IteratorTag, DataType, ValueType value, int rand_base)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -172,9 +170,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType,
 void test_remove_if(
     ExPolicy policy, IteratorTag, DataType, Pred pred, int rand_base)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -199,9 +196,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType,
 void test_remove_if_async(
     ExPolicy policy, IteratorTag, DataType, Pred pred, int rand_base)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -227,9 +223,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_remove_exception(
     ExPolicy policy, IteratorTag, bool test_for_remove_if = false)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -326,9 +321,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_remove_bad_alloc(
     ExPolicy policy, IteratorTag, bool test_for_remove_if = false)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -423,9 +417,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType>
 void test_remove_etc(ExPolicy policy, IteratorTag, DataType, int rand_base,
     bool test_for_remove_if = false)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/replace.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/replace.cpp
@@ -22,9 +22,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_replace(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -102,9 +101,8 @@ void replace_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -197,9 +195,8 @@ void replace_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/replace_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/replace_copy.cpp
@@ -22,9 +22,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -106,9 +105,8 @@ void replace_copy_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -205,9 +203,8 @@ void replace_copy_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/replace_copy_if.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/replace_copy_if.cpp
@@ -37,9 +37,8 @@ struct equal_f
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_if(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -121,9 +120,8 @@ void replace_copy_if_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_if_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -220,9 +218,8 @@ void replace_copy_if_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_if_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/replace_if.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/replace_if.cpp
@@ -37,9 +37,8 @@ struct equal_f
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_if(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -117,9 +116,8 @@ void replace_if_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_if_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -212,9 +210,8 @@ void replace_if_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_if_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/reverse.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/reverse.cpp
@@ -22,9 +22,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -100,9 +99,8 @@ void reverse_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -194,9 +192,8 @@ void reverse_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/reverse_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/reverse_copy.cpp
@@ -22,9 +22,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse_copy(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -100,9 +99,8 @@ void reverse_copy_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse_copy_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -198,9 +196,8 @@ void reverse_copy_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse_copy_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/rotate.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/rotate.cpp
@@ -22,9 +22,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_rotate(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -113,9 +112,8 @@ void rotate_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_rotate_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -222,9 +220,8 @@ void rotate_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_rotate_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/rotate_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/rotate_copy.cpp
@@ -22,9 +22,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_rotate_copy(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -106,9 +105,8 @@ void rotate_copy_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_rotate_copy_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -219,9 +217,8 @@ void rotate_copy_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_rotate_copy_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/search.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/search.cpp
@@ -22,9 +22,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_search1(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -92,9 +91,8 @@ void search_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_search2(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -166,9 +164,8 @@ void search_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_search3(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -238,9 +235,8 @@ void search_test3()
 template <typename ExPolicy, typename IteratorTag>
 void test_search4(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -314,9 +310,8 @@ void search_test4()
 template <typename ExPolicy, typename IteratorTag>
 void test_search_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -418,9 +413,8 @@ void search_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_search_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/searchn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/searchn.cpp
@@ -22,9 +22,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_search_n1(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -92,9 +91,8 @@ void search_n_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_search_n2(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -166,9 +164,8 @@ void search_n_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_search_n3(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -238,9 +235,8 @@ void search_n_test3()
 template <typename ExPolicy, typename IteratorTag>
 void test_search_n4(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -314,9 +310,8 @@ void search_n_test4()
 template <typename ExPolicy, typename IteratorTag>
 void test_search_n5(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -389,9 +384,8 @@ void search_n_test5()
 template <typename ExPolicy, typename IteratorTag>
 void test_search_n_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -489,9 +483,8 @@ void search_n_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_search_n_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/set_difference.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/set_difference.cpp
@@ -21,9 +21,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference1(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -95,9 +94,8 @@ void set_difference_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference2(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -126,9 +124,8 @@ void test_set_difference2(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference2_async(ExPolicy p, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -178,9 +175,8 @@ void set_difference_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -221,9 +217,8 @@ void test_set_difference_exception(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference_exception_async(ExPolicy p, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -291,9 +286,8 @@ void set_difference_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -333,9 +327,8 @@ void test_set_difference_bad_alloc(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference_bad_alloc_async(ExPolicy p, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/set_intersection.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/set_intersection.cpp
@@ -21,9 +21,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection1(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -95,9 +94,8 @@ void set_intersection_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection2(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -126,9 +124,8 @@ void test_set_intersection2(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection2_async(ExPolicy p, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -178,9 +175,8 @@ void set_intersection_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -221,9 +217,8 @@ void test_set_intersection_exception(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection_exception_async(ExPolicy p, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -291,9 +286,8 @@ void set_intersection_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -333,9 +327,8 @@ void test_set_intersection_bad_alloc(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection_bad_alloc_async(ExPolicy p, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/set_symmetric_difference.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/set_symmetric_difference.cpp
@@ -21,9 +21,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference1(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -95,9 +94,8 @@ void set_symmetric_difference_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference2(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -126,9 +124,8 @@ void test_set_symmetric_difference2(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference2_async(ExPolicy p, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -178,9 +175,8 @@ void set_symmetric_difference_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -221,9 +217,8 @@ void test_set_symmetric_difference_exception(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference_exception_async(ExPolicy p, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -291,9 +286,8 @@ void set_symmetric_difference_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -333,9 +327,8 @@ void test_set_symmetric_difference_bad_alloc(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference_bad_alloc_async(ExPolicy p, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/set_union.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/set_union.cpp
@@ -21,9 +21,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union1(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -95,9 +94,8 @@ void set_union_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union2(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -126,9 +124,8 @@ void test_set_union2(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union2_async(ExPolicy p, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -178,9 +175,8 @@ void set_union_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -221,9 +217,8 @@ void test_set_union_exception(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union_exception_async(ExPolicy p, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -291,9 +286,8 @@ void set_union_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -333,9 +327,8 @@ void test_set_union_bad_alloc(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union_bad_alloc_async(ExPolicy p, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/sort_by_key.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/sort_by_key.cpp
@@ -118,9 +118,8 @@ template <typename ExPolicy, typename Tkey, typename Tval, typename Op,
 void test_sort_by_key1(
     ExPolicy&& policy, Tkey, Tval, const Op& op, const HelperOp& ho)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(Tval).name(), typeid(Op).name(), sync);
     std::cout << "\n";
 
@@ -172,9 +171,8 @@ template <typename ExPolicy, typename Tkey, typename Tval, typename Op,
 void test_sort_by_key_async(
     ExPolicy&& policy, Tkey, Tval, const Op& op, const HelperOp& ho)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(Tval).name(), typeid(Op).name(), async);
     std::cout << "\n";
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/sort_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/sort_tests.hpp
@@ -124,9 +124,8 @@ int verify_(
 template <typename ExPolicy, typename T>
 void test_sort1(ExPolicy&& policy, T)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, random);
 
     // Fill vector with random values
@@ -148,9 +147,8 @@ void test_sort1(ExPolicy&& policy, T)
 template <typename ExPolicy, typename T, typename Compare = std::less<T>>
 void test_sort1_comp(ExPolicy&& policy, T, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(), sync,
         random);
 
@@ -174,9 +172,8 @@ void test_sort1_comp(ExPolicy&& policy, T, Compare comp = Compare())
 template <typename ExPolicy, typename T, typename Compare = std::less<T>>
 void test_sort1_async(ExPolicy&& policy, T, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(),
         async, random);
 
@@ -200,9 +197,8 @@ void test_sort1_async(ExPolicy&& policy, T, Compare comp = Compare())
 template <typename ExPolicy, typename T>
 void test_sort_exception(ExPolicy&& policy, T)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, random);
 
     // Fill vector with random values
@@ -279,9 +275,8 @@ void test_sort_exception(ExPolicy&& policy, T)
 template <typename ExPolicy, typename T, typename Compare>
 void test_sort_exception(ExPolicy&& policy, T, Compare comp)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(), sync,
         random);
 
@@ -360,9 +355,8 @@ void test_sort_exception(ExPolicy&& policy, T, Compare comp)
 template <typename ExPolicy, typename T>
 void test_sort_exception_async(ExPolicy&& policy, T)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", async, random);
 
     // Fill vector with random values
@@ -451,9 +445,8 @@ void test_sort_exception_async(ExPolicy&& policy, T)
 template <typename ExPolicy, typename T, typename Compare>
 void test_sort_exception_async(ExPolicy&& policy, T, Compare comp)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(),
         async, random);
 
@@ -545,9 +538,8 @@ void test_sort_exception_async(ExPolicy&& policy, T, Compare comp)
 template <typename ExPolicy, typename T>
 void test_sort2(ExPolicy&& policy, T)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, sorted);
 
     // Fill vector with increasing values
@@ -567,9 +559,8 @@ void test_sort2(ExPolicy&& policy, T)
 template <typename ExPolicy, typename T, typename Compare = std::less<T>>
 void test_sort2_comp(ExPolicy&& policy, T, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(), sync,
         sorted);
 
@@ -591,9 +582,8 @@ void test_sort2_comp(ExPolicy&& policy, T, Compare comp = Compare())
 template <typename ExPolicy, typename T, typename Compare = std::less<T>>
 void test_sort2_async(ExPolicy&& policy, T, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(),
         async, sorted);
 
@@ -618,9 +608,8 @@ void test_sort2_async(ExPolicy&& policy, T, Compare comp = Compare())
 template <typename ExPolicy>
 void test_sort1(ExPolicy&& policy, const std::string&)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(std::string).name(), "default", sync,
         random);
 
@@ -644,9 +633,8 @@ template <typename ExPolicy, typename Compare = std::less<std::string>>
 void test_sort1_comp(
     ExPolicy&& policy, const std::string&, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(std::string).name(),
         typeid(Compare).name(), sync, random);
 
@@ -670,9 +658,8 @@ void test_sort1_comp(
 template <typename ExPolicy, typename Compare = std::less<std::string>>
 void test_sort1_async_str(ExPolicy&& policy, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(std::string).name(),
         typeid(Compare).name(), async, random);
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/stable_partition_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/stable_partition_tests.hpp
@@ -73,9 +73,8 @@ struct throw_bad_alloc
 template <typename ExPolicy, typename IteratorTag>
 void test_stable_partition(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -111,9 +110,8 @@ void test_stable_partition(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_stable_partition_async(ExPolicy p, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -150,9 +148,8 @@ void test_stable_partition_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_stable_partition_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -221,9 +218,8 @@ void test_stable_partition_exception_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_stable_partition_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/stable_sort_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/stable_sort_tests.hpp
@@ -124,9 +124,8 @@ int verify_(
 template <typename ExPolicy, typename T>
 void test_stable_sort1(ExPolicy&& policy, T)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, random);
 
     // Fill vector with random values
@@ -149,9 +148,8 @@ void test_stable_sort1(ExPolicy&& policy, T)
 template <typename ExPolicy, typename T, typename Compare = std::less<T>>
 void test_stable_sort1_comp(ExPolicy&& policy, T, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(), sync,
         random);
 
@@ -175,9 +173,8 @@ void test_stable_sort1_comp(ExPolicy&& policy, T, Compare comp = Compare())
 template <typename ExPolicy, typename T, typename Compare = std::less<T>>
 void test_stable_sort1_async(ExPolicy&& policy, T, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(),
         async, random);
 
@@ -201,9 +198,8 @@ void test_stable_sort1_async(ExPolicy&& policy, T, Compare comp = Compare())
 template <typename ExPolicy, typename T>
 void test_stable_sort_exception(ExPolicy&& policy, T)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, random);
 
     // Fill vector with random values
@@ -280,9 +276,8 @@ void test_stable_sort_exception(ExPolicy&& policy, T)
 template <typename ExPolicy, typename T, typename Compare>
 void test_stable_sort_exception(ExPolicy&& policy, T, Compare comp)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(), sync,
         random);
 
@@ -361,9 +356,8 @@ void test_stable_sort_exception(ExPolicy&& policy, T, Compare comp)
 template <typename ExPolicy, typename T>
 void test_stable_sort_exception_async(ExPolicy&& policy, T)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", async, random);
 
     // Fill vector with random values
@@ -452,9 +446,8 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T)
 template <typename ExPolicy, typename T, typename Compare>
 void test_stable_sort_exception_async(ExPolicy&& policy, T, Compare comp)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(),
         async, random);
 
@@ -546,9 +539,8 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T, Compare comp)
 template <typename ExPolicy, typename T>
 void test_stable_sort2(ExPolicy&& policy, T)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, sorted);
 
     // Fill vector with increasing values
@@ -569,9 +561,8 @@ void test_stable_sort2(ExPolicy&& policy, T)
 template <typename ExPolicy, typename T, typename Compare = std::less<T>>
 void test_stable_sort2_comp(ExPolicy&& policy, T, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(), sync,
         sorted);
 
@@ -593,9 +584,8 @@ void test_stable_sort2_comp(ExPolicy&& policy, T, Compare comp = Compare())
 template <typename ExPolicy, typename T, typename Compare = std::less<T>>
 void test_stable_sort2_async(ExPolicy&& policy, T, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(),
         async, sorted);
 
@@ -620,9 +610,8 @@ void test_stable_sort2_async(ExPolicy&& policy, T, Compare comp = Compare())
 template <typename ExPolicy>
 void test_stable_sort1(ExPolicy&& policy, const std::string&)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(std::string).name(), "default", sync,
         random);
 
@@ -647,9 +636,8 @@ template <typename ExPolicy, typename Compare = std::less<std::string>>
 void test_stable_sort1_comp(
     ExPolicy&& policy, const std::string&, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(std::string).name(),
         typeid(Compare).name(), sync, random);
 
@@ -673,9 +661,8 @@ void test_stable_sort1_comp(
 template <typename ExPolicy, typename Compare = std::less<std::string>>
 void test_stable_sort1_async_str(ExPolicy&& policy, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(std::string).name(),
         typeid(Compare).name(), async, random);
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/swapranges.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/swapranges.cpp
@@ -22,9 +22,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_swap_ranges(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -113,9 +112,8 @@ void swap_ranges_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_swap_ranges_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -212,9 +210,8 @@ void swap_ranges_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_swap_ranges_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary2_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary2_tests.hpp
@@ -49,9 +49,8 @@ struct throw_bad_alloc
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary2(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -130,9 +129,8 @@ void test_transform_binary2_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary2_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -207,9 +205,8 @@ void test_transform_binary2_exception_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary2_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary_tests.hpp
@@ -49,9 +49,8 @@ struct throw_bad_alloc
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -128,9 +127,8 @@ void test_transform_binary_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -205,9 +203,8 @@ void test_transform_binary_exception_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_exclusive_scan.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_exclusive_scan.cpp
@@ -22,9 +22,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_exclusive_scan(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -114,9 +113,8 @@ void transform_exclusive_scan_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_exclusive_scan_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -217,9 +215,8 @@ void transform_exclusive_scan_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_exclusive_scan_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_inclusive_scan.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_inclusive_scan.cpp
@@ -22,9 +22,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_inclusive_scan1(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -114,9 +113,8 @@ void transform_inclusive_scan_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_inclusive_scan2(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -204,9 +202,8 @@ void transform_inclusive_scan_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_inclusive_scan_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -306,9 +303,8 @@ void transform_inclusive_scan_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_inclusive_scan_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce.cpp
@@ -60,9 +60,8 @@ void test_transform_reduce(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -180,9 +179,8 @@ void test_transform_reduce_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -314,9 +312,8 @@ void test_transform_reduce_bad_alloc(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce_binary_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce_binary_bad_alloc.cpp
@@ -53,9 +53,8 @@ void test_transform_reduce_binary_bad_alloc(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce_binary_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce_binary_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce_binary_exception.cpp
@@ -55,9 +55,8 @@ void test_transform_reduce_binary_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce_binary_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce_binary_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce_binary_tests.hpp
@@ -41,9 +41,8 @@ void test_transform_reduce_binary(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce_binary(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -62,9 +61,8 @@ void test_transform_reduce_binary(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce_binary_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_tests.hpp
@@ -49,9 +49,8 @@ struct throw_bad_alloc
 template <typename ExPolicy, typename IteratorTag>
 void test_transform(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -110,9 +109,8 @@ void test_transform_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -181,9 +179,8 @@ void test_transform_exception_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_copy_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_copy_tests.hpp
@@ -26,9 +26,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_copy(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -78,9 +77,8 @@ void test_uninitialized_copy_async(ExPolicy&& p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_copy_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<test::count_instances>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -169,9 +167,8 @@ void test_uninitialized_copy_exception_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_copy_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<test::count_instances>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_copyn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_copyn.cpp
@@ -23,9 +23,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_copy_n(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -94,9 +93,8 @@ void uninitialized_copy_n_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_copy_n_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<test::count_instances>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -206,9 +204,8 @@ void uninitialized_copy_n_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_copy_n_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<test::count_instances>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_default_construct_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_default_construct_tests.hpp
@@ -43,9 +43,8 @@ std::size_t const data_size = 10007;
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_default_construct(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef default_constructable* base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -96,9 +95,8 @@ void test_uninitialized_default_construct_async(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_default_construct2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef value_constructable* base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -151,9 +149,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_default_construct_exception(
     ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef test::count_instances_v<default_constructable> data_type;
     typedef data_type* base_iterator;
@@ -256,9 +253,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_default_construct_bad_alloc(
     ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef test::count_instances_v<default_constructable> data_type;
     typedef data_type* base_iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_default_constructn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_default_constructn.cpp
@@ -40,9 +40,8 @@ std::size_t const data_size = 10007;
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_default_construct_n(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef default_constructable* base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -93,9 +92,8 @@ void test_uninitialized_default_construct_n_async(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_default_construct_n2(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef value_constructable* base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -174,9 +172,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_default_construct_n_exception(
     ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef test::count_instances_v<default_constructable> data_type;
     typedef data_type* base_iterator;
@@ -304,9 +301,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_default_construct_n_bad_alloc(
     ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef test::count_instances_v<default_constructable> data_type;
     typedef data_type* base_iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_fill.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_fill.cpp
@@ -23,9 +23,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_fill(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -88,9 +87,8 @@ void uninitialized_fill_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_fill_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<test::count_instances>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -199,9 +197,8 @@ void uninitialized_fill_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_fill_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<test::count_instances>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_filln.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_filln.cpp
@@ -23,9 +23,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_fill_n(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -88,9 +87,8 @@ void uninitialized_fill_n_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_fill_n_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<test::count_instances>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -199,9 +197,8 @@ void uninitialized_fill_n_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_fill_n_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<test::count_instances>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_move_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_move_tests.hpp
@@ -26,9 +26,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_move(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -78,9 +77,8 @@ void test_uninitialized_move_async(ExPolicy&& p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_move_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<test::count_instances>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -169,9 +167,8 @@ void test_uninitialized_move_exception_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_move_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<test::count_instances>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_moven.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_moven.cpp
@@ -23,9 +23,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_move_n(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -94,9 +93,8 @@ void uninitialized_move_n_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_move_n_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<test::count_instances>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -206,9 +204,8 @@ void uninitialized_move_n_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_move_n_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<test::count_instances>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_value_construct_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_value_construct_tests.hpp
@@ -33,9 +33,8 @@ std::size_t const data_size = 10007;
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_value_construct(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef value_constructable* base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -87,9 +86,8 @@ void test_uninitialized_value_construct_async(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_value_construct_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef test::count_instances_v<value_constructable> data_type;
     typedef data_type* base_iterator;
@@ -191,9 +189,8 @@ void test_uninitialized_value_construct_exception_async(
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_value_construct_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef test::count_instances_v<value_constructable> data_type;
     typedef data_type* base_iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_value_constructn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_value_constructn.cpp
@@ -30,9 +30,8 @@ std::size_t const data_size = 10007;
 template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_value_construct_n(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef value_constructable* base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -104,9 +103,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_value_construct_n_exception(
     ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef test::count_instances_v<value_constructable> data_type;
     typedef data_type* base_iterator;
@@ -233,9 +231,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_uninitialized_value_construct_n_bad_alloc(
     ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef test::count_instances_v<value_constructable> data_type;
     typedef data_type* base_iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/unique_copy_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/unique_copy_tests.hpp
@@ -123,9 +123,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType,
 void test_unique_copy(
     ExPolicy policy, IteratorTag, DataType, Pred pred, int rand_base)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -152,9 +151,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType,
 void test_unique_copy_async(
     ExPolicy policy, IteratorTag, DataType, Pred pred, int rand_base)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -181,9 +179,8 @@ void test_unique_copy_async(
 template <typename ExPolicy, typename IteratorTag>
 void test_unique_copy_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -254,9 +251,8 @@ void test_unique_copy_exception_async(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_unique_copy_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -326,9 +322,8 @@ void test_unique_copy_bad_alloc_async(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag, typename DataType>
 void test_unique_copy_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/unique_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/unique_tests.hpp
@@ -123,9 +123,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType,
 void test_unique(
     ExPolicy policy, IteratorTag, DataType, Pred pred, int rand_base)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -150,9 +149,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType,
 void test_unique_async(
     ExPolicy policy, IteratorTag, DataType, Pred pred, int rand_base)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -177,9 +175,8 @@ void test_unique_async(
 template <typename ExPolicy, typename IteratorTag>
 void test_unique_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -249,9 +246,8 @@ void test_unique_exception_async(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_unique_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -319,9 +315,8 @@ void test_unique_bad_alloc_async(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag, typename DataType>
 void test_unique_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/all_of_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/all_of_range.cpp
@@ -48,9 +48,8 @@ template <typename ExPolicy, typename IteratorTag,
     typename Proj = hpx::parallel::util::projection_identity>
 void test_all_of(ExPolicy&& policy, IteratorTag, Proj proj = Proj())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -199,9 +198,8 @@ void test_all_of_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_all_of_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -301,9 +299,8 @@ void all_of_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_all_of_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/any_of_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/any_of_range.cpp
@@ -48,9 +48,8 @@ template <typename ExPolicy, typename IteratorTag,
     typename Proj = hpx::parallel::util::projection_identity>
 void test_any_of(ExPolicy&& policy, IteratorTag, Proj proj = Proj())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -199,9 +198,8 @@ void test_any_of_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_any_of_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -301,9 +299,8 @@ void any_of_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_any_of_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/copy_range.cpp
@@ -47,9 +47,8 @@ void test_copy(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_copy(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -156,9 +155,8 @@ void test_copy_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_copy_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -257,9 +255,8 @@ void copy_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_copy_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/copyif_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/copyif_range.cpp
@@ -55,9 +55,8 @@ void test_copy_if_seq()
 template <typename ExPolicy>
 void test_copy_if(ExPolicy&& policy)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, std::random_access_iterator_tag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/copyn_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/copyn_range.cpp
@@ -49,9 +49,8 @@ void test_copy_n(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_copy_n(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -155,9 +154,8 @@ void test_copy_n_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_copy_n_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -255,9 +253,8 @@ void copy_n_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_copy_n_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/count_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/count_range.cpp
@@ -72,9 +72,8 @@ void test_count(IteratorTag, DataType)
 template <typename ExPolicy, typename IteratorTag, typename DataType>
 void test_count(ExPolicy&& policy, IteratorTag, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<DataType> c{10007};
     std::generate(std::begin(c), std::end(c), random_fill(0, 20));
@@ -90,9 +89,8 @@ void test_count(ExPolicy&& policy, IteratorTag, DataType)
 template <typename ExPolicy, typename IteratorTag, typename DataType>
 void test_count_async(ExPolicy&& policy, IteratorTag, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<DataType> c{10007};
     std::generate(std::begin(c), std::end(c), random_fill(0, 20));

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/countif_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/countif_range.cpp
@@ -77,9 +77,8 @@ void test_count(IteratorTag, DataType)
 template <typename ExPolicy, typename IteratorTag, typename DataType>
 void test_count(ExPolicy&& policy, IteratorTag, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<DataType> c{10007};
     std::generate(std::begin(c), std::end(c), random_fill(0, 20));
@@ -95,9 +94,8 @@ void test_count(ExPolicy&& policy, IteratorTag, DataType)
 template <typename ExPolicy, typename IteratorTag, typename DataType>
 void test_count_async(ExPolicy&& policy, IteratorTag, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<DataType> c{10007};
     std::generate(std::begin(c), std::end(c), random_fill(0, 20));

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/destroy_range_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/destroy_range_tests.hpp
@@ -73,9 +73,8 @@ void test_destroy(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_destroy(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef destructable* base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -180,9 +179,8 @@ void test_destroy_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_destroy_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef test::count_instances_v<destructable> data_type;
     typedef data_type* base_iterator;
@@ -297,9 +295,8 @@ void test_destroy_exception_async(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_destroy_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef test::count_instances_v<destructable> data_type;
     typedef data_type* base_iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/destroyn_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/destroyn_range.cpp
@@ -71,9 +71,8 @@ void test_destroy_n(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_destroy_n(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef destructable* base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -199,9 +198,8 @@ void test_destroy_n_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_destroy_n_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef test::count_instances_v<destructable> data_type;
     typedef data_type* base_iterator;
@@ -339,9 +337,8 @@ void destroy_n_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_destroy_n_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef test::count_instances_v<destructable> data_type;
     typedef data_type* base_iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/equal_binary_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/equal_binary_range.cpp
@@ -68,9 +68,8 @@ void test_equal_binary1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_equal_binary1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef hpx::util::iterator_range<base_iterator> base_range;
@@ -225,9 +224,8 @@ void test_equal_binary2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_equal_binary2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef hpx::util::iterator_range<base_iterator> base_range;
@@ -383,9 +381,8 @@ void test_equal_binary_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_equal_binary_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef hpx::util::iterator_range<base_iterator> base_range;
@@ -495,9 +492,8 @@ void equal_binary_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_equal_binary_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef hpx::util::iterator_range<base_iterator> base_range;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/equal_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/equal_range.cpp
@@ -64,9 +64,8 @@ void test_equal1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_equal1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -211,9 +210,8 @@ void test_equal2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_equal2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -357,9 +355,8 @@ void test_equal_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_equal_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -463,9 +460,8 @@ void equal_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_equal_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/fill_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/fill_range.cpp
@@ -41,9 +41,8 @@ void test_fill(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_fill(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/filln_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/filln_range.cpp
@@ -40,9 +40,8 @@ void test_fill_n(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_fill_n(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), std::rand());

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_end_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_end_range.cpp
@@ -53,9 +53,8 @@ void test_find_end1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
 
@@ -102,9 +101,8 @@ void test_find_end1_proj(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end1_proj(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
 
@@ -229,9 +227,8 @@ void test_find_end2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
 
@@ -284,9 +281,8 @@ void test_find_end2_proj(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end2_proj(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
 
@@ -421,9 +417,8 @@ void test_find_end3(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end3(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
 
@@ -474,9 +469,8 @@ void test_find_end3_proj(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end3_proj(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
 
@@ -611,9 +605,8 @@ void test_find_end4(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end4(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
 
@@ -664,9 +657,8 @@ void test_find_end4_proj(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end4_proj(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_end_range2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_end_range2.cpp
@@ -56,9 +56,8 @@ void test_find_end1_proj(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end1_proj(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -164,9 +163,8 @@ void test_find_end2_proj(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end2_proj(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -278,9 +276,8 @@ void test_find_end3_proj(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end3_proj(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -392,9 +389,8 @@ void test_find_end4_proj(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end4_proj(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -476,9 +472,8 @@ void find_end_test4()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -626,9 +621,8 @@ void find_end_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_end_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_first_of_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_first_of_range.cpp
@@ -48,9 +48,8 @@ void test_find_first_of(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
 
@@ -95,9 +94,8 @@ void test_find_first_of_proj(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of_proj(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_first_of_range2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_first_of_range2.cpp
@@ -53,9 +53,8 @@ void test_find_first_of_proj(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of_proj(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -166,9 +165,8 @@ void test_find_first_of_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -268,9 +266,8 @@ void find_first_of_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_first_of_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_if_not_exception_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_if_not_exception_range.cpp
@@ -59,9 +59,8 @@ void test_find_if_not_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_if_not_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_if_not_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_if_not_range.cpp
@@ -46,9 +46,8 @@ void test_find_if_not(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_if_not(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_if_range.cpp
@@ -47,9 +47,8 @@ void test_find_if(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_if(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -147,9 +146,8 @@ void test_find_if_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_if_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -245,9 +243,8 @@ void find_if_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_if_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_range.cpp
@@ -46,9 +46,8 @@ void test_find(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -144,9 +143,8 @@ void test_find_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_find_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -242,9 +240,8 @@ void find_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_find_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_tests.hpp
@@ -60,8 +60,7 @@ void test_for_each_seq(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each(ExPolicy&& policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value);
+    BOOST_STATIC_ASSERT(hpx::is_execution_policy<ExPolicy>::value);
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -155,8 +154,7 @@ void test_for_each_exception_seq(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_exception(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value);
+    BOOST_STATIC_ASSERT(hpx::is_execution_policy<ExPolicy>::value);
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -270,8 +268,7 @@ void test_for_each_bad_alloc_seq(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    BOOST_STATIC_ASSERT(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value);
+    BOOST_STATIC_ASSERT(hpx::is_execution_policy<ExPolicy>::value);
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_tests_projection.hpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_tests_projection.hpp
@@ -55,8 +55,7 @@ void test_for_each_seq(IteratorTag, Proj&& proj)
 template <typename ExPolicy, typename IteratorTag, typename Proj>
 void test_for_each(ExPolicy&& policy, IteratorTag, Proj&& proj)
 {
-    BOOST_STATIC_ASSERT(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value);
+    BOOST_STATIC_ASSERT(hpx::is_execution_policy<ExPolicy>::value);
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -153,8 +152,7 @@ void test_for_each_exception_seq(IteratorTag, Proj&& proj)
 template <typename ExPolicy, typename IteratorTag, typename Proj>
 void test_for_each_exception(ExPolicy policy, IteratorTag, Proj&& proj)
 {
-    BOOST_STATIC_ASSERT(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value);
+    BOOST_STATIC_ASSERT(hpx::is_execution_policy<ExPolicy>::value);
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -270,8 +268,7 @@ void test_for_each_bad_alloc_seq(IteratorTag, Proj&& proj)
 template <typename ExPolicy, typename IteratorTag, typename Proj>
 void test_for_each_bad_alloc(ExPolicy policy, IteratorTag, Proj&& proj)
 {
-    BOOST_STATIC_ASSERT(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value);
+    BOOST_STATIC_ASSERT(hpx::is_execution_policy<ExPolicy>::value);
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/generate_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/generate_range.cpp
@@ -50,9 +50,8 @@ void test_generate(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_generate(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -161,9 +160,8 @@ void test_generate_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_generate_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -263,9 +261,8 @@ void generate_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_generate_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/inplace_merge_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/inplace_merge_range.cpp
@@ -92,9 +92,8 @@ struct random_fill
 template <typename ExPolicy, typename DataType>
 void test_inplace_merge(ExPolicy policy, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::size_t const left_size = 300007, right_size = 123456;
     std::vector<DataType> res(left_size + right_size), sol;
@@ -126,9 +125,8 @@ void test_inplace_merge(ExPolicy policy, DataType)
 template <typename ExPolicy, typename DataType>
 void test_inplace_merge_async(ExPolicy policy, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::size_t const left_size = 300007, right_size = 123456;
     std::vector<DataType> res(left_size + right_size), sol;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/is_heap_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/is_heap_range.cpp
@@ -74,9 +74,8 @@ void test_is_heap(DataType)
 template <typename ExPolicy, typename DataType>
 void test_is_heap(ExPolicy&& policy, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     using hpx::get;
 
@@ -96,9 +95,8 @@ void test_is_heap(ExPolicy&& policy, DataType)
 template <typename ExPolicy, typename DataType>
 void test_is_heap_async(ExPolicy&& policy, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     using hpx::get;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/is_heap_until_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/is_heap_until_range.cpp
@@ -74,9 +74,8 @@ void test_is_heap_until(DataType)
 template <typename ExPolicy, typename DataType>
 void test_is_heap_until(ExPolicy&& policy, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     using hpx::get;
 
@@ -96,9 +95,8 @@ void test_is_heap_until(ExPolicy&& policy, DataType)
 template <typename ExPolicy, typename DataType>
 void test_is_heap_until_async(ExPolicy&& policy, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     using hpx::get;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/max_element_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/max_element_range.cpp
@@ -22,9 +22,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_max_element(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
@@ -105,9 +104,8 @@ void max_element_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_max_element_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -262,9 +260,8 @@ void max_element_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_max_element_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/merge_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/merge_range.cpp
@@ -92,9 +92,8 @@ struct random_fill
 template <typename ExPolicy, typename DataType>
 void test_merge(ExPolicy policy, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     using hpx::get;
 
@@ -124,9 +123,8 @@ void test_merge(ExPolicy policy, DataType)
 template <typename ExPolicy, typename DataType>
 void test_merge_async(ExPolicy policy, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     using hpx::get;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/min_element_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/min_element_range.cpp
@@ -22,9 +22,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_min_element(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
@@ -104,9 +103,8 @@ void min_element_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_min_element_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -264,9 +262,8 @@ void min_element_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_min_element_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/minmax_element_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/minmax_element_range.cpp
@@ -24,9 +24,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_minmax_element(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -116,9 +115,8 @@ void minmax_element_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_minmax_element_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -276,9 +274,8 @@ void minmax_element_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_minmax_element_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/mismatch_binary_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/mismatch_binary_range.cpp
@@ -73,9 +73,8 @@ void test_mismatch_binary1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_binary1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef hpx::util::iterator_range<base_iterator> base_range;
@@ -240,9 +239,8 @@ void test_mismatch_binary2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_binary2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef hpx::util::iterator_range<base_iterator> base_range;
@@ -405,9 +403,8 @@ void test_mismatch_binary_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_binary_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef hpx::util::iterator_range<base_iterator> base_range;
@@ -517,9 +514,8 @@ void mismatch_binary_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_binary_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef hpx::util::iterator_range<base_iterator> base_range;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/mismatch_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/mismatch_range.cpp
@@ -71,9 +71,8 @@ void test_mismatch1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef hpx::util::iterator_range<base_iterator> base_range;
@@ -230,9 +229,8 @@ void test_mismatch2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef hpx::util::iterator_range<base_iterator> base_range;
@@ -385,9 +383,8 @@ void test_mismatch_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef hpx::util::iterator_range<base_iterator> base_range;
@@ -493,9 +490,8 @@ void mismatch_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef hpx::util::iterator_range<base_iterator> base_range;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/move_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/move_range.cpp
@@ -53,9 +53,8 @@ void test_move(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_move(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -136,9 +135,8 @@ void move_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_move_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -237,9 +235,8 @@ void move_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_move_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/none_of_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/none_of_range.cpp
@@ -47,9 +47,8 @@ template <typename ExPolicy, typename IteratorTag,
     typename Proj = hpx::parallel::util::projection_identity>
 void test_none_of(ExPolicy&& policy, IteratorTag, Proj proj = Proj())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -197,9 +196,8 @@ void test_none_of_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_none_of_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -299,9 +297,8 @@ void none_of_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_none_of_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/partition_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/partition_copy_range.cpp
@@ -83,9 +83,8 @@ struct random_fill
 template <typename ExPolicy, typename DataType>
 void test_partition_copy(ExPolicy policy, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     using hpx::get;
 
@@ -119,9 +118,8 @@ void test_partition_copy(ExPolicy policy, DataType)
 template <typename ExPolicy, typename DataType>
 void test_partition_copy_async(ExPolicy policy, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     using hpx::get;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/partition_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/partition_range.cpp
@@ -89,9 +89,8 @@ struct random_fill
 template <typename ExPolicy, typename DataType>
 void test_partition(ExPolicy policy, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     using hpx::get;
 
@@ -127,9 +126,8 @@ void test_partition(ExPolicy policy, DataType)
 template <typename ExPolicy, typename DataType>
 void test_partition_async(ExPolicy policy, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     using hpx::get;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/reduce_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/reduce_range.cpp
@@ -26,9 +26,8 @@ std::mt19937 gen(seed);
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce1(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -89,9 +88,8 @@ void reduce_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce2(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -148,9 +146,8 @@ void reduce_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce3(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -207,9 +204,8 @@ void reduce_test3()
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -301,9 +297,8 @@ void reduce_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_if_range.cpp
@@ -22,9 +22,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_if(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -103,9 +102,8 @@ void test_remove_copy_if_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_if_outiter(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -186,9 +184,8 @@ void remove_copy_if_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_if_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -286,9 +283,8 @@ void remove_copy_if_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_if_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_range.cpp
@@ -23,9 +23,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -86,9 +85,8 @@ void test_remove_copy_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_outiter(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -174,9 +172,8 @@ void remove_copy_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -275,9 +272,8 @@ void remove_copy_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_if_range.cpp
@@ -70,9 +70,8 @@ struct random_fill
 template <typename ExPolicy, typename DataType>
 void test_remove_if(ExPolicy policy, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     using hpx::get;
 
@@ -94,9 +93,8 @@ void test_remove_if(ExPolicy policy, DataType)
 template <typename ExPolicy, typename DataType>
 void test_remove_if_async(ExPolicy policy, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     using hpx::get;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_range.cpp
@@ -70,9 +70,8 @@ struct random_fill
 template <typename ExPolicy, typename DataType>
 void test_remove(ExPolicy policy, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     using hpx::get;
 
@@ -94,9 +93,8 @@ void test_remove(ExPolicy policy, DataType)
 template <typename ExPolicy, typename DataType>
 void test_remove_async(ExPolicy policy, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     using hpx::get;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_if_range.cpp
@@ -38,9 +38,8 @@ struct equal_f
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_if(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -128,9 +127,8 @@ void replace_copy_if_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_if_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -229,9 +227,8 @@ void replace_copy_if_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_if_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_range.cpp
@@ -23,9 +23,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -112,9 +111,8 @@ void replace_copy_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -213,9 +211,8 @@ void replace_copy_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_if_range.cpp
@@ -38,9 +38,8 @@ struct equal_f
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_if(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -122,9 +121,8 @@ void replace_if_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_if_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -221,9 +219,8 @@ void replace_if_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_if_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_range.cpp
@@ -23,9 +23,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_replace(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -107,9 +106,8 @@ void replace_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -206,9 +204,8 @@ void replace_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/reverse_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/reverse_copy_range.cpp
@@ -23,9 +23,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse_copy(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -105,9 +104,8 @@ void reverse_copy_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse_copy_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -204,9 +202,8 @@ void reverse_copy_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse_copy_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/reverse_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/reverse_range.cpp
@@ -23,9 +23,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -105,9 +104,8 @@ void reverse_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -200,9 +198,8 @@ void reverse_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/rotate_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/rotate_copy_range.cpp
@@ -23,9 +23,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_rotate_copy(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -123,9 +122,8 @@ void rotate_copy_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_rotate_copy_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -238,9 +236,8 @@ void rotate_copy_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_rotate_copy_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/rotate_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/rotate_range.cpp
@@ -23,9 +23,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_rotate(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -118,9 +117,8 @@ void rotate_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_rotate_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -231,9 +229,8 @@ void rotate_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_rotate_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/search_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/search_range.cpp
@@ -42,9 +42,8 @@ struct user_defined_type_2
 template <typename ExPolicy, typename IteratorTag>
 void test_search1(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     // fill vector with random values above 2
@@ -103,9 +102,8 @@ void search_test1()
 template <typename ExPolicy, typename IteratorTag>
 void test_search2(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     // fill vector with random values about 2
@@ -172,9 +170,8 @@ void search_test2()
 template <typename ExPolicy, typename IteratorTag>
 void test_search3(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     // fill vector with random values above 2
@@ -236,9 +233,8 @@ void search_test3()
 template <typename ExPolicy, typename IteratorTag>
 void test_search4(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     // fill vector with random values above 2
@@ -303,9 +299,8 @@ void search_test4()
 template <typename ExPolicy, typename IteratorTag>
 void test_search5(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<user_defined_type_1> c(10007);
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/searchn_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/searchn_range.cpp
@@ -42,9 +42,8 @@ struct user_defined_type_2
 template <typename ExPolicy, typename IteratorTag>
 void test_search_n1(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     // fill vector with random values above 2
@@ -103,9 +102,8 @@ void search_test_n1()
 template <typename ExPolicy, typename IteratorTag>
 void test_search_n2(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     // fill vector with random values about 2
@@ -173,9 +171,8 @@ void search_test_n2()
 template <typename ExPolicy, typename IteratorTag>
 void test_search_n3(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     // fill vector with random values above 2
@@ -237,9 +234,8 @@ void search_test_n3()
 template <typename ExPolicy, typename IteratorTag>
 void test_search_n4(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<std::size_t> c(10007);
     // fill vector with random values above 2
@@ -304,9 +300,8 @@ void search_test_n4()
 template <typename ExPolicy, typename IteratorTag>
 void test_search_n5(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     std::vector<user_defined_type_1> c(10007);
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/sort_range_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/sort_range_tests.hpp
@@ -125,9 +125,8 @@ int verify_(
 template <typename ExPolicy, typename T>
 void test_sort1(ExPolicy&& policy, T)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, random);
 
     // Fill vector with random values
@@ -149,9 +148,8 @@ void test_sort1(ExPolicy&& policy, T)
 template <typename ExPolicy, typename T, typename Compare = std::less<T>>
 void test_sort1_comp(ExPolicy&& policy, T, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(), sync,
         random);
 
@@ -174,9 +172,8 @@ void test_sort1_comp(ExPolicy&& policy, T, Compare comp = Compare())
 template <typename ExPolicy, typename T, typename Compare = std::less<T>>
 void test_sort1_async(ExPolicy&& policy, T, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(),
         async, random);
 
@@ -200,9 +197,8 @@ void test_sort1_async(ExPolicy&& policy, T, Compare comp = Compare())
 template <typename ExPolicy, typename T>
 void test_sort_exception(ExPolicy&& policy, T)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, random);
 
     // Fill vector with random values
@@ -282,9 +278,8 @@ void test_sort_exception(ExPolicy&& policy, T)
 template <typename ExPolicy, typename T, typename Compare>
 void test_sort_exception(ExPolicy&& policy, T, Compare comp)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(), sync,
         random);
 
@@ -368,9 +363,8 @@ void test_sort_exception(ExPolicy&& policy, T, Compare comp)
 template <typename ExPolicy, typename T>
 void test_sort_exception_async(ExPolicy&& policy, T)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", async, random);
 
     // Fill vector with random values
@@ -462,9 +456,8 @@ void test_sort_exception_async(ExPolicy&& policy, T)
 template <typename ExPolicy, typename T, typename Compare>
 void test_sort_exception_async(ExPolicy&& policy, T, Compare comp)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(),
         async, random);
 
@@ -561,9 +554,8 @@ void test_sort_exception_async(ExPolicy&& policy, T, Compare comp)
 template <typename ExPolicy, typename T>
 void test_sort2(ExPolicy&& policy, T)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, sorted);
 
     // Fill vector with increasing values
@@ -583,9 +575,8 @@ void test_sort2(ExPolicy&& policy, T)
 template <typename ExPolicy, typename T, typename Compare = std::less<T>>
 void test_sort2_comp(ExPolicy&& policy, T, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(), sync,
         sorted);
 
@@ -607,9 +598,8 @@ void test_sort2_comp(ExPolicy&& policy, T, Compare comp = Compare())
 template <typename ExPolicy, typename T, typename Compare = std::less<T>>
 void test_sort2_async(ExPolicy&& policy, T, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(),
         async, sorted);
 
@@ -634,9 +624,8 @@ void test_sort2_async(ExPolicy&& policy, T, Compare comp = Compare())
 template <typename ExPolicy>
 void test_sort1(ExPolicy&& policy, const std::string&)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(std::string).name(), "default", sync,
         random);
 
@@ -660,9 +649,8 @@ template <typename ExPolicy, typename Compare = std::less<std::string>>
 void test_sort1_comp(
     ExPolicy&& policy, const std::string&, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(std::string).name(),
         typeid(Compare).name(), sync, random);
 
@@ -687,9 +675,8 @@ template <typename ExPolicy, typename Compare = std::less<std::string>>
 void test_sort1_async_string(
     ExPolicy&& policy, const std::string&, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(std::string).name(),
         typeid(Compare).name(), async, random);
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/stable_sort_range_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/stable_sort_range_tests.hpp
@@ -125,9 +125,8 @@ int verify_(
 template <typename ExPolicy, typename T>
 void test_stable_sort1(ExPolicy&& policy, T)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, random);
 
     // Fill vector with random values
@@ -149,9 +148,8 @@ void test_stable_sort1(ExPolicy&& policy, T)
 template <typename ExPolicy, typename T, typename Compare = std::less<T>>
 void test_stable_sort1_comp(ExPolicy&& policy, T, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(), sync,
         random);
 
@@ -174,9 +172,8 @@ void test_stable_sort1_comp(ExPolicy&& policy, T, Compare comp = Compare())
 template <typename ExPolicy, typename T, typename Compare = std::less<T>>
 void test_stable_sort1_async(ExPolicy&& policy, T, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(),
         async, random);
 
@@ -200,9 +197,8 @@ void test_stable_sort1_async(ExPolicy&& policy, T, Compare comp = Compare())
 template <typename ExPolicy, typename T>
 void test_stable_sort_exception(ExPolicy&& policy, T)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, random);
 
     // Fill vector with random values
@@ -282,9 +278,8 @@ void test_stable_sort_exception(ExPolicy&& policy, T)
 template <typename ExPolicy, typename T, typename Compare>
 void test_stable_sort_exception(ExPolicy&& policy, T, Compare comp)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(), sync,
         random);
 
@@ -368,9 +363,8 @@ void test_stable_sort_exception(ExPolicy&& policy, T, Compare comp)
 template <typename ExPolicy, typename T>
 void test_stable_sort_exception_async(ExPolicy&& policy, T)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", async, random);
 
     // Fill vector with random values
@@ -462,9 +456,8 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T)
 template <typename ExPolicy, typename T, typename Compare>
 void test_stable_sort_exception_async(ExPolicy&& policy, T, Compare comp)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(),
         async, random);
 
@@ -561,9 +554,8 @@ void test_stable_sort_exception_async(ExPolicy&& policy, T, Compare comp)
 template <typename ExPolicy, typename T>
 void test_stable_sort2(ExPolicy&& policy, T)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), "default", sync, sorted);
 
     // Fill vector with increasing values
@@ -583,9 +575,8 @@ void test_stable_sort2(ExPolicy&& policy, T)
 template <typename ExPolicy, typename T, typename Compare = std::less<T>>
 void test_stable_sort2_comp(ExPolicy&& policy, T, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(), sync,
         sorted);
 
@@ -607,9 +598,8 @@ void test_stable_sort2_comp(ExPolicy&& policy, T, Compare comp = Compare())
 template <typename ExPolicy, typename T, typename Compare = std::less<T>>
 void test_stable_sort2_async(ExPolicy&& policy, T, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(T).name(), typeid(Compare).name(),
         async, sorted);
 
@@ -634,9 +624,8 @@ void test_stable_sort2_async(ExPolicy&& policy, T, Compare comp = Compare())
 template <typename ExPolicy>
 void test_stable_sort1(ExPolicy&& policy, const std::string&)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(std::string).name(), "default", sync,
         random);
 
@@ -660,9 +649,8 @@ template <typename ExPolicy, typename Compare = std::less<std::string>>
 void test_stable_sort1_comp(
     ExPolicy&& policy, const std::string&, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(std::string).name(),
         typeid(Compare).name(), sync, random);
 
@@ -687,9 +675,8 @@ template <typename ExPolicy, typename Compare = std::less<std::string>>
 void test_stable_sort1_async_string(
     ExPolicy&& policy, const std::string&, Compare comp = Compare())
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
     msg(typeid(ExPolicy).name(), typeid(std::string).name(),
         typeid(Compare).name(), async, random);
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range.cpp
@@ -23,9 +23,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_transform(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -108,9 +107,8 @@ void transform_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -206,9 +204,8 @@ void transform_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary.cpp
@@ -23,9 +23,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -125,9 +124,8 @@ void transform_binary_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -229,9 +227,8 @@ void transform_binary_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary2.cpp
@@ -23,9 +23,8 @@
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -123,9 +122,8 @@ void transform_binary_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -229,9 +227,8 @@ void transform_binary_exception_test()
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_binary_bad_alloc_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_binary_bad_alloc_range.cpp
@@ -53,9 +53,8 @@ void test_transform_reduce_binary_bad_alloc(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce_binary_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_binary_exception_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_binary_exception_range.cpp
@@ -56,9 +56,8 @@ void test_transform_reduce_binary_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce_binary_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_binary_tests_range.hpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_binary_tests_range.hpp
@@ -41,9 +41,8 @@ void test_transform_reduce_binary(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce_binary(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -62,9 +61,8 @@ void test_transform_reduce_binary(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce_binary_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_range.cpp
@@ -61,9 +61,8 @@ void test_transform_reduce(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -182,9 +181,8 @@ void test_transform_reduce_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -316,9 +314,8 @@ void test_transform_reduce_bad_alloc(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_reduce_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_copy_range.cpp
@@ -70,9 +70,8 @@ struct random_fill
 template <typename ExPolicy, typename DataType>
 void test_unique_copy(ExPolicy policy, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     using hpx::get;
 
@@ -95,9 +94,8 @@ void test_unique_copy(ExPolicy policy, DataType)
 template <typename ExPolicy, typename DataType>
 void test_unique_copy_async(ExPolicy policy, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     using hpx::get;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_range.cpp
@@ -70,9 +70,8 @@ struct random_fill
 template <typename ExPolicy, typename DataType>
 void test_unique(ExPolicy policy, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     using hpx::get;
 
@@ -92,9 +91,8 @@ void test_unique(ExPolicy policy, DataType)
 template <typename ExPolicy, typename DataType>
 void test_unique_async(ExPolicy policy, DataType)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     using hpx::get;
 

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_datapar_zipiter.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_datapar_zipiter.cpp
@@ -36,9 +36,8 @@ struct set_42
 template <typename ExPolicy, typename IteratorTag>
 void for_each_zipiter_test(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_tests.hpp
@@ -54,9 +54,8 @@ struct throw_bad_alloc
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -106,9 +105,8 @@ void test_for_each_async(ExPolicy&& p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -175,9 +173,8 @@ void test_for_each_exception_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -242,9 +239,8 @@ void test_for_each_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_n(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/execution/include/hpx/execution/traits/is_execution_policy.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/traits/is_execution_policy.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016-2017 Hartmut Kaiser
+//  Copyright (c) 2016-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -13,7 +13,7 @@
 
 #include <type_traits>
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx {
     namespace detail {
         /// \cond NOINTERNAL
         template <typename T>
@@ -61,10 +61,13 @@ namespace hpx { namespace parallel { namespace execution {
     ///
     template <typename T>
     struct is_execution_policy
-      : execution::detail::is_execution_policy<
-            typename hpx::util::decay<T>::type>
+      : hpx::detail::is_execution_policy<typename hpx::util::decay<T>::type>
     {
     };
+
+    template <typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_execution_policy_v =
+        is_execution_policy<T>::value;
 
     ///////////////////////////////////////////////////////////////////////////
     /// Extension: Detect whether given execution policy enables parallelization
@@ -81,10 +84,14 @@ namespace hpx { namespace parallel { namespace execution {
     ///
     template <typename T>
     struct is_parallel_execution_policy
-      : execution::detail::is_parallel_execution_policy<
+      : hpx::detail::is_parallel_execution_policy<
             typename hpx::util::decay<T>::type>
     {
     };
+
+    template <typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_parallel_execution_policy_v =
+        is_parallel_execution_policy<T>::value;
 
     ///////////////////////////////////////////////////////////////////////////
     /// Extension: Detect whether given execution policy does not enable
@@ -104,10 +111,14 @@ namespace hpx { namespace parallel { namespace execution {
     // extension:
     template <typename T>
     struct is_sequenced_execution_policy
-      : execution::detail::is_sequenced_execution_policy<
+      : hpx::detail::is_sequenced_execution_policy<
             typename hpx::util::decay<T>::type>
     {
     };
+
+    template <typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_sequenced_execution_policy_v =
+        is_sequenced_execution_policy<T>::value;
 
     ///////////////////////////////////////////////////////////////////////////
     /// Extension: Detect whether given execution policy makes algorithms
@@ -127,25 +138,77 @@ namespace hpx { namespace parallel { namespace execution {
     // extension:
     template <typename T>
     struct is_async_execution_policy
-      : execution::detail::is_async_execution_policy<
+      : hpx::detail::is_async_execution_policy<
             typename hpx::util::decay<T>::type>
     {
     };
+
+    template <typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_async_execution_policy_v =
+        is_async_execution_policy<T>::value;
 
     /// \cond NOINTERNAL
     template <typename T>
     struct is_rebound_execution_policy
-      : execution::detail::is_rebound_execution_policy<
+      : hpx::detail::is_rebound_execution_policy<
             typename hpx::util::decay<T>::type>
     {
     };
 
+    template <typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_rebound_execution_policy_v =
+        is_rebound_execution_policy<T>::value;
+
     // extension:
     template <typename T>
     struct is_vectorpack_execution_policy
-      : execution::detail::is_vectorpack_execution_policy<
+      : hpx::detail::is_vectorpack_execution_policy<
             typename hpx::util::decay<T>::type>
     {
     };
+
+    template <typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_vectorpack_execution_policy_v =
+        is_vectorpack_execution_policy<T>::value;
+    /// \endcond
+}    // namespace hpx
+
+namespace hpx { namespace parallel { namespace execution {
+
+    template <typename T>
+    using is_execution_policy HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::is_execution_policy is deprecated, use "
+        "hpx::is_execution_policy instead") = hpx::is_execution_policy<T>;
+
+    template <typename T>
+    using is_parallel_execution_policy HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::is_parallel_execution_policy is deprecated, "
+        "use hpx::is_parallel_execution_policy instead") =
+        hpx::is_parallel_execution_policy<T>;
+
+    template <typename T>
+    using is_sequenced_execution_policy HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::is_sequenced_execution_policy is "
+        "deprecated, use hpx::is_sequenced_execution_policy instead") =
+        hpx::is_sequenced_execution_policy<T>;
+
+    /// \cond
+    template <typename T>
+    using is_async_execution_policy HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::is_async_execution_policy is deprecated, "
+        "use hpx::is_async_execution_policy instead") =
+        hpx::is_async_execution_policy<T>;
+
+    template <typename T>
+    using is_rebound_execution_policy HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::execution::is_rebound_execution_policy is deprecated, "
+        "use hpx::is_rebound_execution_policy instead") =
+        hpx::is_rebound_execution_policy<T>;
+
+    template <typename T>
+    using is_vectorpack_execution_policy HPX_DEPRECATED_V(1, 6,
+        "hpx:parallel::execution:::is_vectorpack_execution_policy is "
+        "deprecated, use hpx::is_vectorpack_execution_policy instead") =
+        hpx::is_vectorpack_execution_policy<T>;
     /// \endcond
 }}}    // namespace hpx::parallel::execution

--- a/libs/parallelism/execution/include_compatibility/hpx/parallel/traits/vector_pack_type.hpp
+++ b/libs/parallelism/execution/include_compatibility/hpx/parallel/traits/vector_pack_type.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2019 Ste||ar Group
+//  Copyright (c) 2019-2020 Ste||ar Group
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,13 +10,17 @@
 #include <hpx/execution/config/defines.hpp>
 #include <hpx/execution.hpp>
 
+// different versions of clang-format produce different results
+// clang-format off
 #if HPX_EXECUTION_HAVE_DEPRECATION_WARNINGS
 #if defined(HPX_MSVC)
 #pragma message(                                                               \
     "The header hpx/parallel/traits/vector_pack_type.hpp is deprecated, \
     please include hpx/execution.hpp instead")
 #else
-#warning "The header hpx/parallel/traits/vector_pack_type.hpp is deprecated, \
+#warning                                                                       \
+    "The header hpx/parallel/traits/vector_pack_type.hpp is deprecated, \
     please include hpx/execution.hpp instead"
 #endif
 #endif
+// clang-format on

--- a/libs/parallelism/execution/tests/unit/foreach_tests.hpp
+++ b/libs/parallelism/execution/tests/unit/foreach_tests.hpp
@@ -54,9 +54,8 @@ struct throw_bad_alloc
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -102,9 +101,8 @@ void test_for_each_async(ExPolicy&& p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_exception(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -171,9 +169,8 @@ void test_for_each_exception_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_bad_alloc(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -238,9 +235,8 @@ void test_for_each_bad_alloc_async(ExPolicy p, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_n(ExPolicy policy, IteratorTag)
 {
-    static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/executors/include/hpx/executors/datapar/execution_policy.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/datapar/execution_policy.hpp
@@ -1181,206 +1181,193 @@ namespace hpx { namespace execution { inline namespace v1 {
     };
 }}}    // namespace hpx::execution::v1
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     // extensions
-    namespace detail {
-        /// \cond NOINTERNAL
-        template <>
-        struct is_execution_policy<hpx::execution::dataseq_policy>
-          : std::true_type
-        {
-        };
 
-        template <typename Executor, typename Parameters>
-        struct is_execution_policy<
-            hpx::execution::dataseq_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
+    /// \cond NOINTERNAL
+    template <>
+    struct is_execution_policy<hpx::execution::dataseq_policy> : std::true_type
+    {
+    };
 
-        template <>
-        struct is_execution_policy<hpx::execution::dataseq_task_policy>
-          : std::true_type
-        {
-        };
+    template <typename Executor, typename Parameters>
+    struct is_execution_policy<
+        hpx::execution::dataseq_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_execution_policy<
-            hpx::execution::dataseq_task_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
+    template <>
+    struct is_execution_policy<hpx::execution::dataseq_task_policy>
+      : std::true_type
+    {
+    };
 
-        template <>
-        struct is_execution_policy<hpx::execution::datapar_policy>
-          : std::true_type
-        {
-        };
+    template <typename Executor, typename Parameters>
+    struct is_execution_policy<
+        hpx::execution::dataseq_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_execution_policy<
-            hpx::execution::datapar_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
+    template <>
+    struct is_execution_policy<hpx::execution::datapar_policy> : std::true_type
+    {
+    };
 
-        template <>
-        struct is_execution_policy<hpx::execution::datapar_task_policy>
-          : std::true_type
-        {
-        };
+    template <typename Executor, typename Parameters>
+    struct is_execution_policy<
+        hpx::execution::datapar_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_execution_policy<
-            hpx::execution::datapar_task_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
-        /// \endcond
-    }    // namespace detail
+    template <>
+    struct is_execution_policy<hpx::execution::datapar_task_policy>
+      : std::true_type
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_execution_policy<
+        hpx::execution::datapar_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
+    /// \endcond
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail {
-        /// \cond NOINTERNAL
-        template <>
-        struct is_sequenced_execution_policy<hpx::execution::dataseq_policy>
-          : std::true_type
-        {
-        };
+    /// \cond NOINTERNAL
+    template <>
+    struct is_sequenced_execution_policy<hpx::execution::dataseq_policy>
+      : std::true_type
+    {
+    };
 
-        template <>
-        struct is_sequenced_execution_policy<
-            hpx::execution::dataseq_task_policy> : std::true_type
-        {
-        };
+    template <>
+    struct is_sequenced_execution_policy<hpx::execution::dataseq_task_policy>
+      : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_sequenced_execution_policy<
-            hpx::execution::dataseq_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
+    template <typename Executor, typename Parameters>
+    struct is_sequenced_execution_policy<
+        hpx::execution::dataseq_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_sequenced_execution_policy<
-            hpx::execution::dataseq_task_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
-        /// \endcond
-    }    // namespace detail
+    template <typename Executor, typename Parameters>
+    struct is_sequenced_execution_policy<
+        hpx::execution::dataseq_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
+    /// \endcond
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail {
-        /// \cond NOINTERNAL
-        template <>
-        struct is_async_execution_policy<hpx::execution::dataseq_task_policy>
-          : std::true_type
-        {
-        };
+    /// \cond NOINTERNAL
+    template <>
+    struct is_async_execution_policy<hpx::execution::dataseq_task_policy>
+      : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_async_execution_policy<
-            hpx::execution::dataseq_task_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
+    template <typename Executor, typename Parameters>
+    struct is_async_execution_policy<
+        hpx::execution::dataseq_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
 
-        template <>
-        struct is_async_execution_policy<datapar_task_policy> : std::true_type
-        {
-        };
+    template <>
+    struct is_async_execution_policy<datapar_task_policy> : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_async_execution_policy<
-            datapar_task_policy_shim<Executor, Parameters>> : std::true_type
-        {
-        };
-        /// \endcond
-    }    // namespace detail
+    template <typename Executor, typename Parameters>
+    struct is_async_execution_policy<
+        datapar_task_policy_shim<Executor, Parameters>> : std::true_type
+    {
+    };
+    /// \endcond
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail {
-        /// \cond NOINTERNAL
-        template <>
-        struct is_parallel_execution_policy<datapar_policy> : std::true_type
-        {
-        };
+    /// \cond NOINTERNAL
+    template <>
+    struct is_parallel_execution_policy<datapar_policy> : std::true_type
+    {
+    };
 
-        template <>
-        struct is_parallel_execution_policy<datapar_task_policy>
-          : std::true_type
-        {
-        };
+    template <>
+    struct is_parallel_execution_policy<datapar_task_policy> : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_parallel_execution_policy<
-            datapar_policy_shim<Executor, Parameters>> : std::true_type
-        {
-        };
+    template <typename Executor, typename Parameters>
+    struct is_parallel_execution_policy<
+        datapar_policy_shim<Executor, Parameters>> : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_parallel_execution_policy<
-            datapar_task_policy_shim<Executor, Parameters>> : std::true_type
-        {
-        };
-        /// \endcond
-    }    // namespace detail
+    template <typename Executor, typename Parameters>
+    struct is_parallel_execution_policy<
+        datapar_task_policy_shim<Executor, Parameters>> : std::true_type
+    {
+    };
+    /// \endcond
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail {
-        /// \cond NOINTERNAL
-        template <>
-        struct is_vectorpack_execution_policy<hpx::execution::dataseq_policy>
-          : std::true_type
-        {
-        };
+    /// \cond NOINTERNAL
+    template <>
+    struct is_vectorpack_execution_policy<hpx::execution::dataseq_policy>
+      : std::true_type
+    {
+    };
 
-        template <>
-        struct is_vectorpack_execution_policy<
-            hpx::execution::dataseq_task_policy> : std::true_type
-        {
-        };
+    template <>
+    struct is_vectorpack_execution_policy<hpx::execution::dataseq_task_policy>
+      : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_vectorpack_execution_policy<
-            hpx::execution::dataseq_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
+    template <typename Executor, typename Parameters>
+    struct is_vectorpack_execution_policy<
+        hpx::execution::dataseq_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_vectorpack_execution_policy<
-            hpx::execution::dataseq_task_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
+    template <typename Executor, typename Parameters>
+    struct is_vectorpack_execution_policy<
+        hpx::execution::dataseq_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
 
-        template <>
-        struct is_vectorpack_execution_policy<datapar_policy> : std::true_type
-        {
-        };
+    template <>
+    struct is_vectorpack_execution_policy<datapar_policy> : std::true_type
+    {
+    };
 
-        template <>
-        struct is_vectorpack_execution_policy<datapar_task_policy>
-          : std::true_type
-        {
-        };
+    template <>
+    struct is_vectorpack_execution_policy<datapar_task_policy> : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_vectorpack_execution_policy<
-            datapar_policy_shim<Executor, Parameters>> : std::true_type
-        {
-        };
+    template <typename Executor, typename Parameters>
+    struct is_vectorpack_execution_policy<
+        datapar_policy_shim<Executor, Parameters>> : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_vectorpack_execution_policy<
-            datapar_task_policy_shim<Executor, Parameters>> : std::true_type
-        {
-        };
-        /// \endcond
-    }    // namespace detail
-}}}      // namespace hpx::parallel::execution
+    template <typename Executor, typename Parameters>
+    struct is_vectorpack_execution_policy<
+        datapar_task_policy_shim<Executor, Parameters>> : std::true_type
+    {
+    };
+    /// \endcond
+}}    // namespace hpx::detail
 
 #endif

--- a/libs/parallelism/executors/include/hpx/executors/execution_policy.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/execution_policy.hpp
@@ -1415,202 +1415,191 @@ namespace hpx { namespace parallel { namespace execution {
         hpx::execution::sequenced_task_policy_shim<Executor, Parameters>;
 }}}    // namespace hpx::parallel::execution
 
-namespace hpx { namespace parallel { namespace execution {
+namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     // Allow to detect execution policies which were created as a result
     // of a rebind operation. This information can be used to inhibit the
     // construction of a generic execution_policy from any of the rebound
     // policies.
-    namespace detail {
-        template <typename Executor, typename Parameters>
-        struct is_rebound_execution_policy<
-            hpx::execution::sequenced_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
+    template <typename Executor, typename Parameters>
+    struct is_rebound_execution_policy<
+        hpx::execution::sequenced_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_rebound_execution_policy<
-            hpx::execution::sequenced_task_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
+    template <typename Executor, typename Parameters>
+    struct is_rebound_execution_policy<
+        hpx::execution::sequenced_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_rebound_execution_policy<
-            hpx::execution::parallel_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
+    template <typename Executor, typename Parameters>
+    struct is_rebound_execution_policy<
+        hpx::execution::parallel_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_rebound_execution_policy<
-            hpx::execution::parallel_task_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
-    }    // namespace detail
+    template <typename Executor, typename Parameters>
+    struct is_rebound_execution_policy<
+        hpx::execution::parallel_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail {
-        /// \cond NOINTERNAL
-        template <>
-        struct is_execution_policy<hpx::execution::parallel_policy>
-          : std::true_type
-        {
-        };
+    /// \cond NOINTERNAL
+    template <>
+    struct is_execution_policy<hpx::execution::parallel_policy> : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_execution_policy<
-            hpx::execution::parallel_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
+    template <typename Executor, typename Parameters>
+    struct is_execution_policy<
+        hpx::execution::parallel_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
 
-        template <>
-        struct is_execution_policy<hpx::execution::parallel_unsequenced_policy>
-          : std::true_type
-        {
-        };
+    template <>
+    struct is_execution_policy<hpx::execution::parallel_unsequenced_policy>
+      : std::true_type
+    {
+    };
 
-        template <>
-        struct is_execution_policy<hpx::execution::sequenced_policy>
-          : std::true_type
-        {
-        };
+    template <>
+    struct is_execution_policy<hpx::execution::sequenced_policy>
+      : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_execution_policy<
-            hpx::execution::sequenced_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
+    template <typename Executor, typename Parameters>
+    struct is_execution_policy<
+        hpx::execution::sequenced_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
 
-        // extension
-        template <>
-        struct is_execution_policy<hpx::execution::sequenced_task_policy>
-          : std::true_type
-        {
-        };
+    // extension
+    template <>
+    struct is_execution_policy<hpx::execution::sequenced_task_policy>
+      : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_execution_policy<
-            hpx::execution::sequenced_task_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
+    template <typename Executor, typename Parameters>
+    struct is_execution_policy<
+        hpx::execution::sequenced_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
 
-        template <>
-        struct is_execution_policy<hpx::execution::parallel_task_policy>
-          : std::true_type
-        {
-        };
+    template <>
+    struct is_execution_policy<hpx::execution::parallel_task_policy>
+      : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_execution_policy<
-            hpx::execution::parallel_task_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
-        /// \endcond
-    }    // namespace detail
+    template <typename Executor, typename Parameters>
+    struct is_execution_policy<
+        hpx::execution::parallel_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
+    /// \endcond
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail {
-        /// \cond NOINTERNAL
-        template <>
-        struct is_parallel_execution_policy<hpx::execution::parallel_policy>
-          : std::true_type
-        {
-        };
+    /// \cond NOINTERNAL
+    template <>
+    struct is_parallel_execution_policy<hpx::execution::parallel_policy>
+      : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_parallel_execution_policy<
-            hpx::execution::parallel_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
+    template <typename Executor, typename Parameters>
+    struct is_parallel_execution_policy<
+        hpx::execution::parallel_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
 
-        template <>
-        struct is_parallel_execution_policy<
-            hpx::execution::parallel_unsequenced_policy> : std::true_type
-        {
-        };
+    template <>
+    struct is_parallel_execution_policy<
+        hpx::execution::parallel_unsequenced_policy> : std::true_type
+    {
+    };
 
-        template <>
-        struct is_parallel_execution_policy<
-            hpx::execution::parallel_task_policy> : std::true_type
-        {
-        };
+    template <>
+    struct is_parallel_execution_policy<hpx::execution::parallel_task_policy>
+      : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_parallel_execution_policy<
-            hpx::execution::parallel_task_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
-        /// \endcond
-    }    // namespace detail
+    template <typename Executor, typename Parameters>
+    struct is_parallel_execution_policy<
+        hpx::execution::parallel_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
+    /// \endcond
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail {
-        /// \cond NOINTERNAL
-        template <>
-        struct is_sequenced_execution_policy<
-            hpx::execution::sequenced_task_policy> : std::true_type
-        {
-        };
+    /// \cond NOINTERNAL
+    template <>
+    struct is_sequenced_execution_policy<hpx::execution::sequenced_task_policy>
+      : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_sequenced_execution_policy<
-            hpx::execution::sequenced_task_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
+    template <typename Executor, typename Parameters>
+    struct is_sequenced_execution_policy<
+        hpx::execution::sequenced_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
 
-        template <>
-        struct is_sequenced_execution_policy<hpx::execution::sequenced_policy>
-          : std::true_type
-        {
-        };
+    template <>
+    struct is_sequenced_execution_policy<hpx::execution::sequenced_policy>
+      : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_sequenced_execution_policy<
-            hpx::execution::sequenced_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
-        /// \endcond
-    }    // namespace detail
+    template <typename Executor, typename Parameters>
+    struct is_sequenced_execution_policy<
+        hpx::execution::sequenced_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
+    /// \endcond
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail {
-        /// \cond NOINTERNAL
-        template <>
-        struct is_async_execution_policy<hpx::execution::sequenced_task_policy>
-          : std::true_type
-        {
-        };
+    /// \cond NOINTERNAL
+    template <>
+    struct is_async_execution_policy<hpx::execution::sequenced_task_policy>
+      : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_async_execution_policy<
-            hpx::execution::sequenced_task_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
+    template <typename Executor, typename Parameters>
+    struct is_async_execution_policy<
+        hpx::execution::sequenced_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
 
-        template <>
-        struct is_async_execution_policy<hpx::execution::parallel_task_policy>
-          : std::true_type
-        {
-        };
+    template <>
+    struct is_async_execution_policy<hpx::execution::parallel_task_policy>
+      : std::true_type
+    {
+    };
 
-        template <typename Executor, typename Parameters>
-        struct is_async_execution_policy<
-            hpx::execution::parallel_task_policy_shim<Executor, Parameters>>
-          : std::true_type
-        {
-        };
-        /// \endcond
-    }    // namespace detail
-}}}      // namespace hpx::parallel::execution
+    template <typename Executor, typename Parameters>
+    struct is_async_execution_policy<
+        hpx::execution::parallel_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
+    /// \endcond
+}}    // namespace hpx::detail


### PR DESCRIPTION
- flyby: add `hpx::is_execution_policy_v` and friends

This improves conformance as the equivalent types are defined in `namespace std`