### PR TITLE
Removing use of get_temporary_buffer and return_temporary_buffer

### DIFF
--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/parallel_stable_sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/parallel_stable_sort.hpp
@@ -17,6 +17,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <functional>
 #include <iterator>
 #include <list>
@@ -56,7 +57,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         {
             if (ptr != nullptr)
             {
-                std::return_temporary_buffer(ptr);
+                std::free(ptr);
             }
         }
     };    // end struct parallel_stable_sort
@@ -101,7 +102,10 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                 return last;
             }
 
-            ptr = std::get_temporary_buffer<value_type>(nptr).first;
+            // leave memory uninitialized, sample_sort will manage construction
+            // etc.
+            ptr = static_cast<value_type*>(
+                std::malloc(sizeof(value_type) * nptr));
             if (ptr == nullptr)
             {
                 throw std::bad_alloc();

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/sample_sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/sample_sort.hpp
@@ -22,6 +22,7 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <functional>
 #include <iterator>
 #include <memory>
@@ -199,14 +200,15 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         }
         else
         {
-            value_type* ptr =
-                std::get_temporary_buffer<value_type>(nelem).first;
+            // acquire uninitialized memory
+            value_type* ptr = static_cast<value_type*>(
+                std::malloc(sizeof(value_type) * nelem));
             if (ptr == nullptr)
             {
                 throw std::bad_alloc();
             }
-            owner = true;
             global_buf = range_buf(ptr, ptr + nelem);
+            owner = true;
         }
 
         // processing
@@ -226,9 +228,9 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             construct = false;
         }
 
-        if (global_buf.begin() != nullptr && owner)
+        if (owner)
         {
-            std::return_temporary_buffer(global_buf.begin());
+            std::free(global_buf.begin());
         }
     }
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/spin_sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/spin_sort.hpp
@@ -124,9 +124,9 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                 construct = false;
             }
 
-            if (owner && ptr != nullptr)
+            if (owner)
             {
-                std::return_temporary_buffer(ptr);
+                std::free(ptr);
             }
         }
     };    // End of class spin_sort_helper
@@ -163,7 +163,9 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
         if (ptr == nullptr)
         {
-            ptr = std::get_temporary_buffer<value_type>(nptr).first;
+            // acquire uninitialized memory
+            ptr = static_cast<value_type*>(
+                std::malloc(nptr * sizeof(value_type)));
             if (ptr == nullptr)
             {
                 throw std::bad_alloc();
@@ -171,7 +173,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             owner = true;
         }
 
-        range_buf rng_buf(ptr, (ptr + nptr));
+        range_buf rng_buf(ptr, ptr + nptr);
 
         std::uint32_t nlevel =
             util::nbits64(((nelem + sort_min - 1) / sort_min) - 1) - 1;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_sample_sort.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_sample_sort.cpp
@@ -138,15 +138,23 @@ void test5()
         K.push_back(my_rand());
     M = K;
 
-    std::uint64_t* Ptr = std::get_temporary_buffer<std::uint64_t>(KMax).first;
+    // sample_sort assumes that the memory is uninitialized
+    std::uint64_t* Ptr =
+        static_cast<std::uint64_t*>(std::malloc(sizeof(std::uint64_t) * KMax));
     if (Ptr == nullptr)
         throw std::bad_alloc();
-    range<std::uint64_t*> Rbuf(Ptr, Ptr + KMax);
-
-    sample_sort(parallel_executor{}, K.begin(), K.end(), comp,
-        hpx::threads::hardware_concurrency(), Rbuf);
-
-    std::return_temporary_buffer(Ptr);
+    try
+    {
+        range<std::uint64_t*> Rbuf(Ptr, Ptr + KMax);
+        sample_sort(parallel_executor{}, K.begin(), K.end(), comp,
+            hpx::threads::hardware_concurrency(), Rbuf);
+    }
+    catch (...)
+    {
+        std::free(Ptr);
+        throw;
+    }
+    std::free(Ptr);
 
     std::stable_sort(M.begin(), M.end(), comp);
     for (unsigned i = 0; i < KMax; i++)

--- a/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_spin_sort.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_spin_sort.cpp
@@ -168,15 +168,22 @@ void test5()
         K.push_back(my_rand());
     M = K;
 
-    std::uint64_t* Ptr =
-        std::get_temporary_buffer<std::uint64_t>(KMax >> 1).first;
+    // spin_sort assumes that the memory is uninitialized
+    std::uint64_t* Ptr = static_cast<std::uint64_t*>(
+        std::malloc(sizeof(std::uint64_t) * (KMax >> 1)));
     if (Ptr == nullptr)
         throw std::bad_alloc();
-    range<std::uint64_t*> Rbuf(Ptr, Ptr + (KMax >> 1));
-
-    spin_sort(K.begin(), K.end(), comp, Rbuf);
-
-    std::return_temporary_buffer(Ptr);
+    try
+    {
+        range<std::uint64_t*> Rbuf(Ptr, Ptr + (KMax >> 1));
+        spin_sort(K.begin(), K.end(), comp, Rbuf);
+    }
+    catch (...)
+    {
+        std::free(Ptr);
+        throw;
+    }
+    std::free(Ptr);
 
     std::stable_sort(M.begin(), M.end(), comp);
     for (unsigned i = 0; i < KMax; i++)


### PR DESCRIPTION
- these functions have been deprecated in C++17 and removed in C++20

Fixes #4971