### PR TITLE
Making set algorithms conform to C++20

### DIFF
--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -51,7 +51,7 @@ Functions
 - :cpp:func:`hpx::for_each_n`
 - :cpp:func:`hpx::generate`
 - :cpp:func:`hpx::generate_n`
-- :cpp:func:`hpx::parallel::v1::includes`
+- :cpp:func:`hpx::includes`
 - :cpp:func:`hpx::parallel::v1::inplace_merge`
 - :cpp:func:`hpx::is_heap`
 - :cpp:func:`hpx::is_heap_until`

--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -83,10 +83,10 @@ Functions
 - :cpp:func:`hpx::parallel::v1::rotate_copy`
 - :cpp:func:`hpx::parallel::v1::search`
 - :cpp:func:`hpx::parallel::v1::search_n`
-- :cpp:func:`hpx::parallel::v1::set_difference`
+- :cpp:func:`hpx::set_difference`
 - :cpp:func:`hpx::set_intersection`
-- :cpp:func:`hpx::parallel::v1::set_symmetric_difference`
-- :cpp:func:`hpx::parallel::v1::set_union`
+- :cpp:func:`hpx::set_symmetric_difference`
+- :cpp:func:`hpx::set_union`
 - :cpp:func:`hpx::parallel::v1::sort`
 - :cpp:func:`hpx::parallel::v1::stable_partition`
 - :cpp:func:`hpx::parallel::v1::stable_sort`
@@ -117,8 +117,16 @@ Functions
 - :cpp:func:`hpx::ranges::for_each_n`
 - :cpp:func:`hpx::ranges::generate`
 - :cpp:func:`hpx::ranges::generate_n`
+- :cpp:func:`hpx::ranges::includes`
+- :cpp:func:`hpx::ranges::is_heap`
+- :cpp:func:`hpx::ranges::is_heap_until`
+- :cpp:func:`hpx::ranges::make_heap`
 - :cpp:func:`hpx::ranges::move`
 - :cpp:func:`hpx::ranges::none_of`
+- :cpp:func:`hpx::ranges::set_difference`
+- :cpp:func:`hpx::ranges::set_intersection`
+- :cpp:func:`hpx::ranges::set_symmetric_difference`
+- :cpp:func:`hpx::ranges::set_union`
 
 Header ``hpx/any.hpp``
 ======================

--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -84,7 +84,7 @@ Functions
 - :cpp:func:`hpx::parallel::v1::search`
 - :cpp:func:`hpx::parallel::v1::search_n`
 - :cpp:func:`hpx::parallel::v1::set_difference`
-- :cpp:func:`hpx::parallel::v1::set_intersection`
+- :cpp:func:`hpx::set_intersection`
 - :cpp:func:`hpx::parallel::v1::set_symmetric_difference`
 - :cpp:func:`hpx::parallel::v1::set_union`
 - :cpp:func:`hpx::parallel::v1::sort`

--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -52,7 +52,7 @@ Functions
 - :cpp:func:`hpx::generate`
 - :cpp:func:`hpx::generate_n`
 - :cpp:func:`hpx::includes`
-- :cpp:func:`hpx::parallel::v1::inplace_merge`
+- :cpp:func:`hpx::inplace_merge`
 - :cpp:func:`hpx::is_heap`
 - :cpp:func:`hpx::is_heap_until`
 - :cpp:func:`hpx::parallel::v1::is_partitioned`
@@ -61,7 +61,7 @@ Functions
 - :cpp:func:`hpx::parallel::v1::lexicographical_compare`
 - :cpp:func:`hpx::make_heap`
 - :cpp:func:`hpx::parallel::v1::max_element`
-- :cpp:func:`hpx::parallel::v1::merge`
+- :cpp:func:`hpx::merge`
 - :cpp:func:`hpx::parallel::v1::min_element`
 - :cpp:func:`hpx::parallel::v1::minmax_element`
 - :cpp:func:`hpx::parallel::v1::mismatch`
@@ -118,9 +118,11 @@ Functions
 - :cpp:func:`hpx::ranges::generate`
 - :cpp:func:`hpx::ranges::generate_n`
 - :cpp:func:`hpx::ranges::includes`
+- :cpp:func:`hpx::ranges::inplace_merge`
 - :cpp:func:`hpx::ranges::is_heap`
 - :cpp:func:`hpx::ranges::is_heap_until`
 - :cpp:func:`hpx::ranges::make_heap`
+- :cpp:func:`hpx::ranges::merge`
 - :cpp:func:`hpx::ranges::move`
 - :cpp:func:`hpx::ranges::none_of`
 - :cpp:func:`hpx::ranges::set_difference`

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -549,7 +549,7 @@ Parallel algorithms
      * Returns true if one set is a subset of another.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`includes`
-   * * :cpp:func:`hpx::parallel::v1::set_difference`
+   * * :cpp:func:`hpx::set_difference`
      * Computes the difference between two sets.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`set_difference`
@@ -557,11 +557,11 @@ Parallel algorithms
      * Computes the intersection of two sets.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`set_intersection`
-   * * :cpp:func:`hpx::parallel::v1::set_symmetric_difference`
+   * * :cpp:func:`hpx::set_symmetric_difference`
      * Computes the symmetric difference between two sets.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`set_symmetric_difference`
-   * * :cpp:func:`hpx::parallel::v1::set_union`
+   * * :cpp:func:`hpx::set_union`
      * Computes the union of two sets.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`set_union`

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -537,11 +537,11 @@ Parallel algorithms
      * Description
      * In header
      * Algorithm page at cppreference.com
-   * * :cpp:func:`hpx::parallel::v1::merge`
+   * * :cpp:func:`hpx::merge`
      * Merges two sorted ranges.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`merge`
-   * * :cpp:func:`hpx::parallel::v1::inplace_merge`
+   * * :cpp:func:`hpx::inplace_merge`
      * Merges two ordered ranges in-place.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`inplace_merge`

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -545,7 +545,7 @@ Parallel algorithms
      * Merges two ordered ranges in-place.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`inplace_merge`
-   * * :cpp:func:`hpx::parallel::v1::includes`
+   * * :cpp:func:`hpx::includes`
      * Returns true if one set is a subset of another.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`includes`

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -553,7 +553,7 @@ Parallel algorithms
      * Computes the difference between two sets.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`set_difference`
-   * * :cpp:func:`hpx::parallel::v1::set_intersection`
+   * * :cpp:func:`hpx::set_intersection`
      * Computes the intersection of two sets.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`set_intersection`

--- a/libs/full/include/include/hpx/algorithm.hpp
+++ b/libs/full/include/include/hpx/algorithm.hpp
@@ -42,7 +42,6 @@ namespace hpx {
     using hpx::parallel::search;
     using hpx::parallel::search_n;
     using hpx::parallel::set_difference;
-    using hpx::parallel::set_intersection;
     using hpx::parallel::set_symmetric_difference;
     using hpx::parallel::set_union;
     using hpx::parallel::sort;

--- a/libs/full/include/include/hpx/algorithm.hpp
+++ b/libs/full/include/include/hpx/algorithm.hpp
@@ -15,7 +15,6 @@
 
 namespace hpx {
     using hpx::parallel::adjacent_find;
-    using hpx::parallel::includes;
     using hpx::parallel::inplace_merge;
     using hpx::parallel::is_partitioned;
     using hpx::parallel::is_sorted;

--- a/libs/full/include/include/hpx/algorithm.hpp
+++ b/libs/full/include/include/hpx/algorithm.hpp
@@ -40,8 +40,6 @@ namespace hpx {
     using hpx::parallel::rotate_copy;
     using hpx::parallel::search;
     using hpx::parallel::search_n;
-    using hpx::parallel::set_symmetric_difference;
-    using hpx::parallel::set_union;
     using hpx::parallel::sort;
     using hpx::parallel::stable_partition;
     using hpx::parallel::stable_sort;

--- a/libs/full/include/include/hpx/algorithm.hpp
+++ b/libs/full/include/include/hpx/algorithm.hpp
@@ -15,13 +15,11 @@
 
 namespace hpx {
     using hpx::parallel::adjacent_find;
-    using hpx::parallel::inplace_merge;
     using hpx::parallel::is_partitioned;
     using hpx::parallel::is_sorted;
     using hpx::parallel::is_sorted_until;
     using hpx::parallel::lexicographical_compare;
     using hpx::parallel::max_element;
-    using hpx::parallel::merge;
     using hpx::parallel::min_element;
     using hpx::parallel::minmax_element;
     using hpx::parallel::partition;

--- a/libs/full/include/include/hpx/algorithm.hpp
+++ b/libs/full/include/include/hpx/algorithm.hpp
@@ -40,7 +40,6 @@ namespace hpx {
     using hpx::parallel::rotate_copy;
     using hpx::parallel::search;
     using hpx::parallel::search_n;
-    using hpx::parallel::set_difference;
     using hpx::parallel::set_symmetric_difference;
     using hpx::parallel::set_union;
     using hpx::parallel::sort;

--- a/libs/full/include/include/hpx/include/parallel_set_operations.hpp
+++ b/libs/full/include/include/hpx/include/parallel_set_operations.hpp
@@ -12,4 +12,5 @@
 #include <hpx/parallel/algorithms/set_symmetric_difference.hpp>
 #include <hpx/parallel/algorithms/set_union.hpp>
 
+#include <hpx/parallel/container_algorithms/includes.hpp>
 #include <hpx/parallel/container_algorithms/set_intersection.hpp>

--- a/libs/full/include/include/hpx/include/parallel_set_operations.hpp
+++ b/libs/full/include/include/hpx/include/parallel_set_operations.hpp
@@ -15,3 +15,5 @@
 #include <hpx/parallel/container_algorithms/includes.hpp>
 #include <hpx/parallel/container_algorithms/set_difference.hpp>
 #include <hpx/parallel/container_algorithms/set_intersection.hpp>
+#include <hpx/parallel/container_algorithms/set_symmetric_difference.hpp>
+#include <hpx/parallel/container_algorithms/set_union.hpp>

--- a/libs/full/include/include/hpx/include/parallel_set_operations.hpp
+++ b/libs/full/include/include/hpx/include/parallel_set_operations.hpp
@@ -13,4 +13,5 @@
 #include <hpx/parallel/algorithms/set_union.hpp>
 
 #include <hpx/parallel/container_algorithms/includes.hpp>
+#include <hpx/parallel/container_algorithms/set_difference.hpp>
 #include <hpx/parallel/container_algorithms/set_intersection.hpp>

--- a/libs/full/include/include/hpx/include/parallel_set_operations.hpp
+++ b/libs/full/include/include/hpx/include/parallel_set_operations.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,3 +11,5 @@
 #include <hpx/parallel/algorithms/set_intersection.hpp>
 #include <hpx/parallel/algorithms/set_symmetric_difference.hpp>
 #include <hpx/parallel/algorithms/set_union.hpp>
+
+#include <hpx/parallel/container_algorithms/set_intersection.hpp>

--- a/libs/parallelism/algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/CMakeLists.txt
@@ -104,6 +104,7 @@ set(algorithms_headers
     hpx/parallel/container_algorithms/reverse.hpp
     hpx/parallel/container_algorithms/rotate.hpp
     hpx/parallel/container_algorithms/search.hpp
+    hpx/parallel/container_algorithms/set_intersection.hpp
     hpx/parallel/container_algorithms/sort.hpp
     hpx/parallel/container_algorithms/stable_sort.hpp
     hpx/parallel/container_algorithms/transform.hpp

--- a/libs/parallelism/algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/CMakeLists.txt
@@ -90,6 +90,7 @@ set(algorithms_headers
     hpx/parallel/container_algorithms/for_each.hpp
     hpx/parallel/container_algorithms/generate.hpp
     hpx/parallel/container_algorithms.hpp
+    hpx/parallel/container_algorithms/includes.hpp
     hpx/parallel/container_algorithms/is_heap.hpp
     hpx/parallel/container_algorithms/make_heap.hpp
     hpx/parallel/container_algorithms/merge.hpp

--- a/libs/parallelism/algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/CMakeLists.txt
@@ -28,6 +28,7 @@ set(algorithms_headers
     hpx/parallel/algorithms/detail/insertion_sort.hpp
     hpx/parallel/algorithms/detail/is_sorted.hpp
     hpx/parallel/algorithms/detail/parallel_stable_sort.hpp
+    hpx/parallel/algorithms/detail/rotate.hpp
     hpx/parallel/algorithms/detail/sample_sort.hpp
     hpx/parallel/algorithms/detail/set_operation.hpp
     hpx/parallel/algorithms/detail/spin_sort.hpp

--- a/libs/parallelism/algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/CMakeLists.txt
@@ -105,6 +105,7 @@ set(algorithms_headers
     hpx/parallel/container_algorithms/reverse.hpp
     hpx/parallel/container_algorithms/rotate.hpp
     hpx/parallel/container_algorithms/search.hpp
+    hpx/parallel/container_algorithms/set_difference.hpp
     hpx/parallel/container_algorithms/set_intersection.hpp
     hpx/parallel/container_algorithms/sort.hpp
     hpx/parallel/container_algorithms/stable_sort.hpp

--- a/libs/parallelism/algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/CMakeLists.txt
@@ -32,6 +32,7 @@ set(algorithms_headers
     hpx/parallel/algorithms/detail/set_operation.hpp
     hpx/parallel/algorithms/detail/spin_sort.hpp
     hpx/parallel/algorithms/detail/transfer.hpp
+    hpx/parallel/algorithms/detail/upper_lower_bound.hpp
     hpx/parallel/algorithms/equal.hpp
     hpx/parallel/algorithms/exclusive_scan.hpp
     hpx/parallel/algorithms/fill.hpp
@@ -107,6 +108,8 @@ set(algorithms_headers
     hpx/parallel/container_algorithms/search.hpp
     hpx/parallel/container_algorithms/set_difference.hpp
     hpx/parallel/container_algorithms/set_intersection.hpp
+    hpx/parallel/container_algorithms/set_symmetric_difference.hpp
+    hpx/parallel/container_algorithms/set_union.hpp
     hpx/parallel/container_algorithms/sort.hpp
     hpx/parallel/container_algorithms/stable_sort.hpp
     hpx/parallel/container_algorithms/transform.hpp

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
@@ -345,7 +345,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter, typename F,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter>::value &&
             traits::is_projected<Proj, FwdIter>::value &&
             traits::is_indirect_callable<ExPolicy, F,
@@ -456,7 +456,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter, typename F,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter>::value &&
             traits::is_projected<Proj, FwdIter>::value &&
             traits::is_indirect_callable<ExPolicy, F,
@@ -567,7 +567,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter, typename F,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value&&
+            hpx::is_execution_policy<ExPolicy>::value&&
             hpx::traits::is_iterator<FwdIter>::value&&
             traits::is_projected<Proj, FwdIter>::value&&
             traits::is_indirect_callable<ExPolicy, F,
@@ -598,7 +598,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
@@ -636,7 +636,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
@@ -674,7 +674,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -342,7 +342,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value)>
     // clang-format on
@@ -412,7 +412,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename Size,
         typename FwdIter2,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value)>
     // clang-format on
@@ -584,7 +584,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Pred,
         HPX_CONCEPT_REQUIRES_(
-            hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value &&
             hpx::traits::is_invocable<Pred,
@@ -623,7 +623,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             HPX_CONCEPT_REQUIRES_(
-                parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value
             )>
@@ -666,7 +666,7 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter1, typename Size,
             typename FwdIter2,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value
             )>
@@ -740,7 +740,7 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename Pred,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value &&
                 hpx::traits::is_invocable<Pred,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -337,21 +337,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
         };
 #endif
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename I, typename O>
-        O get_second_element(util::in_out_result<I, O>&& p)
-        {
-            return p.out;
-        }
-
-        template <typename I, typename O>
-        hpx::future<O> get_second_element(
-            hpx::future<util::in_out_result<I, O>>&& f)
-        {
-            return lcos::make_future<O>(std::move(f),
-                [](util::in_out_result<I, O>&& p) { return p.out; });
-        }
     }    // namespace detail
 
     // clang-format off
@@ -648,7 +633,7 @@ namespace hpx {
         tag_invoke(hpx::copy_t, ExPolicy&& policy, FwdIter1 first,
             FwdIter1 last, FwdIter2 dest)
         {
-            return parallel::v1::detail::get_second_element(
+            return parallel::util::get_second_element(
                 parallel::v1::detail::transfer<
                     parallel::v1::detail::copy_iter<FwdIter1, FwdIter2>>(
                     std::forward<ExPolicy>(policy), first, last, dest));
@@ -664,7 +649,7 @@ namespace hpx {
         friend FwdIter2 tag_invoke(
             hpx::copy_t, FwdIter1 first, FwdIter1 last, FwdIter2 dest)
         {
-            return parallel::v1::detail::get_second_element(
+            return parallel::util::get_second_element(
                 parallel::v1::detail::transfer<
                     parallel::v1::detail::copy_iter<FwdIter1, FwdIter2>>(
                     hpx::execution::seq, first, last, dest));
@@ -707,7 +692,7 @@ namespace hpx {
                 hpx::parallel::execution::is_sequenced_execution_policy<
                     ExPolicy>;
 
-            return hpx::parallel::v1::detail::get_second_element(
+            return hpx::parallel::util::get_second_element(
                 hpx::parallel::v1::detail::copy_n<
                     hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
                     .call(std::forward<ExPolicy>(policy), is_seq(), first,
@@ -737,7 +722,7 @@ namespace hpx {
                     FwdIter2>::get(std::move(dest));
             }
 
-            return hpx::parallel::v1::detail::get_second_element(
+            return hpx::parallel::util::get_second_element(
                 hpx::parallel::v1::detail::copy_n<
                     hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
                     .call(hpx::execution::seq, std::true_type{}, first,
@@ -777,7 +762,7 @@ namespace hpx {
                 hpx::parallel::execution::is_sequenced_execution_policy<
                     ExPolicy>;
 
-            return hpx::parallel::v1::detail::get_second_element(
+            return hpx::parallel::util::get_second_element(
                 hpx::parallel::v1::detail::copy_if<
                     hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
                     .call(std::forward<ExPolicy>(policy), is_seq(), first, last,
@@ -803,7 +788,7 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::v1::detail::get_second_element(
+            return hpx::parallel::util::get_second_element(
                 hpx::parallel::v1::detail::copy_if<
                     hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
                     .call(hpx::execution::seq, std::true_type{}, first, last,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/count.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/count.hpp
@@ -335,7 +335,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIterB, typename FwdIterE,
         typename T, typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             traits::is_projected<Proj, FwdIterB>::value &&
             hpx::traits::is_iterator<FwdIterB>::value
         )>
@@ -447,7 +447,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIterB, typename FwdIterE,
         typename F, typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIterB>::value &&
             traits::is_projected<Proj, FwdIterB>::value &&
             traits::is_indirect_callable<ExPolicy, F,
@@ -483,7 +483,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename T,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
@@ -529,7 +529,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value &&
                 hpx::traits::is_invocable<F,
                     typename std::iterator_traits<FwdIter>::value_type

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/rotate.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/rotate.hpp
@@ -1,0 +1,49 @@
+//  Copyright (c) 2019-2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/functional/invoke.hpp>
+
+#include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/parallel/algorithms/detail/distance.hpp>
+
+#include <functional>
+
+namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
+
+    // provide implementation of std::rotate supporting iterators/sentinels
+    template <typename Iter, typename Sent>
+    inline constexpr void sequential_rotate_helper(
+        Iter first, Iter new_first, Sent last)
+    {
+        Iter next = new_first;
+        while (first != next)
+        {
+            std::iter_swap(first++, next++);
+            if (next == last)
+            {
+                next = new_first;
+            }
+            else if (first == new_first)
+            {
+                new_first = next;
+            }
+        }
+    }
+
+    template <typename Iter, typename Sent>
+    inline constexpr util::in_out_result<Iter, Sent> sequential_rotate(
+        Iter first, Iter new_first, Sent last)
+    {
+        if (first != new_first && new_first != last)
+            sequential_rotate_helper(first, new_first, last);
+
+        detail::advance(first, detail::distance(new_first, last));
+        return {first, last};
+    }
+}}}}    // namespace hpx::parallel::v1::detail

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/rotate.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/rotate.hpp
@@ -12,6 +12,7 @@
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 
+#include <algorithm>
 #include <functional>
 
 namespace hpx { namespace parallel { inline namespace v1 { namespace detail {

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
@@ -12,6 +12,7 @@
 #include <hpx/execution/executors/execution_information.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
+#include <hpx/parallel/algorithms/detail/upper_lower_bound.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
@@ -22,6 +23,7 @@
 #include <memory>
 #endif
 
+#include <algorithm>
 #include <cstddef>
 #include <type_traits>
 #include <utility>
@@ -76,16 +78,22 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         std::size_t start = std::size_t(-1);
         std::size_t len = std::size_t(-1);
         std::size_t start_index = std::size_t(-1);
+        std::size_t first1 = std::size_t(-1);
+        std::size_t first2 = std::size_t(-1);
     };
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename ExPolicy, typename Iter1, typename Sent1, typename Iter2,
-        typename Sent2, typename Iter3, typename F, typename Combiner,
-        typename SetOp>
-    typename util::detail::algorithm_result<ExPolicy, Iter3>::type
-    set_operation(ExPolicy policy, Iter1 first1, Sent1 last1, Iter2 first2,
-        Sent2 last2, Iter3 dest, F&& f, Combiner&& combiner, SetOp&& setop)
+        typename Sent2, typename Iter3, typename F, typename Proj1,
+        typename Proj2, typename Combiner, typename SetOp>
+    typename util::detail::algorithm_result<ExPolicy,
+        util::in_in_out_result<Iter1, Iter2, Iter3>>::type
+    set_operation(ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
+        Sent2 last2, Iter3 dest, F&& f, Proj1&& proj1, Proj2&& proj2,
+        Combiner&& combiner, SetOp&& setop)
     {
+        using result_type = util::in_in_out_result<Iter1, Iter2, Iter3>;
+
         using difference_type1 =
             typename std::iterator_traits<Iter1>::difference_type;
         using difference_type2 =
@@ -95,7 +103,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         difference_type1 len1 = detail::distance(first1, last1);
         difference_type2 len2 = detail::distance(first2, last2);
 
-        typedef typename set_operations_buffer<Iter3>::type buffer_type;
+        using buffer_type = typename set_operations_buffer<Iter3>::type;
 
         std::size_t cores = execution::processing_units_count(
             policy.parameters(), policy.executor());
@@ -122,44 +130,71 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             std::size_t end1 = (std::min)(start1 + step, std::size_t(len1));
 
             if (start1 >= end1)
+            {
                 return;
+            }
 
             bool first_partition = (start1 == 0);
             bool last_partition = (end1 == std::size_t(len1));
+
+            auto start_value = hpx::util::invoke(proj1, first1[start1]);
+            auto end_value = hpx::util::invoke(proj1, first1[end1]);
 
             // all but the last chunk require special handling
             if (!last_partition)
             {
                 // this chunk will be handled by the next one if all
                 // elements of this partition are equal
-                if (!f(first1[start1], first1[end1]))
+                if (!hpx::util::invoke(f, start_value, end_value))
+                {
                     return;
+                }
 
                 // move backwards to find earliest element which is equal to
                 // the last element of the current chunk
-                while (end1 != 0 && !f(first1[end1 - 1], first1[end1]))
-                    --end1;
+                if (end1 != 0)
+                {
+                    auto end_value1 =
+                        hpx::util::invoke(proj1, first1[end1 - 1]);
+
+                    while (!hpx::util::invoke(f, end_value1, end_value) &&
+                        --end1 != 0)
+                    {
+                        end_value = std::move(end_value1);
+                        end_value1 = hpx::util::invoke(proj1, first1[end1 - 1]);
+                    }
+                }
             }
 
             // move backwards to find earliest element which is equal to
             // the first element of the current chunk
-            while (start1 != 0 && !f(first1[start1 - 1], first1[start1]))
-                --start1;
+            if (start1 != 0)
+            {
+                auto start_value1 =
+                    hpx::util::invoke(proj1, first1[start1 - 1]);
+
+                while (!hpx::util::invoke(f, start_value1, start_value) &&
+                    --start1 != 0)
+                {
+                    start_value = std::move(start_value1);
+                    start_value1 = hpx::util::invoke(proj1, first1[start1 - 1]);
+                }
+            }
 
             // find start and end in sequence 2
             std::size_t start2 = 0;
             if (!first_partition)
             {
-                start2 =
-                    std::lower_bound(first2, first2 + len2, first1[start1], f) -
+                start2 = detail::lower_bound(
+                             first2, first2 + len2, start_value, f, proj2) -
                     first2;
             }
 
             std::size_t end2 = len2;
             if (!last_partition)
             {
-                end2 = std::lower_bound(
-                           first2 + start2, first2 + len2, first1[end1], f) -
+                end2 = detail::lower_bound(first2 + start2, first2 + len2,
+                           end_value, f, proj2) -
                     first2;
             }
 
@@ -167,26 +202,39 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             // intermediate buffer
             curr_chunk->start = combiner(start1, start2);
             auto buffer_dest = buffer.get() + curr_chunk->start;
-            curr_chunk->len =
-                setop(first1 + start1, first1 + end1, first2 + start2,
-                    first2 + end2, buffer_dest, f) -
-                buffer_dest;
+            auto op_result = setop(first1 + start1, first1 + end1,
+                first2 + start2, first2 + end2, buffer_dest, f);
+            curr_chunk->first1 = op_result.in1 - first1;
+            curr_chunk->first2 = op_result.in2 - first2;
+            curr_chunk->len = op_result.out - buffer_dest;
         };
 
         // second step, is executed after all partitions are done running
 
         // different versions of clang-format produce different formatting
         // clang-format off
-        auto f2 = [buffer, chunks, cores, dest](
-                      std::vector<future<void>>&&) -> Iter3 {
+        auto f2 = [buffer, chunks, cores, first1, first2, dest](
+                      std::vector<future<void>>&&) -> result_type {
             // clang-format on
-            // accumulate real length
+
+            // accumulate real length and rightmost positions in input sequences
+            std::size_t first1_pos = 0;
+            std::size_t first2_pos = 0;
+
             set_chunk_data* chunk = chunks.get();
             chunk->start_index = 0;
             for (size_t i = 1; i != cores; ++i)
             {
                 set_chunk_data* curr_chunk = chunk++;
                 chunk->start_index = curr_chunk->start_index + curr_chunk->len;
+                if (curr_chunk->first1 != std::size_t(-1))
+                {
+                    first1_pos = (std::max)(first1_pos, curr_chunk->first1);
+                }
+                if (curr_chunk->first2 != std::size_t(-1))
+                {
+                    first2_pos = (std::max)(first2_pos, curr_chunk->first2);
+                }
             }
 
             // finally, copy data to destination
@@ -195,11 +243,12 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                     hpx::execution::par, chunks.get(), cores,
                     [buffer, dest](
                         set_chunk_data* chunk, std::size_t, std::size_t) {
-                        if (chunk->start == (size_t)(-1) ||
-                            chunk->start_index == (size_t)(-1) ||
-                            chunk->len == (size_t)(-1))
+                        if (chunk->start == std::size_t(-1) ||
+                            chunk->start_index == std::size_t(-1) ||
+                            chunk->len == std::size_t(-1))
+                        {
                             return;
-
+                        }
                         std::copy(buffer.get() + chunk->start,
                             buffer.get() + chunk->start + chunk->len,
                             dest + chunk->start_index);
@@ -208,11 +257,13 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                         return last;
                     });
 
-            return dest;
+            return {std::next(first1, first1_pos),
+                std::next(first2, first2_pos),
+                std::next(dest, chunk->start_index + chunk->len)};
         };
 
         // fill the buffer piecewise
-        return parallel::util::partitioner<ExPolicy, Iter3, void>::call(
+        return parallel::util::partitioner<ExPolicy, result_type, void>::call(
             policy, chunks.get(), cores, std::move(f1), std::move(f2));
     }
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/upper_lower_bound.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/upper_lower_bound.hpp
@@ -1,0 +1,135 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/functional/invoke.hpp>
+
+#include <hpx/parallel/algorithms/detail/distance.hpp>
+#include <hpx/parallel/util/cancellation_token.hpp>
+
+#include <functional>
+#include <iterator>
+
+namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Iter, typename Sent, typename T, typename F,
+        typename Proj, typename CancelToken>
+    Iter lower_bound(
+        Iter first, Sent last, T&& value, F&& f, Proj&& proj, CancelToken& tok)
+    {
+        using difference_type =
+            typename std::iterator_traits<Iter>::difference_type;
+
+        difference_type count = detail::distance(first, last);
+        while (count > 0)
+        {
+            if (tok.was_cancelled())
+                break;
+
+            difference_type step = count / 2;
+            Iter it = std::next(first, step);
+
+            if (hpx::util::invoke(f, hpx::util::invoke(proj, *it), value))
+            {
+                first = ++it;
+                count -= step + 1;
+            }
+            else
+            {
+                count = step;
+            }
+        }
+        return first;
+    }
+
+    template <typename Iter, typename Sent, typename T, typename F,
+        typename Proj>
+    constexpr Iter lower_bound(
+        Iter first, Sent last, T&& value, F&& f, Proj&& proj)
+    {
+        using difference_type =
+            typename std::iterator_traits<Iter>::difference_type;
+
+        difference_type count = detail::distance(first, last);
+        while (count > 0)
+        {
+            difference_type step = count / 2;
+            Iter it = std::next(first, step);
+
+            if (hpx::util::invoke(f, hpx::util::invoke(proj, *it), value))
+            {
+                first = ++it;
+                count -= step + 1;
+            }
+            else
+            {
+                count = step;
+            }
+        }
+        return first;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Iter, typename Sent, typename T, typename F,
+        typename Proj, typename CancelToken>
+    Iter upper_bound(
+        Iter first, Sent last, T&& value, F&& f, Proj&& proj, CancelToken& tok)
+    {
+        using difference_type =
+            typename std::iterator_traits<Iter>::difference_type;
+
+        difference_type count = detail::distance(first, last);
+        while (count > 0)
+        {
+            if (tok.was_cancelled())
+                break;
+
+            difference_type step = count / 2;
+            Iter it = std::next(first, step);
+
+            if (!hpx::util::invoke(f, value, hpx::util::invoke(proj, *it)))
+            {
+                first = ++it;
+                count -= step + 1;
+            }
+            else
+            {
+                count = step;
+            }
+        }
+        return first;
+    }
+
+    template <typename Iter, typename Sent, typename T, typename F,
+        typename Proj>
+    constexpr Iter upper_bound(
+        Iter first, Sent last, T&& value, F&& f, Proj&& proj)
+    {
+        using difference_type =
+            typename std::iterator_traits<Iter>::difference_type;
+
+        difference_type count = detail::distance(first, last);
+        while (count > 0)
+        {
+            difference_type step = count / 2;
+            Iter it = std::next(first, step);
+
+            if (!hpx::util::invoke(f, value, hpx::util::invoke(proj, *it)))
+            {
+                first = ++it;
+                count -= step + 1;
+            }
+            else
+            {
+                count = step;
+            }
+        }
+        return first;
+    }
+}}}}    // namespace hpx::parallel::v1::detail

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/equal.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/equal.hpp
@@ -315,7 +315,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Pred = detail::equal_to,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value &&
             hpx::traits::is_invocable<Pred,
@@ -414,7 +414,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Pred = detail::equal_to,
         HPX_CONCEPT_REQUIRES_(
-            hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value &&
             hpx::traits::is_invocable<Pred,
@@ -455,7 +455,7 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename Pred,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value &&
                 hpx::traits::is_invocable<Pred,
@@ -488,7 +488,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value
             )>
@@ -518,7 +518,7 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename Pred,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value &&
                 hpx::traits::is_invocable<Pred,
@@ -549,7 +549,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value
             )>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -270,7 +270,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename T, typename Op>
     inline typename std::enable_if<
-        execution::is_execution_policy<ExPolicy>::value,
+        hpx::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type>::type
     exclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
         FwdIter2 dest, T init, Op&& op)
@@ -350,7 +350,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename T>
     inline typename std::enable_if<
-        execution::is_execution_policy<ExPolicy>::value,
+        hpx::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type>::type
     exclusive_scan(
         ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest, T init)

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -269,8 +269,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename T, typename Op>
-    inline typename std::enable_if<
-        hpx::is_execution_policy<ExPolicy>::value,
+    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type>::type
     exclusive_scan(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
         FwdIter2 dest, T init, Op&& op)
@@ -349,8 +348,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename T>
-    inline typename std::enable_if<
-        hpx::is_execution_policy<ExPolicy>::value,
+    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type>::type
     exclusive_scan(
         ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest, T init)

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/fill.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/fill.hpp
@@ -215,7 +215,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename FwdIter, typename T,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_forward_iterator<FwdIter>::value
         )>
     // clang-format on
@@ -272,7 +272,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename FwdIter, typename Size, typename T,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_forward_iterator<FwdIter>::value
         )>
     // clang-format on
@@ -309,7 +309,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename T,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
@@ -358,7 +358,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename Size, typename T,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/find.hpp
@@ -513,7 +513,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename FwdIter, typename T,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter>::value
         )>
     // clang-format on
@@ -643,7 +643,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename FwdIter, typename F,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter>::value &&
             hpx::traits::is_invocable<F,
                 typename std::iterator_traits<FwdIter>::value_type
@@ -777,7 +777,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename FwdIter, typename F,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter>::value &&
             hpx::traits::is_invocable<F,
                 typename std::iterator_traits<FwdIter>::value_type
@@ -976,7 +976,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         typename Pred = detail::equal_to,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value
         )>
@@ -1120,7 +1120,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value
         )>
@@ -1158,7 +1158,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename T,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
@@ -1199,7 +1199,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value &&
                 hpx::traits::is_invocable<F,
                     typename std::iterator_traits<FwdIter>::value_type
@@ -1245,7 +1245,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value &&
                 hpx::traits::is_invocable<F,
                     typename std::iterator_traits<FwdIter>::value_type
@@ -1293,7 +1293,7 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename Pred,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value &&
                 hpx::traits::is_invocable<Pred,
@@ -1326,7 +1326,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value
             )>
@@ -1412,7 +1412,7 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename Pred,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value &&
                 hpx::traits::is_invocable<Pred,
@@ -1445,7 +1445,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value
             )>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -466,7 +466,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter, typename Size, typename F,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter>::value &&
             hpx::parallel::traits::is_projected<Proj, FwdIter>::value &&
             hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
@@ -584,7 +584,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIterB, typename FwdIterE,
         typename F, typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIterB>::value &&
             hpx::traits::is_sentinel_for<FwdIterE, FwdIterB>::value &&
             hpx::parallel::traits::is_projected<Proj, FwdIterB>::value
@@ -635,7 +635,7 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter,
             typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_forward_iterator<FwdIter>::value
             )>
         // clang-format on
@@ -680,7 +680,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename Size, typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_forward_iterator<FwdIter>::value
             )>
         // clang-format on

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -1068,7 +1068,7 @@ namespace hpx {
 
         template <typename ExPolicy, typename I, typename... Args,
             HPX_CONCEPT_REQUIRES_(
-                execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 (hpx::traits::is_iterator<I>::value ||
                     std::is_integral<I>::value))>
         HPX_DEPRECATED_V(1, 6,
@@ -1103,7 +1103,7 @@ namespace hpx {
 
         template <typename ExPolicy, typename I, typename S, typename... Args,
             HPX_CONCEPT_REQUIRES_(
-                execution::is_execution_policy<ExPolicy>::value&&
+                hpx::is_execution_policy<ExPolicy>::value&&
                     std::is_integral<S>::value &&
                 (hpx::traits::is_iterator<I>::value ||
                     std::is_integral<I>::value))>
@@ -1144,7 +1144,7 @@ namespace hpx {
         template <typename ExPolicy, typename I, typename Size,
             typename... Args,
             HPX_CONCEPT_REQUIRES_(
-                execution::is_execution_policy<ExPolicy>::value&&
+                hpx::is_execution_policy<ExPolicy>::value&&
                     std::is_integral<Size>::value &&
                 (hpx::traits::is_iterator<I>::value ||
                     std::is_integral<I>::value))>
@@ -1180,7 +1180,7 @@ namespace hpx {
         template <typename ExPolicy, typename I, typename Size, typename S,
             typename... Args,
             HPX_CONCEPT_REQUIRES_(
-                execution::is_execution_policy<ExPolicy>::value&& std::
+                hpx::is_execution_policy<ExPolicy>::value&& std::
                     is_integral<Size>::value&& std::is_integral<S>::value &&
                 (hpx::traits::is_iterator<I>::value ||
                     std::is_integral<I>::value))>
@@ -1225,7 +1225,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename I, typename... Args,
             HPX_CONCEPT_REQUIRES_(
-                parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 (hpx::traits::is_iterator<I>::value ||
                  std::is_integral<I>::value)
             )>
@@ -1269,7 +1269,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename I, typename S, typename... Args,
             HPX_CONCEPT_REQUIRES_(
-                parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 std::is_integral<S>::value &&
                 (hpx::traits::is_iterator<I>::value ||
                  std::is_integral<I>::value)
@@ -1320,7 +1320,7 @@ namespace hpx {
         template <typename ExPolicy, typename I, typename Size,
             typename... Args,
             HPX_CONCEPT_REQUIRES_(
-                parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 std::is_integral<Size>::value &&
                 (hpx::traits::is_iterator<I>::value ||
                  std::is_integral<I>::value)
@@ -1367,7 +1367,7 @@ namespace hpx {
         template <typename ExPolicy, typename I, typename Size, typename S,
             typename... Args,
             HPX_CONCEPT_REQUIRES_(
-                parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 std::is_integral<Size>::value &&
                 std::is_integral<S>::value &&
                 (hpx::traits::is_iterator<I>::value ||

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -1067,8 +1067,7 @@ namespace hpx {
         }    // namespace detail
 
         template <typename ExPolicy, typename I, typename... Args,
-            HPX_CONCEPT_REQUIRES_(
-                hpx::is_execution_policy<ExPolicy>::value &&
+            HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value &&
                 (hpx::traits::is_iterator<I>::value ||
                     std::is_integral<I>::value))>
         HPX_DEPRECATED_V(1, 6,
@@ -1102,9 +1101,8 @@ namespace hpx {
         }
 
         template <typename ExPolicy, typename I, typename S, typename... Args,
-            HPX_CONCEPT_REQUIRES_(
-                hpx::is_execution_policy<ExPolicy>::value&&
-                    std::is_integral<S>::value &&
+            HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
+                                      std::is_integral<S>::value &&
                 (hpx::traits::is_iterator<I>::value ||
                     std::is_integral<I>::value))>
         HPX_DEPRECATED_V(1, 6,
@@ -1143,9 +1141,8 @@ namespace hpx {
 
         template <typename ExPolicy, typename I, typename Size,
             typename... Args,
-            HPX_CONCEPT_REQUIRES_(
-                hpx::is_execution_policy<ExPolicy>::value&&
-                    std::is_integral<Size>::value &&
+            HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
+                                      std::is_integral<Size>::value &&
                 (hpx::traits::is_iterator<I>::value ||
                     std::is_integral<I>::value))>
         HPX_DEPRECATED_V(1, 6,
@@ -1180,8 +1177,8 @@ namespace hpx {
         template <typename ExPolicy, typename I, typename Size, typename S,
             typename... Args,
             HPX_CONCEPT_REQUIRES_(
-                hpx::is_execution_policy<ExPolicy>::value&& std::
-                    is_integral<Size>::value&& std::is_integral<S>::value &&
+                hpx::is_execution_policy<ExPolicy>::value&& std::is_integral<
+                    Size>::value&& std::is_integral<S>::value &&
                 (hpx::traits::is_iterator<I>::value ||
                     std::is_integral<I>::value))>
         HPX_DEPRECATED_V(1, 6,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/generate.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/generate.hpp
@@ -219,7 +219,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename FwdIter, typename F,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter>::value
         )>
     // clang-format on
@@ -277,7 +277,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename FwdIter, typename Size, typename F,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter>::value
         )>
     // clang-format on
@@ -314,7 +314,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
@@ -359,7 +359,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename Size, typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/includes.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/includes.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,202 +8,9 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/iterator_support/range.hpp>
-#include <hpx/iterator_support/traits/is_iterator.hpp>
-
-#include <hpx/execution/algorithms/detail/predicates.hpp>
-#include <hpx/executors/execution_policy.hpp>
-#include <hpx/parallel/algorithms/detail/dispatch.hpp>
-#include <hpx/parallel/util/cancellation_token.hpp>
-#include <hpx/parallel/util/detail/algorithm_result.hpp>
-#include <hpx/parallel/util/partitioner.hpp>
-
-#include <algorithm>
-#include <cstddef>
-#include <iterator>
-#include <type_traits>
-#include <utility>
-#include <vector>
-
-namespace hpx { namespace parallel { inline namespace v1 {
-    ///////////////////////////////////////////////////////////////////////////
-    // includes
-    namespace detail {
-        /// \cond NOINTERNAL
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename FwdIter, typename T, typename F,
-            typename CancelToken>
-        FwdIter lower_bound(FwdIter first, FwdIter last, T const& value, F&& f,
-            CancelToken& tok)
-        {
-            typedef typename std::iterator_traits<FwdIter>::difference_type
-                difference_type;
-
-            difference_type count = std::distance(first, last);
-            while (count > 0)
-            {
-                if (tok.was_cancelled())
-                    break;
-
-                difference_type step = count / 2;
-                FwdIter it = detail::next(first, step);
-
-                if (f(*it, value))
-                {
-                    first = ++it;
-                    count -= step + 1;
-                }
-                else
-                {
-                    count = step;
-                }
-            }
-            return first;
-        }
-
-        template <typename FwdIter, typename T, typename F,
-            typename CancelToken>
-        FwdIter upper_bound(FwdIter first, FwdIter last, T const& value, F&& f,
-            CancelToken& tok)
-        {
-            typedef typename std::iterator_traits<FwdIter>::difference_type
-                difference_type;
-
-            difference_type count = std::distance(first, last);
-            while (count > 0)
-            {
-                if (tok.was_cancelled())
-                    break;
-
-                difference_type step = count / 2;
-                FwdIter it = detail::next(first, step);
-
-                if (!f(*it, value))
-                {
-                    first = ++it;
-                    count -= step + 1;
-                }
-                else
-                {
-                    count = step;
-                }
-            }
-            return first;
-        }
-
-        template <typename FwdIter1, typename FwdIter2, typename F,
-            typename CancelToken>
-        bool sequential_includes(FwdIter1 first1, FwdIter1 last1,
-            FwdIter2 first2, FwdIter2 last2, F&& f, CancelToken& tok)
-        {
-            while (first2 != last2)
-            {
-                if (tok.was_cancelled())
-                    return false;
-
-                if (first1 == last1 || f(*first2, *first1))
-                    return false;
-                if (!f(*first1, *first2))
-                    ++first2;
-
-                ++first1;
-            }
-            return true;
-        }
-
-        ///////////////////////////////////////////////////////////////////////
-        struct includes : public detail::algorithm<includes, bool>
-        {
-            includes()
-              : includes::algorithm("includes")
-            {
-            }
-
-            template <typename ExPolicy, typename InIter1, typename InIter2,
-                typename F>
-            static bool sequential(ExPolicy, InIter1 first1, InIter1 last1,
-                InIter2 first2, InIter2 last2, F&& f)
-            {
-                return std::includes(
-                    first1, last1, first2, last2, std::forward<F>(f));
-            }
-
-            template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-                typename F>
-            static typename util::detail::algorithm_result<ExPolicy, bool>::type
-            parallel(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
-                FwdIter2 first2, FwdIter2 last2, F&& f)
-            {
-                if (first1 == last1)
-                {
-                    return util::detail::algorithm_result<ExPolicy, bool>::get(
-                        false);
-                }
-
-                if (first2 == last2)
-                {
-                    return util::detail::algorithm_result<ExPolicy, bool>::get(
-                        true);
-                }
-
-                util::cancellation_token<> tok;
-                return util::partitioner<ExPolicy, bool>::call(
-                    std::forward<ExPolicy>(policy), first2,
-                    std::distance(first2, last2),
-                    [first1, last1, first2, last2, tok, f = std::forward<F>(f)](
-                        FwdIter2 part_begin,
-                        std::size_t part_count) mutable -> bool {
-                        FwdIter2 part_end =
-                            detail::next(part_begin, part_count);
-                        if (first2 != part_begin)
-                        {
-                            part_begin = upper_bound(
-                                part_begin, part_end, *part_begin, f, tok);
-                            if (tok.was_cancelled())
-                                return false;
-                            if (part_begin == part_end)
-                                return true;
-                        }
-
-                        FwdIter1 low =
-                            lower_bound(first1, last1, *part_begin, f, tok);
-                        if (tok.was_cancelled())
-                            return false;
-
-                        if (low == last1 || f(*part_begin, *low))
-                        {
-                            tok.cancel();
-                            return false;
-                        }
-
-                        FwdIter1 high = last1;
-                        if (part_end != last2)
-                        {
-                            high = upper_bound(low, last1, *part_end, f, tok);
-                            part_end =
-                                upper_bound(part_end, last2, *part_end, f, tok);
-                            if (tok.was_cancelled())
-                                return false;
-                        }
-
-                        if (!sequential_includes(
-                                low, high, part_begin, part_end, f, tok))
-                        {
-                            tok.cancel();
-                        }
-                        return !tok.was_cancelled();
-                    },
-                    [](std::vector<hpx::future<bool>>&& results) {
-                        return std::all_of(hpx::util::begin(results),
-                            hpx::util::end(results),
-                            [](hpx::future<bool>& val) { return val.get(); });
-                    });
-            }
-        };
-        /// \endcond
-    }    // namespace detail
+#if defined(DOXYGEN)
+namespace hpx {
+    // clang-format off
 
     /// Returns true if every element from the sorted range [first2, last2) is
     /// found within the sorted range [first1, last1). Also returns true if
@@ -277,19 +84,367 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Pred = detail::less>
-    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
-        typename util::detail::algorithm_result<ExPolicy, bool>::type>::type
+    typename util::detail::algorithm_result<ExPolicy, bool>::type>::type
     includes(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
-        FwdIter2 first2, FwdIter2 last2, Pred&& op = Pred())
+            FwdIter2 first2, FwdIter2 last2, Pred&& op = Pred());
+
+    // clang-format on
+}    // namespace hpx
+
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+
+#include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/util/cancellation_token.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+#include <hpx/parallel/util/partitioner.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace parallel { inline namespace v1 {
+    ///////////////////////////////////////////////////////////////////////////
+    // includes
+    namespace detail {
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Iter, typename Sent, typename T, typename F,
+            typename Proj, typename CancelToken>
+        Iter lower_bound(Iter first, Sent last, T&& value, F&& f, Proj&& proj,
+            CancelToken& tok)
+        {
+            using difference_type =
+                typename std::iterator_traits<Iter>::difference_type;
+
+            difference_type count = detail::distance(first, last);
+            while (count > 0)
+            {
+                if (tok.was_cancelled())
+                    break;
+
+                difference_type step = count / 2;
+                Iter it = detail::next(first, step);
+
+                if (hpx::util::invoke(f, hpx::util::invoke(proj, *it), value))
+                {
+                    first = ++it;
+                    count -= step + 1;
+                }
+                else
+                {
+                    count = step;
+                }
+            }
+            return first;
+        }
+
+        template <typename Iter, typename Sent, typename T, typename F,
+            typename Proj, typename CancelToken>
+        Iter upper_bound(Iter first, Sent last, T&& value, F&& f, Proj&& proj,
+            CancelToken& tok)
+        {
+            using difference_type =
+                typename std::iterator_traits<Iter>::difference_type;
+
+            difference_type count = detail::distance(first, last);
+            while (count > 0)
+            {
+                if (tok.was_cancelled())
+                    break;
+
+                difference_type step = count / 2;
+                Iter it = detail::next(first, step);
+
+                if (!hpx::util::invoke(f, hpx::util::invoke(proj, *it), value))
+                {
+                    first = ++it;
+                    count -= step + 1;
+                }
+                else
+                {
+                    count = step;
+                }
+            }
+            return first;
+        }
+
+        template <typename Iter1, typename Sent1, typename Iter2,
+            typename Sent2, typename F, typename Proj1, typename Proj2,
+            typename CancelToken>
+        bool sequential_includes(Iter1 first1, Sent1 last1, Iter2 first2,
+            Sent2 last2, F&& f, Proj1&& proj1, Proj2&& proj2, CancelToken& tok)
+        {
+            while (first2 != last2)
+            {
+                if (tok.was_cancelled())
+                {
+                    return false;
+                }
+
+                if (first1 == last1 ||
+                    hpx::util::invoke(f, hpx::util::invoke(proj2, *first2),
+                        hpx::util::invoke(proj1, *first1)))
+                {
+                    return false;
+                }
+                if (!hpx::util::invoke(f, hpx::util::invoke(proj1, *first1),
+                        hpx::util::invoke(proj2, *first2)))
+                {
+                    ++first2;
+                }
+
+                ++first1;
+            }
+            return true;
+        }
+
+        template <typename Iter1, typename Sent1, typename Iter2,
+            typename Sent2, typename F, typename Proj1, typename Proj2>
+        constexpr bool sequential_includes(Iter1 first1, Sent1 last1,
+            Iter2 first2, Sent2 last2, F&& f, Proj1&& proj1, Proj2&& proj2)
+        {
+            while (first2 != last2)
+            {
+                if (first1 == last1 ||
+                    hpx::util::invoke(f, hpx::util::invoke(proj2, *first2),
+                        hpx::util::invoke(proj1, *first1)))
+                {
+                    return false;
+                }
+                if (!hpx::util::invoke(f, hpx::util::invoke(proj1, *first1),
+                        hpx::util::invoke(proj2, *first2)))
+                {
+                    ++first2;
+                }
+
+                ++first1;
+            }
+            return true;
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        struct includes : public detail::algorithm<includes, bool>
+        {
+            includes()
+              : includes::algorithm("includes")
+            {
+            }
+
+            template <typename ExPolicy, typename Iter1, typename Sent1,
+                typename Iter2, typename Sent2, typename F, typename Proj1,
+                typename Proj2>
+            static bool sequential(ExPolicy, Iter1 first1, Sent1 last1,
+                Iter2 first2, Sent2 last2, F&& f, Proj1&& proj1, Proj2&& proj2)
+            {
+                return sequential_includes(first1, last1, first2, last2,
+                    std::forward<F>(f), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2));
+            }
+
+            template <typename ExPolicy, typename Iter1, typename Sent1,
+                typename Iter2, typename Sent2, typename F, typename Proj1,
+                typename Proj2>
+            static typename util::detail::algorithm_result<ExPolicy, bool>::type
+            parallel(ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
+                Sent2 last2, F&& f, Proj1&& proj1, Proj2&& proj2)
+            {
+                if (first1 == last1)
+                {
+                    return util::detail::algorithm_result<ExPolicy, bool>::get(
+                        false);
+                }
+                if (first2 == last2)
+                {
+                    return util::detail::algorithm_result<ExPolicy, bool>::get(
+                        true);
+                }
+
+                util::cancellation_token<> tok;
+                return util::partitioner<ExPolicy, bool>::call(
+                    std::forward<ExPolicy>(policy), first2,
+                    detail::distance(first2, last2),
+                    [first1, last1, first2, last2, tok, f = std::forward<F>(f),
+                        proj1 = std::forward<Proj1>(proj1),
+                        proj2 = std::forward<Proj2>(proj2)](Iter2 part_begin,
+                        std::size_t part_count) mutable -> bool {
+                        Iter2 part_end = detail::next(part_begin, part_count);
+                        auto&& value = hpx::util::invoke(proj2, *part_begin);
+                        if (first2 != part_begin)
+                        {
+                            part_begin = upper_bound(
+                                part_begin, part_end, value, f, proj2, tok);
+                            if (tok.was_cancelled())
+                            {
+                                return false;
+                            }
+                            if (part_begin == part_end)
+                            {
+                                return true;
+                            }
+                        }
+
+                        Iter1 low =
+                            lower_bound(first1, last1, value, f, proj1, tok);
+                        if (tok.was_cancelled())
+                        {
+                            return false;
+                        }
+
+                        if (low == last1 ||
+                            hpx::util::invoke(f,
+                                hpx::util::invoke(proj1, *part_begin),
+                                hpx::util::invoke(proj2, *low)))
+                        {
+                            tok.cancel();
+                            return false;
+                        }
+
+                        Iter1 high = last1;
+                        if (part_end != last2)
+                        {
+                            auto&& value1 = hpx::util::invoke(proj2, *part_end);
+
+                            high =
+                                upper_bound(low, last1, value1, f, proj1, tok);
+                            part_end = upper_bound(
+                                part_end, last2, value1, f, proj2, tok);
+
+                            if (tok.was_cancelled())
+                            {
+                                return false;
+                            }
+                        }
+
+                        if (!sequential_includes(low, high, part_begin,
+                                part_end, f, proj1, proj2, tok))
+                        {
+                            tok.cancel();
+                        }
+                        return !tok.was_cancelled();
+                    },
+                    [](std::vector<hpx::future<bool>>&& results) {
+                        return std::all_of(hpx::util::begin(results),
+                            hpx::util::end(results),
+                            [](hpx::future<bool>& val) { return val.get(); });
+                    });
+            }
+        };
+    }    // namespace detail
+
+    // clang-format off
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename Pred = detail::less,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<FwdIter1>::value &&
+            hpx::traits::is_iterator<FwdIter2>::value &&
+            hpx::traits::is_invocable<Pred,
+                typename std::iterator_traits<FwdIter1>::value_type,
+                typename std::iterator_traits<FwdIter2>::value_type
+            >::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::includes is deprecated, use hpx::includes instead")
+        typename util::detail::algorithm_result<ExPolicy, bool>::type
+        includes(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+            FwdIter2 first2, FwdIter2 last2, Pred&& op = Pred())
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
             "Requires at least forward iterator.");
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
+        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 
         return detail::includes().call(std::forward<ExPolicy>(policy), is_seq(),
-            first1, last1, first2, last2, std::forward<Pred>(op));
+            first1, last1, first2, last2, std::forward<Pred>(op),
+            util::projection_identity(), util::projection_identity());
     }
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::includes
+    HPX_INLINE_CONSTEXPR_VARIABLE struct includes_t final
+      : hpx::functional::tag<includes_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+            typename Pred = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_invocable<Pred,
+                    typename std::iterator_traits<FwdIter1>::value_type,
+                    typename std::iterator_traits<FwdIter2>::value_type
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            bool>::type
+        tag_invoke(includes_t, ExPolicy&& policy, FwdIter1 first1,
+            FwdIter1 last1, FwdIter2 first2, FwdIter2 last2, Pred&& op = Pred())
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+                "Requires at least forward iterator.");
+
+            using is_seq =
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>;
+
+            return hpx::parallel::v1::detail::includes().call(
+                std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
+                last2, std::forward<Pred>(op),
+                hpx::parallel::util::projection_identity(),
+                hpx::parallel::util::projection_identity());
+        }
+
+        // clang-format off
+        template <typename FwdIter1, typename FwdIter2,
+            typename Pred = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_invocable<Pred,
+                    typename std::iterator_traits<FwdIter1>::value_type,
+                    typename std::iterator_traits<FwdIter2>::value_type
+                >::value
+            )>
+        // clang-format on
+        friend bool tag_invoke(includes_t, FwdIter1 first1, FwdIter1 last1,
+            FwdIter2 first2, FwdIter2 last2, Pred&& op = Pred())
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::includes().call(
+                hpx::execution::seq, std::true_type(), first1, last1, first2,
+                last2, std::forward<Pred>(op),
+                hpx::parallel::util::projection_identity(),
+                hpx::parallel::util::projection_identity());
+        }
+    } includes{};
+}    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/includes.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/includes.hpp
@@ -346,7 +346,7 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename Pred = hpx::parallel::v1::detail::less,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value &&
                 hpx::traits::is_invocable<Pred,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -330,7 +330,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Op, typename T,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value &&
             hpx::traits::is_invocable<Op,
@@ -433,7 +433,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Op,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value &&
             hpx::traits::is_invocable<Op,
@@ -517,7 +517,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2>
     inline typename std::enable_if<
-        execution::is_execution_policy<ExPolicy>::value,
+        hpx::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type>::type
     inclusive_scan(
         ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest)

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -516,8 +516,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// \a inclusive_scan includes the ith input element in the ith sum.
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2>
-    inline typename std::enable_if<
-        hpx::is_execution_policy<ExPolicy>::value,
+    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
         typename util::detail::algorithm_result<ExPolicy, FwdIter2>::type>::type
     inclusive_scan(
         ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest)

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_heap.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_heap.hpp
@@ -270,7 +270,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename RandIter,
         typename Comp = detail::less, typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<RandIter>::value &&
             traits::is_projected<Proj, RandIter>::value &&
             traits::is_indirect_callable<ExPolicy, Comp,
@@ -410,7 +410,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename RandIter,
         typename Comp = detail::less, typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<RandIter>::value &&
             traits::is_projected<Proj, RandIter>::value &&
             traits::is_indirect_callable<ExPolicy, Comp,
@@ -449,7 +449,7 @@ namespace hpx {
         template <typename ExPolicy, typename RandIter,
             typename Comp = hpx::parallel::v1::detail::less,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<RandIter>::value &&
                 hpx::traits::is_invocable<Comp,
                     typename std::iterator_traits<RandIter>::value_type,
@@ -511,7 +511,7 @@ namespace hpx {
         template <typename ExPolicy, typename RandIter,
             typename Comp = hpx::parallel::v1::detail::less,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<RandIter>::value &&
                 hpx::traits::is_invocable<Comp,
                     typename std::iterator_traits<RandIter>::value_type,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
@@ -420,7 +420,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename RndIter, typename Comp,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<RndIter>::value &&
                 hpx::traits::is_invocable<Comp,
                     typename std::iterator_traits<RndIter>::value_type,
@@ -451,7 +451,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename RndIter,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<RndIter>::value
             )>
         // clang-format on

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/merge.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/merge.hpp
@@ -6,333 +6,10 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/assert.hpp>
-#include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/invoke.hpp>
-#include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/parallel/util/tagged_tuple.hpp>
+#if defined(DOXYGEN)
+namespace hpx {
+    // clang-format off
 
-#include <hpx/algorithms/traits/projected.hpp>
-#include <hpx/execution/algorithms/detail/is_negative.hpp>
-#include <hpx/execution/algorithms/detail/predicates.hpp>
-#include <hpx/executors/execution_policy.hpp>
-#include <hpx/parallel/algorithms/detail/dispatch.hpp>
-#include <hpx/parallel/algorithms/detail/transfer.hpp>
-#include <hpx/parallel/tagspec.hpp>
-#include <hpx/parallel/util/compare_projected.hpp>
-#include <hpx/parallel/util/detail/algorithm_result.hpp>
-#include <hpx/parallel/util/detail/handle_local_exceptions.hpp>
-#include <hpx/parallel/util/loop.hpp>
-#include <hpx/parallel/util/projection_identity.hpp>
-#include <hpx/parallel/util/transfer.hpp>
-
-#include <algorithm>
-#include <cstddef>
-#include <exception>
-#include <iterator>
-#include <list>
-#include <memory>
-#include <type_traits>
-#include <utility>
-#include <vector>
-
-namespace hpx { namespace parallel { inline namespace v1 {
-    /////////////////////////////////////////////////////////////////////////////
-    // merge
-    namespace detail {
-        /// \cond NOINTERNAL
-
-        // sequential merge with projection function.
-        template <typename InIter1, typename InIter2, typename OutIter,
-            typename Comp, typename Proj1, typename Proj2>
-        hpx::tuple<InIter1, InIter2, OutIter> sequential_merge(InIter1 first1,
-            InIter1 last1, InIter2 first2, InIter2 last2, OutIter dest,
-            Comp&& comp, Proj1&& proj1, Proj2&& proj2)
-        {
-            if (first1 != last1 && first2 != last2)
-            {
-                while (true)
-                {
-                    if (hpx::util::invoke(comp,
-                            hpx::util::invoke(proj2, *first2),
-                            hpx::util::invoke(proj1, *first1)))
-                    {
-                        *dest++ = *first2++;
-                        if (first2 == last2)
-                            break;
-                    }
-                    else
-                    {
-                        *dest++ = *first1++;
-                        if (first1 == last1)
-                            break;
-                    }
-                }
-            }
-            dest = std::copy(first1, last1, dest);
-            dest = std::copy(first2, last2, dest);
-
-            return hpx::make_tuple(last1, last2, dest);
-        }
-
-        struct upper_bound_helper
-        {
-            // upper_bound with projection function.
-            template <typename RandIter, typename Type, typename Comp,
-                typename Proj>
-            static RandIter call(RandIter first, RandIter last,
-                const Type& value, Comp comp, Proj proj)
-            {
-                typedef typename std::iterator_traits<RandIter>::difference_type
-                    difference_type;
-
-                difference_type count = std::distance(first, last);
-
-                while (count > 0)
-                {
-                    difference_type step = count / 2;
-                    RandIter mid = std::next(first, step);
-
-                    if (!hpx::util::invoke(
-                            comp, value, hpx::util::invoke(proj, *mid)))
-                    {
-                        first = ++mid;
-                        count -= step + 1;
-                    }
-                    else
-                    {
-                        count = step;
-                    }
-                }
-
-                return first;
-            }
-
-            typedef struct lower_bound_helper another_type;
-        };
-
-        struct lower_bound_helper
-        {
-            // lower_bound with projection function.
-            template <typename RandIter, typename Type, typename Comp,
-                typename Proj>
-            static RandIter call(RandIter first, RandIter last,
-                const Type& value, Comp comp, Proj proj)
-            {
-                typedef typename std::iterator_traits<RandIter>::difference_type
-                    difference_type;
-
-                difference_type count = std::distance(first, last);
-
-                while (count > 0)
-                {
-                    difference_type step = count / 2;
-                    RandIter mid = std::next(first, step);
-
-                    if (hpx::util::invoke(
-                            comp, hpx::util::invoke(proj, *mid), value))
-                    {
-                        first = ++mid;
-                        count -= step + 1;
-                    }
-                    else
-                    {
-                        count = step;
-                    }
-                }
-
-                return first;
-            }
-
-            typedef struct upper_bound_helper another_type;
-        };
-
-        template <typename ExPolicy, typename RandIter1, typename RandIter2,
-            typename RandIter3, typename Comp, typename Proj1, typename Proj2,
-            typename BinarySearchHelper>
-        void parallel_merge_helper(ExPolicy policy, RandIter1 first1,
-            RandIter1 last1, RandIter2 first2, RandIter2 last2, RandIter3 dest,
-            Comp comp, Proj1 proj1, Proj2 proj2, bool range_reversal,
-            BinarySearchHelper)
-        {
-            const std::size_t threshold = 65536ul;
-            HPX_ASSERT(threshold >= 1ul);
-
-            std::size_t size1 = last1 - first1;
-            std::size_t size2 = last2 - first2;
-
-            // Perform sequential merge if data size is smaller than threshold.
-            if (size1 + size2 <= threshold)
-            {
-                if (range_reversal)
-                {
-                    sequential_merge(first2, first2 + size2, first1,
-                        first1 + size1, dest, comp, proj2, proj1);
-                }
-                else
-                {
-                    sequential_merge(first1, first1 + size1, first2,
-                        first2 + size2, dest, comp, proj1, proj2);
-                }
-                return;
-            }
-
-            // Let size1 is bigger than size2 always.
-            if (size1 < size2)
-            {
-                // For stability of algorithm, must switch binary search methods
-                //   when swapping size1 and size2.
-                parallel_merge_helper(policy, first2, last2, first1, last1,
-                    dest, comp, proj2, proj1, !range_reversal,
-                    typename BinarySearchHelper::another_type());
-                return;
-            }
-
-            HPX_ASSERT(size1 >= size2);
-            HPX_ASSERT(size1 >= 1ul);
-
-            RandIter1 mid1 = first1 + size1 / 2;
-            RandIter2 boundary2 = BinarySearchHelper::call(
-                first2, last2, hpx::util::invoke(proj1, *mid1), comp, proj2);
-            RandIter3 target = dest + (mid1 - first1) + (boundary2 - first2);
-
-            *target = *mid1;
-
-            hpx::future<void> fut =
-                execution::async_execute(policy.executor(), [&]() -> void {
-                    // Process leftside ranges.
-                    parallel_merge_helper(policy, first1, mid1, first2,
-                        boundary2, dest, comp, proj1, proj2, range_reversal,
-                        BinarySearchHelper());
-                });
-
-            try
-            {
-                // Process rightside ranges.
-                parallel_merge_helper(policy, mid1 + 1, last1, boundary2, last2,
-                    target + 1, comp, proj1, proj2, range_reversal,
-                    BinarySearchHelper());
-            }
-            catch (...)
-            {
-                fut.wait();
-
-                std::vector<hpx::future<void>> futures(2);
-                futures[0] = std::move(fut);
-                futures[1] = hpx::make_exceptional_future<void>(
-                    std::current_exception());
-
-                std::list<std::exception_ptr> errors;
-                util::detail::handle_local_exceptions<ExPolicy>::call(
-                    futures, errors);
-
-                // Not reachable.
-                HPX_ASSERT(false);
-                return;
-            }
-
-            fut.get();
-        }
-
-        template <typename ExPolicy, typename RandIter1, typename RandIter2,
-            typename RandIter3, typename Comp, typename Proj1, typename Proj2>
-        hpx::future<hpx::tuple<RandIter1, RandIter2, RandIter3>> parallel_merge(
-            ExPolicy&& policy, RandIter1 first1, RandIter1 last1,
-            RandIter2 first2, RandIter2 last2, RandIter3 dest, Comp&& comp,
-            Proj1&& proj1, Proj2&& proj2)
-        {
-            typedef hpx::tuple<RandIter1, RandIter2, RandIter3> result_type;
-
-            typedef typename std::remove_reference<ExPolicy>::type ExPolicy_;
-            typedef typename std::remove_reference<Comp>::type Comp_;
-            typedef typename std::remove_reference<Proj1>::type Proj1_;
-            typedef typename std::remove_reference<Proj2>::type Proj2_;
-
-            hpx::future<result_type> f = execution::async_execute(
-                policy.executor(),
-                std::bind(
-                    [first1, last1, first2, last2, dest](ExPolicy_& policy,
-                        Comp_& comp, Proj1_& proj1,
-                        Proj2_& proj2) -> result_type {
-                        try
-                        {
-                            parallel_merge_helper(std::move(policy), first1,
-                                last1, first2, last2, dest, std::move(comp),
-                                std::move(proj1), std::move(proj2), false,
-                                lower_bound_helper());
-
-                            return hpx::make_tuple(last1, last2,
-                                dest + (last1 - first1) + (last2 - first2));
-                        }
-                        catch (...)
-                        {
-                            util::detail::handle_local_exceptions<
-                                ExPolicy>::call(std::current_exception());
-                        }
-
-                        // Not reachable.
-                        HPX_ASSERT(false);
-                    },
-                    std::forward<ExPolicy>(policy), std::forward<Comp>(comp),
-                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2)));
-
-            return f;
-        }
-
-        template <typename IterTuple>
-        struct merge : public detail::algorithm<merge<IterTuple>, IterTuple>
-        {
-            merge()
-              : merge::algorithm("merge")
-            {
-            }
-
-            template <typename ExPolicy, typename InIter1, typename InIter2,
-                typename OutIter, typename Comp, typename Proj1, typename Proj2>
-            static hpx::tuple<InIter1, InIter2, OutIter> sequential(ExPolicy,
-                InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
-                OutIter dest, Comp&& comp, Proj1&& proj1, Proj2&& proj2)
-            {
-                return sequential_merge(first1, last1, first2, last2, dest,
-                    std::forward<Comp>(comp), std::forward<Proj1>(proj1),
-                    std::forward<Proj2>(proj2));
-            }
-
-            template <typename ExPolicy, typename RandIter1, typename RandIter2,
-                typename RandIter3, typename Comp, typename Proj1,
-                typename Proj2>
-            static typename util::detail::algorithm_result<ExPolicy,
-                hpx::tuple<RandIter1, RandIter2, RandIter3>>::type
-            parallel(ExPolicy&& policy, RandIter1 first1, RandIter1 last1,
-                RandIter2 first2, RandIter2 last2, RandIter3 dest, Comp&& comp,
-                Proj1&& proj1, Proj2&& proj2)
-            {
-                typedef hpx::tuple<RandIter1, RandIter2, RandIter3> result_type;
-                typedef util::detail::algorithm_result<ExPolicy, result_type>
-                    algorithm_result;
-
-                try
-                {
-                    return algorithm_result::get(parallel_merge(
-                        std::forward<ExPolicy>(policy), first1, last1, first2,
-                        last2, dest, std::forward<Comp>(comp),
-                        std::forward<Proj1>(proj1),
-                        std::forward<Proj2>(proj2)));
-                }
-                catch (...)
-                {
-                    return algorithm_result::get(
-                        detail::handle_exception<ExPolicy, result_type>::call(
-                            std::current_exception()));
-                }
-            }
-        };
-        /// \endcond
-    }    // namespace detail
-
-    // TODO: Support forward and bidirectional iterator. (#2826)
-    // For now, only support random access iterator.
     /// Merges two sorted ranges [first1, last1) and [first2, last2)
     /// into one sorted range beginning at \a dest. The order of
     /// equivalent elements in the each of original two ranges is preserved.
@@ -365,12 +42,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///                     overload of \a merge requires \a Comp to meet the
     ///                     requirements of \a CopyConstructible. This defaults
     ///                     to std::less<>
-    /// \tparam Proj1       The type of an optional projection function to be
-    ///                     used for elements of the first range. This defaults
-    ///                     to \a util::projection_identity
-    /// \tparam Proj2       The type of an optional projection function to be
-    ///                     used for elements of the second range. This defaults
-    ///                     to \a util::projection_identity
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
@@ -396,14 +67,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///                     objects of types \a RandIter1 and \a RandIter2 can be
     ///                     dereferenced and then implicitly converted to
     ///                     both \a Type1 and \a Type2
-    /// \param proj1        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the
-    ///                     first range as a projection operation before the
-    ///                     actual comparison \a comp is invoked.
-    /// \param proj2        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the
-    ///                     second range as a projection operation before the
-    ///                     actual comparison \a comp is invoked.
     ///
     /// The assignments in the parallel \a merge algorithm invoked with
     /// an execution policy object of type \a sequenced_policy
@@ -416,273 +79,20 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// within each thread.
     ///
     /// \returns  The \a merge algorithm returns a
-    /// \a hpx::future<tagged_tuple<tag::in1(RandIter1), tag::in2(RandIter2), tag::out(RandIter3)> >
+    /// \a hpx::future<RandIter3> >
     ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and returns
-    /// \a tagged_tuple<tag::in1(RandIter1), tag::in2(RandIter2), tag::out(RandIter3)>
-    ///           otherwise.
-    ///           The \a merge algorithm returns the tuple of
-    ///           the source iterator \a last1,
-    ///           the source iterator \a last2,
-    ///           the destination iterator to the end of the \a dest range.
+    ///           \a tagged_tuple<RandIter3> otherwise.
+    ///           The \a merge algorithm returns the destination iterator to
+    ///           the end of the \a dest range.
     ///
     template <typename ExPolicy, typename RandIter1, typename RandIter2,
-        typename RandIter3, typename Comp = detail::less,
-        typename Proj1 = util::projection_identity,
-        typename Proj2 = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<RandIter1>::value&& hpx::traits::
-                    is_iterator<RandIter2>::value&& hpx::traits::is_iterator<
-                        RandIter3>::value&& traits::is_projected<Proj1,
-                        RandIter1>::value&&
-                        traits::is_projected<Proj2, RandIter2>::value&&
-                            traits::is_indirect_callable<ExPolicy, Comp,
-                                traits::projected<Proj1, RandIter1>,
-                                traits::projected<Proj2, RandIter2>>::value)>
-    typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_tuple<tag::in1(RandIter1), tag::in2(RandIter2),
-            tag::out(RandIter3)>>::type
+        typename RandIter3, typename Comp = detail::less>
+    typename util::detail::algorithm_result<ExPolicy, RandIter3>::type
     merge(ExPolicy&& policy, RandIter1 first1, RandIter1 last1,
-        RandIter2 first2, RandIter2 last2, RandIter3 dest, Comp&& comp = Comp(),
-        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
-    {
-        static_assert(
-            (hpx::traits::is_random_access_iterator<RandIter1>::value),
-            "Required at least random access iterator.");
-        static_assert(
-            (hpx::traits::is_random_access_iterator<RandIter2>::value),
-            "Requires at least random access iterator.");
-        static_assert(
-            (hpx::traits::is_random_access_iterator<RandIter3>::value),
-            "Requires at least random access iterator.");
+        RandIter2 first2, RandIter2 last2, RandIter3 dest, Comp&& comp = Comp());
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
-        typedef hpx::tuple<RandIter1, RandIter2, RandIter3> result_type;
-
-        return hpx::util::make_tagged_tuple<tag::in1, tag::in2, tag::out>(
-            detail::merge<result_type>().call(std::forward<ExPolicy>(policy),
-                is_seq(), first1, last1, first2, last2, dest,
-                std::forward<Comp>(comp), std::forward<Proj1>(proj1),
-                std::forward<Proj2>(proj2)));
-    }
-
-    /////////////////////////////////////////////////////////////////////////////
-    // inplace_merge
-    namespace detail {
-        /// \cond NOINTERNAL
-
-        // sequential inplace_merge with projection function.
-        template <typename BidirIter, typename Comp, typename Proj>
-        inline BidirIter sequential_inplace_merge(BidirIter first,
-            BidirIter middle, BidirIter last, Comp&& comp, Proj&& proj)
-        {
-            std::inplace_merge(first, middle, last,
-                util::compare_projected<Comp, Proj>(
-                    std::forward<Comp>(comp), std::forward<Proj>(proj)));
-            return last;
-        }
-
-        template <typename ExPolicy, typename RandIter, typename Comp,
-            typename Proj>
-        void parallel_inplace_merge_helper(ExPolicy&& policy, RandIter first,
-            RandIter middle, RandIter last, Comp&& comp, Proj&& proj)
-        {
-            const std::size_t threshold = 65536ul;
-            HPX_ASSERT(threshold >= 5ul);
-
-            std::size_t left_size = middle - first;
-            std::size_t right_size = last - middle;
-
-            // Perform sequential inplace_merge
-            //   if data size is smaller than threshold.
-            if (left_size + right_size <= threshold)
-            {
-                sequential_inplace_merge(first, middle, last,
-                    std::forward<Comp>(comp), std::forward<Proj>(proj));
-                return;
-            }
-
-            if (left_size >= right_size)
-            {
-                // Means that always 'pivot' < 'middle'.
-                HPX_ASSERT(left_size >= 3ul);
-
-                // Select pivot in left-side range.
-                RandIter pivot = first + left_size / 2;
-                RandIter boundary = lower_bound_helper::call(
-                    middle, last, hpx::util::invoke(proj, *pivot), comp, proj);
-                RandIter target = pivot + (boundary - middle);
-
-                // Swap two blocks, [pivot, middle) and [middle, boundary).
-                // After this, [first, last) will be divided into three blocks,
-                //   [first, target), target, and [target+1, last).
-                // And all elements of [first, target) are less than
-                //   the thing of target.
-                // And all elements of [target+1, last) are greater or equal than
-                //   the thing of target.
-                std::rotate(pivot, middle, boundary);
-
-                hpx::future<void> fut =
-                    execution::async_execute(policy.executor(), [&]() -> void {
-                        // Process the range which is left-side of 'target'.
-                        parallel_inplace_merge_helper(
-                            policy, first, pivot, target, comp, proj);
-                    });
-
-                try
-                {
-                    // Process the range which is right-side of 'target'.
-                    parallel_inplace_merge_helper(
-                        policy, target + 1, boundary, last, comp, proj);
-                }
-                catch (...)
-                {
-                    fut.wait();
-
-                    std::vector<hpx::future<void>> futures(2);
-                    futures[0] = std::move(fut);
-                    futures[1] = hpx::make_exceptional_future<void>(
-                        std::current_exception());
-
-                    std::list<std::exception_ptr> errors;
-                    util::detail::handle_local_exceptions<ExPolicy>::call(
-                        futures, errors);
-
-                    // Not reachable.
-                    HPX_ASSERT(false);
-                }
-                if (fut.valid())    // NOLINT
-                    fut.get();
-            }
-            else /* left_size < right_size */
-            {
-                // Means that always 'pivot' < 'last'.
-                HPX_ASSERT(right_size >= 3ul);
-
-                // Select pivot in right-side range.
-                RandIter pivot = middle + right_size / 2;
-                RandIter boundary = upper_bound_helper::call(
-                    first, middle, hpx::util::invoke(proj, *pivot), comp, proj);
-                RandIter target = boundary + (pivot - middle);
-
-                // Swap two blocks, [boundary, middle) and [middle, pivot+1).
-                // After this, [first, last) will be divided into three blocks,
-                //   [first, target), target, and [target+1, last).
-                // And all elements of [first, target) are less than
-                //   the thing of target.
-                // And all elements of [target+1, last) are greater or equal than
-                //   the thing of target.
-                std::rotate(boundary, middle, pivot + 1);
-
-                hpx::future<void> fut =
-                    execution::async_execute(policy.executor(), [&]() -> void {
-                        // Process the range which is left-side of 'target'.
-                        parallel_inplace_merge_helper(
-                            policy, first, boundary, target, comp, proj);
-                    });
-
-                try
-                {
-                    // Process the range which is right-side of 'target'.
-                    parallel_inplace_merge_helper(
-                        policy, target + 1, pivot + 1, last, comp, proj);
-                }
-                catch (...)
-                {
-                    fut.wait();
-
-                    std::vector<hpx::future<void>> futures(2);
-                    futures[0] = std::move(fut);
-                    futures[1] = hpx::make_exceptional_future<void>(
-                        std::current_exception());
-
-                    std::list<std::exception_ptr> errors;
-                    util::detail::handle_local_exceptions<ExPolicy>::call(
-                        futures, errors);
-
-                    // Not reachable.
-                    HPX_ASSERT(false);
-                }
-
-                if (fut.valid())    // NOLINT
-                    fut.get();
-            }
-        }
-
-        template <typename ExPolicy, typename RandIter, typename Comp,
-            typename Proj>
-        inline hpx::future<RandIter> parallel_inplace_merge(ExPolicy&& policy,
-            RandIter first, RandIter middle, RandIter last, Comp&& comp,
-            Proj&& proj)
-        {
-            return execution::async_execute(policy.executor(),
-                [policy, first, middle, last, comp = std::forward<Comp>(comp),
-                    proj = std::forward<Proj>(proj)]() mutable -> RandIter {
-                    try
-                    {
-                        parallel_inplace_merge_helper(policy, first, middle,
-                            last, std::move(comp), std::move(proj));
-                        return last;
-                    }
-                    catch (...)
-                    {
-                        util::detail::handle_local_exceptions<ExPolicy>::call(
-                            std::current_exception());
-                    }
-
-                    // Not reachable.
-                    HPX_ASSERT(false);
-                });
-        }
-
-        template <typename Iter>
-        struct inplace_merge
-          : public detail::algorithm<inplace_merge<Iter>, Iter>
-        {
-            inplace_merge()
-              : inplace_merge::algorithm("inplace_merge")
-            {
-            }
-
-            template <typename ExPolicy, typename RandIter, typename Comp,
-                typename Proj>
-            static RandIter sequential(ExPolicy, RandIter first,
-                RandIter middle, RandIter last, Comp&& comp, Proj&& proj)
-            {
-                return sequential_inplace_merge(first, middle, last,
-                    std::forward<Comp>(comp), std::forward<Proj>(proj));
-            }
-
-            template <typename ExPolicy, typename RandIter, typename Comp,
-                typename Proj>
-            static typename util::detail::algorithm_result<ExPolicy,
-                RandIter>::type
-            parallel(ExPolicy&& policy, RandIter first, RandIter middle,
-                RandIter last, Comp&& comp, Proj&& proj)
-            {
-                typedef util::detail::algorithm_result<ExPolicy, RandIter>
-                    algorithm_result;
-
-                try
-                {
-                    return algorithm_result::get(parallel_inplace_merge(
-                        std::forward<ExPolicy>(policy), first, middle, last,
-                        std::forward<Comp>(comp), std::forward<Proj>(proj)));
-                }
-                catch (...)
-                {
-                    return algorithm_result::get(
-                        detail::handle_exception<ExPolicy, RandIter>::call(
-                            std::current_exception()));
-                }
-            }
-        };
-        /// \endcond
-    }    // namespace detail
-
-    // TODO: Support bidirectional iterator. (#2826)
-    // For now, only support random access iterator.
     /// Merges two consecutive sorted ranges [first, middle) and
     /// [middle, last) into one sorted range [first, last). The order of
     /// equivalent elements in the each of original two ranges is preserved.
@@ -704,8 +114,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///                     overload of \a inplace_merge requires \a Comp
     ///                     to meet the requirements of \a CopyConstructible.
     ///                     This defaults to std::less<>
-    /// \tparam Proj        The type of an optional projection function. This
-    ///                     defaults to \a util::projection_identity
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
@@ -729,10 +137,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///                     such that objects of types \a RandIter can be
     ///                     dereferenced and then implicitly converted to both
     ///                     \a Type1 and \a Type2
-    /// \param proj         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements as a
-    ///                     projection operation before the actual predicate
-    ///                     \a is invoked.
     ///
     /// The assignments in the parallel \a inplace_merge algorithm invoked
     /// with an execution policy object of type \a sequenced_policy
@@ -745,31 +149,783 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// within each thread.
     ///
     /// \returns  The \a inplace_merge algorithm returns a
-    ///           \a hpx::future<RandIter> if the execution policy is of type
+    ///           \a hpx::future<void> if the execution policy is of type
     ///           \a sequenced_task_policy or \a parallel_task_policy
-    ///           and returns \a RandIter otherwise.
+    ///           and returns void otherwise.
     ///           The \a inplace_merge algorithm returns
     ///           the source iterator \a last
     ///
     template <typename ExPolicy, typename RandIter,
-        typename Comp = detail::less, typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<RandIter>::value&&
-                    traits::is_projected<Proj, RandIter>::value&&
-                        traits::is_indirect_callable<ExPolicy, Comp,
-                            traits::projected<Proj, RandIter>,
-                            traits::projected<Proj, RandIter>>::value)>
-    typename util::detail::algorithm_result<ExPolicy, RandIter>::type
+        typename Comp = detail::less>
+    typename util::detail::algorithm_result<ExPolicy>::type
     inplace_merge(ExPolicy&& policy, RandIter first, RandIter middle,
-        RandIter last, Comp&& comp = Comp(), Proj&& proj = Proj())
+        RandIter last, Comp&& comp = Comp());
+
+    // clang-format on
+}    // namespace hpx
+
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/assert.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+
+#include <hpx/algorithms/traits/projected.hpp>
+#include <hpx/execution/algorithms/detail/is_negative.hpp>
+#include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/algorithms/copy.hpp>
+#include <hpx/parallel/algorithms/detail/advance_to_sentinel.hpp>
+#include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/algorithms/detail/rotate.hpp>
+#include <hpx/parallel/algorithms/detail/upper_lower_bound.hpp>
+#include <hpx/parallel/util/compare_projected.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/handle_local_exceptions.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <exception>
+#include <iterator>
+#include <list>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace parallel { inline namespace v1 {
+    /////////////////////////////////////////////////////////////////////////////
+    // merge
+    namespace detail {
+        /// \cond NOINTERNAL
+
+        // sequential merge with projection function.
+        template <typename Iter1, typename Sent1, typename Iter2,
+            typename Sent2, typename OutIter, typename Comp, typename Proj1,
+            typename Proj2>
+        constexpr util::in_in_out_result<Iter1, Iter2, OutIter>
+        sequential_merge(Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2,
+            OutIter dest, Comp&& comp, Proj1&& proj1, Proj2&& proj2)
+        {
+            if (first1 != last1 && first2 != last2)
+            {
+                while (true)
+                {
+                    if (hpx::util::invoke(comp,
+                            hpx::util::invoke(proj2, *first2),
+                            hpx::util::invoke(proj1, *first1)))
+                    {
+                        *dest++ = *first2++;
+                        if (first2 == last2)
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        *dest++ = *first1++;
+                        if (first1 == last1)
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            auto copy_result1 = util::copy(first1, last1, dest);
+            auto copy_result2 = util::copy(first2, last2, copy_result1.out);
+
+            return {copy_result1.in, copy_result2.in, copy_result2.out};
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        struct lower_bound_helper;
+
+        struct upper_bound_helper
+        {
+            // upper_bound with projection function.
+            template <typename Iter, typename Sent, typename T, typename Comp,
+                typename Proj>
+            static constexpr Iter call(
+                Iter first, Sent last, T const& value, Comp&& comp, Proj&& proj)
+            {
+                return detail::upper_bound(first, last, value,
+                    std::forward<Comp>(comp), std::forward<Proj>(proj));
+            }
+
+            using another_type = lower_bound_helper;
+        };
+
+        struct lower_bound_helper
+        {
+            // lower_bound with projection function.
+            template <typename Iter, typename Sent, typename T, typename Comp,
+                typename Proj>
+            static constexpr Iter call(
+                Iter first, Sent last, T const& value, Comp&& comp, Proj&& proj)
+            {
+                return detail::lower_bound(first, last, value,
+                    std::forward<Comp>(comp), std::forward<Proj>(proj));
+            }
+
+            using another_type = upper_bound_helper;
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename ExPolicy, typename Iter1, typename Sent1,
+            typename Iter2, typename Sent2, typename Iter3, typename Comp,
+            typename Proj1, typename Proj2, typename BinarySearchHelper>
+        void parallel_merge_helper(ExPolicy policy, Iter1 first1, Sent1 last1,
+            Iter2 first2, Sent2 last2, Iter3 dest, Comp&& comp, Proj1&& proj1,
+            Proj2&& proj2, bool range_reversal, BinarySearchHelper)
+        {
+            constexpr std::size_t threshold = 65536;
+
+            std::size_t size1 = detail::distance(first1, last1);
+            std::size_t size2 = detail::distance(first2, last2);
+
+            // Perform sequential merge if data size is smaller than threshold.
+            if (size1 + size2 <= threshold)
+            {
+                if (range_reversal)
+                {
+                    sequential_merge(first2, last2, first1, last1, dest,
+                        std::forward<Comp>(comp), std::forward<Proj2>(proj2),
+                        std::forward<Proj1>(proj1));
+                }
+                else
+                {
+                    sequential_merge(first1, last1, first2, last2, dest,
+                        std::forward<Comp>(comp), std::forward<Proj1>(proj1),
+                        std::forward<Proj2>(proj2));
+                }
+                return;
+            }
+
+            // Let size1 is bigger than size2 always.
+            if (size1 < size2)
+            {
+                // For stability of algorithm, must switch binary search methods
+                // when swapping size1 and size2.
+                parallel_merge_helper(policy, first2, last2, first1, last1,
+                    dest, std::forward<Comp>(comp), std::forward<Proj2>(proj2),
+                    std::forward<Proj1>(proj1), !range_reversal,
+                    typename BinarySearchHelper::another_type());
+                return;
+            }
+
+            HPX_ASSERT(size1 >= size2);
+            HPX_ASSERT(size1 >= 1ul);
+
+            Iter1 mid1 = first1 + size1 / 2;
+            Iter2 boundary2 = BinarySearchHelper::call(
+                first2, last2, hpx::util::invoke(proj1, *mid1), comp, proj2);
+            Iter3 target = dest + (mid1 - first1) + (boundary2 - first2);
+
+            *target = *mid1;
+
+            hpx::future<void> fut =
+                execution::async_execute(policy.executor(), [&]() -> void {
+                    // Process left side ranges.
+                    parallel_merge_helper(policy, first1, mid1, first2,
+                        boundary2, dest, comp, proj1, proj2, range_reversal,
+                        BinarySearchHelper());
+                });
+
+            try
+            {
+                // Process right side ranges.
+                parallel_merge_helper(policy, mid1 + 1, last1, boundary2, last2,
+                    target + 1, std::forward<Comp>(comp),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2),
+                    range_reversal, BinarySearchHelper());
+            }
+            catch (...)
+            {
+                fut.wait();
+
+                std::vector<hpx::future<void>> futures;
+                futures.reserve(2);
+                futures.emplace_back(std::move(fut));
+                futures.emplace_back(hpx::make_exceptional_future<void>(
+                    std::current_exception()));
+
+                std::list<std::exception_ptr> errors;
+                util::detail::handle_local_exceptions<ExPolicy>::call(
+                    futures, errors);
+
+                // Not reachable.
+                HPX_ASSERT(false);
+                return;
+            }
+
+            fut.get();
+        }
+
+        template <typename ExPolicy, typename Iter1, typename Sent1,
+            typename Iter2, typename Sent2, typename Iter3, typename Comp,
+            typename Proj1, typename Proj2>
+        hpx::future<util::in_in_out_result<Iter1, Iter2, Iter3>> parallel_merge(
+            ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
+            Sent2 last2, Iter3 dest, Comp&& comp, Proj1&& proj1, Proj2&& proj2)
+        {
+            using result_type = util::in_in_out_result<Iter1, Iter2, Iter3>;
+
+            auto f1 = [first1, last1, first2, last2, dest,
+                          policy = std::forward<ExPolicy>(policy),
+                          comp = std::forward<Comp>(comp),
+                          proj1 = std::forward<Proj1>(proj1),
+                          proj2 = std::forward<Proj2>(proj2)]() -> result_type {
+                try
+                {
+                    parallel_merge_helper(std::move(policy), first1, last1,
+                        first2, last2, dest, std::move(comp), std::move(proj1),
+                        std::move(proj2), false, lower_bound_helper());
+
+                    auto len1 = detail::distance(first1, last1);
+                    auto len2 = detail::distance(first2, last2);
+                    return {std::next(first1, len1), std::next(first2, len2),
+                        std::next(dest, len1 + len2)};
+                }
+                catch (...)
+                {
+                    util::detail::handle_local_exceptions<ExPolicy>::call(
+                        std::current_exception());
+                }
+
+                // Not reachable.
+                HPX_ASSERT(false);
+            };
+
+            return execution::async_execute(policy.executor(), std::move(f1));
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename IterTuple>
+        struct merge : public detail::algorithm<merge<IterTuple>, IterTuple>
+        {
+            merge()
+              : merge::algorithm("merge")
+            {
+            }
+
+            template <typename ExPolicy, typename Iter1, typename Sent1,
+                typename Iter2, typename Sent2, typename Iter3, typename Comp,
+                typename Proj1, typename Proj2>
+            static util::in_in_out_result<Iter1, Iter2, Iter3> sequential(
+                ExPolicy, Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2,
+                Iter3 dest, Comp&& comp, Proj1&& proj1, Proj2&& proj2)
+            {
+                return sequential_merge(first1, last1, first2, last2, dest,
+                    std::forward<Comp>(comp), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2));
+            }
+
+            template <typename ExPolicy, typename Iter1, typename Sent1,
+                typename Iter2, typename Sent2, typename Iter3, typename Comp,
+                typename Proj1, typename Proj2>
+            static typename util::detail::algorithm_result<ExPolicy,
+                util::in_in_out_result<Iter1, Iter2, Iter3>>::type
+            parallel(ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
+                Sent2 last2, Iter3 dest, Comp&& comp, Proj1&& proj1,
+                Proj2&& proj2)
+            {
+                typedef util::in_in_out_result<Iter1, Iter2, Iter3> result_type;
+                typedef util::detail::algorithm_result<ExPolicy, result_type>
+                    algorithm_result;
+
+                try
+                {
+                    return algorithm_result::get(parallel_merge(
+                        std::forward<ExPolicy>(policy), first1, last1, first2,
+                        last2, dest, std::forward<Comp>(comp),
+                        std::forward<Proj1>(proj1),
+                        std::forward<Proj2>(proj2)));
+                }
+                catch (...)
+                {
+                    return algorithm_result::get(
+                        detail::handle_exception<ExPolicy, result_type>::call(
+                            std::current_exception()));
+                }
+            }
+        };
+        /// \endcond
+    }    // namespace detail
+
+    // TODO: Support forward and bidirectional iterator. (#2826)
+    // For now, only support random access iterator.
+
+    // clang-format off
+    template <typename ExPolicy, typename RandIter1, typename RandIter2,
+        typename RandIter3, typename Comp = detail::less,
+        typename Proj1 = util::projection_identity,
+        typename Proj2 = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<RandIter1>::value &&
+            hpx::traits::is_iterator<RandIter2>::value &&
+            hpx::traits::is_iterator<RandIter3>::value &&
+            traits::is_projected<Proj1, RandIter1>::value &&
+            traits::is_projected<Proj2, RandIter2>::value &&
+            traits::is_indirect_callable<ExPolicy, Comp,
+                traits::projected<Proj1, RandIter1>,
+                traits::projected<Proj2, RandIter2>
+            >::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(
+        1, 6, "hpx::parallel::merge is deprecated, use hpx::merge instead")
+        typename util::detail::algorithm_result<ExPolicy,
+            util::in_in_out_result<RandIter1, RandIter2, RandIter3>>::type
+        merge(ExPolicy&& policy, RandIter1 first1, RandIter1 last1,
+            RandIter2 first2, RandIter2 last2, RandIter3 dest,
+            Comp&& comp = Comp(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+    {
+        static_assert(
+            (hpx::traits::is_random_access_iterator<RandIter1>::value),
+            "Required at least random access iterator.");
+        static_assert(
+            (hpx::traits::is_random_access_iterator<RandIter2>::value),
+            "Requires at least random access iterator.");
+        static_assert(
+            (hpx::traits::is_random_access_iterator<RandIter3>::value),
+            "Requires at least random access iterator.");
+
+        using is_seq = execution::is_sequenced_execution_policy<ExPolicy>;
+        using result_type =
+            util::in_in_out_result<RandIter1, RandIter2, RandIter3>;
+
+        return detail::merge<result_type>().call(std::forward<ExPolicy>(policy),
+            is_seq(), first1, last1, first2, last2, dest,
+            std::forward<Comp>(comp), std::forward<Proj1>(proj1),
+            std::forward<Proj2>(proj2));
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // inplace_merge
+    namespace detail {
+
+        // sequential inplace_merge with projection function.
+        template <typename Iter, typename Sent, typename Comp, typename Proj>
+        inline Iter sequential_inplace_merge(
+            Iter first, Iter middle, Sent last, Comp&& comp, Proj&& proj)
+        {
+            std::inplace_merge(first, middle,
+                detail::advance_to_sentinel(middle, last),
+                util::compare_projected<typename std::decay<Comp>::type,
+                    typename std::decay<Proj>::type>(
+                    std::forward<Comp>(comp), std::forward<Proj>(proj)));
+            return last;
+        }
+
+        template <typename ExPolicy, typename Iter, typename Sent,
+            typename Comp, typename Proj>
+        void parallel_inplace_merge_helper(ExPolicy&& policy, Iter first,
+            Iter middle, Sent last, Comp&& comp, Proj&& proj)
+        {
+            const std::size_t threshold = 65536ul;
+            HPX_ASSERT(threshold >= 5ul);
+
+            std::size_t left_size = middle - first;
+            std::size_t right_size = last - middle;
+
+            // Perform sequential inplace_merge
+            //   if data size is smaller than threshold.
+            if (left_size + right_size <= threshold)
+            {
+                sequential_inplace_merge(first, middle, last,
+                    std::forward<Comp>(comp), std::forward<Proj>(proj));
+                return;
+            }
+
+            if (left_size >= right_size)
+            {
+                // Means that always 'pivot' < 'middle'.
+                HPX_ASSERT(left_size >= 3ul);
+
+                // Select pivot in left-side range.
+                Iter pivot = first + left_size / 2;
+                Iter boundary = lower_bound_helper::call(
+                    middle, last, hpx::util::invoke(proj, *pivot), comp, proj);
+                Iter target = pivot + (boundary - middle);
+
+                // Swap two blocks, [pivot, middle) and [middle, boundary).
+                // After this, [first, last) will be divided into three blocks,
+                //   [first, target), target, and [target+1, last).
+                // And all elements of [first, target) are less than
+                //   the thing of target.
+                // And all elements of [target+1, last) are greater or equal than
+                //   the thing of target.
+                detail::sequential_rotate(pivot, middle, boundary);
+
+                hpx::future<void> fut =
+                    execution::async_execute(policy.executor(), [&]() -> void {
+                        // Process the range which is left-side of 'target'.
+                        parallel_inplace_merge_helper(
+                            policy, first, pivot, target, comp, proj);
+                    });
+
+                try
+                {
+                    // Process the range which is right-side of 'target'.
+                    parallel_inplace_merge_helper(
+                        policy, target + 1, boundary, last, comp, proj);
+                }
+                catch (...)
+                {
+                    fut.wait();
+
+                    std::vector<hpx::future<void>> futures;
+                    futures.reserve(2);
+                    futures.emplace_back(std::move(fut));
+                    futures.emplace_back(hpx::make_exceptional_future<void>(
+                        std::current_exception()));
+
+                    std::list<std::exception_ptr> errors;
+                    util::detail::handle_local_exceptions<ExPolicy>::call(
+                        futures, errors);
+
+                    // Not reachable.
+                    HPX_ASSERT(false);
+                }
+
+                if (fut.valid())    // NOLINT
+                {
+                    fut.get();
+                }
+            }
+            else    // left_size < right_size
+            {
+                // Means that always 'pivot' < 'last'.
+                HPX_ASSERT(right_size >= 3ul);
+
+                // Select pivot in right-side range.
+                Iter pivot = middle + right_size / 2;
+                Iter boundary = upper_bound_helper::call(
+                    first, middle, hpx::util::invoke(proj, *pivot), comp, proj);
+                Iter target = boundary + (pivot - middle);
+
+                // Swap two blocks, [boundary, middle) and [middle, pivot+1).
+                // After this, [first, last) will be divided into three blocks,
+                //   [first, target), target, and [target+1, last).
+                // And all elements of [first, target) are less than
+                //   the thing of target.
+                // And all elements of [target+1, last) are greater or equal than
+                //   the thing of target.
+                detail::sequential_rotate(boundary, middle, pivot + 1);
+
+                hpx::future<void> fut =
+                    execution::async_execute(policy.executor(), [&]() -> void {
+                        // Process the range which is left-side of 'target'.
+                        parallel_inplace_merge_helper(
+                            policy, first, boundary, target, comp, proj);
+                    });
+
+                try
+                {
+                    // Process the range which is right-side of 'target'.
+                    parallel_inplace_merge_helper(
+                        policy, target + 1, pivot + 1, last, comp, proj);
+                }
+                catch (...)
+                {
+                    fut.wait();
+
+                    std::vector<hpx::future<void>> futures;
+                    futures.reserve(2);
+                    futures.emplace_back(std::move(fut));
+                    futures.emplace_back(hpx::make_exceptional_future<void>(
+                        std::current_exception()));
+
+                    std::list<std::exception_ptr> errors;
+                    util::detail::handle_local_exceptions<ExPolicy>::call(
+                        futures, errors);
+
+                    // Not reachable.
+                    HPX_ASSERT(false);
+                }
+
+                if (fut.valid())    // NOLINT
+                {
+                    fut.get();
+                }
+            }
+        }
+
+        template <typename ExPolicy, typename Iter, typename Sent,
+            typename Comp, typename Proj>
+        inline hpx::future<Iter> parallel_inplace_merge(ExPolicy&& policy,
+            Iter first, Iter middle, Sent last, Comp&& comp, Proj&& proj)
+        {
+            return execution::async_execute(policy.executor(),
+                [policy, first, middle, last, comp = std::forward<Comp>(comp),
+                    proj = std::forward<Proj>(proj)]() mutable -> Iter {
+                    try
+                    {
+                        parallel_inplace_merge_helper(policy, first, middle,
+                            last, std::move(comp), std::move(proj));
+                        return last;
+                    }
+                    catch (...)
+                    {
+                        util::detail::handle_local_exceptions<ExPolicy>::call(
+                            std::current_exception());
+                    }
+
+                    // Not reachable.
+                    HPX_ASSERT(false);
+                });
+        }
+
+        template <typename Result>
+        struct inplace_merge
+          : public detail::algorithm<inplace_merge<Result>, Result>
+        {
+            inplace_merge()
+              : inplace_merge::algorithm("inplace_merge")
+            {
+            }
+
+            template <typename ExPolicy, typename Iter, typename Sent,
+                typename Comp, typename Proj>
+            static Iter sequential(ExPolicy, Iter first, Iter middle, Sent last,
+                Comp&& comp, Proj&& proj)
+            {
+                return sequential_inplace_merge(first, middle, last,
+                    std::forward<Comp>(comp), std::forward<Proj>(proj));
+            }
+
+            template <typename ExPolicy, typename Iter, typename Sent,
+                typename Comp, typename Proj>
+            static typename util::detail::algorithm_result<ExPolicy, Iter>::type
+            parallel(ExPolicy&& policy, Iter first, Iter middle, Sent last,
+                Comp&& comp, Proj&& proj)
+            {
+                using result = util::detail::algorithm_result<ExPolicy, Iter>;
+
+                try
+                {
+                    return result::get(parallel_inplace_merge(
+                        std::forward<ExPolicy>(policy), first, middle, last,
+                        std::forward<Comp>(comp), std::forward<Proj>(proj)));
+                }
+                catch (...)
+                {
+                    return result::get(
+                        detail::handle_exception<ExPolicy, Iter>::call(
+                            std::current_exception()));
+                }
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////////
+        template <typename Iter>
+        inline void get_void_result(Iter)
+        {
+        }
+
+        template <typename Iter>
+        inline hpx::future<void> get_void_result(hpx::future<Iter>&& f)
+        {
+            return hpx::future<void>(std::move(f));
+        }
+    }    // namespace detail
+
+    // TODO: Support bidirectional iterator. (#2826)
+    // For now, only support random access iterator.
+
+    // clang-format off
+    template <typename ExPolicy, typename RandIter,
+        typename Comp = detail::less, typename Proj = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<RandIter>::value &&
+            traits::is_projected<Proj, RandIter>::value &&
+            traits::is_indirect_callable<ExPolicy, Comp,
+                traits::projected<Proj, RandIter>,
+                traits::projected<Proj, RandIter>
+            >::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::inplace_merge is deprecated, use hpx::inplace_merge "
+        "instead")
+        typename util::detail::algorithm_result<ExPolicy, RandIter>::type
+        inplace_merge(ExPolicy&& policy, RandIter first, RandIter middle,
+            RandIter last, Comp&& comp = Comp(), Proj&& proj = Proj())
     {
         static_assert((hpx::traits::is_random_access_iterator<RandIter>::value),
             "Required at least random access iterator.");
 
-        typedef execution::is_sequenced_execution_policy<ExPolicy> is_seq;
+        using is_seq = execution::is_sequenced_execution_policy<ExPolicy>;
 
         return detail::inplace_merge<RandIter>().call(
             std::forward<ExPolicy>(policy), is_seq(), first, middle, last,
             std::forward<Comp>(comp), std::forward<Proj>(proj));
     }
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::merge
+    HPX_INLINE_CONSTEXPR_VARIABLE struct merge_t final
+      : hpx::functional::tag<merge_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename RandIter1, typename RandIter2,
+            typename RandIter3, typename Comp = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<RandIter1>::value &&
+                hpx::traits::is_iterator<RandIter2>::value &&
+                hpx::traits::is_iterator<RandIter3>::value &&
+                hpx::traits::is_invocable<Comp,
+                    typename std::iterator_traits<RandIter1>::value_type,
+                    typename std::iterator_traits<RandIter2>::value_type
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            RandIter3>::type
+        tag_invoke(merge_t, ExPolicy&& policy, RandIter1 first1,
+            RandIter1 last1, RandIter2 first2, RandIter2 last2, RandIter3 dest,
+            Comp&& comp = Comp())
+        {
+            static_assert(
+                (hpx::traits::is_random_access_iterator<RandIter1>::value),
+                "Required at least random access iterator.");
+            static_assert(
+                (hpx::traits::is_random_access_iterator<RandIter2>::value),
+                "Requires at least random access iterator.");
+            static_assert(
+                (hpx::traits::is_random_access_iterator<RandIter3>::value),
+                "Requires at least random access iterator.");
+
+            using is_seq =
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>;
+            using result_type = hpx::parallel::util::in_in_out_result<RandIter1,
+                RandIter2, RandIter3>;
+
+            return hpx::parallel::util::get_third_element(
+                hpx::parallel::v1::detail::merge<result_type>().call(
+                    std::forward<ExPolicy>(policy), is_seq(), first1, last1,
+                    first2, last2, dest, std::forward<Comp>(comp),
+                    hpx::parallel::util::projection_identity(),
+                    hpx::parallel::util::projection_identity()));
+        }
+
+        // clang-format off
+        template <typename RandIter1, typename RandIter2, typename RandIter3,
+            typename Comp = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<RandIter1>::value &&
+                hpx::traits::is_iterator<RandIter2>::value &&
+                hpx::traits::is_iterator<RandIter3>::value &&
+                hpx::traits::is_invocable<Comp,
+                    typename std::iterator_traits<RandIter1>::value_type,
+                    typename std::iterator_traits<RandIter2>::value_type
+                >::value
+            )>
+        // clang-format on
+        friend RandIter3 tag_invoke(merge_t, RandIter1 first1, RandIter1 last1,
+            RandIter2 first2, RandIter2 last2, RandIter3 dest,
+            Comp&& comp = Comp())
+        {
+            static_assert(
+                (hpx::traits::is_random_access_iterator<RandIter1>::value),
+                "Required at least random access iterator.");
+            static_assert(
+                (hpx::traits::is_random_access_iterator<RandIter2>::value),
+                "Requires at least random access iterator.");
+            static_assert(
+                (hpx::traits::is_random_access_iterator<RandIter3>::value),
+                "Requires at least random access iterator.");
+
+            using result_type = hpx::parallel::util::in_in_out_result<RandIter1,
+                RandIter2, RandIter3>;
+
+            return hpx::parallel::util::get_third_element(
+                hpx::parallel::v1::detail::merge<result_type>().call(
+                    hpx::execution::seq, std::true_type(), first1, last1,
+                    first2, last2, dest, std::forward<Comp>(comp),
+                    hpx::parallel::util::projection_identity(),
+                    hpx::parallel::util::projection_identity()));
+        }
+    } merge{};
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::inplace_merge
+    HPX_INLINE_CONSTEXPR_VARIABLE struct inplace_merge_t final
+      : hpx::functional::tag<inplace_merge_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename RandIter,
+            typename Comp = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<RandIter>::value &&
+                hpx::traits::is_invocable<Comp,
+                    typename std::iterator_traits<RandIter>::value_type,
+                    typename std::iterator_traits<RandIter>::value_type
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<
+            ExPolicy>::type
+        tag_invoke(inplace_merge_t, ExPolicy&& policy, RandIter first,
+            RandIter middle, RandIter last, Comp&& comp = Comp())
+        {
+            static_assert(
+                (hpx::traits::is_random_access_iterator<RandIter>::value),
+                "Required at least random access iterator.");
+
+            using is_seq =
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>;
+
+            return hpx::parallel::v1::detail::get_void_result(
+                hpx::parallel::v1::detail::inplace_merge<RandIter>().call(
+                    std::forward<ExPolicy>(policy), is_seq(), first, middle,
+                    last, std::forward<Comp>(comp),
+                    hpx::parallel::util::projection_identity()));
+        }
+
+        // clang-format off
+        template <typename RandIter,
+            typename Comp = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<RandIter>::value &&
+                hpx::traits::is_invocable<Comp,
+                    typename std::iterator_traits<RandIter>::value_type,
+                    typename std::iterator_traits<RandIter>::value_type
+                >::value
+            )>
+        // clang-format on
+        friend void tag_invoke(inplace_merge_t, RandIter first, RandIter middle,
+            RandIter last, Comp&& comp = Comp())
+        {
+            static_assert(
+                (hpx::traits::is_random_access_iterator<RandIter>::value),
+                "Required at least random access iterator.");
+
+            return hpx::parallel::v1::detail::get_void_result(
+                hpx::parallel::v1::detail::inplace_merge<RandIter>().call(
+                    hpx::execution::seq, std::true_type(), first, middle, last,
+                    std::forward<Comp>(comp),
+                    hpx::parallel::util::projection_identity()));
+        }
+    } inplace_merge{};
+}    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/merge.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/merge.hpp
@@ -467,7 +467,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<RandIter1>::value &&
             hpx::traits::is_iterator<RandIter2>::value &&
             hpx::traits::is_iterator<RandIter3>::value &&
@@ -725,7 +725,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             }
         };
 
-        ///////////////////////////////////////////////////////////////////////////
+        ///////////////////////////////////////////////////////////////////////
         template <typename Iter>
         inline void get_void_result(Iter)
         {
@@ -745,7 +745,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename RandIter,
         typename Comp = detail::less, typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<RandIter>::value &&
             traits::is_projected<Proj, RandIter>::value &&
             traits::is_indirect_callable<ExPolicy, Comp,
@@ -784,7 +784,7 @@ namespace hpx {
         template <typename ExPolicy, typename RandIter1, typename RandIter2,
             typename RandIter3, typename Comp = hpx::parallel::v1::detail::less,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<RandIter1>::value &&
                 hpx::traits::is_iterator<RandIter2>::value &&
                 hpx::traits::is_iterator<RandIter3>::value &&
@@ -873,7 +873,7 @@ namespace hpx {
         template <typename ExPolicy, typename RandIter,
             typename Comp = hpx::parallel::v1::detail::less,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<RandIter>::value &&
                 hpx::traits::is_invocable<Comp,
                     typename std::iterator_traits<RandIter>::value_type,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/minmax.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/minmax.hpp
@@ -234,12 +234,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter,
         typename Proj = util::projection_identity, typename F = detail::less,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<FwdIter>::value&&
-                    traits::is_projected<Proj, FwdIter>::value&&
-                        traits::is_indirect_callable<ExPolicy, F,
-                            traits::projected<Proj, FwdIter>,
-                            traits::projected<Proj, FwdIter>>::value)>
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&& hpx::
+                traits::is_iterator<FwdIter>::value&& traits::is_projected<Proj,
+                    FwdIter>::value&& traits::is_indirect_callable<ExPolicy, F,
+                    traits::projected<Proj, FwdIter>,
+                    traits::projected<Proj, FwdIter>>::value)>
     typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
     min_element(ExPolicy&& policy, FwdIter first, FwdIter last, F&& f = F(),
         Proj&& proj = Proj())
@@ -452,12 +451,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter,
         typename Proj = util::projection_identity, typename F = detail::less,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<FwdIter>::value&&
-                    traits::is_projected<Proj, FwdIter>::value&&
-                        traits::is_indirect_callable<ExPolicy, F,
-                            traits::projected<Proj, FwdIter>,
-                            traits::projected<Proj, FwdIter>>::value)>
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&& hpx::
+                traits::is_iterator<FwdIter>::value&& traits::is_projected<Proj,
+                    FwdIter>::value&& traits::is_indirect_callable<ExPolicy, F,
+                    traits::projected<Proj, FwdIter>,
+                    traits::projected<Proj, FwdIter>>::value)>
     typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
     max_element(ExPolicy&& policy, FwdIter first, FwdIter last, F&& f = F(),
         Proj&& proj = Proj())
@@ -703,12 +701,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #endif
     template <typename ExPolicy, typename FwdIter,
         typename Proj = util::projection_identity, typename F = detail::less,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<FwdIter>::value&&
-                    traits::is_projected<Proj, FwdIter>::value&&
-                        traits::is_indirect_callable<ExPolicy, F,
-                            traits::projected<Proj, FwdIter>,
-                            traits::projected<Proj, FwdIter>>::value)>
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&& hpx::
+                traits::is_iterator<FwdIter>::value&& traits::is_projected<Proj,
+                    FwdIter>::value&& traits::is_indirect_callable<ExPolicy, F,
+                    traits::projected<Proj, FwdIter>,
+                    traits::projected<Proj, FwdIter>>::value)>
     typename util::detail::algorithm_result<ExPolicy,
         hpx::util::tagged_pair<tag::min(FwdIter), tag::max(FwdIter)>>::type
     minmax_element(ExPolicy&& policy, FwdIter first, FwdIter last, F&& f = F(),

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/minmax.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/minmax.hpp
@@ -234,7 +234,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter,
         typename Proj = util::projection_identity, typename F = detail::less,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value&&
                     traits::is_projected<Proj, FwdIter>::value&&
                         traits::is_indirect_callable<ExPolicy, F,
@@ -452,7 +452,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter,
         typename Proj = util::projection_identity, typename F = detail::less,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value&&
                     traits::is_projected<Proj, FwdIter>::value&&
                         traits::is_indirect_callable<ExPolicy, F,
@@ -703,7 +703,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #endif
     template <typename ExPolicy, typename FwdIter,
         typename Proj = util::projection_identity, typename F = detail::less,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value&&
                     traits::is_projected<Proj, FwdIter>::value&&
                         traits::is_indirect_callable<ExPolicy, F,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
@@ -340,7 +340,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Pred = detail::equal_to,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value &&
             hpx::traits::is_invocable<Pred,
@@ -449,7 +449,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Pred = detail::equal_to,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value &&
             hpx::traits::is_invocable<Pred,
@@ -492,7 +492,7 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename Pred,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value &&
                 hpx::traits::is_invocable<Pred,
@@ -527,7 +527,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value
             )>
@@ -560,7 +560,7 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename Pred,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value &&
                 hpx::traits::is_invocable<Pred,
@@ -592,7 +592,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value
             )>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/move.hpp
@@ -206,7 +206,7 @@ namespace hpx {
         tag_invoke(move_t, ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
             FwdIter2 dest)
         {
-            return hpx::parallel::v1::detail::get_second_element(
+            return hpx::parallel::util::get_second_element(
                 hpx::parallel::v1::detail::transfer<
                     hpx::parallel::v1::detail::move<FwdIter1, FwdIter2>>(
                     std::forward<ExPolicy>(policy), first, last, dest));

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partition.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partition.hpp
@@ -281,7 +281,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename BidirIter, typename F,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<BidirIter>::value&&
                     traits::is_projected<Proj, BidirIter>::value&&
                         traits::is_indirect_callable<ExPolicy, F,
@@ -1054,7 +1054,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter, typename Pred,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value&&
                     traits::is_projected<Proj, FwdIter>::value&&
                         traits::is_indirect_callable<ExPolicy, Pred,
@@ -1328,7 +1328,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename FwdIter3, typename Pred,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter1>::value&&
                     hpx::traits::is_iterator<FwdIter2>::value&&
                         hpx::traits::is_iterator<FwdIter3>::value&&

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partition.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partition.hpp
@@ -1054,11 +1054,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter, typename Pred,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<FwdIter>::value&&
-                    traits::is_projected<Proj, FwdIter>::value&&
-                        traits::is_indirect_callable<ExPolicy, Pred,
-                            traits::projected<Proj, FwdIter>>::value)>
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&& hpx::
+                traits::is_iterator<FwdIter>::value&& traits::is_projected<Proj,
+                    FwdIter>::value&& traits::is_indirect_callable<ExPolicy,
+                    Pred, traits::projected<Proj, FwdIter>>::value)>
     typename util::detail::algorithm_result<ExPolicy, FwdIter>::type partition(
         ExPolicy&& policy, FwdIter first, FwdIter last, Pred&& pred,
         Proj&& proj = Proj())

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -318,7 +318,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIterB, typename FwdIterE,
         typename T, typename F,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_sentinel_for<FwdIterE, FwdIterB>::value
         )>
     // clang-format on
@@ -337,7 +337,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIterB, typename FwdIterE,
         typename T,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_sentinel_for<FwdIterE, FwdIterB>::value
         )>
     // clang-format on
@@ -355,7 +355,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename FwdIterB, typename FwdIterE,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_sentinel_for<FwdIterE, FwdIterB>::value
         )>
     // clang-format on
@@ -385,7 +385,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename T, typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
@@ -404,7 +404,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename T,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
@@ -423,7 +423,7 @@ namespace hpx {
         // clang-format off
         template <typename ExPolicy, typename FwdIter,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
@@ -265,7 +265,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter, typename Pred,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value&&
                     traits::is_projected<Proj, FwdIter>::value&&
                         traits::is_indirect_callable<ExPolicy, Pred,
@@ -339,7 +339,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter, typename T,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value&&
                     traits::is_projected<Proj, FwdIter>::value)>
     typename util::detail::algorithm_result<ExPolicy, FwdIter>::type remove(

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
@@ -265,11 +265,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter, typename Pred,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<FwdIter>::value&&
-                    traits::is_projected<Proj, FwdIter>::value&&
-                        traits::is_indirect_callable<ExPolicy, Pred,
-                            traits::projected<Proj, FwdIter>>::value)>
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&& hpx::
+                traits::is_iterator<FwdIter>::value&& traits::is_projected<Proj,
+                    FwdIter>::value&& traits::is_indirect_callable<ExPolicy,
+                    Pred, traits::projected<Proj, FwdIter>>::value)>
     typename util::detail::algorithm_result<ExPolicy, FwdIter>::type remove_if(
         ExPolicy&& policy, FwdIter first, FwdIter last, Pred&& pred,
         Proj&& proj = Proj())

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
@@ -153,7 +153,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename T, typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<
             ExPolicy>::value&& hpx::traits::is_iterator<FwdIter1>::value&&
                 hpx::traits::is_iterator<FwdIter2>::value&&
                     traits::is_projected<Proj, FwdIter1>::value&&
@@ -321,7 +321,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename F, typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter1>::value&&
                     traits::is_projected<Proj, FwdIter1>::value&&
                         traits::is_indirect_callable<ExPolicy, F,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
@@ -153,13 +153,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename T, typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<
-            ExPolicy>::value&& hpx::traits::is_iterator<FwdIter1>::value&&
-                hpx::traits::is_iterator<FwdIter2>::value&&
-                    traits::is_projected<Proj, FwdIter1>::value&&
-                        traits::is_indirect_callable<ExPolicy, std::equal_to<T>,
-                            traits::projected<Proj, FwdIter1>,
-                            traits::projected<Proj, T const*>>::value)>
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&& hpx::
+                traits::is_iterator<FwdIter1>::value&& hpx::traits::is_iterator<
+                    FwdIter2>::value&& traits::is_projected<Proj,
+                    FwdIter1>::value&& traits::is_indirect_callable<ExPolicy,
+                    std::equal_to<T>, traits::projected<Proj, FwdIter1>,
+                    traits::projected<Proj, T const*>>::value)>
     typename util::detail::algorithm_result<ExPolicy,
         util::in_out_result<FwdIter1, FwdIter2>>::type
     remove_copy(ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/replace.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/replace.hpp
@@ -145,12 +145,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter, typename T1, typename T2,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<FwdIter>::value&&
-                    traits::is_projected<Proj, FwdIter>::value&&
-                        traits::is_indirect_callable<ExPolicy,
-                            std::equal_to<T1>, traits::projected<Proj, FwdIter>,
-                            traits::projected<Proj, T1 const*>>::value)>
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&& hpx::
+                traits::is_iterator<FwdIter>::value&& traits::is_projected<Proj,
+                    FwdIter>::value&& traits::is_indirect_callable<ExPolicy,
+                    std::equal_to<T1>, traits::projected<Proj, FwdIter>,
+                    traits::projected<Proj, T1 const*>>::value)>
     typename util::detail::algorithm_result<ExPolicy, FwdIter>::type replace(
         ExPolicy&& policy, FwdIter first, FwdIter last, T1 const& old_value,
         T2 const& new_value, Proj&& proj = Proj())
@@ -299,11 +298,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter, typename F, typename T,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<FwdIter>::value&&
-                    traits::is_projected<Proj, FwdIter>::value&&
-                        traits::is_indirect_callable<ExPolicy, F,
-                            traits::projected<Proj, FwdIter>>::value)>
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&& hpx::
+                traits::is_iterator<FwdIter>::value&& traits::is_projected<Proj,
+                    FwdIter>::value&& traits::is_indirect_callable<ExPolicy, F,
+                    traits::projected<Proj, FwdIter>>::value)>
     typename util::detail::algorithm_result<ExPolicy, FwdIter>::type replace_if(
         ExPolicy&& policy, FwdIter first, FwdIter last, F&& f,
         T const& new_value, Proj&& proj = Proj())

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/replace.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/replace.hpp
@@ -145,7 +145,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter, typename T1, typename T2,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value&&
                     traits::is_projected<Proj, FwdIter>::value&&
                         traits::is_indirect_callable<ExPolicy,
@@ -299,7 +299,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter, typename F, typename T,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value&&
                     traits::is_projected<Proj, FwdIter>::value&&
                         traits::is_indirect_callable<ExPolicy, F,
@@ -455,7 +455,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename T1, typename T2, typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<
             ExPolicy>::value&& hpx::traits::is_iterator<FwdIter1>::value&&
                 traits::is_projected<Proj, FwdIter1>::value&&
                     traits::is_indirect_callable<ExPolicy, std::equal_to<T1>,
@@ -637,7 +637,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename F, typename T, typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter1>::value&&
                     traits::is_projected<Proj, FwdIter1>::value&&
                         traits::is_indirect_callable<ExPolicy, F,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/rotate.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/rotate.hpp
@@ -19,6 +19,7 @@
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/copy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/algorithms/detail/rotate.hpp>
 #include <hpx/parallel/algorithms/reverse.hpp>
 #include <hpx/parallel/tagspec.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
@@ -35,36 +36,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // rotate
     namespace detail {
         /// \cond NOINTERNAL
-        template <typename InIter>
-        void sequential_rotate_helper(
-            InIter first, InIter new_first, InIter last)
-        {
-            InIter next = new_first;
-            while (first != next)
-            {
-                std::iter_swap(first++, next++);
-                if (next == last)
-                {
-                    next = new_first;
-                }
-                else if (first == new_first)
-                {
-                    new_first = next;
-                }
-            }
-        }
-
-        template <typename InIter>
-        inline util::in_out_result<InIter, InIter> sequential_rotate(
-            InIter first, InIter new_first, InIter last)
-        {
-            if (first != new_first && new_first != last)
-                sequential_rotate_helper(first, new_first, last);
-
-            std::advance(first, std::distance(new_first, last));
-            return util::in_out_result<InIter, InIter>{first, last};
-        }
-
         template <typename ExPolicy, typename FwdIter>
         hpx::future<util::in_out_result<FwdIter, FwdIter>> rotate_helper(
             ExPolicy policy, FwdIter first, FwdIter new_first, FwdIter last)
@@ -109,7 +80,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static IterPair sequential(
                 ExPolicy, InIter first, InIter new_first, InIter last)
             {
-                return sequential_rotate(first, new_first, last);
+                return detail::sequential_rotate(first, new_first, last);
             }
 
             template <typename ExPolicy, typename FwdIter>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/search.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/search.hpp
@@ -229,7 +229,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         typename Pred = detail::equal_to,
         typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value&&
                     traits::is_projected<Proj1, FwdIter>::value&&
                         hpx::traits::is_iterator<FwdIter2>::value&&
@@ -445,7 +445,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         typename Pred = detail::equal_to,
         typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value&&
                     traits::is_projected<Proj1, FwdIter>::value&&
                         hpx::traits::is_iterator<FwdIter2>::value&&

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,96 +8,9 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/type_support/decay.hpp>
-
-#include <hpx/executors/execution_policy.hpp>
-#include <hpx/parallel/algorithms/copy.hpp>
-#include <hpx/parallel/algorithms/detail/dispatch.hpp>
-#include <hpx/parallel/algorithms/detail/set_operation.hpp>
-#include <hpx/parallel/util/detail/algorithm_result.hpp>
-#include <hpx/parallel/util/loop.hpp>
-#include <hpx/parallel/util/result_types.hpp>
-
-#include <algorithm>
-#include <iterator>
-#include <type_traits>
-#include <utility>
-
-namespace hpx { namespace parallel { inline namespace v1 {
-    ///////////////////////////////////////////////////////////////////////////
-    // set_difference
-    namespace detail {
-        /// \cond NOINTERNAL
-        template <typename FwdIter>
-        struct set_difference
-          : public detail::algorithm<set_difference<FwdIter>, FwdIter>
-        {
-            set_difference()
-              : set_difference::algorithm("set_difference")
-            {
-            }
-
-            template <typename ExPolicy, typename InIter1, typename InIter2,
-                typename OutIter, typename F>
-            static OutIter sequential(ExPolicy, InIter1 first1, InIter1 last1,
-                InIter2 first2, InIter2 last2, OutIter dest, F&& f)
-            {
-                return std::set_difference(
-                    first1, last1, first2, last2, dest, std::forward<F>(f));
-            }
-
-            template <typename ExPolicy, typename RanIter1, typename RanIter2,
-                typename F>
-            static
-                typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
-                parallel(ExPolicy&& policy, RanIter1 first1, RanIter1 last1,
-                    RanIter2 first2, RanIter2 last2, FwdIter dest, F&& f)
-            {
-                typedef typename std::iterator_traits<RanIter1>::difference_type
-                    difference_type1;
-                typedef typename std::iterator_traits<RanIter2>::difference_type
-                    difference_type2;
-
-                if (first1 == last1)
-                {
-                    typedef util::detail::algorithm_result<ExPolicy, FwdIter>
-                        result;
-                    return result::get(std::move(dest));
-                }
-
-                if (first2 == last2)
-                {
-                    return util::detail::convert_to_result(
-                        detail::copy<util::in_out_result<RanIter1, FwdIter>>()
-                            .call(std::forward<ExPolicy>(policy),
-                                std::false_type(), first1, last1, dest),
-                        [](util::in_out_result<RanIter1, FwdIter> const& p)
-                            -> FwdIter { return p.out; });
-                }
-
-                typedef
-                    typename set_operations_buffer<FwdIter>::type buffer_type;
-                typedef typename hpx::util::decay<F>::type func_type;
-
-                return set_operation(
-                    std::forward<ExPolicy>(policy), first1, last1, first2,
-                    last2, dest, std::forward<F>(f),
-                    // calculate approximate destination index
-                    [](difference_type1 idx1, difference_type2 idx2)
-                        -> difference_type1 { return idx1; },
-                    // perform required set operation for one chunk
-                    [](RanIter1 part_first1, RanIter1 part_last1,
-                        RanIter2 part_first2, RanIter2 part_last2,
-                        buffer_type* dest, func_type const& f) -> buffer_type* {
-                        return std::set_difference(part_first1, part_last1,
-                            part_first2, part_last2, dest, f);
-                    });
-            }
-        };
-        /// \endcond
-    }    // namespace detail
+#if defined(DOXYGEN)
+namespace hpx {
+    // clang-format off
 
     /// Constructs a sorted range beginning at dest consisting of all elements
     /// present in the range [first1, last1) and not present in the range
@@ -186,10 +99,194 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename FwdIter3, typename Pred = detail::less>
-    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
-        typename util::detail::algorithm_result<ExPolicy, FwdIter3>::type>::type
+    typename util::detail::algorithm_result<ExPolicy, FwdIter3>::type>::type
     set_difference(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
-        FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, Pred&& op = Pred())
+            FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, Pred&& op = Pred());
+
+    // clang-format on
+}    // namespace hpx
+
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/type_support/decay.hpp>
+
+#include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/algorithms/detail/set_operation.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1 {
+    ///////////////////////////////////////////////////////////////////////////
+    // set_difference
+    namespace detail {
+
+        template <typename Iter1, typename Sent1, typename Iter2,
+            typename Sent2, typename Iter3, typename Comp, typename Proj1,
+            typename Proj2>
+        util::in_out_result<Iter1, Iter3> sequential_set_difference(
+            Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
+            Comp&& comp, Proj1&& proj1, Proj2&& proj2)
+        {
+            while (first1 != last1)
+            {
+                if (first2 == last2)
+                {
+                    return util::copy(first1, last1, dest);
+                }
+
+                if (hpx::util::invoke(comp, hpx::util::invoke(proj1, *first1),
+                        hpx::util::invoke(proj2, *first2)))
+                {
+                    *dest++ = *first1++;
+                }
+                else
+                {
+                    if (!hpx::util::invoke(comp,
+                            hpx::util::invoke(proj2, *first2),
+                            hpx::util::invoke(proj1, *first1)))
+                    {
+                        ++first1;
+                    }
+                    ++first2;
+                }
+            }
+            return {first1, dest};
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Iter1, typename Iter3>
+        util::in_out_result<Iter1, Iter3> compose_in_out_result(
+            Iter1 it1, Iter3 dest)
+        {
+            return util::in_out_result<Iter1, Iter3>{it1, dest};
+        }
+
+        template <typename Iter1, typename Iter3>
+        hpx::future<util::in_out_result<Iter1, Iter3>> compose_in_out_result(
+            Iter1 it1, hpx::future<Iter3>&& dest)
+        {
+            return dest.then([it1](hpx::future<Iter3>&& f) {
+                return util::in_out_result<Iter1, Iter3>{it1, f.get()};
+            });
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Result>
+        struct set_difference
+          : public detail::algorithm<set_difference<Result>, Result>
+        {
+            set_difference()
+              : set_difference::algorithm("set_difference")
+            {
+            }
+
+            template <typename ExPolicy, typename Iter1, typename Sent1,
+                typename Iter2, typename Sent2, typename Iter3, typename F,
+                typename Proj1, typename Proj2>
+            static util::in_out_result<Iter1, Iter3> sequential(ExPolicy,
+                Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2,
+                Iter3 dest, F&& f, Proj1&& proj1, Proj2&& proj2)
+            {
+                return sequential_set_difference(first1, last1, first2, last2,
+                    dest, std::forward<F>(f), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2));
+            }
+
+            template <typename ExPolicy, typename Iter1, typename Sent1,
+                typename Iter2, typename Sent2, typename Iter3, typename F,
+                typename Proj1, typename Proj2>
+            static typename util::detail::algorithm_result<ExPolicy,
+                util::in_out_result<Iter1, Iter3>>::type
+            parallel(ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
+                Sent2 last2, Iter3 dest, F&& f, Proj1&& proj1, Proj2&& proj2)
+            {
+                using difference_type1 =
+                    typename std::iterator_traits<Iter1>::difference_type;
+                using difference_type2 =
+                    typename std::iterator_traits<Iter2>::difference_type;
+
+                using result_type = util::in_out_result<Iter1, Iter3>;
+                using result =
+                    util::detail::algorithm_result<ExPolicy, result_type>;
+
+                if (first1 == last1)
+                {
+                    return result::get(
+                        result_type{std::move(first1), std::move(dest)});
+                }
+
+                if (first2 == last2)
+                {
+                    return detail::copy<result_type>().call(
+                        std::forward<ExPolicy>(policy), std::false_type(),
+                        first1, last1, dest);
+                }
+
+                using buffer_type = typename set_operations_buffer<Iter3>::type;
+                using func_type = typename hpx::util::decay<F>::type;
+
+                auto last = set_operation(
+                    std::forward<ExPolicy>(policy), first1, last1, first2,
+                    last2, dest, std::forward<F>(f),
+                    // calculate approximate destination index
+                    [](difference_type1 idx1, difference_type2 idx2)
+                        -> difference_type1 { return idx1; },
+                    // perform required set operation for one chunk
+                    [proj1 = std::forward<Proj1>(proj1),
+                        proj2 = std::forward<Proj2>(proj2)](Iter1 part_first1,
+                        Sent1 part_last1, Iter2 part_first2, Sent2 part_last2,
+                        buffer_type* dest, func_type const& f) -> buffer_type* {
+                        return sequential_set_difference(part_first1,
+                            part_last1, part_first2, part_last2, dest, f, proj1,
+                            proj2)
+                            .out;
+                    });
+
+                // construct return value
+                difference_type1 len1 = detail::distance(first1, last1);
+                difference_type2 len2 = detail::distance(first2, last2);
+                auto len = (std::min)(len1, len2);
+
+                return compose_in_out_result(
+                    std::next(first1, len), std::move(last));
+            }
+        };
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
+    // clang-format off
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename FwdIter3, typename Pred = detail::less,
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<FwdIter1>::value &&
+            hpx::traits::is_iterator<FwdIter2>::value &&
+            hpx::traits::is_iterator<FwdIter3>::value &&
+            hpx::traits::is_invocable<Pred,
+                typename std::iterator_traits<FwdIter1>::value_type,
+                typename std::iterator_traits<FwdIter2>::value_type
+            >::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::set_difference is deprecated, use hpx::set_difference "
+        "instead")
+        typename util::detail::algorithm_result<ExPolicy, FwdIter3>::type
+        set_difference(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+            FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, Pred&& op = Pred())
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
             "Requires at least forward iterator.");
@@ -198,14 +295,106 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
             "Requires at least forward iterator.");
 
-        typedef std::integral_constant<bool,
+        using is_seq = std::integral_constant<bool,
             hpx::is_sequenced_execution_policy<ExPolicy>::value ||
                 !hpx::traits::is_random_access_iterator<FwdIter1>::value ||
-                !hpx::traits::is_random_access_iterator<FwdIter2>::value>
-            is_seq;
+                !hpx::traits::is_random_access_iterator<FwdIter2>::value>;
 
-        return detail::set_difference<FwdIter3>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
-            last2, dest, std::forward<Pred>(op));
+        return hpx::parallel::util::get_second_element(
+            detail::set_difference<util::in_out_result<FwdIter1, FwdIter3>>()
+                .call(std::forward<ExPolicy>(policy), is_seq(), first1, last1,
+                    first2, last2, dest, std::forward<Pred>(op),
+                    util::projection_identity(), util::projection_identity()));
     }
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::set_difference
+    HPX_INLINE_CONSTEXPR_VARIABLE struct set_difference_t final
+      : hpx::functional::tag<set_difference_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+            typename FwdIter3, typename Pred = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_iterator<FwdIter3>::value &&
+                hpx::traits::is_invocable<Pred,
+                    typename std::iterator_traits<FwdIter1>::value_type,
+                    typename std::iterator_traits<FwdIter2>::value_type
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter3>::type
+        tag_invoke(set_difference_t, ExPolicy&& policy, FwdIter1 first1,
+            FwdIter1 last1, FwdIter2 first2, FwdIter2 last2, FwdIter3 dest,
+            Pred&& op = Pred())
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
+                "Requires at least forward iterator.");
+
+            using is_seq = std::integral_constant<bool,
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>::value ||
+                    !hpx::traits::is_random_access_iterator<FwdIter1>::value ||
+                    !hpx::traits::is_random_access_iterator<FwdIter2>::value>;
+
+            using result_type =
+                hpx::parallel::util::in_out_result<FwdIter1, FwdIter3>;
+
+            return hpx::parallel::util::get_second_element(
+                hpx::parallel::v1::detail::set_difference<result_type>().call(
+                    std::forward<ExPolicy>(policy), is_seq(), first1, last1,
+                    first2, last2, dest, std::forward<Pred>(op),
+                    hpx::parallel::util::projection_identity(),
+                    hpx::parallel::util::projection_identity()));
+        }
+
+        // clang-format off
+        template <typename FwdIter1, typename FwdIter2, typename FwdIter3,
+            typename Pred = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_iterator<FwdIter3>::value &&
+                hpx::traits::is_invocable<Pred,
+                    typename std::iterator_traits<FwdIter1>::value_type,
+                    typename std::iterator_traits<FwdIter2>::value_type
+                >::value
+            )>
+        // clang-format on
+        friend FwdIter3 tag_invoke(set_difference_t, FwdIter1 first1,
+            FwdIter1 last1, FwdIter2 first2, FwdIter2 last2, FwdIter3 dest,
+            Pred&& op = Pred())
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
+                "Requires at least forward iterator.");
+
+            using result_type =
+                hpx::parallel::util::in_out_result<FwdIter1, FwdIter3>;
+
+            return hpx::parallel::util::get_second_element(
+                hpx::parallel::v1::detail::set_difference<result_type>().call(
+                    hpx::execution::seq, std::true_type(), first1, last1,
+                    first2, last2, dest, std::forward<Pred>(op),
+                    hpx::parallel::util::projection_identity(),
+                    hpx::parallel::util::projection_identity()));
+        }
+    } set_difference{};
+}    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
@@ -260,7 +260,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename FwdIter3, typename Pred = detail::less,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value &&
             hpx::traits::is_iterator<FwdIter3>::value &&
@@ -309,7 +309,7 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename FwdIter3, typename Pred = hpx::parallel::v1::detail::less,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value &&
                 hpx::traits::is_iterator<FwdIter3>::value &&

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_intersection.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_intersection.hpp
@@ -225,8 +225,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         std::move(first1), std::move(first2), std::move(dest)});
                 }
 
-                typedef typename set_operations_buffer<Iter3>::type buffer_type;
-                typedef typename hpx::util::decay<F>::type func_type;
+                using buffer_type = typename set_operations_buffer<Iter3>::type;
+                using func_type = typename hpx::util::decay<F>::type;
 
                 auto last = set_operation(
                     std::forward<ExPolicy>(policy), first1, last1, first2,
@@ -250,10 +250,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 difference_type2 len2 = detail::distance(first2, last2);
                 auto len = (std::min)(len1, len2);
 
-                detail::advance(first1, len);
-                detail::advance(first2, len);
-                return compose_in_in_out_result(
-                    std::move(first1), std::move(first2), std::move(last));
+                return compose_in_in_out_result(std::next(first1, len),
+                    std::next(first2, len), std::move(last));
             }
         };
     }    // namespace detail

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_intersection.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_intersection.hpp
@@ -235,7 +235,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename FwdIter3, typename Pred = detail::less,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value &&
             hpx::traits::is_iterator<FwdIter3>::value &&
@@ -287,7 +287,7 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename FwdIter3, typename Pred = hpx::parallel::v1::detail::less,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value &&
                 hpx::traits::is_iterator<FwdIter3>::value &&

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,99 +8,9 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/type_support/decay.hpp>
-
-#include <hpx/executors/execution_policy.hpp>
-#include <hpx/parallel/algorithms/copy.hpp>
-#include <hpx/parallel/algorithms/detail/dispatch.hpp>
-#include <hpx/parallel/algorithms/detail/set_operation.hpp>
-#include <hpx/parallel/util/detail/algorithm_result.hpp>
-#include <hpx/parallel/util/loop.hpp>
-#include <hpx/parallel/util/result_types.hpp>
-
-#include <algorithm>
-#include <iterator>
-#include <type_traits>
-#include <utility>
-
-namespace hpx { namespace parallel { inline namespace v1 {
-    ///////////////////////////////////////////////////////////////////////////
-    // set_symmetric_difference
-    namespace detail {
-        /// \cond NOINTERNAL
-        template <typename FwdIter>
-        struct set_symmetric_difference
-          : public detail::algorithm<set_symmetric_difference<FwdIter>, FwdIter>
-        {
-            set_symmetric_difference()
-              : set_symmetric_difference::algorithm("set_symmetric_difference")
-            {
-            }
-
-            template <typename ExPolicy, typename InIter1, typename InIter2,
-                typename OutIter, typename F>
-            static FwdIter sequential(ExPolicy, InIter1 first1, InIter1 last1,
-                InIter2 first2, InIter2 last2, OutIter dest, F&& f)
-            {
-                return std::set_symmetric_difference(
-                    first1, last1, first2, last2, dest, std::forward<F>(f));
-            }
-
-            template <typename ExPolicy, typename RanIter1, typename RanIter2,
-                typename F>
-            static
-                typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
-                parallel(ExPolicy&& policy, RanIter1 first1, RanIter1 last1,
-                    RanIter2 first2, RanIter2 last2, FwdIter dest, F&& f)
-            {
-                typedef typename std::iterator_traits<RanIter1>::difference_type
-                    difference_type1;
-                typedef typename std::iterator_traits<RanIter2>::difference_type
-                    difference_type2;
-
-                if (first1 == last1)
-                {
-                    return util::detail::convert_to_result(
-                        detail::copy<util::in_out_result<RanIter2, FwdIter>>()
-                            .call(std::forward<ExPolicy>(policy),
-                                std::false_type(), first2, last2, dest),
-                        [](util::in_out_result<RanIter2, FwdIter> const& p)
-                            -> FwdIter { return p.out; });
-                }
-
-                if (first2 == last2)
-                {
-                    return util::detail::convert_to_result(
-                        detail::copy<util::in_out_result<RanIter1, FwdIter>>()
-                            .call(std::forward<ExPolicy>(policy),
-                                std::false_type(), first1, last1, dest),
-                        [](util::in_out_result<RanIter1, FwdIter> const& p)
-                            -> FwdIter { return p.out; });
-                }
-
-                typedef
-                    typename set_operations_buffer<FwdIter>::type buffer_type;
-                typedef typename hpx::util::decay<F>::type func_type;
-
-                return set_operation(
-                    std::forward<ExPolicy>(policy), first1, last1, first2,
-                    last2, dest, std::forward<F>(f),
-                    // calculate approximate destination index
-                    [](difference_type1 idx1, difference_type2 idx2)
-                        -> difference_type1 { return idx1 + idx2; },
-                    // perform required set operation for one chunk
-                    [](RanIter1 part_first1, RanIter1 part_last1,
-                        RanIter2 part_first2, RanIter2 part_last2,
-                        buffer_type* dest, func_type const& f) -> buffer_type* {
-                        return std::set_symmetric_difference(part_first1,
-                            part_last1, part_first2, part_last2, dest, f);
-                    });
-            }
-        };
-        /// \endcond
-    }    // namespace detail
+#if defined(DOXYGEN)
+namespace hpx {
+    // clang-format off
 
     /// Constructs a sorted range beginning at dest consisting of all elements
     /// present in either of the sorted ranges [first1, last1) and
@@ -194,10 +104,192 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename FwdIter3, typename Pred = detail::less>
-    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
-        typename util::detail::algorithm_result<ExPolicy, FwdIter3>::type>::type
+    typename util::detail::algorithm_result<ExPolicy, FwdIter3>::type>::type
     set_symmetric_difference(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
-        FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, Pred&& op = Pred())
+        FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, Pred&& op = Pred());
+
+    // clang-format on
+}    // namespace hpx
+
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/type_support/decay.hpp>
+
+#include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/algorithms/copy.hpp>
+#include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/algorithms/detail/set_operation.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1 {
+    ///////////////////////////////////////////////////////////////////////////
+    // set_symmetric_difference
+    namespace detail {
+
+        template <typename Iter1, typename Sent1, typename Iter2,
+            typename Sent2, typename Iter3, typename Comp, typename Proj1,
+            typename Proj2>
+        constexpr util::in_in_out_result<Iter1, Iter2, Iter3>
+        sequential_set_symmetric_difference(Iter1 first1, Sent1 last1,
+            Iter2 first2, Sent2 last2, Iter3 dest, Comp&& comp, Proj1&& proj1,
+            Proj2&& proj2)
+        {
+            while (first1 != last1)
+            {
+                if (first2 == last2)
+                {
+                    auto result = util::copy(first1, last1, dest);
+                    return {result.in, first2, result.out};
+                }
+
+                auto&& value1 = hpx::util::invoke(proj1, *first1);
+                auto&& value2 = hpx::util::invoke(proj2, *first2);
+
+                if (hpx::util::invoke(comp, value1, value2))
+                {
+                    *dest++ = *first1++;
+                }
+                else
+                {
+                    if (hpx::util::invoke(comp, value2, value1))
+                    {
+                        *dest++ = *first2;
+                    }
+                    else
+                    {
+                        ++first1;
+                    }
+                    ++first2;
+                }
+            }
+
+            auto result = util::copy(first2, last2, dest);
+            return {first1, result.in, result.out};
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Result>
+        struct set_symmetric_difference
+          : public detail::algorithm<set_symmetric_difference<Result>, Result>
+        {
+            set_symmetric_difference()
+              : set_symmetric_difference::algorithm("set_symmetric_difference")
+            {
+            }
+
+            template <typename ExPolicy, typename Iter1, typename Sent1,
+                typename Iter2, typename Sent2, typename Iter3, typename F,
+                typename Proj1, typename Proj2>
+            static util::in_in_out_result<Iter1, Iter2, Iter3> sequential(
+                ExPolicy, Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2,
+                Iter3 dest, F&& f, Proj1&& proj1, Proj2&& proj2)
+            {
+                return sequential_set_symmetric_difference(first1, last1,
+                    first2, last2, dest, std::forward<F>(f),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+            }
+
+            template <typename ExPolicy, typename Iter1, typename Sent1,
+                typename Iter2, typename Sent2, typename Iter3, typename F,
+                typename Proj1, typename Proj2>
+            static typename util::detail::algorithm_result<ExPolicy,
+                util::in_in_out_result<Iter1, Iter2, Iter3>>::type
+            parallel(ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
+                Sent2 last2, Iter3 dest, F&& f, Proj1&& proj1, Proj2&& proj2)
+            {
+                using difference_type1 =
+                    typename std::iterator_traits<Iter1>::difference_type;
+                using difference_type2 =
+                    typename std::iterator_traits<Iter2>::difference_type;
+
+                using result_type = util::in_in_out_result<Iter1, Iter2, Iter3>;
+                using result =
+                    util::detail::algorithm_result<ExPolicy, result_type>;
+
+                if (first1 == last1)
+                {
+                    return util::detail::convert_to_result(
+                        detail::copy<util::in_out_result<Iter2, Iter3>>().call(
+                            std::forward<ExPolicy>(policy), std::false_type(),
+                            first2, last2, dest),
+                        [first1](util::in_out_result<Iter2, Iter3> const& p)
+                            -> result_type {
+                            return {first1, p.in, p.out};
+                        });
+                }
+
+                if (first2 == last2)
+                {
+                    return util::detail::convert_to_result(
+                        detail::copy<util::in_out_result<Iter1, Iter3>>().call(
+                            std::forward<ExPolicy>(policy), std::false_type(),
+                            first1, last1, dest),
+                        [first2](util::in_out_result<Iter1, Iter3> const& p)
+                            -> result_type {
+                            return {p.in, first2, p.out};
+                        });
+                }
+
+                using buffer_type = typename set_operations_buffer<Iter3>::type;
+                using func_type = typename hpx::util::decay<F>::type;
+
+                // calculate approximate destination index
+                auto f1 = [](difference_type1 idx1,
+                              difference_type2 idx2) -> difference_type1 {
+                    return idx1 + idx2;
+                };
+
+                // perform required set operation for one chunk
+                auto f2 = [proj1, proj2](Iter1 part_first1, Sent1 part_last1,
+                              Iter2 part_first2, Sent2 part_last2,
+                              buffer_type* dest, func_type const& f) {
+                    return sequential_set_symmetric_difference(part_first1,
+                        part_last1, part_first2, part_last2, dest, f, proj1,
+                        proj2);
+                };
+
+                return set_operation(std::forward<ExPolicy>(policy), first1,
+                    last1, first2, last2, dest, std::forward<F>(f),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2),
+                    std::move(f1), std::move(f2));
+            }
+        };
+    }    // namespace detail
+
+    // clang-format off
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename FwdIter3, typename Pred = detail::less,
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<FwdIter1>::value &&
+            hpx::traits::is_iterator<FwdIter2>::value &&
+            hpx::traits::is_iterator<FwdIter3>::value &&
+            hpx::traits::is_invocable<Pred,
+                typename std::iterator_traits<FwdIter1>::value_type,
+                typename std::iterator_traits<FwdIter2>::value_type
+            >::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::set_symmetric_difference is deprecated, use "
+        "hpx::set_symmetric_difference instead")
+        typename util::detail::algorithm_result<ExPolicy, FwdIter3>::type
+        set_symmetric_difference(ExPolicy&& policy, FwdIter1 first1,
+            FwdIter1 last1, FwdIter2 first2, FwdIter2 last2, FwdIter3 dest,
+            Pred&& op = Pred())
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
             "Requires at least forward iterator.");
@@ -206,14 +298,111 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
             "Requires at least forward iterator.");
 
-        typedef std::integral_constant<bool,
+        using is_seq = std::integral_constant<bool,
             hpx::is_sequenced_execution_policy<ExPolicy>::value ||
                 !hpx::traits::is_random_access_iterator<FwdIter1>::value ||
-                !hpx::traits::is_random_access_iterator<FwdIter2>::value>
-            is_seq;
+                !hpx::traits::is_random_access_iterator<FwdIter2>::value>;
 
-        return detail::set_symmetric_difference<FwdIter3>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
-            last2, dest, std::forward<Pred>(op));
+        using result_type =
+            parallel::util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>;
+
+        return util::get_third_element(
+            detail::set_symmetric_difference<result_type>().call(
+                std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
+                last2, dest, std::forward<Pred>(op),
+                util::projection_identity(), util::projection_identity()));
     }
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::set_symmetric_difference
+    HPX_INLINE_CONSTEXPR_VARIABLE struct set_symmetric_difference_t final
+      : hpx::functional::tag<set_symmetric_difference_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+            typename FwdIter3, typename Pred = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_iterator<FwdIter3>::value &&
+                hpx::traits::is_invocable<Pred,
+                    typename std::iterator_traits<FwdIter1>::value_type,
+                    typename std::iterator_traits<FwdIter2>::value_type
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter3>::type
+        tag_invoke(set_symmetric_difference_t, ExPolicy&& policy,
+            FwdIter1 first1, FwdIter1 last1, FwdIter2 first2, FwdIter2 last2,
+            FwdIter3 dest, Pred&& op = Pred())
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
+                "Requires at least forward iterator.");
+
+            using is_seq = std::integral_constant<bool,
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>::value ||
+                    !hpx::traits::is_random_access_iterator<FwdIter1>::value ||
+                    !hpx::traits::is_random_access_iterator<FwdIter2>::value>;
+
+            using result_type = hpx::parallel::util::in_in_out_result<FwdIter1,
+                FwdIter2, FwdIter3>;
+
+            return hpx::parallel::util::get_third_element(
+                hpx::parallel::v1::detail::set_symmetric_difference<
+                    result_type>()
+                    .call(std::forward<ExPolicy>(policy), is_seq(), first1,
+                        last1, first2, last2, dest, std::forward<Pred>(op),
+                        hpx::parallel::util::projection_identity(),
+                        hpx::parallel::util::projection_identity()));
+        }
+
+        // clang-format off
+        template <typename FwdIter1, typename FwdIter2, typename FwdIter3,
+            typename Pred = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_iterator<FwdIter3>::value &&
+                hpx::traits::is_invocable<Pred,
+                    typename std::iterator_traits<FwdIter1>::value_type,
+                    typename std::iterator_traits<FwdIter2>::value_type
+                >::value
+            )>
+        // clang-format on
+        friend FwdIter3 tag_invoke(set_symmetric_difference_t, FwdIter1 first1,
+            FwdIter1 last1, FwdIter2 first2, FwdIter2 last2, FwdIter3 dest,
+            Pred&& op = Pred())
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
+                "Requires at least forward iterator.");
+
+            using result_type = hpx::parallel::util::in_in_out_result<FwdIter1,
+                FwdIter2, FwdIter3>;
+
+            return hpx::parallel::util::get_third_element(
+                hpx::parallel::v1::detail::set_symmetric_difference<
+                    result_type>()
+                    .call(hpx::execution::seq, std::true_type(), first1, last1,
+                        first2, last2, dest, std::forward<Pred>(op),
+                        hpx::parallel::util::projection_identity(),
+                        hpx::parallel::util::projection_identity()));
+        }
+    } set_symmetric_difference{};
+}    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
@@ -273,7 +273,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename FwdIter3, typename Pred = detail::less,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value &&
             hpx::traits::is_iterator<FwdIter3>::value &&
@@ -326,7 +326,7 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename FwdIter3, typename Pred = hpx::parallel::v1::detail::less,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value &&
                 hpx::traits::is_iterator<FwdIter3>::value &&

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_union.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_union.hpp
@@ -263,7 +263,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename FwdIter3, typename Pred = detail::less,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value &&
             hpx::traits::is_iterator<FwdIter3>::value &&
@@ -313,7 +313,7 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename FwdIter3, typename Pred = hpx::parallel::v1::detail::less,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value &&
                 hpx::traits::is_iterator<FwdIter3>::value &&

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_union.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_union.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,102 +8,9 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/type_support/decay.hpp>
-
-#include <hpx/executors/execution_policy.hpp>
-#include <hpx/parallel/algorithms/copy.hpp>
-#include <hpx/parallel/algorithms/detail/dispatch.hpp>
-#include <hpx/parallel/algorithms/detail/set_operation.hpp>
-#include <hpx/parallel/util/detail/algorithm_result.hpp>
-#include <hpx/parallel/util/loop.hpp>
-#include <hpx/parallel/util/result_types.hpp>
-
-#include <algorithm>
-#include <iterator>
-#include <type_traits>
-#include <utility>
-
-namespace hpx { namespace parallel { inline namespace v1 {
-    ///////////////////////////////////////////////////////////////////////////
-    // set_union
-    namespace detail {
-        /// \cond NOINTERNAL
-        template <typename FwdIter>
-        struct set_union : public detail::algorithm<set_union<FwdIter>, FwdIter>
-        {
-            set_union()
-              : set_union::algorithm("set_union")
-            {
-            }
-
-            template <typename ExPolicy, typename InIter1, typename InIter2,
-                typename OutIter, typename F>
-            static OutIter sequential(ExPolicy, InIter1 first1, InIter1 last1,
-                InIter2 first2, InIter2 last2, OutIter dest, F&& f)
-            {
-                return std::set_union(
-                    first1, last1, first2, last2, dest, std::forward<F>(f));
-            }
-
-            template <typename ExPolicy, typename RanIter1, typename RanIter2,
-                typename F>
-            static
-                typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
-                parallel(ExPolicy&& policy, RanIter1 first1, RanIter1 last1,
-                    RanIter2 first2, RanIter2 last2, FwdIter dest, F&& f)
-            {
-                typedef typename std::iterator_traits<RanIter1>::difference_type
-                    difference_type1;
-                typedef typename std::iterator_traits<RanIter2>::difference_type
-                    difference_type2;
-
-                if (first1 == last1)
-                {
-                    return util::detail::convert_to_result(
-                        detail::copy<util::in_out_result<RanIter2, FwdIter>>()
-                            .call(std::forward<ExPolicy>(policy),
-                                std::false_type(), first2, last2, dest),
-                        [](util::in_out_result<RanIter2, FwdIter> const& p)
-                            -> FwdIter { return p.out; });
-                }
-
-                if (first2 == last2)
-                {
-                    return util::detail::convert_to_result(
-                        detail::copy<util::in_out_result<RanIter1, FwdIter>>()
-                            .call(std::forward<ExPolicy>(policy),
-                                std::false_type(), first1, last1, dest),
-                        [](util::in_out_result<RanIter1, FwdIter> const& p)
-                            -> FwdIter { return p.out; });
-                }
-
-                typedef
-                    typename set_operations_buffer<FwdIter>::type buffer_type;
-                typedef typename hpx::util::decay<F>::type func_type;
-
-                // calculate approximate destination index
-                auto f1 = [](difference_type1 idx1,
-                              difference_type2 idx2) -> difference_type1 {
-                    return idx1 + idx2;
-                };
-                // perform required set operation for one chunk
-                auto f2 = [](RanIter1 part_first1, RanIter1 part_last1,
-                              RanIter2 part_first2, RanIter2 part_last2,
-                              buffer_type* dest,
-                              func_type const& f) -> buffer_type* {
-                    return std::set_union(part_first1, part_last1, part_first2,
-                        part_last2, dest, f);
-                };
-
-                return set_operation(std::forward<ExPolicy>(policy), first1,
-                    last1, first2, last2, dest, std::forward<F>(f),
-                    std::move(f1), std::move(f2));
-            }
-        };
-        /// \endcond
-    }    // namespace detail
+#if defined(DOXYGEN)
+namespace hpx {
+    // clang-format off
 
     /// Constructs a sorted range beginning at dest consisting of all elements
     /// present in one or both sorted ranges [first1, last1) and
@@ -192,10 +99,185 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename FwdIter3, typename Pred = detail::less>
-    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
-        typename util::detail::algorithm_result<ExPolicy, FwdIter3>::type>::type
+    typename util::detail::algorithm_result<ExPolicy, FwdIter3>::type>::type
     set_union(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
-        FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, Pred&& op = Pred())
+        FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, Pred&& op = Pred());
+
+    // clang-format on
+}    // namespace hpx
+
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/type_support/decay.hpp>
+
+#include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/algorithms/copy.hpp>
+#include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/algorithms/detail/set_operation.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1 {
+    ///////////////////////////////////////////////////////////////////////////
+    // set_union
+    namespace detail {
+
+        template <typename Iter1, typename Sent1, typename Iter2,
+            typename Sent2, typename Iter3, typename Comp, typename Proj1,
+            typename Proj2>
+        constexpr util::in_in_out_result<Iter1, Iter2, Iter3>
+        sequential_set_union(Iter1 first1, Sent1 last1, Iter2 first2,
+            Sent2 last2, Iter3 dest, Comp&& comp, Proj1&& proj1, Proj2&& proj2)
+        {
+            for (; first1 != last1; ++dest)
+            {
+                if (first2 == last2)
+                {
+                    auto result = util::copy(first1, last1, dest);
+                    return {result.in, first2, result.out};
+                }
+
+                auto&& value1 = hpx::util::invoke(proj1, *first1);
+                auto&& value2 = hpx::util::invoke(proj2, *first2);
+
+                if (hpx::util::invoke(comp, value2, value1))
+                {
+                    *dest = *first2++;
+                }
+                else
+                {
+                    *dest = *first1;
+                    if (!hpx::util::invoke(comp, value1, value2))
+                    {
+                        ++first2;
+                    }
+                    ++first1;
+                }
+            }
+
+            auto result = util::copy(first2, last2, dest);
+            return {first1, result.in, result.out};
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Result>
+        struct set_union : public detail::algorithm<set_union<Result>, Result>
+        {
+            set_union()
+              : set_union::algorithm("set_union")
+            {
+            }
+
+            template <typename ExPolicy, typename Iter1, typename Sent1,
+                typename Iter2, typename Sent2, typename Iter3, typename F,
+                typename Proj1, typename Proj2>
+            static util::in_in_out_result<Iter1, Iter2, Iter3> sequential(
+                ExPolicy, Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2,
+                Iter3 dest, F&& f, Proj1&& proj1, Proj2&& proj2)
+            {
+                return sequential_set_union(first1, last1, first2, last2, dest,
+                    std::forward<F>(f), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2));
+            }
+
+            template <typename ExPolicy, typename Iter1, typename Sent1,
+                typename Iter2, typename Sent2, typename Iter3, typename F,
+                typename Proj1, typename Proj2>
+            static typename util::detail::algorithm_result<ExPolicy,
+                util::in_in_out_result<Iter1, Iter2, Iter3>>::type
+            parallel(ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
+                Sent2 last2, Iter3 dest, F&& f, Proj1&& proj1, Proj2&& proj2)
+            {
+                using difference_type1 =
+                    typename std::iterator_traits<Iter1>::difference_type;
+                using difference_type2 =
+                    typename std::iterator_traits<Iter2>::difference_type;
+
+                using result_type = util::in_in_out_result<Iter1, Iter2, Iter3>;
+                using result =
+                    util::detail::algorithm_result<ExPolicy, result_type>;
+
+                if (first1 == last1)
+                {
+                    return util::detail::convert_to_result(
+                        detail::copy<util::in_out_result<Iter2, Iter3>>().call(
+                            std::forward<ExPolicy>(policy), std::false_type(),
+                            first2, last2, dest),
+                        [first1](util::in_out_result<Iter2, Iter3> const& p)
+                            -> result_type {
+                            return {first1, p.in, p.out};
+                        });
+                }
+
+                if (first2 == last2)
+                {
+                    return util::detail::convert_to_result(
+                        detail::copy<util::in_out_result<Iter1, Iter3>>().call(
+                            std::forward<ExPolicy>(policy), std::false_type(),
+                            first1, last1, dest),
+                        [first2](util::in_out_result<Iter1, Iter3> const& p)
+                            -> result_type {
+                            return {p.in, first2, p.out};
+                        });
+                }
+
+                using buffer_type = typename set_operations_buffer<Iter3>::type;
+                using func_type = typename hpx::util::decay<F>::type;
+
+                // calculate approximate destination index
+                auto f1 = [](difference_type1 idx1,
+                              difference_type2 idx2) -> difference_type1 {
+                    return idx1 + idx2;
+                };
+
+                // perform required set operation for one chunk
+                auto f2 = [proj1, proj2](Iter1 part_first1, Sent1 part_last1,
+                              Iter2 part_first2, Sent2 part_last2,
+                              buffer_type* dest, func_type const& f) {
+                    return sequential_set_union(part_first1, part_last1,
+                        part_first2, part_last2, dest, f, proj1, proj2);
+                };
+
+                return set_operation(std::forward<ExPolicy>(policy), first1,
+                    last1, first2, last2, dest, std::forward<F>(f),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2),
+                    std::move(f1), std::move(f2));
+            }
+        };
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
+    // clang-format off
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename FwdIter3, typename Pred = detail::less,
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<FwdIter1>::value &&
+            hpx::traits::is_iterator<FwdIter2>::value &&
+            hpx::traits::is_iterator<FwdIter3>::value &&
+            hpx::traits::is_invocable<Pred,
+                typename std::iterator_traits<FwdIter1>::value_type,
+                typename std::iterator_traits<FwdIter2>::value_type
+            >::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::set_union is deprecated, use hpx::set_union instead")
+        typename util::detail::algorithm_result<ExPolicy, FwdIter3>::type
+        set_union(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+            FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, Pred&& op = Pred())
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
             "Requires at least forward iterator.");
@@ -204,14 +286,107 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
             "Requires at least forward iterator.");
 
-        typedef std::integral_constant<bool,
+        using is_seq = std::integral_constant<bool,
             hpx::is_sequenced_execution_policy<ExPolicy>::value ||
                 !hpx::traits::is_random_access_iterator<FwdIter1>::value ||
-                !hpx::traits::is_random_access_iterator<FwdIter2>::value>
-            is_seq;
+                !hpx::traits::is_random_access_iterator<FwdIter2>::value>;
 
-        return detail::set_union<FwdIter3>().call(
+        using result_type =
+            parallel::util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>;
+
+        return util::get_third_element(detail::set_union<result_type>().call(
             std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
-            last2, dest, std::forward<Pred>(op));
+            last2, dest, std::forward<Pred>(op), util::projection_identity(),
+            util::projection_identity()));
     }
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::set_union
+    HPX_INLINE_CONSTEXPR_VARIABLE struct set_union_t final
+      : hpx::functional::tag<set_union_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+            typename FwdIter3, typename Pred = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_iterator<FwdIter3>::value &&
+                hpx::traits::is_invocable<Pred,
+                    typename std::iterator_traits<FwdIter1>::value_type,
+                    typename std::iterator_traits<FwdIter2>::value_type
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter3>::type
+        tag_invoke(set_union_t, ExPolicy&& policy, FwdIter1 first1,
+            FwdIter1 last1, FwdIter2 first2, FwdIter2 last2, FwdIter3 dest,
+            Pred&& op = Pred())
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
+                "Requires at least forward iterator.");
+
+            using is_seq = std::integral_constant<bool,
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>::value ||
+                    !hpx::traits::is_random_access_iterator<FwdIter1>::value ||
+                    !hpx::traits::is_random_access_iterator<FwdIter2>::value>;
+
+            using result_type = hpx::parallel::util::in_in_out_result<FwdIter1,
+                FwdIter2, FwdIter3>;
+
+            return hpx::parallel::util::get_third_element(
+                hpx::parallel::v1::detail::set_union<result_type>().call(
+                    std::forward<ExPolicy>(policy), is_seq(), first1, last1,
+                    first2, last2, dest, std::forward<Pred>(op),
+                    hpx::parallel::util::projection_identity(),
+                    hpx::parallel::util::projection_identity()));
+        }
+
+        // clang-format off
+        template <typename FwdIter1, typename FwdIter2, typename FwdIter3,
+            typename Pred = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_iterator<FwdIter3>::value &&
+                hpx::traits::is_invocable<Pred,
+                    typename std::iterator_traits<FwdIter1>::value_type,
+                    typename std::iterator_traits<FwdIter2>::value_type
+                >::value
+            )>
+        // clang-format on
+        friend FwdIter3 tag_invoke(set_union_t, FwdIter1 first1, FwdIter1 last1,
+            FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, Pred&& op = Pred())
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
+                "Requires at least forward iterator.");
+
+            using result_type = hpx::parallel::util::in_in_out_result<FwdIter1,
+                FwdIter3, FwdIter3>;
+
+            return hpx::parallel::util::get_third_element(
+                hpx::parallel::v1::detail::set_union<result_type>().call(
+                    hpx::execution::seq, std::true_type(), first1, last1,
+                    first2, last2, dest, std::forward<Pred>(op),
+                    hpx::parallel::util::projection_identity(),
+                    hpx::parallel::util::projection_identity()));
+        }
+    } set_union{};
+}    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/sort.hpp
@@ -371,7 +371,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         typename Compare = detail::less,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<RandomIt>::value &&
             traits::is_projected<Proj, RandomIt>::value &&
             traits::is_indirect_callable<ExPolicy, Compare,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
@@ -276,7 +276,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename F, typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter1>::value&&
                     hpx::traits::is_iterator<FwdIter2>::value&&
                         traits::is_projected<Proj, FwdIter1>::value&&
@@ -567,7 +567,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         typename FwdIter3, typename F,
         typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<
             ExPolicy>::value&& hpx::traits::is_iterator<FwdIter1>::value&&
                 hpx::traits::is_iterator<FwdIter2>::value&&
                     hpx::traits::is_iterator<FwdIter3>::value&&
@@ -783,7 +783,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         typename FwdIter3, typename F,
         typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<
             ExPolicy>::value&& hpx::traits::is_iterator<FwdIter1>::value&&
                 hpx::traits::is_iterator<FwdIter2>::value&&
                     hpx::traits::is_iterator<FwdIter3>::value&&

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -367,7 +367,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Op, typename Conv, typename T,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value &&
             hpx::traits::is_invocable<Conv,
@@ -493,7 +493,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Conv, typename Op,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value &&
             hpx::traits::is_invocable<Conv,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
@@ -377,7 +377,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter, typename T, typename Reduce,
         typename Convert,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter>::value &&
             hpx::traits::is_invocable<Convert,
                 typename std::iterator_traits<FwdIter>::value_type>::value &&
@@ -631,7 +631,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename T,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value
         )>
@@ -653,7 +653,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename T, typename Reduce, typename Convert,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_iterator<FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter2>::value &&
             hpx::traits::is_invocable<Convert,
@@ -699,7 +699,7 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter, typename T,
             typename Reduce, typename Convert,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value &&
                 hpx::traits::is_invocable<Convert,
                    typename std::iterator_traits<FwdIter>::value_type>::value &&
@@ -764,7 +764,7 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename T,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value
             )>
@@ -804,7 +804,7 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename T, typename Reduce, typename Convert,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value &&
                 hpx::traits::is_invocable<Convert,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -282,12 +282,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter,
         typename Pred = detail::equal_to,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<FwdIter>::value&&
-                    traits::is_projected<Proj, FwdIter>::value&&
-                        traits::is_indirect_callable<ExPolicy, Pred,
-                            traits::projected<Proj, FwdIter>,
-                            traits::projected<Proj, FwdIter>>::value)>
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&& hpx::
+                traits::is_iterator<FwdIter>::value&& traits::is_projected<Proj,
+                    FwdIter>::value&& traits::is_indirect_callable<ExPolicy,
+                    Pred, traits::projected<Proj, FwdIter>,
+                    traits::projected<Proj, FwdIter>>::value)>
     typename util::detail::algorithm_result<ExPolicy, FwdIter>::type unique(
         ExPolicy&& policy, FwdIter first, FwdIter last, Pred&& pred = Pred(),
         Proj&& proj = Proj())

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -282,7 +282,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter,
         typename Pred = detail::equal_to,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter>::value&&
                     traits::is_projected<Proj, FwdIter>::value&&
                         traits::is_indirect_callable<ExPolicy, Pred,
@@ -566,7 +566,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename Pred = detail::equal_to,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<FwdIter1>::value&&
                     hpx::traits::is_iterator<FwdIter2>::value&&
                         traits::is_projected<Proj, FwdIter1>::value&&

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms.hpp
@@ -32,6 +32,7 @@
 #include <hpx/parallel/container_algorithms/reverse.hpp>
 #include <hpx/parallel/container_algorithms/rotate.hpp>
 #include <hpx/parallel/container_algorithms/search.hpp>
+#include <hpx/parallel/container_algorithms/set_difference.hpp>
 #include <hpx/parallel/container_algorithms/set_intersection.hpp>
 #include <hpx/parallel/container_algorithms/sort.hpp>
 #include <hpx/parallel/container_algorithms/stable_sort.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms.hpp
@@ -31,6 +31,7 @@
 #include <hpx/parallel/container_algorithms/reverse.hpp>
 #include <hpx/parallel/container_algorithms/rotate.hpp>
 #include <hpx/parallel/container_algorithms/search.hpp>
+#include <hpx/parallel/container_algorithms/set_intersection.hpp>
 #include <hpx/parallel/container_algorithms/sort.hpp>
 #include <hpx/parallel/container_algorithms/stable_sort.hpp>
 #include <hpx/parallel/container_algorithms/transform.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms.hpp
@@ -17,6 +17,7 @@
 #include <hpx/parallel/container_algorithms/find.hpp>
 #include <hpx/parallel/container_algorithms/for_each.hpp>
 #include <hpx/parallel/container_algorithms/generate.hpp>
+#include <hpx/parallel/container_algorithms/includes.hpp>
 #include <hpx/parallel/container_algorithms/is_heap.hpp>
 #include <hpx/parallel/container_algorithms/make_heap.hpp>
 #include <hpx/parallel/container_algorithms/merge.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms.hpp
@@ -34,6 +34,8 @@
 #include <hpx/parallel/container_algorithms/search.hpp>
 #include <hpx/parallel/container_algorithms/set_difference.hpp>
 #include <hpx/parallel/container_algorithms/set_intersection.hpp>
+#include <hpx/parallel/container_algorithms/set_symmetric_difference.hpp>
+#include <hpx/parallel/container_algorithms/set_union.hpp>
 #include <hpx/parallel/container_algorithms/sort.hpp>
 #include <hpx/parallel/container_algorithms/stable_sort.hpp>
 #include <hpx/parallel/container_algorithms/transform.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/all_any_none.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/all_any_none.hpp
@@ -242,7 +242,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename Rng, typename F,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_range<Rng>::value &&
             traits::is_projected_range<Proj, Rng>::value &&
             traits::is_indirect_callable<ExPolicy, F,
@@ -267,7 +267,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename Rng, typename F,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value&&
+            hpx::is_execution_policy<ExPolicy>::value&&
             hpx::traits::is_range<Rng>::value&&
             traits::is_projected_range<Proj, Rng>::value&&
             traits::is_indirect_callable<ExPolicy, F,
@@ -291,7 +291,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename Rng, typename F,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value&&
+            hpx::is_execution_policy<ExPolicy>::value&&
             hpx::traits::is_range<Rng>::value&&
             traits::is_projected_range<Proj, Rng>::value&&
             traits::is_indirect_callable<ExPolicy, F,
@@ -322,7 +322,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Rng, typename F,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value &&
                 hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
@@ -350,7 +350,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Iter, typename Sent, typename F,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<Iter>::value &&
                 hpx::traits::is_sentinel_for<Sent, Iter>::value &&
                 hpx::parallel::traits::is_projected<Proj, Iter>::value &&
@@ -430,7 +430,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Rng, typename F,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value&&
+                hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value&&
                 hpx::parallel::traits::is_projected_range<Proj, Rng>::value&&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
@@ -458,7 +458,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Iter, typename Sent, typename F,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value&&
+                hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<Iter>::value&&
                 hpx::traits::is_sentinel_for<Sent, Iter>::value&&
                 hpx::parallel::traits::is_projected<Proj, Iter>::value&&
@@ -537,7 +537,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Rng, typename F,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value&&
+                hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value&&
                 hpx::parallel::traits::is_projected_range<Proj, Rng>::value&&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
@@ -565,7 +565,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Iter, typename Sent, typename F,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value&&
+                hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_iterator<Iter>::value&&
                 hpx::traits::is_sentinel_for<Sent, Iter>::value&&
                 hpx::parallel::traits::is_projected<Proj, Iter>::value&&

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/copy.hpp
@@ -385,7 +385,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename FwdIter1, typename Sent1,
             typename FwdIter,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
@@ -406,7 +406,7 @@ namespace hpx { namespace ranges {
         // clang-format off
         template <typename ExPolicy, typename Rng, typename FwdIter,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
@@ -476,7 +476,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename FwdIter1, typename Size,
             typename FwdIter2,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value)>
         // clang-format on
@@ -548,7 +548,7 @@ namespace hpx { namespace ranges {
             typename FwdIter, typename Pred,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
                 hpx::parallel::traits::is_projected<Proj, FwdIter1>::value &&
@@ -584,7 +584,7 @@ namespace hpx { namespace ranges {
             typename Pred,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value &&
                 hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
                 hpx::traits::is_iterator<FwdIter>::value &&
@@ -687,7 +687,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename Sent1,
         typename FwdIter,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value&&
+            hpx::is_execution_policy<ExPolicy>::value&&
             hpx::traits::is_iterator<FwdIter1>::value&&
             hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value&&
             hpx::traits::is_iterator<FwdIter>::value
@@ -707,7 +707,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename Rng, typename FwdIter,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value&&
+            hpx::is_execution_policy<ExPolicy>::value&&
             hpx::traits::is_range<Rng>::value&&
             hpx::traits::is_iterator<FwdIter>::value
         )>
@@ -730,7 +730,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename Rng, typename OutIter, typename F,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value&&
+            hpx::is_execution_policy<ExPolicy>::value&&
             hpx::traits::is_range<Rng>::value&&
             traits::is_projected_range<Proj, Rng>::value&&
             hpx::traits::is_iterator<OutIter>::value&&

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/count.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/count.hpp
@@ -166,7 +166,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename Rng, typename T,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             traits::is_projected_range<Proj, Rng>::value &&
             hpx::traits::is_range<Rng>::value
         )>
@@ -196,7 +196,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename Rng, typename F,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_range<Rng>::value &&
             traits::is_projected_range<Proj, Rng>::value &&
             traits::is_indirect_callable<ExPolicy, F,
@@ -238,7 +238,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Rng, typename T,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
                 hpx::traits::is_range<Rng>::value
             )>
@@ -269,7 +269,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Iter, typename Sent, typename T,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent, Iter>::value
             )>
         // clang-format on
@@ -346,7 +346,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Rng, typename F,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value &&
                 hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
@@ -380,7 +380,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Iter, typename Sent, typename F,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent, Iter>::value &&
                 hpx::parallel::traits::is_projected<Proj, Iter>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, F,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/equal.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/equal.hpp
@@ -237,7 +237,7 @@ namespace hpx { namespace ranges {
             typename Proj1 = hpx::parallel::util::projection_identity,
             typename Proj2 = hpx::parallel::util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
                 hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
@@ -273,7 +273,7 @@ namespace hpx { namespace ranges {
             typename Proj1 = hpx::parallel::util::projection_identity,
             typename Proj2 = hpx::parallel::util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
                 hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/find.hpp
@@ -546,7 +546,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         typename Pred = detail::equal_to,
         typename Proj = hpx::parallel::util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::parallel::traits::is_projected_range<Proj, Rng1>::value &&
             hpx::parallel::traits::is_projected_range<Proj, Rng2>::value &&
             hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
@@ -590,7 +590,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         typename Proj1 = hpx::parallel::util::projection_identity,
         typename Proj2 = hpx::parallel::util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
             hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
             hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
@@ -641,7 +641,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Iter, typename Sent, typename T,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent, Iter>::value &&
                 hpx::parallel::traits::is_projected<Proj, Iter>::value
             )>
@@ -662,7 +662,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Rng, typename T,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value &&
                 hpx::parallel::traits::is_projected_range<Proj, Rng>::value
             )>
@@ -723,7 +723,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Iter, typename Sent, typename Pred,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent, Iter>::value &&
                 hpx::parallel::traits::is_projected<Proj, Iter>::value &&
                 hpx::traits::is_invocable<Pred,
@@ -748,7 +748,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Rng, typename Pred,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value &&
                 hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
                 hpx::traits::is_invocable<Pred,
@@ -824,7 +824,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Iter, typename Sent, typename Pred,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent, Iter>::value &&
                 hpx::parallel::traits::is_projected<Proj, Iter>::value &&
                 hpx::traits::is_invocable<Pred,
@@ -849,7 +849,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Rng, typename Pred,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value &&
                 hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
                 hpx::traits::is_invocable<Pred,
@@ -927,7 +927,7 @@ namespace hpx { namespace ranges {
             typename Proj1 = hpx::parallel::util::projection_identity,
             typename Proj2 = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
                 hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
@@ -971,7 +971,7 @@ namespace hpx { namespace ranges {
             typename Proj1 = hpx::parallel::util::projection_identity,
             typename Proj2 = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
                 hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
@@ -1080,7 +1080,7 @@ namespace hpx { namespace ranges {
             typename Proj1 = hpx::parallel::util::projection_identity,
             typename Proj2 = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
                 hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
@@ -1124,7 +1124,7 @@ namespace hpx { namespace ranges {
             typename Proj1 = hpx::parallel::util::projection_identity,
             typename Proj2 = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
                 hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/for_each.hpp
@@ -393,7 +393,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename Rng, typename F,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_range<Rng>::value &&
             hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
             hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
@@ -474,7 +474,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename FwdIter, typename Sent, typename F,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_forward_iterator<FwdIter>::value &&
                 hpx::traits::is_sentinel_for<Sent, FwdIter>::value &&
                 hpx::parallel::traits::is_projected<Proj, FwdIter>::value &&
@@ -497,7 +497,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Rng, typename F,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value &&
                 hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
@@ -554,7 +554,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename FwdIter, typename Size, typename F,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_forward_iterator<FwdIter>::value &&
                 hpx::parallel::traits::is_projected<Proj, FwdIter>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, F,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/generate.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/generate.hpp
@@ -201,7 +201,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename Rng, typename F,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_range<Rng>::value
         )>
     // clang-format on
@@ -235,7 +235,7 @@ namespace hpx { namespace ranges {
         // clang-format off
         template <typename ExPolicy, typename Rng, typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value
             )>
         // clang-format on
@@ -261,7 +261,7 @@ namespace hpx { namespace ranges {
         // clang-format off
         template <typename ExPolicy, typename Iter, typename Sent, typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent, Iter>::value
             )>
         // clang-format on
@@ -330,7 +330,7 @@ namespace hpx { namespace ranges {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename Size, typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/includes.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/includes.hpp
@@ -1,0 +1,393 @@
+//  Copyright (c) 2007-2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/container_algorithms/includes.hpp
+
+#pragma once
+
+#if defined(DOXYGEN)
+namespace hpx { namespace ranges {
+    // clang-format off
+
+    /// Returns true if every element from the sorted range [first2, last2) is
+    /// found within the sorted range [first1, last1). Also returns true if
+    /// [first2, last2) is empty. The version expects both ranges to be sorted
+    /// with the user supplied binary predicate \a f.
+    ///
+    /// \note   At most 2*(N1+N2-1) comparisons, where
+    ///         N1 = std::distance(first1, last1) and
+    ///         N2 = std::distance(first2, last2).
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Iter1       The type of the source iterators used (deduced)
+    ///                     representing the first sequence.
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent1       The type of the end source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     sentinel for Iter1.
+    /// \tparam Iter2       The type of the source iterators used (deduced)
+    ///                     representing the second sequence.
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent2       The type of the end source iterators used (deduced)
+    ///                     representing the second sequence.
+    ///                     This iterator type must meet the requirements of an
+    ///                     sentinel for Iter2.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a includes requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function applied
+    ///                     to the first sequence. This
+    ///                     defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function applied
+    ///                     to the second sequence. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     of the first range the algorithm will be applied to.
+    /// \param last1        Refers to the end of the sequence of elements of
+    ///                     the first range the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the sequence of elements
+    ///                     of the second range the algorithm will be applied to.
+    /// \param last2        Refers to the end of the sequence of elements of
+    ///                     the second range the algorithm will be applied to.
+    /// \param op           The binary predicate which returns true if the
+    ///                     elements should be treated as includes. The signature
+    ///                     of the predicate function should be equivalent to
+    ///                     the following:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type2 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const &, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The types \a Type1 and \a Type2 must be such
+    ///                     that objects of types \a FwdIter1 and \a FwdIter2 can
+    ///                     be dereferenced and then implicitly converted to
+    ///                     \a Type1 and \a Type2 respectively
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     first sequence as a projection operation before the
+    ///                     actual predicate \a op is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     second sequence as a projection operation before the
+    ///                     actual predicate \a op is invoked.
+    ///
+    /// The comparison operations in the parallel \a includes algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The comparison operations in the parallel \a includes algorithm invoked
+    /// with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a includes algorithm returns a \a hpx::future<bool> if the
+    ///           execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a bool otherwise.
+    ///           The \a includes algorithm returns true every element from the
+    ///           sorted range [first2, last2) is found within the sorted range
+    ///           [first1, last1). Also returns true if [first2, last2) is empty.
+    ///
+    template <typename ExPolicy, typename Iter1, typename Sent1, typename Iter2,
+        typename Sent2, typename Pred = detail::less,
+        typename Proj1 = util::projection_identity,
+        typename Proj2 = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy, bool>::type>::type
+    includes(ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
+        Sent2 last2, Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+        Proj2&& proj2 = Proj2());
+
+    /// Returns true if every element from the sorted range [first2, last2) is
+    /// found within the sorted range [first1, last1). Also returns true if
+    /// [first2, last2) is empty. The version expects both ranges to be sorted
+    /// with the user supplied binary predicate \a f.
+    ///
+    /// \note   At most 2*(N1+N2-1) comparisons, where
+    ///         N1 = std::distance(first1, last1) and
+    ///         N2 = std::distance(first2, last2).
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng1        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Rng2        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a includes requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function applied
+    ///                     to the first sequence. This
+    ///                     defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function applied
+    ///                     to the second sequence. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng1         Refers to the first sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param rng2         Refers to the second sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param op           The binary predicate which returns true if the
+    ///                     elements should be treated as includes. The signature
+    ///                     of the predicate function should be equivalent to
+    ///                     the following:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type2 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const &, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The types \a Type1 and \a Type2 must be such
+    ///                     that objects of types \a FwdIter1 and \a FwdIter2 can
+    ///                     be dereferenced and then implicitly converted to
+    ///                     \a Type1 and \a Type2 respectively
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     first sequence as a projection operation before the
+    ///                     actual predicate \a op is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     second sequence as a projection operation before the
+    ///                     actual predicate \a op is invoked.
+    ///
+    /// The comparison operations in the parallel \a includes algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The comparison operations in the parallel \a includes algorithm invoked
+    /// with an execution policy object of type \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a includes algorithm returns a \a hpx::future<bool> if the
+    ///           execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a bool otherwise.
+    ///           The \a includes algorithm returns true every element from the
+    ///           sorted range [first2, last2) is found within the sorted range
+    ///           [first1, last1). Also returns true if [first2, last2) is empty.
+    ///
+    template <typename ExPolicy, typename Rng1, typename Rng2,
+        typename Pred = detail::less,
+        typename Proj1 = util::projection_identity,
+        typename Proj2 = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy, bool>::type>::type
+    includes(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2, Pred&& op = Pred(),
+        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+
+    // clang-format on
+}}    // namespace hpx::ranges
+
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/iterator_support/traits/is_sentinel_for.hpp>
+
+#include <hpx/algorithms/traits/projected.hpp>
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/algorithms/includes.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace ranges {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::includes
+    HPX_INLINE_CONSTEXPR_VARIABLE struct includes_t final
+      : hpx::functional::tag<includes_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename Iter1, typename Sent1,
+            typename Iter2, typename Sent2,
+            typename Pred = hpx::parallel::v1::detail::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
+                hpx::parallel::traits::is_projected<Proj1, Iter1>::value &&
+                hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
+                hpx::parallel::traits::is_projected<Proj2, Iter2>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
+                    hpx::parallel::traits::projected<Proj1, Iter1>,
+                    hpx::parallel::traits::projected<Proj2, Iter2>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            bool>::type
+        tag_invoke(includes_t, ExPolicy&& policy, Iter1 first1, Sent1 last1,
+            Iter2 first2, Sent2 last2, Pred&& op = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        {
+            static_assert((hpx::traits::is_forward_iterator<Iter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
+                "Requires at least forward iterator.");
+
+            using is_seq =
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>;
+
+            return hpx::parallel::v1::detail::includes().call(
+                std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
+                last2, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename Iter1, typename Sent1, typename Iter2, typename Sent2,
+            typename Pred = hpx::parallel::v1::detail::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
+                hpx::parallel::traits::is_projected<Proj1, Iter1>::value &&
+                hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
+                hpx::parallel::traits::is_projected<Proj2, Iter2>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::execution::sequenced_policy, Pred,
+                    hpx::parallel::traits::projected<Proj1, Iter1>,
+                    hpx::parallel::traits::projected<Proj2, Iter2>
+                >::value
+            )>
+        // clang-format on
+        friend bool tag_invoke(includes_t, Iter1 first1, Sent1 last1,
+            Iter2 first2, Sent2 last2, Pred&& op = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        {
+            static_assert((hpx::traits::is_forward_iterator<Iter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::includes().call(
+                hpx::execution::seq, std::true_type(), first1, last1, first2,
+                last2, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng1, typename Rng2,
+            typename Pred = hpx::parallel::v1::detail::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value &&
+                hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
+                    hpx::parallel::traits::projected_range<Proj1, Rng1>,
+                    hpx::parallel::traits::projected_range<Proj2, Rng2>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            bool>::type
+        tag_invoke(includes_t, ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2,
+            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_iterator<Rng1>::type;
+            using iterator_type2 =
+                typename hpx::traits::range_iterator<Rng2>::type;
+
+            static_assert(
+                (hpx::traits::is_forward_iterator<iterator_type1>::value),
+                "Requires at least forward iterator.");
+            static_assert(
+                (hpx::traits::is_forward_iterator<iterator_type2>::value),
+                "Requires at least forward iterator.");
+
+            using is_seq =
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>;
+
+            return hpx::parallel::v1::detail::includes().call(
+                std::forward<ExPolicy>(policy), is_seq(),
+                hpx::util::begin(rng1), hpx::util::end(rng1),
+                hpx::util::begin(rng2), hpx::util::end(rng2),
+                std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename Rng1, typename Rng2,
+            typename Pred = hpx::parallel::v1::detail::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value &&
+                hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::execution::sequenced_policy, Pred,
+                    hpx::parallel::traits::projected_range<Proj1, Rng1>,
+                    hpx::parallel::traits::projected_range<Proj2, Rng2>
+                >::value
+            )>
+        // clang-format on
+        friend bool tag_invoke(includes_t, Rng1&& rng1, Rng2&& rng2,
+            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_iterator<Rng1>::type;
+            using iterator_type2 =
+                typename hpx::traits::range_iterator<Rng2>::type;
+
+            static_assert(
+                (hpx::traits::is_forward_iterator<iterator_type1>::value),
+                "Requires at least forward iterator.");
+            static_assert(
+                (hpx::traits::is_forward_iterator<iterator_type2>::value),
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::includes().call(
+                hpx::execution::seq, std::true_type(), hpx::util::begin(rng1),
+                hpx::util::end(rng1), hpx::util::begin(rng2),
+                hpx::util::end(rng2), std::forward<Pred>(op),
+                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+        }
+    } includes{};
+}}    // namespace hpx::ranges
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/includes.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/includes.hpp
@@ -237,7 +237,7 @@ namespace hpx { namespace ranges {
             typename Proj1 = hpx::parallel::util::projection_identity,
             typename Proj2 = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
                 hpx::parallel::traits::is_projected<Proj1, Iter1>::value &&
                 hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
@@ -307,7 +307,7 @@ namespace hpx { namespace ranges {
             typename Proj1 = hpx::parallel::util::projection_identity,
             typename Proj2 = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng1>::value &&
                 hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
                 hpx::traits::is_range<Rng2>::value &&

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/is_heap.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/is_heap.hpp
@@ -308,7 +308,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename Rng, typename Comp = detail::less,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_range<Rng>::value &&
             traits::is_projected_range<Proj, Rng>::value &&
             traits::is_indirect_callable<ExPolicy, Comp,
@@ -342,7 +342,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename Rng, typename Comp = detail::less,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::is_execution_policy<ExPolicy>::value &&
             hpx::traits::is_range<Rng>::value &&
             traits::is_projected_range<Proj, Rng>::value &&
             traits::is_indirect_callable<ExPolicy, Comp,
@@ -387,7 +387,7 @@ namespace hpx { namespace ranges {
             typename Comp = hpx::parallel::v1::detail::less,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value &&
                 hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, Comp,
@@ -423,7 +423,7 @@ namespace hpx { namespace ranges {
             typename Comp = hpx::parallel::v1::detail::less,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent, Iter>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, Comp,
                     hpx::parallel::traits::projected<Proj, Iter>,
@@ -514,7 +514,7 @@ namespace hpx { namespace ranges {
             typename Comp = hpx::parallel::v1::detail::less,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value &&
                 hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, Comp,
@@ -550,7 +550,7 @@ namespace hpx { namespace ranges {
             typename Comp = hpx::parallel::v1::detail::less,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent, Iter>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, Comp,
                     hpx::parallel::traits::projected<Proj, Iter>,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/make_heap.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/make_heap.hpp
@@ -151,7 +151,7 @@ namespace hpx { namespace ranges {
             typename Comp,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent, Iter>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, Comp,
                     hpx::parallel::traits::projected<Proj, Iter>,
@@ -180,7 +180,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Rng, typename Comp,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, Comp,
                     hpx::parallel::traits::projected_range<Proj, Rng>,
@@ -214,7 +214,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Iter, typename Sent,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent, Iter>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy,
                     std::less<typename std::iterator_traits<Iter>::value_type>,
@@ -245,7 +245,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Rng,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy,
                     std::less<typename std::iterator_traits<

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/merge.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/merge.hpp
@@ -8,24 +8,120 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/concepts/concepts.hpp>
-#include <hpx/iterator_support/range.hpp>
-#include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/iterator_support/traits/is_range.hpp>
-#include <hpx/parallel/util/tagged_tuple.hpp>
+#if defined(DOXYGEN)
+namespace hpx { namespace ranges {
+    // clang-format off
 
-#include <hpx/algorithms/traits/projected.hpp>
-#include <hpx/algorithms/traits/projected_range.hpp>
-#include <hpx/parallel/algorithms/merge.hpp>
-#include <hpx/parallel/tagspec.hpp>
+    /// Merges two sorted ranges [first1, last1) and [first2, last2)
+    /// into one sorted range beginning at \a dest. The order of
+    /// equivalent elements in the each of original two ranges is preserved.
+    /// For equivalent elements in the original two ranges, the elements from
+    /// the first range precede the elements from the second range.
+    /// The destination range cannot overlap with either of the input ranges.
+    ///
+    /// \note   Complexity: Performs
+    ///         O(std::distance(first1, last1) + std::distance(first2, last2))
+    ///         applications of the comparison \a comp and the each projection.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Iter1       The type of the source iterators used (deduced)
+    ///                     representing the first sequence.
+    ///                     This iterator type must meet the requirements of an
+    ///                     random access iterator.
+    /// \tparam Sent1       The type of the end source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     sentinel for Iter1.
+    /// \tparam Iter2       The type of the source iterators used (deduced)
+    ///                     representing the second sequence.
+    ///                     This iterator type must meet the requirements of an
+    ///                     random access iterator.
+    /// \tparam Sent2       The type of the end source iterators used (deduced)
+    ///                     representing the second sequence.
+    ///                     This iterator type must meet the requirements of an
+    ///                     sentinel for Iter2.
+    /// \tparam Iter3       The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     random access iterator.
+    /// \tparam Comp        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a merge requires \a Comp to meet the
+    ///                     requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function to be
+    ///                     used for elements of the first range. This defaults
+    ///                     to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function to be
+    ///                     used for elements of the second range. This defaults
+    ///                     to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     of the first range the algorithm will be applied to.
+    /// \param last1        Refers to the end of the sequence of elements of
+    ///                     the first range the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the sequence of elements
+    ///                     of the second range the algorithm will be applied to.
+    /// \param last2        Refers to the end of the sequence of elements of
+    ///                     the second range the algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param comp         \a comp is a callable object which returns true if
+    ///                     the first argument is less than the second,
+    ///                     and false otherwise. The signature of this
+    ///                     comparison should be equivalent to:
+    ///                     \code
+    ///                     bool comp(const Type1 &a, const Type2 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The types \a Type1 and \a Type2 must be such that
+    ///                     objects of types \a RandIter1 and \a RandIter2 can be
+    ///                     dereferenced and then implicitly converted to
+    ///                     both \a Type1 and \a Type2
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     first range as a projection operation before the
+    ///                     actual comparison \a comp is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     second range as a projection operation before the
+    ///                     actual comparison \a comp is invoked.
+    ///
+    /// The assignments in the parallel \a merge algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a merge algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a merge algorithm returns a
+    /// \a hpx::future<merge_result<Iter1, Iter2, Iter3>>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and returns
+    ///           \a merge_result<Iter1, Iter2, Iter3> otherwise.
+    ///           The \a merge algorithm returns the tuple of
+    ///           the source iterator \a last1,
+    ///           the source iterator \a last2,
+    ///           the destination iterator to the end of the \a dest range.
+    ///
+    template <typename ExPolicy, typename Iter1, typename Sent, typename Iter2,
+        typename Sent2, typename Iter3, typename Comp = hpx::ranges::less,
+        typename Proj1 = util::projection_identity,
+        typename Proj2 = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy,
+        hpx::ranges::merge_result<Iter1, Iter2, Iter3>>::type
+    merge(ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
+        Sent2 last2, Iter3 dest, Comp&& comp = Comp(), Proj1&& proj1 = Proj1(),
+        Proj2&& proj2 = Proj2());
 
-#include <type_traits>
-#include <utility>
-
-namespace hpx { namespace parallel { inline namespace v1 {
-    // TODO: Support forward and bidirectional iterator. (#2826)
-    // For now, only support random access iterator.
     /// Merges two sorted ranges [first1, last1) and [first2, last2)
     /// into one sorted range beginning at \a dest. The order of
     /// equivalent elements in the each of original two ranges is preserved.
@@ -103,45 +199,108 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// within each thread.
     ///
     /// \returns  The \a merge algorithm returns a
-    /// \a hpx::future<tagged_tuple<tag::in1(RandIter1), tag::in2(RandIter2), tag::out(RandIter3)> >
+    /// \a hpx::future<merge_result<RandIter1, RandIter2, RandIter3>>
     ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and returns
-    /// \a tagged_tuple<tag::in1(RandIter1), tag::in2(RandIter2), tag::out(RandIter3)>
-    ///           otherwise.
+    ///           \a merge_result<RandIter1, RandIter2, RandIter3> otherwise.
     ///           The \a merge algorithm returns the tuple of
     ///           the source iterator \a last1,
     ///           the source iterator \a last2,
     ///           the destination iterator to the end of the \a dest range.
     ///
     template <typename ExPolicy, typename Rng1, typename Rng2,
-        typename RandIter3, typename Comp = detail::less,
+        typename RandIter3, typename Comp = hpx::ranges::less,
         typename Proj1 = util::projection_identity,
-        typename Proj2 = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng1>::value&& hpx::traits::is_range<
-                    Rng2>::value&& hpx::traits::is_iterator<RandIter3>::value&&
-                    traits::is_projected_range<Proj1, Rng1>::value&&
-                        traits::is_projected_range<Proj2, Rng2>::value&&
-                            traits::is_indirect_callable<ExPolicy, Comp,
-                                traits::projected_range<Proj1, Rng1>,
-                                traits::projected_range<Proj2, Rng2>>::value)>
+        typename Proj2 = util::projection_identity>
     typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_tuple<
-            tag::in1(typename hpx::traits::range_iterator<Rng1>::type),
-            tag::in2(typename hpx::traits::range_iterator<Rng2>::type),
-            tag::out(RandIter3)>>::type
+        hpx::ranges::merge_result<
+            typename hpx::traits::range_iterator<Rng1>::type,
+            typename hpx::traits::range_iterator<Rng2>::type,
+            RandIter3
+        >
+    >::type
     merge(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2, RandIter3 dest,
-        Comp&& comp = Comp(), Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
-    {
-        return merge(std::forward<ExPolicy>(policy), hpx::util::begin(rng1),
-            hpx::util::end(rng1), hpx::util::begin(rng2), hpx::util::end(rng2),
-            dest, std::forward<Comp>(comp), std::forward<Proj1>(proj1),
-            std::forward<Proj2>(proj2));
-    }
+        Comp&& comp = Comp(), Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
 
-    // TODO: Support bidirectional iterator. (#2826)
-    // For now, only support random access iterator.
+    /// Merges two consecutive sorted ranges [first, middle) and
+    /// [middle, last) into one sorted range [first, last). The order of
+    /// equivalent elements in the each of original two ranges is preserved.
+    /// For equivalent elements in the original two ranges, the elements from
+    /// the first range precede the elements from the second range.
+    ///
+    /// \note   Complexity: Performs O(std::distance(first, last))
+    ///         applications of the comparison \a comp and the each projection.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Iter        The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     random access iterator.
+    /// \tparam Sent       The type of the end source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     sentinel for Iter1.
+    /// \tparam Comp        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a inplace_merge requires \a Comp
+    ///                     to meet the requirements of \a CopyConstructible.
+    ///                     This defaults to std::less<>
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the first sorted range
+    ///                     the algorithm will be applied to.
+    /// \param middle       Refers to the end of the first sorted range and
+    ///                     the beginning of the second sorted range
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the second sorted range
+    ///                     the algorithm will be applied to.
+    /// \param comp         \a comp is a callable object which returns true if
+    ///                     the first argument is less than the second,
+    ///                     and false otherwise. The signature of this
+    ///                     comparison should be equivalent to:
+    ///                     \code
+    ///                     bool comp(const Type1 &a, const Type2 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The types \a Type1 and \a Type2 must be
+    ///                     such that objects of types \a RandIter can be
+    ///                     dereferenced and then implicitly converted to both
+    ///                     \a Type1 and \a Type2
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a inplace_merge algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a inplace_merge algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a inplace_merge algorithm returns a
+    ///           \a hpx::future<Iter> if the execution policy is of type
+    ///           \a sequenced_task_policy or \a parallel_task_policy
+    ///           and returns \a Iter otherwise.
+    ///           The \a inplace_merge algorithm returns
+    ///           the source iterator \a last
+    ///
+    template <typename ExPolicy, typename Iter, typename Sent,
+        typename Comp = hpx::ranges::less,
+        typename Proj = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy, Iter>::type
+    inplace_merge(ExPolicy&& policy, Iter first, Iter middle, Sent last,
+        Comp&& comp = Comp(), Proj&& proj = Proj());
+
     /// Merges two consecutive sorted ranges [first, middle) and
     /// [middle, last) into one sorted range [first, last). The order of
     /// equivalent elements in the each of original two ranges is preserved.
@@ -212,20 +371,469 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           the source iterator \a last
     ///
     template <typename ExPolicy, typename Rng, typename RandIter,
-        typename Comp = detail::less, typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
-                    RandIter>::value&& traits::is_projected_range<Proj,
-                    Rng>::value&& traits::is_projected<Proj, RandIter>::value&&
-                    traits::is_indirect_callable<ExPolicy, Comp,
-                        traits::projected_range<Proj, Rng>,
-                        traits::projected_range<Proj, Rng>>::value)>
+        typename Comp = hpx::ranges::less,
+        typename Proj = util::projection_identity>
     typename util::detail::algorithm_result<ExPolicy, RandIter>::type
     inplace_merge(ExPolicy&& policy, Rng&& rng, RandIter middle,
-        Comp&& comp = Comp(), Proj&& proj = Proj())
+        Comp&& comp = Comp(), Proj&& proj = Proj());
+
+    // clang-format on
+}}    // namespace hpx::ranges
+
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/iterator_support/traits/is_sentinel_for.hpp>
+
+#include <hpx/algorithms/traits/projected.hpp>
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/algorithms/merge.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1 {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // TODO: Support forward and bidirectional iterator. (#2826)
+    // For now, only support random access iterator.
+
+    // clang-format off
+    template <typename ExPolicy, typename Rng1, typename Rng2,
+        typename RandIter3, typename Comp = detail::less,
+        typename Proj1 = util::projection_identity,
+        typename Proj2 = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng1>::value &&
+            hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
+            hpx::traits::is_range<Rng2>::value &&
+            hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
+            hpx::traits::is_iterator<RandIter3>::value &&
+            hpx::parallel::traits::is_indirect_callable<ExPolicy, Comp,
+                hpx::parallel::traits::projected_range<Proj1, Rng1>,
+                hpx::parallel::traits::projected_range<Proj2, Rng2>
+            >::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::merge is deprecated, use hpx::ranges::merge instead")
+        typename util::detail::algorithm_result<ExPolicy,
+            hpx::parallel::util::in_in_out_result<
+                typename hpx::traits::range_iterator<Rng1>::type,
+                typename hpx::traits::range_iterator<Rng2>::type,
+                RandIter3>>::type merge(ExPolicy&& policy, Rng1&& rng1,
+            Rng2&& rng2, RandIter3 dest, Comp&& comp = Comp(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
     {
-        return inplace_merge(std::forward<ExPolicy>(policy),
-            hpx::util::begin(rng), middle, hpx::util::end(rng),
-            std::forward<Comp>(comp), std::forward<Proj>(proj));
+        using iterator_type1 = typename hpx::traits::range_iterator<Rng1>::type;
+        using iterator_type2 = typename hpx::traits::range_iterator<Rng2>::type;
+
+        static_assert(
+            hpx::traits::is_random_access_iterator<iterator_type1>::value,
+            "Required at least random access iterator.");
+        static_assert(
+            hpx::traits::is_random_access_iterator<iterator_type2>::value,
+            "Requires at least random access iterator.");
+        static_assert(
+            (hpx::traits::is_random_access_iterator<RandIter3>::value),
+            "Requires at least random access iterator.");
+
+        using is_seq =
+            hpx::parallel::execution::is_sequenced_execution_policy<ExPolicy>;
+        using result_type =
+            hpx::parallel::util::in_in_out_result<iterator_type1,
+                iterator_type2, RandIter3>;
+
+        return hpx::parallel::v1::detail::merge<result_type>().call(
+            std::forward<ExPolicy>(policy), is_seq(), hpx::util::begin(rng1),
+            hpx::util::end(rng1), hpx::util::begin(rng2), hpx::util::end(rng2),
+            dest, std::forward<Comp>(comp), std::forward<Proj1>(proj1),
+            std::forward<Proj2>(proj2));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // TODO: Support bidirectional iterator. (#2826)
+    // For now, only support random access iterator.
+
+    // clang-format off
+    template <typename ExPolicy, typename Rng, typename RandIter,
+        typename Comp = detail::less, typename Proj = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value &&
+            hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
+            hpx::traits::is_iterator<RandIter>::value &&
+            hpx::parallel::traits::is_projected<Proj, RandIter>::value &&
+            hpx::parallel::traits::is_indirect_callable<ExPolicy, Comp,
+                hpx::parallel::traits::projected_range<Proj, Rng>,
+                hpx::parallel::traits::projected_range<Proj, Rng>
+            >::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::inplace_merge is deprecated, use "
+        "hpx::ranges::inplace_merge instead")
+        typename util::detail::algorithm_result<ExPolicy, RandIter>::type
+        inplace_merge(ExPolicy&& policy, Rng&& rng, RandIter middle,
+            Comp&& comp = Comp(), Proj&& proj = Proj())
+    {
+        using iterator_type = typename hpx::traits::range_iterator<Rng>::type;
+
+        static_assert(
+            hpx::traits::is_random_access_iterator<iterator_type>::value,
+            "Required at least random access iterator.");
+
+        using is_seq =
+            hpx::parallel::execution::is_sequenced_execution_policy<ExPolicy>;
+
+        return hpx::parallel::v1::detail::inplace_merge<RandIter>().call(
+            std::forward<ExPolicy>(policy), is_seq(), hpx::util::begin(rng),
+            middle, hpx::util::end(rng), std::forward<Comp>(comp),
+            std::forward<Proj>(proj));
     }
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx { namespace ranges {
+
+    template <typename I1, typename I2, typename O>
+    using merge_result = parallel::util::in_in_out_result<I1, I2, O>;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::merge
+    HPX_INLINE_CONSTEXPR_VARIABLE struct merge_t final
+      : hpx::functional::tag<merge_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename Rng1, typename Rng2,
+            typename Iter3, typename Comp = hpx::ranges::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value &&
+                hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
+                hpx::traits::is_iterator<Iter3>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, Comp,
+                    hpx::parallel::traits::projected_range<Proj1, Rng1>,
+                    hpx::parallel::traits::projected_range<Proj2, Rng2>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            hpx::ranges::merge_result<
+                typename hpx::traits::range_iterator<Rng1>::type,
+                typename hpx::traits::range_iterator<Rng2>::type, Iter3>>::type
+        tag_invoke(merge_t, ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2,
+            Iter3 dest, Comp&& comp = Comp(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_iterator<Rng1>::type;
+            using iterator_type2 =
+                typename hpx::traits::range_iterator<Rng2>::type;
+
+            static_assert(
+                hpx::traits::is_random_access_iterator<iterator_type1>::value,
+                "Required at least random access iterator.");
+            static_assert(
+                hpx::traits::is_random_access_iterator<iterator_type2>::value,
+                "Requires at least random access iterator.");
+            static_assert(hpx::traits::is_random_access_iterator<Iter3>::value,
+                "Requires at least random access iterator.");
+
+            using is_seq =
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>;
+            using result_type = hpx::ranges::merge_result<iterator_type1,
+                iterator_type2, Iter3>;
+
+            return hpx::parallel::v1::detail::merge<result_type>().call(
+                std::forward<ExPolicy>(policy), is_seq(),
+                hpx::util::begin(rng1), hpx::util::end(rng1),
+                hpx::util::begin(rng2), hpx::util::end(rng2), dest,
+                std::forward<Comp>(comp), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Iter1, typename Sent1,
+            typename Iter2, typename Sent2, typename Iter3,
+            typename Comp = hpx::ranges::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
+                hpx::parallel::traits::is_projected<Proj1, Iter1>::value &&
+                hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
+                hpx::parallel::traits::is_projected<Proj2, Iter2>::value &&
+                hpx::traits::is_iterator<Iter3>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, Comp,
+                    hpx::parallel::traits::projected<Proj1, Iter1>,
+                    hpx::parallel::traits::projected<Proj2, Iter2>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            hpx::ranges::merge_result<Iter1, Iter2, Iter3>>::type
+        tag_invoke(merge_t, ExPolicy&& policy, Iter1 first1, Sent1 last1,
+            Iter2 first2, Sent2 last2, Iter3 dest, Comp&& comp = Comp(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        {
+            static_assert(hpx::traits::is_random_access_iterator<Iter1>::value,
+                "Required at least random access iterator.");
+            static_assert(hpx::traits::is_random_access_iterator<Iter2>::value,
+                "Requires at least random access iterator.");
+            static_assert(hpx::traits::is_random_access_iterator<Iter3>::value,
+                "Requires at least random access iterator.");
+
+            using is_seq =
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>;
+            using result_type = hpx::ranges::merge_result<Iter1, Iter2, Iter3>;
+
+            return hpx::parallel::v1::detail::merge<result_type>().call(
+                std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
+                last2, dest, std::forward<Comp>(comp),
+                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename Rng1, typename Rng2,
+            typename Iter3, typename Comp = hpx::ranges::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value &&
+                hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
+                hpx::traits::is_iterator<Iter3>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::execution::sequenced_policy, Comp,
+                    hpx::parallel::traits::projected_range<Proj1, Rng1>,
+                    hpx::parallel::traits::projected_range<Proj2, Rng2>
+                >::value
+            )>
+        // clang-format on
+        friend hpx::ranges::merge_result<
+            typename hpx::traits::range_iterator<Rng1>::type,
+            typename hpx::traits::range_iterator<Rng2>::type, Iter3>
+        tag_invoke(merge_t, Rng1&& rng1, Rng2&& rng2, Iter3 dest,
+            Comp&& comp = Comp(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_iterator<Rng1>::type;
+            using iterator_type2 =
+                typename hpx::traits::range_iterator<Rng2>::type;
+
+            static_assert(
+                hpx::traits::is_random_access_iterator<iterator_type1>::value,
+                "Required at least random access iterator.");
+            static_assert(
+                hpx::traits::is_random_access_iterator<iterator_type2>::value,
+                "Requires at least random access iterator.");
+            static_assert(hpx::traits::is_random_access_iterator<Iter3>::value,
+                "Requires at least random access iterator.");
+
+            using result_type = hpx::ranges::merge_result<iterator_type1,
+                iterator_type2, Iter3>;
+
+            return hpx::parallel::v1::detail::merge<result_type>().call(
+                hpx::execution::seq, std::true_type(), hpx::util::begin(rng1),
+                hpx::util::end(rng1), hpx::util::begin(rng2),
+                hpx::util::end(rng2), dest, std::forward<Comp>(comp),
+                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename Iter1, typename Sent1,
+            typename Iter2, typename Sent2, typename Iter3,
+            typename Comp = hpx::ranges::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
+                hpx::parallel::traits::is_projected<Proj1, Iter1>::value &&
+                hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
+                hpx::parallel::traits::is_projected<Proj2, Iter2>::value &&
+                hpx::traits::is_iterator<Iter3>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::execution::sequenced_policy, Comp,
+                    hpx::parallel::traits::projected<Proj1, Iter1>,
+                    hpx::parallel::traits::projected<Proj2, Iter2>
+                >::value
+            )>
+        // clang-format on
+        friend hpx::ranges::merge_result<Iter1, Iter2, Iter3> tag_invoke(
+            merge_t, Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2,
+            Iter3 dest, Comp&& comp = Comp(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            static_assert(hpx::traits::is_random_access_iterator<Iter1>::value,
+                "Required at least random access iterator.");
+            static_assert(hpx::traits::is_random_access_iterator<Iter2>::value,
+                "Requires at least random access iterator.");
+            static_assert(hpx::traits::is_random_access_iterator<Iter3>::value,
+                "Requires at least random access iterator.");
+
+            using result_type = hpx::ranges::merge_result<Iter1, Iter2, Iter3>;
+
+            return hpx::parallel::v1::detail::merge<result_type>().call(
+                hpx::execution::seq, std::true_type(), first1, last1, first2,
+                last2, dest, std::forward<Comp>(comp),
+                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+        }
+    } merge{};
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::inplace_merge
+    HPX_INLINE_CONSTEXPR_VARIABLE struct inplace_merge_t final
+      : hpx::functional::tag<inplace_merge_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename Rng, typename Iter,
+            typename Comp = hpx::ranges::less,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
+                hpx::traits::is_iterator<Iter>::value &&
+                hpx::parallel::traits::is_projected<Proj, Iter>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, Comp,
+                    hpx::parallel::traits::projected_range<Proj, Rng>,
+                    hpx::parallel::traits::projected_range<Proj, Rng>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            Iter>::type
+        tag_invoke(inplace_merge_t, ExPolicy&& policy, Rng&& rng, Iter middle,
+            Comp&& comp = Comp(), Proj&& proj = Proj())
+        {
+            using iterator_type =
+                typename hpx::traits::range_iterator<Rng>::type;
+
+            static_assert(
+                hpx::traits::is_random_access_iterator<iterator_type>::value,
+                "Required at least random access iterator.");
+            static_assert(hpx::traits::is_random_access_iterator<Iter>::value,
+                "Required at least random access iterator.");
+
+            using is_seq =
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>;
+
+            return hpx::parallel::v1::detail::inplace_merge<Iter>().call(
+                std::forward<ExPolicy>(policy), is_seq(), hpx::util::begin(rng),
+                middle, hpx::util::end(rng), std::forward<Comp>(comp),
+                std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Iter, typename Sent,
+            typename Comp = hpx::ranges::less,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_sentinel_for<Sent, Iter>::value &&
+                hpx::parallel::traits::is_projected<Proj, Iter>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, Comp,
+                    hpx::parallel::traits::projected<Proj, Iter>,
+                    hpx::parallel::traits::projected<Proj, Iter>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            Iter>::type
+        tag_invoke(inplace_merge_t, ExPolicy&& policy, Iter first, Iter middle,
+            Sent last, Comp&& comp = Comp(), Proj&& proj = Proj())
+        {
+            static_assert(hpx::traits::is_random_access_iterator<Iter>::value,
+                "Required at least random access iterator.");
+
+            using is_seq =
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>;
+
+            return hpx::parallel::v1::detail::inplace_merge<Iter>().call(
+                std::forward<ExPolicy>(policy), is_seq(), first, middle, last,
+                std::forward<Comp>(comp), std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename Rng, typename Iter,
+            typename Comp = hpx::ranges::less,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
+                hpx::traits::is_iterator<Iter>::value &&
+                hpx::parallel::traits::is_projected<Proj, Iter>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::execution::sequenced_policy, Comp,
+                    hpx::parallel::traits::projected_range<Proj, Rng>,
+                    hpx::parallel::traits::projected_range<Proj, Rng>
+                >::value
+            )>
+        // clang-format on
+        friend Iter tag_invoke(inplace_merge_t, Rng&& rng, Iter middle,
+            Comp&& comp = Comp(), Proj&& proj = Proj())
+        {
+            using iterator_type =
+                typename hpx::traits::range_iterator<Rng>::type;
+
+            static_assert(
+                hpx::traits::is_random_access_iterator<iterator_type>::value,
+                "Required at least random access iterator.");
+            static_assert(hpx::traits::is_random_access_iterator<Iter>::value,
+                "Required at least random access iterator.");
+
+            return hpx::parallel::v1::detail::inplace_merge<Iter>().call(
+                hpx::execution::seq, std::true_type(), hpx::util::begin(rng),
+                middle, hpx::util::end(rng), std::forward<Comp>(comp),
+                std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename Iter, typename Sent,
+            typename Comp = hpx::ranges::less,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_sentinel_for<Sent, Iter>::value &&
+                hpx::parallel::traits::is_projected<Proj, Iter>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::execution::sequenced_policy, Comp,
+                    hpx::parallel::traits::projected<Proj, Iter>,
+                    hpx::parallel::traits::projected<Proj, Iter>
+                >::value
+            )>
+        // clang-format on
+        friend Iter tag_invoke(inplace_merge_t, Iter first, Iter middle,
+            Sent last, Comp&& comp = Comp(), Proj&& proj = Proj())
+        {
+            static_assert(hpx::traits::is_random_access_iterator<Iter>::value,
+                "Required at least random access iterator.");
+
+            return hpx::parallel::v1::detail::inplace_merge<Iter>().call(
+                hpx::execution::seq, std::true_type(), first, middle, last,
+                std::forward<Comp>(comp), std::forward<Proj>(proj));
+        }
+    } inplace_merge{};
+
+}}    // namespace hpx::ranges
+#endif    //DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/mismatch.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/mismatch.hpp
@@ -244,7 +244,7 @@ namespace hpx { namespace ranges {
             typename Proj1 = hpx::parallel::util::projection_identity,
             typename Proj2 = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
                 hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
@@ -281,7 +281,7 @@ namespace hpx { namespace ranges {
             typename Proj1 = hpx::parallel::util::projection_identity,
             typename Proj2 = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
                 hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/reduce.hpp
@@ -436,7 +436,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename FwdIter, typename Sent,
             typename T, typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent, FwdIter>::value
             )>
         // clang-format on
@@ -455,7 +455,7 @@ namespace hpx { namespace ranges {
         // clang-format off
         template <typename ExPolicy, typename Rng, typename T, typename F,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value
             )>
         // clang-format on
@@ -477,7 +477,7 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename FwdIter, typename Sent,
             typename T,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent, FwdIter>::value
             )>
         // clang-format on
@@ -496,7 +496,7 @@ namespace hpx { namespace ranges {
         // clang-format off
         template <typename ExPolicy, typename Rng, typename T,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value
             )>
         // clang-format on
@@ -516,7 +516,7 @@ namespace hpx { namespace ranges {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename Sent,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent, FwdIter>::value
             )>
         // clang-format on
@@ -538,7 +538,7 @@ namespace hpx { namespace ranges {
         // clang-format off
         template <typename ExPolicy, typename Rng,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value
             )>
         // clang-format on

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_difference.hpp
@@ -276,7 +276,7 @@ namespace hpx { namespace ranges {
             typename Proj1 = hpx::parallel::util::projection_identity,
             typename Proj2 = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
                 hpx::parallel::traits::is_projected<Proj1, Iter1>::value &&
                 hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
@@ -322,7 +322,7 @@ namespace hpx { namespace ranges {
             typename Proj1 = hpx::parallel::util::projection_identity,
             typename Proj2 = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng1>::value &&
                 hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
                 hpx::traits::is_range<Rng2>::value &&

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_difference.hpp
@@ -1,0 +1,465 @@
+//  Copyright (c) 2007-2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/container_algorithms/set_difference.hpp
+
+#pragma once
+
+#if defined(DOXYGEN)
+namespace hpx { namespace ranges {
+    // clang-format off
+
+    /// Constructs a sorted range beginning at dest consisting of all elements
+    /// present in the range [first1, last1) and not present in the range
+    /// [first2, last2). This algorithm expects both input ranges to be sorted
+    /// with the given binary predicate \a f.
+    ///
+    /// \note   Complexity: At most 2*(N1 + N2 - 1) comparisons, where \a N1 is
+    ///         the length of the first sequence and \a N2 is the length of the
+    ///         second sequence.
+    ///
+    /// Equivalent elements are treated individually, that is, if some element
+    /// is found \a m times in [first1, last1) and \a n times in
+    /// [first2, last2), it will be copied to \a dest exactly std::max(m-n, 0)
+    /// times. The resulting range cannot overlap with either of the input
+    /// ranges.
+    ///
+    /// The resulting range cannot overlap with either of the input ranges.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it applies user-provided function objects.
+    /// \tparam Iter1       The type of the source iterators used (deduced)
+    ///                     representing the first sequence.
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent1       The type of the end source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     sentinel for Iter1.
+    /// \tparam Iter2       The type of the source iterators used (deduced)
+    ///                     representing the second sequence.
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent2       The type of the end source iterators used (deduced)
+    ///                     representing the second sequence.
+    ///                     This iterator type must meet the requirements of an
+    ///                     sentinel for Iter2.
+    /// \tparam Iter3       The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a set_difference requires \a Pred to meet
+    ///                     the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function applied
+    ///                     to the first sequence. This
+    ///                     defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function applied
+    ///                     to the second sequence. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     of the first range the algorithm will be applied to.
+    /// \param last1        Refers to the end of the sequence of elements of
+    ///                     the first range the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the sequence of elements
+    ///                     of the second range the algorithm will be applied to.
+    /// \param last2        Refers to the end of the sequence of elements of
+    ///                     the second range the algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           The binary predicate which returns true if the
+    ///                     elements should be treated as equal. The signature
+    ///                     of the predicate function should be equivalent to
+    ///                     the following:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const &, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type1 must be such
+    ///                     that objects of type \a InIter can
+    ///                     be dereferenced and then implicitly converted to
+    ///                     \a Type1
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     first sequence as a projection operation before the
+    ///                     actual predicate \a op is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     second sequence as a projection operation before the
+    ///                     actual predicate \a op is invoked.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with a sequential execution policy object execute in sequential
+    /// order in the calling thread (\a sequenced_policy) or in a
+    /// single new thread spawned from the current thread
+    /// (for \a sequenced_task_policy).
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified
+    /// threads, and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a set_difference algorithm returns a
+    ///           \a hpx::future<ranges::set_difference_result<Iter1, Iter3>>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a ranges::set_difference_result<Iter1, Iter3> otherwise.
+    ///           The \a set_difference algorithm returns the output iterator to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename ExPolicy, typename Iter1, typename Sent1, typename Iter2,
+        typename Sent2, typename Iter3, typename Pred = detail::less,
+        typename Proj1 = util::projection_identity,
+        typename Proj2 = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy,
+        ranges::set_difference_result<Iter1, Iter3>>::type
+    set_difference(ExPolicy&& policy, Iter1 first1, Sent1 last1,
+        Iter2 first2, Sent2 last2, Iter3 dest, Pred&& op = Pred(),
+        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+
+    /// Constructs a sorted range beginning at dest consisting of all elements
+    /// present in the range [first1, last1) and not present in the range
+    /// [first2, last2). This algorithm expects both input ranges to be sorted
+    /// with the given binary predicate \a f.
+    ///
+    /// \note   Complexity: At most 2*(N1 + N2 - 1) comparisons, where \a N1 is
+    ///         the length of the first sequence and \a N2 is the length of the
+    ///         second sequence.
+    ///
+    /// Equivalent elements are treated individually, that is, if some element
+    /// is found \a m times in [first1, last1) and \a n times in
+    /// [first2, last2), it will be copied to \a dest exactly std::max(m-n, 0)
+    /// times. The resulting range cannot overlap with either of the input
+    /// ranges.
+    ///
+    /// The resulting range cannot overlap with either of the input ranges.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it applies user-provided function objects.
+    /// \tparam Rng1        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Rng2        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Iter3       The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a set_difference requires \a Pred to meet
+    ///                     the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function applied
+    ///                     to the first sequence. This
+    ///                     defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function applied
+    ///                     to the second sequence. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng1         Refers to the first sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param rng2         Refers to the second sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           The binary predicate which returns true if the
+    ///                     elements should be treated as equal. The signature
+    ///                     of the predicate function should be equivalent to
+    ///                     the following:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const &, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type1 must be such
+    ///                     that objects of type \a InIter can
+    ///                     be dereferenced and then implicitly converted to
+    ///                     \a Type1
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     first sequence as a projection operation before the
+    ///                     actual predicate \a op is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     second sequence as a projection operation before the
+    ///                     actual predicate \a op is invoked.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with a sequential execution policy object execute in sequential
+    /// order in the calling thread (\a sequenced_policy) or in a
+    /// single new thread spawned from the current thread
+    /// (for \a sequenced_task_policy).
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified
+    /// threads, and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a set_difference algorithm returns a
+    ///           \a hpx::future<ranges::set_difference_result<Iter1, Iter3>>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a ranges::set_difference_result<Iter1, Iter3> otherwise.
+    ///           where Iter1 is range_iterator_t<Rng1> and Iter2 is range_iterator_t<Rng2>
+    ///           The \a set_difference algorithm returns the output iterator to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename ExPolicy, typename Rng1, typename Rng2, typename Iter3,
+        typename Pred = detail::less,
+        typename Proj1 = util::projection_identity,
+        typename Proj2 = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy,
+        ranges::set_difference_result<
+            typename traits::range_iterator<Rng1>::type, Iter3>>::type
+    set_difference(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2, Iter3 dest,
+        Pred&& op = Pred(), Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+
+    // clang-format on
+}}    // namespace hpx::ranges
+
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/iterator_support/traits/is_sentinel_for.hpp>
+
+#include <hpx/algorithms/traits/projected.hpp>
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/algorithms/set_difference.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace ranges {
+
+    template <typename I1, typename O>
+    using set_difference_result = parallel::util::in_out_result<I1, O>;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::set_difference
+    HPX_INLINE_CONSTEXPR_VARIABLE struct set_difference_t final
+      : hpx::functional::tag<set_difference_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename Iter1, typename Sent1,
+            typename Iter2, typename Sent2, typename Iter3,
+            typename Pred = hpx::parallel::v1::detail::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
+                hpx::parallel::traits::is_projected<Proj1, Iter1>::value &&
+                hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
+                hpx::parallel::traits::is_projected<Proj2, Iter2>::value &&
+                hpx::traits::is_iterator<Iter3>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
+                    hpx::parallel::traits::projected<Proj1, Iter1>,
+                    hpx::parallel::traits::projected<Proj2, Iter2>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            set_difference_result<Iter1, Iter3>>::type
+        tag_invoke(set_difference_t, ExPolicy&& policy, Iter1 first1,
+            Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
+            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            static_assert((hpx::traits::is_forward_iterator<Iter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
+                "Requires at least forward iterator.");
+
+            using is_seq = std::integral_constant<bool,
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>::value ||
+                    !hpx::traits::is_random_access_iterator<Iter1>::value ||
+                    !hpx::traits::is_random_access_iterator<Iter2>::value>;
+
+            using result_type = set_difference_result<Iter1, Iter3>;
+
+            return hpx::parallel::v1::detail::set_difference<result_type>()
+                .call(std::forward<ExPolicy>(policy), is_seq(), first1, last1,
+                    first2, last2, dest, std::forward<Pred>(op),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng1, typename Rng2, typename Iter3,
+            typename Pred = hpx::parallel::v1::detail::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value &&
+                hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
+                hpx::traits::is_iterator<Iter3>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
+                    hpx::parallel::traits::projected_range<Proj1, Rng1>,
+                    hpx::parallel::traits::projected_range<Proj2, Rng2>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            set_difference_result<
+                typename hpx::traits::range_iterator<Rng1>::type, Iter3>>::type
+        tag_invoke(set_difference_t, ExPolicy&& policy, Rng1&& rng1,
+            Rng2&& rng2, Iter3 dest, Pred&& op = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_iterator<Rng1>::type;
+            using iterator_type2 =
+                typename hpx::traits::range_iterator<Rng2>::type;
+
+            static_assert(
+                (hpx::traits::is_forward_iterator<iterator_type1>::value),
+                "Requires at least forward iterator.");
+            static_assert(
+                (hpx::traits::is_forward_iterator<iterator_type2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
+                "Requires at least forward iterator.");
+
+            using is_seq = std::integral_constant<bool,
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>::value ||
+                    !hpx::traits::is_random_access_iterator<
+                        iterator_type1>::value ||
+                    !hpx::traits::is_random_access_iterator<
+                        iterator_type2>::value>;
+
+            using result_type = set_difference_result<iterator_type1, Iter3>;
+
+            return hpx::parallel::v1::detail::set_difference<result_type>()
+                .call(std::forward<ExPolicy>(policy), is_seq(),
+                    hpx::util::begin(rng1), hpx::util::end(rng1),
+                    hpx::util::begin(rng2), hpx::util::end(rng2), dest,
+                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename Iter1, typename Sent1, typename Iter2, typename Sent2,
+            typename Iter3, typename Pred = hpx::parallel::v1::detail::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
+                hpx::parallel::traits::is_projected<Proj1, Iter1>::value &&
+                hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
+                hpx::parallel::traits::is_projected<Proj2, Iter2>::value &&
+                hpx::traits::is_iterator<Iter3>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::execution::sequenced_policy, Pred,
+                    hpx::parallel::traits::projected<Proj1, Iter1>,
+                    hpx::parallel::traits::projected<Proj2, Iter2>
+                >::value
+            )>
+        // clang-format on
+        friend set_difference_result<Iter1, Iter3> tag_invoke(set_difference_t,
+            Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
+            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            static_assert((hpx::traits::is_forward_iterator<Iter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
+                "Requires at least forward iterator.");
+
+            using result_type = set_difference_result<Iter1, Iter3>;
+
+            return hpx::parallel::v1::detail::set_difference<result_type>()
+                .call(hpx::execution::seq, std::true_type(), first1, last1,
+                    first2, last2, dest, std::forward<Pred>(op),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename Rng1, typename Rng2, typename Iter3,
+            typename Pred = hpx::parallel::v1::detail::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value &&
+                hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
+                hpx::traits::is_iterator<Iter3>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::execution::sequenced_policy, Pred,
+                    hpx::parallel::traits::projected_range<Proj1, Rng1>,
+                    hpx::parallel::traits::projected_range<Proj2, Rng2>
+                >::value
+            )>
+        // clang-format on
+        friend set_difference_result<
+            typename hpx::traits::range_iterator<Rng1>::type, Iter3>
+        tag_invoke(set_difference_t, Rng1&& rng1, Rng2&& rng2, Iter3 dest,
+            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_iterator<Rng1>::type;
+            using iterator_type2 =
+                typename hpx::traits::range_iterator<Rng2>::type;
+
+            static_assert(
+                (hpx::traits::is_forward_iterator<iterator_type1>::value),
+                "Requires at least forward iterator.");
+            static_assert(
+                (hpx::traits::is_forward_iterator<iterator_type2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
+                "Requires at least forward iterator.");
+
+            using result_type = set_difference_result<iterator_type1, Iter3>;
+
+            return hpx::parallel::v1::detail::set_difference<result_type>()
+                .call(hpx::execution::seq, std::true_type(),
+                    hpx::util::begin(rng1), hpx::util::end(rng1),
+                    hpx::util::begin(rng2), hpx::util::end(rng2), dest,
+                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2));
+        }
+    } set_difference{};
+
+}}    // namespace hpx::ranges
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_intersection.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_intersection.hpp
@@ -277,7 +277,7 @@ namespace hpx { namespace ranges {
             typename Proj1 = hpx::parallel::util::projection_identity,
             typename Proj2 = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
                 hpx::parallel::traits::is_projected<Proj1, Iter1>::value &&
                 hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
@@ -323,7 +323,7 @@ namespace hpx { namespace ranges {
             typename Proj1 = hpx::parallel::util::projection_identity,
             typename Proj2 = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng1>::value &&
                 hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
                 hpx::traits::is_range<Rng2>::value &&

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_intersection.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_intersection.hpp
@@ -1,0 +1,470 @@
+//  Copyright (c) 2007-2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/container_algorithms/set_intersection.hpp
+
+#pragma once
+
+#if defined(DOXYGEN)
+namespace hpx { namespace ranges {
+    // clang-format off
+
+    /// Constructs a sorted range beginning at dest consisting of all elements
+    /// present in both sorted ranges [first1, last1) and
+    /// [first2, last2). This algorithm expects both input ranges to be sorted
+    /// with the given binary predicate \a f.
+    ///
+    /// \note   Complexity: At most 2*(N1 + N2 - 1) comparisons, where \a N1 is
+    ///         the length of the first sequence and \a N2 is the length of the
+    ///         second sequence.
+    ///
+    /// If some element is found \a m times in [first1, last1) and \a n times
+    /// in [first2, last2), the first std::min(m, n) elements will be copied
+    /// from the first range to the destination range. The order of equivalent
+    /// elements is preserved. The resulting range cannot overlap with either
+    /// of the input ranges.
+    ///
+    /// The resulting range cannot overlap with either of the input ranges.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it applies user-provided function objects.
+    /// \tparam Iter1       The type of the source iterators used (deduced)
+    ///                     representing the first sequence.
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent1       The type of the end source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     sentinel for Iter1.
+    /// \tparam Iter2       The type of the source iterators used (deduced)
+    ///                     representing the second sequence.
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent2       The type of the end source iterators used (deduced)
+    ///                     representing the second sequence.
+    ///                     This iterator type must meet the requirements of an
+    ///                     sentinel for Iter2.
+    /// \tparam Iter3       The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a set_intersection requires \a Pred to meet
+    ///                     the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function applied
+    ///                     to the first sequence. This
+    ///                     defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function applied
+    ///                     to the second sequence. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     of the first range the algorithm will be applied to.
+    /// \param last1        Refers to the end of the sequence of elements of
+    ///                     the first range the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the sequence of elements
+    ///                     of the second range the algorithm will be applied to.
+    /// \param last2        Refers to the end of the sequence of elements of
+    ///                     the second range the algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           The binary predicate which returns true if the
+    ///                     elements should be treated as equal. The signature
+    ///                     of the predicate function should be equivalent to
+    ///                     the following:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const &, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type1 must be such
+    ///                     that objects of type \a InIter can
+    ///                     be dereferenced and then implicitly converted to
+    ///                     \a Type1
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     first sequence as a projection operation before the
+    ///                     actual predicate \a op is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     second sequence as a projection operation before the
+    ///                     actual predicate \a op is invoked.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with a sequential execution policy object execute in sequential
+    /// order in the calling thread (\a sequenced_policy) or in a
+    /// single new thread spawned from the current thread
+    /// (for \a sequenced_task_policy).
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified
+    /// threads, and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a set_intersection algorithm returns a
+    ///           \a hpx::future<ranges::set_intersection_result<Iter1, Iter2, Iter3>>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a ranges::set_intersection_result<Iter1, Iter2, Iter3> otherwise.
+    ///           The \a set_intersection algorithm returns the output iterator to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename ExPolicy, typename Iter1, typename Sent1, typename Iter2,
+        typename Sent2, typename Iter3, typename Pred = detail::less,
+        typename Proj1 = util::projection_identity,
+        typename Proj2 = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy,
+        ranges::set_intersection_result<Iter1, Iter2, Iter3>>::type
+    set_intersection(ExPolicy&& policy, Iter1 first1, Sent1 last1,
+        Iter2 first2, Sent2 last2, Iter3 dest, Pred&& op = Pred(),
+        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+
+    /// Constructs a sorted range beginning at dest consisting of all elements
+    /// present in both sorted ranges [first1, last1) and
+    /// [first2, last2). This algorithm expects both input ranges to be sorted
+    /// with the given binary predicate \a f.
+    ///
+    /// \note   Complexity: At most 2*(N1 + N2 - 1) comparisons, where \a N1 is
+    ///         the length of the first sequence and \a N2 is the length of the
+    ///         second sequence.
+    ///
+    /// If some element is found \a m times in [first1, last1) and \a n times
+    /// in [first2, last2), the first std::min(m, n) elements will be copied
+    /// from the first range to the destination range. The order of equivalent
+    /// elements is preserved. The resulting range cannot overlap with either
+    /// of the input ranges.
+    ///
+    /// The resulting range cannot overlap with either of the input ranges.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it applies user-provided function objects.
+    /// \tparam Rng1        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Rng2        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Iter3       The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a set_intersection requires \a Pred to meet
+    ///                     the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function applied
+    ///                     to the first sequence. This
+    ///                     defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function applied
+    ///                     to the second sequence. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng1         Refers to the first sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param rng2         Refers to the second sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           The binary predicate which returns true if the
+    ///                     elements should be treated as equal. The signature
+    ///                     of the predicate function should be equivalent to
+    ///                     the following:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const &, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type1 must be such
+    ///                     that objects of type \a InIter can
+    ///                     be dereferenced and then implicitly converted to
+    ///                     \a Type1
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     first sequence as a projection operation before the
+    ///                     actual predicate \a op is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     second sequence as a projection operation before the
+    ///                     actual predicate \a op is invoked.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with a sequential execution policy object execute in sequential
+    /// order in the calling thread (\a sequenced_policy) or in a
+    /// single new thread spawned from the current thread
+    /// (for \a sequenced_task_policy).
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified
+    /// threads, and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a set_intersection algorithm returns a
+    ///           \a hpx::future<ranges::set_intersection_result<Iter1, Iter2, Iter3>>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a ranges::set_intersection_result<Iter1, Iter2, Iter3> otherwise.
+    ///           where Iter1 is range_iterator_t<Rng1> and Iter2 is range_iterator_t<Rng2>
+    ///           The \a set_intersection algorithm returns the output iterator to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename ExPolicy, typename Rng1, typename Rng2, typename Iter3,
+        typename Pred = detail::less,
+        typename Proj1 = util::projection_identity,
+        typename Proj2 = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy,
+        ranges::set_intersection_result<
+            typename traits::range_iterator<Rng1>::type,
+            typename traits::range_iterator<Rng2>::type, Iter3>>::type
+    set_intersection(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2, Iter3 dest,
+        Pred&& op = Pred(), Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+
+    // clang-format on
+}}    // namespace hpx::ranges
+
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/iterator_support/traits/is_sentinel_for.hpp>
+
+#include <hpx/algorithms/traits/projected.hpp>
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/algorithms/set_intersection.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace ranges {
+
+    template <typename I1, typename I2, typename O>
+    using set_intersection_result = parallel::util::in_in_out_result<I1, I2, O>;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::set_intersection
+    HPX_INLINE_CONSTEXPR_VARIABLE struct set_intersection_t final
+      : hpx::functional::tag<set_intersection_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename Iter1, typename Sent1,
+            typename Iter2, typename Sent2, typename Iter3,
+            typename Pred = hpx::parallel::v1::detail::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
+                hpx::parallel::traits::is_projected<Proj1, Iter1>::value &&
+                hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
+                hpx::parallel::traits::is_projected<Proj2, Iter2>::value &&
+                hpx::traits::is_iterator<Iter3>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
+                    hpx::parallel::traits::projected<Proj1, Iter1>,
+                    hpx::parallel::traits::projected<Proj2, Iter2>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            set_intersection_result<Iter1, Iter2, Iter3>>::type
+        tag_invoke(set_intersection_t, ExPolicy&& policy, Iter1 first1,
+            Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
+            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            static_assert((hpx::traits::is_forward_iterator<Iter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
+                "Requires at least forward iterator.");
+
+            using is_seq = std::integral_constant<bool,
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>::value ||
+                    !hpx::traits::is_random_access_iterator<Iter1>::value ||
+                    !hpx::traits::is_random_access_iterator<Iter2>::value>;
+
+            using result_type = set_intersection_result<Iter1, Iter2, Iter3>;
+
+            return hpx::parallel::v1::detail::set_intersection<result_type>()
+                .call(std::forward<ExPolicy>(policy), is_seq(), first1, last1,
+                    first2, last2, dest, std::forward<Pred>(op),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng1, typename Rng2, typename Iter3,
+            typename Pred = hpx::parallel::v1::detail::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value &&
+                hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
+                hpx::traits::is_iterator<Iter3>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
+                    hpx::parallel::traits::projected_range<Proj1, Rng1>,
+                    hpx::parallel::traits::projected_range<Proj2, Rng2>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            set_intersection_result<
+                typename hpx::traits::range_iterator<Rng1>::type,
+                typename hpx::traits::range_iterator<Rng2>::type, Iter3>>::type
+        tag_invoke(set_intersection_t, ExPolicy&& policy, Rng1&& rng1,
+            Rng2&& rng2, Iter3 dest, Pred&& op = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_iterator<Rng1>::type;
+            using iterator_type2 =
+                typename hpx::traits::range_iterator<Rng2>::type;
+
+            static_assert(
+                (hpx::traits::is_forward_iterator<iterator_type1>::value),
+                "Requires at least forward iterator.");
+            static_assert(
+                (hpx::traits::is_forward_iterator<iterator_type2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
+                "Requires at least forward iterator.");
+
+            using is_seq = std::integral_constant<bool,
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>::value ||
+                    !hpx::traits::is_random_access_iterator<
+                        iterator_type1>::value ||
+                    !hpx::traits::is_random_access_iterator<
+                        iterator_type2>::value>;
+
+            using result_type =
+                set_intersection_result<iterator_type1, iterator_type2, Iter3>;
+
+            return hpx::parallel::v1::detail::set_intersection<result_type>()
+                .call(std::forward<ExPolicy>(policy), is_seq(),
+                    hpx::util::begin(rng1), hpx::util::end(rng1),
+                    hpx::util::begin(rng2), hpx::util::end(rng2), dest,
+                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename Iter1, typename Sent1, typename Iter2, typename Sent2,
+            typename Iter3, typename Pred = hpx::parallel::v1::detail::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
+                hpx::parallel::traits::is_projected<Proj1, Iter1>::value &&
+                hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
+                hpx::parallel::traits::is_projected<Proj2, Iter2>::value &&
+                hpx::traits::is_iterator<Iter3>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::execution::sequenced_policy, Pred,
+                    hpx::parallel::traits::projected<Proj1, Iter1>,
+                    hpx::parallel::traits::projected<Proj2, Iter2>
+                >::value
+            )>
+        // clang-format on
+        friend set_intersection_result<Iter1, Iter2, Iter3> tag_invoke(
+            set_intersection_t, Iter1 first1, Sent1 last1, Iter2 first2,
+            Sent2 last2, Iter3 dest, Pred&& op = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        {
+            static_assert((hpx::traits::is_forward_iterator<Iter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
+                "Requires at least forward iterator.");
+
+            using result_type = set_intersection_result<Iter1, Iter2, Iter3>;
+
+            return hpx::parallel::v1::detail::set_intersection<result_type>()
+                .call(hpx::execution::seq, std::true_type(), first1, last1,
+                    first2, last2, dest, std::forward<Pred>(op),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename Rng1, typename Rng2, typename Iter3,
+            typename Pred = hpx::parallel::v1::detail::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value &&
+                hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
+                hpx::traits::is_iterator<Iter3>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::execution::sequenced_policy, Pred,
+                    hpx::parallel::traits::projected_range<Proj1, Rng1>,
+                    hpx::parallel::traits::projected_range<Proj2, Rng2>
+                >::value
+            )>
+        // clang-format on
+        friend set_intersection_result<
+            typename hpx::traits::range_iterator<Rng1>::type,
+            typename hpx::traits::range_iterator<Rng2>::type, Iter3>
+        tag_invoke(set_intersection_t, Rng1&& rng1, Rng2&& rng2, Iter3 dest,
+            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_iterator<Rng1>::type;
+            using iterator_type2 =
+                typename hpx::traits::range_iterator<Rng2>::type;
+
+            static_assert(
+                (hpx::traits::is_forward_iterator<iterator_type1>::value),
+                "Requires at least forward iterator.");
+            static_assert(
+                (hpx::traits::is_forward_iterator<iterator_type2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
+                "Requires at least forward iterator.");
+
+            using result_type =
+                set_intersection_result<iterator_type1, iterator_type2, Iter3>;
+
+            return hpx::parallel::v1::detail::set_intersection<result_type>()
+                .call(hpx::execution::seq, std::true_type(),
+                    hpx::util::begin(rng1), hpx::util::end(rng1),
+                    hpx::util::begin(rng2), hpx::util::end(rng2), dest,
+                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2));
+        }
+    } set_intersection{};
+
+}}    // namespace hpx::ranges
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_symmetric_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_symmetric_difference.hpp
@@ -1,0 +1,484 @@
+//  Copyright (c) 2007-2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/container_algorithms/set_symmetric_difference.hpp
+
+#pragma once
+
+#if defined(DOXYGEN)
+namespace hpx { namespace ranges {
+    // clang-format off
+
+    /// Constructs a sorted range beginning at dest consisting of all elements
+    /// present in either of the sorted ranges [first1, last1) and
+    /// [first2, last2), but not in both of them are copied to the range
+    /// beginning at \a dest. The resulting range is also sorted. This
+    /// algorithm expects both input ranges to be sorted with the given binary
+    /// predicate \a f.
+    ///
+    /// \note   Complexity: At most 2*(N1 + N2 - 1) comparisons, where \a N1 is
+    ///         the length of the first sequence and \a N2 is the length of the
+    ///         second sequence.
+    ///
+    /// If some element is found \a m times in [first1, last1) and \a n times
+    /// in [first2, last2), it will be copied to \a dest exactly std::abs(m-n)
+    /// times. If m>n, then the last m-n of those elements are copied from
+    /// [first1,last1), otherwise the last n-m elements are copied from
+    /// [first2,last2). The resulting range cannot overlap with either of the
+    /// input ranges.
+    ///
+    /// The resulting range cannot overlap with either of the input ranges.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it applies user-provided function objects.
+    /// \tparam Iter1       The type of the source iterators used (deduced)
+    ///                     representing the first sequence.
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent1       The type of the end source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     sentinel for Iter1.
+    /// \tparam Iter2       The type of the source iterators used (deduced)
+    ///                     representing the second sequence.
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent2       The type of the end source iterators used (deduced)
+    ///                     representing the second sequence.
+    ///                     This iterator type must meet the requirements of an
+    ///                     sentinel for Iter2.
+    /// \tparam Iter3       The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a set_symmetric_difference requires \a Pred to meet
+    ///                     the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function applied
+    ///                     to the first sequence. This
+    ///                     defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function applied
+    ///                     to the second sequence. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     of the first range the algorithm will be applied to.
+    /// \param last1        Refers to the end of the sequence of elements of
+    ///                     the first range the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the sequence of elements
+    ///                     of the second range the algorithm will be applied to.
+    /// \param last2        Refers to the end of the sequence of elements of
+    ///                     the second range the algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           The binary predicate which returns true if the
+    ///                     elements should be treated as equal. The signature
+    ///                     of the predicate function should be equivalent to
+    ///                     the following:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const &, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type1 must be such
+    ///                     that objects of type \a InIter can
+    ///                     be dereferenced and then implicitly converted to
+    ///                     \a Type1
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     first sequence as a projection operation before the
+    ///                     actual predicate \a op is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     second sequence as a projection operation before the
+    ///                     actual predicate \a op is invoked.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with a sequential execution policy object execute in sequential
+    /// order in the calling thread (\a sequenced_policy) or in a
+    /// single new thread spawned from the current thread
+    /// (for \a sequenced_task_policy).
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified
+    /// threads, and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a set_symmetric_difference algorithm returns a
+    ///           \a hpx::future<ranges::set_symmetric_difference_result<Iter1, Iter2, Iter3>>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a ranges::set_symmetric_difference_result<Iter1, Iter2, Iter3> otherwise.
+    ///           The \a set_symmetric_difference algorithm returns the output iterator to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename ExPolicy, typename Iter1, typename Sent1, typename Iter2,
+        typename Sent2, typename Iter3, typename Pred = detail::less,
+        typename Proj1 = util::projection_identity,
+        typename Proj2 = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy,
+        ranges::set_symmetric_difference_result<Iter1, Iter2, Iter3>>::type
+    set_symmetric_difference(ExPolicy&& policy, Iter1 first1, Sent1 last1,
+        Iter2 first2, Sent2 last2, Iter3 dest, Pred&& op = Pred(),
+        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+
+    /// Constructs a sorted range beginning at dest consisting of all elements
+    /// present in either of the sorted ranges [first1, last1) and
+    /// [first2, last2), but not in both of them are copied to the range
+    /// beginning at \a dest. The resulting range is also sorted. This
+    /// algorithm expects both input ranges to be sorted with the given binary
+    /// predicate \a f.
+    ///
+    /// \note   Complexity: At most 2*(N1 + N2 - 1) comparisons, where \a N1 is
+    ///         the length of the first sequence and \a N2 is the length of the
+    ///         second sequence.
+    ///
+    /// If some element is found \a m times in [first1, last1) and \a n times
+    /// in [first2, last2), it will be copied to \a dest exactly std::abs(m-n)
+    /// times. If m>n, then the last m-n of those elements are copied from
+    /// [first1,last1), otherwise the last n-m elements are copied from
+    /// [first2,last2). The resulting range cannot overlap with either of the
+    /// input ranges.
+    ///
+    /// The resulting range cannot overlap with either of the input ranges.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it applies user-provided function objects.
+    /// \tparam Rng1        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Rng2        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Iter3       The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a set_symmetric_difference requires \a Pred to meet
+    ///                     the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function applied
+    ///                     to the first sequence. This
+    ///                     defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function applied
+    ///                     to the second sequence. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng1         Refers to the first sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param rng2         Refers to the second sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           The binary predicate which returns true if the
+    ///                     elements should be treated as equal. The signature
+    ///                     of the predicate function should be equivalent to
+    ///                     the following:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const &, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type1 must be such
+    ///                     that objects of type \a InIter can
+    ///                     be dereferenced and then implicitly converted to
+    ///                     \a Type1
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     first sequence as a projection operation before the
+    ///                     actual predicate \a op is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     second sequence as a projection operation before the
+    ///                     actual predicate \a op is invoked.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with a sequential execution policy object execute in sequential
+    /// order in the calling thread (\a sequenced_policy) or in a
+    /// single new thread spawned from the current thread
+    /// (for \a sequenced_task_policy).
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified
+    /// threads, and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a set_symmetric_difference algorithm returns a
+    ///           \a hpx::future<ranges::set_symmetric_difference_result<Iter1, Iter2, Iter3>>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a ranges::set_symmetric_difference_result<Iter1, Iter2, Iter3> otherwise.
+    ///           where Iter1 is range_iterator_t<Rng1> and Iter2 is range_iterator_t<Rng2>
+    ///           The \a set_symmetric_difference algorithm returns the output iterator to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename ExPolicy, typename Rng1, typename Rng2, typename Iter3,
+        typename Pred = detail::less,
+        typename Proj1 = util::projection_identity,
+        typename Proj2 = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy,
+        ranges::set_symmetric_difference_result<
+            typename traits::range_iterator<Rng1>::type,
+            typename traits::range_iterator<Rng2>::type, Iter3>>::type
+    set_symmetric_difference(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2,
+        Iter3 dest, Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+        Proj2&& proj2 = Proj2());
+
+    // clang-format on
+}}    // namespace hpx::ranges
+
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/iterator_support/traits/is_sentinel_for.hpp>
+
+#include <hpx/algorithms/traits/projected.hpp>
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/algorithms/set_symmetric_difference.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace ranges {
+
+    template <typename I1, typename I2, typename O>
+    using set_symmetric_difference_result =
+        parallel::util::in_in_out_result<I1, I2, O>;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::set_symmetric_difference
+    HPX_INLINE_CONSTEXPR_VARIABLE struct set_symmetric_difference_t final
+      : hpx::functional::tag<set_symmetric_difference_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename Iter1, typename Sent1,
+            typename Iter2, typename Sent2, typename Iter3,
+            typename Pred = hpx::parallel::v1::detail::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
+                hpx::parallel::traits::is_projected<Proj1, Iter1>::value &&
+                hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
+                hpx::parallel::traits::is_projected<Proj2, Iter2>::value &&
+                hpx::traits::is_iterator<Iter3>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
+                    hpx::parallel::traits::projected<Proj1, Iter1>,
+                    hpx::parallel::traits::projected<Proj2, Iter2>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            set_symmetric_difference_result<Iter1, Iter2, Iter3>>::type
+        tag_invoke(set_symmetric_difference_t, ExPolicy&& policy, Iter1 first1,
+            Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
+            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            static_assert((hpx::traits::is_forward_iterator<Iter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
+                "Requires at least forward iterator.");
+
+            using is_seq = std::integral_constant<bool,
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>::value ||
+                    !hpx::traits::is_random_access_iterator<Iter1>::value ||
+                    !hpx::traits::is_random_access_iterator<Iter2>::value>;
+
+            using result_type =
+                set_symmetric_difference_result<Iter1, Iter2, Iter3>;
+
+            return hpx::parallel::v1::detail::set_symmetric_difference<
+                result_type>()
+                .call(std::forward<ExPolicy>(policy), is_seq(), first1, last1,
+                    first2, last2, dest, std::forward<Pred>(op),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng1, typename Rng2, typename Iter3,
+            typename Pred = hpx::parallel::v1::detail::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value &&
+                hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
+                hpx::traits::is_iterator<Iter3>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
+                    hpx::parallel::traits::projected_range<Proj1, Rng1>,
+                    hpx::parallel::traits::projected_range<Proj2, Rng2>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            set_symmetric_difference_result<
+                typename hpx::traits::range_iterator<Rng1>::type,
+                typename hpx::traits::range_iterator<Rng2>::type, Iter3>>::type
+        tag_invoke(set_symmetric_difference_t, ExPolicy&& policy, Rng1&& rng1,
+            Rng2&& rng2, Iter3 dest, Pred&& op = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_iterator<Rng1>::type;
+            using iterator_type2 =
+                typename hpx::traits::range_iterator<Rng2>::type;
+
+            static_assert(
+                (hpx::traits::is_forward_iterator<iterator_type1>::value),
+                "Requires at least forward iterator.");
+            static_assert(
+                (hpx::traits::is_forward_iterator<iterator_type2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
+                "Requires at least forward iterator.");
+
+            using is_seq = std::integral_constant<bool,
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>::value ||
+                    !hpx::traits::is_random_access_iterator<
+                        iterator_type1>::value ||
+                    !hpx::traits::is_random_access_iterator<
+                        iterator_type2>::value>;
+
+            using result_type = set_symmetric_difference_result<iterator_type1,
+                iterator_type2, Iter3>;
+
+            return hpx::parallel::v1::detail::set_symmetric_difference<
+                result_type>()
+                .call(std::forward<ExPolicy>(policy), is_seq(),
+                    hpx::util::begin(rng1), hpx::util::end(rng1),
+                    hpx::util::begin(rng2), hpx::util::end(rng2), dest,
+                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename Iter1, typename Sent1, typename Iter2, typename Sent2,
+            typename Iter3, typename Pred = hpx::parallel::v1::detail::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
+                hpx::parallel::traits::is_projected<Proj1, Iter1>::value &&
+                hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
+                hpx::parallel::traits::is_projected<Proj2, Iter2>::value &&
+                hpx::traits::is_iterator<Iter3>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::execution::sequenced_policy, Pred,
+                    hpx::parallel::traits::projected<Proj1, Iter1>,
+                    hpx::parallel::traits::projected<Proj2, Iter2>
+                >::value
+            )>
+        // clang-format on
+        friend set_symmetric_difference_result<Iter1, Iter2, Iter3> tag_invoke(
+            set_symmetric_difference_t, Iter1 first1, Sent1 last1, Iter2 first2,
+            Sent2 last2, Iter3 dest, Pred&& op = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        {
+            static_assert((hpx::traits::is_forward_iterator<Iter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
+                "Requires at least forward iterator.");
+
+            using result_type =
+                set_symmetric_difference_result<Iter1, Iter2, Iter3>;
+
+            return hpx::parallel::v1::detail::set_symmetric_difference<
+                result_type>()
+                .call(hpx::execution::seq, std::true_type(), first1, last1,
+                    first2, last2, dest, std::forward<Pred>(op),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename Rng1, typename Rng2, typename Iter3,
+            typename Pred = hpx::parallel::v1::detail::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value &&
+                hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
+                hpx::traits::is_iterator<Iter3>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::execution::sequenced_policy, Pred,
+                    hpx::parallel::traits::projected_range<Proj1, Rng1>,
+                    hpx::parallel::traits::projected_range<Proj2, Rng2>
+                >::value
+            )>
+        // clang-format on
+        friend set_symmetric_difference_result<
+            typename hpx::traits::range_iterator<Rng1>::type,
+            typename hpx::traits::range_iterator<Rng2>::type, Iter3>
+        tag_invoke(set_symmetric_difference_t, Rng1&& rng1, Rng2&& rng2,
+            Iter3 dest, Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_iterator<Rng1>::type;
+            using iterator_type2 =
+                typename hpx::traits::range_iterator<Rng2>::type;
+
+            static_assert(
+                (hpx::traits::is_forward_iterator<iterator_type1>::value),
+                "Requires at least forward iterator.");
+            static_assert(
+                (hpx::traits::is_forward_iterator<iterator_type2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
+                "Requires at least forward iterator.");
+
+            using result_type = set_symmetric_difference_result<iterator_type1,
+                iterator_type2, Iter3>;
+
+            return hpx::parallel::v1::detail::set_symmetric_difference<
+                result_type>()
+                .call(hpx::execution::seq, std::true_type(),
+                    hpx::util::begin(rng1), hpx::util::end(rng1),
+                    hpx::util::begin(rng2), hpx::util::end(rng2), dest,
+                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2));
+        }
+    } set_symmetric_difference{};
+
+}}    // namespace hpx::ranges
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_symmetric_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_symmetric_difference.hpp
@@ -285,7 +285,7 @@ namespace hpx { namespace ranges {
             typename Proj1 = hpx::parallel::util::projection_identity,
             typename Proj2 = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
                 hpx::parallel::traits::is_projected<Proj1, Iter1>::value &&
                 hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
@@ -333,7 +333,7 @@ namespace hpx { namespace ranges {
             typename Proj1 = hpx::parallel::util::projection_identity,
             typename Proj2 = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng1>::value &&
                 hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
                 hpx::traits::is_range<Rng2>::value &&

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_union.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_union.hpp
@@ -277,7 +277,7 @@ namespace hpx { namespace ranges {
             typename Proj1 = hpx::parallel::util::projection_identity,
             typename Proj2 = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
                 hpx::parallel::traits::is_projected<Proj1, Iter1>::value &&
                 hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
@@ -322,7 +322,7 @@ namespace hpx { namespace ranges {
             typename Proj1 = hpx::parallel::util::projection_identity,
             typename Proj2 = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng1>::value &&
                 hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
                 hpx::traits::is_range<Rng2>::value &&

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_union.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_union.hpp
@@ -1,0 +1,467 @@
+//  Copyright (c) 2007-2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/container_algorithms/set_union.hpp
+
+#pragma once
+
+#if defined(DOXYGEN)
+namespace hpx { namespace ranges {
+    // clang-format off
+
+    /// Constructs a sorted range beginning at dest consisting of all elements
+    /// present in one or both sorted ranges [first1, last1) and
+    /// [first2, last2). This algorithm expects both input ranges to be sorted
+    /// with the given binary predicate \a f.
+    ///
+    /// \note   Complexity: At most 2*(N1 + N2 - 1) comparisons, where \a N1 is
+    ///         the length of the first sequence and \a N2 is the length of the
+    ///         second sequence.
+    ///
+    /// If some element is found \a m times in [first1, last1) and \a n times
+    /// in [first2, last2), then all \a m elements will be copied from
+    /// [first1, last1) to dest, preserving order, and then exactly
+    /// std::max(n-m, 0) elements will be copied from [first2, last2) to dest,
+    /// also preserving order.
+    ///
+    /// The resulting range cannot overlap with either of the input ranges.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it applies user-provided function objects.
+    /// \tparam Iter1       The type of the source iterators used (deduced)
+    ///                     representing the first sequence.
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent1       The type of the end source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     sentinel for Iter1.
+    /// \tparam Iter2       The type of the source iterators used (deduced)
+    ///                     representing the second sequence.
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent2       The type of the end source iterators used (deduced)
+    ///                     representing the second sequence.
+    ///                     This iterator type must meet the requirements of an
+    ///                     sentinel for Iter2.
+    /// \tparam Iter3       The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a set_union requires \a Pred to meet
+    ///                     the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function applied
+    ///                     to the first sequence. This
+    ///                     defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function applied
+    ///                     to the second sequence. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     of the first range the algorithm will be applied to.
+    /// \param last1        Refers to the end of the sequence of elements of
+    ///                     the first range the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the sequence of elements
+    ///                     of the second range the algorithm will be applied to.
+    /// \param last2        Refers to the end of the sequence of elements of
+    ///                     the second range the algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           The binary predicate which returns true if the
+    ///                     elements should be treated as equal. The signature
+    ///                     of the predicate function should be equivalent to
+    ///                     the following:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const &, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type1 must be such
+    ///                     that objects of type \a InIter can
+    ///                     be dereferenced and then implicitly converted to
+    ///                     \a Type1
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     first sequence as a projection operation before the
+    ///                     actual predicate \a op is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     second sequence as a projection operation before the
+    ///                     actual predicate \a op is invoked.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with a sequential execution policy object execute in sequential
+    /// order in the calling thread (\a sequenced_policy) or in a
+    /// single new thread spawned from the current thread
+    /// (for \a sequenced_task_policy).
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified
+    /// threads, and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a set_union algorithm returns a
+    ///           \a hpx::future<ranges::set_union_result<Iter1, Iter2, Iter3>>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a ranges::set_union_result<Iter1, Iter2, Iter3> otherwise.
+    ///           The \a set_union algorithm returns the output iterator to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename ExPolicy, typename Iter1, typename Sent1, typename Iter2,
+        typename Sent2, typename Iter3, typename Pred = detail::less,
+        typename Proj1 = util::projection_identity,
+        typename Proj2 = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy,
+        ranges::set_union_result<Iter1, Iter2, Iter3>>::type
+    set_union(ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
+        Sent2 last2, Iter3 dest, Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+        Proj2&& proj2 = Proj2());
+
+    /// Constructs a sorted range beginning at dest consisting of all elements
+    /// present in one or both sorted ranges [first1, last1) and
+    /// [first2, last2). This algorithm expects both input ranges to be sorted
+    /// with the given binary predicate \a f.
+    ///
+    /// \note   Complexity: At most 2*(N1 + N2 - 1) comparisons, where \a N1 is
+    ///         the length of the first sequence and \a N2 is the length of the
+    ///         second sequence.
+    ///
+    /// If some element is found \a m times in [first1, last1) and \a n times
+    /// in [first2, last2), then all \a m elements will be copied from
+    /// [first1, last1) to dest, preserving order, and then exactly
+    /// std::max(n-m, 0) elements will be copied from [first2, last2) to dest,
+    /// also preserving order.
+    ///
+    /// The resulting range cannot overlap with either of the input ranges.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it applies user-provided function objects.
+    /// \tparam Rng1        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Rng2        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Iter3       The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a set_union requires \a Pred to meet
+    ///                     the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function applied
+    ///                     to the first sequence. This
+    ///                     defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function applied
+    ///                     to the second sequence. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng1         Refers to the first sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param rng2         Refers to the second sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param op           The binary predicate which returns true if the
+    ///                     elements should be treated as equal. The signature
+    ///                     of the predicate function should be equivalent to
+    ///                     the following:
+    ///                     \code
+    ///                     bool pred(const Type1 &a, const Type1 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const &, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type1 must be such
+    ///                     that objects of type \a InIter can
+    ///                     be dereferenced and then implicitly converted to
+    ///                     \a Type1
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     first sequence as a projection operation before the
+    ///                     actual predicate \a op is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the
+    ///                     second sequence as a projection operation before the
+    ///                     actual predicate \a op is invoked.
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with a sequential execution policy object execute in sequential
+    /// order in the calling thread (\a sequenced_policy) or in a
+    /// single new thread spawned from the current thread
+    /// (for \a sequenced_task_policy).
+    ///
+    /// The application of function objects in parallel algorithm
+    /// invoked with an execution policy object of type
+    /// \a parallel_policy or \a parallel_task_policy are
+    /// permitted to execute in an unordered fashion in unspecified
+    /// threads, and indeterminately sequenced within each thread.
+    ///
+    /// \returns  The \a set_union algorithm returns a
+    ///           \a hpx::future<ranges::set_union_result<Iter1, Iter2, Iter3>>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a ranges::set_union_result<Iter1, Iter2, Iter3> otherwise.
+    ///           where Iter1 is range_iterator_t<Rng1> and Iter2 is range_iterator_t<Rng2>
+    ///           The \a set_union algorithm returns the output iterator to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename ExPolicy, typename Rng1, typename Rng2, typename Iter3,
+        typename Pred = detail::less,
+        typename Proj1 = util::projection_identity,
+        typename Proj2 = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy,
+        ranges::set_union_result<
+            typename traits::range_iterator<Rng1>::type,
+            typename traits::range_iterator<Rng2>::type, Iter3>>::type
+    set_union(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2, Iter3 dest,
+        Pred&& op = Pred(), Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+
+    // clang-format on
+}}    // namespace hpx::ranges
+
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/iterator_support/traits/is_sentinel_for.hpp>
+
+#include <hpx/algorithms/traits/projected.hpp>
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/algorithms/set_union.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace ranges {
+
+    template <typename I1, typename I2, typename O>
+    using set_union_result = parallel::util::in_in_out_result<I1, I2, O>;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::set_union
+    HPX_INLINE_CONSTEXPR_VARIABLE struct set_union_t final
+      : hpx::functional::tag<set_union_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename Iter1, typename Sent1,
+            typename Iter2, typename Sent2, typename Iter3,
+            typename Pred = hpx::parallel::v1::detail::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
+                hpx::parallel::traits::is_projected<Proj1, Iter1>::value &&
+                hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
+                hpx::parallel::traits::is_projected<Proj2, Iter2>::value &&
+                hpx::traits::is_iterator<Iter3>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
+                    hpx::parallel::traits::projected<Proj1, Iter1>,
+                    hpx::parallel::traits::projected<Proj2, Iter2>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            set_union_result<Iter1, Iter2, Iter3>>::type
+        tag_invoke(set_union_t, ExPolicy&& policy, Iter1 first1, Sent1 last1,
+            Iter2 first2, Sent2 last2, Iter3 dest, Pred&& op = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        {
+            static_assert((hpx::traits::is_forward_iterator<Iter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
+                "Requires at least forward iterator.");
+
+            using is_seq = std::integral_constant<bool,
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>::value ||
+                    !hpx::traits::is_random_access_iterator<Iter1>::value ||
+                    !hpx::traits::is_random_access_iterator<Iter2>::value>;
+
+            using result_type = set_union_result<Iter1, Iter2, Iter3>;
+
+            return hpx::parallel::v1::detail::set_union<result_type>().call(
+                std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
+                last2, dest, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng1, typename Rng2, typename Iter3,
+            typename Pred = hpx::parallel::v1::detail::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value &&
+                hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
+                hpx::traits::is_iterator<Iter3>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy, Pred,
+                    hpx::parallel::traits::projected_range<Proj1, Rng1>,
+                    hpx::parallel::traits::projected_range<Proj2, Rng2>
+                >::value
+            )>
+        // clang-format on
+        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            set_union_result<typename hpx::traits::range_iterator<Rng1>::type,
+                typename hpx::traits::range_iterator<Rng2>::type, Iter3>>::type
+        tag_invoke(set_union_t, ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2,
+            Iter3 dest, Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_iterator<Rng1>::type;
+            using iterator_type2 =
+                typename hpx::traits::range_iterator<Rng2>::type;
+
+            static_assert(
+                (hpx::traits::is_forward_iterator<iterator_type1>::value),
+                "Requires at least forward iterator.");
+            static_assert(
+                (hpx::traits::is_forward_iterator<iterator_type2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
+                "Requires at least forward iterator.");
+
+            using is_seq = std::integral_constant<bool,
+                hpx::parallel::execution::is_sequenced_execution_policy<
+                    ExPolicy>::value ||
+                    !hpx::traits::is_random_access_iterator<
+                        iterator_type1>::value ||
+                    !hpx::traits::is_random_access_iterator<
+                        iterator_type2>::value>;
+
+            using result_type =
+                set_union_result<iterator_type1, iterator_type2, Iter3>;
+
+            return hpx::parallel::v1::detail::set_union<result_type>().call(
+                std::forward<ExPolicy>(policy), is_seq(),
+                hpx::util::begin(rng1), hpx::util::end(rng1),
+                hpx::util::begin(rng2), hpx::util::end(rng2), dest,
+                std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename Iter1, typename Sent1, typename Iter2, typename Sent2,
+            typename Iter3, typename Pred = hpx::parallel::v1::detail::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_sentinel_for<Sent1, Iter1>::value &&
+                hpx::parallel::traits::is_projected<Proj1, Iter1>::value &&
+                hpx::traits::is_sentinel_for<Sent2, Iter2>::value &&
+                hpx::parallel::traits::is_projected<Proj2, Iter2>::value &&
+                hpx::traits::is_iterator<Iter3>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::execution::sequenced_policy, Pred,
+                    hpx::parallel::traits::projected<Proj1, Iter1>,
+                    hpx::parallel::traits::projected<Proj2, Iter2>
+                >::value
+            )>
+        // clang-format on
+        friend set_union_result<Iter1, Iter2, Iter3> tag_invoke(set_union_t,
+            Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
+            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            static_assert((hpx::traits::is_forward_iterator<Iter1>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
+                "Requires at least forward iterator.");
+
+            using result_type = set_union_result<Iter1, Iter2, Iter3>;
+
+            return hpx::parallel::v1::detail::set_union<result_type>().call(
+                hpx::execution::seq, std::true_type(), first1, last1, first2,
+                last2, dest, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename Rng1, typename Rng2, typename Iter3,
+            typename Pred = hpx::parallel::v1::detail::less,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value &&
+                hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
+                hpx::traits::is_iterator<Iter3>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::execution::sequenced_policy, Pred,
+                    hpx::parallel::traits::projected_range<Proj1, Rng1>,
+                    hpx::parallel::traits::projected_range<Proj2, Rng2>
+                >::value
+            )>
+        // clang-format on
+        friend set_union_result<
+            typename hpx::traits::range_iterator<Rng1>::type,
+            typename hpx::traits::range_iterator<Rng2>::type, Iter3>
+        tag_invoke(set_union_t, Rng1&& rng1, Rng2&& rng2, Iter3 dest,
+            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_iterator<Rng1>::type;
+            using iterator_type2 =
+                typename hpx::traits::range_iterator<Rng2>::type;
+
+            static_assert(
+                (hpx::traits::is_forward_iterator<iterator_type1>::value),
+                "Requires at least forward iterator.");
+            static_assert(
+                (hpx::traits::is_forward_iterator<iterator_type2>::value),
+                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
+                "Requires at least forward iterator.");
+
+            using result_type =
+                set_union_result<iterator_type1, iterator_type2, Iter3>;
+
+            return hpx::parallel::v1::detail::set_union<result_type>().call(
+                hpx::execution::seq, std::true_type(), hpx::util::begin(rng1),
+                hpx::util::end(rng1), hpx::util::begin(rng2),
+                hpx::util::end(rng2), dest, std::forward<Pred>(op),
+                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+        }
+    } set_union{};
+
+}}    // namespace hpx::ranges
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/compare_projected.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/compare_projected.hpp
@@ -25,7 +25,7 @@ namespace hpx { namespace parallel { namespace util {
     struct compare_projected<Compare, Proj>
     {
         template <typename Compare_, typename Proj_>
-        compare_projected(Compare_&& comp, Proj_&& proj)
+        constexpr compare_projected(Compare_&& comp, Proj_&& proj)
           : comp_(std::forward<Compare_>(comp))
           , proj_(std::forward<Proj_>(proj))
         {
@@ -47,7 +47,7 @@ namespace hpx { namespace parallel { namespace util {
     struct compare_projected<Compare, util::projection_identity>
     {
         template <typename Compare_>
-        compare_projected(Compare_&& comp, util::projection_identity)
+        constexpr compare_projected(Compare_&& comp, util::projection_identity)
           : comp_(std::forward<Compare_>(comp))
         {
         }
@@ -67,7 +67,8 @@ namespace hpx { namespace parallel { namespace util {
     struct compare_projected<Compare, Proj1, Proj2>
     {
         template <typename Compare_, typename Proj1_, typename Proj2_>
-        compare_projected(Compare_&& comp, Proj1_&& proj1, Proj2_&& proj2)
+        constexpr compare_projected(
+            Compare_&& comp, Proj1_&& proj1, Proj2_&& proj2)
           : comp_(std::forward<Compare_>(comp))
           , proj1_(std::forward<Proj1_>(proj1))
           , proj2_(std::forward<Proj2_>(proj2))
@@ -91,7 +92,7 @@ namespace hpx { namespace parallel { namespace util {
     struct compare_projected<Compare, util::projection_identity, Proj2>
     {
         template <typename Compare_, typename Proj2_>
-        compare_projected(
+        constexpr compare_projected(
             Compare_&& comp, util::projection_identity, Proj2_&& proj2)
           : comp_(std::forward<Compare_>(comp))
           , proj2_(std::forward<Proj2_>(proj2))
@@ -113,7 +114,7 @@ namespace hpx { namespace parallel { namespace util {
     struct compare_projected<Compare, Proj1, util::projection_identity>
     {
         template <typename Compare_, typename Proj1_>
-        compare_projected(
+        constexpr compare_projected(
             Compare_&& comp, Proj1_&& proj1, util::projection_identity)
           : comp_(std::forward<Compare_>(comp))
           , proj1_(std::forward<Proj1_>(proj1))
@@ -137,7 +138,7 @@ namespace hpx { namespace parallel { namespace util {
         util::projection_identity>
     {
         template <typename Compare_>
-        compare_projected(Compare_&& comp, util::projection_identity,
+        constexpr compare_projected(Compare_&& comp, util::projection_identity,
             util::projection_identity)
           : comp_(std::forward<Compare_>(comp))
         {

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
@@ -267,9 +267,9 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     hpx::future<typename hpx::util::invoke_result<Conv, U>::type>
     convert_to_result(hpx::future<U>&& f, Conv&& conv)
     {
-        typedef typename hpx::util::invoke_result<Conv, U>::type result_type;
+        using result_type = typename hpx::util::invoke_result<Conv, U>::type;
 
-        return lcos::make_future<result_type>(
+        return hpx::make_future<result_type>(
             std::move(f), std::forward<Conv>(conv));
     }
 }}}}    // namespace hpx::parallel::util::detail

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/projection_identity.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/projection_identity.hpp
@@ -18,8 +18,8 @@ namespace hpx { namespace parallel { namespace util {
         using is_transparent = std::true_type;
 
         template <typename T>
-        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr T&& operator()(
-            T&& val) const noexcept
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr T&& operator()(T&& val) const
+            noexcept
         {
             return std::forward<T>(val);
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/projection_identity.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/projection_identity.hpp
@@ -8,16 +8,26 @@
 
 #include <hpx/config.hpp>
 
+#include <type_traits>
 #include <utility>
 
 namespace hpx { namespace parallel { namespace util {
     ///////////////////////////////////////////////////////////////////////////
     struct projection_identity
     {
+        using is_transparent = std::true_type;
+
         template <typename T>
-        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr T&& operator()(T&& val) const
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr T&& operator()(
+            T&& val) const noexcept
         {
             return std::forward<T>(val);
         }
     };
 }}}    // namespace hpx::parallel::util
+
+namespace hpx {
+
+    // C++20 introduces std::identity
+    using identity = hpx::parallel::util::projection_identity;
+}    // namespace hpx

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -96,7 +96,7 @@ namespace hpx { namespace parallel { namespace util {
     hpx::future<O> get_second_element(
         hpx::future<util::in_out_result<I, O>>&& f)
     {
-        return lcos::make_future<O>(
+        return hpx::make_future<O>(
             std::move(f), [](util::in_out_result<I, O>&& p) { return p.out; });
     }
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -85,6 +85,21 @@ namespace hpx { namespace parallel { namespace util {
         }
     };
 
+    ///////////////////////////////////////////////////////////////////////
+    template <typename I, typename O>
+    O get_second_element(util::in_out_result<I, O>&& p)
+    {
+        return p.out;
+    }
+
+    template <typename I, typename O>
+    hpx::future<O> get_second_element(
+        hpx::future<util::in_out_result<I, O>>&& f)
+    {
+        return lcos::make_future<O>(
+            std::move(f), [](util::in_out_result<I, O>&& p) { return p.out; });
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename I1, typename I2, typename O>
     struct in_in_out_result

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -86,6 +86,58 @@ namespace hpx { namespace parallel { namespace util {
     };
 
     ///////////////////////////////////////////////////////////////////////////
+    template <typename I1, typename I2, typename O>
+    struct in_in_out_result
+    {
+        HPX_NO_UNIQUE_ADDRESS I1 in1;
+        HPX_NO_UNIQUE_ADDRESS I2 in2;
+        HPX_NO_UNIQUE_ADDRESS O out;
+
+        template <typename II1, typename II2, typename O1,
+            typename Enable = typename std::enable_if<
+                std::is_convertible<I1 const&, II1&>::value &&
+                std::is_convertible<I2 const&, II2&>::value &&
+                std::is_convertible<O const&, O1&>::value>::type>
+        constexpr operator in_in_out_result<II1, II2, O1>() const&
+        {
+            return {in1, in2, out};
+        }
+
+        template <typename II2, typename II1, typename O1,
+            typename Enable =
+                typename std::enable_if<std::is_convertible<I1, II1>::value &&
+                    std::is_convertible<I2, II2>::value &&
+                    std::is_convertible<O, O1>::value>::type>
+        constexpr operator in_in_out_result<II1, II2, O1>() &&
+        {
+            return {std::move(in1), std::move(in2), std::move(out)};
+        }
+
+        template <typename Archive>
+        void serialize(Archive& ar, unsigned)
+        {
+            // clang-format off
+            ar & in1 & in2 & out;
+            // clang-format on
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////
+    template <typename I1, typename I2, typename O>
+    O get_third_element(util::in_in_out_result<I1, I2, O>&& p)
+    {
+        return p.out;
+    }
+
+    template <typename I1, typename I2, typename O>
+    hpx::future<O> get_third_element(
+        hpx::future<util::in_in_out_result<I1, I2, O>>&& f)
+    {
+        return lcos::make_future<O>(std::move(f),
+            [](in_in_out_result<I1, I2, O>&& p) { return p.out; });
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     template <typename I, typename F>
     struct in_fun_result
     {
@@ -162,5 +214,7 @@ namespace hpx { namespace parallel { namespace util {
 
 namespace hpx { namespace ranges {
     using hpx::parallel::util::in_fun_result;
+    using hpx::parallel::util::in_in_out_result;
+    using hpx::parallel::util::in_in_result;
     using hpx::parallel::util::in_out_result;
 }}    // namespace hpx::ranges

--- a/libs/parallelism/algorithms/tests/performance/benchmark_inplace_merge.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_inplace_merge.cpp
@@ -84,7 +84,7 @@ double run_inplace_merge_benchmark_hpx(int test_count, ExPolicy policy,
         hpx::copy(hpx::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::util::high_resolution_clock::now();
-        hpx::parallel::inplace_merge(policy, first, middle, last);
+        hpx::inplace_merge(policy, first, middle, last);
         time += hpx::util::high_resolution_clock::now() - elapsed;
     }
 

--- a/libs/parallelism/algorithms/tests/performance/benchmark_merge.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_merge.cpp
@@ -75,7 +75,7 @@ double run_merge_benchmark_hpx(int test_count, ExPolicy policy, FwdIter1 first1,
 
     for (int i = 0; i < test_count; ++i)
     {
-        hpx::parallel::merge(policy, first1, last1, first2, last2, dest);
+        hpx::merge(policy, first1, last1, first2, last2, dest);
     }
 
     time = hpx::util::high_resolution_clock::now() - time;

--- a/libs/parallelism/algorithms/tests/regressions/set_operations_3442.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/set_operations_3442.cpp
@@ -91,8 +91,8 @@ void set_intersection_small_test(int rounds)
 
     while (--rounds)
     {
-        hpx::parallel::set_intersection(hpx::execution::par, set_a.begin(),
-            set_a.end(), set_b.begin(), set_b.end(), a_and_b.begin());
+        hpx::set_intersection(hpx::execution::par, set_a.begin(), set_a.end(),
+            set_b.begin(), set_b.end(), a_and_b.begin());
         HPX_TEST(perfect == a_and_b);
     }
 }
@@ -113,8 +113,8 @@ void set_intersection_medium_test(int rounds)
 
     while (--rounds)
     {
-        hpx::parallel::set_intersection(hpx::execution::par, set_a.begin(),
-            set_a.end(), set_b.begin(), set_b.end(), a_and_b.begin());
+        hpx::set_intersection(hpx::execution::par, set_a.begin(), set_a.end(),
+            set_b.begin(), set_b.end(), a_and_b.begin());
         HPX_TEST(perfect == a_and_b);
     }
 }
@@ -136,8 +136,8 @@ void set_intersection_large_test(int rounds)
 
     while (--rounds)
     {
-        hpx::parallel::set_intersection(hpx::execution::par, set_a.begin(),
-            set_a.end(), set_b.begin(), set_b.end(), a_and_b.begin());
+        hpx::set_intersection(hpx::execution::par, set_a.begin(), set_a.end(),
+            set_b.begin(), set_b.end(), a_and_b.begin());
         HPX_TEST(perfect == a_and_b);
     }
 }

--- a/libs/parallelism/algorithms/tests/regressions/stable_merge_2964.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/stable_merge_2964.cpp
@@ -70,7 +70,7 @@ void test_merge_stable(ExPolicy policy, DataType, int rand_base)
     std::sort(std::begin(src1), std::end(src1));
     std::sort(std::begin(src2), std::end(src2));
 
-    hpx::parallel::merge(
+    hpx::ranges::merge(
         policy, std::begin(src1), std::end(src1), std::begin(src2),
         std::end(src2), std::begin(dest),
         [](DataType const& a, DataType const& b) -> bool { return a < b; },
@@ -127,7 +127,7 @@ int hpx_main(int argc, char** argv)
 
     // I expect a stable merge to order {3, 'a'} and {3, 'b'} before {3, 'c'}
     // because they come from the first sequence
-    hpx::parallel::merge(hpx::execution::par, a1.begin(), a1.end(), a2.begin(),
+    hpx::ranges::merge(hpx::execution::par, a1.begin(), a1.end(), a2.begin(),
         a2.end(), result.begin(), [](ElemType const& a, ElemType const& b) {
             return std::get<0>(a) < std::get<0>(b);
         });
@@ -139,7 +139,7 @@ int hpx_main(int argc, char** argv)
     HPX_TEST(result == solution);
 
     // Expect {3, 'c'}, {3, 'a'}, {3, 'b'} in order.
-    hpx::parallel::merge(hpx::execution::par, a2.begin(), a2.end(), a1.begin(),
+    hpx::ranges::merge(hpx::execution::par, a2.begin(), a2.end(), a1.begin(),
         a1.end(), result.begin(), [](ElemType const& a, ElemType const& b) {
             return std::get<0>(a) < std::get<0>(b);
         });
@@ -150,7 +150,7 @@ int hpx_main(int argc, char** argv)
 
     HPX_TEST(result == solution);
 
-    // Do moduler operation for avoiding overflow in ramdom_fill. (#2954)
+    // Do modulus operation for avoiding overflow in ramdom_fill. (#2954)
     std::uniform_int_distribution<> dis(0, 9999);
     int rand_base = dis(_rand);
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/includes.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/includes.cpp
@@ -56,6 +56,11 @@ void test_includes1(IteratorTag)
     }
 
     {
+        // make sure std::less is not violated by incrementing one of the
+        // elements
+        std::transform(std::begin(c1), std::end(c1), std::begin(c1),
+            [](std::size_t val) { return 2 * val; });
+
         std::vector<std::size_t> c2;
         std::copy(start_it, end_it, std::back_inserter(c2));
 
@@ -111,6 +116,11 @@ void test_includes1(ExPolicy&& policy, IteratorTag)
     }
 
     {
+        // make sure std::less is not violated by incrementing one of the
+        // elements
+        std::transform(std::begin(c1), std::end(c1), std::begin(c1),
+            [](std::size_t val) { return 2 * val; });
+
         std::vector<std::size_t> c2;
         std::copy(start_it, end_it, std::back_inserter(c2));
 
@@ -163,6 +173,11 @@ void test_includes1_async(ExPolicy&& p, IteratorTag)
     }
 
     {
+        // make sure std::less is not violated by incrementing one of the
+        // elements
+        std::transform(std::begin(c1), std::end(c1), std::begin(c1),
+            [](std::size_t val) { return 2 * val; });
+
         std::vector<std::size_t> c2;
         std::copy(start_it, end_it, std::back_inserter(c2));
 
@@ -239,6 +254,11 @@ void test_includes2(IteratorTag)
     }
 
     {
+        // make sure std::less is not violated by incrementing one of the
+        // elements
+        std::transform(std::begin(c1), std::end(c1), std::begin(c1),
+            [](std::size_t val) { return 2 * val; });
+
         std::vector<std::size_t> c2;
         std::copy(start_it, end_it, std::back_inserter(c2));
 
@@ -295,6 +315,11 @@ void test_includes2(ExPolicy&& policy, IteratorTag)
     }
 
     {
+        // make sure std::less is not violated by incrementing one of the
+        // elements
+        std::transform(std::begin(c1), std::end(c1), std::begin(c1),
+            [](std::size_t val) { return 2 * val; });
+
         std::vector<std::size_t> c2;
         std::copy(start_it, end_it, std::back_inserter(c2));
 
@@ -349,6 +374,11 @@ void test_includes2_async(ExPolicy&& p, IteratorTag)
     }
 
     {
+        // make sure std::less is not violated by incrementing one of the
+        // elements
+        std::transform(std::begin(c1), std::end(c1), std::begin(c1),
+            [](std::size_t val) { return 2 * val; });
+
         std::vector<std::size_t> c2;
         std::copy(start_it, end_it, std::back_inserter(c2));
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/inplace_merge.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/inplace_merge.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <random>
 #include <string>
 #include <vector>
 
@@ -41,12 +42,12 @@ void inplace_merge_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(hpx::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int) std::time(nullptr);
+    unsigned int seed = std::random_device{}();
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 
+    inplace_merge_seed(seed);
     std::cout << "using seed: " << seed << std::endl;
-    std::srand(seed);
 
     inplace_merge_test();
     inplace_merge_exception_test();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/inplace_merge_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/inplace_merge_tests.hpp
@@ -249,8 +249,8 @@ void test_inplace_merge_exception(IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::inplace_merge(iterator(res_first),
-            iterator(res_middle), iterator(res_last), throw_always());
+        hpx::inplace_merge(iterator(res_first), iterator(res_middle),
+            iterator(res_last), throw_always());
 
         HPX_TEST(false);
     }
@@ -292,8 +292,8 @@ void test_inplace_merge_exception(ExPolicy&& policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::inplace_merge(policy, iterator(res_first),
-            iterator(res_middle), iterator(res_last), throw_always());
+        hpx::inplace_merge(policy, iterator(res_first), iterator(res_middle),
+            iterator(res_last), throw_always());
 
         HPX_TEST(false);
     }
@@ -375,8 +375,8 @@ void test_inplace_merge_bad_alloc(IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::inplace_merge(iterator(res_first),
-            iterator(res_middle), iterator(res_last), throw_bad_alloc());
+        hpx::inplace_merge(iterator(res_first), iterator(res_middle),
+            iterator(res_last), throw_bad_alloc());
 
         HPX_TEST(false);
     }
@@ -416,8 +416,8 @@ void test_inplace_merge_bad_alloc(ExPolicy&& policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::inplace_merge(policy, iterator(res_first),
-            iterator(res_middle), iterator(res_last), throw_bad_alloc());
+        hpx::inplace_merge(policy, iterator(res_first), iterator(res_middle),
+            iterator(res_last), throw_bad_alloc());
 
         HPX_TEST(false);
     }
@@ -512,30 +512,6 @@ void test_inplace_merge_etc(IteratorTag, DataType, int rand_base)
 
         HPX_TEST(equality);
     }
-
-//     // Test projection.
-//     {
-// #if defined(HPX_HAVE_STABLE_INPLACE_MERGE)
-//         typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-//
-//         sol = res = org;
-//
-//         DataType val;
-//         hpx::inplace_merge(
-//             policy, iterator(res_first), iterator(res_middle),
-//             iterator(res_last),
-//             [](DataType const& a, DataType const& b) -> bool { return a < b; },
-//             [&val](DataType const& elem) -> DataType& {
-//                 // This is projection.
-//                 return val;
-//             });
-//
-//         // The container must not be changed.
-//         bool equality = test::equal(res_first, res_last, sol_first, sol_last);
-//
-//         HPX_TEST(equality);
-// #endif
-//     }
 }
 
 template <typename ExPolicy, typename IteratorTag, typename DataType>
@@ -578,30 +554,6 @@ void test_inplace_merge_etc(
 
         HPX_TEST(equality);
     }
-
-//     // Test projection.
-//     {
-// #if defined(HPX_HAVE_STABLE_INPLACE_MERGE)
-//         typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-//
-//         sol = res = org;
-//
-//         DataType val;
-//         hpx::inplace_merge(
-//             policy, iterator(res_first), iterator(res_middle),
-//             iterator(res_last),
-//             [](DataType const& a, DataType const& b) -> bool { return a < b; },
-//             [&val](DataType const& elem) -> DataType& {
-//                 // This is projection.
-//                 return val;
-//             });
-//
-//         // The container must not be changed.
-//         bool equality = test::equal(res_first, res_last, sol_first, sol_last);
-//
-//         HPX_TEST(equality);
-// #endif
-//     }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/algorithms/tests/unit/algorithms/inplace_merge_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/inplace_merge_tests.hpp
@@ -24,9 +24,14 @@
 #include "test_utils.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
-int seed = std::random_device{}();
-std::mt19937 _gen(seed);
+std::mt19937 _gen(0);
 
+inline void inplace_merge_seed(unsigned int seed)
+{
+    _gen.seed(seed);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 struct throw_always
 {
     template <typename T>
@@ -115,18 +120,11 @@ struct random_fill
 };
 
 ///////////////////////////////////////////////////////////////////////////////
-template <typename ExPolicy, typename IteratorTag, typename DataType,
-    typename Comp>
-void test_inplace_merge(
-    ExPolicy policy, IteratorTag, DataType, Comp comp, int rand_base)
+template <typename IteratorTag, typename DataType, typename Comp>
+void test_inplace_merge(IteratorTag, DataType, Comp comp, int rand_base)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
-
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    using hpx::get;
 
     std::size_t const left_size = 300007, right_size = 123456;
     std::vector<DataType> res(left_size + right_size), sol;
@@ -145,8 +143,45 @@ void test_inplace_merge(
     base_iterator sol_middle = sol_first + left_size;
     base_iterator sol_last = std::end(sol);
 
-    hpx::parallel::inplace_merge(policy, iterator(res_first),
-        iterator(res_middle), iterator(res_last), comp);
+    hpx::inplace_merge(
+        iterator(res_first), iterator(res_middle), iterator(res_last), comp);
+    std::inplace_merge(sol_first, sol_middle, sol_last, comp);
+
+    bool equality = test::equal(res_first, res_last, sol_first, sol_last);
+
+    HPX_TEST(equality);
+}
+
+template <typename ExPolicy, typename IteratorTag, typename DataType,
+    typename Comp>
+void test_inplace_merge(
+    ExPolicy&& policy, IteratorTag, DataType, Comp comp, int rand_base)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef typename std::vector<DataType>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::size_t const left_size = 300007, right_size = 123456;
+    std::vector<DataType> res(left_size + right_size), sol;
+
+    base_iterator res_first = std::begin(res);
+    base_iterator res_middle = res_first + left_size;
+    base_iterator res_last = std::end(res);
+
+    std::generate(res_first, res_middle, random_fill(rand_base, 6));
+    std::generate(res_middle, res_last, random_fill(rand_base, 8));
+    std::sort(res_first, res_middle, comp);
+    std::sort(res_middle, res_last, comp);
+
+    sol = res;
+    base_iterator sol_first = std::begin(sol);
+    base_iterator sol_middle = sol_first + left_size;
+    base_iterator sol_last = std::end(sol);
+
+    hpx::inplace_merge(policy, iterator(res_first), iterator(res_middle),
+        iterator(res_last), comp);
     std::inplace_merge(sol_first, sol_middle, sol_last, comp);
 
     bool equality = test::equal(res_first, res_last, sol_first, sol_last);
@@ -157,15 +192,13 @@ void test_inplace_merge(
 template <typename ExPolicy, typename IteratorTag, typename DataType,
     typename Comp>
 void test_inplace_merge_async(
-    ExPolicy policy, IteratorTag, DataType, Comp comp, int rand_base)
+    ExPolicy&& policy, IteratorTag, DataType, Comp comp, int rand_base)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    using hpx::get;
 
     std::size_t const left_size = 300007, right_size = 123456;
     std::vector<DataType> res(left_size + right_size), sol;
@@ -184,7 +217,7 @@ void test_inplace_merge_async(
     base_iterator sol_middle = sol_first + left_size;
     base_iterator sol_last = std::end(sol);
 
-    auto f = hpx::parallel::inplace_merge(policy, iterator(res_first),
+    auto f = hpx::inplace_merge(policy, iterator(res_first),
         iterator(res_middle), iterator(res_last), comp);
     f.get();
     std::inplace_merge(sol_first, sol_middle, sol_last, comp);
@@ -195,8 +228,48 @@ void test_inplace_merge_async(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_inplace_merge_exception(IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::size_t const left_size = 300007, right_size = 123456;
+    std::vector<int> res(left_size + right_size);
+
+    base_iterator res_first = std::begin(res);
+    base_iterator res_middle = res_first + left_size;
+    base_iterator res_last = std::end(res);
+
+    std::generate(res_first, res_middle, random_fill());
+    std::generate(res_middle, res_last, random_fill());
+    std::sort(res_first, res_middle);
+    std::sort(res_middle, res_last);
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::inplace_merge(iterator(res_first),
+            iterator(res_middle), iterator(res_last), throw_always());
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
 template <typename ExPolicy, typename IteratorTag>
-void test_inplace_merge_exception(ExPolicy policy, IteratorTag)
+void test_inplace_merge_exception(ExPolicy&& policy, IteratorTag)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
@@ -219,10 +292,9 @@ void test_inplace_merge_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        auto result = hpx::parallel::inplace_merge(policy, iterator(res_first),
+        hpx::inplace_merge(policy, iterator(res_first),
             iterator(res_middle), iterator(res_last), throw_always());
 
-        HPX_UNUSED(result);
         HPX_TEST(false);
     }
     catch (hpx::exception_list const& e)
@@ -239,7 +311,7 @@ void test_inplace_merge_exception(ExPolicy policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_inplace_merge_exception_async(ExPolicy policy, IteratorTag)
+void test_inplace_merge_exception_async(ExPolicy&& policy, IteratorTag)
 {
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -260,7 +332,7 @@ void test_inplace_merge_exception_async(ExPolicy policy, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::inplace_merge(policy, iterator(res_first),
+        auto f = hpx::inplace_merge(policy, iterator(res_first),
             iterator(res_middle), iterator(res_last), throw_always());
         returned_from_algorithm = true;
         f.get();
@@ -282,8 +354,46 @@ void test_inplace_merge_exception_async(ExPolicy policy, IteratorTag)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_inplace_merge_bad_alloc(IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::size_t const left_size = 300007, right_size = 123456;
+    std::vector<int> res(left_size + right_size);
+
+    base_iterator res_first = std::begin(res);
+    base_iterator res_middle = res_first + left_size;
+    base_iterator res_last = std::end(res);
+
+    std::generate(res_first, res_middle, random_fill());
+    std::generate(res_middle, res_last, random_fill());
+    std::sort(res_first, res_middle);
+    std::sort(res_middle, res_last);
+
+    bool caught_bad_alloc = false;
+    try
+    {
+        hpx::inplace_merge(iterator(res_first),
+            iterator(res_middle), iterator(res_last), throw_bad_alloc());
+
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_bad_alloc = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
 template <typename ExPolicy, typename IteratorTag>
-void test_inplace_merge_bad_alloc(ExPolicy policy, IteratorTag)
+void test_inplace_merge_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
@@ -306,10 +416,9 @@ void test_inplace_merge_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        auto result = hpx::parallel::inplace_merge(policy, iterator(res_first),
+        hpx::inplace_merge(policy, iterator(res_first),
             iterator(res_middle), iterator(res_last), throw_bad_alloc());
 
-        HPX_UNUSED(result);
         HPX_TEST(false);
     }
     catch (std::bad_alloc const&)
@@ -325,7 +434,7 @@ void test_inplace_merge_bad_alloc(ExPolicy policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_inplace_merge_bad_alloc_async(ExPolicy policy, IteratorTag)
+void test_inplace_merge_bad_alloc_async(ExPolicy&& policy, IteratorTag)
 {
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -346,7 +455,7 @@ void test_inplace_merge_bad_alloc_async(ExPolicy policy, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::inplace_merge(policy, iterator(res_first),
+        auto f = hpx::inplace_merge(policy, iterator(res_first),
             iterator(res_middle), iterator(res_last), throw_bad_alloc());
         returned_from_algorithm = true;
         f.get();
@@ -367,16 +476,10 @@ void test_inplace_merge_bad_alloc_async(ExPolicy policy, IteratorTag)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-template <typename ExPolicy, typename IteratorTag, typename DataType>
-void test_inplace_merge_etc(
-    ExPolicy policy, IteratorTag, DataType, int rand_base)
+template <typename IteratorTag, typename DataType>
+void test_inplace_merge_etc(IteratorTag, DataType, int rand_base)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
-
     typedef typename std::vector<DataType>::iterator base_iterator;
-
-    using hpx::get;
 
     std::size_t const left_size = 300007, right_size = 123456;
     std::vector<DataType> res(left_size + right_size), sol, org;
@@ -401,8 +504,8 @@ void test_inplace_merge_etc(
 
         sol = res = org;
 
-        hpx::parallel::inplace_merge(policy, iterator(res_first),
-            iterator(res_middle), iterator(res_last));
+        hpx::inplace_merge(
+            iterator(res_first), iterator(res_middle), iterator(res_last));
         std::inplace_merge(sol_first, sol_middle, sol_last);
 
         bool equality = test::equal(res_first, res_last, sol_first, sol_last);
@@ -410,90 +513,95 @@ void test_inplace_merge_etc(
         HPX_TEST(equality);
     }
 
-    // Test projection.
-    {
-#if defined(HPX_HAVE_STABLE_INPLACE_MERGE)
-        typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-        sol = res = org;
-
-        DataType val;
-        hpx::parallel::inplace_merge(
-            policy, iterator(res_first), iterator(res_middle),
-            iterator(res_last),
-            [](DataType const& a, DataType const& b) -> bool { return a < b; },
-            [&val](DataType const& elem) -> DataType& {
-                // This is projection.
-                return val;
-            });
-
-        // The container must not be changed.
-        bool equality = test::equal(res_first, res_last, sol_first, sol_last);
-
-        HPX_TEST(equality);
-#endif
-    }
+//     // Test projection.
+//     {
+// #if defined(HPX_HAVE_STABLE_INPLACE_MERGE)
+//         typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+//
+//         sol = res = org;
+//
+//         DataType val;
+//         hpx::inplace_merge(
+//             policy, iterator(res_first), iterator(res_middle),
+//             iterator(res_last),
+//             [](DataType const& a, DataType const& b) -> bool { return a < b; },
+//             [&val](DataType const& elem) -> DataType& {
+//                 // This is projection.
+//                 return val;
+//             });
+//
+//         // The container must not be changed.
+//         bool equality = test::equal(res_first, res_last, sol_first, sol_last);
+//
+//         HPX_TEST(equality);
+// #endif
+//     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
 template <typename ExPolicy, typename IteratorTag, typename DataType>
-void test_inplace_merge_stable(
-    ExPolicy policy, IteratorTag, DataType, int rand_base)
+void test_inplace_merge_etc(
+    ExPolicy&& policy, IteratorTag, DataType, int rand_base)
 {
-#if defined(HPX_HAVE_STABLE_INPLACE_MERGE)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef typename std::pair<DataType, int> ElemType;
-    typedef typename std::vector<ElemType>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    using hpx::get;
+    typedef typename std::vector<DataType>::iterator base_iterator;
 
     std::size_t const left_size = 300007, right_size = 123456;
-    std::vector<ElemType> res(left_size + right_size);
+    std::vector<DataType> res(left_size + right_size), sol, org;
 
     base_iterator res_first = std::begin(res);
     base_iterator res_middle = res_first + left_size;
     base_iterator res_last = std::end(res);
 
-    int no = 0;
-    auto rf = random_fill(rand_base, 6);
-    std::generate(res_first, res_middle, [&no, &rf]() -> std::pair<int, int> {
-        return {rf(), no++};
-    });
-    rf = random_fill(rand_base, 8);
-    std::generate(res_middle, res_last, [&no, &rf]() -> std::pair<int, int> {
-        return {rf(), no++};
-    });
+    std::generate(res_first, res_middle, random_fill(rand_base, 6));
+    std::generate(res_middle, res_last, random_fill(rand_base, 8));
     std::sort(res_first, res_middle);
     std::sort(res_middle, res_last);
 
-    hpx::parallel::inplace_merge(
-        policy, iterator(res_first), iterator(res_middle), iterator(res_last),
-        [](DataType const& a, DataType const& b) -> bool { return a < b; },
-        [](ElemType const& elem) -> DataType const& {
-            // This is projection.
-            return elem.first;
-        });
+    org = sol = res;
+    base_iterator sol_first = std::begin(sol);
+    base_iterator sol_middle = sol_first + left_size;
+    base_iterator sol_last = std::end(sol);
 
-    bool stable = true;
-    int check_count = 0;
-    for (std::size_t i = 1u; i < left_size + right_size; ++i)
+    // Test default comparison.
     {
-        if (res[i - 1].first == res[i].first)
-        {
-            ++check_count;
-            if (res[i - 1].second > res[i].second)
-                stable = false;
-        }
+        typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+        sol = res = org;
+
+        hpx::inplace_merge(policy, iterator(res_first), iterator(res_middle),
+            iterator(res_last));
+        std::inplace_merge(sol_first, sol_middle, sol_last);
+
+        bool equality = test::equal(res_first, res_last, sol_first, sol_last);
+
+        HPX_TEST(equality);
     }
 
-    bool test_is_meaningful = check_count >= 100;
-
-    HPX_TEST(test_is_meaningful);
-    HPX_TEST(stable);
-#endif
+//     // Test projection.
+//     {
+// #if defined(HPX_HAVE_STABLE_INPLACE_MERGE)
+//         typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+//
+//         sol = res = org;
+//
+//         DataType val;
+//         hpx::inplace_merge(
+//             policy, iterator(res_first), iterator(res_middle),
+//             iterator(res_last),
+//             [](DataType const& a, DataType const& b) -> bool { return a < b; },
+//             [&val](DataType const& elem) -> DataType& {
+//                 // This is projection.
+//                 return val;
+//             });
+//
+//         // The container must not be changed.
+//         bool equality = test::equal(res_first, res_last, sol_first, sol_last);
+//
+//         HPX_TEST(equality);
+// #endif
+//     }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -506,6 +614,9 @@ void test_inplace_merge()
 
     ////////// Test cases for 'int' type.
     test_inplace_merge(
+        IteratorTag(), int(),
+        [](const int a, const int b) -> bool { return a < b; }, rand_base);
+    test_inplace_merge(
         seq, IteratorTag(), int(),
         [](const int a, const int b) -> bool { return a < b; }, rand_base);
     test_inplace_merge(
@@ -516,6 +627,12 @@ void test_inplace_merge()
         [](const int a, const int b) -> bool { return a > b; }, rand_base);
 
     ////////// Test cases for user defined type.
+    test_inplace_merge(
+        IteratorTag(), user_defined_type(),
+        [](user_defined_type const& a, user_defined_type const& b) -> bool {
+            return a < b;
+        },
+        rand_base);
     test_inplace_merge(
         seq, IteratorTag(), user_defined_type(),
         [](user_defined_type const& a, user_defined_type const& b) -> bool {
@@ -558,20 +675,10 @@ void test_inplace_merge()
         rand_base);
 
     ////////// Another test cases for justifying the implementation.
+    test_inplace_merge_etc(IteratorTag(), user_defined_type(), rand_base);
     test_inplace_merge_etc(seq, IteratorTag(), user_defined_type(), rand_base);
     test_inplace_merge_etc(par, IteratorTag(), user_defined_type(), rand_base);
     test_inplace_merge_etc(
-        par_unseq, IteratorTag(), user_defined_type(), rand_base);
-
-    ////////// Test cases for checking whether the algorithm is stable.
-    test_inplace_merge_stable(seq, IteratorTag(), int(), rand_base);
-    test_inplace_merge_stable(par, IteratorTag(), int(), rand_base);
-    test_inplace_merge_stable(par_unseq, IteratorTag(), int(), rand_base);
-    test_inplace_merge_stable(
-        seq, IteratorTag(), user_defined_type(), rand_base);
-    test_inplace_merge_stable(
-        par, IteratorTag(), user_defined_type(), rand_base);
-    test_inplace_merge_stable(
         par_unseq, IteratorTag(), user_defined_type(), rand_base);
 }
 
@@ -580,6 +687,8 @@ template <typename IteratorTag>
 void test_inplace_merge_exception()
 {
     using namespace hpx::execution;
+
+    test_inplace_merge_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
@@ -596,6 +705,8 @@ template <typename IteratorTag>
 void test_inplace_merge_bad_alloc()
 {
     using namespace hpx::execution;
+
+    test_inplace_merge_bad_alloc(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions

--- a/libs/parallelism/algorithms/tests/unit/algorithms/make_heap.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/make_heap.cpp
@@ -43,8 +43,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_make_heap1(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -116,8 +116,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_make_heap2(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -205,8 +205,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_make_heap_exception(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -327,8 +327,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_make_heap_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/algorithms/make_heap.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/make_heap.cpp
@@ -42,8 +42,7 @@ void test_make_heap1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_make_heap1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -115,8 +114,7 @@ void test_make_heap2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_make_heap2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -204,8 +202,7 @@ void test_make_heap_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_make_heap_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -326,8 +323,7 @@ void test_make_heap_bad_alloc(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_make_heap_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/merge.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/merge.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <random>
 #include <string>
 #include <vector>
 
@@ -44,12 +45,12 @@ void merge_bad_alloc_test()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(hpx::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int) std::time(nullptr);
+    unsigned int seed = std::random_device{}();
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 
+    merge_seed(seed);
     std::cout << "using seed: " << seed << std::endl;
-    std::srand(seed);
 
     merge_test();
     merge_exception_test();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/merge_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/merge_tests.hpp
@@ -23,9 +23,14 @@
 #include "test_utils.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
-int seed = std::random_device{}();
-std::mt19937 _gen(seed);
+std::mt19937 _gen(0);
 
+inline void merge_seed(unsigned int seed)
+{
+    _gen.seed(seed);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 struct throw_always
 {
     template <typename T>
@@ -114,18 +119,11 @@ struct random_fill
 };
 
 ///////////////////////////////////////////////////////////////////////////////
-template <typename ExPolicy, typename IteratorTag, typename DataType,
-    typename Comp>
-void test_merge(
-    ExPolicy policy, IteratorTag, DataType, Comp comp, int rand_base)
+template <typename IteratorTag, typename DataType, typename Comp>
+void test_merge(IteratorTag, DataType, Comp comp, int rand_base)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
-
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    using hpx::get;
 
     std::size_t const size1 = 300007, size2 = 123456;
     std::vector<DataType> src1(size1), src2(size2), dest_res(size1 + size2),
@@ -136,13 +134,45 @@ void test_merge(
     std::sort(std::begin(src1), std::end(src1), comp);
     std::sort(std::begin(src2), std::end(src2), comp);
 
-    auto result = hpx::parallel::merge(policy, iterator(std::begin(src1)),
+    auto result = hpx::merge(iterator(std::begin(src1)),
         iterator(std::end(src1)), iterator(std::begin(src2)),
         iterator(std::end(src2)), iterator(std::begin(dest_res)), comp);
     auto solution = std::merge(std::begin(src1), std::end(src1),
         std::begin(src2), std::end(src2), std::begin(dest_sol), comp);
 
-    bool equality = test::equal(std::begin(dest_res), get<2>(result).base(),
+    bool equality = test::equal(std::begin(dest_res), result.base(),
+        std::begin(dest_sol), solution);
+
+    HPX_TEST(equality);
+}
+
+template <typename ExPolicy, typename IteratorTag, typename DataType,
+    typename Comp>
+void test_merge(
+    ExPolicy&& policy, IteratorTag, DataType, Comp comp, int rand_base)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef typename std::vector<DataType>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::size_t const size1 = 300007, size2 = 123456;
+    std::vector<DataType> src1(size1), src2(size2), dest_res(size1 + size2),
+        dest_sol(size1 + size2);
+
+    std::generate(std::begin(src1), std::end(src1), random_fill(rand_base, 6));
+    std::generate(std::begin(src2), std::end(src2), random_fill(rand_base, 8));
+    std::sort(std::begin(src1), std::end(src1), comp);
+    std::sort(std::begin(src2), std::end(src2), comp);
+
+    auto result = hpx::merge(policy, iterator(std::begin(src1)),
+        iterator(std::end(src1)), iterator(std::begin(src2)),
+        iterator(std::end(src2)), iterator(std::begin(dest_res)), comp);
+    auto solution = std::merge(std::begin(src1), std::end(src1),
+        std::begin(src2), std::end(src2), std::begin(dest_sol), comp);
+
+    bool equality = test::equal(std::begin(dest_res), result.base(),
         std::begin(dest_sol), solution);
 
     HPX_TEST(equality);
@@ -151,15 +181,13 @@ void test_merge(
 template <typename ExPolicy, typename IteratorTag, typename DataType,
     typename Comp>
 void test_merge_async(
-    ExPolicy policy, IteratorTag, DataType, Comp comp, int rand_base)
+    ExPolicy&& policy, IteratorTag, DataType, Comp comp, int rand_base)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    using hpx::get;
 
     std::size_t const size1 = 300007, size2 = 123456;
     std::vector<DataType> src1(size1), src2(size2), dest_res(size1 + size2),
@@ -170,22 +198,61 @@ void test_merge_async(
     std::sort(std::begin(src1), std::end(src1), comp);
     std::sort(std::begin(src2), std::end(src2), comp);
 
-    auto f = hpx::parallel::merge(policy, iterator(std::begin(src1)),
+    auto f = hpx::merge(policy, iterator(std::begin(src1)),
         iterator(std::end(src1)), iterator(std::begin(src2)),
         iterator(std::end(src2)), iterator(std::begin(dest_res)), comp);
     auto result = f.get();
     auto solution = std::merge(std::begin(src1), std::end(src1),
         std::begin(src2), std::end(src2), std::begin(dest_sol), comp);
 
-    bool equality = test::equal(std::begin(dest_res), get<2>(result).base(),
+    bool equality = test::equal(std::begin(dest_res), result.base(),
         std::begin(dest_sol), solution);
 
     HPX_TEST(equality);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_merge_exception(IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::size_t const size1 = 300007, size2 = 123456;
+    std::vector<int> src1(size1), src2(size2), dest(size1 + size2);
+
+    std::generate(std::begin(src1), std::end(src1), random_fill());
+    std::generate(std::begin(src2), std::end(src2), random_fill());
+    std::sort(std::begin(src1), std::end(src1));
+    std::sort(std::begin(src2), std::end(src2));
+
+    bool caught_exception = false;
+    try
+    {
+        auto result =
+            hpx::merge(iterator(std::begin(src1)), iterator(std::end(src1)),
+                iterator(std::begin(src2)), iterator(std::end(src2)),
+                iterator(std::begin(dest)), throw_always());
+
+        HPX_UNUSED(result);
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
 template <typename ExPolicy, typename IteratorTag>
-void test_merge_exception(ExPolicy policy, IteratorTag)
+void test_merge_exception(ExPolicy&& policy, IteratorTag)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
@@ -204,7 +271,7 @@ void test_merge_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        auto result = hpx::parallel::merge(policy, iterator(std::begin(src1)),
+        auto result = hpx::merge(policy, iterator(std::begin(src1)),
             iterator(std::end(src1)), iterator(std::begin(src2)),
             iterator(std::end(src2)), iterator(std::begin(dest)),
             throw_always());
@@ -226,7 +293,7 @@ void test_merge_exception(ExPolicy policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_merge_exception_async(ExPolicy policy, IteratorTag)
+void test_merge_exception_async(ExPolicy&& policy, IteratorTag)
 {
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -243,7 +310,7 @@ void test_merge_exception_async(ExPolicy policy, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::merge(policy, iterator(std::begin(src1)),
+        auto f = hpx::merge(policy, iterator(std::begin(src1)),
             iterator(std::end(src1)), iterator(std::begin(src2)),
             iterator(std::end(src2)), iterator(std::begin(dest)),
             throw_always());
@@ -267,8 +334,45 @@ void test_merge_exception_async(ExPolicy policy, IteratorTag)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_merge_bad_alloc(IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::size_t const size1 = 300007, size2 = 123456;
+    std::vector<int> src1(size1), src2(size2), dest(size1 + size2);
+
+    std::generate(std::begin(src1), std::end(src1), random_fill());
+    std::generate(std::begin(src2), std::end(src2), random_fill());
+    std::sort(std::begin(src1), std::end(src1));
+    std::sort(std::begin(src2), std::end(src2));
+
+    bool caught_bad_alloc = false;
+    try
+    {
+        auto result =
+            hpx::merge(iterator(std::begin(src1)), iterator(std::end(src1)),
+                iterator(std::begin(src2)), iterator(std::end(src2)),
+                iterator(std::begin(dest)), throw_bad_alloc());
+
+        HPX_UNUSED(result);
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_bad_alloc = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
 template <typename ExPolicy, typename IteratorTag>
-void test_merge_bad_alloc(ExPolicy policy, IteratorTag)
+void test_merge_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
@@ -287,7 +391,7 @@ void test_merge_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        auto result = hpx::parallel::merge(policy, iterator(std::begin(src1)),
+        auto result = hpx::merge(policy, iterator(std::begin(src1)),
             iterator(std::end(src1)), iterator(std::begin(src2)),
             iterator(std::end(src2)), iterator(std::begin(dest)),
             throw_bad_alloc());
@@ -308,7 +412,7 @@ void test_merge_bad_alloc(ExPolicy policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_merge_bad_alloc_async(ExPolicy policy, IteratorTag)
+void test_merge_bad_alloc_async(ExPolicy&& policy, IteratorTag)
 {
     typedef std::vector<int>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -325,7 +429,7 @@ void test_merge_bad_alloc_async(ExPolicy policy, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::merge(policy, iterator(std::begin(src1)),
+        auto f = hpx::merge(policy, iterator(std::begin(src1)),
             iterator(std::end(src1)), iterator(std::begin(src2)),
             iterator(std::end(src2)), iterator(std::begin(dest)),
             throw_bad_alloc());
@@ -348,15 +452,10 @@ void test_merge_bad_alloc_async(ExPolicy policy, IteratorTag)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-template <typename ExPolicy, typename IteratorTag, typename DataType>
-void test_merge_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
+template <typename IteratorTag, typename DataType>
+void test_merge_etc(IteratorTag, DataType, int rand_base)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
-
     typedef typename std::vector<DataType>::iterator base_iterator;
-
-    using hpx::get;
 
     std::size_t const size1 = 300007, size2 = 123456;
     std::vector<DataType> src1(size1), src2(size2), dest_res(size1 + size2),
@@ -371,44 +470,16 @@ void test_merge_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
     {
         typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-        auto result = hpx::parallel::merge(policy, iterator(std::begin(src1)),
+        auto result = hpx::merge(iterator(std::begin(src1)),
             iterator(std::end(src1)), iterator(std::begin(src2)),
             iterator(std::end(src2)), iterator(std::begin(dest_res)));
         auto solution = std::merge(std::begin(src1), std::end(src1),
             std::begin(src2), std::end(src2), std::begin(dest_sol));
 
-        bool equality = test::equal(std::begin(dest_res), get<2>(result).base(),
+        bool equality = test::equal(std::begin(dest_res), result.base(),
             std::begin(dest_sol), solution);
 
         HPX_TEST(equality);
-    }
-
-    // Test projection.
-    {
-        typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-        DataType val;
-        hpx::parallel::merge(
-            policy, iterator(std::begin(src1)), iterator(std::end(src1)),
-            iterator(std::begin(src2)), iterator(std::end(src2)),
-            iterator(std::begin(dest_res)),
-            [](DataType const& a, DataType const& b) -> bool { return a < b; },
-            [&val](DataType const&) -> DataType {
-                // This is projection.
-                return val;
-            },
-            [&val](DataType const&) -> DataType {
-                // This is projection.
-                return val + 1;
-            });
-
-        bool equality1 =
-            std::equal(std::begin(src1), std::end(src1), std::begin(dest_res));
-        bool equality2 = std::equal(
-            std::begin(src2), std::end(src2), std::begin(dest_res) + size1);
-
-        HPX_TEST(equality1);
-        HPX_TEST(equality2);
     }
 
     // Test sequential_merge with input_iterator_tag.
@@ -428,73 +499,68 @@ void test_merge_etc(ExPolicy policy, IteratorTag, DataType, int rand_base)
         auto solution = std::merge(std::begin(src1), std::end(src1),
             std::begin(src2), std::end(src2), std::begin(dest_sol));
 
-        bool equality = test::equal(std::begin(dest_res), get<2>(result).base(),
+        bool equality = test::equal(std::begin(dest_res), result.out.base(),
             std::begin(dest_sol), solution);
 
         HPX_TEST(equality);
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
 template <typename ExPolicy, typename IteratorTag, typename DataType>
-void test_merge_stable(ExPolicy policy, IteratorTag, DataType, int rand_base)
+void test_merge_etc(ExPolicy&& policy, IteratorTag, DataType, int rand_base)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef typename std::pair<DataType, int> ElemType;
-    typedef typename std::vector<ElemType>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    using hpx::get;
+    typedef typename std::vector<DataType>::iterator base_iterator;
 
     std::size_t const size1 = 300007, size2 = 123456;
-    std::vector<ElemType> src1(size1), src2(size2), dest(size1 + size2);
+    std::vector<DataType> src1(size1), src2(size2), dest_res(size1 + size2),
+        dest_sol(size1 + size2);
 
-    int no = 0;
-    auto rf = random_fill(rand_base, 6);
-    std::generate(
-        std::begin(src1), std::end(src1), [&no, &rf]() -> std::pair<int, int> {
-            return {rf(), no++};
-        });
-    rf = random_fill(rand_base, 8);
-    std::generate(
-        std::begin(src2), std::end(src2), [&no, &rf]() -> std::pair<int, int> {
-            return {rf(), no++};
-        });
+    std::generate(std::begin(src1), std::end(src1), random_fill(rand_base, 6));
+    std::generate(std::begin(src2), std::end(src2), random_fill(rand_base, 8));
     std::sort(std::begin(src1), std::end(src1));
     std::sort(std::begin(src2), std::end(src2));
 
-    hpx::parallel::merge(
-        policy, iterator(std::begin(src1)), iterator(std::end(src1)),
-        iterator(std::begin(src2)), iterator(std::end(src2)),
-        iterator(std::begin(dest)),
-        [](DataType const& a, DataType const& b) -> bool { return a < b; },
-        [](ElemType const& elem) -> DataType const& {
-            // This is projection.
-            return elem.first;
-        },
-        [](ElemType const& elem) -> DataType const& {
-            // This is projection.
-            return elem.first;
-        });
-
-    bool stable = true;
-    int check_count = 0;
-    for (auto i = 1u; i < size1 + size2; ++i)
+    // Test default comparison.
     {
-        if (dest[i - 1].first == dest[i].first)
-        {
-            ++check_count;
-            if (dest[i - 1].second > dest[i].second)
-                stable = false;
-        }
+        typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+        auto result = hpx::merge(policy, iterator(std::begin(src1)),
+            iterator(std::end(src1)), iterator(std::begin(src2)),
+            iterator(std::end(src2)), iterator(std::begin(dest_res)));
+        auto solution = std::merge(std::begin(src1), std::end(src1),
+            std::begin(src2), std::end(src2), std::begin(dest_sol));
+
+        bool equality = test::equal(std::begin(dest_res), result.base(),
+            std::begin(dest_sol), solution);
+
+        HPX_TEST(equality);
     }
 
-    bool test_is_meaningful = check_count >= 100;
+    // Test sequential_merge with input_iterator_tag.
+    {
+        typedef test::test_iterator<base_iterator, std::input_iterator_tag>
+            input_iterator;
+        typedef test::test_iterator<base_iterator, std::output_iterator_tag>
+            output_iterator;
 
-    HPX_TEST(test_is_meaningful);
-    HPX_TEST(stable);
+        auto result = hpx::parallel::v1::detail::sequential_merge(
+            input_iterator(std::begin(src1)), input_iterator(std::end(src1)),
+            input_iterator(std::begin(src2)), input_iterator(std::end(src2)),
+            output_iterator(std::begin(dest_res)),
+            [](DataType const& a, DataType const& b) -> bool { return a < b; },
+            [](DataType const& t) -> DataType const& { return t; },
+            [](DataType const& t) -> DataType const& { return t; });
+        auto solution = std::merge(std::begin(src1), std::end(src1),
+            std::begin(src2), std::end(src2), std::begin(dest_sol));
+
+        bool equality = test::equal(std::begin(dest_res), result.out.base(),
+            std::begin(dest_sol), solution);
+
+        HPX_TEST(equality);
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -507,6 +573,9 @@ void test_merge()
 
     ////////// Test cases for 'int' type.
     test_merge(
+        IteratorTag(), int(),
+        [](const int a, const int b) -> bool { return a < b; }, rand_base);
+    test_merge(
         seq, IteratorTag(), int(),
         [](const int a, const int b) -> bool { return a < b; }, rand_base);
     test_merge(
@@ -517,6 +586,12 @@ void test_merge()
         [](const int a, const int b) -> bool { return a > b; }, rand_base);
 
     ////////// Test cases for user defined type.
+    test_merge(
+        IteratorTag(), user_defined_type(),
+        [](user_defined_type const& a, user_defined_type const& b) -> bool {
+            return a < b;
+        },
+        rand_base);
     test_merge(
         seq, IteratorTag(), user_defined_type(),
         [](user_defined_type const& a, user_defined_type const& b) -> bool {
@@ -559,17 +634,10 @@ void test_merge()
         rand_base);
 
     ////////// Another test cases for justifying the implementation.
+    test_merge_etc(IteratorTag(), user_defined_type(), rand_base);
     test_merge_etc(seq, IteratorTag(), user_defined_type(), rand_base);
     test_merge_etc(par, IteratorTag(), user_defined_type(), rand_base);
     test_merge_etc(par_unseq, IteratorTag(), user_defined_type(), rand_base);
-
-    ////////// Test cases for checking whether the algorithm is stable.
-    test_merge_stable(seq, IteratorTag(), int(), rand_base);
-    test_merge_stable(par, IteratorTag(), int(), rand_base);
-    test_merge_stable(par_unseq, IteratorTag(), int(), rand_base);
-    test_merge_stable(seq, IteratorTag(), user_defined_type(), rand_base);
-    test_merge_stable(par, IteratorTag(), user_defined_type(), rand_base);
-    test_merge_stable(par_unseq, IteratorTag(), user_defined_type(), rand_base);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -577,6 +645,8 @@ template <typename IteratorTag>
 void test_merge_exception()
 {
     using namespace hpx::execution;
+
+    test_merge_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
@@ -593,6 +663,8 @@ template <typename IteratorTag>
 void test_merge_bad_alloc()
 {
     using namespace hpx::execution;
+
+    test_merge_bad_alloc(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions

--- a/libs/parallelism/algorithms/tests/unit/algorithms/merge_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/merge_tests.hpp
@@ -140,8 +140,8 @@ void test_merge(IteratorTag, DataType, Comp comp, int rand_base)
     auto solution = std::merge(std::begin(src1), std::end(src1),
         std::begin(src2), std::end(src2), std::begin(dest_sol), comp);
 
-    bool equality = test::equal(std::begin(dest_res), result.base(),
-        std::begin(dest_sol), solution);
+    bool equality = test::equal(
+        std::begin(dest_res), result.base(), std::begin(dest_sol), solution);
 
     HPX_TEST(equality);
 }
@@ -172,8 +172,8 @@ void test_merge(
     auto solution = std::merge(std::begin(src1), std::end(src1),
         std::begin(src2), std::end(src2), std::begin(dest_sol), comp);
 
-    bool equality = test::equal(std::begin(dest_res), result.base(),
-        std::begin(dest_sol), solution);
+    bool equality = test::equal(
+        std::begin(dest_res), result.base(), std::begin(dest_sol), solution);
 
     HPX_TEST(equality);
 }
@@ -205,8 +205,8 @@ void test_merge_async(
     auto solution = std::merge(std::begin(src1), std::end(src1),
         std::begin(src2), std::end(src2), std::begin(dest_sol), comp);
 
-    bool equality = test::equal(std::begin(dest_res), result.base(),
-        std::begin(dest_sol), solution);
+    bool equality = test::equal(
+        std::begin(dest_res), result.base(), std::begin(dest_sol), solution);
 
     HPX_TEST(equality);
 }

--- a/libs/parallelism/algorithms/tests/unit/algorithms/set_union.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/set_union.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015-2017 Hartmut Kaiser
+//  Copyright (c) 2015-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -18,8 +18,32 @@
 #include "test_utils.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_set_union1(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c1 = test::random_fill(10007);
+    std::vector<std::size_t> c2 = test::random_fill(c1.size());
+
+    std::sort(std::begin(c1), std::end(c1));
+    std::sort(std::begin(c2), std::end(c2));
+
+    std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
+
+    hpx::set_union(iterator(std::begin(c1)), iterator(std::end(c1)),
+        std::begin(c2), std::end(c2), std::begin(c3));
+
+    std::set_union(std::begin(c1), std::end(c1), std::begin(c2), std::end(c2),
+        std::begin(c4));
+
+    // verify values
+    HPX_TEST(std::equal(std::begin(c3), std::end(c3), std::begin(c4)));
+}
+
 template <typename ExPolicy, typename IteratorTag>
-void test_set_union1(ExPolicy policy, IteratorTag)
+void test_set_union1(ExPolicy&& policy, IteratorTag)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
@@ -35,8 +59,8 @@ void test_set_union1(ExPolicy policy, IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::parallel::set_union(policy, iterator(std::begin(c1)),
-        iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(c3));
+    hpx::set_union(policy, iterator(std::begin(c1)), iterator(std::end(c1)),
+        std::begin(c2), std::end(c2), std::begin(c3));
 
     std::set_union(std::begin(c1), std::end(c1), std::begin(c2), std::end(c2),
         std::begin(c4));
@@ -46,7 +70,7 @@ void test_set_union1(ExPolicy policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_set_union1_async(ExPolicy p, IteratorTag)
+void test_set_union1_async(ExPolicy&& p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -59,9 +83,8 @@ void test_set_union1_async(ExPolicy p, IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::future<void> result = hpx::parallel::set_union(p,
-        iterator(std::begin(c1)), iterator(std::end(c1)), std::begin(c2),
-        std::end(c2), std::begin(c3));
+    hpx::future<void> result = hpx::set_union(p, iterator(std::begin(c1)),
+        iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(c3));
     result.wait();
 
     std::set_union(std::begin(c1), std::end(c1), std::begin(c2), std::end(c2),
@@ -75,6 +98,8 @@ template <typename IteratorTag>
 void test_set_union1()
 {
     using namespace hpx::execution;
+
+    test_set_union1(IteratorTag());
 
     test_set_union1(seq, IteratorTag());
     test_set_union1(par, IteratorTag());
@@ -91,12 +116,9 @@ void set_union_test1()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-template <typename ExPolicy, typename IteratorTag>
-void test_set_union2(ExPolicy policy, IteratorTag)
+template <typename IteratorTag>
+void test_set_union2(IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
-
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
@@ -110,9 +132,8 @@ void test_set_union2(ExPolicy policy, IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::parallel::set_union(policy, iterator(std::begin(c1)),
-        iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(c3),
-        comp);
+    hpx::set_union(iterator(std::begin(c1)), iterator(std::end(c1)),
+        std::begin(c2), std::end(c2), std::begin(c3), comp);
 
     std::set_union(std::begin(c1), std::end(c1), std::begin(c2), std::end(c2),
         std::begin(c4), comp);
@@ -122,7 +143,7 @@ void test_set_union2(ExPolicy policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_set_union2_async(ExPolicy p, IteratorTag)
+void test_set_union2(ExPolicy&& policy, IteratorTag)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
@@ -140,9 +161,38 @@ void test_set_union2_async(ExPolicy p, IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::future<void> result = hpx::parallel::set_union(p,
-        iterator(std::begin(c1)), iterator(std::end(c1)), std::begin(c2),
-        std::end(c2), std::begin(c3), comp);
+    hpx::set_union(policy, iterator(std::begin(c1)), iterator(std::end(c1)),
+        std::begin(c2), std::end(c2), std::begin(c3), comp);
+
+    std::set_union(std::begin(c1), std::end(c1), std::begin(c2), std::end(c2),
+        std::begin(c4), comp);
+
+    // verify values
+    HPX_TEST(std::equal(std::begin(c3), std::end(c3), std::begin(c4)));
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_set_union2_async(ExPolicy&& p, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c1 = test::random_fill(10007);
+    std::vector<std::size_t> c2 = test::random_fill(c1.size());
+
+    auto comp = [](std::size_t l, std::size_t r) { return l > r; };
+
+    std::sort(std::begin(c1), std::end(c1), comp);
+    std::sort(std::begin(c2), std::end(c2), comp);
+
+    std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
+
+    hpx::future<void> result =
+        hpx::set_union(p, iterator(std::begin(c1)), iterator(std::end(c1)),
+            std::begin(c2), std::end(c2), std::begin(c3), comp);
     result.wait();
 
     std::set_union(std::begin(c1), std::end(c1), std::begin(c2), std::end(c2),
@@ -156,6 +206,8 @@ template <typename IteratorTag>
 void test_set_union2()
 {
     using namespace hpx::execution;
+
+    test_set_union2(IteratorTag());
 
     test_set_union2(seq, IteratorTag());
     test_set_union2(par, IteratorTag());
@@ -172,8 +224,47 @@ void set_union_test2()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_set_union_exception(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c1 = test::random_fill(10007);
+    std::vector<std::size_t> c2 = test::random_fill(c1.size());
+
+    std::sort(std::begin(c1), std::end(c1));
+    std::sort(std::begin(c2), std::end(c2));
+
+    std::vector<std::size_t> c3(2 * c1.size());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::set_union(decorated_iterator(std::begin(c1),
+                           []() { throw std::runtime_error("test"); }),
+            decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
+            std::begin(c3));
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
 template <typename ExPolicy, typename IteratorTag>
-void test_set_union_exception(ExPolicy policy, IteratorTag)
+void test_set_union_exception(ExPolicy&& policy, IteratorTag)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
@@ -193,7 +284,7 @@ void test_set_union_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::set_union(policy,
+        hpx::set_union(policy,
             decorated_iterator(
                 std::begin(c1), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
@@ -215,7 +306,7 @@ void test_set_union_exception(ExPolicy policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_set_union_exception_async(ExPolicy p, IteratorTag)
+void test_set_union_exception_async(ExPolicy&& p, IteratorTag)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
@@ -236,7 +327,7 @@ void test_set_union_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::parallel::set_union(p,
+        hpx::future<void> f = hpx::set_union(p,
             decorated_iterator(
                 std::begin(c1), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
@@ -266,6 +357,8 @@ void test_set_union_exception()
 {
     using namespace hpx::execution;
 
+    test_set_union_exception(IteratorTag());
+
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
@@ -283,8 +376,45 @@ void set_union_exception_test()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_set_union_bad_alloc(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c1 = test::random_fill(10007);
+    std::vector<std::size_t> c2 = test::random_fill(c1.size());
+
+    std::sort(std::begin(c1), std::end(c1));
+    std::sort(std::begin(c2), std::end(c2));
+
+    std::vector<std::size_t> c3(2 * c1.size());
+
+    bool caught_bad_alloc = false;
+    try
+    {
+        hpx::set_union(decorated_iterator(
+                           std::begin(c1), []() { throw std::bad_alloc(); }),
+            decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
+            std::begin(c3));
+
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_bad_alloc = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
 template <typename ExPolicy, typename IteratorTag>
-void test_set_union_bad_alloc(ExPolicy policy, IteratorTag)
+void test_set_union_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
@@ -304,7 +434,7 @@ void test_set_union_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::set_union(policy,
+        hpx::set_union(policy,
             decorated_iterator(
                 std::begin(c1), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
@@ -325,7 +455,7 @@ void test_set_union_bad_alloc(ExPolicy policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_set_union_bad_alloc_async(ExPolicy p, IteratorTag)
+void test_set_union_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
@@ -346,7 +476,7 @@ void test_set_union_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::parallel::set_union(p,
+        hpx::future<void> f = hpx::set_union(p,
             decorated_iterator(
                 std::begin(c1), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
@@ -374,6 +504,8 @@ template <typename IteratorTag>
 void test_set_union_bad_alloc()
 {
     using namespace hpx::execution;
+
+    test_set_union_bad_alloc(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -62,6 +62,8 @@ set(tests
     searchn_range
     set_difference_range
     set_intersection_range
+    set_symmetric_difference_range
+    set_union_range
     sort_range
     stable_sort_range
     transform_range

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -59,6 +59,7 @@ set(tests
     rotate_copy_range
     search_range
     searchn_range
+    set_intersection_range
     sort_range
     stable_sort_range
     transform_range

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -60,6 +60,7 @@ set(tests
     rotate_copy_range
     search_range
     searchn_range
+    set_difference_range
     set_intersection_range
     sort_range
     stable_sort_range

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -30,6 +30,7 @@ set(tests
     foreach_range
     foreach_range_projection
     generate_range
+    includes_range
     inplace_merge_range
     is_heap_range
     is_heap_until_range

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/includes_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/includes_range.cpp
@@ -112,13 +112,19 @@ void test_includes1(ExPolicy&& policy, IteratorTag)
     }
 
     {
+        // make sure std::less is not violated by incrementing one of the
+        // elements
+        std::transform(std::begin(c1), std::end(c1), std::begin(c1),
+            [](std::size_t val) { return 2 * val; });
+
         std::vector<std::size_t> c2;
         std::copy(start_it, end_it, std::back_inserter(c2));
 
         if (!c2.empty())
         {
             std::uniform_int_distribution<> dis(0, c2.size() - 1);
-            ++c2[dis(gen)];    //-V104
+            auto index = dis(gen);
+            ++c2[index];    //-V104
 
             bool result =
                 hpx::ranges::includes(policy, iterator(std::begin(c1)),
@@ -165,6 +171,11 @@ void test_includes1_async(ExPolicy&& p, IteratorTag)
     }
 
     {
+        // make sure std::less is not violated by incrementing one of the
+        // elements
+        std::transform(std::begin(c1), std::end(c1), std::begin(c1),
+            [](std::size_t val) { return 2 * val; });
+
         std::vector<std::size_t> c2;
         std::copy(start_it, end_it, std::back_inserter(c2));
 
@@ -241,6 +252,11 @@ void test_includes2(IteratorTag)
     }
 
     {
+        // make sure std::less is not violated by incrementing one of the
+        // elements
+        std::transform(std::begin(c1), std::end(c1), std::begin(c1),
+            [](std::size_t val) { return 2 * val; });
+
         std::vector<std::size_t> c2;
         std::copy(start_it, end_it, std::back_inserter(c2));
 
@@ -298,6 +314,11 @@ void test_includes2(ExPolicy&& policy, IteratorTag)
     }
 
     {
+        // make sure std::less is not violated by incrementing one of the
+        // elements
+        std::transform(std::begin(c1), std::end(c1), std::begin(c1),
+            [](std::size_t val) { return 2 * val; });
+
         std::vector<std::size_t> c2;
         std::copy(start_it, end_it, std::back_inserter(c2));
 
@@ -353,6 +374,11 @@ void test_includes2_async(ExPolicy&& p, IteratorTag)
     }
 
     {
+        // make sure std::less is not violated by incrementing one of the
+        // elements
+        std::transform(std::begin(c1), std::end(c1), std::begin(c1),
+            [](std::size_t val) { return 2 * val; });
+
         std::vector<std::size_t> c2;
         std::copy(start_it, end_it, std::back_inserter(c2));
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/includes_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/includes_range.cpp
@@ -80,8 +80,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_includes1(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -282,8 +282,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_includes2(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -476,8 +476,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_includes_exception(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -653,8 +653,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_includes_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/includes_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/includes_range.cpp
@@ -79,8 +79,7 @@ void test_includes1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_includes1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -281,8 +280,7 @@ void test_includes2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_includes2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -475,8 +473,7 @@ void test_includes_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_includes_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -652,8 +649,7 @@ void test_includes_bad_alloc(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_includes_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/includes_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/includes_range.cpp
@@ -45,7 +45,7 @@ void test_includes1(IteratorTag)
     base_iterator end_it = std::next(std::begin(c1), end);
 
     {
-        bool result = hpx::includes(
+        bool result = hpx::ranges::includes(
             iterator(std::begin(c1)), iterator(std::end(c1)), start_it, end_it);
 
         bool expected =
@@ -64,7 +64,7 @@ void test_includes1(IteratorTag)
             std::uniform_int_distribution<> dis(0, c2.size() - 1);
             ++c2[dis(gen)];    //-V104
 
-            bool result = hpx::includes(iterator(std::begin(c1)),
+            bool result = hpx::ranges::includes(iterator(std::begin(c1)),
                 iterator(std::end(c1)), std::begin(c2), std::end(c2));
 
             bool expected = std::includes(
@@ -79,8 +79,9 @@ void test_includes1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_includes1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -100,7 +101,7 @@ void test_includes1(ExPolicy&& policy, IteratorTag)
     base_iterator end_it = std::next(std::begin(c1), end);
 
     {
-        bool result = hpx::includes(policy, iterator(std::begin(c1)),
+        bool result = hpx::ranges::includes(policy, iterator(std::begin(c1)),
             iterator(std::end(c1)), start_it, end_it);
 
         bool expected =
@@ -119,8 +120,9 @@ void test_includes1(ExPolicy&& policy, IteratorTag)
             std::uniform_int_distribution<> dis(0, c2.size() - 1);
             ++c2[dis(gen)];    //-V104
 
-            bool result = hpx::includes(policy, iterator(std::begin(c1)),
-                iterator(std::end(c1)), std::begin(c2), std::end(c2));
+            bool result =
+                hpx::ranges::includes(policy, iterator(std::begin(c1)),
+                    iterator(std::end(c1)), std::begin(c2), std::end(c2));
 
             bool expected = std::includes(
                 std::begin(c1), std::end(c1), std::begin(c2), std::end(c2));
@@ -151,8 +153,8 @@ void test_includes1_async(ExPolicy&& p, IteratorTag)
     base_iterator end_it = std::next(std::begin(c1), end);
 
     {
-        hpx::future<bool> result = hpx::includes(p, iterator(std::begin(c1)),
-            iterator(std::end(c1)), start_it, end_it);
+        hpx::future<bool> result = hpx::ranges::includes(p,
+            iterator(std::begin(c1)), iterator(std::end(c1)), start_it, end_it);
         result.wait();
 
         bool expected =
@@ -172,7 +174,7 @@ void test_includes1_async(ExPolicy&& p, IteratorTag)
             ++c2[dis(gen)];    //-V104
 
             hpx::future<bool> result =
-                hpx::includes(p, iterator(std::begin(c1)),
+                hpx::ranges::includes(p, iterator(std::begin(c1)),
                     iterator(std::end(c1)), std::begin(c2), std::end(c2));
             result.wait();
 
@@ -228,7 +230,7 @@ void test_includes2(IteratorTag)
     base_iterator end_it = std::next(std::begin(c1), end);
 
     {
-        bool result = hpx::includes(iterator(std::begin(c1)),
+        bool result = hpx::ranges::includes(iterator(std::begin(c1)),
             iterator(std::end(c1)), start_it, end_it, std::less<std::size_t>());
 
         bool expected = std::includes(std::begin(c1), std::end(c1), start_it,
@@ -247,9 +249,9 @@ void test_includes2(IteratorTag)
             std::uniform_int_distribution<> dis(0, c2.size() - 1);
             ++c2[dis(gen)];    //-V104
 
-            bool result =
-                hpx::includes(iterator(std::begin(c1)), iterator(std::end(c1)),
-                    std::begin(c2), std::end(c2), std::less<std::size_t>());
+            bool result = hpx::ranges::includes(iterator(std::begin(c1)),
+                iterator(std::end(c1)), std::begin(c2), std::end(c2),
+                std::less<std::size_t>());
 
             bool expected = std::includes(std::begin(c1), std::end(c1),
                 std::begin(c2), std::end(c2), std::less<std::size_t>());
@@ -263,8 +265,9 @@ void test_includes2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_includes2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -284,7 +287,7 @@ void test_includes2(ExPolicy&& policy, IteratorTag)
     base_iterator end_it = std::next(std::begin(c1), end);
 
     {
-        bool result = hpx::includes(policy, iterator(std::begin(c1)),
+        bool result = hpx::ranges::includes(policy, iterator(std::begin(c1)),
             iterator(std::end(c1)), start_it, end_it, std::less<std::size_t>());
 
         bool expected = std::includes(std::begin(c1), std::end(c1), start_it,
@@ -303,9 +306,9 @@ void test_includes2(ExPolicy&& policy, IteratorTag)
             std::uniform_int_distribution<> dis(0, c2.size() - 1);
             ++c2[dis(gen)];    //-V104
 
-            bool result = hpx::includes(policy, iterator(std::begin(c1)),
-                iterator(std::end(c1)), std::begin(c2), std::end(c2),
-                std::less<std::size_t>());
+            bool result = hpx::ranges::includes(policy,
+                iterator(std::begin(c1)), iterator(std::end(c1)),
+                std::begin(c2), std::end(c2), std::less<std::size_t>());
 
             bool expected = std::includes(std::begin(c1), std::end(c1),
                 std::begin(c2), std::end(c2), std::less<std::size_t>());
@@ -337,8 +340,9 @@ void test_includes2_async(ExPolicy&& p, IteratorTag)
     base_iterator end_it = std::next(std::begin(c1), end);
 
     {
-        hpx::future<bool> result = hpx::includes(p, iterator(std::begin(c1)),
-            iterator(std::end(c1)), start_it, end_it, std::less<std::size_t>());
+        hpx::future<bool> result = hpx::ranges::includes(p,
+            iterator(std::begin(c1)), iterator(std::end(c1)), start_it, end_it,
+            std::less<std::size_t>());
         result.wait();
 
         bool expected = std::includes(std::begin(c1), std::end(c1), start_it,
@@ -357,7 +361,7 @@ void test_includes2_async(ExPolicy&& p, IteratorTag)
             std::uniform_int_distribution<> dis(0, c2.size() - 1);
             ++c2[dis(gen)];    //-V104
 
-            hpx::future<bool> result = hpx::includes(p,
+            hpx::future<bool> result = hpx::ranges::includes(p,
                 iterator(std::begin(c1)), iterator(std::end(c1)),
                 std::begin(c2), std::end(c2), std::less<std::size_t>());
             result.wait();
@@ -421,7 +425,7 @@ void test_includes_exception(IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::includes(iterator(std::begin(c1)), iterator(std::end(c1)),
+        hpx::ranges::includes(iterator(std::begin(c1)), iterator(std::end(c1)),
             start_it, end_it, [](std::size_t v1, std::size_t v2) {
                 return throw std::runtime_error("test"), true;
             });
@@ -445,8 +449,9 @@ void test_includes_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_includes_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -473,8 +478,9 @@ void test_includes_exception(ExPolicy&& policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::includes(policy, iterator(std::begin(c1)), iterator(std::end(c1)),
-            start_it, end_it, [](std::size_t v1, std::size_t v2) {
+        hpx::ranges::includes(policy, iterator(std::begin(c1)),
+            iterator(std::end(c1)), start_it, end_it,
+            [](std::size_t v1, std::size_t v2) {
                 return throw std::runtime_error("test"), true;
             });
 
@@ -522,11 +528,11 @@ void test_includes_exception_async(ExPolicy&& p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<bool> f =
-            hpx::includes(p, iterator(std::begin(c1)), iterator(std::end(c1)),
-                start_it, end_it, [](std::size_t v1, std::size_t v2) {
-                    return throw std::runtime_error("test"), true;
-                });
+        hpx::future<bool> f = hpx::ranges::includes(p, iterator(std::begin(c1)),
+            iterator(std::end(c1)), start_it, end_it,
+            [](std::size_t v1, std::size_t v2) {
+                return throw std::runtime_error("test"), true;
+            });
         returned_from_algorithm = true;
         f.get();
 
@@ -598,7 +604,7 @@ void test_includes_bad_alloc(IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::includes(iterator(std::begin(c1)), iterator(std::end(c1)),
+        hpx::ranges::includes(iterator(std::begin(c1)), iterator(std::end(c1)),
             start_it, end_it, [](std::size_t v1, std::size_t v2) {
                 return throw std::bad_alloc(), true;
             });
@@ -620,8 +626,9 @@ void test_includes_bad_alloc(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_includes_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -648,8 +655,9 @@ void test_includes_bad_alloc(ExPolicy&& policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::includes(policy, iterator(std::begin(c1)), iterator(std::end(c1)),
-            start_it, end_it, [](std::size_t v1, std::size_t v2) {
+        hpx::ranges::includes(policy, iterator(std::begin(c1)),
+            iterator(std::end(c1)), start_it, end_it,
+            [](std::size_t v1, std::size_t v2) {
                 return throw std::bad_alloc(), true;
             });
 
@@ -696,11 +704,11 @@ void test_includes_bad_alloc_async(ExPolicy&& p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<bool> f =
-            hpx::includes(p, iterator(std::begin(c1)), iterator(std::end(c1)),
-                start_it, end_it, [](std::size_t v1, std::size_t v2) {
-                    return throw std::bad_alloc(), true;
-                });
+        hpx::future<bool> f = hpx::ranges::includes(p, iterator(std::begin(c1)),
+            iterator(std::end(c1)), start_it, end_it,
+            [](std::size_t v1, std::size_t v2) {
+                return throw std::bad_alloc(), true;
+            });
         returned_from_algorithm = true;
         f.get();
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/inplace_merge_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/inplace_merge_range.cpp
@@ -296,8 +296,7 @@ void test_inplace_merge_etc(IteratorTag, DataType, int rand_base)
 
         DataType val;
         hpx::ranges::inplace_merge(
-            iterator(res_first), iterator(res_middle),
-            iterator(res_last),
+            iterator(res_first), iterator(res_middle), iterator(res_last),
             [](DataType const& a, DataType const& b) -> bool { return a < b; },
             [&val](DataType const& elem) -> DataType& {
                 // This is projection.

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/inplace_merge_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/inplace_merge_range.cpp
@@ -296,7 +296,7 @@ void test_inplace_merge_etc(IteratorTag, DataType, int rand_base)
 
         DataType val;
         hpx::ranges::inplace_merge(
-            policy, iterator(res_first), iterator(res_middle),
+            iterator(res_first), iterator(res_middle),
             iterator(res_last),
             [](DataType const& a, DataType const& b) -> bool { return a < b; },
             [&val](DataType const& elem) -> DataType& {

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/inplace_merge_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/inplace_merge_range.cpp
@@ -168,8 +168,8 @@ void test_inplace_merge_stable(
 {
 #if defined(HPX_HAVE_STABLE_INPLACE_MERGE)
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::pair<DataType, int> ElemType;
     typedef typename std::vector<ElemType>::iterator base_iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/make_heap_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/make_heap_range.cpp
@@ -44,8 +44,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_make_heap1(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -118,8 +118,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_make_heap2(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -209,8 +209,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_make_heap_exception(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -333,8 +333,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_make_heap_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/make_heap_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/make_heap_range.cpp
@@ -43,8 +43,7 @@ void test_make_heap1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_make_heap1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -117,8 +116,7 @@ void test_make_heap2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_make_heap2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -208,8 +206,7 @@ void test_make_heap_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_make_heap_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -332,8 +329,7 @@ void test_make_heap_bad_alloc(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_make_heap_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/merge_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/merge_range.cpp
@@ -223,8 +223,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType>
 void test_merge_etc(ExPolicy&& policy, IteratorTag, DataType, int rand_base)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::vector<DataType>::iterator base_iterator;
 
@@ -327,8 +327,8 @@ template <typename ExPolicy, typename IteratorTag, typename DataType>
 void test_merge_stable(ExPolicy&& policy, IteratorTag, DataType, int rand_base)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef typename std::pair<DataType, int> ElemType;
     typedef typename std::vector<ElemType>::iterator base_iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/set_difference_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/set_difference_range.cpp
@@ -46,8 +46,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_difference1(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -149,8 +149,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_difference2(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -180,8 +180,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_difference2_async(ExPolicy&& p, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -274,8 +274,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_difference_exception(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -317,8 +317,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_difference_exception_async(ExPolicy&& p, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -426,8 +426,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_difference_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -468,8 +468,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_difference_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/set_difference_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/set_difference_range.cpp
@@ -45,8 +45,7 @@ void test_set_difference1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -148,8 +147,7 @@ void test_set_difference2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -179,8 +177,7 @@ void test_set_difference2(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference2_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -273,8 +270,7 @@ void test_set_difference_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -316,8 +312,7 @@ void test_set_difference_exception(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference_exception_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -425,8 +420,7 @@ void test_set_difference_bad_alloc(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -467,8 +461,7 @@ void test_set_difference_bad_alloc(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/set_difference_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/set_difference_range.cpp
@@ -32,8 +32,8 @@ void test_set_difference1(IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::set_difference(iterator(std::begin(c1)), iterator(std::end(c1)),
-        std::begin(c2), std::end(c2), std::begin(c3));
+    hpx::ranges::set_difference(iterator(std::begin(c1)),
+        iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(c3));
 
     std::set_difference(std::begin(c1), std::end(c1), std::begin(c2),
         std::end(c2), std::begin(c4));
@@ -45,8 +45,9 @@ void test_set_difference1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -59,7 +60,7 @@ void test_set_difference1(ExPolicy&& policy, IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::set_difference(policy, iterator(std::begin(c1)),
+    hpx::ranges::set_difference(policy, iterator(std::begin(c1)),
         iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(c3));
 
     std::set_difference(std::begin(c1), std::end(c1), std::begin(c2),
@@ -83,8 +84,9 @@ void test_set_difference1_async(ExPolicy&& p, IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::future<void> result = hpx::set_difference(p, iterator(std::begin(c1)),
-        iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(c3));
+    hpx::future<void> result = hpx::ranges::set_difference(p,
+        iterator(std::begin(c1)), iterator(std::end(c1)), std::begin(c2),
+        std::end(c2), std::begin(c3));
     result.wait();
 
     std::set_difference(std::begin(c1), std::end(c1), std::begin(c2),
@@ -132,8 +134,9 @@ void test_set_difference2(IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::set_difference(iterator(std::begin(c1)), iterator(std::end(c1)),
-        std::begin(c2), std::end(c2), std::begin(c3), comp);
+    hpx::ranges::set_difference(iterator(std::begin(c1)),
+        iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(c3),
+        comp);
 
     std::set_difference(std::begin(c1), std::end(c1), std::begin(c2),
         std::end(c2), std::begin(c4), comp);
@@ -145,8 +148,9 @@ void test_set_difference2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -161,7 +165,7 @@ void test_set_difference2(ExPolicy&& policy, IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::set_difference(policy, iterator(std::begin(c1)),
+    hpx::ranges::set_difference(policy, iterator(std::begin(c1)),
         iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(c3),
         comp);
 
@@ -175,8 +179,9 @@ void test_set_difference2(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference2_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -191,9 +196,9 @@ void test_set_difference2_async(ExPolicy&& p, IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::future<void> result =
-        hpx::set_difference(p, iterator(std::begin(c1)), iterator(std::end(c1)),
-            std::begin(c2), std::end(c2), std::begin(c3), comp);
+    hpx::future<void> result = hpx::ranges::set_difference(p,
+        iterator(std::begin(c1)), iterator(std::end(c1)), std::begin(c2),
+        std::end(c2), std::begin(c3), comp);
     result.wait();
 
     std::set_difference(std::begin(c1), std::end(c1), std::begin(c2),
@@ -243,8 +248,9 @@ void test_set_difference_exception(IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::set_difference(decorated_iterator(std::begin(c1),
-                                []() { throw std::runtime_error("test"); }),
+        hpx::ranges::set_difference(
+            decorated_iterator(
+                std::begin(c1), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
             std::begin(c3));
 
@@ -267,8 +273,9 @@ void test_set_difference_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -285,7 +292,7 @@ void test_set_difference_exception(ExPolicy&& policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::set_difference(policy,
+        hpx::ranges::set_difference(policy,
             decorated_iterator(
                 std::begin(c1), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
@@ -309,8 +316,9 @@ void test_set_difference_exception(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference_exception_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -328,7 +336,7 @@ void test_set_difference_exception_async(ExPolicy&& p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::set_difference(p,
+        hpx::future<void> f = hpx::ranges::set_difference(p,
             decorated_iterator(
                 std::begin(c1), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
@@ -395,8 +403,8 @@ void test_set_difference_bad_alloc(IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::set_difference(decorated_iterator(std::begin(c1),
-                                []() { throw std::bad_alloc(); }),
+        hpx::ranges::set_difference(decorated_iterator(std::begin(c1),
+                                        []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
             std::begin(c3));
 
@@ -417,8 +425,9 @@ void test_set_difference_bad_alloc(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -435,7 +444,7 @@ void test_set_difference_bad_alloc(ExPolicy&& policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::set_difference(policy,
+        hpx::ranges::set_difference(policy,
             decorated_iterator(
                 std::begin(c1), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
@@ -458,8 +467,9 @@ void test_set_difference_bad_alloc(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_difference_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -477,7 +487,7 @@ void test_set_difference_bad_alloc_async(ExPolicy&& p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::set_difference(p,
+        hpx::future<void> f = hpx::ranges::set_difference(p,
             decorated_iterator(
                 std::begin(c1), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/set_intersection_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/set_intersection_range.cpp
@@ -32,8 +32,8 @@ void test_set_intersection1(IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::set_intersection(iterator(std::begin(c1)), iterator(std::end(c1)),
-        std::begin(c2), std::end(c2), std::begin(c3));
+    hpx::ranges::set_intersection(iterator(std::begin(c1)),
+        iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(c3));
 
     std::set_intersection(std::begin(c1), std::end(c1), std::begin(c2),
         std::end(c2), std::begin(c4));
@@ -45,8 +45,9 @@ void test_set_intersection1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -59,7 +60,7 @@ void test_set_intersection1(ExPolicy&& policy, IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::set_intersection(policy, iterator(std::begin(c1)),
+    hpx::ranges::set_intersection(policy, iterator(std::begin(c1)),
         iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(c3));
 
     std::set_intersection(std::begin(c1), std::end(c1), std::begin(c2),
@@ -83,7 +84,7 @@ void test_set_intersection1_async(ExPolicy&& p, IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::future<void> result = hpx::set_intersection(p,
+    hpx::future<void> result = hpx::ranges::set_intersection(p,
         iterator(std::begin(c1)), iterator(std::end(c1)), std::begin(c2),
         std::end(c2), std::begin(c3));
     result.wait();
@@ -133,8 +134,9 @@ void test_set_intersection2(IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::set_intersection(iterator(std::begin(c1)), iterator(std::end(c1)),
-        std::begin(c2), std::end(c2), std::begin(c3), comp);
+    hpx::ranges::set_intersection(iterator(std::begin(c1)),
+        iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(c3),
+        comp);
 
     std::set_intersection(std::begin(c1), std::end(c1), std::begin(c2),
         std::end(c2), std::begin(c4), comp);
@@ -146,8 +148,9 @@ void test_set_intersection2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -162,7 +165,7 @@ void test_set_intersection2(ExPolicy&& policy, IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::set_intersection(policy, iterator(std::begin(c1)),
+    hpx::ranges::set_intersection(policy, iterator(std::begin(c1)),
         iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(c3),
         comp);
 
@@ -176,8 +179,9 @@ void test_set_intersection2(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection2_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -192,7 +196,7 @@ void test_set_intersection2_async(ExPolicy&& p, IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::future<void> result = hpx::set_intersection(p,
+    hpx::future<void> result = hpx::ranges::set_intersection(p,
         iterator(std::begin(c1)), iterator(std::end(c1)), std::begin(c2),
         std::end(c2), std::begin(c3), comp);
     result.wait();
@@ -244,8 +248,9 @@ void test_set_intersection_exception(IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::set_intersection(decorated_iterator(std::begin(c1),
-                                  []() { throw std::runtime_error("test"); }),
+        hpx::ranges::set_intersection(
+            decorated_iterator(
+                std::begin(c1), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
             std::begin(c3));
 
@@ -268,8 +273,9 @@ void test_set_intersection_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -286,7 +292,7 @@ void test_set_intersection_exception(ExPolicy&& policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::set_intersection(policy,
+        hpx::ranges::set_intersection(policy,
             decorated_iterator(
                 std::begin(c1), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
@@ -310,8 +316,9 @@ void test_set_intersection_exception(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection_exception_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -329,7 +336,7 @@ void test_set_intersection_exception_async(ExPolicy&& p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::set_intersection(p,
+        hpx::future<void> f = hpx::ranges::set_intersection(p,
             decorated_iterator(
                 std::begin(c1), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
@@ -396,8 +403,8 @@ void test_set_intersection_bad_alloc(IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::set_intersection(decorated_iterator(std::begin(c1),
-                                  []() { throw std::bad_alloc(); }),
+        hpx::ranges::set_intersection(decorated_iterator(std::begin(c1),
+                                          []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
             std::begin(c3));
 
@@ -418,8 +425,9 @@ void test_set_intersection_bad_alloc(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -436,7 +444,7 @@ void test_set_intersection_bad_alloc(ExPolicy&& policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::set_intersection(policy,
+        hpx::ranges::set_intersection(policy,
             decorated_iterator(
                 std::begin(c1), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
@@ -459,8 +467,9 @@ void test_set_intersection_bad_alloc(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -478,7 +487,7 @@ void test_set_intersection_bad_alloc_async(ExPolicy&& p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::set_intersection(p,
+        hpx::future<void> f = hpx::ranges::set_intersection(p,
             decorated_iterator(
                 std::begin(c1), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/set_intersection_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/set_intersection_range.cpp
@@ -45,8 +45,7 @@ void test_set_intersection1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -148,8 +147,7 @@ void test_set_intersection2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -179,8 +177,7 @@ void test_set_intersection2(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection2_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -273,8 +270,7 @@ void test_set_intersection_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -316,8 +312,7 @@ void test_set_intersection_exception(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection_exception_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -425,8 +420,7 @@ void test_set_intersection_bad_alloc(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -467,8 +461,7 @@ void test_set_intersection_bad_alloc(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/set_intersection_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/set_intersection_range.cpp
@@ -46,8 +46,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection1(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -149,8 +149,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection2(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -180,8 +180,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection2_async(ExPolicy&& p, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -274,8 +274,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection_exception(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -317,8 +317,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection_exception_async(ExPolicy&& p, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -426,8 +426,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -468,8 +468,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_intersection_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/set_symmetric_difference_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/set_symmetric_difference_range.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015-2107 Hartmut Kaiser
+//  Copyright (c) 2015-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -32,7 +32,7 @@ void test_set_symmetric_difference1(IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::set_symmetric_difference(iterator(std::begin(c1)),
+    hpx::ranges::set_symmetric_difference(iterator(std::begin(c1)),
         iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(c3));
 
     std::set_symmetric_difference(std::begin(c1), std::end(c1), std::begin(c2),
@@ -45,8 +45,9 @@ void test_set_symmetric_difference1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -59,7 +60,7 @@ void test_set_symmetric_difference1(ExPolicy&& policy, IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::set_symmetric_difference(policy, iterator(std::begin(c1)),
+    hpx::ranges::set_symmetric_difference(policy, iterator(std::begin(c1)),
         iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(c3));
 
     std::set_symmetric_difference(std::begin(c1), std::end(c1), std::begin(c2),
@@ -83,7 +84,7 @@ void test_set_symmetric_difference1_async(ExPolicy&& p, IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::future<void> result = hpx::set_symmetric_difference(p,
+    hpx::future<void> result = hpx::ranges::set_symmetric_difference(p,
         iterator(std::begin(c1)), iterator(std::end(c1)), std::begin(c2),
         std::end(c2), std::begin(c3));
     result.wait();
@@ -133,7 +134,7 @@ void test_set_symmetric_difference2(IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::set_symmetric_difference(iterator(std::begin(c1)),
+    hpx::ranges::set_symmetric_difference(iterator(std::begin(c1)),
         iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(c3),
         comp);
 
@@ -147,8 +148,9 @@ void test_set_symmetric_difference2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -163,7 +165,7 @@ void test_set_symmetric_difference2(ExPolicy&& policy, IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::set_symmetric_difference(policy, iterator(std::begin(c1)),
+    hpx::ranges::set_symmetric_difference(policy, iterator(std::begin(c1)),
         iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(c3),
         comp);
 
@@ -177,8 +179,9 @@ void test_set_symmetric_difference2(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference2_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -193,7 +196,7 @@ void test_set_symmetric_difference2_async(ExPolicy&& p, IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::future<void> result = hpx::set_symmetric_difference(p,
+    hpx::future<void> result = hpx::ranges::set_symmetric_difference(p,
         iterator(std::begin(c1)), iterator(std::end(c1)), std::begin(c2),
         std::end(c2), std::begin(c3), comp);
     result.wait();
@@ -245,7 +248,7 @@ void test_set_symmetric_difference_exception(IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::set_symmetric_difference(
+        hpx::ranges::set_symmetric_difference(
             decorated_iterator(
                 std::begin(c1), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
@@ -270,8 +273,9 @@ void test_set_symmetric_difference_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -288,7 +292,7 @@ void test_set_symmetric_difference_exception(ExPolicy&& policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::set_symmetric_difference(policy,
+        hpx::ranges::set_symmetric_difference(policy,
             decorated_iterator(
                 std::begin(c1), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
@@ -312,8 +316,9 @@ void test_set_symmetric_difference_exception(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference_exception_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -331,7 +336,7 @@ void test_set_symmetric_difference_exception_async(ExPolicy&& p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::set_symmetric_difference(p,
+        hpx::future<void> f = hpx::ranges::set_symmetric_difference(p,
             decorated_iterator(
                 std::begin(c1), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
@@ -398,8 +403,9 @@ void test_set_symmetric_difference_bad_alloc(IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::set_symmetric_difference(decorated_iterator(std::begin(c1),
-                                          []() { throw std::bad_alloc(); }),
+        hpx::ranges::set_symmetric_difference(
+            decorated_iterator(
+                std::begin(c1), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
             std::begin(c3));
 
@@ -420,8 +426,9 @@ void test_set_symmetric_difference_bad_alloc(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -438,7 +445,7 @@ void test_set_symmetric_difference_bad_alloc(ExPolicy&& policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::set_symmetric_difference(policy,
+        hpx::ranges::set_symmetric_difference(policy,
             decorated_iterator(
                 std::begin(c1), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
@@ -461,8 +468,9 @@ void test_set_symmetric_difference_bad_alloc(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -480,7 +488,7 @@ void test_set_symmetric_difference_bad_alloc_async(ExPolicy&& p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::set_symmetric_difference(p,
+        hpx::future<void> f = hpx::ranges::set_symmetric_difference(p,
             decorated_iterator(
                 std::begin(c1), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/set_symmetric_difference_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/set_symmetric_difference_range.cpp
@@ -45,8 +45,7 @@ void test_set_symmetric_difference1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -148,8 +147,7 @@ void test_set_symmetric_difference2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -179,8 +177,7 @@ void test_set_symmetric_difference2(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference2_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -273,8 +270,7 @@ void test_set_symmetric_difference_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -316,8 +312,7 @@ void test_set_symmetric_difference_exception(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference_exception_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -426,8 +421,7 @@ void test_set_symmetric_difference_bad_alloc(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -468,8 +462,7 @@ void test_set_symmetric_difference_bad_alloc(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/set_symmetric_difference_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/set_symmetric_difference_range.cpp
@@ -46,8 +46,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference1(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -149,8 +149,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference2(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -180,8 +180,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference2_async(ExPolicy&& p, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -274,8 +274,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference_exception(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -317,8 +317,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference_exception_async(ExPolicy&& p, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -427,8 +427,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -469,8 +469,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_symmetric_difference_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/set_union_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/set_union_range.cpp
@@ -45,8 +45,7 @@ void test_set_union1(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -147,8 +146,7 @@ void test_set_union2(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -178,8 +176,7 @@ void test_set_union2(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union2_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -271,8 +268,7 @@ void test_set_union_exception(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -314,8 +310,7 @@ void test_set_union_exception(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union_exception_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -423,8 +418,7 @@ void test_set_union_bad_alloc(IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
@@ -465,8 +459,7 @@ void test_set_union_bad_alloc(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_set_union_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(
-        hpx::is_execution_policy<ExPolicy>::value,
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/set_union_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/set_union_range.cpp
@@ -46,8 +46,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_union1(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -148,8 +148,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_union2(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -179,8 +179,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_union2_async(ExPolicy&& p, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -272,8 +272,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_union_exception(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -315,8 +315,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_union_exception_async(ExPolicy&& p, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -424,8 +424,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_union_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -466,8 +466,8 @@ template <typename ExPolicy, typename IteratorTag>
 void test_set_union_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     static_assert(
-        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
-        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
+        hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/set_union_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/set_union_range.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015-2107 Hartmut Kaiser
+//  Copyright (c) 2015-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -19,7 +19,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
-void test_set_symmetric_difference1(IteratorTag)
+void test_set_union1(IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -32,21 +32,22 @@ void test_set_symmetric_difference1(IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::set_symmetric_difference(iterator(std::begin(c1)),
-        iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(c3));
+    hpx::ranges::set_union(iterator(std::begin(c1)), iterator(std::end(c1)),
+        std::begin(c2), std::end(c2), std::begin(c3));
 
-    std::set_symmetric_difference(std::begin(c1), std::end(c1), std::begin(c2),
-        std::end(c2), std::begin(c4));
+    std::set_union(std::begin(c1), std::end(c1), std::begin(c2), std::end(c2),
+        std::begin(c4));
 
     // verify values
     HPX_TEST(std::equal(std::begin(c3), std::end(c3), std::begin(c4)));
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_set_symmetric_difference1(ExPolicy&& policy, IteratorTag)
+void test_set_union1(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -59,18 +60,18 @@ void test_set_symmetric_difference1(ExPolicy&& policy, IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::set_symmetric_difference(policy, iterator(std::begin(c1)),
+    hpx::ranges::set_union(policy, iterator(std::begin(c1)),
         iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(c3));
 
-    std::set_symmetric_difference(std::begin(c1), std::end(c1), std::begin(c2),
-        std::end(c2), std::begin(c4));
+    std::set_union(std::begin(c1), std::end(c1), std::begin(c2), std::end(c2),
+        std::begin(c4));
 
     // verify values
     HPX_TEST(std::equal(std::begin(c3), std::end(c3), std::begin(c4)));
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_set_symmetric_difference1_async(ExPolicy&& p, IteratorTag)
+void test_set_union1_async(ExPolicy&& p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -83,42 +84,42 @@ void test_set_symmetric_difference1_async(ExPolicy&& p, IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::future<void> result = hpx::set_symmetric_difference(p,
+    hpx::future<void> result = hpx::ranges::set_union(p,
         iterator(std::begin(c1)), iterator(std::end(c1)), std::begin(c2),
         std::end(c2), std::begin(c3));
     result.wait();
 
-    std::set_symmetric_difference(std::begin(c1), std::end(c1), std::begin(c2),
-        std::end(c2), std::begin(c4));
+    std::set_union(std::begin(c1), std::end(c1), std::begin(c2), std::end(c2),
+        std::begin(c4));
 
     // verify values
     HPX_TEST(std::equal(std::begin(c3), std::end(c3), std::begin(c4)));
 }
 
 template <typename IteratorTag>
-void test_set_symmetric_difference1()
+void test_set_union1()
 {
     using namespace hpx::execution;
 
-    test_set_symmetric_difference1(IteratorTag());
+    test_set_union1(IteratorTag());
 
-    test_set_symmetric_difference1(seq, IteratorTag());
-    test_set_symmetric_difference1(par, IteratorTag());
-    test_set_symmetric_difference1(par_unseq, IteratorTag());
+    test_set_union1(seq, IteratorTag());
+    test_set_union1(par, IteratorTag());
+    test_set_union1(par_unseq, IteratorTag());
 
-    test_set_symmetric_difference1_async(seq(task), IteratorTag());
-    test_set_symmetric_difference1_async(par(task), IteratorTag());
+    test_set_union1_async(seq(task), IteratorTag());
+    test_set_union1_async(par(task), IteratorTag());
 }
 
-void set_symmetric_difference_test1()
+void set_union_test1()
 {
-    test_set_symmetric_difference1<std::random_access_iterator_tag>();
-    test_set_symmetric_difference1<std::forward_iterator_tag>();
+    test_set_union1<std::random_access_iterator_tag>();
+    test_set_union1<std::forward_iterator_tag>();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
-void test_set_symmetric_difference2(IteratorTag)
+void test_set_union2(IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -133,22 +134,22 @@ void test_set_symmetric_difference2(IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::set_symmetric_difference(iterator(std::begin(c1)),
-        iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(c3),
-        comp);
+    hpx::ranges::set_union(iterator(std::begin(c1)), iterator(std::end(c1)),
+        std::begin(c2), std::end(c2), std::begin(c3), comp);
 
-    std::set_symmetric_difference(std::begin(c1), std::end(c1), std::begin(c2),
-        std::end(c2), std::begin(c4), comp);
+    std::set_union(std::begin(c1), std::end(c1), std::begin(c2), std::end(c2),
+        std::begin(c4), comp);
 
     // verify values
     HPX_TEST(std::equal(std::begin(c3), std::end(c3), std::begin(c4)));
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_set_symmetric_difference2(ExPolicy&& policy, IteratorTag)
+void test_set_union2(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -163,22 +164,23 @@ void test_set_symmetric_difference2(ExPolicy&& policy, IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::set_symmetric_difference(policy, iterator(std::begin(c1)),
+    hpx::ranges::set_union(policy, iterator(std::begin(c1)),
         iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(c3),
         comp);
 
-    std::set_symmetric_difference(std::begin(c1), std::end(c1), std::begin(c2),
-        std::end(c2), std::begin(c4), comp);
+    std::set_union(std::begin(c1), std::end(c1), std::begin(c2), std::end(c2),
+        std::begin(c4), comp);
 
     // verify values
     HPX_TEST(std::equal(std::begin(c3), std::end(c3), std::begin(c4)));
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_set_symmetric_difference2_async(ExPolicy&& p, IteratorTag)
+void test_set_union2_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
@@ -193,42 +195,42 @@ void test_set_symmetric_difference2_async(ExPolicy&& p, IteratorTag)
 
     std::vector<std::size_t> c3(2 * c1.size()), c4(2 * c1.size());    //-V656
 
-    hpx::future<void> result = hpx::set_symmetric_difference(p,
+    hpx::future<void> result = hpx::ranges::set_union(p,
         iterator(std::begin(c1)), iterator(std::end(c1)), std::begin(c2),
         std::end(c2), std::begin(c3), comp);
     result.wait();
 
-    std::set_symmetric_difference(std::begin(c1), std::end(c1), std::begin(c2),
-        std::end(c2), std::begin(c4), comp);
+    std::set_union(std::begin(c1), std::end(c1), std::begin(c2), std::end(c2),
+        std::begin(c4), comp);
 
     // verify values
     HPX_TEST(std::equal(std::begin(c3), std::end(c3), std::begin(c4)));
 }
 
 template <typename IteratorTag>
-void test_set_symmetric_difference2()
+void test_set_union2()
 {
     using namespace hpx::execution;
 
-    test_set_symmetric_difference2(IteratorTag());
+    test_set_union2(IteratorTag());
 
-    test_set_symmetric_difference2(seq, IteratorTag());
-    test_set_symmetric_difference2(par, IteratorTag());
-    test_set_symmetric_difference2(par_unseq, IteratorTag());
+    test_set_union2(seq, IteratorTag());
+    test_set_union2(par, IteratorTag());
+    test_set_union2(par_unseq, IteratorTag());
 
-    test_set_symmetric_difference2_async(seq(task), IteratorTag());
-    test_set_symmetric_difference2_async(par(task), IteratorTag());
+    test_set_union2_async(seq(task), IteratorTag());
+    test_set_union2_async(par(task), IteratorTag());
 }
 
-void set_symmetric_difference_test2()
+void set_union_test2()
 {
-    test_set_symmetric_difference2<std::random_access_iterator_tag>();
-    test_set_symmetric_difference2<std::forward_iterator_tag>();
+    test_set_union2<std::random_access_iterator_tag>();
+    test_set_union2<std::forward_iterator_tag>();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
-void test_set_symmetric_difference_exception(IteratorTag)
+void test_set_union_exception(IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -245,9 +247,8 @@ void test_set_symmetric_difference_exception(IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::set_symmetric_difference(
-            decorated_iterator(
-                std::begin(c1), []() { throw std::runtime_error("test"); }),
+        hpx::ranges::set_union(decorated_iterator(std::begin(c1),
+                                   []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
             std::begin(c3));
 
@@ -268,10 +269,11 @@ void test_set_symmetric_difference_exception(IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_set_symmetric_difference_exception(ExPolicy&& policy, IteratorTag)
+void test_set_union_exception(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -288,7 +290,7 @@ void test_set_symmetric_difference_exception(ExPolicy&& policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::set_symmetric_difference(policy,
+        hpx::ranges::set_union(policy,
             decorated_iterator(
                 std::begin(c1), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
@@ -310,10 +312,11 @@ void test_set_symmetric_difference_exception(ExPolicy&& policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_set_symmetric_difference_exception_async(ExPolicy&& p, IteratorTag)
+void test_set_union_exception_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -331,7 +334,7 @@ void test_set_symmetric_difference_exception_async(ExPolicy&& p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::set_symmetric_difference(p,
+        hpx::future<void> f = hpx::ranges::set_union(p,
             decorated_iterator(
                 std::begin(c1), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
@@ -357,31 +360,31 @@ void test_set_symmetric_difference_exception_async(ExPolicy&& p, IteratorTag)
 }
 
 template <typename IteratorTag>
-void test_set_symmetric_difference_exception()
+void test_set_union_exception()
 {
     using namespace hpx::execution;
 
-    test_set_symmetric_difference_exception(IteratorTag());
+    test_set_union_exception(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_set_symmetric_difference_exception(seq, IteratorTag());
-    test_set_symmetric_difference_exception(par, IteratorTag());
+    test_set_union_exception(seq, IteratorTag());
+    test_set_union_exception(par, IteratorTag());
 
-    test_set_symmetric_difference_exception_async(seq(task), IteratorTag());
-    test_set_symmetric_difference_exception_async(par(task), IteratorTag());
+    test_set_union_exception_async(seq(task), IteratorTag());
+    test_set_union_exception_async(par(task), IteratorTag());
 }
 
-void set_symmetric_difference_exception_test()
+void set_union_exception_test()
 {
-    test_set_symmetric_difference_exception<std::random_access_iterator_tag>();
-    test_set_symmetric_difference_exception<std::forward_iterator_tag>();
+    test_set_union_exception<std::random_access_iterator_tag>();
+    test_set_union_exception<std::forward_iterator_tag>();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
-void test_set_symmetric_difference_bad_alloc(IteratorTag)
+void test_set_union_bad_alloc(IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -398,8 +401,8 @@ void test_set_symmetric_difference_bad_alloc(IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::set_symmetric_difference(decorated_iterator(std::begin(c1),
-                                          []() { throw std::bad_alloc(); }),
+        hpx::ranges::set_union(decorated_iterator(std::begin(c1),
+                                   []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
             std::begin(c3));
 
@@ -418,10 +421,11 @@ void test_set_symmetric_difference_bad_alloc(IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_set_symmetric_difference_bad_alloc(ExPolicy&& policy, IteratorTag)
+void test_set_union_bad_alloc(ExPolicy&& policy, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -438,7 +442,7 @@ void test_set_symmetric_difference_bad_alloc(ExPolicy&& policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::set_symmetric_difference(policy,
+        hpx::ranges::set_union(policy,
             decorated_iterator(
                 std::begin(c1), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
@@ -459,10 +463,11 @@ void test_set_symmetric_difference_bad_alloc(ExPolicy&& policy, IteratorTag)
 }
 
 template <typename ExPolicy, typename IteratorTag>
-void test_set_symmetric_difference_bad_alloc_async(ExPolicy&& p, IteratorTag)
+void test_set_union_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
+    static_assert(
+        hpx::parallel::execution::is_execution_policy<ExPolicy>::value,
+        "hpx::parallel::execution::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
@@ -480,7 +485,7 @@ void test_set_symmetric_difference_bad_alloc_async(ExPolicy&& p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::set_symmetric_difference(p,
+        hpx::future<void> f = hpx::ranges::set_union(p,
             decorated_iterator(
                 std::begin(c1), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c1)), std::begin(c2), std::end(c2),
@@ -505,26 +510,26 @@ void test_set_symmetric_difference_bad_alloc_async(ExPolicy&& p, IteratorTag)
 }
 
 template <typename IteratorTag>
-void test_set_symmetric_difference_bad_alloc()
+void test_set_union_bad_alloc()
 {
     using namespace hpx::execution;
 
-    test_set_symmetric_difference_bad_alloc(IteratorTag());
+    test_set_union_bad_alloc(IteratorTag());
 
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
-    test_set_symmetric_difference_bad_alloc(seq, IteratorTag());
-    test_set_symmetric_difference_bad_alloc(par, IteratorTag());
+    test_set_union_bad_alloc(seq, IteratorTag());
+    test_set_union_bad_alloc(par, IteratorTag());
 
-    test_set_symmetric_difference_bad_alloc_async(seq(task), IteratorTag());
-    test_set_symmetric_difference_bad_alloc_async(par(task), IteratorTag());
+    test_set_union_bad_alloc_async(seq(task), IteratorTag());
+    test_set_union_bad_alloc_async(par(task), IteratorTag());
 }
 
-void set_symmetric_difference_bad_alloc_test()
+void set_union_bad_alloc_test()
 {
-    test_set_symmetric_difference_bad_alloc<std::random_access_iterator_tag>();
-    test_set_symmetric_difference_bad_alloc<std::forward_iterator_tag>();
+    test_set_union_bad_alloc<std::random_access_iterator_tag>();
+    test_set_union_bad_alloc<std::forward_iterator_tag>();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -537,10 +542,10 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::cout << "using seed: " << seed << std::endl;
     std::srand(seed);
 
-    set_symmetric_difference_test1();
-    set_symmetric_difference_test2();
-    set_symmetric_difference_exception_test();
-    set_symmetric_difference_bad_alloc_test();
+    set_union_test1();
+    set_union_test2();
+    set_union_exception_test();
+    set_union_bad_alloc_test();
     return hpx::finalize();
 }
 


### PR DESCRIPTION
This PR make sure the following algorithms conform to C++20

- [x] `set_intersection`
- [x] `set_difference`
- [x] `set_symmetric_difference`
- [x] `set_union`
- [x] `includes`
- [x] `merge`
- [x] `inplace_merge`
