### PR TITLE
Cleaning up debug::print functionalities

### DIFF
--- a/libs/core/debugging/CMakeLists.txt
+++ b/libs/core/debugging/CMakeLists.txt
@@ -17,7 +17,7 @@ set(debugging_compat_headers
     hpx/util/debug/demangle_helper.hpp
 )
 
-set(debugging_sources attach_debugger.cpp backtrace.cpp)
+set(debugging_sources attach_debugger.cpp backtrace.cpp print.cpp)
 
 include(HPX_AddModule)
 add_hpx_module(

--- a/libs/core/debugging/include/hpx/debugging/print.hpp
+++ b/libs/core/debugging/include/hpx/debugging/print.hpp
@@ -9,34 +9,16 @@
 #include <hpx/config.hpp>
 
 #include <array>
-#include <bitset>
 #include <chrono>
-#include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
-#include <iomanip>
 #include <iostream>
-#include <iterator>
 #include <sstream>
 #include <string>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
-
-#if defined(__linux) || defined(linux) || defined(__linux__)
-#include <sys/mman.h>
-#include <unistd.h>
-#elif defined(__APPLE__)
-#include <crt_externs.h>
-#include <unistd.h>
-#define environ (*_NSGetEnviron())
-#elif defined(HPX_WINDOWS)
-#include <winsock2.h>
-#define environ _environ
-#else
-extern char** environ;
-#endif
 
 // ------------------------------------------------------------
 // This file provides a simple to use printf style debugging
@@ -84,10 +66,13 @@ namespace hpx { namespace debug {
     // ------------------------------------------------------------------
     namespace detail {
 
+        template <typename Int>
+        HPX_CORE_EXPORT void print_dec(std::ostream& os, Int const& v, int n);
+
         template <int N, typename T>
         struct dec
         {
-            dec(T const& v)
+            constexpr dec(T const& v)
               : data_(v)
             {
             }
@@ -97,15 +82,14 @@ namespace hpx { namespace debug {
             friend std::ostream& operator<<(
                 std::ostream& os, dec<N, T> const& d)
             {
-                os << std::right << std::setfill('0') << std::setw(N)
-                   << std::noshowbase << std::dec << d.data_;
+                detail::print_dec(os, d.data_, N);
                 return os;
             }
         };
     }    // namespace detail
 
     template <int N = 2, typename T>
-    detail::dec<N, T> dec(T const& v)
+    constexpr detail::dec<N, T> dec(T const& v)
     {
         return detail::dec<N, T>(v);
     }
@@ -115,26 +99,22 @@ namespace hpx { namespace debug {
     // ------------------------------------------------------------------
     struct ptr
     {
-        ptr(void const* v)
-          : data_(v)
-        {
-        }
-        ptr(std::uintptr_t const v)
-          : data_(reinterpret_cast<void const*>(v))
-        {
-        }
+        HPX_CORE_EXPORT ptr(void const* v);
+        HPX_CORE_EXPORT ptr(std::uintptr_t v);
+
         void const* data_;
-        friend std::ostream& operator<<(std::ostream& os, ptr const& d)
-        {
-            os << d.data_;
-            return os;
-        }
+
+        HPX_CORE_EXPORT friend std::ostream& operator<<(
+            std::ostream& os, ptr const& d);
     };
 
     // ------------------------------------------------------------------
     // format as zero padded hex
     // ------------------------------------------------------------------
     namespace detail {
+
+        template <typename Int>
+        HPX_CORE_EXPORT void print_hex(std::ostream& os, Int v, int n);
 
         template <int N = 4, typename T = int, typename Enable = void>
         struct hex;
@@ -143,41 +123,46 @@ namespace hpx { namespace debug {
         struct hex<N, T,
             typename std::enable_if<!std::is_pointer<T>::value>::type>
         {
-            hex(T const& v)
+            constexpr hex(T const& v)
               : data_(v)
             {
             }
+
             T const& data_;
+
             friend std::ostream& operator<<(
-                std::ostream& os, const hex<N, T>& d)
+                std::ostream& os, hex<N, T> const& d)
             {
-                os << std::right << "0x" << std::setfill('0') << std::setw(N)
-                   << std::noshowbase << std::hex << d.data_;
+                detail::print_hex(os, d.data_, N);
                 return os;
             }
         };
+
+        template <typename Int>
+        HPX_CORE_EXPORT void print_ptr(std::ostream& os, Int v, int n);
 
         template <int N, typename T>
         struct hex<N, T,
             typename std::enable_if<std::is_pointer<T>::value>::type>
         {
-            hex(T const& v)
+            constexpr hex(T const& v)
               : data_(v)
             {
             }
+
             T const& data_;
+
             friend std::ostream& operator<<(
-                std::ostream& os, const hex<N, T>& d)
+                std::ostream& os, hex<N, T> const& d)
             {
-                os << std::right << std::setw(N) << std::noshowbase << std::hex
-                   << d.data_;
+                detail::print_ptr(os, d.data_, N);
                 return os;
             }
         };
     }    // namespace detail
 
     template <int N = 4, typename T>
-    detail::hex<N, T> hex(T const& v)
+    constexpr detail::hex<N, T> hex(T const& v)
     {
         return detail::hex<N, T>(v);
     }
@@ -187,25 +172,30 @@ namespace hpx { namespace debug {
     // ------------------------------------------------------------------
     namespace detail {
 
+        template <typename Int>
+        HPX_CORE_EXPORT void print_bin(std::ostream& os, Int v, int n);
+
         template <int N = 8, typename T = int>
         struct bin
         {
-            bin(T const& v)
+            constexpr bin(T const& v)
               : data_(v)
             {
             }
+
             T const& data_;
+
             friend std::ostream& operator<<(
-                std::ostream& os, const bin<N, T>& d)
+                std::ostream& os, bin<N, T> const& d)
             {
-                os << std::bitset<N>(d.data_);
+                detail::print_bin(os, d.data_, N);
                 return os;
             }
         };
     }    // namespace detail
 
     template <int N = 8, typename T>
-    detail::bin<N, T> bin(T const& v)
+    constexpr detail::bin<N, T> bin(T const& v)
     {
         return detail::bin<N, T>(v);
     }
@@ -213,17 +203,24 @@ namespace hpx { namespace debug {
     // ------------------------------------------------------------------
     // format as padded string
     // ------------------------------------------------------------------
+    namespace detail {
+
+        HPX_CORE_EXPORT void print_str(std::ostream& os, char const* v, int n);
+    }
+
     template <int N = 20>
     struct str
     {
-        str(const char* v)
+        constexpr str(char const* v)
           : data_(v)
         {
         }
-        const char* data_;
+
+        char const* data_;
+
         friend std::ostream& operator<<(std::ostream& os, str<N> const& d)
         {
-            os << std::left << std::setfill(' ') << std::setw(N) << d.data_;
+            detail::print_str(os, d.data_, N);
             return os;
         }
     };
@@ -233,35 +230,32 @@ namespace hpx { namespace debug {
     // ------------------------------------------------------------------
     struct ipaddr
     {
-        ipaddr(const void* a)
-          : data_(reinterpret_cast<const uint8_t*>(a))
-          , ipdata_(0)
-        {
-        }
-        ipaddr(const uint32_t a)
-          : data_(reinterpret_cast<const uint8_t*>(&ipdata_))
-          , ipdata_(a)
-        {
-        }
-        const uint8_t* data_;
-        const uint32_t ipdata_;
+        HPX_CORE_EXPORT ipaddr(void const* a);
+        HPX_CORE_EXPORT ipaddr(std::uint32_t a);
 
-        friend std::ostream& operator<<(std::ostream& os, ipaddr const& p)
-        {
-            os << std::dec << int(p.data_[0]) << "." << int(p.data_[1]) << "."
-               << int(p.data_[2]) << "." << int(p.data_[3]);
-            return os;
-        }
+        std::uint8_t const* data_;
+        std::uint32_t const ipdata_;
+
+        HPX_CORE_EXPORT friend std::ostream& operator<<(
+            std::ostream& os, ipaddr const& p);
     };
+
+    // ------------------------------------------------------------------
+    // helper class for printing time since start
+    // ------------------------------------------------------------------
+    namespace detail {
+        struct current_time_print_helper
+        {
+            HPX_CORE_EXPORT friend std::ostream& operator<<(
+                std::ostream& os, current_time_print_helper const&);
+        };
+    }    // namespace detail
 
     // ------------------------------------------------------------------
     // helper function for printing CRC32
     // ------------------------------------------------------------------
-    inline uint32_t crc32(const void* /*address*/, size_t /*length*/)
+    constexpr inline std::uint32_t crc32(void const*, std::size_t)
     {
-        //        boost::crc_32_type result;
-        //        result.process_bytes(address, length);
-        //        return result.checksum();
         return 0;
     }
 
@@ -272,32 +266,15 @@ namespace hpx { namespace debug {
     // ------------------------------------------------------------------
     struct mem_crc32
     {
-        mem_crc32(const void* a, std::size_t len, const char* txt)
-          : addr_(reinterpret_cast<const uint64_t*>(a))
-          , len_(len)
-          , txt_(txt)
-        {
-        }
-        const uint64_t* addr_;
-        const std::size_t len_;
-        const char* txt_;
-        friend std::ostream& operator<<(std::ostream& os, mem_crc32 const& p)
-        {
-            const uint64_t* uintBuf = static_cast<const uint64_t*>(p.addr_);
-            os << "Memory:";
-            os << " address " << hpx::debug::ptr(p.addr_) << " length "
-               << hpx::debug::hex<6>(p.len_)
-               << " CRC32:" << hpx::debug::hex<8>(crc32(p.addr_, p.len_))
-               << "\n";
-            for (size_t i = 0;
-                 i < (std::min)(size_t(std::ceil(p.len_ / 8.0)), size_t(128));
-                 i++)
-            {
-                os << hpx::debug::hex<16>(*uintBuf++) << " ";
-            }
-            os << " : " << p.txt_;
-            return os;
-        }
+        HPX_CORE_EXPORT mem_crc32(
+            void const* a, std::size_t len, char const* txt);
+
+        std::uint64_t const* addr_;
+        std::size_t const len_;
+        char const* txt_;
+
+        HPX_CORE_EXPORT friend std::ostream& operator<<(
+            std::ostream& os, mem_crc32 const& p);
     };
 
     namespace detail {
@@ -315,7 +292,6 @@ namespace hpx { namespace debug {
         {
             tuple_print(os, t, std::make_index_sequence<sizeof...(Args)>());
         }
-
 #else
         // C++14 version
         // helper function to print a tuple of any size
@@ -345,9 +321,7 @@ namespace hpx { namespace debug {
             using expander = int[];
             (void) expander{0, (void(os << ' ' << args), 0)...};
         }
-
 #endif
-
     }    // namespace detail
 
     namespace detail {
@@ -357,49 +331,45 @@ namespace hpx { namespace debug {
         // ------------------------------------------------------------------
         struct hostname_print_helper
         {
-            const char* get_hostname() const
-            {
-                static bool initialized = false;
-                static char hostname_[20];
-                if (!initialized)
-                {
-                    initialized = true;
-                    gethostname(hostname_, std::size_t(12));
-                    std::string temp = "(" + std::to_string(guess_rank()) + ")";
-                    std::strcat(hostname_, temp.c_str());
-                }
-                return hostname_;
-            }
+            HPX_CORE_EXPORT char const* get_hostname() const;
+            HPX_CORE_EXPORT int guess_rank() const;
 
-            int guess_rank() const
-            {
-                std::vector<std::string> env_strings{"_RANK=", "_NODEID="};
-                for (char** current = environ; *current; current++)
-                {
-                    auto e = std::string(*current);
-                    for (auto s : env_strings)
-                    {
-                        auto pos = e.find(s);
-                        if (pos != std::string::npos)
-                        {
-                            //std::cout << "Got a rank string : " << e << std::endl;
-                            return std::stoi(e.substr(pos + s.size(), 5));
-                        }
-                    }
-                }
-                return -1;
-            }
+            HPX_CORE_EXPORT friend std::ostream& operator<<(
+                std::ostream& os, hostname_print_helper const& h);
         };
 
-        inline std::ostream& operator<<(
-            std::ostream& os, hostname_print_helper const& h)
-        {
-            os << debug::str<13>(h.get_hostname()) << " ";
-            return os;
-        }
+        ///////////////////////////////////////////////////////////////////////
+        HPX_CORE_EXPORT void register_print_info(void (*)(std::ostream&));
+        HPX_CORE_EXPORT void generate_prefix(std::ostream& os);
 
+        ///////////////////////////////////////////////////////////////////////
+#if defined(HPX_HAVE_CXX17_FOLD_EXPRESSIONS)
         template <typename... Args>
-        void display(const char* prefix, Args const&... args);
+        void display(char const* prefix, Args const&... args)
+        {
+            // using a temp stream object with a single copy to cout at the end
+            // prevents multiple threads from injecting overlapping text
+            std::stringstream tempstream;
+            tempstream << prefix;
+            generate_prefix(tempstream);
+            ((tempstream << args << " "), ...);
+            tempstream << std::endl;
+            std::cout << tempstream.str();
+        }
+#else
+        template <typename... Args>
+        void display(char const* prefix, Args const&... args)
+        {
+            // using a temp stream object with a single copy to cout at the end
+            // prevents multiple threads from injecting overlapping text
+            std::stringstream tempstream;
+            tempstream << prefix;
+            generate_prefix(tempstream);
+            variadic_print(tempstream, args...);
+            tempstream << std::endl;
+            std::cout << tempstream.str();
+        }
+#endif
 
         template <typename... Args>
         void debug(Args const&... args)
@@ -442,11 +412,12 @@ namespace hpx { namespace debug {
     struct scoped_var
     {
         // capture tuple elements by reference - no temp vars in constructor please
-        const char* prefix_;
-        const std::tuple<Args const&...> message_;
+        char const* prefix_;
+        std::tuple<Args const&...> const message_;
         std::string buffered_msg;
+
         //
-        scoped_var(const char* p, Args const&... args)
+        scoped_var(char const* p, Args const&... args)
           : prefix_(p)
           , message_(args...)
         {
@@ -468,8 +439,8 @@ namespace hpx { namespace debug {
     struct timed_var
     {
         mutable std::chrono::steady_clock::time_point time_start_;
-        const double delay_;
-        const std::tuple<Args...> message_;
+        double const delay_;
+        std::tuple<Args...> const message_;
         //
         timed_var(double const& delay, Args const&... args)
           : time_start_(std::chrono::steady_clock::now())
@@ -494,13 +465,14 @@ namespace hpx { namespace debug {
         }
 
         friend std::ostream& operator<<(
-            std::ostream& os, const timed_var<Args...>& ti)
+            std::ostream& os, timed_var<Args...> const& ti)
         {
             detail::tuple_print(os, ti.message_);
             return os;
         }
     };
 
+    ///////////////////////////////////////////////////////////////////////////
     template <bool enable>
     struct enable_print;
 
@@ -548,13 +520,13 @@ namespace hpx { namespace debug {
 
         template <typename T, std::size_t N>
         constexpr void array(
-            std::string const& name, const std::array<T, N>&) const
+            std::string const& name, std::array<T, N> const&) const
         {
         }
 
-        template <typename Iter>
+        template <typename T>
         constexpr void array(
-            std::string const& name, Iter begin, Iter end) const
+            std::string const& name, T const* data, std::size_t size) const
         {
         }
 
@@ -571,7 +543,7 @@ namespace hpx { namespace debug {
         }
 
         template <typename T, typename V>
-        void set(T& var, V const& val)
+        constexpr void set(T& var, V const& val)
         {
         }
 
@@ -589,12 +561,18 @@ namespace hpx { namespace debug {
         }
     };
 
+    namespace detail {
+        template <typename T>
+        HPX_CORE_EXPORT void print_array(
+            std::string const& name, T const* data, std::size_t size);
+    }
+
     // when true, debug statements produce valid output
     template <>
     struct enable_print<true>
     {
     private:
-        const char* prefix_;
+        char const* prefix_;
 
     public:
         constexpr enable_print()
@@ -643,7 +621,7 @@ namespace hpx { namespace debug {
         }
 
         template <typename... T, typename... Args>
-        void timed(const timed_var<T...>& init, Args const&... args) const
+        void timed(timed_var<T...> const& init, Args const&... args) const
         {
             auto now = std::chrono::steady_clock::now();
             if (init.elapsed(now))
@@ -655,33 +633,20 @@ namespace hpx { namespace debug {
         template <typename T>
         void array(std::string const& name, std::vector<T> const& v) const
         {
-            std::cout << str<20>(name.c_str()) << ": {"
-                      << debug::dec<4>(v.size()) << "} : ";
-            std::copy(std::begin(v), std::end(v),
-                std::ostream_iterator<T>(std::cout, ", "));
-            std::cout << "\n";
+            detail::print_array(name, v.data(), v.size());
         }
 
         template <typename T, std::size_t N>
-        void array(std::string const& name, const std::array<T, N>& v) const
+        void array(std::string const& name, std::array<T, N> const& v) const
         {
-            std::cout << str<20>(name.c_str()) << ": {"
-                      << debug::dec<4>(v.size()) << "} : ";
-            std::copy(std::begin(v), std::end(v),
-                std::ostream_iterator<T>(std::cout, ", "));
-            std::cout << "\n";
+            detail::print_array(name, v.data(), N);
         }
 
-        template <typename Iter>
-        void array(std::string const& name, Iter begin, Iter end) const
+        template <typename T>
+        void array(
+            std::string const& name, T const* data, std::size_t size) const
         {
-            std::cout << str<20>(name.c_str()) << ": {"
-                      << debug::dec<4>(std::distance(begin, end)) << "} : ";
-            std::copy(begin, end,
-                std::ostream_iterator<
-                    typename std::iterator_traits<Iter>::value_type>(
-                    std::cout, ", "));
-            std::cout << std::endl;
+            detail::print_array(name, data, size);
         }
 
         template <typename T, typename... Args>

--- a/libs/core/debugging/src/print.cpp
+++ b/libs/core/debugging/src/print.cpp
@@ -1,0 +1,307 @@
+//  Copyright (c) 2019-2020 John Biddiscombe
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/debugging/print.hpp>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <bitset>
+#include <chrono>
+#include <climits>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#if defined(__linux) || defined(linux) || defined(__linux__)
+#include <sys/mman.h>
+#include <unistd.h>
+#elif defined(__APPLE__)
+#include <crt_externs.h>
+#include <unistd.h>
+#define environ (*_NSGetEnviron())
+#elif defined(HPX_WINDOWS)
+#include <winsock2.h>
+#define environ _environ
+#else
+extern char** environ;
+#endif
+
+// ------------------------------------------------------------
+/// \cond NODETAIL
+namespace hpx { namespace debug {
+
+    // ------------------------------------------------------------------
+    // format as zero padded int
+    // ------------------------------------------------------------------
+    namespace detail {
+
+        template <typename Int>
+        HPX_CORE_EXPORT void print_dec(std::ostream& os, Int const& v, int N)
+        {
+            os << std::right << std::setfill('0') << std::setw(N)
+               << std::noshowbase << std::dec << v;
+        }
+
+        template HPX_CORE_EXPORT void print_dec(
+            std::ostream&, std::int16_t const&, int);
+        template HPX_CORE_EXPORT void print_dec(
+            std::ostream&, std::int32_t const&, int);
+        template HPX_CORE_EXPORT void print_dec(
+            std::ostream&, std::int64_t const&, int);
+        template HPX_CORE_EXPORT void print_dec(
+            std::ostream&, std::uint64_t const&, int);
+
+        template HPX_CORE_EXPORT void print_dec(
+            std::ostream&, std::atomic<int> const&, int);
+    }    // namespace detail
+
+    // ------------------------------------------------------------------
+    // format as pointer
+    // ------------------------------------------------------------------
+    ptr::ptr(void const* v)
+      : data_(v)
+    {
+    }
+
+    ptr::ptr(std::uintptr_t v)
+      : data_(reinterpret_cast<void const*>(v))
+    {
+    }
+
+    std::ostream& operator<<(std::ostream& os, ptr const& d)
+    {
+        os << d.data_;
+        return os;
+    }
+
+    // ------------------------------------------------------------------
+    // format as zero padded hex
+    // ------------------------------------------------------------------
+    namespace detail {
+
+        template <typename Int>
+        HPX_CORE_EXPORT void print_hex(std::ostream& os, Int v, int N)
+        {
+            os << std::right << "0x" << std::setfill('0') << std::setw(N)
+               << std::noshowbase << std::hex << v;
+        }
+
+        template HPX_CORE_EXPORT void print_hex(
+            std::ostream&, std::thread::id, int);
+        template HPX_CORE_EXPORT void print_hex(
+            std::ostream&, unsigned long, int);
+
+        template <typename Int>
+        HPX_CORE_EXPORT void print_ptr(std::ostream& os, Int v, int N)
+        {
+            os << std::right << std::setw(N) << std::noshowbase << std::hex
+               << v;
+        }
+
+        template HPX_CORE_EXPORT void print_ptr(std::ostream&, void*, int);
+    }    // namespace detail
+
+    // ------------------------------------------------------------------
+    // format as binary bits
+    // ------------------------------------------------------------------
+    namespace detail {
+
+        template <typename Int>
+        HPX_CORE_EXPORT void print_bin(std::ostream& os, Int v, int N)
+        {
+            char const* beg = reinterpret_cast<char const*>(&v);
+            char const* end = beg + sizeof(v);
+
+            N = (N + CHAR_BIT - 1) / CHAR_BIT;
+            while (beg != end && N-- > 0)
+            {
+                os << std::bitset<CHAR_BIT>(*beg++);
+            }
+        }
+
+        template HPX_CORE_EXPORT void print_bin(
+            std::ostream&, std::uint64_t, int);
+    }    // namespace detail
+
+    // ------------------------------------------------------------------
+    // format as padded string
+    // ------------------------------------------------------------------
+    namespace detail {
+        void print_str(std::ostream& os, char const* v, int N)
+        {
+            os << std::left << std::setfill(' ') << std::setw(N) << v;
+        }
+    }    // namespace detail
+
+    // ------------------------------------------------------------------
+    // format as ip address
+    // ------------------------------------------------------------------
+    ipaddr::ipaddr(void const* a)
+      : data_(reinterpret_cast<std::uint8_t const*>(a))
+      , ipdata_(0)
+    {
+    }
+
+    ipaddr::ipaddr(std::uint32_t a)
+      : data_(reinterpret_cast<const uint8_t*>(&ipdata_))
+      , ipdata_(a)
+    {
+    }
+
+    std::ostream& operator<<(std::ostream& os, ipaddr const& p)
+    {
+        os << std::dec << int(p.data_[0]) << "." << int(p.data_[1]) << "."
+           << int(p.data_[2]) << "." << int(p.data_[3]);
+        return os;
+    }
+
+    // ------------------------------------------------------------------
+    // helper class for printing time since start
+    // ------------------------------------------------------------------
+    namespace detail {
+        std::ostream& operator<<(
+            std::ostream& os, current_time_print_helper const&)
+        {
+            static std::chrono::steady_clock::time_point log_t_start =
+                std::chrono::steady_clock::now();
+
+            auto now = std::chrono::steady_clock::now();
+            auto nowt = std::chrono::duration_cast<std::chrono::microseconds>(
+                now - log_t_start)
+                            .count();
+
+            os << debug::dec<10>(nowt) << " ";
+            return os;
+        }
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail {
+
+        std::function<void(std::ostream&)> print_info;
+
+        void register_print_info(void (*printer)(std::ostream&))
+        {
+            print_info = printer;
+        }
+
+        void generate_prefix(std::ostream& os)
+        {
+            os << detail::current_time_print_helper();
+            if (print_info)
+            {
+                print_info(os);
+            }
+            os << detail::hostname_print_helper();
+        }
+    }    // namespace detail
+
+    // ------------------------------------------------------------------
+    // helper function for printing short memory dump and crc32
+    // useful for debugging corruptions in buffers during
+    // rma or other transfers
+    // ------------------------------------------------------------------
+    mem_crc32::mem_crc32(void const* a, std::size_t len, char const* txt)
+      : addr_(reinterpret_cast<const uint64_t*>(a))
+      , len_(len)
+      , txt_(txt)
+    {
+    }
+
+    std::ostream& operator<<(std::ostream& os, mem_crc32 const& p)
+    {
+        std::uint64_t const* uintBuf =
+            static_cast<std::uint64_t const*>(p.addr_);
+        os << "Memory:";
+        os << " address " << hpx::debug::ptr(p.addr_) << " length "
+           << hpx::debug::hex<6>(p.len_)
+           << " CRC32:" << hpx::debug::hex<8>(crc32(p.addr_, p.len_)) << "\n";
+
+        for (std::size_t i = 0;
+             i < (std::min)(size_t(std::ceil(p.len_ / 8.0)), std::size_t(128));
+             i++)
+        {
+            os << hpx::debug::hex<16>(*uintBuf++) << " ";
+        }
+        os << " : " << p.txt_;
+        return os;
+    }
+
+    namespace detail {
+
+        // ------------------------------------------------------------------
+        // helper class for printing time since start
+        // ------------------------------------------------------------------
+        char const* hostname_print_helper::get_hostname() const
+        {
+            static bool initialized = false;
+            static char hostname_[20];
+            if (!initialized)
+            {
+                initialized = true;
+                gethostname(hostname_, std::size_t(12));
+                std::string temp = "(" + std::to_string(guess_rank()) + ")";
+                std::strcat(hostname_, temp.c_str());
+            }
+            return hostname_;
+        }
+
+        int hostname_print_helper::guess_rank() const
+        {
+            std::vector<std::string> env_strings{"_RANK=", "_NODEID="};
+            for (char** current = environ; *current; current++)
+            {
+                auto e = std::string(*current);
+                for (auto s : env_strings)
+                {
+                    auto pos = e.find(s);
+                    if (pos != std::string::npos)
+                    {
+                        //std::cout << "Got a rank string : " << e << std::endl;
+                        return std::stoi(e.substr(pos + s.size(), 5));
+                    }
+                }
+            }
+            return -1;
+        }
+
+        std::ostream& operator<<(
+            std::ostream& os, hostname_print_helper const& h)
+        {
+            os << debug::str<13>(h.get_hostname()) << " ";
+            return os;
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename T>
+        HPX_CORE_EXPORT void print_array(
+            std::string const& name, T const* data, std::size_t size)
+        {
+            std::cout << str<20>(name.c_str()) << ": {" << debug::dec<4>(size)
+                      << "} : ";
+            std::copy(
+                data, data + size, std::ostream_iterator<T>(std::cout, ", "));
+            std::cout << "\n";
+        }
+
+        template HPX_CORE_EXPORT void print_array(
+            std::string const&, std::uint64_t const*, std::size_t);
+    }    // namespace detail
+}}       // namespace hpx::debug
+/// \endcond

--- a/libs/core/debugging/tests/unit/CMakeLists.txt
+++ b/libs/core/debugging/tests/unit/CMakeLists.txt
@@ -19,8 +19,6 @@ foreach(test ${tests})
     SOURCES ${sources} ${${test}_FLAGS} ${${test}_LIBS}
     EXCLUDE_FROM_ALL
     FOLDER ${folder_name}
-    NOLIBS
-    DEPENDENCIES hpx_errors hpx_debugging hpx_threading_base hpx_testing
   )
 
   add_hpx_unit_test("modules.debugging" ${test} ${${test}_PARAMETERS})

--- a/libs/core/schedulers/include/hpx/schedulers/queue_holder_numa.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/queue_holder_numa.hpp
@@ -35,12 +35,10 @@
 #include <utility>
 
 #if !defined(QUEUE_HOLDER_NUMA_DEBUG)
-#if !defined(NDEBUG)
+#if defined(HPX_DEBUG)
 #define QUEUE_HOLDER_NUMA_DEBUG false
 #else
-#if !defined(QUEUE_HOLDER_NUMA_DEBUG)
 #define QUEUE_HOLDER_NUMA_DEBUG false
-#endif
 #endif
 #endif
 

--- a/libs/core/schedulers/include/hpx/schedulers/queue_holder_thread.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/queue_holder_thread.hpp
@@ -37,12 +37,10 @@
 #include <utility>
 
 #if !defined(QUEUE_HOLDER_THREAD_DEBUG)
-#if !defined(NDEBUG)
+#if defined(HPX_DEBUG)
 #define QUEUE_HOLDER_THREAD_DEBUG false
 #else
-#if !defined(QUEUE_HOLDER_THREAD_DEBUG)
 #define QUEUE_HOLDER_THREAD_DEBUG false
-#endif
 #endif
 #endif
 

--- a/libs/core/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
@@ -52,12 +52,10 @@ static_assert(false,
 #else
 
 #if !defined(SHARED_PRIORITY_SCHEDULER_DEBUG)
-#if !defined(NDEBUG)
+#if defined(HPX_DEBUG)
 #define SHARED_PRIORITY_SCHEDULER_DEBUG false
 #else
-#if !defined(SHARED_PRIORITY_SCHEDULER_DEBUG)
 #define SHARED_PRIORITY_SCHEDULER_DEBUG false
-#endif
 #endif
 #endif
 
@@ -1206,17 +1204,12 @@ namespace hpx { namespace threads { namespace policies {
             if (!debug_init_)
             {
                 debug_init_ = true;
-                spq_arr.array(
-                    "# d_lookup_  ", &d_lookup_[0], &d_lookup_[num_workers_]);
-                spq_arr.array(
-                    "# q_lookup_  ", &q_lookup_[0], &q_lookup_[num_workers_]);
-                spq_arr.array(
-                    "# q_counts_  ", &q_counts_[0], &q_counts_[num_domains_]);
-                spq_arr.array(
-                    "# q_offset_  ", &q_offset_[0], &q_offset_[num_domains_]);
+                spq_arr.array("# d_lookup_  ", &d_lookup_[0], num_workers_);
+                spq_arr.array("# q_lookup_  ", &q_lookup_[0], num_workers_);
+                spq_arr.array("# q_counts_  ", &q_counts_[0], num_domains_);
+                spq_arr.array("# q_offset_  ", &q_offset_[0], num_domains_);
 #ifdef SHARED_PRIORITY_SCHEDULER_LINUX
-                spq_arr.array(
-                    "# schedcpu_  ", &schedcpu_[0], &schedcpu_[num_workers_]);
+                spq_arr.array("# schedcpu_  ", &schedcpu_[0], num_workers_);
 #endif
                 for (std::size_t d = 0; d < num_domains_; ++d)
                 {

--- a/libs/core/schedulers/include/hpx/schedulers/thread_queue_mc.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/thread_queue_mc.hpp
@@ -45,12 +45,10 @@
 #include <vector>
 
 #if !defined(THREAD_QUEUE_MC_DEBUG)
-#if !defined(NDEBUG)
+#if defined(HPX_DEBUG)
 #define THREAD_QUEUE_MC_DEBUG false
 #else
-#if !defined(THREAD_QUEUE_MC_DEBUG)
 #define THREAD_QUEUE_MC_DEBUG false
-#endif
 #endif
 #endif
 

--- a/libs/core/thread_pools/CMakeLists.txt
+++ b/libs/core/thread_pools/CMakeLists.txt
@@ -30,7 +30,13 @@ add_hpx_module(
   SOURCES ${thread_pools_sources}
   HEADERS ${thread_pools_headers}
   COMPAT_HEADERS ${thread_pools_compat_headers}
-  MODULE_DEPENDENCIES hpx_assertion hpx_config hpx_errors hpx_itt_notify
-                      hpx_logging hpx_schedulers
+  MODULE_DEPENDENCIES
+    hpx_assertion
+    hpx_config
+    hpx_debugging
+    hpx_errors
+    hpx_itt_notify
+    hpx_logging
+    hpx_schedulers
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
@@ -33,6 +33,9 @@
 
 #include <algorithm>
 #include <atomic>
+#ifdef HPX_HAVE_MAX_CPU_COUNT
+#include <bitset>
+#endif
 #include <cstddef>
 #include <cstdint>
 #include <exception>

--- a/libs/core/threading_base/CMakeLists.txt
+++ b/libs/core/threading_base/CMakeLists.txt
@@ -59,6 +59,7 @@ set(threading_base_compat_headers
 set(threading_base_sources
     execution_agent.cpp
     external_timer.cpp
+    print.cpp
     register_thread.cpp
     scheduler_base.cpp
     thread_data.cpp
@@ -92,6 +93,7 @@ add_hpx_module(
     hpx_execution_base
     hpx_config
     hpx_coroutines
+    hpx_debugging
     hpx_errors
     hpx_format
     hpx_functional

--- a/libs/core/threading_base/src/print.cpp
+++ b/libs/core/threading_base/src/print.cpp
@@ -1,0 +1,93 @@
+//  Copyright (c) 2019 John Biddiscombe
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/threading_base/print.hpp>
+#include <hpx/threading_base/thread_data.hpp>
+
+#include <cstdint>
+#include <thread>
+
+// ------------------------------------------------------------
+/// \cond NODETAIL
+namespace hpx { namespace debug {
+
+    std::ostream& operator<<(
+        std::ostream& os, threadinfo<threads::thread_data*> const& d)
+    {
+        os << ptr(d.data) << " \""
+           << ((d.data != nullptr) ? d.data->get_description() : "nullptr")
+           << "\"";
+        return os;
+    }
+
+    std::ostream& operator<<(
+        std::ostream& os, threadinfo<threads::thread_id_type*> const& d)
+    {
+        if (d.data == nullptr)
+        {
+            os << "nullptr";
+        }
+        else
+        {
+            os << threadinfo<threads::thread_data*>(
+                get_thread_id_data(*d.data));
+        }
+        return os;
+    }
+
+    std::ostream& operator<<(
+        std::ostream& os, threadinfo<hpx::threads::thread_init_data> const& d)
+    {
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+        os << std::left << " \"" << d.data.description.get_description()
+           << "\"";
+#else
+        os << "??? " << /*hex<8,uintptr_t>*/ (std::uintptr_t(&d.data));
+#endif
+        return os;
+    }
+
+    // ------------------------------------------------------------------
+    // helper class for printing thread ID, either std:: or hpx::
+    // ------------------------------------------------------------------
+    namespace detail {
+
+        void print_thread_info(std::ostream& os)
+        {
+            if (hpx::threads::get_self_id() == hpx::threads::invalid_thread_id)
+            {
+                os << "-------------- ";
+            }
+            else
+            {
+                hpx::threads::thread_data* dummy =
+                    hpx::threads::get_self_id_data();
+                os << dummy << " ";
+            }
+            os << hex<12, std::thread::id>(std::this_thread::get_id())
+#ifdef DEBUGGING_PRINT_LINUX
+               << " cpu " << debug::dec<3, int>(sched_getcpu()) << " ";
+#else
+               << " cpu "
+               << "--- ";
+#endif
+        }
+
+        struct current_thread_print_helper
+        {
+            current_thread_print_helper()
+            {
+                detail::register_print_info(&detail::print_thread_info);
+            }
+
+            static current_thread_print_helper helper_;
+        };
+
+        current_thread_print_helper current_thread_print_helper::helper_{};
+    }    // namespace detail
+}}       // namespace hpx::debug
+/// \endcond

--- a/libs/full/collectives/tests/performance/osu/osu_bibw.cpp
+++ b/libs/full/collectives/tests/performance/osu/osu_bibw.cpp
@@ -14,6 +14,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <iomanip>
 #include <iostream>
 #include <vector>
 

--- a/libs/full/collectives/tests/performance/osu/osu_bw.cpp
+++ b/libs/full/collectives/tests/performance/osu/osu_bw.cpp
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <iomanip>
 #include <iostream>
 #include <memory>
 #include <vector>

--- a/libs/full/collectives/tests/performance/osu/osu_latency.cpp
+++ b/libs/full/collectives/tests/performance/osu/osu_latency.cpp
@@ -16,6 +16,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <iomanip>
 #include <iostream>
 #include <iterator>
 #include <utility>

--- a/libs/full/collectives/tests/performance/osu/osu_multi_lat.cpp
+++ b/libs/full/collectives/tests/performance/osu/osu_multi_lat.cpp
@@ -19,6 +19,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <iomanip>
 #include <iostream>
 #include <numeric>
 #include <vector>

--- a/libs/full/compute/include/hpx/compute/host/numa_binding_allocator.hpp
+++ b/libs/full/compute/include/hpx/compute/host/numa_binding_allocator.hpp
@@ -36,11 +36,11 @@
 // Can be used to enable debugging of the allocator page mapping
 //#define NUMA_BINDING_ALLOCATOR_INIT_MEMORY
 
-#if !defined(NDEBUG)
-#define NUMA_BINDING_ALLOCATOR_DEBUG true
-#else
 #if !defined(NUMA_BINDING_ALLOCATOR_DEBUG)
-#define NUMA_BINDING_ALLOCATOR_DEBUG true
+#if defined(HPX_DEBUG)
+#define NUMA_BINDING_ALLOCATOR_DEBUG false
+#else
+#define NUMA_BINDING_ALLOCATOR_DEBUG false
 #endif
 #endif
 

--- a/libs/parallelism/algorithms/tests/performance/transform_reduce_scaling.cpp
+++ b/libs/parallelism/algorithms/tests/performance/transform_reduce_scaling.cpp
@@ -16,6 +16,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
+#include <iomanip>
 #include <stdexcept>
 #include <string>
 #include <vector>

--- a/tests/performance/local/agas_cache_timings.cpp
+++ b/tests/performance/local/agas_cache_timings.cpp
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <iomanip>
 #include <iostream>
 #include <map>
 #include <string>

--- a/tests/performance/local/foreach_scaling.cpp
+++ b/tests/performance/local/foreach_scaling.cpp
@@ -17,6 +17,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <iomanip>
 #include <iterator>
 #include <memory>
 #include <numeric>


### PR DESCRIPTION
- move as much as possible into separate compilation units
- break circular dependency between threading_base and debugging modules
- flyby: disable debug output from numa allocator
