### PR TITLE
Fixing some warnings from HPX complaining about use of obsolete types

### DIFF
--- a/libs/core/datastructures/include/hpx/datastructures/tagged.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/tagged.hpp
@@ -1,5 +1,5 @@
 //  Copyright Eric Niebler 2013-2015
-//  Copyright 2015 Hartmut Kaiser
+//  Copyright 2015-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -43,7 +43,7 @@ namespace hpx { namespace util {
             struct unpack_getter
             {
                 typedef typename Tag::template getter<T,
-                    typename tuple_element<I, T>::type, I>
+                    typename hpx::tuple_element<I, T>::type, I>
                     type;
 
             private:

--- a/libs/core/datastructures/include/hpx/datastructures/tagged_pair.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/tagged_pair.hpp
@@ -1,5 +1,5 @@
 //  Copyright Eric Niebler 2013-2015
-//  Copyright 2015 Hartmut Kaiser
+//  Copyright 2015-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -67,32 +67,34 @@ namespace hpx { namespace util {
     }
 
     template <typename Tag1, typename Tag2, typename... Ts>
-    constexpr HPX_FORCEINLINE
-        tagged_pair<Tag1(typename tuple_element<0, tuple<Ts...>>::type),
-            Tag2(typename tuple_element<1, tuple<Ts...>>::type)>
-        make_tagged_pair(tuple<Ts...>&& p)
+    constexpr HPX_FORCEINLINE tagged_pair<
+        Tag1(typename hpx::tuple_element<0, hpx::tuple<Ts...>>::type),
+        Tag2(typename hpx::tuple_element<1, hpx::tuple<Ts...>>::type)>
+    make_tagged_pair(hpx::tuple<Ts...>&& p)
     {
         static_assert(
-            sizeof...(Ts) >= 2, "tuple must have at least 2 elements");
+            sizeof...(Ts) >= 2, "hpx::tuple must have at least 2 elements");
 
-        typedef tagged_pair<Tag1(typename tuple_element<0, tuple<Ts...>>::type),
-            Tag2(typename tuple_element<1, tuple<Ts...>>::type)>
+        typedef tagged_pair<
+            Tag1(typename hpx::tuple_element<0, hpx::tuple<Ts...>>::type),
+            Tag2(typename hpx::tuple_element<1, hpx::tuple<Ts...>>::type)>
             result_type;
 
         return result_type(std::move(get<0>(p)), std::move(get<1>(p)));
     }
 
     template <typename Tag1, typename Tag2, typename... Ts>
-    constexpr HPX_FORCEINLINE
-        tagged_pair<Tag1(typename tuple_element<0, tuple<Ts...>>::type),
-            Tag2(typename tuple_element<1, tuple<Ts...>>::type)>
-        make_tagged_pair(tuple<Ts...> const& p)
+    constexpr HPX_FORCEINLINE tagged_pair<
+        Tag1(typename hpx::tuple_element<0, hpx::tuple<Ts...>>::type),
+        Tag2(typename hpx::tuple_element<1, hpx::tuple<Ts...>>::type)>
+    make_tagged_pair(hpx::tuple<Ts...> const& p)
     {
         static_assert(
-            sizeof...(Ts) >= 2, "tuple must have at least 2 elements");
+            sizeof...(Ts) >= 2, "hpx::tuple must have at least 2 elements");
 
-        typedef tagged_pair<Tag1(typename tuple_element<0, tuple<Ts...>>::type),
-            Tag2(typename tuple_element<1, tuple<Ts...>>::type)>
+        typedef tagged_pair<
+            Tag1(typename hpx::tuple_element<0, hpx::tuple<Ts...>>::type),
+            Tag2(typename hpx::tuple_element<1, hpx::tuple<Ts...>>::type)>
             result_type;
 
         return result_type(get<0>(p), get<1>(p));
