### PR TITLE
Add page about citing HPX to documentation

### DIFF
--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -217,6 +217,12 @@ rst_prolog += '''
 .. _hpx_cdash: https://cdash.cscs.ch/index.php?project=HPX
 .. |support| replace:: Support Website
 .. _support: https://stellar.cct.lsu.edu/support/
+.. |hpx_zenodo| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.598202.svg
+     :target: https://doi.org/10.5281/zenodo.598202
+     :alt: Latest software release of HPX
+.. |hpx_joss| image:: https://joss.theoj.org/papers/022e5917b95517dff20cd3742ab95eca/status.svg
+    :target: https://joss.theoj.org/papers/022e5917b95517dff20cd3742ab95eca
+    :alt: JOSS Paper about HPX
 
 .. |hpxpi| replace:: HPXPI
 .. _hpxpi: https://github.com/STEllAR-GROUP/hpxpi/

--- a/docs/sphinx/citing.rst
+++ b/docs/sphinx/citing.rst
@@ -1,0 +1,17 @@
+..
+    Copyright (C) 2020 ETH Zurich
+
+    SPDX-License-Identifier: BSL-1.0
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+.. _citing_hpx:
+
+============
+Citing |hpx|
+============
+
+Please cite |hpx| whenever you use it for publications. Use our paper in The
+Journal of Open Source Software as the main citation for |HPX|: |hpx_joss|. Use
+the Zenodo entry for referring to the latest version of |hpx|: |hpx_zenodo|.
+Entries for citing specific versions of |hpx| can also be found at |hpx_zenodo|.

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -25,6 +25,8 @@ If you can't find what you're looking for in the documentation, please:
 * read or ask questions tagged with |hpx| on `StackOverflow
   <hpx_stackoverflow_>`_.
 
+See :ref:`citing_hpx` for details on how to cite |hpx| in publications.
+
 What is |hpx|?
 ==============
 
@@ -103,6 +105,7 @@ What's so special about |hpx|?
    :maxdepth: 2
 
    releases
+   citing
    about_hpx
 
 


### PR DESCRIPTION
I added a separate section in the documentation and link to it on the intro page. Prominent enough? I also left the links in place in the readme. I don't think it hurts to have it in both places.