### PR TITLE
Remove leftover format export hack

### DIFF
--- a/libs/core/format/include/hpx/modules/format.hpp
+++ b/libs/core/format/include/hpx/modules/format.hpp
@@ -253,16 +253,11 @@ namespace hpx { namespace util {
         };
 
         ///////////////////////////////////////////////////////////////////////
-        // Use dedicated macro so it may be overridden
-#if !defined(HPX_FORMAT_EXPORT)
-#define HPX_FORMAT_EXPORT HPX_CORE_EXPORT
-#endif
-
-        HPX_FORMAT_EXPORT void format_to(std::ostream& os,
+        HPX_CORE_EXPORT void format_to(std::ostream& os,
             boost::string_ref format_str, format_arg const* args,
             std::size_t count);
 
-        HPX_FORMAT_EXPORT std::string format(boost::string_ref format_str,
+        HPX_CORE_EXPORT std::string format(boost::string_ref format_str,
             format_arg const* args, std::size_t count);
     }    // namespace detail
 


### PR DESCRIPTION
Before there was a format module, this hack was necessary to have performance tests not depend on all of HPX. The hack was dropped once format became a module. The format export macro is a left-over.