@@ -122,7 +124,7 @@ namespace hpx {
 
     template <std::size_t N, typename Tag1, typename Tag2>
     struct tuple_element<N, util::tagged_pair<Tag1, Tag2>>
-      : tuple_element<N,
+      : hpx::tuple_element<N,
             std::pair<typename util::detail::tag_elem<Tag1>::type,
                 typename util::detail::tag_elem<Tag2>::type>>
     {

--- a/libs/core/datastructures/include/hpx/datastructures/tagged_tuple.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/tagged_tuple.hpp
@@ -1,5 +1,5 @@
 //  Copyright Eric Niebler 2013-2015
-//  Copyright 2015 Hartmut Kaiser
+//  Copyright 2015-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -22,10 +22,10 @@ namespace hpx { namespace util {
     ///////////////////////////////////////////////////////////////////////////
     template <typename... Ts>
     struct tagged_tuple
-      : tagged<tuple<typename detail::tag_elem<Ts>::type...>,
+      : tagged<hpx::tuple<typename detail::tag_elem<Ts>::type...>,
             typename detail::tag_spec<Ts>::type...>
     {
-        typedef tagged<tuple<typename detail::tag_elem<Ts>::type...>,
+        typedef tagged<hpx::tuple<typename detail::tag_elem<Ts>::type...>,
             typename detail::tag_spec<Ts>::type...>
             base_type;
 
@@ -60,9 +60,9 @@ namespace hpx { namespace util {
     template <typename... Tags, typename... Ts>
     constexpr HPX_FORCEINLINE
         tagged_tuple<typename detail::tagged_type<Tags, Ts>::type...>
-        make_tagged_tuple(tuple<Ts...>&& t)
+        make_tagged_tuple(hpx::tuple<Ts...>&& t)
     {
-        static_assert(sizeof...(Tags) == tuple_size<tuple<Ts...>>::value,
+        static_assert(sizeof...(Tags) == tuple_size<hpx::tuple<Ts...>>::value,
             "the number of tags must be identical to the size of the given "
             "tuple");
 
@@ -77,7 +77,7 @@ namespace hpx { namespace util {
         template <typename Tag, std::size_t I, typename Tuple>
         struct tagged_element_type
         {
-            typedef typename tuple_element<I, Tuple>::type element_type;
+            typedef typename hpx::tuple_element<I, Tuple>::type element_type;
             typedef typename hpx::util::identity<Tag(element_type)>::type type;
         };
 
@@ -85,10 +85,11 @@ namespace hpx { namespace util {
         struct tagged_tuple_helper;
 
         template <typename... Ts, std::size_t... Is, typename... Tags>
-        struct tagged_tuple_helper<tuple<Ts...>, index_pack<Is...>, Tags...>
+        struct tagged_tuple_helper<hpx::tuple<Ts...>, index_pack<Is...>,
+            Tags...>
         {
-            typedef tagged_tuple<
-                typename tagged_element_type<Tags, Is, tuple<Ts...>>::type...>
+            typedef tagged_tuple<typename tagged_element_type<Tags, Is,
+                hpx::tuple<Ts...>>::type...>
                 type;
         };
     }    // namespace detail
@@ -98,13 +99,14 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     template <typename... Ts>
     struct tuple_size<util::tagged_tuple<Ts...>>
-      : tuple_size<tuple<typename util::detail::tag_elem<Ts>::type...>>
+      : tuple_size<hpx::tuple<typename util::detail::tag_elem<Ts>::type...>>
     {
     };
 
     template <std::size_t N, typename... Ts>
     struct tuple_element<N, util::tagged_tuple<Ts...>>
-      : tuple_element<N, tuple<typename util::detail::tag_elem<Ts>::type...>>
+      : tuple_element<N,
+            hpx::tuple<typename util::detail::tag_elem<Ts>::type...>>
     {
     };
 }    // namespace hpx

--- a/libs/core/iterator_support/include/hpx/iterator_support/zip_iterator.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/zip_iterator.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2020 Hartmut Kaiser
 //  Copyright (c) 2014 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -29,9 +29,9 @@ namespace hpx { namespace util {
         struct zip_iterator_value;
 
         template <typename... Ts>
-        struct zip_iterator_value<tuple<Ts...>>
+        struct zip_iterator_value<hpx::tuple<Ts...>>
         {
-            typedef tuple<typename std::iterator_traits<Ts>::value_type...>
+            typedef hpx::tuple<typename std::iterator_traits<Ts>::value_type...>
                 type;
         };
 
@@ -40,9 +40,10 @@ namespace hpx { namespace util {
         struct zip_iterator_reference;
 
         template <typename... Ts>
-        struct zip_iterator_reference<tuple<Ts...>>
+        struct zip_iterator_reference<hpx::tuple<Ts...>>
         {
-            typedef tuple<typename std::iterator_traits<Ts>::reference...> type;
+            typedef hpx::tuple<typename std::iterator_traits<Ts>::reference...>
+                type;
         };
 
         ///////////////////////////////////////////////////////////////////////
@@ -174,15 +175,17 @@ namespace hpx { namespace util {
         struct zip_iterator_category;
 
         template <typename T>
-        struct zip_iterator_category<tuple<T>,
-            typename std::enable_if<tuple_size<tuple<T>>::value == 1>::type>
+        struct zip_iterator_category<hpx::tuple<T>,
+            typename std::enable_if<hpx::tuple_size<hpx::tuple<T>>::value ==
+                1>::type>
         {
             typedef typename std::iterator_traits<T>::iterator_category type;
         };
 
         template <typename T, typename U>
-        struct zip_iterator_category<tuple<T, U>,
-            typename std::enable_if<tuple_size<tuple<T, U>>::value == 2>::type>
+        struct zip_iterator_category<hpx::tuple<T, U>,
+            typename std::enable_if<hpx::tuple_size<hpx::tuple<T, U>>::value ==
+                2>::type>
           : zip_iterator_category_impl<
                 typename std::iterator_traits<T>::iterator_category,
                 typename std::iterator_traits<U>::iterator_category>
@@ -190,14 +193,14 @@ namespace hpx { namespace util {
         };
 
         template <typename T, typename U, typename... Tail>
-        struct zip_iterator_category<tuple<T, U, Tail...>,
+        struct zip_iterator_category<hpx::tuple<T, U, Tail...>,
             typename std::enable_if<(
-                tuple_size<tuple<T, U, Tail...>>::value > 2)>::type>
+                hpx::tuple_size<hpx::tuple<T, U, Tail...>>::value > 2)>::type>
           : zip_iterator_category_impl<
                 typename zip_iterator_category_impl<
                     typename std::iterator_traits<T>::iterator_category,
                     typename std::iterator_traits<U>::iterator_category>::type,
-                typename zip_iterator_category<tuple<Tail...>>::type>
+                typename zip_iterator_category<hpx::tuple<Tail...>>::type>
         {
         };
 
@@ -206,12 +209,13 @@ namespace hpx { namespace util {
         struct dereference_iterator;
 
         template <typename... Ts>
-        struct dereference_iterator<tuple<Ts...>>
+        struct dereference_iterator<hpx::tuple<Ts...>>
         {
             template <std::size_t... Is>
             HPX_HOST_DEVICE static
-                typename zip_iterator_reference<tuple<Ts...>>::type
-                call(util::index_pack<Is...>, tuple<Ts...> const& iterators)
+                typename zip_iterator_reference<hpx::tuple<Ts...>>::type
+                call(
+                    util::index_pack<Is...>, hpx::tuple<Ts...> const& iterators)
             {
                 return hpx::forward_as_tuple(*hpx::get<Is>(iterators)...);
             }
@@ -357,12 +361,13 @@ namespace hpx { namespace util {
 
     template <typename... Ts>
     class zip_iterator
-      : public detail::zip_iterator_base<tuple<Ts...>, zip_iterator<Ts...>>
+      : public detail::zip_iterator_base<hpx::tuple<Ts...>, zip_iterator<Ts...>>
     {
         static_assert(
             sizeof...(Ts) != 0, "zip_iterator must wrap at least one iterator");
 
-        typedef detail::zip_iterator_base<tuple<Ts...>, zip_iterator<Ts...>>
+        typedef detail::zip_iterator_base<hpx::tuple<Ts...>,
+            zip_iterator<Ts...>>
             base_type;
 
     public:
@@ -376,7 +381,7 @@ namespace hpx { namespace util {
         {
         }
 
-        HPX_HOST_DEVICE explicit zip_iterator(tuple<Ts...>&& t)
+        HPX_HOST_DEVICE explicit zip_iterator(hpx::tuple<Ts...>&& t)
           : base_type(std::move(t))
         {
         }
@@ -426,15 +431,15 @@ namespace hpx { namespace util {
     };
 
     template <typename... Ts>
-    class zip_iterator<tuple<Ts...>>
-      : public detail::zip_iterator_base<tuple<Ts...>,
-            zip_iterator<tuple<Ts...>>>
+    class zip_iterator<hpx::tuple<Ts...>>
+      : public detail::zip_iterator_base<hpx::tuple<Ts...>,
+            zip_iterator<hpx::tuple<Ts...>>>
     {
         static_assert(
             sizeof...(Ts) != 0, "zip_iterator must wrap at least one iterator");
 
-        typedef detail::zip_iterator_base<tuple<Ts...>,
-            zip_iterator<tuple<Ts...>>>
+        typedef detail::zip_iterator_base<hpx::tuple<Ts...>,
+            zip_iterator<hpx::tuple<Ts...>>>
             base_type;
 
     public:
@@ -448,7 +453,7 @@ namespace hpx { namespace util {
         {
         }
 
-        HPX_HOST_DEVICE explicit zip_iterator(tuple<Ts...>&& t)
+        HPX_HOST_DEVICE explicit zip_iterator(hpx::tuple<Ts...>&& t)
           : base_type(std::move(t))
         {
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -1017,8 +1017,7 @@ namespace hpx {
                     "Requires at least forward iterator or integral loop "
                     "boundaries.");
 
-                typedef execution::is_sequenced_execution_policy<ExPolicy>
-                    is_seq;
+                typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
                 std::size_t size = parallel::v1::detail::distance(first, last);
                 auto&& t = hpx::forward_as_tuple(std::forward<Args>(args)...);
@@ -1054,8 +1053,7 @@ namespace hpx {
                     "Requires at least forward iterator or integral loop "
                     "boundaries.");
 
-                typedef execution::is_sequenced_execution_policy<ExPolicy>
-                    is_seq;
+                typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
                 auto&& t = hpx::forward_as_tuple(std::forward<Args>(args)...);
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -209,8 +209,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         inclusive_scan_(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
             FwdIter2 dest, T&& init, Op&& op, std::false_type, Conv&& conv)
         {
-            typedef parallel::execution::is_sequenced_execution_policy<ExPolicy>
-                is_seq;
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
             return inclusive_scan<FwdIter2>().call(
                 std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
@@ -223,8 +222,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         inclusive_scan_(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
             FwdIter2 dest, Op&& op, std::false_type, Conv&& conv)
         {
-            typedef parallel::execution::is_sequenced_execution_policy<ExPolicy>
-                is_seq;
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
             return inclusive_scan<FwdIter2>().call(
                 std::forward<ExPolicy>(policy), is_seq(), first, last, dest,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -300,7 +300,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static_assert((hpx::traits::is_forward_iterator<FwdIterB>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = execution::is_sequenced_execution_policy<ExPolicy>;
+            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 
             return detail::reduce<T>().call(std::forward<ExPolicy>(policy),
                 is_seq(), first, last, std::move(init), std::forward<F>(f));

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/tagged_pair.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/tagged_pair.hpp
@@ -1,5 +1,5 @@
 //  Copyright Eric Niebler 2013-2015
-//  Copyright 2015 Hartmut Kaiser
+//  Copyright 2015-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -43,16 +43,17 @@ namespace hpx { namespace util {
     }
 
     template <typename Tag1, typename Tag2, typename... Ts>
-    hpx::future<tagged_pair<Tag1(typename tuple_element<0, tuple<Ts...>>::type),
-        Tag2(typename tuple_element<1, tuple<Ts...>>::type)>>
-    make_tagged_pair(hpx::future<tuple<Ts...>>&& f)
+    hpx::future<tagged_pair<
+        Tag1(typename hpx::tuple_element<0, hpx::tuple<Ts...>>::type),
+        Tag2(typename hpx::tuple_element<1, hpx::tuple<Ts...>>::type)>>
+    make_tagged_pair(hpx::future<hpx::tuple<Ts...>>&& f)
     {
         static_assert(
             sizeof...(Ts) >= 2, "tuple must have at least 2 elements");
 
         typedef hpx::util::tagged_pair<
-            Tag1(typename tuple_element<0, tuple<Ts...>>::type),
-            Tag2(typename tuple_element<1, tuple<Ts...>>::type)>
+            Tag1(typename hpx::tuple_element<0, hpx::tuple<Ts...>>::type),
+            Tag2(typename hpx::tuple_element<1, hpx::tuple<Ts...>>::type)>
             result_type;
 
 #if defined(HPX_COMPUTE_DEVICE_CODE)
@@ -60,7 +61,7 @@ namespace hpx { namespace util {
         return hpx::future<result_type>();
 #else
         return lcos::make_future<result_type>(
-            std::move(f), [](tuple<Ts...>&& p) -> result_type {
+            std::move(f), [](hpx::tuple<Ts...>&& p) -> result_type {
                 return make_tagged_pair<Tag1, Tag2>(std::move(p));
             });
 #endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/tagged_tuple.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/tagged_tuple.hpp
@@ -1,5 +1,5 @@
 //  Copyright Eric Niebler 2013-2015
-//  Copyright 2015 Hartmut Kaiser
+//  Copyright 2015-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -21,20 +21,21 @@
 
 namespace hpx { namespace util {
     template <typename... Tags, typename... Ts>
-    hpx::future<typename detail::tagged_tuple_helper<tuple<Ts...>,
+    hpx::future<typename detail::tagged_tuple_helper<hpx::tuple<Ts...>,
         typename util::make_index_pack<sizeof...(Tags)>::type, Tags...>::type>
-    make_tagged_tuple(hpx::future<tuple<Ts...>>&& f)
+    make_tagged_tuple(hpx::future<hpx::tuple<Ts...>>&& f)
     {
-        static_assert(sizeof...(Tags) == tuple_size<tuple<Ts...>>::value,
+        static_assert(
+            sizeof...(Tags) == hpx::tuple_size<hpx::tuple<Ts...>>::value,
             "the number of tags must be identical to the size of the given "
             "tuple");
 
-        typedef typename detail::tagged_tuple_helper<tuple<Ts...>,
+        typedef typename detail::tagged_tuple_helper<hpx::tuple<Ts...>,
             typename util::make_index_pack<sizeof...(Tags)>::type,
             Tags...>::type result_type;
 
         return lcos::make_future<result_type>(
-            std::move(f), [](tuple<Ts...>&& t) -> result_type {
+            std::move(f), [](hpx::tuple<Ts...>&& t) -> result_type {
                 return make_tagged_tuple<Tags...>(std::move(t));
             });
     }

--- a/libs/parallelism/execution/include/hpx/execution/executors/rebind_executor.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/executors/rebind_executor.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016-2017 Hartmut Kaiser
+//  Copyright (c) 2016-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -29,20 +29,20 @@ namespace hpx { namespace parallel { namespace execution {
         };
 
         template <>
-        struct is_not_weaker<parallel_execution_tag, unsequenced_execution_tag>
-          : std::true_type
+        struct is_not_weaker<hpx::execution::parallel_execution_tag,
+            hpx::execution::unsequenced_execution_tag> : std::true_type
         {
         };
 
         template <>
-        struct is_not_weaker<sequenced_execution_tag, unsequenced_execution_tag>
-          : std::true_type
+        struct is_not_weaker<hpx::execution::sequenced_execution_tag,
+            hpx::execution::unsequenced_execution_tag> : std::true_type
         {
         };
 
         template <>
-        struct is_not_weaker<sequenced_execution_tag, parallel_execution_tag>
-          : std::true_type
+        struct is_not_weaker<hpx::execution::sequenced_execution_tag,
+            hpx::execution::parallel_execution_tag> : std::true_type
         {
         };
         /// \endcond

--- a/libs/parallelism/executors/include/hpx/executors/dataflow.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/dataflow.hpp
@@ -234,8 +234,8 @@ namespace hpx { namespace lcos { namespace detail {
         {
             detail::dataflow_finalization<dataflow_type> this_f_(this);
 
-            parallel::execution::parallel_policy_executor<launch::async_policy>
-                exec{policy};
+            hpx::execution::parallel_policy_executor<launch::async_policy> exec{
+                policy};
 
             exec.post(std::move(this_f_), std::move(futures));
         }
@@ -244,8 +244,8 @@ namespace hpx { namespace lcos { namespace detail {
         {
             detail::dataflow_finalization<dataflow_type> this_f_(this);
 
-            parallel::execution::parallel_policy_executor<launch::fork_policy>
-                exec{policy};
+            hpx::execution::parallel_policy_executor<launch::fork_policy> exec{
+                policy};
 
             exec.post(std::move(this_f_), std::move(futures));
         }
@@ -318,7 +318,7 @@ namespace hpx { namespace lcos { namespace detail {
         {
             detail::dataflow_finalization<dataflow_type> this_f_(this);
 
-            parallel::execution::post(std::forward<Executor>(exec),
+            hpx::parallel::execution::post(std::forward<Executor>(exec),
                 std::move(this_f_), std::move(futures));
         }
 

--- a/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
+++ b/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
@@ -104,7 +104,7 @@ namespace hpx {
         class async_traversal_frame : public Visitor
         {
         protected:
-            tuple<Args...> args_;
+            hpx::tuple<Args...> args_;
             std::atomic<bool> finished_;
 
             Visitor& visitor() noexcept
@@ -141,7 +141,7 @@ namespace hpx {
             }
 
             /// Returns the arguments of the frame
-            tuple<Args...>& head() noexcept
+            hpx::tuple<Args...>& head() noexcept
             {
                 return args_;
             }
@@ -376,12 +376,12 @@ namespace hpx {
         class async_traversal_point
         {
             Frame frame_;
-            tuple<Hierarchy...> hierarchy_;
+            hpx::tuple<Hierarchy...> hierarchy_;
             bool& detached_;
 
         public:
             explicit async_traversal_point(
-                Frame frame, tuple<Hierarchy...> hierarchy, bool& detached)
+                Frame frame, hpx::tuple<Hierarchy...> hierarchy, bool& detached)
               : frame_(std::move(frame))
               , hierarchy_(std::move(hierarchy))
               , detached_(detached)

--- a/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_impl.hpp
+++ b/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_impl.hpp
@@ -31,29 +31,30 @@ namespace hpx { namespace util { namespace detail {
         template <typename... T>
         class spread_box
         {
-            tuple<T...> boxed_;
+            hpx::tuple<T...> boxed_;
 
         public:
-            explicit constexpr spread_box(tuple<T...> boxed)
+            explicit constexpr spread_box(hpx::tuple<T...> boxed)
               : boxed_(std::move(boxed))
             {
             }
 
-            tuple<T...> unbox()
+            hpx::tuple<T...> unbox()
             {
                 return std::move(boxed_);
             }
         };
+
         template <>
         class spread_box<>
         {
         public:
             explicit constexpr spread_box() noexcept {}
-            explicit constexpr spread_box(tuple<> const&) noexcept {}
+            explicit constexpr spread_box(hpx::tuple<> const&) noexcept {}
 
-            constexpr tuple<> unbox() const noexcept
+            constexpr hpx::tuple<> unbox() const noexcept
             {
-                return tuple<>{};
+                return hpx::tuple<>{};
             }
         };
 
@@ -117,9 +118,9 @@ namespace hpx { namespace util { namespace detail {
         /// Converts types to the a tuple carrying the single type and
         /// spread_box objects to its underlying tuple.
         template <typename T>
-        constexpr tuple<T> undecorate(T&& type)
+        constexpr hpx::tuple<T> undecorate(T&& type)
         {
-            return tuple<T>{std::forward<T>(type)};
+            return hpx::tuple<T>{std::forward<T>(type)};
         }
         template <typename... T>
         constexpr auto undecorate(spread_box<T...> type)
@@ -153,14 +154,14 @@ namespace hpx { namespace util { namespace detail {
         };
 
         /// A callable object which maps its content back to a tuple.
-        template <template <typename...> class Type = tuple>
-        using tupelizer_of_t = tupelizer_base<tuple<>, Type>;
+        template <template <typename...> class Type = hpx::tuple>
+        using tupelizer_of_t = tupelizer_base<hpx::tuple<>, Type>;
 
         /// A callable object which maps its content back to a tuple like
         /// type if it wasn't empty. For empty types arguments an empty
         /// spread box is returned instead. This is useful to propagate
         /// empty mappings back to the caller.
-        template <template <typename...> class Type = tuple>
+        template <template <typename...> class Type = hpx::tuple>
         using flat_tupelizer_of_t = tupelizer_base<spread_box<>, Type>;
 
         /// A callable object which maps its content back to an
@@ -267,17 +268,17 @@ namespace hpx { namespace util { namespace detail {
 
         /// Converts an empty tuple to void
         template <typename First, typename... Rest>
-        constexpr tuple<First, Rest...> voidify_empty_tuple(
-            tuple<First, Rest...> val)
+        constexpr hpx::tuple<First, Rest...> voidify_empty_tuple(
+            hpx::tuple<First, Rest...> val)
         {
             return val;
         }
-        inline void voidify_empty_tuple(tuple<> const&) noexcept {}
+        inline void voidify_empty_tuple(hpx::tuple<> const&) noexcept {}
 
         /// Converts the given variadic arguments into a tuple in a way
         /// that spread return values are inserted into the current pack.
         ///
-        /// If the returned tuple is empty, voidis returned instead.
+        /// If the returned tuple is empty, void is returned instead.
         template <typename... T>
         constexpr auto tupelize_or_void(T&&... args)
             -> decltype(voidify_empty_tuple(tupelize(std::forward<T>(args)...)))

--- a/libs/parallelism/timed_execution/include/hpx/timed_execution/timed_executors.hpp
+++ b/libs/parallelism/timed_execution/include/hpx/timed_execution/timed_executors.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2020 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -110,7 +110,7 @@ namespace hpx { namespace parallel { namespace execution {
         };
 
         template <>
-        struct sync_execute_at_helper<sequenced_execution_tag>
+        struct sync_execute_at_helper<hpx::execution::sequenced_execution_tag>
         {
             template <typename Executor, typename F, typename... Ts>
             static auto call(hpx::traits::detail::wrap_int, Executor&& exec,
@@ -199,7 +199,7 @@ namespace hpx { namespace parallel { namespace execution {
         };
 
         template <>
-        struct async_execute_at_helper<sequenced_execution_tag>
+        struct async_execute_at_helper<hpx::execution::sequenced_execution_tag>
         {
             template <typename Executor, typename F, typename... Ts>
             static auto call(hpx::traits::detail::wrap_int, Executor&& exec,
@@ -281,7 +281,7 @@ namespace hpx { namespace parallel { namespace execution {
         };
 
         template <>
-        struct post_at_helper<sequenced_execution_tag>
+        struct post_at_helper<hpx::execution::sequenced_execution_tag>
         {
             template <typename Executor, typename F, typename... Ts>
             static void call(hpx::traits::detail::wrap_int, Executor&& exec,


### PR DESCRIPTION
There are probably more warnings caused by the recent enabling of the deprecation macros. The changes in this PR make Phylanx compile without those.