### PR TITLE
Avoid unnecessarily including entire modules

### DIFF
--- a/hpx/lcos/packaged_action.hpp
+++ b/hpx/lcos/packaged_action.hpp
@@ -27,6 +27,7 @@
 
 #include <exception>
 #include <memory>
+#include <type_traits>
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -199,7 +200,7 @@ namespace hpx { namespace lcos {
                         << hpx::actions::detail::get_action_name<action_type>()
                         << ", " << id << ") args(" << sizeof...(Ts) << ")";
 
-            using callback_type = typename util::decay<Callback>::type;
+            using callback_type = typename std::decay<Callback>::type;
 
 #if defined(HPX_HAVE_NETWORKING)
             auto&& f = detail::parcel_write_handler_cb<Result, callback_type>{
@@ -241,7 +242,7 @@ namespace hpx { namespace lcos {
                         << hpx::actions::detail::get_action_name<action_type>()
                         << ", " << id << ") args(" << sizeof...(Ts) << ")";
 
-            using callback_type = typename util::decay<Callback>::type;
+            using callback_type = typename std::decay<Callback>::type;
 
 #if defined(HPX_HAVE_NETWORKING)
             auto&& f = detail::parcel_write_handler_cb<Result, callback_type>{
@@ -375,7 +376,7 @@ namespace hpx { namespace lcos {
                         << hpx::actions::detail::get_action_name<action_type>()
                         << ", " << id << ") args(" << sizeof...(Ts) << ")";
 
-            using callback_type = typename util::decay<Callback>::type;
+            using callback_type = typename std::decay<Callback>::type;
 
 #if defined(HPX_HAVE_NETWORKING)
             auto&& f = detail::parcel_write_handler_cb<Result, callback_type>{

--- a/hpx/runtime/actions/continuation.hpp
+++ b/hpx/runtime/actions/continuation.hpp
@@ -25,7 +25,6 @@
 #include <hpx/serialization/base_object.hpp>
 #include <hpx/serialization/serialize.hpp>
 #include <hpx/traits/is_continuation.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <exception>
 #include <type_traits>
@@ -136,7 +135,7 @@ namespace hpx { namespace actions
         template <typename F, typename Enable =
             typename std::enable_if<
                !std::is_same<
-                    typename util::decay<F>::type, typed_continuation
+                    typename std::decay<F>::type, typed_continuation
                 >::value
             >::type
         >
@@ -254,7 +253,7 @@ namespace hpx { namespace actions
         template <typename F, typename Enable =
             typename std::enable_if<
                !std::is_same<
-                    typename util::decay<F>::type, typed_continuation
+                    typename std::decay<F>::type, typed_continuation
                 >::value
             >::type
         >
@@ -365,7 +364,7 @@ namespace hpx { namespace actions
         template <typename F, typename Enable =
             typename std::enable_if<
                !std::is_same<
-                    typename util::decay<F>::type, typed_continuation
+                    typename std::decay<F>::type, typed_continuation
                 >::value
             >::type
         >

--- a/hpx/runtime/actions/continuation2_impl.hpp
+++ b/hpx/runtime/actions/continuation2_impl.hpp
@@ -12,8 +12,8 @@
 #include <hpx/async_distributed/applier/apply_continue_fwd.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/serialization/access.hpp>
-#include <hpx/type_support/decay.hpp>
 
+#include <type_traits>
 #include <utility>
 
 namespace hpx { namespace actions {
@@ -22,8 +22,8 @@ namespace hpx { namespace actions {
     struct continuation2_impl
     {
     private:
-        typedef typename util::decay<Cont>::type cont_type;
-        typedef typename util::decay<F>::type function_type;
+        typedef typename std::decay<Cont>::type cont_type;
+        typedef typename std::decay<F>::type function_type;
 
     public:
         continuation2_impl() {}

--- a/hpx/runtime/actions/continuation_impl.hpp
+++ b/hpx/runtime/actions/continuation_impl.hpp
@@ -6,13 +6,13 @@
 
 #pragma once
 
-#include <hpx/functional/invoke_result.hpp>
-#include <hpx/async_distributed/applier/detail/apply_implementations_fwd.hpp>
 #include <hpx/async_distributed/applier/apply.hpp>
+#include <hpx/async_distributed/applier/detail/apply_implementations_fwd.hpp>
+#include <hpx/functional/invoke_result.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/serialization/access.hpp>
-#include <hpx/type_support/decay.hpp>
 
+#include <type_traits>
 #include <utility>
 
 namespace hpx { namespace actions {
@@ -21,7 +21,7 @@ namespace hpx { namespace actions {
     struct continuation_impl
     {
     private:
-        typedef typename util::decay<Cont>::type cont_type;
+        typedef typename std::decay<Cont>::type cont_type;
 
     public:
         continuation_impl() {}

--- a/hpx/runtime/actions/make_continuation.hpp
+++ b/hpx/runtime/actions/make_continuation.hpp
@@ -12,7 +12,6 @@
 #include <hpx/runtime/actions/continuation_impl.hpp>
 #include <hpx/runtime/actions/continuation2_impl.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -26,22 +25,22 @@ namespace hpx {
 
     template <typename Cont>
     inline hpx::actions::continuation_impl<
-        typename util::decay<Cont>::type
+        typename std::decay<Cont>::type
     >
     make_continuation(Cont && cont)
     {
-        typedef typename util::decay<Cont>::type cont_type;
+        typedef typename std::decay<Cont>::type cont_type;
         return hpx::actions::continuation_impl<cont_type>(
             std::forward<Cont>(cont), hpx::find_here());
     }
 
     template <typename Cont>
     inline hpx::actions::continuation_impl<
-        typename util::decay<Cont>::type
+        typename std::decay<Cont>::type
     >
     make_continuation(Cont && f, hpx::naming::id_type const& target)
     {
-        typedef typename util::decay<Cont>::type cont_type;
+        typedef typename std::decay<Cont>::type cont_type;
         return hpx::actions::continuation_impl<cont_type>(
             std::forward<Cont>(f), target);
     }
@@ -49,18 +48,18 @@ namespace hpx {
     template <typename Cont, typename F>
     inline typename std::enable_if<
         !std::is_same<
-            typename util::decay<F>::type,
+            typename std::decay<F>::type,
             hpx::naming::id_type
         >::value,
         hpx::actions::continuation2_impl<
-            typename util::decay<Cont>::type,
-            typename util::decay<F>::type
+            typename std::decay<Cont>::type,
+            typename std::decay<F>::type
         >
     >::type
     make_continuation(Cont && cont, F && f)
     {
-        typedef typename util::decay<Cont>::type cont_type;
-        typedef typename util::decay<F>::type function_type;
+        typedef typename std::decay<Cont>::type cont_type;
+        typedef typename std::decay<F>::type function_type;
 
         return hpx::actions::continuation2_impl<cont_type, function_type>(
             std::forward<Cont>(cont), hpx::find_here(), std::forward<F>(f));
@@ -68,14 +67,14 @@ namespace hpx {
 
     template <typename Cont, typename F>
     inline hpx::actions::continuation2_impl<
-        typename util::decay<Cont>::type,
-        typename util::decay<F>::type
+        typename std::decay<Cont>::type,
+        typename std::decay<F>::type
     >
     make_continuation(Cont && cont, hpx::naming::id_type const& target,
         F && f)
     {
-        typedef typename util::decay<Cont>::type cont_type;
-        typedef typename util::decay<F>::type function_type;
+        typedef typename std::decay<Cont>::type cont_type;
+        typedef typename std::decay<F>::type function_type;
 
         return hpx::actions::continuation2_impl<cont_type, function_type>(
             std::forward<Cont>(cont), target, std::forward<F>(f));

--- a/hpx/runtime/actions/trigger.hpp
+++ b/hpx/runtime/actions/trigger.hpp
@@ -9,7 +9,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions_base/continuation_fwd.hpp>
-#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <exception>
@@ -24,7 +24,7 @@ namespace hpx { namespace actions
     {
         try
         {
-            cont.trigger_value(util::invoke(
+            cont.trigger_value(HPX_INVOKE(
                 std::forward<F>(f), std::forward<Ts>(vs)...));
         } catch (...) {
             // make sure hpx::exceptions are propagated back to the client
@@ -39,7 +39,7 @@ namespace hpx { namespace actions
     {
         try
         {
-            util::invoke(std::forward<F>(f), std::forward<Ts>(vs)...);
+            HPX_INVOKE(std::forward<F>(f), std::forward<Ts>(vs)...);
             cont.trigger();
         } catch (...) {
             // make sure hpx::exceptions are propagated back to the client

--- a/hpx/runtime/components/server/locking_hook.hpp
+++ b/hpx/runtime/components/server/locking_hook.hpp
@@ -17,8 +17,8 @@
 #include <hpx/traits/action_decorate_function.hpp>
 
 #include <mutex>
-#include <utility>
 #include <type_traits>
+#include <utility>
 
 namespace hpx { namespace components
 {
@@ -83,7 +83,7 @@ namespace hpx { namespace components
         struct decorate_wrapper
         {
             template <typename F, typename Enable = typename
-                std::enable_if<!std::is_same<typename hpx::util::decay<F>::type,
+                std::enable_if<!std::is_same<typename std::decay<F>::type,
                     decorate_wrapper>::value>::type>
             // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
             decorate_wrapper(F && f)

--- a/hpx/runtime/components/stubs/runtime_support.hpp
+++ b/hpx/runtime/components/stubs/runtime_support.hpp
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -50,7 +51,7 @@ namespace hpx { namespace components { namespace stubs
             }
 
             typedef server::create_component_action<
-                Component, typename hpx::util::decay<Ts>::type...
+                Component, typename std::decay<Ts>::type...
             > action_type;
             return hpx::async<action_type>(gid, std::forward<Ts>(vs)...);
         }
@@ -74,7 +75,7 @@ namespace hpx { namespace components { namespace stubs
             std::size_t count, Ts&&... vs)
         {
             typedef server::bulk_create_component_action<
-                Component, typename hpx::util::decay<Ts>::type...
+                Component, typename std::decay<Ts>::type...
             > action_type;
 
             return hpx::detail::async_colocated<action_type>(gid, count,
@@ -109,7 +110,7 @@ namespace hpx { namespace components { namespace stubs
             }
 
             typedef server::bulk_create_component_action<
-                Component, typename hpx::util::decay<Ts>::type...
+                Component, typename std::decay<Ts>::type...
             > action_type;
             return hpx::async<action_type>(gid, count,
                 std::forward<Ts>(vs)...);
@@ -135,7 +136,7 @@ namespace hpx { namespace components { namespace stubs
             Ts&&... vs)
         {
             typedef server::create_component_action<
-                Component, typename hpx::util::decay<Ts>::type...
+                Component, typename std::decay<Ts>::type...
             > action_type;
             return hpx::detail::async_colocated<action_type>(gid,
                 std::forward<Ts>(vs)...);

--- a/hpx/runtime/components/stubs/stub_base.hpp
+++ b/hpx/runtime/components/stubs/stub_base.hpp
@@ -18,6 +18,7 @@
 #include <hpx/runtime/naming/name.hpp>
 
 #include <cstddef>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -62,7 +63,7 @@ namespace hpx { namespace components
             }
 
             typedef server::create_component_action<
-                ServerComponent, typename hpx::util::decay<Ts>::type...
+                ServerComponent, typename std::decay<Ts>::type...
             > action_type;
             return hpx::async<action_type>(gid, std::forward<Ts>(vs)...);
         }
@@ -82,7 +83,7 @@ namespace hpx { namespace components
             }
 
             typedef server::bulk_create_component_action<
-                ServerComponent, typename hpx::util::decay<Ts>::type...
+                ServerComponent, typename std::decay<Ts>::type...
             > action_type;
             return hpx::async<action_type>(gid, count,
                 std::forward<Ts>(vs)...);
@@ -107,7 +108,7 @@ namespace hpx { namespace components
         create_colocated_async(naming::id_type const& gid, Ts&&... vs)
         {
             typedef server::create_component_action<
-                ServerComponent, typename hpx::util::decay<Ts>::type...
+                ServerComponent, typename std::decay<Ts>::type...
             > action_type;
             return hpx::detail::async_colocated<action_type>(
                 gid, std::forward<Ts>(vs)...);
@@ -126,7 +127,7 @@ namespace hpx { namespace components
             std::size_t count, Ts&&... vs)
         {
             typedef server::bulk_create_component_action<
-                ServerComponent, typename hpx::util::decay<Ts>::type...
+                ServerComponent, typename std::decay<Ts>::type...
             > action_type;
 
             return hpx::detail::async_colocated<action_type>(gid, count,

--- a/hpx/runtime/parcelset/locality.hpp
+++ b/hpx/runtime/parcelset/locality.hpp
@@ -70,11 +70,11 @@ namespace hpx { namespace parcelset
 
         template <typename Impl,
             typename Enable1 = typename std::enable_if<!std::is_same<locality,
-                typename util::decay<Impl>::type>::value>::type,
+                typename std::decay<Impl>::type>::value>::type,
             typename Enable2 = typename std::enable_if<
                 !traits::is_iterator<Impl>::value>::type>
         explicit locality(Impl&& i)
-          : impl_(new impl<typename util::decay<Impl>::type>(
+          : impl_(new impl<typename std::decay<Impl>::type>(
                 std::forward<Impl>(i)))
         {}
 

--- a/hpx/runtime/trigger_lco.hpp
+++ b/hpx/runtime/trigger_lco.hpp
@@ -18,7 +18,6 @@
 #include <hpx/runtime/naming/address.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime/naming/name.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <exception>
 #include <type_traits>
@@ -105,7 +104,7 @@ namespace hpx
     ///                     message. The default value is \a true.
     template <typename Result>
     typename std::enable_if<
-        !std::is_same<typename util::decay<Result>::type, naming::address>::value
+        !std::is_same<typename std::decay<Result>::type, naming::address>::value
     >::type
     set_lco_value(naming::id_type const& id, Result && t, bool move_credits = true)
     {
@@ -123,7 +122,7 @@ namespace hpx
     ///                     message. The default value is \a true.
     template <typename Result>
     typename std::enable_if<
-        !std::is_same<typename util::decay<Result>::type, naming::address>::value
+        !std::is_same<typename std::decay<Result>::type, naming::address>::value
     >::type
     set_lco_value_unmanaged(naming::id_type const& id, Result && t,
         bool move_credits = true)
@@ -160,7 +159,7 @@ namespace hpx
     ///                     message. The default value is \a true.
     template <typename Result>
     typename std::enable_if<
-        !std::is_same<typename util::decay<Result>::type, naming::address>::value
+        !std::is_same<typename std::decay<Result>::type, naming::address>::value
     >::type
     set_lco_value(naming::id_type const& id, Result && t,
         naming::id_type const& cont, bool move_credits = true)
@@ -181,7 +180,7 @@ namespace hpx
     ///                     message. The default value is \a true.
     template <typename Result>
     typename std::enable_if<
-        !std::is_same<typename util::decay<Result>::type, naming::address>::value
+        !std::is_same<typename std::decay<Result>::type, naming::address>::value
     >::type
     set_lco_value_unmanaged(naming::id_type const& id, Result && t,
         naming::id_type const& cont, bool move_credits = true)
@@ -464,7 +463,7 @@ namespace hpx
     void set_lco_value(naming::id_type const& id, naming::address && addr,
         Result && t, bool move_credits)
     {
-        typedef typename util::decay<Result>::type remote_result_type;
+        typedef typename std::decay<Result>::type remote_result_type;
         typedef typename traits::promise_local_result<
                 remote_result_type
             >::type local_result_type;
@@ -500,7 +499,7 @@ namespace hpx
     void set_lco_value(naming::id_type const& id, naming::address && addr,
         Result && t, naming::id_type const& cont, bool move_credits)
     {
-        typedef typename util::decay<Result>::type remote_result_type;
+        typedef typename std::decay<Result>::type remote_result_type;
         typedef typename traits::promise_local_result<
                 remote_result_type
             >::type local_result_type;

--- a/hpx/traits/is_continuation.hpp
+++ b/hpx/traits/is_continuation.hpp
@@ -8,7 +8,6 @@
 
 #include <hpx/config.hpp>
 #include <hpx/type_support/always_void.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <type_traits>
 
@@ -30,7 +29,7 @@ namespace hpx { namespace traits
 
     template <typename Continuation, typename Enable = void>
     struct is_continuation
-      : detail::is_continuation_impl<typename util::decay<Continuation>::type>
+      : detail::is_continuation_impl<typename std::decay<Continuation>::type>
     {};
 }}
 

--- a/hpx/traits/is_valid_action.hpp
+++ b/hpx/traits/is_valid_action.hpp
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <type_traits>
 
@@ -17,8 +16,8 @@ namespace hpx { namespace traits
     template <typename Action, typename Component, typename Enable = void>
     struct is_valid_action
       : std::is_same<
-            typename util::decay<typename Action::component_type>::type,
-            typename util::decay<Component>::type>
+            typename std::decay<typename Action::component_type>::type,
+            typename std::decay<Component>::type>
     {};
 }}
 

--- a/hpx/util/functional/colocated_helpers.hpp
+++ b/hpx/util/functional/colocated_helpers.hpp
@@ -20,8 +20,8 @@
 #include <hpx/type_support/unused.hpp>
 
 #include <memory>
-#include <utility>
 #include <type_traits>
+#include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace util { namespace functional
@@ -54,8 +54,8 @@ namespace hpx { namespace util { namespace functional
         struct apply_continuation_impl
         {
 
-            typedef typename util::decay<Bound>::type bound_type;
-            typedef typename util::decay<Continuation>::type continuation_type;
+            typedef typename std::decay<Bound>::type bound_type;
+            typedef typename std::decay<Continuation>::type continuation_type;
 
             apply_continuation_impl() = default;
 
@@ -109,12 +109,12 @@ namespace hpx { namespace util { namespace functional
         struct apply_continuation_impl<Bound, hpx::util::unused_type>
         {
 
-            typedef typename util::decay<Bound>::type bound_type;
+            typedef typename std::decay<Bound>::type bound_type;
 
             apply_continuation_impl() = default;
 
             template <typename Bound_, typename Enable = typename
-                std::enable_if<!std::is_same<typename hpx::util::decay<Bound_>::type,
+                std::enable_if<!std::is_same<typename std::decay<Bound_>::type,
                     apply_continuation_impl>::value>::type>
             explicit apply_continuation_impl(Bound_ && bound)
               : bound_(std::forward<Bound_>(bound))
@@ -183,8 +183,8 @@ namespace hpx { namespace util { namespace functional
         struct async_continuation_impl
         {
 
-            typedef typename util::decay<Bound>::type bound_type;
-            typedef typename util::decay<Continuation>::type continuation_type;
+            typedef typename std::decay<Bound>::type bound_type;
+            typedef typename std::decay<Continuation>::type continuation_type;
 
             async_continuation_impl()
               : bound_(), cont_()
@@ -247,14 +247,14 @@ namespace hpx { namespace util { namespace functional
         struct async_continuation_impl<Bound, hpx::util::unused_type>
         {
 
-            typedef typename util::decay<Bound>::type bound_type;
+            typedef typename std::decay<Bound>::type bound_type;
 
             async_continuation_impl()
               : bound_()
             {}
 
             template <typename Bound_, typename Enable = typename
-                std::enable_if<!std::is_same<typename hpx::util::decay<Bound_>::type,
+                std::enable_if<!std::is_same<typename std::decay<Bound_>::type,
                     async_continuation_impl>::value>::type>
             explicit async_continuation_impl(Bound_ && bound)
               : bound_(std::forward<Bound_>(bound))

--- a/hpx/util/storage/tuple.hpp
+++ b/hpx/util/storage/tuple.hpp
@@ -6,10 +6,9 @@
 
 #pragma once
 
+#include <hpx/serialization/serializable_any.hpp>
 #include <hpx/serialization/serialize.hpp>
 #include <hpx/serialization/vector.hpp>
-#include <hpx/type_support/decay.hpp>
-#include <hpx/serialization/serializable_any.hpp>
 
 #include <type_traits>
 #include <vector>
@@ -84,7 +83,7 @@ namespace hpx { namespace util { namespace storage {
         template <typename T>
         tuple& push_back(const T& field,
             typename std::enable_if<!std::is_same<elem_type,
-                typename util::decay<T>::type>::value>::type* = nullptr)
+                typename std::decay<T>::type>::value>::type* = nullptr)
         {
             tuple_.push_back(elem_type(field));    // insert an any object
             return *this;

--- a/libs/core/datastructures/include/hpx/datastructures/tagged.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/tagged.hpp
@@ -12,7 +12,6 @@
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/datastructures/tuple.hpp>
-#include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/pack.hpp>
 
 #include <cstddef>
@@ -155,7 +154,7 @@ namespace hpx { namespace util {
         // Returns: *this.
         template <typename U,
             HPX_CONCEPT_REQUIRES_(
-                !std::is_same<tagged, typename decay<U>::type>::value &&
+                !std::is_same<tagged, typename std::decay<U>::type>::value &&
                 std::is_convertible<U, Base>::value)>
         tagged& operator=(U&& u)
         {

--- a/libs/core/datastructures/include/hpx/datastructures/tagged_pair.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/tagged_pair.hpp
@@ -13,7 +13,6 @@
 #include <hpx/assert.hpp>
 #include <hpx/datastructures/tagged.hpp>
 #include <hpx/datastructures/tuple.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <cstddef>
 #include <type_traits>
@@ -43,24 +42,24 @@ namespace hpx { namespace util {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Tag1, typename Tag2, typename T1, typename T2>
-    constexpr HPX_FORCEINLINE tagged_pair<Tag1(typename decay<T1>::type),
-        Tag2(typename decay<T2>::type)>
+    constexpr HPX_FORCEINLINE tagged_pair<Tag1(typename std::decay<T1>::type),
+        Tag2(typename std::decay<T2>::type)>
     make_tagged_pair(std::pair<T1, T2>&& p)
     {
-        typedef tagged_pair<Tag1(typename decay<T1>::type),
-            Tag2(typename decay<T2>::type)>
+        typedef tagged_pair<Tag1(typename std::decay<T1>::type),
+            Tag2(typename std::decay<T2>::type)>
             result_type;
 
         return result_type(std::move(p));
     }
 
     template <typename Tag1, typename Tag2, typename T1, typename T2>
-    constexpr HPX_FORCEINLINE tagged_pair<Tag1(typename decay<T1>::type),
-        Tag2(typename decay<T2>::type)>
+    constexpr HPX_FORCEINLINE tagged_pair<Tag1(typename std::decay<T1>::type),
+        Tag2(typename std::decay<T2>::type)>
     make_tagged_pair(std::pair<T1, T2> const& p)
     {
-        typedef tagged_pair<Tag1(typename decay<T1>::type),
-            Tag2(typename decay<T2>::type)>
+        typedef tagged_pair<Tag1(typename std::decay<T1>::type),
+            Tag2(typename std::decay<T2>::type)>
             result_type;
 
         return result_type(p);
@@ -102,12 +101,12 @@ namespace hpx { namespace util {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Tag1, typename Tag2, typename T1, typename T2>
-    constexpr HPX_FORCEINLINE tagged_pair<Tag1(typename decay<T1>::type),
-        Tag2(typename decay<T2>::type)>
+    constexpr HPX_FORCEINLINE tagged_pair<Tag1(typename std::decay<T1>::type),
+        Tag2(typename std::decay<T2>::type)>
     make_tagged_pair(T1&& t1, T2&& t2)
     {
-        typedef tagged_pair<Tag1(typename decay<T1>::type),
-            Tag2(typename decay<T2>::type)>
+        typedef tagged_pair<Tag1(typename std::decay<T1>::type),
+            Tag2(typename std::decay<T2>::type)>
             result_type;
 
         return result_type(std::forward<T1>(t1), std::forward<T2>(t2));

--- a/libs/core/datastructures/include/hpx/datastructures/tagged_tuple.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/tagged_tuple.hpp
@@ -12,10 +12,10 @@
 #include <hpx/config.hpp>
 #include <hpx/datastructures/tagged.hpp>
 #include <hpx/datastructures/tuple.hpp>
-#include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/identity.hpp>
 
 #include <cstddef>
+#include <type_traits>
 #include <utility>
 
 namespace hpx { namespace util {
@@ -41,7 +41,7 @@ namespace hpx { namespace util {
         template <typename Tag, typename T>
         struct tagged_type
         {
-            typedef typename decay<T>::type decayed_type;
+            typedef typename std::decay<T>::type decayed_type;
             typedef typename hpx::util::identity<Tag(decayed_type)>::type type;
         };
     }    // namespace detail

--- a/libs/core/datastructures/tests/unit/tagged.cpp
+++ b/libs/core/datastructures/tests/unit/tagged.cpp
@@ -57,11 +57,11 @@ void tagged_pair_test()
         static_assert(std::is_same<decltype(p.second), B>::value, "");
 
         static_assert(
-            std::is_same<typename hpx::util::decay<decltype(p.tag1())>::type,
+            std::is_same<typename std::decay<decltype(p.tag1())>::type,
                 A>::value,
             "");
         static_assert(
-            std::is_same<typename hpx::util::decay<decltype(p.tag2())>::type,
+            std::is_same<typename std::decay<decltype(p.tag2())>::type,
                 B>::value,
             "");
     }
@@ -115,15 +115,15 @@ void tagged_tuple_test()
             "");
 
         static_assert(
-            std::is_same<typename hpx::util::decay<decltype(t.tag1())>::type,
+            std::is_same<typename std::decay<decltype(t.tag1())>::type,
                 A>::value,
             "");
         static_assert(
-            std::is_same<typename hpx::util::decay<decltype(t.tag2())>::type,
+            std::is_same<typename std::decay<decltype(t.tag2())>::type,
                 B>::value,
             "");
         static_assert(
-            std::is_same<typename hpx::util::decay<decltype(t.tag3())>::type,
+            std::is_same<typename std::decay<decltype(t.tag3())>::type,
                 C>::value,
             "");
     }

--- a/libs/core/execution_base/include/hpx/execution_base/execution.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/execution.hpp
@@ -10,7 +10,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/iterator_support.hpp>
+#include <hpx/iterator_support/counting_iterator.hpp>
+#include <hpx/iterator_support/iterator_range.hpp>
 
 #include <type_traits>
 #include <utility>

--- a/libs/core/execution_base/include/hpx/execution_base/register_locks.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/register_locks.hpp
@@ -9,7 +9,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/has_member_xxx.hpp>
-#include <hpx/modules/functional.hpp>
+#include <hpx/functional/function.hpp>
 
 #include <cstddef>
 #include <map>

--- a/libs/core/functional/include/hpx/functional/mem_fn.hpp
+++ b/libs/core/functional/include/hpx/functional/mem_fn.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/functional/invoke_result.hpp>
 
 #include <utility>
@@ -32,7 +32,7 @@ namespace hpx { namespace util {
             constexpr typename util::invoke_result<MemberPointer, Ts...>::type
             operator()(Ts&&... vs) const
             {
-                return util::invoke(_pm, std::forward<Ts>(vs)...);
+                return HPX_INVOKE(_pm, std::forward<Ts>(vs)...);
             }
 
             MemberPointer _pm;

--- a/libs/core/functional/include/hpx/functional/traits/is_action.hpp
+++ b/libs/core/functional/include/hpx/functional/traits/is_action.hpp
@@ -8,7 +8,6 @@
 
 #include <hpx/config.hpp>
 #include <hpx/type_support/always_void.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <type_traits>
 
@@ -28,8 +27,7 @@ namespace hpx { namespace traits {
     }    // namespace detail
 
     template <typename Action, typename Enable = void>
-    struct is_action
-      : detail::is_action_impl<typename util::decay<Action>::type>
+    struct is_action : detail::is_action_impl<typename std::decay<Action>::type>
     {
     };
 

--- a/libs/core/iterator_support/include/hpx/iterator_support/counting_iterator.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/counting_iterator.hpp
@@ -11,7 +11,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/iterator_support/iterator_adaptor.hpp>
-#include <hpx/modules/type_support.hpp>
+#include <hpx/type_support/identity.hpp>
+#include <hpx/type_support/lazy_conditional.hpp>
 
 #include <cstddef>
 #include <iterator>

--- a/libs/core/iterator_support/tests/unit/stencil3_iterator.cpp
+++ b/libs/core/iterator_support/tests/unit/stencil3_iterator.cpp
@@ -163,10 +163,10 @@ namespace test {
     };
 
     template <typename F>
-    inline custom_stencil_transformer<typename hpx::util::decay<F>::type>
+    inline custom_stencil_transformer<typename std::decay<F>::type>
     make_custom_stencil_transformer(F&& f)
     {
-        typedef custom_stencil_transformer<typename hpx::util::decay<F>::type>
+        typedef custom_stencil_transformer<typename std::decay<F>::type>
             transformer_type;
         return transformer_type(std::forward<F>(f));
     }

--- a/libs/core/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
@@ -11,8 +11,8 @@
 #include <hpx/affinity/affinity_data.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/concurrency/cache_line_data.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/modules/errors.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/schedulers/deadlock_detection.hpp>
 #include <hpx/schedulers/lockfree_queue_backends.hpp>

--- a/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
@@ -12,8 +12,8 @@
 #if defined(HPX_HAVE_LOCAL_SCHEDULER)
 #include <hpx/affinity/affinity_data.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/modules/errors.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/schedulers/deadlock_detection.hpp>
 #include <hpx/schedulers/lockfree_queue_backends.hpp>

--- a/libs/core/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
@@ -14,8 +14,8 @@
 #include <hpx/assert.hpp>
 #include <hpx/debugging/print.hpp>
 #include <hpx/execution_base/this_thread.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/modules/errors.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/schedulers/lockfree_queue_backends.hpp>
 #include <hpx/schedulers/queue_holder_numa.hpp>
 #include <hpx/schedulers/queue_holder_thread.hpp>

--- a/libs/core/serialization/include/hpx/serialization/access.hpp
+++ b/libs/core/serialization/include/hpx/serialization/access.hpp
@@ -12,7 +12,6 @@
 #include <hpx/serialization/serialization_fwd.hpp>
 #include <hpx/serialization/traits/brace_initializable_traits.hpp>
 #include <hpx/serialization/traits/polymorphic_traits.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <string>
 #include <type_traits>
@@ -211,7 +210,7 @@ namespace hpx { namespace serialization {
                 {
                     // cast it to let it be run for templated
                     // member functions
-                    const_cast<typename util::decay<T>::type&>(t).serialize(
+                    const_cast<typename std::decay<T>::type&>(t).serialize(
                         ar, 0);
                 }
             };

--- a/libs/core/serialization/include/hpx/serialization/base_object.hpp
+++ b/libs/core/serialization/include/hpx/serialization/base_object.hpp
@@ -14,8 +14,6 @@
 #include <hpx/serialization/serialize.hpp>
 #include <hpx/serialization/traits/polymorphic_traits.hpp>
 
-#include <hpx/type_support/decay.hpp>
-
 #include <type_traits>
 
 namespace hpx { namespace serialization {
@@ -36,7 +34,7 @@ namespace hpx { namespace serialization {
         {
             access::serialize(ar,
                 static_cast<Base&>(
-                    const_cast<typename hpx::util::decay<Derived>::type&>(d_)),
+                    const_cast<typename std::decay<Derived>::type&>(d_)),
                 0);
         }
     };

--- a/libs/core/serialization/include/hpx/serialization/basic_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/basic_archive.hpp
@@ -9,7 +9,6 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
-#include <hpx/modules/datastructures.hpp>
 #include <hpx/serialization/detail/extra_archive_data.hpp>
 
 #include <algorithm>

--- a/libs/core/serialization/include/hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp
@@ -14,13 +14,13 @@
 #include <hpx/modules/debugging.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/hashing.hpp>
-#include <hpx/modules/type_support.hpp>
 #include <hpx/preprocessor/stringize.hpp>
 #include <hpx/preprocessor/strip_parens.hpp>
 #include <hpx/serialization/detail/non_default_constructible.hpp>
 #include <hpx/serialization/serialization_fwd.hpp>
 #include <hpx/serialization/traits/needs_automatic_registration.hpp>
 #include <hpx/serialization/traits/polymorphic_traits.hpp>
+#include <hpx/type_support/static.hpp>
 
 #include <memory>
 #include <string>

--- a/libs/core/serialization/include/hpx/serialization/serializable_any.hpp
+++ b/libs/core/serialization/include/hpx/serialization/serializable_any.hpp
@@ -161,11 +161,11 @@ namespace hpx { namespace util {
         basic_any(T&& x,
             typename std::enable_if<std::is_copy_constructible<
                 typename std::decay<T>::type>::value>::type* = nullptr)
-          : table(detail::any::get_table<typename util::decay<T>::type>::
+          : table(detail::any::get_table<typename std::decay<T>::type>::
                     template get<IArch, OArch, Char, std::true_type>())
           , object(nullptr)
         {
-            using value_type = typename util::decay<T>::type;
+            using value_type = typename std::decay<T>::type;
             new_object<T>(object,
                 typename detail::any::get_table<value_type>::is_small(),
                 std::forward<T>(x));

--- a/libs/core/serialization/include/hpx/serialization/serialize_buffer.hpp
+++ b/libs/core/serialization/include/hpx/serialization/serialize_buffer.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/datastructures.hpp>
+#include <hpx/datastructures/traits/supports_streaming_with_any.hpp>
 #include <hpx/modules/errors.hpp>
 
 #include <hpx/serialization/array.hpp>

--- a/libs/core/serialization/tests/performance/serialization_performance.cpp
+++ b/libs/core/serialization/tests/performance/serialization_performance.cpp
@@ -5,7 +5,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/modules/datastructures.hpp>
 #include <hpx/serialization/detail/preprocess_container.hpp>
 #include <hpx/serialization/serialize.hpp>
 #include <hpx/serialization/string.hpp>

--- a/libs/core/serialization/tests/unit/serialization_optional.cpp
+++ b/libs/core/serialization/tests/unit/serialization_optional.cpp
@@ -4,7 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/modules/datastructures.hpp>
+#include <hpx/datastructures/optional.hpp>
 #include <hpx/serialization/input_archive.hpp>
 #include <hpx/serialization/optional.hpp>
 #include <hpx/serialization/output_archive.hpp>

--- a/libs/core/synchronization/include/hpx/synchronization/once.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/once.hpp
@@ -11,7 +11,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/synchronization/event.hpp>
 
 #include <atomic>
@@ -60,8 +60,7 @@ namespace hpx { namespace lcos { namespace local {
                     // wrapped function was throwing an exception before
                     flag.event_.reset();
 
-                    util::invoke(
-                        std::forward<F>(f), std::forward<Args>(args)...);
+                    HPX_INVOKE(std::forward<F>(f), std::forward<Args>(args)...);
 
                     // set status to done, release waiting threads
                     flag.status_.store(function_complete_flag_value);

--- a/libs/core/testing/include/hpx/modules/testing.hpp
+++ b/libs/core/testing/include/hpx/modules/testing.hpp
@@ -10,7 +10,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
-#include <hpx/modules/functional.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/preprocessor/expand.hpp>
 #include <hpx/preprocessor/nargs.hpp>

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
@@ -12,7 +12,7 @@
 #include <hpx/concurrency/barrier.hpp>
 #include <hpx/execution_base/this_thread.hpp>
 #include <hpx/functional/deferred_call.hpp>
-#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/schedulers.hpp>
 #include <hpx/thread_pools/scheduled_thread_pool.hpp>
@@ -649,7 +649,7 @@ namespace hpx { namespace threads { namespace detail {
     {
         while (first != last)
         {
-            util::invoke(destproj, *dest++) = util::invoke(srcproj, *first++);
+            HPX_INVOKE(destproj, *dest++) = HPX_INVOKE(srcproj, *first++);
         }
         return dest;
     }
@@ -659,7 +659,7 @@ namespace hpx { namespace threads { namespace detail {
     {
         while (first != last)
         {
-            init = std::move(init) + util::invoke(proj, *first++);
+            init = std::move(init) + HPX_INVOKE(proj, *first++);
         }
         return init;
     }

--- a/libs/core/threading_base/include/hpx/threading_base/annotated_function.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/annotated_function.hpp
@@ -9,7 +9,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
-#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/functional/traits/get_function_address.hpp>
 #include <hpx/functional/traits/get_function_annotation.hpp>
 #include <hpx/threading_base/thread_description.hpp>
@@ -139,7 +139,7 @@ namespace hpx { namespace util {
                 Ts...>::type
             operator()(Ts&&... ts)
             {
-                return util::invoke(f_, std::forward<Ts>(ts)...);
+                return HPX_INVOKE(f_, std::forward<Ts>(ts)...);
             }
 
             template <typename Archive>

--- a/libs/core/threading_base/include/hpx/threading_base/external_timer.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/external_timer.hpp
@@ -9,7 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/coroutines/thread_id_type.hpp>
-#include <hpx/modules/functional.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/threading_base/thread_description.hpp>
 
 #include <cstdint>

--- a/libs/core/threading_base/include/hpx/threading_base/register_thread.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/register_thread.hpp
@@ -12,8 +12,8 @@
 #include <hpx/config.hpp>
 #include <hpx/config/asio.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/modules/errors.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/threading_base/scheduler_base.hpp>
 #include <hpx/threading_base/thread_data.hpp>
 #include <hpx/threading_base/thread_pool_base.hpp>

--- a/libs/core/threading_base/include/hpx/threading_base/scheduler_base.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/scheduler_base.hpp
@@ -9,9 +9,9 @@
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/concurrency/cache_line_data.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/threading_base/scheduler_mode.hpp>
 #include <hpx/threading_base/scheduler_state.hpp>
 #include <hpx/threading_base/thread_data.hpp>

--- a/libs/core/threading_base/include/hpx/threading_base/thread_pool_base.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_pool_base.hpp
@@ -10,8 +10,8 @@
 #include <hpx/config.hpp>
 #include <hpx/affinity/affinity_data.hpp>
 #include <hpx/concurrency/barrier.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/modules/errors.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/threading_base/callback_notifier.hpp>
 #include <hpx/threading_base/network_background_callback.hpp>
 #include <hpx/threading_base/scheduler_mode.hpp>

--- a/libs/core/timing/include/hpx/timing/high_resolution_clock.hpp
+++ b/libs/core/timing/include/hpx/timing/high_resolution_clock.hpp
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/type_support.hpp>
 
 #if defined(__bgq__)
 #include <hwi/include/bqc/A2_inlines.h>

--- a/libs/full/actions/include/hpx/actions/transfer_continuation_action.hpp
+++ b/libs/full/actions/include/hpx/actions/transfer_continuation_action.hpp
@@ -16,7 +16,6 @@
 #include <hpx/actions/transfer_base_action.hpp>
 #include <hpx/actions_base/actions_base_support.hpp>
 #include <hpx/async_distributed/applier/apply_helper.hpp>
-#include <hpx/modules/datastructures.hpp>
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/serialization/input_archive.hpp>
 #include <hpx/serialization/output_archive.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/applier/apply_callback.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/applier/apply_callback.hpp
@@ -435,15 +435,15 @@ namespace hpx {
         };
 
         template <typename Action, typename Callback, typename... Ts>
-        apply_c_p_cb_impl<Action, typename util::decay<Callback>::type,
-            typename util::decay<Ts>::type...>
+        apply_c_p_cb_impl<Action, typename std::decay<Callback>::type,
+            typename std::decay<Ts>::type...>
         apply_c_p_cb(naming::id_type const& contid, naming::address&& addr,
             naming::id_type const& id, threads::thread_priority p,
             Callback&& cb, Ts&&... vs)
         {
             typedef apply_c_p_cb_impl<Action,
-                typename util::decay<Callback>::type,
-                typename util::decay<Ts>::type...>
+                typename std::decay<Callback>::type,
+                typename std::decay<Ts>::type...>
                 result_type;
 
             return result_type(contid, std::move(addr), id, p,

--- a/libs/full/async_distributed/include/hpx/async_distributed/applier/apply_helper.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/applier/apply_helper.hpp
@@ -21,7 +21,6 @@
 #include <hpx/threading_base/thread_helpers.hpp>
 #include <hpx/traits/action_decorate_continuation.hpp>
 #include <hpx/traits/action_schedule_thread.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <chrono>
 #include <exception>

--- a/libs/full/async_distributed/include/hpx/async_distributed/async.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async.hpp
@@ -193,11 +193,11 @@ namespace hpx {
     template <typename Action, typename F, typename... Ts>
     HPX_FORCEINLINE auto async(F&& f, Ts&&... ts)
         -> decltype(detail::async_action_dispatch<Action,
-            typename util::decay<F>::type>::call(std::forward<F>(f),
+            typename std::decay<F>::type>::call(std::forward<F>(f),
             std::forward<Ts>(ts)...))
     {
         return detail::async_action_dispatch<Action,
-            typename util::decay<F>::type>::call(std::forward<F>(f),
+            typename std::decay<F>::type>::call(std::forward<F>(f),
             std::forward<Ts>(ts)...);
     }
 }    // namespace hpx
@@ -261,11 +261,11 @@ namespace hpx { namespace detail {
         HPX_FORCEINLINE static auto call(
             Policy_&& launch_policy, F&& f, Ts&&... ts)
             -> decltype(
-                detail::async_launch_policy_dispatch<typename util::decay<
+                detail::async_launch_policy_dispatch<typename std::decay<
                     F>::type>::call(std::forward<Policy_>(launch_policy),
                     std::forward<F>(f), std::forward<Ts>(ts)...))
         {
-            return detail::async_launch_policy_dispatch<typename util::decay<
+            return detail::async_launch_policy_dispatch<typename std::decay<
                 F>::type>::call(std::forward<Policy_>(launch_policy),
                 std::forward<F>(f), std::forward<Ts>(ts)...);
         }

--- a/libs/full/async_distributed/include/hpx/async_distributed/async_callback.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_callback.hpp
@@ -145,11 +145,11 @@ namespace hpx {
     template <typename Action, typename F, typename... Ts>
     HPX_FORCEINLINE auto async_cb(F&& f, Ts&&... ts)
         -> decltype(detail::async_cb_action_dispatch<Action,
-            typename util::decay<F>::type>::call(std::forward<F>(f),
+            typename std::decay<F>::type>::call(std::forward<F>(f),
             std::forward<Ts>(ts)...))
     {
         return detail::async_cb_action_dispatch<Action,
-            typename util::decay<F>::type>::call(std::forward<F>(f),
+            typename std::decay<F>::type>::call(std::forward<F>(f),
             std::forward<Ts>(ts)...);
     }
 }    // namespace hpx
@@ -265,10 +265,10 @@ namespace hpx { namespace detail {
 namespace hpx {
     template <typename F, typename... Ts>
     HPX_FORCEINLINE auto async_cb(F&& f, Ts&&... ts) -> decltype(
-        detail::async_cb_dispatch<typename util::decay<F>::type>::call(
+        detail::async_cb_dispatch<typename std::decay<F>::type>::call(
             std::forward<F>(f), std::forward<Ts>(ts)...))
     {
-        return detail::async_cb_dispatch<typename util::decay<F>::type>::call(
+        return detail::async_cb_dispatch<typename std::decay<F>::type>::call(
             std::forward<F>(f), std::forward<Ts>(ts)...);
     }
 }    // namespace hpx

--- a/libs/full/async_distributed/include/hpx/async_distributed/async_callback_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_callback_fwd.hpp
@@ -13,6 +13,7 @@
 #include <hpx/futures/future.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 
+#include <type_traits>
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -33,6 +34,6 @@ namespace hpx {
     template <typename Action, typename F, typename... Ts>
     HPX_FORCEINLINE auto async_cb(F&& f, Ts&&... ts)
         -> decltype(detail::async_cb_action_dispatch<Action,
-            typename util::decay<F>::type>::call(std::forward<F>(f),
+            typename std::decay<F>::type>::call(std::forward<F>(f),
             std::forward<Ts>(ts)...));
 }    // namespace hpx

--- a/libs/full/async_distributed/include/hpx/async_distributed/async_continue_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_continue_fwd.hpp
@@ -17,11 +17,8 @@
 #include <hpx/futures/traits/promise_local_result.hpp>
 #include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/traits/is_distribution_policy.hpp>
-#include <hpx/type_support/decay.hpp>
 
-#ifndef HPX_MSVC
 #include <type_traits>
-#endif
 
 namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
@@ -29,7 +26,7 @@ namespace hpx {
         template <typename Action, typename Cont>
         struct result_of_async_continue
           : traits::action_remote_result<typename util::invoke_result<
-                typename util::decay<Cont>::type, naming::id_type,
+                typename std::decay<Cont>::type, naming::id_type,
                 typename hpx::traits::extract_action<
                     Action>::remote_result_type>::type>
         {

--- a/libs/full/async_distributed/include/hpx/async_distributed/sync.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/sync.hpp
@@ -156,11 +156,11 @@ namespace hpx {
     template <typename Action, typename F, typename... Ts>
     HPX_FORCEINLINE auto sync(F&& f, Ts&&... ts)
         -> decltype(detail::sync_action_dispatch<Action,
-            typename util::decay<F>::type>::call(std::forward<F>(f),
+            typename std::decay<F>::type>::call(std::forward<F>(f),
             std::forward<Ts>(ts)...))
     {
         return detail::sync_action_dispatch<Action,
-            typename util::decay<F>::type>::call(std::forward<F>(f),
+            typename std::decay<F>::type>::call(std::forward<F>(f),
             std::forward<Ts>(ts)...);
     }
 }    // namespace hpx
@@ -209,13 +209,14 @@ namespace hpx { namespace detail {
         typename std::enable_if<traits::is_action<Func>::value>::type>
     {
         template <typename Policy_, typename F, typename... Ts>
-        HPX_FORCEINLINE static auto
-        call(Policy_&& launch_policy, F&& f, Ts&&... ts) -> decltype(
-            sync_launch_policy_dispatch<typename util::decay<F>::type>::call(
-                std::forward<Policy_>(launch_policy), std::forward<F>(f),
-                std::forward<Ts>(ts)...))
+        HPX_FORCEINLINE static auto call(
+            Policy_&& launch_policy, F&& f, Ts&&... ts)
+            -> decltype(
+                sync_launch_policy_dispatch<typename std::decay<F>::type>::call(
+                    std::forward<Policy_>(launch_policy), std::forward<F>(f),
+                    std::forward<Ts>(ts)...))
         {
-            return sync_launch_policy_dispatch<typename util::decay<F>::type>::
+            return sync_launch_policy_dispatch<typename std::decay<F>::type>::
                 call(std::forward<Policy_>(launch_policy), std::forward<F>(f),
                     std::forward<Ts>(ts)...);
         }

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -107,7 +107,6 @@ namespace hpx { namespace lcos {
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime_local/get_num_localities.hpp>
 #include <hpx/thread_support/assert_owns_lock.hpp>
-#include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <cstddef>
@@ -266,7 +265,7 @@ namespace hpx { namespace lcos {
     ///////////////////////////////////////////////////////////////////////////
     // all_gather plain values
     template <typename T>
-    hpx::future<std::vector<typename util::decay<T>::type>> all_gather(
+    hpx::future<std::vector<typename std::decay<T>::type>> all_gather(
         hpx::future<hpx::id_type>&& fid, T&& local_result,
         std::size_t this_site = std::size_t(-1))
     {
@@ -275,7 +274,7 @@ namespace hpx { namespace lcos {
             this_site = static_cast<std::size_t>(hpx::get_locality_id());
         }
 
-        using arg_type = typename util::decay<T>::type;
+        using arg_type = typename std::decay<T>::type;
 
         auto all_gather_data_direct =
             [local_result = std::forward<T>(local_result), this_site](
@@ -301,7 +300,7 @@ namespace hpx { namespace lcos {
     }
 
     template <typename T>
-    hpx::future<std::vector<typename util::decay<T>::type>> all_gather(
+    hpx::future<std::vector<typename std::decay<T>::type>> all_gather(
         char const* basename, T&& local_result,
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -108,7 +108,6 @@ namespace hpx { namespace lcos {
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime_local/get_num_localities.hpp>
 #include <hpx/thread_support/assert_owns_lock.hpp>
-#include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <cstddef>

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -105,7 +105,6 @@ namespace hpx { namespace lcos {
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime_local/get_num_localities.hpp>
 #include <hpx/thread_support/assert_owns_lock.hpp>
-#include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <cstddef>

--- a/libs/full/collectives/include/hpx/collectives/broadcast.hpp
+++ b/libs/full/collectives/include/hpx/collectives/broadcast.hpp
@@ -132,7 +132,6 @@ namespace hpx { namespace lcos {
 #include <hpx/runtime/basename_registration.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime_local/get_num_localities.hpp>
-#include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <cstddef>

--- a/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
@@ -26,7 +26,6 @@
 #include <hpx/runtime_local/get_num_localities.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/thread_support/assert_owns_lock.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <cstddef>
 #include <memory>

--- a/libs/full/collectives/include/hpx/collectives/fold.hpp
+++ b/libs/full/collectives/include/hpx/collectives/fold.hpp
@@ -174,10 +174,10 @@ namespace hpx { namespace lcos {
 #include <hpx/preprocessor/nargs.hpp>
 #include <hpx/runtime/naming/name.hpp>
 #include <hpx/serialization/vector.hpp>
-#include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/pack.hpp>
 
 #include <cstddef>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -255,7 +255,7 @@ namespace hpx { namespace lcos {
             template <typename FoldOp>
             struct fold_invoker
             {
-                typedef typename util::decay<FoldOp>::type fold_op_type;
+                typedef typename std::decay<FoldOp>::type fold_op_type;
 
                 typedef detail::fold_invoker<Action, fold_op_type,
                     typename hpx::tuple_element<Is,

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -173,7 +173,6 @@ namespace hpx { namespace lcos {
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime_local/get_num_localities.hpp>
 #include <hpx/thread_support/assert_owns_lock.hpp>
-#include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <cstddef>
@@ -352,7 +351,7 @@ namespace hpx { namespace lcos {
     ///////////////////////////////////////////////////////////////////////////
     // gather plain values
     template <typename T>
-    hpx::future<std::vector<typename util::decay<T>::type>> gather_here(
+    hpx::future<std::vector<typename std::decay<T>::type>> gather_here(
         hpx::future<hpx::id_type>&& fid, T&& local_result,
         std::size_t this_site = std::size_t(-1))
     {
@@ -387,7 +386,7 @@ namespace hpx { namespace lcos {
     }
 
     template <typename T>
-    hpx::future<std::vector<typename util::decay<T>::type>> gather_here(
+    hpx::future<std::vector<typename std::decay<T>::type>> gather_here(
         char const* basename, T&& result,
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
@@ -466,7 +465,7 @@ namespace hpx { namespace lcos {
             this_site = static_cast<std::size_t>(hpx::get_locality_id());
         }
 
-        using arg_type = typename util::decay<T>::type;
+        using arg_type = typename std::decay<T>::type;
 
         auto gather_there_data_direct =
             [this_site](hpx::future<hpx::id_type>&& fid,

--- a/libs/full/collectives/include/hpx/collectives/reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/reduce.hpp
@@ -90,11 +90,11 @@ namespace hpx { namespace lcos {
 #include <hpx/preprocessor/nargs.hpp>
 #include <hpx/runtime/naming/name.hpp>
 #include <hpx/serialization/vector.hpp>
-#include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/pack.hpp>
 #include <hpx/util/calculate_fanout.hpp>
 
 #include <cstddef>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -172,7 +172,7 @@ namespace hpx { namespace lcos {
             template <typename ReduceOp>
             struct reduce_invoker_helper
             {
-                typedef typename util::decay<ReduceOp>::type reduce_op_type;
+                typedef typename std::decay<ReduceOp>::type reduce_op_type;
 
                 typedef detail::reduce_invoker<Action, reduce_op_type,
                     typename hpx::tuple_element<Is,

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -176,7 +176,6 @@ namespace hpx { namespace lcos {
 #include <hpx/runtime/naming/id_type.hpp>
 #include <hpx/runtime_local/get_num_localities.hpp>
 #include <hpx/thread_support/assert_owns_lock.hpp>
-#include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <cstddef>

--- a/libs/full/collectives/src/detail/communication_set_node.cpp
+++ b/libs/full/collectives/src/detail/communication_set_node.cpp
@@ -11,9 +11,10 @@
 #include <hpx/assert.hpp>
 #include <hpx/collectives/detail/communication_set_node.hpp>
 #include <hpx/exception.hpp>
+#include <hpx/functional/bind_back.hpp>
+#include <hpx/iterator_support/counting_iterator.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/futures.hpp>
-#include <hpx/modules/iterator_support.hpp>
 #include <hpx/parallel/container_algorithms/count.hpp>
 #include <hpx/runtime/basename_registration.hpp>
 #include <hpx/runtime/components/component_factory.hpp>

--- a/libs/full/collectives/tests/regressions/barrier_3792.cpp
+++ b/libs/full/collectives/tests/regressions/barrier_3792.cpp
@@ -9,7 +9,6 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/lcos.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <atomic>

--- a/libs/full/collectives/tests/unit/barrier.cpp
+++ b/libs/full/collectives/tests/unit/barrier.cpp
@@ -9,7 +9,6 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/format.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <atomic>
@@ -48,8 +47,7 @@ void local_tests(hpx::program_options::variables_map& vm)
         std::atomic<std::size_t> c(0);
         for (std::size_t j = 1; j <= pxthreads; ++j)
         {
-            hpx::async(
-                hpx::util::bind(&barrier_test, pxthreads + 1, j, std::ref(c)));
+            hpx::async(&barrier_test, pxthreads + 1, j, std::ref(c));
         }
 
         hpx::lcos::barrier b(

--- a/libs/full/command_line_handling/include/hpx/command_line_handling/command_line_handling.hpp
+++ b/libs/full/command_line_handling/include/hpx/command_line_handling/command_line_handling.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/functional.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/modules/program_options.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/util.hpp>

--- a/libs/full/compute/include/hpx/compute/detail/get_proxy_type.hpp
+++ b/libs/full/compute/include/hpx/compute/detail/get_proxy_type.hpp
@@ -11,7 +11,6 @@
 #include <hpx/config.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/type_support/always_void.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <type_traits>
 
@@ -25,9 +24,9 @@ namespace hpx { namespace compute { namespace detail {
     template <typename T>
     struct get_proxy_type_impl<T,
         typename hpx::util::always_void<
-            typename hpx::util::decay<T>::type::proxy_type>::type>
+            typename std::decay<T>::type::proxy_type>::type>
     {
-        typedef typename hpx::util::decay<T>::type::proxy_type proxy_type;
+        typedef typename std::decay<T>::type::proxy_type proxy_type;
     };
 
     template <typename T, typename Enable = void>
@@ -35,11 +34,11 @@ namespace hpx { namespace compute { namespace detail {
     {
     };
 
-    //     template <typename T>
-    //     struct get_proxy_type<T,
-    //         typename std::enable_if<hpx::traits::is_iterator<T>::value>::type>
-    //       : get_proxy_type<
-    //             typename std::iterator_traits<T>::value_type>
-    //     {};
+    //template <typename T>
+    //struct get_proxy_type<T,
+    //    typename std::enable_if<hpx::traits::is_iterator<T>::value>::type>
+    //  : get_proxy_type<typename std::iterator_traits<T>::value_type>
+    //{
+    //};
 
 }}}    // namespace hpx::compute::detail

--- a/libs/full/compute_cuda/include/hpx/compute/cuda/concurrent_executor.hpp
+++ b/libs/full/compute_cuda/include/hpx/compute/cuda/concurrent_executor.hpp
@@ -171,8 +171,8 @@ namespace hpx { namespace cuda { namespace experimental {
                 result.push_back(parallel::execution::async_execute(
                     host_executor_,
                     [this, current, s](F&& f, Ts&&... ts) mutable {
-                        typedef typename hpx::util::decay<decltype(s)>::type
-                            shape_type;
+                        typedef
+                            typename std::decay<decltype(s)>::type shape_type;
 
                         std::array<shape_type, 1> cuda_shape{{s}};
                         parallel::execution::bulk_sync_execute(

--- a/libs/full/compute_cuda/include/hpx/compute/cuda/default_executor.hpp
+++ b/libs/full/compute_cuda/include/hpx/compute/cuda/default_executor.hpp
@@ -17,7 +17,6 @@
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
 #include <hpx/modules/errors.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <hpx/execution/executors/execution.hpp>
 

--- a/libs/full/compute_cuda/include/hpx/compute/cuda/detail/launch.hpp
+++ b/libs/full/compute_cuda/include/hpx/compute/cuda/detail/launch.hpp
@@ -15,7 +15,6 @@
 #include <hpx/async_cuda/target.hpp>
 #include <hpx/compute/cuda/detail/scoped_active_target.hpp>
 #include <hpx/functional/invoke_fused.hpp>
-#include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <cuda_runtime.h>
@@ -37,8 +36,8 @@ namespace hpx { namespace cuda { namespace experimental { namespace detail {
     template <typename F, typename... Ts>
     struct closure
     {
-        typedef hpx::tuple<typename util::decay<Ts>::type...> args_type;
-        typedef typename util::decay<F>::type fun_type;
+        typedef hpx::tuple<typename std::decay<Ts>::type...> args_type;
+        typedef typename std::decay<F>::type fun_type;
 
         fun_type f_;
         args_type args_;

--- a/libs/full/compute_cuda/include/hpx/compute/cuda/transfer.hpp
+++ b/libs/full/compute_cuda/include/hpx/compute/cuda/transfer.hpp
@@ -55,7 +55,7 @@ namespace hpx { namespace traits {
         compute::detail::iterator<T, cuda::experimental::allocator<T>>,
         compute::detail::iterator<T, cuda::experimental::allocator<T>>,
         typename std::enable_if<!std::is_trivially_copyable<
-            typename hpx::util::decay<T>::type>::value>::type>
+            typename std::decay<T>::type>::value>::type>
     {
         typedef cuda_copyable_pointer_tag type;
     };
@@ -89,7 +89,7 @@ namespace hpx { namespace traits {
     {
         // FIXME: turn into proper pointer category
         static_assert(
-            std::is_same<typename hpx::util::decay<T>::type,
+            std::is_same<typename std::decay<T>::type,
                 typename std::iterator_traits<Dest>::value_type>::value,
             "The value types of the iterators must match");
 
@@ -113,7 +113,7 @@ namespace hpx { namespace traits {
         compute::detail::iterator<T, cuda::experimental::allocator<T>>,
         compute::detail::iterator<T, cuda::experimental::allocator<T>>,
         typename std::enable_if<std::is_trivially_copyable<
-            typename hpx::util::decay<T>::type>::value>::type>
+            typename std::decay<T>::type>::value>::type>
     {
         typedef trivially_cuda_copyable_pointer_tag type;
     };
@@ -147,7 +147,7 @@ namespace hpx { namespace traits {
     {
         // FIXME: turn into proper pointer category
         static_assert(
-            std::is_same<typename hpx::util::decay<T>::type,
+            std::is_same<typename std::decay<T>::type,
                 typename std::iterator_traits<Dest>::value_type>::value,
             "The value types of the iterators must match");
 

--- a/libs/full/compute_cuda/include/hpx/compute/detail/get_proxy_type.hpp
+++ b/libs/full/compute_cuda/include/hpx/compute/detail/get_proxy_type.hpp
@@ -11,7 +11,6 @@
 #include <hpx/config.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/type_support/always_void.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <type_traits>
 
@@ -25,9 +24,9 @@ namespace hpx { namespace compute { namespace detail {
     template <typename T>
     struct get_proxy_type_impl<T,
         typename hpx::util::always_void<
-            typename hpx::util::decay<T>::type::proxy_type>::type>
+            typename std::decay<T>::type::proxy_type>::type>
     {
-        typedef typename hpx::util::decay<T>::type::proxy_type proxy_type;
+        typedef typename std::decay<T>::type::proxy_type proxy_type;
     };
 
     template <typename T, typename Enable = void>
@@ -35,11 +34,11 @@ namespace hpx { namespace compute { namespace detail {
     {
     };
 
-    //     template <typename T>
-    //     struct get_proxy_type<T,
-    //         typename std::enable_if<hpx::traits::is_iterator<T>::value>::type>
-    //       : get_proxy_type<
-    //             typename std::iterator_traits<T>::value_type>
-    //     {};
+    //template <typename T>
+    //struct get_proxy_type<T,
+    //    typename std::enable_if<hpx::traits::is_iterator<T>::value>::type>
+    //  : get_proxy_type<typename std::iterator_traits<T>::value_type>
+    //{
+    //};
 
 }}}    // namespace hpx::compute::detail

--- a/libs/full/executors_distributed/include/hpx/executors_distributed/distribution_policy_executor.hpp
+++ b/libs/full/executors_distributed/include/hpx/executors_distributed/distribution_policy_executor.hpp
@@ -17,7 +17,6 @@
 #include <hpx/futures/future.hpp>
 #include <hpx/runtime/components/server/invoke_function.hpp>
 #include <hpx/traits/is_distribution_policy.hpp>
-#include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/pack.hpp>
 
 #include <type_traits>
@@ -39,15 +38,13 @@ namespace hpx { namespace parallel { namespace execution {
         template <typename Action, typename... Ts>
         struct distribution_policy_execute_result_impl<Action, true, Ts...>
         {
-            typedef
-                typename hpx::util::decay<Action>::type::local_result_type type;
+            typedef typename std::decay<Action>::type::local_result_type type;
         };
 
         template <typename F, typename... Ts>
         struct distribution_policy_execute_result
           : distribution_policy_execute_result_impl<F,
-                hpx::traits::is_action<
-                    typename hpx::util::decay<F>::type>::value,
+                hpx::traits::is_action<typename std::decay<F>::type>::value,
                 Ts...>
         {
         };
@@ -121,7 +118,7 @@ namespace hpx { namespace parallel { namespace execution {
         template <typename DistPolicy_,
             typename Enable = typename std::enable_if<
                 !std::is_same<distribution_policy_executor,
-                    typename hpx::util::decay<DistPolicy_>::type>::value>::type>
+                    typename std::decay<DistPolicy_>::type>::value>::type>
         distribution_policy_executor(DistPolicy_&& policy)
           : policy_(std::forward<DistPolicy_>(policy))
         {
@@ -182,10 +179,10 @@ namespace hpx { namespace parallel { namespace execution {
     /// \param policy   The distribution_policy to create an executor from
     ///
     template <typename DistPolicy>
-    distribution_policy_executor<typename hpx::util::decay<DistPolicy>::type>
+    distribution_policy_executor<typename std::decay<DistPolicy>::type>
     make_distribution_policy_executor(DistPolicy&& policy)
     {
-        typedef typename hpx::util::decay<DistPolicy>::type dist_policy_type;
+        typedef typename std::decay<DistPolicy>::type dist_policy_type;
         return distribution_policy_executor<dist_policy_type>(
             std::forward<DistPolicy>(policy));
     }

--- a/libs/full/include/include/hpx/include/util.hpp
+++ b/libs/full/include/include/hpx/include/util.hpp
@@ -30,7 +30,6 @@
 #include <hpx/threading_base/annotated_function.hpp>
 #include <hpx/timing/high_resolution_clock.hpp>
 #include <hpx/timing/high_resolution_timer.hpp>
-#include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/unused.hpp>
 #include <hpx/util/from_string.hpp>
 #include <hpx/util/get_and_reset_value.hpp>

--- a/libs/full/resiliency/include/hpx/resiliency/async_replay.hpp
+++ b/libs/full/resiliency/include/hpx/resiliency/async_replay.hpp
@@ -13,6 +13,7 @@
 #include <hpx/resiliency/config.hpp>
 #include <hpx/resiliency/resiliency_cpos.hpp>
 
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/type_support/pack.hpp>
@@ -116,7 +117,7 @@ namespace hpx { namespace resiliency { namespace experimental {
 
                         auto&& result = f.get();
 
-                        if (!hpx::util::invoke(this_->pred_, result))
+                        if (!HPX_INVOKE(this_->pred_, result))
                         {
                             // execute the task again if an error occurred and
                             // this was not the last attempt

--- a/libs/full/resiliency/include/hpx/resiliency/async_replay_executor.hpp
+++ b/libs/full/resiliency/include/hpx/resiliency/async_replay_executor.hpp
@@ -15,11 +15,12 @@
 #include <hpx/resiliency/resiliency_cpos.hpp>
 
 #include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/deferred_call.hpp>
 #include <hpx/functional/detail/invoke.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/futures.hpp>
-#include <hpx/modules/type_support.hpp>
+#include <hpx/type_support/pack.hpp>
 
 #include <cstddef>
 #include <exception>

--- a/libs/full/resiliency/include/hpx/resiliency/async_replay_executor.hpp
+++ b/libs/full/resiliency/include/hpx/resiliency/async_replay_executor.hpp
@@ -14,9 +14,9 @@
 #include <hpx/resiliency/async_replay.hpp>
 #include <hpx/resiliency/resiliency_cpos.hpp>
 
+#include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/detail/invoke.hpp>
 #include <hpx/modules/async_local.hpp>
-#include <hpx/modules/concepts.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/type_support.hpp>

--- a/libs/full/resiliency/include/hpx/resiliency/async_replay_executor.hpp
+++ b/libs/full/resiliency/include/hpx/resiliency/async_replay_executor.hpp
@@ -14,6 +14,7 @@
 #include <hpx/resiliency/async_replay.hpp>
 #include <hpx/resiliency/resiliency_cpos.hpp>
 
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/execution.hpp>
@@ -97,7 +98,7 @@ namespace hpx { namespace resiliency { namespace experimental {
 
                         auto&& result = f.get();
 
-                        if (!hpx::util::invoke(this_->pred_, result))
+                        if (!HPX_INVOKE(this_->pred_, result))
                         {
                             // execute the task again if an error occurred and
                             // this was not the last attempt

--- a/libs/full/resiliency/include/hpx/resiliency/async_replicate.hpp
+++ b/libs/full/resiliency/include/hpx/resiliency/async_replicate.hpp
@@ -13,6 +13,7 @@
 #include <hpx/resiliency/config.hpp>
 #include <hpx/resiliency/resiliency_cpos.hpp>
 
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/modules/async_local.hpp>
 
@@ -116,7 +117,7 @@ namespace hpx { namespace resiliency { namespace experimental {
                         else
                         {
                             auto&& result = f.get();
-                            if (hpx::util::invoke(pred, result))
+                            if (HPX_INVOKE(pred, result))
                             {
                                 valid_results.emplace_back(std::move(result));
                             }
@@ -125,7 +126,7 @@ namespace hpx { namespace resiliency { namespace experimental {
 
                     if (!valid_results.empty())
                     {
-                        return hpx::util::invoke(
+                        return HPX_INVOKE(
                             std::forward<Vote>(vote), std::move(valid_results));
                     }
 

--- a/libs/full/resiliency/include/hpx/resiliency/async_replicate_executor.hpp
+++ b/libs/full/resiliency/include/hpx/resiliency/async_replicate_executor.hpp
@@ -14,10 +14,11 @@
 #include <hpx/resiliency/async_replicate.hpp>
 #include <hpx/resiliency/resiliency_cpos.hpp>
 
+#include <hpx/functional/detail/invoke.hpp>
+#include <hpx/functional/invoke_fused.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/datastructures.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/modules/futures.hpp>
 
 #include <cstddef>
@@ -84,7 +85,7 @@ namespace hpx { namespace resiliency { namespace experimental {
                             else
                             {
                                 auto&& result = f.get();
-                                if (hpx::util::invoke(pred, result))
+                                if (HPX_INVOKE(pred, result))
                                 {
                                     valid_results.emplace_back(
                                         std::move(result));
@@ -94,7 +95,7 @@ namespace hpx { namespace resiliency { namespace experimental {
 
                         if (!valid_results.empty())
                         {
-                            return hpx::util::invoke(std::forward<Vote>(vote),
+                            return HPX_INVOKE(std::forward<Vote>(vote),
                                 std::move(valid_results));
                         }
 

--- a/libs/full/resiliency/include/hpx/resiliency/async_replicate_executor.hpp
+++ b/libs/full/resiliency/include/hpx/resiliency/async_replicate_executor.hpp
@@ -15,10 +15,10 @@
 #include <hpx/resiliency/resiliency_cpos.hpp>
 
 #include <hpx/concepts/concepts.hpp>
+#include <hpx/datastructures/tuple.hpp>
 #include <hpx/functional/detail/invoke.hpp>
 #include <hpx/functional/invoke_fused.hpp>
 #include <hpx/modules/async_local.hpp>
-#include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/futures.hpp>
 
 #include <cstddef>

--- a/libs/full/resiliency/include/hpx/resiliency/async_replicate_executor.hpp
+++ b/libs/full/resiliency/include/hpx/resiliency/async_replicate_executor.hpp
@@ -14,10 +14,10 @@
 #include <hpx/resiliency/async_replicate.hpp>
 #include <hpx/resiliency/resiliency_cpos.hpp>
 
+#include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/detail/invoke.hpp>
 #include <hpx/functional/invoke_fused.hpp>
 #include <hpx/modules/async_local.hpp>
-#include <hpx/modules/concepts.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/futures.hpp>
 

--- a/libs/full/resiliency/include/hpx/resiliency/resiliency_cpos.hpp
+++ b/libs/full/resiliency/include/hpx/resiliency/resiliency_cpos.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <hpx/resiliency/config.hpp>
+#include <hpx/functional/tag_invoke.hpp>
 #include <hpx/modules/async_local.hpp>
-#include <hpx/modules/functional.hpp>
 
 #include <utility>
 

--- a/libs/full/resource_partitioner/examples/async_customization.cpp
+++ b/libs/full/resource_partitioner/examples/async_customization.cpp
@@ -27,7 +27,6 @@
 #include <hpx/functional/invoke_fused.hpp>
 #include <hpx/functional/invoke_result.hpp>
 #include <hpx/pack_traversal/pack_traversal.hpp>
-#include <hpx/type_support/decay.hpp>
 //
 #include <chrono>
 #include <complex>

--- a/libs/full/resource_partitioner/tests/unit/named_pool_executor.cpp
+++ b/libs/full/resource_partitioner/tests/unit/named_pool_executor.cpp
@@ -16,7 +16,6 @@
 #include <hpx/include/threads.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/testing.hpp>
-#include <hpx/modules/type_support.hpp>
 
 #include <cstddef>
 #include <iostream>

--- a/libs/full/runtime_configuration/include/hpx/runtime_configuration/ini.hpp
+++ b/libs/full/runtime_configuration/include/hpx/runtime_configuration/ini.hpp
@@ -10,7 +10,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/concurrency/spinlock.hpp>
-#include <hpx/modules/functional.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/serialization/serialization_fwd.hpp>
 #include <hpx/util/to_string.hpp>
 

--- a/libs/full/runtime_configuration/src/ini.cpp
+++ b/libs/full/runtime_configuration/src/ini.cpp
@@ -13,13 +13,13 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-
 #include <fstream>
 #include <iostream>
 #include <list>
 #include <mutex>
 #include <regex>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -557,8 +557,8 @@ namespace hpx { namespace util {
             return std::forward<F1>(f1);
 
         // otherwise create a combined callback
-        typedef compose_callback_impl<typename util::decay<F1>::type,
-            typename util::decay<F2>::type>
+        typedef compose_callback_impl<typename std::decay<F1>::type,
+            typename std::decay<F2>::type>
             result_type;
         return result_type(std::forward<F1>(f1), std::forward<F2>(f2));
     }

--- a/libs/full/runtime_local/include/hpx/runtime_local/run_as_hpx_thread.hpp
+++ b/libs/full/runtime_local/include/hpx/runtime_local/run_as_hpx_thread.hpp
@@ -10,7 +10,7 @@
 #include <hpx/assert.hpp>
 #include <hpx/datastructures/optional.hpp>
 #include <hpx/datastructures/tuple.hpp>
-#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/functional/invoke_result.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/threading_base/thread_helpers.hpp>
@@ -55,8 +55,7 @@ namespace hpx { namespace threads {
                     {
                         // Execute the given function, forward all parameters,
                         // store result.
-                        result.emplace(
-                            util::invoke(f, std::forward<Ts>(ts)...));
+                        result.emplace(HPX_INVOKE(f, std::forward<Ts>(ts)...));
                     }
                     catch (...)
                     {
@@ -105,7 +104,7 @@ namespace hpx { namespace threads {
                     try
                     {
                         // Execute the given function, forward all parameters.
-                        util::invoke(f, std::forward<Ts>(ts)...);
+                        HPX_INVOKE(f, std::forward<Ts>(ts)...);
                     }
                     catch (...)
                     {

--- a/libs/full/runtime_local/src/runtime_local.cpp
+++ b/libs/full/runtime_local/src/runtime_local.cpp
@@ -10,10 +10,11 @@
 #include <hpx/coroutines/coroutine.hpp>
 #include <hpx/debugging/backtrace.hpp>
 #include <hpx/execution_base/this_thread.hpp>
+#include <hpx/functional/bind.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/itt_notify/thread_name.hpp>
 #include <hpx/modules/command_line_handling.hpp>
 #include <hpx/modules/errors.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/threadmanager.hpp>
 #include <hpx/runtime_local/config_entry.hpp>

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/adjacent_difference.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/adjacent_difference.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
+#include <hpx/functional/invoke.hpp>
 
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/adjacent_difference.hpp>

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/adjacent_find.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/adjacent_find.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
+#include <hpx/functional/invoke.hpp>
 
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/adjacent_find.hpp>

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
@@ -14,7 +14,6 @@
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/runtime/components/colocating_distribution_policy.hpp>
 #include <hpx/runtime/naming/id_type.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
@@ -256,7 +255,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             using hpx::traits::segmented_local_iterator_traits;
             return detail::algorithm_result_helper<R>::call(
                 algo.call(std::forward<ExPolicy>(policy), std::true_type(),
-                    segmented_local_iterator_traits<typename hpx::util::decay<
+                    segmented_local_iterator_traits<typename std::decay<
                         Args>::type>::local(std::forward<Args>(args))...));
         }
 
@@ -267,7 +266,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             using hpx::traits::segmented_local_iterator_traits;
             return detail::algorithm_result_helper<R>::call(
                 algo.call(std::forward<ExPolicy>(policy), std::false_type(),
-                    segmented_local_iterator_traits<typename hpx::util::decay<
+                    segmented_local_iterator_traits<typename std::decay<
                         Args>::type>::local(std::forward<Args>(args))...));
         }
     };
@@ -282,7 +281,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         {
             using hpx::traits::segmented_local_iterator_traits;
             return algo.call(std::forward<ExPolicy>(policy), std::true_type(),
-                segmented_local_iterator_traits<typename hpx::util::decay<
+                segmented_local_iterator_traits<typename std::decay<
                     Args>::type>::local(std::forward<Args>(args))...);
         }
 
@@ -293,7 +292,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         {
             using hpx::traits::segmented_local_iterator_traits;
             return algo.call(std::forward<ExPolicy>(policy), std::false_type(),
-                segmented_local_iterator_traits<typename hpx::util::decay<
+                segmented_local_iterator_traits<typename std::decay<
                     Args>::type>::local(std::forward<Args>(args))...);
         }
     };
@@ -303,8 +302,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     struct dispatcher
     {
         typedef typename parallel::util::detail::algorithm_result<ExPolicy,
-            typename hpx::util::decay<Algo>::type::result_type>::type
-            result_type;
+            typename std::decay<Algo>::type::result_type>::type result_type;
 
         typedef dispatcher_helper<result_type, Algo> base_dispatcher;
 
@@ -350,16 +348,16 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Algo, typename ExPolicy, typename IsSeq,
         typename... Args>
-    HPX_FORCEINLINE future<typename hpx::util::decay<Algo>::type::result_type>
+    HPX_FORCEINLINE future<typename std::decay<Algo>::type::result_type>
     dispatch_async(id_type const& id, Algo&& algo, ExPolicy const& policy,
         IsSeq, Args&&... args)
     {
-        typedef typename hpx::util::decay<Algo>::type algo_type;
+        typedef typename std::decay<Algo>::type algo_type;
         typedef typename parallel::util::detail::algorithm_result<ExPolicy,
             typename algo_type::result_type>::type result_type;
 
         algorithm_invoker_action<algo_type, ExPolicy, typename IsSeq::type,
-            result_type(typename hpx::util::decay<Args>::type...)>
+            result_type(typename std::decay<Args>::type...)>
             act;
 
         return hpx::async(act, hpx::colocated(id), std::forward<Algo>(algo),
@@ -368,12 +366,12 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
     template <typename Algo, typename ExPolicy, typename IsSeq,
         typename... Args>
-    HPX_FORCEINLINE typename hpx::util::decay<Algo>::type::result_type dispatch(
+    HPX_FORCEINLINE typename std::decay<Algo>::type::result_type dispatch(
         id_type const& id, Algo&& algo, ExPolicy const& policy, IsSeq is_seq,
         Args&&... args)
     {
         // synchronously invoke remote operation
-        future<typename hpx::util::decay<Algo>::type::result_type> f =
+        future<typename std::decay<Algo>::type::result_type> f =
             dispatch_async(id, std::forward<Algo>(algo), policy, is_seq,
                 std::forward<Args>(args)...);
         f.wait();

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/reduce.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/reduce.hpp
@@ -196,7 +196,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             std::true_type)
         {
             typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-            typedef typename hpx::util::decay<T>::type init_type;
+            typedef typename std::decay<T>::type init_type;
 
             if (first == last)
             {

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform_reduce.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform_reduce.hpp
@@ -195,12 +195,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename ExPolicy, typename InIter, typename T,
             typename Reduce, typename Convert>
         typename util::detail::algorithm_result<ExPolicy,
-            typename hpx::util::decay<T>::type>::type
+            typename std::decay<T>::type>::type
         transform_reduce_(ExPolicy&& policy, InIter first, InIter last,
             T&& init, Reduce&& red_op, Convert&& conv_op, std::true_type)
         {
             using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-            using init_type = typename hpx::util::decay<T>::type;
+            using init_type = typename std::decay<T>::type;
 
             if (first == last)
             {
@@ -218,7 +218,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename ExPolicy, typename Iter, typename Sent, typename T,
             typename Reduce, typename Convert>
         typename util::detail::algorithm_result<ExPolicy,
-            typename hpx::util::decay<T>::type>::type
+            typename std::decay<T>::type>::type
         transform_reduce_(ExPolicy&& policy, Iter first, Sent last, T&& init,
             Reduce&& red_op, Convert&& conv_op, std::false_type);
 
@@ -413,7 +413,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             std::true_type)
         {
             using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-            using init_type = typename hpx::util::decay<T>::type;
+            using init_type = typename std::decay<T>::type;
 
             if (first1 == last1)
             {

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce1.cpp
@@ -13,17 +13,16 @@
 #include <hpx/parallel/segmented_algorithms/traits/zip_iterator.hpp>
 #include <hpx/parallel/util/zip_iterator.hpp>
 
-#include <iterator>
-
 #include <cstddef>
+#include <iterator>
+#include <type_traits>
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
 struct multiply
 {
     template <typename T>
-    typename hpx::util::decay<T>::type operator()(
-        hpx::tuple<T, T> const& r) const
+    typename std::decay<T>::type operator()(hpx::tuple<T, T> const& r) const
     {
         using hpx::get;
         return get<0>(r) * get<1>(r);

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce2.cpp
@@ -13,17 +13,16 @@
 #include <hpx/parallel/segmented_algorithms/traits/zip_iterator.hpp>
 #include <hpx/parallel/util/zip_iterator.hpp>
 
-#include <iterator>
-
 #include <cstddef>
+#include <iterator>
+#include <type_traits>
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
 struct multiply
 {
     template <typename T>
-    typename hpx::util::decay<T>::type operator()(
-        hpx::tuple<T, T> const& r) const
+    typename std::decay<T>::type operator()(hpx::tuple<T, T> const& r) const
     {
         using hpx::get;
         return get<0>(r) * get<1>(r);

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce_binary1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce_binary1.cpp
@@ -12,17 +12,16 @@
 #include <hpx/parallel/segmented_algorithms/traits/zip_iterator.hpp>
 #include <hpx/parallel/util/zip_iterator.hpp>
 
-#include <iterator>
-
 #include <cstddef>
+#include <iterator>
+#include <type_traits>
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
 struct multiply
 {
     template <typename T>
-    typename hpx::util::decay<T>::type operator()(
-        hpx::tuple<T, T> const& r) const
+    typename std::decay<T>::type operator()(hpx::tuple<T, T> const& r) const
     {
         using hpx::get;
         return get<0>(r) * get<1>(r);

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce_binary2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform_reduce_binary2.cpp
@@ -12,17 +12,16 @@
 #include <hpx/parallel/segmented_algorithms/traits/zip_iterator.hpp>
 #include <hpx/parallel/util/zip_iterator.hpp>
 
-#include <iterator>
-
 #include <cstddef>
+#include <iterator>
+#include <type_traits>
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
 struct multiply
 {
     template <typename T>
-    typename hpx::util::decay<T>::type operator()(
-        hpx::tuple<T, T> const& r) const
+    typename std::decay<T>::type operator()(hpx::tuple<T, T> const& r) const
     {
         using hpx::get;
         return get<0>(r) * get<1>(r);

--- a/libs/full/thread_executors/include/hpx/thread_executors/thread_execution.hpp
+++ b/libs/full/thread_executors/include/hpx/thread_executors/thread_execution.hpp
@@ -50,7 +50,7 @@ namespace hpx { namespace threads {
             result_type;
 
         char const* annotation = hpx::traits::get_function_annotation<
-            typename hpx::util::decay<F>::type>::call(f);
+            typename std::decay<F>::type>::call(f);
         lcos::local::futures_factory<result_type()> p(
             std::forward<Executor>(exec),
             util::deferred_call(std::forward<F>(f), std::forward<Ts>(ts)...));
@@ -104,7 +104,7 @@ namespace hpx { namespace threads {
     post(Executor&& exec, F&& f, Ts&&... ts)
     {
         char const* annotation = hpx::traits::get_function_annotation<
-            typename hpx::util::decay<F>::type>::call(f);
+            typename std::decay<F>::type>::call(f);
         exec.add(
             util::deferred_call(std::forward<F>(f), std::forward<Ts>(ts)...),
             annotation, threads::pending, true, exec.get_stacksize(),
@@ -115,7 +115,7 @@ namespace hpx { namespace threads {
     template <typename Executor, typename F, typename Hint, typename... Ts>
     HPX_FORCEINLINE typename std::enable_if<
         hpx::traits::is_threads_executor<Executor>::value &&
-        std::is_same<typename hpx::util::decay<Hint>::type,
+        std::is_same<typename std::decay<Hint>::type,
             hpx::threads::thread_schedule_hint>::value>::type
     post(
         Executor&& exec, F&& f, Hint&& hint, const char* annotation, Ts&&... ts)

--- a/libs/parallelism/algorithms/include/hpx/algorithms/traits/projected.hpp
+++ b/libs/parallelism/algorithms/include/hpx/algorithms/traits/projected.hpp
@@ -15,7 +15,6 @@
 #include <hpx/functional/traits/is_invocable.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/type_support/always_void.hpp>
-#include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/pack.hpp>
 
 #include <iterator>
@@ -27,7 +26,7 @@ namespace hpx { namespace traits {
     template <typename T, typename Enable = void>
     struct projected_iterator
     {
-        typedef typename hpx::util::decay<T>::type type;
+        typedef typename std::decay<T>::type type;
     };
 
     // For segmented iterators, we consider the local_raw_iterator instead of
@@ -46,9 +45,9 @@ namespace hpx { namespace traits {
     template <typename Iterator>
     struct projected_iterator<Iterator,
         typename hpx::util::always_void<
-            typename hpx::util::decay<Iterator>::type::proxy_type>::type>
+            typename std::decay<Iterator>::type::proxy_type>::type>
     {
-        typedef typename hpx::util::decay<Iterator>::type::proxy_type type;
+        typedef typename std::decay<Iterator>::type::proxy_type type;
     };
 }}    // namespace hpx::traits
 
@@ -105,8 +104,8 @@ namespace hpx { namespace parallel { namespace traits {
 
     template <typename F, typename Iter, typename Enable = void>
     struct projected_result_of
-      : detail::projected_result_of<typename hpx::util::decay<F>::type,
-            typename hpx::util::decay<Iter>::type>
+      : detail::projected_result_of<typename std::decay<F>::type,
+            typename std::decay<Iter>::type>
     {
     };
 
@@ -143,7 +142,7 @@ namespace hpx { namespace parallel { namespace traits {
 
     template <typename F, typename Iter, typename Enable = void>
     struct is_projected
-      : detail::is_projected<typename hpx::util::decay<F>::type,
+      : detail::is_projected<typename std::decay<F>::type,
             typename hpx::traits::projected_iterator<Iter>::type>
     {
     };
@@ -152,7 +151,7 @@ namespace hpx { namespace parallel { namespace traits {
     template <typename Proj, typename Iter>
     struct projected
     {
-        typedef typename hpx::util::decay<Proj>::type projector_type;
+        typedef typename std::decay<Proj>::type projector_type;
         typedef
             typename hpx::traits::projected_iterator<Iter>::type iterator_type;
     };
@@ -220,9 +219,9 @@ namespace hpx { namespace parallel { namespace traits {
 
     template <typename ExPolicy, typename F, typename... Projected>
     struct is_indirect_callable
-      : detail::is_indirect_callable<typename hpx::util::decay<ExPolicy>::type,
-            typename hpx::util::decay<F>::type,
-            hpx::util::pack<typename hpx::util::decay<Projected>::type...>>
+      : detail::is_indirect_callable<typename std::decay<ExPolicy>::type,
+            typename std::decay<F>::type,
+            hpx::util::pack<typename std::decay<Projected>::type...>>
     {
     };
 }}}    // namespace hpx::parallel::traits

--- a/libs/parallelism/algorithms/include/hpx/algorithms/traits/projected_range.hpp
+++ b/libs/parallelism/algorithms/include/hpx/algorithms/traits/projected_range.hpp
@@ -9,7 +9,6 @@
 #include <hpx/config.hpp>
 #include <hpx/functional/invoke_result.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>
 
@@ -26,7 +25,7 @@ namespace hpx { namespace parallel { namespace traits {
     template <typename Proj, typename Rng>
     struct projected_range_result_of<Proj, Rng,
         typename std::enable_if<hpx::traits::is_range<Rng>::value>::type>
-      : detail::projected_result_of<typename hpx::util::decay<Proj>::type,
+      : detail::projected_result_of<typename std::decay<Proj>::type,
             typename hpx::traits::range_iterator<Rng>::type>
     {
     };
@@ -40,7 +39,7 @@ namespace hpx { namespace parallel { namespace traits {
     template <typename Proj, typename Rng>
     struct is_projected_range<Proj, Rng,
         typename std::enable_if<hpx::traits::is_range<Rng>::value>::type>
-      : detail::is_projected<typename hpx::util::decay<Proj>::type,
+      : detail::is_projected<typename std::decay<Proj>::type,
             typename hpx::traits::range_iterator<Rng>::type>
     {
     };
@@ -55,7 +54,7 @@ namespace hpx { namespace parallel { namespace traits {
     struct projected_range<Proj, Rng,
         typename std::enable_if<hpx::traits::is_range<Rng>::value>::type>
     {
-        typedef typename hpx::util::decay<Proj>::type projector_type;
+        typedef typename std::decay<Proj>::type projector_type;
         typedef typename hpx::traits::range_iterator<Rng>::type iterator_type;
     };
 }}}    // namespace hpx::parallel::traits

--- a/libs/parallelism/algorithms/include/hpx/algorithms/traits/segmented_iterator_traits.hpp
+++ b/libs/parallelism/algorithms/include/hpx/algorithms/traits/segmented_iterator_traits.hpp
@@ -8,7 +8,6 @@
 
 #include <hpx/config.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <type_traits>
 #include <utility>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/functional/invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/zip_iterator.hpp>
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
@@ -228,6 +228,7 @@ namespace hpx {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/invoke.hpp>
 #include <hpx/functional/tag_invoke.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/count.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/count.hpp
@@ -188,17 +188,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename ExPolicy, typename Op, typename Proj>
         struct count_iteration
         {
-            typedef
-                typename hpx::util::decay<ExPolicy>::type execution_policy_type;
-            typedef typename hpx::util::decay<Proj>::type proj_type;
-            typedef typename hpx::util::decay<Op>::type op_type;
+            typedef typename std::decay<ExPolicy>::type execution_policy_type;
+            typedef typename std::decay<Proj>::type proj_type;
+            typedef typename std::decay<Op>::type op_type;
 
             op_type op_;
             proj_type proj_;
 
             template <typename Op_, typename Proj_,
                 typename U = typename std::enable_if<
-                    !std::is_same<typename hpx::util::decay<Op_>::type,
+                    !std::is_same<typename std::decay<Op_>::type,
                         count_iteration>::value>::type>
             HPX_HOST_DEVICE count_iteration(Op_&& op, Proj_&& proj)
               : op_(std::forward<Op_>(op))

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/count.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/count.hpp
@@ -155,6 +155,7 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
 #include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/invoke.hpp>
 #include <hpx/functional/tag_invoke.hpp>
 #include <hpx/functional/bind_back.hpp>
 #include <hpx/iterator_support/range.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -11,7 +11,6 @@
 #include <hpx/futures/future.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/serialization/serialization_fwd.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/execution/executors/execution.hpp>
@@ -106,9 +105,9 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             try
             {
 #endif
-                typedef typename hpx::util::decay<
+                typedef typename std::decay<
                     ExPolicy>::type::executor_parameters_type parameters_type;
-                typedef typename hpx::util::decay<ExPolicy>::type::executor_type
+                typedef typename std::decay<ExPolicy>::type::executor_type
                     executor_type;
 
                 parallel::util::detail::scoped_executor_parameters_ref<

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/parallel_stable_sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/parallel_stable_sort.hpp
@@ -11,7 +11,6 @@
 #include <hpx/execution/executors/execution.hpp>
 #include <hpx/execution/executors/execution_information.hpp>
 #include <hpx/executors/exception_list.hpp>
-#include <hpx/modules/type_support.hpp>
 #include <hpx/parallel/algorithms/detail/sample_sort.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/sample_sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/sample_sort.hpp
@@ -12,7 +12,6 @@
 #include <hpx/iterator_support/iterator_range.hpp>
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/modules/execution.hpp>
-#include <hpx/modules/type_support.hpp>
 #include <hpx/parallel/algorithms/detail/is_sorted.hpp>
 #include <hpx/parallel/algorithms/detail/spin_sort.hpp>
 #include <hpx/parallel/util/merge_four.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/sample_sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/sample_sort.hpp
@@ -8,9 +8,10 @@
 #pragma once
 
 #include <hpx/assert.hpp>
+#include <hpx/iterator_support/counting_iterator.hpp>
+#include <hpx/iterator_support/iterator_range.hpp>
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/modules/execution.hpp>
-#include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/type_support.hpp>
 #include <hpx/parallel/algorithms/detail/is_sorted.hpp>
 #include <hpx/parallel/algorithms/detail/spin_sort.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/functional/invoke.hpp>
 
 #include <hpx/execution/executors/execution_information.hpp>
 #include <hpx/executors/execution_policy.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/equal.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/equal.hpp
@@ -173,6 +173,7 @@ namespace hpx {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/invoke.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -23,6 +23,7 @@
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 #include <hpx/parallel/util/scan_partitioner.hpp>
+#include <hpx/parallel/util/zip_iterator.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <algorithm>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/fill.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/fill.hpp
@@ -136,7 +136,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename T>
         struct fill_iteration
         {
-            typename hpx::util::decay<T>::type val_;
+            typename std::decay<T>::type val_;
 
             template <typename U>
             HPX_HOST_DEVICE typename std::enable_if<

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -238,10 +238,10 @@ namespace hpx {
 #include <hpx/algorithms/traits/is_value_proxy.hpp>
 #include <hpx/algorithms/traits/projected.hpp>
 #include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
+#include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/detail/invoke.hpp>
 #include <hpx/functional/tag_invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/modules/concepts.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/type_support.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -238,10 +238,11 @@ namespace hpx {
 #include <hpx/algorithms/traits/is_value_proxy.hpp>
 #include <hpx/algorithms/traits/projected.hpp>
 #include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
+#include <hpx/functional/detail/invoke.hpp>
+#include <hpx/functional/tag_invoke.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/executors.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/type_support.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
@@ -275,7 +276,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             call(T&& t)
             {
                 T&& tmp = std::forward<T>(t);
-                hpx::util::invoke(f_, hpx::util::invoke(proj_, tmp));
+                HPX_INVOKE(f_, HPX_INVOKE(proj_, tmp));
             }
 
             template <typename T>
@@ -283,8 +284,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 hpx::traits::is_value_proxy<T>::value>::type
             call(T&& t)
             {
-                auto tmp = hpx::util::invoke(proj_, std::forward<T>(t));
-                hpx::util::invoke_r<void>(f_, tmp);
+                auto tmp = HPX_INVOKE(proj_, std::forward<T>(t));
+                HPX_INVOKE(f_, tmp);
             }
 
             template <typename Iter>
@@ -310,7 +311,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             call(T&& t)
             {
                 T&& tmp = std::forward<T>(t);
-                hpx::util::invoke(f_, tmp);
+                HPX_INVOKE(f_, tmp);
             }
 
             template <typename T>
@@ -319,7 +320,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             call(T&& t)
             {
                 auto tmp = std::forward<T>(t);
-                hpx::util::invoke_r<void>(f_, tmp);
+                HPX_INVOKE(f_, tmp);
             }
 
             template <typename Iter>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -240,10 +240,10 @@ namespace hpx {
 #include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
 #include <hpx/functional/detail/invoke.hpp>
 #include <hpx/functional/tag_invoke.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/executors.hpp>
-#include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/type_support.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -244,7 +244,6 @@ namespace hpx {
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/executors.hpp>
-#include <hpx/modules/type_support.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
@@ -334,10 +333,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename ExPolicy, typename F, typename Proj>
         struct for_each_iteration
         {
-            using execution_policy_type =
-                typename hpx::util::decay<ExPolicy>::type;
-            using fun_type = typename hpx::util::decay<F>::type;
-            using proj_type = typename hpx::util::decay<Proj>::type;
+            using execution_policy_type = typename std::decay<ExPolicy>::type;
+            using fun_type = typename std::decay<F>::type;
+            using proj_type = typename std::decay<Proj>::type;
 
             fun_type f_;
             proj_type proj_;
@@ -729,8 +727,8 @@ namespace hpx { namespace traits {
             parallel::v1::detail::for_each_iteration<ExPolicy, F, Proj> const&
                 f) noexcept
         {
-            return get_function_address<
-                typename hpx::util::decay<F>::type>::call(f.f_);
+            return get_function_address<typename std::decay<F>::type>::call(
+                f.f_);
         }
     };
 
@@ -742,8 +740,8 @@ namespace hpx { namespace traits {
             parallel::v1::detail::for_each_iteration<ExPolicy, F, Proj> const&
                 f) noexcept
         {
-            return get_function_annotation<
-                typename hpx::util::decay<F>::type>::call(f.f_);
+            return get_function_annotation<typename std::decay<F>::type>::call(
+                f.f_);
         }
     };
 
@@ -757,7 +755,7 @@ namespace hpx { namespace traits {
                 f) noexcept
         {
             return get_function_annotation_itt<
-                typename hpx::util::decay<F>::type>::call(f.f_);
+                typename std::decay<F>::type>::call(f.f_);
         }
     };
 #endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -733,11 +733,11 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/concepts/concepts.hpp>
+#include <hpx/datastructures/tuple.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/functional/detail/invoke.hpp>
 #include <hpx/functional/tag_invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/threading_base.hpp>
 #include <hpx/type_support/pack.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -740,7 +740,8 @@ namespace hpx {
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/threading_base.hpp>
-#include <hpx/modules/type_support.hpp>
+#include <hpx/type_support/pack.hpp>
+#include <hpx/type_support/unused.hpp>
 
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/for_loop_induction.hpp>
@@ -810,7 +811,7 @@ namespace hpx {
             template <typename F, typename S, typename... Ts>
             struct part_iterations<F, S, hpx::tuple<Ts...>>
             {
-                typedef typename hpx::util::decay<F>::type fun_type;
+                typedef typename std::decay<F>::type fun_type;
 
                 fun_type f_;
                 S stride_;
@@ -862,7 +863,7 @@ namespace hpx {
             template <typename F, typename S>
             struct part_iterations<F, S, hpx::tuple<>>
             {
-                typedef typename hpx::util::decay<F>::type fun_type;
+                typedef typename std::decay<F>::type fun_type;
 
                 fun_type f_;
                 S stride_;
@@ -971,7 +972,7 @@ namespace hpx {
 
                     // we need to decay copy here to properly transport everything
                     // to a GPU device
-                    typedef hpx::tuple<typename hpx::util::decay<Ts>::type...>
+                    typedef hpx::tuple<typename std::decay<Ts>::type...>
                         args_type;
 
                     args_type args =
@@ -1427,8 +1428,8 @@ namespace hpx { namespace traits {
             parallel::v2::detail::part_iterations<F, S, Tuple> const&
                 f) noexcept
         {
-            return get_function_address<
-                typename hpx::util::decay<F>::type>::call(f.f_);
+            return get_function_address<typename std::decay<F>::type>::call(
+                f.f_);
         }
     };
 
@@ -1440,8 +1441,8 @@ namespace hpx { namespace traits {
             parallel::v2::detail::part_iterations<F, S, Tuple> const&
                 f) noexcept
         {
-            return get_function_annotation<
-                typename hpx::util::decay<F>::type>::call(f.f_);
+            return get_function_annotation<typename std::decay<F>::type>::call(
+                f.f_);
         }
     };
 
@@ -1455,7 +1456,7 @@ namespace hpx { namespace traits {
                 f) noexcept
         {
             return get_function_annotation_itt<
-                typename hpx::util::decay<F>::type>::call(f.f_);
+                typename std::decay<F>::type>::call(f.f_);
         }
     };
 #endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -732,11 +732,11 @@ namespace hpx {
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/concepts/concepts.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/functional/detail/invoke.hpp>
 #include <hpx/functional/tag_invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/modules/concepts.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/threading_base.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -733,10 +733,11 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/functional/detail/invoke.hpp>
+#include <hpx/functional/tag_invoke.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/executors.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/threading_base.hpp>
 #include <hpx/modules/type_support.hpp>
@@ -778,7 +779,7 @@ namespace hpx {
                 hpx::tuple<Ts...>& args, hpx::util::index_pack<Is...>, F&& f,
                 B part_begin)
             {
-                hpx::util::invoke(std::forward<F>(f), part_begin,
+                HPX_INVOKE(std::forward<F>(f), part_begin,
                     hpx::get<Is>(args).iteration_value()...);
             }
 
@@ -879,7 +880,7 @@ namespace hpx {
                 {
                     while (part_steps != 0)
                     {
-                        hpx::util::invoke(f_, part_begin);
+                        HPX_INVOKE(f_, part_begin);
 
                         // NVCC seems to have a bug with std::min...
                         std::size_t chunk =
@@ -935,7 +936,7 @@ namespace hpx {
                     std::size_t count = size;
                     while (count != 0)
                     {
-                        hpx::util::invoke(f, first, args.iteration_value()...);
+                        HPX_INVOKE(f, first, args.iteration_value()...);
 
                         // NVCC seems to have a bug with std::min...
                         std::size_t chunk =

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -735,10 +735,10 @@ namespace hpx {
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/functional/detail/invoke.hpp>
 #include <hpx/functional/tag_invoke.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/executors.hpp>
-#include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/threading_base.hpp>
 #include <hpx/modules/type_support.hpp>
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop_induction.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop_induction.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop_reduction.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop_reduction.hpp
@@ -13,7 +13,6 @@
 #include <hpx/concurrency/cache_line_data.hpp>
 #include <hpx/runtime_local/get_os_thread_count.hpp>
 #include <hpx/runtime_local/get_worker_thread_num.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -22,6 +22,7 @@
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 #include <hpx/parallel/util/scan_partitioner.hpp>
+#include <hpx/parallel/util/zip_iterator.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <algorithm>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/search.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/search.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/functional/invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 
 #include <hpx/execution/algorithms/detail/predicates.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
@@ -113,7 +113,6 @@ namespace hpx {
 #include <hpx/functional/invoke.hpp>
 #include <hpx/functional/tag_invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/executors/execution_policy.hpp>
@@ -220,7 +219,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 }
 
                 using buffer_type = typename set_operations_buffer<Iter3>::type;
-                using func_type = typename hpx::util::decay<F>::type;
+                using func_type = typename std::decay<F>::type;
 
                 // calculate approximate destination index
                 auto f1 = [](difference_type1 idx1,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_intersection.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_intersection.hpp
@@ -113,7 +113,6 @@ namespace hpx {
 #include <hpx/functional/invoke.hpp>
 #include <hpx/functional/tag_invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/executors/execution_policy.hpp>
@@ -207,7 +206,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 }
 
                 using buffer_type = typename set_operations_buffer<Iter3>::type;
-                using func_type = typename hpx::util::decay<F>::type;
+                using func_type = typename std::decay<F>::type;
 
                 // calculate approximate destination index
                 auto f1 = [](difference_type1 idx1,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
@@ -118,7 +118,6 @@ namespace hpx {
 #include <hpx/functional/invoke.hpp>
 #include <hpx/functional/tag_invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/executors/execution_policy.hpp>
@@ -242,7 +241,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 }
 
                 using buffer_type = typename set_operations_buffer<Iter3>::type;
-                using func_type = typename hpx::util::decay<F>::type;
+                using func_type = typename std::decay<F>::type;
 
                 // calculate approximate destination index
                 auto f1 = [](difference_type1 idx1,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_union.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_union.hpp
@@ -113,7 +113,6 @@ namespace hpx {
 #include <hpx/functional/invoke.hpp>
 #include <hpx/functional/tag_invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/executors/execution_policy.hpp>
@@ -232,7 +231,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 }
 
                 using buffer_type = typename set_operations_buffer<Iter3>::type;
-                using func_type = typename hpx::util::decay<F>::type;
+                using func_type = typename std::decay<F>::type;
 
                 // calculate approximate destination index
                 auto f1 = [](difference_type1 idx1,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/sort.hpp
@@ -15,7 +15,6 @@
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/stable_sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/stable_sort.hpp
@@ -13,7 +13,6 @@
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
@@ -48,8 +48,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename F, typename Proj>
         struct transform_projected
         {
-            typename hpx::util::decay<F>::type& f_;
-            typename hpx::util::decay<Proj>::type& proj_;
+            typename std::decay<F>::type& f_;
+            typename std::decay<Proj>::type& proj_;
 
             template <typename Iter>
             HPX_HOST_DEVICE HPX_FORCEINLINE auto operator()(Iter curr)
@@ -63,10 +63,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename ExPolicy, typename F, typename Proj>
         struct transform_iteration
         {
-            typedef
-                typename hpx::util::decay<ExPolicy>::type execution_policy_type;
-            typedef typename hpx::util::decay<F>::type fun_type;
-            typedef typename hpx::util::decay<Proj>::type proj_type;
+            typedef typename std::decay<ExPolicy>::type execution_policy_type;
+            typedef typename std::decay<F>::type fun_type;
+            typedef typename std::decay<Proj>::type proj_type;
 
             fun_type f_;
             proj_type proj_;
@@ -299,9 +298,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename F, typename Proj1, typename Proj2>
         struct transform_binary_projected
         {
-            typename hpx::util::decay<F>::type& f_;
-            typename hpx::util::decay<Proj1>::type& proj1_;
-            typename hpx::util::decay<Proj2>::type& proj2_;
+            typename std::decay<F>::type& f_;
+            typename std::decay<Proj1>::type& proj1_;
+            typename std::decay<Proj2>::type& proj2_;
 
             template <typename Iter1, typename Iter2>
             HPX_HOST_DEVICE HPX_FORCEINLINE auto operator()(
@@ -317,11 +316,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename ExPolicy, typename F, typename Proj1, typename Proj2>
         struct transform_binary_iteration
         {
-            typedef
-                typename hpx::util::decay<ExPolicy>::type execution_policy_type;
-            typedef typename hpx::util::decay<F>::type fun_type;
-            typedef typename hpx::util::decay<Proj1>::type proj1_type;
-            typedef typename hpx::util::decay<Proj2>::type proj2_type;
+            typedef typename std::decay<ExPolicy>::type execution_policy_type;
+            typedef typename std::decay<F>::type fun_type;
+            typedef typename std::decay<Proj1>::type proj1_type;
+            typedef typename std::decay<Proj2>::type proj2_type;
 
             fun_type f_;
             proj1_type proj1_;
@@ -817,8 +815,8 @@ namespace hpx { namespace traits {
             parallel::v1::detail::transform_iteration<ExPolicy, F, Proj> const&
                 f) noexcept
         {
-            return get_function_address<
-                typename hpx::util::decay<F>::type>::call(f.f_);
+            return get_function_address<typename std::decay<F>::type>::call(
+                f.f_);
         }
     };
 
@@ -830,8 +828,8 @@ namespace hpx { namespace traits {
             parallel::v1::detail::transform_iteration<ExPolicy, F, Proj> const&
                 f) noexcept
         {
-            return get_function_annotation<
-                typename hpx::util::decay<F>::type>::call(f.f_);
+            return get_function_annotation<typename std::decay<F>::type>::call(
+                f.f_);
         }
     };
 
@@ -845,7 +843,7 @@ namespace hpx { namespace traits {
                 f) noexcept
         {
             return get_function_annotation_itt<
-                typename hpx::util::decay<F>::type>::call(f.f_);
+                typename std::decay<F>::type>::call(f.f_);
         }
     };
 #endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -23,6 +23,7 @@
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/scan_partitioner.hpp>
+#include <hpx/parallel/util/zip_iterator.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -22,6 +22,7 @@
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/scan_partitioner.hpp>
+#include <hpx/parallel/util/zip_iterator.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <algorithm>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
@@ -270,6 +270,7 @@ namespace hpx {
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
+#include <hpx/parallel/util/zip_iterator.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
@@ -254,6 +254,7 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
 #include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/invoke.hpp>
 #include <hpx/functional/invoke_result.hpp>
 #include <hpx/functional/tag_invoke.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
@@ -351,12 +351,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename ExPolicy, typename Iter, typename Sent, typename T,
             typename Reduce, typename Convert>
         inline typename util::detail::algorithm_result<ExPolicy,
-            typename hpx::util::decay<T>::type>::type
+            typename std::decay<T>::type>::type
         transform_reduce_(ExPolicy&& policy, Iter first, Sent last, T&& init,
             Reduce&& red_op, Convert&& conv_op, std::false_type)
         {
             using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-            using init_type = typename hpx::util::decay<T>::type;
+            using init_type = typename std::decay<T>::type;
 
             return transform_reduce<init_type>().call(
                 std::forward<ExPolicy>(policy), is_seq(), first, last,
@@ -368,7 +368,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename ExPolicy, typename FwdIter, typename T,
             typename Reduce, typename Convert>
         typename util::detail::algorithm_result<ExPolicy,
-            typename hpx::util::decay<T>::type>::type
+            typename std::decay<T>::type>::type
         transform_reduce_(ExPolicy&& policy, FwdIter first, FwdIter last,
             T&& init, Reduce&& red_op, Convert&& conv_op, std::true_type);
 
@@ -436,7 +436,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename Op1, typename Op2, typename T>
         struct transform_reduce_binary_partition
         {
-            typedef typename hpx::util::decay<T>::type value_type;
+            typedef typename std::decay<T>::type value_type;
 
             Op1 op1_;
             Op2 op2_;

--- a/libs/parallelism/algorithms/include/hpx/parallel/datapar/iterator_helpers.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/datapar/iterator_helpers.hpp
@@ -46,8 +46,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     template <typename Iter1, typename Iter2>
     struct iterators_datapar_compatible_impl
     {
-        typedef typename hpx::util::decay<Iter1>::type iterator1_type;
-        typedef typename hpx::util::decay<Iter2>::type iterator2_type;
+        typedef typename std::decay<Iter1>::type iterator1_type;
+        typedef typename std::decay<Iter2>::type iterator2_type;
 
         typedef typename std::iterator_traits<iterator1_type>::value_type
             value1_type;
@@ -84,8 +84,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     struct iterator_datapar_compatible<Iter,
         typename std::enable_if<
             hpx::traits::is_random_access_iterator<Iter>::value>::type>
-      : iterator_datapar_compatible_impl<
-            typename hpx::util::decay<Iter>::type>::type
+      : iterator_datapar_compatible_impl<typename std::decay<Iter>::type>::type
     {
     };
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/datapar/iterator_helpers.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/datapar/iterator_helpers.hpp
@@ -12,6 +12,7 @@
 #include <hpx/execution/traits/vector_pack_alignment_size.hpp>
 #include <hpx/execution/traits/vector_pack_load_store.hpp>
 #include <hpx/execution/traits/vector_pack_type.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/functional/invoke_result.hpp>
 
 #include <cstddef>
@@ -209,22 +210,22 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
         template <typename F>
         HPX_HOST_DEVICE HPX_FORCEINLINE static
-            typename hpx::util::invoke_result<F, V1*>::type
+            typename HPX_INVOKE_result<F, V1*>::type
             call1(F&& f, Iter& it)
         {
             store_on_exit_unaligned<Iter, V1> tmp(it);
             ++it;
-            return hpx::util::invoke(f, &tmp);
+            return HPX_INVOKE(f, &tmp);
         }
 
         template <typename F>
         HPX_HOST_DEVICE HPX_FORCEINLINE static
-            typename hpx::util::invoke_result<F, V*>::type
+            typename HPX_INVOKE_result<F, V*>::type
             callv(F&& f, Iter& it)
         {
             store_on_exit<Iter, V> tmp(it);
             std::advance(it, traits::vector_pack_size<V>::value);
-            return hpx::util::invoke(f, &tmp);
+            return HPX_INVOKE(f, &tmp);
         }
     };
 
@@ -233,8 +234,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     struct invoke_vectorized_in2
     {
         template <typename F, typename Iter1, typename Iter2>
-        static typename hpx::util::invoke_result<F, V1*, V2*>::type
-        call_aligned(F&& f, Iter1& it1, Iter2& it2)
+        static typename HPX_INVOKE_result<F, V1*, V2*>::type call_aligned(
+            F&& f, Iter1& it1, Iter2& it2)
         {
             static_assert(traits::vector_pack_size<V1>::value ==
                     traits::vector_pack_size<V2>::value,
@@ -251,12 +252,12 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             std::advance(it1, traits::vector_pack_size<V1>::value);
             std::advance(it2, traits::vector_pack_size<V2>::value);
 
-            return hpx::util::invoke(std::forward<F>(f), &tmp1, &tmp2);
+            return HPX_INVOKE(std::forward<F>(f), &tmp1, &tmp2);
         }
 
         template <typename F, typename Iter1, typename Iter2>
-        static typename hpx::util::invoke_result<F, V1*, V2*>::type
-        call_unaligned(F&& f, Iter1& it1, Iter2& it2)
+        static typename HPX_INVOKE_result<F, V1*, V2*>::type call_unaligned(
+            F&& f, Iter1& it1, Iter2& it2)
         {
             static_assert(traits::vector_pack_size<V1>::value ==
                     traits::vector_pack_size<V2>::value,
@@ -273,7 +274,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             std::advance(it1, traits::vector_pack_size<V1>::value);
             std::advance(it2, traits::vector_pack_size<V2>::value);
 
-            return hpx::util::invoke(std::forward<F>(f), &tmp1, &tmp2);
+            return HPX_INVOKE(std::forward<F>(f), &tmp1, &tmp2);
         }
     };
 
@@ -291,7 +292,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
         template <typename F>
         HPX_HOST_DEVICE HPX_FORCEINLINE static
-            typename hpx::util::invoke_result<F, V11*, V12*>::type
+            typename HPX_INVOKE_result<F, V11*, V12*>::type
             call1(F&& f, Iter1& it1, Iter2& it2)
         {
             return invoke_vectorized_in2<V11, V12>::call_aligned(
@@ -300,7 +301,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
         template <typename F>
         HPX_HOST_DEVICE HPX_FORCEINLINE static
-            typename hpx::util::invoke_result<F, V1*, V2*>::type
+            typename HPX_INVOKE_result<F, V1*, V2*>::type
             callv(F&& f, Iter1& it1, Iter2& it2)
         {
             if (is_data_aligned(it1) || is_data_aligned(it2))
@@ -327,7 +328,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
             V tmp(traits::vector_pack_load<V, value_type>::aligned(it));
 
-            auto ret = hpx::util::invoke(f, &tmp);
+            auto ret = HPX_INVOKE(f, &tmp);
             traits::vector_pack_store<decltype(ret), value_type>::aligned(
                 ret, dest);
 
@@ -344,7 +345,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
             V tmp(traits::vector_pack_load<V, value_type>::unaligned(it));
 
-            auto ret = hpx::util::invoke(f, &tmp);
+            auto ret = HPX_INVOKE(f, &tmp);
             traits::vector_pack_store<decltype(ret), value_type>::unaligned(
                 ret, dest);
 
@@ -373,7 +374,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             V1 tmp1(traits::vector_pack_load<V1, value_type1>::aligned(it1));
             V2 tmp2(traits::vector_pack_load<V2, value_type2>::aligned(it2));
 
-            auto ret = hpx::util::invoke(f, &tmp1, &tmp2);
+            auto ret = HPX_INVOKE(f, &tmp1, &tmp2);
             traits::vector_pack_store<decltype(ret), value_type1>::aligned(
                 ret, dest);
 
@@ -399,7 +400,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             V1 tmp1(traits::vector_pack_load<V1, value_type1>::unaligned(it1));
             V2 tmp2(traits::vector_pack_load<V2, value_type2>::unaligned(it2));
 
-            auto ret = hpx::util::invoke(f, &tmp1, &tmp2);
+            auto ret = HPX_INVOKE(f, &tmp1, &tmp2);
             traits::vector_pack_store<decltype(ret), value_type1>::unaligned(
                 ret, dest);
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/datapar/loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/datapar/loop.hpp
@@ -17,7 +17,6 @@
 #include <hpx/executors/datapar/execution_policy_fwd.hpp>
 #include <hpx/parallel/datapar/iterator_helpers.hpp>
 #include <hpx/parallel/util/loop.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -48,11 +47,10 @@ namespace hpx { namespace parallel { namespace util {
         HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
             hpx::is_vectorpack_execution_policy<ExPolicy>::value,
             typename traits::vector_pack_type<
-                typename hpx::util::decay<Vector>::type::value_type,
-                1>::type>::type
+                typename std::decay<Vector>::type::value_type, 1>::type>::type
         accumulate_values(F&& f, Vector const& value)
         {
-            typedef typename hpx::util::decay<Vector>::type vector_type;
+            typedef typename std::decay<Vector>::type vector_type;
             typedef typename vector_type::value_type entry_type;
 
             entry_type accum = value[0];
@@ -115,7 +113,7 @@ namespace hpx { namespace parallel { namespace util {
         template <typename Iterator>
         struct datapar_loop
         {
-            typedef typename hpx::util::decay<Iterator>::type iterator_type;
+            typedef typename std::decay<Iterator>::type iterator_type;
             typedef typename std::iterator_traits<iterator_type>::value_type
                 value_type;
 
@@ -178,7 +176,7 @@ namespace hpx { namespace parallel { namespace util {
                 std::pair<InIter1, InIter2>>::type
             call(InIter1 it1, InIter1 last1, InIter2 it2, F&& f)
             {
-                typedef typename hpx::util::decay<InIter1>::type iterator_type;
+                typedef typename std::decay<InIter1>::type iterator_type;
                 typedef typename std::iterator_traits<iterator_type>::value_type
                     value_type;
 
@@ -233,7 +231,7 @@ namespace hpx { namespace parallel { namespace util {
         template <typename Iterator>
         struct datapar_loop_n
         {
-            typedef typename hpx::util::decay<Iterator>::type iterator_type;
+            typedef typename std::decay<Iterator>::type iterator_type;
             typedef typename std::iterator_traits<iterator_type>::value_type
                 value_type;
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
@@ -18,7 +18,6 @@
 #include <hpx/parallel/datapar/iterator_helpers.hpp>
 #include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/transform_loop.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -33,7 +32,7 @@ namespace hpx { namespace parallel { namespace util {
         template <typename Iterator>
         struct datapar_transform_loop_n
         {
-            typedef typename hpx::util::decay<Iterator>::type iterator_type;
+            typedef typename std::decay<Iterator>::type iterator_type;
 
             typedef typename traits::vector_pack_type<
                 typename std::iterator_traits<iterator_type>::value_type>::type
@@ -88,7 +87,7 @@ namespace hpx { namespace parallel { namespace util {
         template <typename Iterator>
         struct datapar_transform_loop
         {
-            typedef typename hpx::util::decay<Iterator>::type iterator_type;
+            typedef typename std::decay<Iterator>::type iterator_type;
             typedef typename std::iterator_traits<iterator_type>::value_type
                 value_type;
 
@@ -125,7 +124,7 @@ namespace hpx { namespace parallel { namespace util {
         template <typename Iter1, typename Iter2>
         struct datapar_transform_binary_loop_n
         {
-            typedef typename hpx::util::decay<Iter1>::type iterator1_type;
+            typedef typename std::decay<Iter1>::type iterator1_type;
             typedef typename std::iterator_traits<iterator1_type>::value_type
                 value_type;
 
@@ -189,8 +188,8 @@ namespace hpx { namespace parallel { namespace util {
         template <typename Iter1, typename Iter2>
         struct datapar_transform_binary_loop
         {
-            typedef typename hpx::util::decay<Iter1>::type iterator1_type;
-            typedef typename hpx::util::decay<Iter2>::type iterator2_type;
+            typedef typename std::decay<Iter1>::type iterator1_type;
+            typedef typename std::decay<Iter2>::type iterator2_type;
 
             typedef typename std::iterator_traits<iterator1_type>::value_type
                 value1_type;

--- a/libs/parallelism/algorithms/include/hpx/parallel/spmd_block.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/spmd_block.hpp
@@ -9,6 +9,7 @@
 #include <hpx/execution/traits/is_execution_policy.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/functional/first_argument.hpp>
+#include <hpx/functional/invoke.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/synchronization/barrier.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/task_block.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/task_block.hpp
@@ -17,7 +17,6 @@
 #include <hpx/futures/traits/is_future.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/synchronization/spinlock.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <hpx/execution/executors/execution.hpp>
 #include <hpx/executors/exception_list.hpp>
@@ -408,7 +407,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
         static_assert(hpx::is_execution_policy<ExPolicy>::value,
             "hpx::is_execution_policy<ExPolicy>::value");
 
-        typedef typename hpx::util::decay<ExPolicy>::type policy_type;
+        typedef typename std::decay<ExPolicy>::type policy_type;
         task_block<policy_type> trh(std::forward<ExPolicy>(policy));
 
         // invoke the user supplied function

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/compare_projected.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/compare_projected.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 
 #include <hpx/parallel/util/projection_identity.hpp>
 
@@ -34,9 +34,8 @@ namespace hpx { namespace parallel { namespace util {
         template <typename T1, typename T2>
         inline constexpr bool operator()(T1&& t1, T2&& t2) const
         {
-            return hpx::util::invoke(comp_,
-                hpx::util::invoke(proj_, std::forward<T1>(t1)),
-                hpx::util::invoke(proj_, std::forward<T2>(t2)));
+            return HPX_INVOKE(comp_, HPX_INVOKE(proj_, std::forward<T1>(t1)),
+                HPX_INVOKE(proj_, std::forward<T2>(t2)));
         }
 
         Compare comp_;
@@ -55,7 +54,7 @@ namespace hpx { namespace parallel { namespace util {
         template <typename T1, typename T2>
         inline constexpr bool operator()(T1&& t1, T2&& t2) const
         {
-            return hpx::util::invoke(
+            return HPX_INVOKE(
                 comp_, std::forward<T1>(t1), std::forward<T2>(t2));
         }
 
@@ -78,9 +77,8 @@ namespace hpx { namespace parallel { namespace util {
         template <typename T1, typename T2>
         inline constexpr bool operator()(T1&& t1, T2&& t2) const
         {
-            return hpx::util::invoke(comp_,
-                hpx::util::invoke(proj1_, std::forward<T1>(t1)),
-                hpx::util::invoke(proj2_, std::forward<T2>(t2)));
+            return HPX_INVOKE(comp_, HPX_INVOKE(proj1_, std::forward<T1>(t1)),
+                HPX_INVOKE(proj2_, std::forward<T2>(t2)));
         }
 
         Compare comp_;
@@ -102,8 +100,8 @@ namespace hpx { namespace parallel { namespace util {
         template <typename T1, typename T2>
         inline constexpr bool operator()(T1&& t1, T2&& t2) const
         {
-            return hpx::util::invoke(comp_, std::forward<T1>(t1),
-                hpx::util::invoke(proj2_, std::forward<T2>(t2)));
+            return HPX_INVOKE(comp_, std::forward<T1>(t1),
+                HPX_INVOKE(proj2_, std::forward<T2>(t2)));
         }
 
         Compare comp_;
@@ -124,8 +122,7 @@ namespace hpx { namespace parallel { namespace util {
         template <typename T1, typename T2>
         inline constexpr bool operator()(T1&& t1, T2&& t2) const
         {
-            return hpx::util::invoke(comp_,
-                hpx::util::invoke(proj1_, std::forward<T1>(t1)),
+            return HPX_INVOKE(comp_, HPX_INVOKE(proj1_, std::forward<T1>(t1)),
                 std::forward<T2>(t2));
         }
 
@@ -147,7 +144,7 @@ namespace hpx { namespace parallel { namespace util {
         template <typename T1, typename T2>
         inline constexpr bool operator()(T1&& t1, T2&& t2) const
         {
-            return hpx::util::invoke(
+            return HPX_INVOKE(
                 comp_, std::forward<T1>(t1), std::forward<T2>(t2));
         }
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
@@ -9,7 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/executors/execution_policy_fwd.hpp>
-#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/type_support/unused.hpp>
 
@@ -259,7 +259,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     typename hpx::util::invoke_result<Conv, U>::type convert_to_result(
         U&& val, Conv&& conv)
     {
-        return hpx::util::invoke(conv, val);
+        return HPX_INVOKE(conv, val);
     }
 
     template <typename U, typename Conv,

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
@@ -247,7 +247,7 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename ExPolicy, typename T = void>
     struct algorithm_result
-      : algorithm_result_impl<typename hpx::util::decay<ExPolicy>::type, T>
+      : algorithm_result_impl<typename std::decay<ExPolicy>::type, T>
     {
         static_assert(!std::is_lvalue_reference<T>::value,
             "T shouldn't be a lvalue reference");

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -11,7 +11,6 @@
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/iterator_support/iterator_range.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <hpx/execution/algorithms/detail/is_negative.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/handle_exception_termination_handler.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/handle_exception_termination_handler.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/functional.hpp>
+#include <hpx/functional/function.hpp>
 
 namespace hpx { namespace parallel { namespace util { namespace detail {
     using parallel_exception_termination_handler_type =

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/invoke_projected.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/invoke_projected.hpp
@@ -8,8 +8,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/functional/detail/invoke.hpp>
-#include <hpx/type_support/decay.hpp>
 
+#include <type_traits>
 #include <utility>
 
 namespace hpx { namespace parallel { namespace util {
@@ -17,8 +17,8 @@ namespace hpx { namespace parallel { namespace util {
     template <typename Pred, typename Proj>
     struct invoke_projected
     {
-        typedef typename hpx::util::decay<Pred>::type pred_type;
-        typedef typename hpx::util::decay<Proj>::type proj_type;
+        typedef typename std::decay<Pred>::type pred_type;
+        typedef typename std::decay<Proj>::type proj_type;
 
         pred_type pred_;
         proj_type proj_;

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/invoke_projected.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/invoke_projected.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/type_support/decay.hpp>
 
 #include <utility>
@@ -20,6 +20,9 @@ namespace hpx { namespace parallel { namespace util {
         typedef typename hpx::util::decay<Pred>::type pred_type;
         typedef typename hpx::util::decay<Proj>::type proj_type;
 
+        pred_type pred_;
+        proj_type proj_;
+
         template <typename Pred_, typename Proj_>
         invoke_projected(Pred_&& pred, Proj_&& proj)
           : pred_(std::forward<Pred_>(pred))
@@ -28,15 +31,10 @@ namespace hpx { namespace parallel { namespace util {
         }
 
         template <typename T>
-        auto operator()(
-            T&& t) -> decltype(hpx::util::invoke(std::declval<pred_type>(),
-            hpx::util::invoke(std::declval<proj_type>(), std::forward<T>(t))))
+        auto operator()(T&& t) -> decltype(
+            HPX_INVOKE(pred_, HPX_INVOKE(proj_, std::forward<T>(t))))
         {
-            return hpx::util::invoke(
-                pred_, hpx::util::invoke(proj_, std::forward<T>(t)));
+            return HPX_INVOKE(pred_, HPX_INVOKE(proj_, std::forward<T>(t)));
         }
-
-        pred_type pred_;
-        proj_type proj_;
     };
 }}}    // namespace hpx::parallel::util

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/loop.hpp
@@ -13,7 +13,7 @@
 #include <hpx/assert.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/execution/traits/is_execution_policy.hpp>
-#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/functional/invoke_result.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/parallel/util/cancellation_token.hpp>
@@ -35,7 +35,7 @@ namespace hpx { namespace parallel { namespace util {
         typename hpx::util::invoke_result<F, Iters...>::type>::type
     loop_step(VecOnly, F&& f, Iters&... its)
     {
-        return hpx::util::invoke(std::forward<F>(f), (its++)...);
+        return HPX_INVOKE(std::forward<F>(f), (its++)...);
     }
 
     template <typename ExPolicy, typename Iter>
@@ -292,7 +292,7 @@ namespace hpx { namespace parallel { namespace util {
             !hpx::is_vectorpack_execution_policy<ExPolicy>::value, T>::type
         accumulate_values(F&& f, T&& v, T1&& init)
         {
-            return hpx::util::invoke(
+            return HPX_INVOKE(
                 std::forward<F>(f), std::forward<T1>(init), std::forward<T>(v));
         }
     }    // namespace detail
@@ -749,11 +749,11 @@ namespace hpx { namespace parallel { namespace util {
     HPX_FORCEINLINE T accumulate(
         Iter first, Iter last, Reduce&& r, Conv&& conv = Conv())
     {
-        T val = hpx::util::invoke(conv, *first);
+        T val = HPX_INVOKE(conv, *first);
         ++first;
         while (last != first)
         {
-            val = hpx::util::invoke(r, val, *first);
+            val = HPX_INVOKE(r, val, *first);
             ++first;
         }
         return val;
@@ -764,13 +764,12 @@ namespace hpx { namespace parallel { namespace util {
     HPX_FORCEINLINE T accumulate(
         Iter1 first1, Iter1 last1, Iter2 first2, Reduce&& r, Conv&& conv)
     {
-        T val = hpx::util::invoke(conv, *first1, *first2);
+        T val = HPX_INVOKE(conv, *first1, *first2);
         ++first1;
         ++first2;
         while (last1 != first1)
         {
-            val = hpx::util::invoke(
-                r, val, hpx::util::invoke(conv, *first1, *first2));
+            val = HPX_INVOKE(r, val, HPX_INVOKE(conv, *first1, *first2));
             ++first1;
             ++first2;
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/range.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/range.hpp
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include <hpx/modules/iterator_support.hpp>
+#include <hpx/config.hpp>
+#include <hpx/iterator_support/iterator_range.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/low_level.hpp>
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/datastructures.hpp>
+#include <hpx/datastructures/tuple.hpp>
 #include <hpx/modules/futures.hpp>
 
 #include <type_traits>

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/tagged_pair.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/tagged_pair.hpp
@@ -14,7 +14,6 @@
 #include <hpx/datastructures/tagged_pair.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <cstddef>
 #include <type_traits>

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/tagged_tuple.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/tagged_tuple.hpp
@@ -14,7 +14,6 @@
 #include <hpx/datastructures/tagged_tuple.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <cstddef>
 #include <utility>

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/transfer.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/transfer.hpp
@@ -8,7 +8,6 @@
 
 #include <hpx/config.hpp>
 #include <hpx/traits/pointer_category.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/result_types.hpp>
@@ -95,9 +94,9 @@ namespace hpx { namespace parallel { namespace util {
         InIter first, Sent last, OutIter dest)
     {
         typedef typename hpx::traits::pointer_category<
-            typename hpx::util::decay<typename hpx::traits::
+            typename std::decay<typename hpx::traits::
                     remove_const_iterator_value_type<InIter>::type>::type,
-            typename hpx::util::decay<OutIter>::type>::type category;
+            typename std::decay<OutIter>::type>::type category;
         return detail::copy_helper<category>::call(first, last, dest);
     }
 
@@ -136,9 +135,9 @@ namespace hpx { namespace parallel { namespace util {
         InIter first, std::size_t count, OutIter dest)
     {
         typedef typename hpx::traits::pointer_category<
-            typename hpx::util::decay<typename hpx::traits::
+            typename std::decay<typename hpx::traits::
                     remove_const_iterator_value_type<InIter>::type>::type,
-            typename hpx::util::decay<OutIter>::type>::type category;
+            typename std::decay<OutIter>::type>::type category;
         return detail::copy_n_helper<category>::call(first, count, dest);
     }
 
@@ -161,8 +160,8 @@ namespace hpx { namespace parallel { namespace util {
         InIter const& first, OutIter const& dest)
     {
         typedef typename hpx::traits::pointer_category<
-            typename hpx::util::decay<InIter>::type,
-            typename hpx::util::decay<OutIter>::type>::type category;
+            typename std::decay<InIter>::type,
+            typename std::decay<OutIter>::type>::type category;
         detail::copy_synchronize_helper<category>::call(first, dest);
     }
 
@@ -201,8 +200,8 @@ namespace hpx { namespace parallel { namespace util {
         InIter first, Sent last, OutIter dest)
     {
         typedef typename hpx::traits::pointer_category<
-            typename hpx::util::decay<InIter>::type,
-            typename hpx::util::decay<OutIter>::type>::type category;
+            typename std::decay<InIter>::type,
+            typename std::decay<OutIter>::type>::type category;
         return detail::move_helper<category>::call(first, last, dest);
     }
 
@@ -240,8 +239,8 @@ namespace hpx { namespace parallel { namespace util {
         InIter first, std::size_t count, OutIter dest)
     {
         typedef typename hpx::traits::pointer_category<
-            typename hpx::util::decay<InIter>::type,
-            typename hpx::util::decay<OutIter>::type>::type category;
+            typename std::decay<InIter>::type,
+            typename std::decay<OutIter>::type>::type category;
         return detail::move_n_helper<category>::call(first, count, dest);
     }
 }}}    // namespace hpx::parallel::util

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/transform_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/transform_loop.hpp
@@ -9,7 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/execution/traits/is_execution_policy.hpp>
-#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/parallel/util/cancellation_token.hpp>
 
 #include <algorithm>
@@ -30,7 +30,7 @@ namespace hpx { namespace parallel { namespace util {
             {
                 for (/* */; first != last; (void) ++first, ++dest)
                 {
-                    *dest = hpx::util::invoke(std::forward<F>(f), first);
+                    *dest = HPX_INVOKE(std::forward<F>(f), first);
                 }
                 return std::make_pair(std::move(first), std::move(dest));
             }
@@ -59,8 +59,7 @@ namespace hpx { namespace parallel { namespace util {
             {
                 for (/* */; first1 != last1; (void) ++first1, ++first2, ++dest)
                 {
-                    *dest =
-                        hpx::util::invoke(std::forward<F>(f), first1, first2);
+                    *dest = HPX_INVOKE(std::forward<F>(f), first1, first2);
                 }
                 return hpx::make_tuple(
                     std::move(first1), std::move(first2), std::move(dest));
@@ -76,8 +75,7 @@ namespace hpx { namespace parallel { namespace util {
                 for (/* */; first1 != last1 && first2 != last2;
                      (void) ++first1, ++first2, ++dest)
                 {
-                    *dest =
-                        hpx::util::invoke(std::forward<F>(f), first1, first2);
+                    *dest = HPX_INVOKE(std::forward<F>(f), first1, first2);
                 }
                 return hpx::make_tuple(first1, first2, dest);
             }
@@ -118,7 +116,7 @@ namespace hpx { namespace parallel { namespace util {
             {
                 for (/* */; count != 0; (void) --count, ++first, ++dest)
                 {
-                    *dest = hpx::util::invoke(f, first);
+                    *dest = HPX_INVOKE(f, first);
                 }
                 return std::make_pair(std::move(first), std::move(dest));
             }
@@ -150,7 +148,7 @@ namespace hpx { namespace parallel { namespace util {
                 for (/* */; count != 0;
                      (void) --count, ++first1, first2++, ++dest)
                 {
-                    *dest = hpx::util::invoke(f, first1, first2);
+                    *dest = HPX_INVOKE(f, first1, first2);
                 }
                 return hpx::make_tuple(
                     std::move(first1), std::move(first2), std::move(dest));

--- a/libs/parallelism/async_base/include/hpx/async_base/apply.hpp
+++ b/libs/parallelism/async_base/include/hpx/async_base/apply.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/type_support/decay.hpp>
 
+#include <type_traits>
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -22,7 +22,7 @@ namespace hpx {
     template <typename F, typename... Ts>
     HPX_FORCEINLINE bool apply(F&& f, Ts&&... ts)
     {
-        return detail::apply_dispatch<typename util::decay<F>::type>::call(
+        return detail::apply_dispatch<typename std::decay<F>::type>::call(
             std::forward<F>(f), std::forward<Ts>(ts)...);
     }
 }    // namespace hpx

--- a/libs/parallelism/async_base/include/hpx/async_base/async.hpp
+++ b/libs/parallelism/async_base/include/hpx/async_base/async.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/type_support/decay.hpp>
 
+#include <type_traits>
 #include <utility>
 
 namespace hpx { namespace detail {
@@ -21,7 +21,7 @@ namespace hpx {
     template <typename F, typename... Ts>
     HPX_FORCEINLINE decltype(auto) async(F&& f, Ts&&... ts)
     {
-        return detail::async_dispatch<typename util::decay<F>::type>::call(
+        return detail::async_dispatch<typename std::decay<F>::type>::call(
             std::forward<F>(f), std::forward<Ts>(ts)...);
     }
 }    // namespace hpx

--- a/libs/parallelism/async_base/include/hpx/async_base/dataflow.hpp
+++ b/libs/parallelism/async_base/include/hpx/async_base/dataflow.hpp
@@ -8,8 +8,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
-#include <hpx/type_support/decay.hpp>
 
+#include <type_traits>
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -22,23 +22,24 @@ namespace hpx { namespace lcos { namespace detail {
 namespace hpx {
     template <typename F, typename... Ts>
     HPX_FORCEINLINE auto dataflow(F&& f, Ts&&... ts) -> decltype(
-        lcos::detail::dataflow_dispatch<typename util::decay<F>::type>::call(
+        lcos::detail::dataflow_dispatch<typename std::decay<F>::type>::call(
             hpx::util::internal_allocator<>{}, std::forward<F>(f),
             std::forward<Ts>(ts)...))
     {
-        return lcos::detail::dataflow_dispatch<typename util::decay<F>::type>::
+        return lcos::detail::dataflow_dispatch<typename std::decay<F>::type>::
             call(hpx::util::internal_allocator<>{}, std::forward<F>(f),
                 std::forward<Ts>(ts)...);
     }
 
     template <typename Allocator, typename F, typename... Ts>
-    HPX_FORCEINLINE auto
-    dataflow_alloc(Allocator const& alloc, F&& f, Ts&&... ts) -> decltype(
-        lcos::detail::dataflow_dispatch<typename util::decay<F>::type>::call(
-            alloc, std::forward<F>(f), std::forward<Ts>(ts)...))
+    HPX_FORCEINLINE auto dataflow_alloc(
+        Allocator const& alloc, F&& f, Ts&&... ts)
+        -> decltype(
+            lcos::detail::dataflow_dispatch<typename std::decay<F>::type>::call(
+                alloc, std::forward<F>(f), std::forward<Ts>(ts)...))
     {
         return lcos::detail::dataflow_dispatch<
-            typename util::decay<F>::type>::call(alloc, std::forward<F>(f),
+            typename std::decay<F>::type>::call(alloc, std::forward<F>(f),
             std::forward<Ts>(ts)...);
     }
 }    // namespace hpx

--- a/libs/parallelism/async_base/include/hpx/async_base/sync.hpp
+++ b/libs/parallelism/async_base/include/hpx/async_base/sync.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/type_support/decay.hpp>
 
+#include <type_traits>
 #include <utility>
 
 namespace hpx { namespace detail {
@@ -20,10 +20,10 @@ namespace hpx { namespace detail {
 namespace hpx {
     template <typename F, typename... Ts>
     HPX_FORCEINLINE auto sync(F&& f, Ts&&... ts)
-        -> decltype(detail::sync_dispatch<typename util::decay<F>::type>::call(
+        -> decltype(detail::sync_dispatch<typename std::decay<F>::type>::call(
             std::forward<F>(f), std::forward<Ts>(ts)...))
     {
-        return detail::sync_dispatch<typename util::decay<F>::type>::call(
+        return detail::sync_dispatch<typename std::decay<F>::type>::call(
             std::forward<F>(f), std::forward<Ts>(ts)...);
     }
 }    // namespace hpx

--- a/libs/parallelism/async_base/include/hpx/async_base/traits/is_launch_policy.hpp
+++ b/libs/parallelism/async_base/include/hpx/async_base/traits/is_launch_policy.hpp
@@ -8,7 +8,6 @@
 
 #include <hpx/config.hpp>
 #include <hpx/async_base/launch_policy.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <type_traits>
 
@@ -23,7 +22,7 @@ namespace hpx { namespace traits {
 
     template <typename Policy>
     struct is_launch_policy
-      : detail::is_launch_policy<typename hpx::util::decay<Policy>::type>
+      : detail::is_launch_policy<typename std::decay<Policy>::type>
     {
     };
 }}    // namespace hpx::traits

--- a/libs/parallelism/async_local/include/hpx/async_local/async_fwd.hpp
+++ b/libs/parallelism/async_local/include/hpx/async_local/async_fwd.hpp
@@ -8,8 +8,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/async_base/async.hpp>
-#include <hpx/type_support/decay.hpp>
 
+#include <type_traits>
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -25,6 +25,6 @@ namespace hpx {
     template <typename Action, typename F, typename... Ts>
     HPX_FORCEINLINE auto async(F&& f, Ts&&... ts)
         -> decltype(detail::async_action_dispatch<Action,
-            typename util::decay<F>::type>::call(std::forward<F>(f),
+            typename std::decay<F>::type>::call(std::forward<F>(f),
             std::forward<Ts>(ts)...));
 }    // namespace hpx

--- a/libs/parallelism/async_local/include/hpx/async_local/sync_fwd.hpp
+++ b/libs/parallelism/async_local/include/hpx/async_local/sync_fwd.hpp
@@ -8,8 +8,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/async_base/sync.hpp>
-#include <hpx/type_support/decay.hpp>
 
+#include <type_traits>
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -25,6 +25,6 @@ namespace hpx {
     template <typename Action, typename F, typename... Ts>
     HPX_FORCEINLINE auto sync(F&& f, Ts&&... ts)
         -> decltype(detail::sync_action_dispatch<Action,
-            typename util::decay<F>::type>::call(std::forward<F>(f),
+            typename std::decay<F>::type>::call(std::forward<F>(f),
             std::forward<Ts>(ts)...));
 }    // namespace hpx

--- a/libs/parallelism/execution/include/hpx/execution/detail/async_launch_policy_dispatch.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/detail/async_launch_policy_dispatch.hpp
@@ -11,7 +11,7 @@
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/functional/deferred_call.hpp>
-#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/functional/traits/is_action.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/futures_factory.hpp>
@@ -38,7 +38,7 @@ namespace hpx { namespace detail {
         try
         {
             return lcos::make_ready_future<R>(
-                util::invoke(std::forward<F>(f), std::move(vs)...));
+                HPX_INVOKE(std::forward<F>(f), std::move(vs)...));
         }
         catch (...)
         {
@@ -53,7 +53,7 @@ namespace hpx { namespace detail {
     {
         try
         {
-            util::invoke(std::forward<F>(f), std::move(vs)...);
+            HPX_INVOKE(std::forward<F>(f), std::move(vs)...);
             return lcos::make_ready_future();
         }
         catch (...)

--- a/libs/parallelism/execution/include/hpx/execution/detail/execution_parameter_callbacks.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/detail/execution_parameter_callbacks.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/functional.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/topology/topology.hpp>
 
 #include <cstddef>

--- a/libs/parallelism/execution/include/hpx/execution/detail/future_exec.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/detail/future_exec.hpp
@@ -26,7 +26,6 @@
 #include <hpx/modules/memory.hpp>
 #include <hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp>
 #include <hpx/timing/steady_clock.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <exception>
 #include <iterator>

--- a/libs/parallelism/execution/include/hpx/execution/detail/sync_launch_policy_dispatch.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/detail/sync_launch_policy_dispatch.hpp
@@ -8,7 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/async_base/launch_policy.hpp>
-#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/functional/traits/is_action.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/futures_factory.hpp>
@@ -70,8 +70,7 @@ namespace hpx { namespace detail {
         {
             try
             {
-                return hpx::util::invoke(
-                    std::forward<F>(f), std::forward<Ts>(ts)...);
+                return HPX_INVOKE(std::forward<F>(f), std::forward<Ts>(ts)...);
             }
             catch (std::bad_alloc const& ba)
             {

--- a/libs/parallelism/execution/include/hpx/execution/executors/execution.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/executors/execution.hpp
@@ -22,7 +22,8 @@
 #include <hpx/execution/traits/is_executor.hpp>
 #include <hpx/functional/bind_back.hpp>
 #include <hpx/functional/deferred_call.hpp>
-#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/detail/invoke.hpp>
+#include <hpx/functional/invoke_result.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/futures/traits/future_traits.hpp>
@@ -297,8 +298,7 @@ namespace hpx { namespace parallel { namespace execution {
             // fall-back: emulate sync_execute using async_execute
             template <typename TwoWayExecutor, typename F, typename... Ts>
             static auto call_impl(std::false_type, TwoWayExecutor&& exec, F&& f,
-                Ts&&... ts) -> decltype(hpx::util::invoke(std::forward<F>(f),
-                std::forward<Ts>(ts)...))
+                Ts&&... ts) -> typename hpx::util::invoke_result<F, Ts...>::type
             {
                 try
                 {
@@ -310,7 +310,7 @@ namespace hpx { namespace parallel { namespace execution {
                     return async_execute_dispatch(0,
                         std::forward<TwoWayExecutor>(exec),
                         [&]() -> result_type {
-                            return hpx::util::invoke(
+                            return HPX_INVOKE(
                                 std::forward<F>(f), std::forward<Ts>(ts)...);
                         })
                         .get();
@@ -336,9 +336,8 @@ namespace hpx { namespace parallel { namespace execution {
 
             template <typename TwoWayExecutor, typename F, typename... Ts>
             HPX_FORCEINLINE static auto call_impl(hpx::traits::detail::wrap_int,
-                TwoWayExecutor&& exec, F&& f, Ts&&... ts)
-                -> decltype(hpx::util::invoke(
-                    std::forward<F>(f), std::forward<Ts>(ts)...))
+                TwoWayExecutor&& exec, F&& f, Ts&&... ts) ->
+                typename hpx::util::invoke_result<F, Ts...>::type
             {
                 typedef typename std::is_void<typename hpx::util::detail::
                         invoke_deferred_result<F, Ts...>::type>::type is_void;

--- a/libs/parallelism/execution/include/hpx/execution/executors/execution_parameters.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/executors/execution_parameters.hpp
@@ -574,9 +574,8 @@ namespace hpx { namespace parallel { namespace execution {
 
             // generic poor-man's forwarding constructor
             template <typename U,
-                typename Enable = typename std::enable_if<
-                    !std::is_same<typename hpx::util::decay<U>::type,
-                        unwrapper>::value>::type>
+                typename Enable = typename std::enable_if<!std::is_same<
+                    typename std::decay<U>::type, unwrapper>::value>::type>
             unwrapper(U&& u)
               : T(std::forward<U>(u))
             {
@@ -825,8 +824,8 @@ namespace hpx { namespace parallel { namespace execution {
     template <typename... Params>
     struct executor_parameters_join
     {
-        using type = detail::executor_parameters<
-            typename hpx::util::decay<Params>::type...>;
+        using type =
+            detail::executor_parameters<typename std::decay<Params>::type...>;
     };
 
     template <typename... Params>

--- a/libs/parallelism/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -14,6 +14,7 @@
 #include <hpx/type_support/decay.hpp>
 
 #include <cstddef>
+#include <type_traits>
 #include <utility>
 
 namespace hpx { namespace parallel { namespace execution {
@@ -95,12 +96,12 @@ namespace hpx { namespace parallel { namespace execution {
             Executor&& exec, F&& f, std::size_t cores, std::size_t num_tasks) ->
             typename get_chunk_size_fn_helper<
                 typename hpx::util::decay_unwrap<Parameters>::type,
-                typename hpx::util::decay<Executor>::type>::
+                typename std::decay<Executor>::type>::
                 template result<Parameters, Executor, F>::type
         {
             return get_chunk_size_fn_helper<
                 typename hpx::util::decay_unwrap<Parameters>::type,
-                typename hpx::util::decay<Executor>::type>::
+                typename std::decay<Executor>::type>::
                 call(std::forward<Parameters>(params),
                     std::forward<Executor>(exec), std::forward<F>(f), cores,
                     num_tasks);
@@ -131,12 +132,12 @@ namespace hpx { namespace parallel { namespace execution {
             Executor&& exec, std::size_t cores, std::size_t num_tasks) ->
             typename maximal_number_of_chunks_fn_helper<
                 typename hpx::util::decay_unwrap<Parameters>::type,
-                typename hpx::util::decay<Executor>::type>::
+                typename std::decay<Executor>::type>::
                 template result<Parameters, Executor>::type
         {
             return maximal_number_of_chunks_fn_helper<
                 typename hpx::util::decay_unwrap<Parameters>::type,
-                typename hpx::util::decay<Executor>::type>::
+                typename std::decay<Executor>::type>::
                 call(std::forward<Parameters>(params),
                     std::forward<Executor>(exec), cores, num_tasks);
         }
@@ -165,12 +166,12 @@ namespace hpx { namespace parallel { namespace execution {
             Parameters&& params, Executor&& exec) ->
             typename reset_thread_distribution_fn_helper<
                 typename hpx::util::decay_unwrap<Parameters>::type,
-                typename hpx::util::decay<Executor>::type>::
+                typename std::decay<Executor>::type>::
                 template result<Parameters, Executor>::type
         {
             return reset_thread_distribution_fn_helper<
                 typename hpx::util::decay_unwrap<Parameters>::type,
-                typename hpx::util::decay<Executor>::type>::
+                typename std::decay<Executor>::type>::
                 call(std::forward<Parameters>(params),
                     std::forward<Executor>(exec));
         }
@@ -199,12 +200,12 @@ namespace hpx { namespace parallel { namespace execution {
             Parameters&& params, Executor&& exec) ->
             typename processing_units_count_fn_helper<
                 typename hpx::util::decay_unwrap<Parameters>::type,
-                typename hpx::util::decay<Executor>::type>::
+                typename std::decay<Executor>::type>::
                 template result<Parameters, Executor>::type
         {
             return processing_units_count_fn_helper<
                 typename hpx::util::decay_unwrap<Parameters>::type,
-                typename hpx::util::decay<Executor>::type>::
+                typename std::decay<Executor>::type>::
                 call(std::forward<Parameters>(params),
                     std::forward<Executor>(exec));
         }
@@ -232,12 +233,12 @@ namespace hpx { namespace parallel { namespace execution {
             Parameters&& params, Executor&& exec) ->
             typename mark_begin_execution_fn_helper<
                 typename hpx::util::decay_unwrap<Parameters>::type,
-                typename hpx::util::decay<Executor>::type>::
+                typename std::decay<Executor>::type>::
                 template result<Parameters, Executor>::type
         {
             return mark_begin_execution_fn_helper<
                 typename hpx::util::decay_unwrap<Parameters>::type,
-                typename hpx::util::decay<Executor>::type>::
+                typename std::decay<Executor>::type>::
                 call(std::forward<Parameters>(params),
                     std::forward<Executor>(exec));
         }
@@ -265,12 +266,12 @@ namespace hpx { namespace parallel { namespace execution {
             Parameters&& params, Executor&& exec) ->
             typename mark_end_of_scheduling_fn_helper<
                 typename hpx::util::decay_unwrap<Parameters>::type,
-                typename hpx::util::decay<Executor>::type>::
+                typename std::decay<Executor>::type>::
                 template result<Parameters, Executor>::type
         {
             return mark_end_of_scheduling_fn_helper<
                 typename hpx::util::decay_unwrap<Parameters>::type,
-                typename hpx::util::decay<Executor>::type>::
+                typename std::decay<Executor>::type>::
                 call(std::forward<Parameters>(params),
                     std::forward<Executor>(exec));
         }
@@ -298,12 +299,12 @@ namespace hpx { namespace parallel { namespace execution {
             Parameters&& params, Executor&& exec) ->
             typename mark_end_execution_fn_helper<
                 typename hpx::util::decay_unwrap<Parameters>::type,
-                typename hpx::util::decay<Executor>::type>::
+                typename std::decay<Executor>::type>::
                 template result<Parameters, Executor>::type
         {
             return mark_end_execution_fn_helper<
                 typename hpx::util::decay_unwrap<Parameters>::type,
-                typename hpx::util::decay<Executor>::type>::
+                typename std::decay<Executor>::type>::
                 call(std::forward<Parameters>(params),
                     std::forward<Executor>(exec));
         }

--- a/libs/parallelism/execution/include/hpx/execution/executors/polymorphic_executor.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/executors/polymorphic_executor.hpp
@@ -12,8 +12,9 @@
 #include <hpx/assert.hpp>
 #include <hpx/execution/traits/is_executor.hpp>
 #include <hpx/execution_base/execution.hpp>
+#include <hpx/functional/function.hpp>
+#include <hpx/functional/unique_function.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/modules/thread_support.hpp>
 
 #include <algorithm>

--- a/libs/parallelism/execution/include/hpx/execution/executors/rebind_executor.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/executors/rebind_executor.hpp
@@ -10,7 +10,6 @@
 #include <hpx/async_base/traits/is_launch_policy.hpp>
 #include <hpx/execution/traits/executor_traits.hpp>
 #include <hpx/execution_base/execution.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <type_traits>
 

--- a/libs/parallelism/execution/include/hpx/execution/traits/executor_traits.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/traits/executor_traits.hpp
@@ -10,7 +10,6 @@
 #include <hpx/async_base/traits/is_launch_policy.hpp>
 #include <hpx/concepts/has_member_xxx.hpp>
 #include <hpx/execution/traits/is_executor.hpp>
-#include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/detected.hpp>
 
 #include <cstddef>
@@ -375,7 +374,7 @@ namespace hpx { namespace traits {
 
     template <typename Executor>
     struct is_threads_executor
-      : detail::is_threads_executor<typename hpx::util::decay<Executor>::type>
+      : detail::is_threads_executor<typename std::decay<Executor>::type>
     {
     };
 

--- a/libs/parallelism/execution/include/hpx/execution/traits/is_execution_policy.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/traits/is_execution_policy.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <type_traits>
 
@@ -61,7 +60,7 @@ namespace hpx {
     ///
     template <typename T>
     struct is_execution_policy
-      : hpx::detail::is_execution_policy<typename hpx::util::decay<T>::type>
+      : hpx::detail::is_execution_policy<typename std::decay<T>::type>
     {
     };
 
@@ -84,8 +83,7 @@ namespace hpx {
     ///
     template <typename T>
     struct is_parallel_execution_policy
-      : hpx::detail::is_parallel_execution_policy<
-            typename hpx::util::decay<T>::type>
+      : hpx::detail::is_parallel_execution_policy<typename std::decay<T>::type>
     {
     };
 
@@ -111,8 +109,7 @@ namespace hpx {
     // extension:
     template <typename T>
     struct is_sequenced_execution_policy
-      : hpx::detail::is_sequenced_execution_policy<
-            typename hpx::util::decay<T>::type>
+      : hpx::detail::is_sequenced_execution_policy<typename std::decay<T>::type>
     {
     };
 
@@ -138,8 +135,7 @@ namespace hpx {
     // extension:
     template <typename T>
     struct is_async_execution_policy
-      : hpx::detail::is_async_execution_policy<
-            typename hpx::util::decay<T>::type>
+      : hpx::detail::is_async_execution_policy<typename std::decay<T>::type>
     {
     };
 
@@ -150,8 +146,7 @@ namespace hpx {
     /// \cond NOINTERNAL
     template <typename T>
     struct is_rebound_execution_policy
-      : hpx::detail::is_rebound_execution_policy<
-            typename hpx::util::decay<T>::type>
+      : hpx::detail::is_rebound_execution_policy<typename std::decay<T>::type>
     {
     };
 
@@ -163,7 +158,7 @@ namespace hpx {
     template <typename T>
     struct is_vectorpack_execution_policy
       : hpx::detail::is_vectorpack_execution_policy<
-            typename hpx::util::decay<T>::type>
+            typename std::decay<T>::type>
     {
     };
 

--- a/libs/parallelism/execution/tests/regressions/lambda_return_type_2402.cpp
+++ b/libs/parallelism/execution/tests/regressions/lambda_return_type_2402.cpp
@@ -11,6 +11,7 @@
 #include <hpx/modules/testing.hpp>
 
 #include <cstddef>
+#include <type_traits>
 #include <vector>
 
 int hpx_main()
@@ -23,7 +24,7 @@ int hpx_main()
     hpx::for_each(
         hpx::execution::datapar, zip_it_begin, zip_it_end, [](auto t) {
             using comp_type = typename hpx::tuple_element<0, decltype(t)>::type;
-            using var_type = typename hpx::util::decay<comp_type>::type;
+            using var_type = typename std::decay<comp_type>::type;
 
             var_type mass_density = 0.0;
             mass_density(mass_density > 0.0) = 7.0;

--- a/libs/parallelism/execution/tests/unit/polymorphic_executor.cpp
+++ b/libs/parallelism/execution/tests/unit/polymorphic_executor.cpp
@@ -7,9 +7,9 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 
+#include <hpx/functional/bind.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/executors.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <algorithm>

--- a/libs/parallelism/executors/include/hpx/executors/async.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/async.hpp
@@ -31,11 +31,11 @@ namespace hpx { namespace detail {
         template <typename Policy_, typename F, typename... Ts>
         HPX_FORCEINLINE static auto
         call(Policy_&& launch_policy, F&& f, Ts&&... ts) -> decltype(
-            async_launch_policy_dispatch<typename util::decay<F>::type>::call(
+            async_launch_policy_dispatch<typename std::decay<F>::type>::call(
                 std::forward<Policy_>(launch_policy), std::forward<F>(f),
                 std::forward<Ts>(ts)...))
         {
-            return async_launch_policy_dispatch<typename util::decay<F>::type>::
+            return async_launch_policy_dispatch<typename std::decay<F>::type>::
                 call(std::forward<Policy_>(launch_policy), std::forward<F>(f),
                     std::forward<Ts>(ts)...);
         }
@@ -48,12 +48,11 @@ namespace hpx { namespace detail {
         template <typename Policy_, typename F, typename... Ts>
         HPX_FORCEINLINE static auto call(
             Policy_&& launch_policy, F&& f, Ts&&... ts)
-            -> decltype(
-                async_dispatch_launch_policy_helper<typename util::decay<
+            -> decltype(async_dispatch_launch_policy_helper<typename std::decay<
                     F>::type>::call(std::forward<Policy_>(launch_policy),
-                    std::forward<F>(f), std::forward<Ts>(ts)...))
+                std::forward<F>(f), std::forward<Ts>(ts)...))
         {
-            return async_dispatch_launch_policy_helper<typename util::decay<
+            return async_dispatch_launch_policy_helper<typename std::decay<
                 F>::type>::call(std::forward<Policy_>(launch_policy),
                 std::forward<F>(f), std::forward<Ts>(ts)...);
         }

--- a/libs/parallelism/executors/include/hpx/executors/dataflow.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/dataflow.hpp
@@ -58,9 +58,8 @@ namespace hpx { namespace traits {
         static char const* call(
             lcos::detail::dataflow_finalization<Frame> const& f) noexcept
         {
-            char const* annotation =
-                hpx::traits::get_function_annotation<typename hpx::util::decay<
-                    function_type>::type>::call(f.this_->func_);
+            char const* annotation = hpx::traits::get_function_annotation<
+                typename std::decay<function_type>::type>::call(f.this_->func_);
             return annotation;
         }
     };

--- a/libs/parallelism/executors/include/hpx/executors/exception_list.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/exception_list.hpp
@@ -10,9 +10,9 @@
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/executors/execution_policy_fwd.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/modules/errors.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/type_support/decay.hpp>
 
 #include <exception>

--- a/libs/parallelism/executors/include/hpx/executors/exception_list.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/exception_list.hpp
@@ -13,9 +13,9 @@
 #include <hpx/functional/function.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/modules/errors.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <exception>
+#include <type_traits>
 #include <utility>
 
 namespace hpx { namespace parallel { inline namespace v1 {
@@ -214,8 +214,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
         template <typename ExPolicy, typename Result = void>
         struct handle_exception
-          : handle_exception_impl<typename hpx::util::decay<ExPolicy>::type,
-                Result>
+          : handle_exception_impl<typename std::decay<ExPolicy>::type, Result>
         {
         };
         /// \endcond

--- a/libs/parallelism/executors/include/hpx/executors/execution_policy.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/execution_policy.hpp
@@ -23,7 +23,6 @@
 #include <hpx/executors/parallel_executor.hpp>
 #include <hpx/executors/sequenced_executor.hpp>
 #include <hpx/serialization/serialize.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <memory>
 #include <type_traits>

--- a/libs/parallelism/executors/include/hpx/executors/limiting_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/limiting_executor.hpp
@@ -12,7 +12,7 @@
 #include <hpx/execution/traits/is_executor.hpp>
 #include <hpx/execution_base/execution.hpp>
 #include <hpx/execution_base/this_thread.hpp>
-#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/threading_base/print.hpp>
 
 #include <atomic>
@@ -91,7 +91,7 @@ namespace hpx { namespace execution { namespace experimental {
             decltype(auto) operator()(Ts&&... ts)
             {
                 on_exit _{limiting_};
-                return hpx::util::invoke(f_, std::forward<Ts>(ts)...);
+                return HPX_INVOKE(f_, std::forward<Ts>(ts)...);
             }
 
             // returns true if too many tasks would be in flight
@@ -143,7 +143,7 @@ namespace hpx { namespace execution { namespace experimental {
             template <typename... Ts>
             decltype(auto) operator()(Ts&&... ts)
             {
-                return hpx::util::invoke(f_, std::forward<Ts>(ts)...);
+                return HPX_INVOKE(f_, std::forward<Ts>(ts)...);
             }
 
             // NB. use ">=" because counting is external

--- a/libs/parallelism/executors/include/hpx/executors/parallel_executor_aggregated.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/parallel_executor_aggregated.hpp
@@ -18,7 +18,7 @@
 #include <hpx/execution/detail/sync_launch_policy_dispatch.hpp>
 #include <hpx/execution/executors/static_chunk_size.hpp>
 #include <hpx/execution/traits/is_executor.hpp>
-#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/future_traits.hpp>
 #include <hpx/iterator_support/range.hpp>
@@ -171,7 +171,7 @@ namespace hpx { namespace parallel { namespace execution {
                         // properly handle all exceptions thrown from 'f'
                         try
                         {
-                            hpx::util::invoke(f, *it, ts...);
+                            HPX_INVOKE(f, *it, ts...);
                         }
                         catch (...)
                         {
@@ -387,7 +387,7 @@ namespace hpx { namespace parallel { namespace execution {
                             // properly handle all exceptions thrown from 'f'
                             try
                             {
-                                hpx::util::invoke(f, *it, ts...);
+                                HPX_INVOKE(f, *it, ts...);
                             }
                             catch (...)
                             {

--- a/libs/parallelism/executors/include/hpx/executors/sync.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/sync.hpp
@@ -26,13 +26,14 @@ namespace hpx { namespace detail {
         typename std::enable_if<!traits::is_action<Func>::value>::type>
     {
         template <typename Policy_, typename F, typename... Ts>
-        HPX_FORCEINLINE static auto
-        call(Policy_&& launch_policy, F&& f, Ts&&... ts) -> decltype(
-            sync_launch_policy_dispatch<typename util::decay<F>::type>::call(
-                std::forward<Policy_>(launch_policy), std::forward<F>(f),
-                std::forward<Ts>(ts)...))
+        HPX_FORCEINLINE static auto call(
+            Policy_&& launch_policy, F&& f, Ts&&... ts)
+            -> decltype(
+                sync_launch_policy_dispatch<typename std::decay<F>::type>::call(
+                    std::forward<Policy_>(launch_policy), std::forward<F>(f),
+                    std::forward<Ts>(ts)...))
         {
-            return sync_launch_policy_dispatch<typename util::decay<F>::type>::
+            return sync_launch_policy_dispatch<typename std::decay<F>::type>::
                 call(std::forward<Policy_>(launch_policy), std::forward<F>(f),
                     std::forward<Ts>(ts)...);
         }
@@ -45,11 +46,11 @@ namespace hpx { namespace detail {
         template <typename Policy_, typename F, typename... Ts>
         HPX_FORCEINLINE static auto call(
             Policy_&& launch_policy, F&& f, Ts&&... ts)
-            -> decltype(sync_dispatch_launch_policy_helper<typename util::decay<
+            -> decltype(sync_dispatch_launch_policy_helper<typename std::decay<
                     F>::type>::call(std::forward<Policy_>(launch_policy),
                 std::forward<F>(f), std::forward<Ts>(ts)...))
         {
-            return sync_dispatch_launch_policy_helper<typename util::decay<
+            return sync_dispatch_launch_policy_helper<typename std::decay<
                 F>::type>::call(std::forward<Policy_>(launch_policy),
                 std::forward<F>(f), std::forward<Ts>(ts)...);
         }

--- a/libs/parallelism/futures/include/hpx/futures/detail/future_data.hpp
+++ b/libs/parallelism/futures/include/hpx/futures/detail/future_data.hpp
@@ -10,11 +10,11 @@
 #include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/coroutines/detail/get_stack_pointer.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/futures/future_fwd.hpp>
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/futures/traits/get_remote_result.hpp>
 #include <hpx/modules/errors.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/modules/memory.hpp>
 #include <hpx/synchronization/condition_variable.hpp>
 #include <hpx/synchronization/spinlock.hpp>

--- a/libs/parallelism/futures/include/hpx/futures/detail/future_data.hpp
+++ b/libs/parallelism/futures/include/hpx/futures/detail/future_data.hpp
@@ -22,7 +22,6 @@
 #include <hpx/thread_support/atomic_count.hpp>
 #include <hpx/threading_base/annotated_function.hpp>
 #include <hpx/threading_base/thread_helpers.hpp>
-#include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <boost/container/small_vector.hpp>
@@ -559,7 +558,7 @@ namespace hpx { namespace lcos { namespace detail {
             // set the received result, reset error status
             try
             {
-                typedef typename util::decay<T>::type naked_type;
+                typedef typename std::decay<T>::type naked_type;
 
                 typedef traits::get_remote_result<result_type, naked_type>
                     get_remote_result_type;

--- a/libs/parallelism/futures/include/hpx/futures/future.hpp
+++ b/libs/parallelism/futures/include/hpx/futures/future.hpp
@@ -13,7 +13,7 @@
 #include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>
 #include <hpx/futures/detail/future_data.hpp>
 #include <hpx/futures/future_fwd.hpp>
@@ -1073,9 +1073,8 @@ namespace hpx { namespace lcos {
         convert_future_helper(Future&& f, Conv&& conv)    //-V659
         {
             return f.then(hpx::launch::sync,
-                [conv = std::forward<Conv>(conv)](Future&& f) -> T {
-                    return hpx::util::invoke(conv, f.get());
-                });
+                [conv = std::forward<Conv>(conv)](
+                    Future&& f) -> T { return HPX_INVOKE(conv, f.get()); });
         }
     }    // namespace detail
 
@@ -1348,7 +1347,7 @@ namespace hpx { namespace lcos {
         return f.then(hpx::launch::sync,
             [conv = std::forward<Conv>(conv)](
                 hpx::lcos::shared_future<U> const& f) {
-                return hpx::util::invoke(conv, f.get());
+                return HPX_INVOKE(conv, f.get());
             });
     }
 

--- a/libs/parallelism/futures/include/hpx/futures/future.hpp
+++ b/libs/parallelism/futures/include/hpx/futures/future.hpp
@@ -25,8 +25,10 @@
 #include <hpx/futures/traits/is_future.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/memory.hpp>
-#include <hpx/modules/serialization.hpp>
+#include <hpx/serialization/detail/non_default_constructible.hpp>
 #include <hpx/serialization/detail/polymorphic_nonintrusive_factory.hpp>
+#include <hpx/serialization/exception_ptr.hpp>
+#include <hpx/serialization/serialization_fwd.hpp>
 #include <hpx/timing/steady_clock.hpp>
 #include <hpx/type_support/decay.hpp>
 

--- a/libs/parallelism/futures/include/hpx/futures/futures_factory.hpp
+++ b/libs/parallelism/futures/include/hpx/futures/futures_factory.hpp
@@ -720,9 +720,8 @@ namespace hpx { namespace lcos { namespace local {
         }
 
         template <typename F,
-            typename Enable = typename std::enable_if<
-                !std::is_same<typename hpx::util::decay<F>::type,
-                    futures_factory>::value>::type>
+            typename Enable = typename std::enable_if<!std::is_same<
+                typename std::decay<F>::type, futures_factory>::value>::type>
         explicit futures_factory(F&& f)
           : task_(detail::create_task_object<Result, Cancelable>::call(
                 hpx::util::internal_allocator<>{}, std::forward<F>(f)))

--- a/libs/parallelism/lcos_local/include/hpx/lcos_local/detail/preprocess_future.hpp
+++ b/libs/parallelism/lcos_local/include/hpx/lcos_local/detail/preprocess_future.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <hpx/assert.hpp>
-#include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/serialization/detail/extra_archive_data.hpp>
 #include <hpx/synchronization/spinlock.hpp>

--- a/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
+++ b/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
@@ -10,8 +10,9 @@
 #include <hpx/allocator_support/allocator_deleter.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/datastructures/tuple.hpp>
-#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/functional/invoke_fused.hpp>
+#include <hpx/functional/invoke_result.hpp>
 #include <hpx/futures/traits/future_access.hpp>
 #include <hpx/modules/memory.hpp>
 #include <hpx/pack_traversal/detail/container_category.hpp>
@@ -148,11 +149,11 @@ namespace hpx {
 
             /// Calls the visitor with the given element
             template <typename T>
-            auto traverse(T&& value)
-                -> decltype(util::invoke(std::declval<Visitor&>(),
-                    async_traverse_visit_tag{}, std::forward<T>(value)))
+            auto traverse(T&& value) ->
+                typename hpx::util::invoke_result<Visitor&,
+                    async_traverse_visit_tag, T>::type
             {
-                return util::invoke(visitor(), async_traverse_visit_tag{},
+                return HPX_INVOKE(visitor(), async_traverse_visit_tag{},
                     std::forward<T>(value));
             }
 
@@ -172,7 +173,7 @@ namespace hpx {
 
                 // Invoke the visitor with the current value and the
                 // callable object to resume the control flow.
-                util::invoke(visitor(), async_traverse_detach_tag{},
+                HPX_INVOKE(visitor(), async_traverse_detach_tag{},
                     std::forward<T>(value), std::move(resumable));
             }
 
@@ -183,7 +184,7 @@ namespace hpx {
                 bool expected = false;
                 if (finished_.compare_exchange_strong(expected, true))
                 {
-                    util::invoke(visitor(), async_traverse_complete_tag{},
+                    HPX_INVOKE(visitor(), async_traverse_complete_tag{},
                         std::move(args_));
                 }
             }

--- a/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
+++ b/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_async_impl.hpp
@@ -17,6 +17,7 @@
 #include <hpx/modules/memory.hpp>
 #include <hpx/pack_traversal/detail/container_category.hpp>
 #include <hpx/type_support/always_void.hpp>
+#include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/pack.hpp>
 
 #include <atomic>

--- a/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_impl.hpp
+++ b/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_impl.hpp
@@ -15,6 +15,7 @@
 #include <hpx/pack_traversal/detail/container_category.hpp>
 #include <hpx/pack_traversal/traits/pack_traversal_rebind_container.hpp>
 #include <hpx/type_support/always_void.hpp>
+#include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/pack.hpp>
 #include <hpx/util/detail/reserve.hpp>
 

--- a/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_impl.hpp
+++ b/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_impl.hpp
@@ -8,7 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/datastructures/tuple.hpp>
-#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/functional/invoke_fused.hpp>
 #include <hpx/functional/invoke_result.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>
@@ -211,7 +211,7 @@ namespace hpx { namespace util { namespace detail {
         constexpr auto apply_spread_impl(std::false_type, C&& callable,
             T&&... args) -> typename invoke_result<C, T...>::type
         {
-            return hpx::util::invoke(
+            return HPX_INVOKE(
                 std::forward<C>(callable), std::forward<T>(args)...);
         }
 

--- a/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/unwrap_impl.hpp
+++ b/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/unwrap_impl.hpp
@@ -8,7 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/datastructures/traits/is_tuple_like.hpp>
-#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/functional/invoke_fused.hpp>
 #include <hpx/functional/invoke_result.hpp>
 #include <hpx/futures/traits/future_traits.hpp>
@@ -157,7 +157,7 @@ namespace hpx { namespace util { namespace detail {
         static auto apply(C&& callable, T&& unwrapped) ->
             typename invoke_result<C, T>::type
         {
-            return util::invoke(
+            return HPX_INVOKE(
                 std::forward<C>(callable), std::forward<T>(unwrapped));
         }
     };

--- a/libs/parallelism/threading/include/hpx/threading/jthread.hpp
+++ b/libs/parallelism/threading/include/hpx/threading/jthread.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/functional.hpp>
+#include <hpx/functional/detail/invoke.hpp>
 #include <hpx/synchronization/stop_token.hpp>
 #include <hpx/threading/thread.hpp>
 
@@ -24,14 +24,14 @@ namespace hpx {
         static void invoke(std::false_type, F&& f, stop_token&& st, Ts&&... ts)
         {
             // started thread does not expect a stop token:
-            hpx::util::invoke(std::forward<F>(f), std::forward<Ts>(ts)...);
+            HPX_INVOKE(std::forward<F>(f), std::forward<Ts>(ts)...);
         }
 
         template <typename F, typename... Ts>
         static void invoke(std::true_type, F&& f, stop_token&& st, Ts&&... ts)
         {
             // pass the stop_token as first argument to the started thread:
-            hpx::util::invoke(
+            HPX_INVOKE(
                 std::forward<F>(f), std::move(st), std::forward<Ts>(ts)...);
         }
 

--- a/libs/parallelism/threading/include/hpx/threading/thread.hpp
+++ b/libs/parallelism/threading/include/hpx/threading/thread.hpp
@@ -8,9 +8,11 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/functional/deferred_call.hpp>
+#include <hpx/functional/function.hpp>
+#include <hpx/functional/unique_function.hpp>
 #include <hpx/futures/future_fwd.hpp>
 #include <hpx/modules/errors.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/threading_base/scheduler_base.hpp>
 #include <hpx/threading_base/thread_data.hpp>

--- a/libs/parallelism/threading/include/hpx/threading/thread.hpp
+++ b/libs/parallelism/threading/include/hpx/threading/thread.hpp
@@ -49,7 +49,7 @@ namespace hpx {
 
         template <typename F,
             typename Enable = typename std::enable_if<!std::is_same<
-                typename hpx::util::decay<F>::type, thread>::value>::type>
+                typename std::decay<F>::type, thread>::value>::type>
         explicit thread(F&& f)
         {
             auto thrd_data = threads::get_self_id_data();

--- a/libs/parallelism/threading/tests/unit/condition_variable2.cpp
+++ b/libs/parallelism/threading/tests/unit/condition_variable2.cpp
@@ -9,8 +9,8 @@
 //  Creative Commons Attribution 4.0 International License
 //  (http://creativecommons.org/licenses/by/4.0/).
 
+#include <hpx/functional/bind_back.hpp>
 #include <hpx/hpx_main.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/modules/synchronization.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/modules/threading.hpp>

--- a/libs/parallelism/threading/tests/unit/stop_token_cb1.cpp
+++ b/libs/parallelism/threading/tests/unit/stop_token_cb1.cpp
@@ -11,7 +11,7 @@
 
 #include <hpx/hpx_main.hpp>
 
-#include <hpx/modules/datastructures.hpp>
+#include <hpx/datastructures/optional.hpp>
 #include <hpx/modules/synchronization.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/modules/threading.hpp>

--- a/libs/parallelism/threading/tests/unit/stop_token_race.cpp
+++ b/libs/parallelism/threading/tests/unit/stop_token_race.cpp
@@ -9,8 +9,8 @@
 //  Creative Commons Attribution 4.0 International License
 //  (http://creativecommons.org/licenses/by/4.0/).
 
+#include <hpx/datastructures/optional.hpp>
 #include <hpx/hpx_main.hpp>
-#include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/modules/threading.hpp>
 
@@ -18,7 +18,6 @@
 #include <chrono>
 #include <cstdlib>
 #include <functional>
-#include <optional>
 #include <thread>
 #include <utility>
 

--- a/libs/parallelism/timed_execution/include/hpx/timed_execution/timed_executors.hpp
+++ b/libs/parallelism/timed_execution/include/hpx/timed_execution/timed_executors.hpp
@@ -15,7 +15,6 @@
 #include <hpx/futures/future.hpp>
 #include <hpx/modules/threading.hpp>
 #include <hpx/timing/steady_clock.hpp>
-#include <hpx/type_support/decay.hpp>
 #include <hpx/type_support/detail/wrap_int.hpp>
 
 #include <hpx/executors/execution_policy.hpp>
@@ -142,12 +141,12 @@ namespace hpx { namespace parallel { namespace execution {
             Ts&&... ts)
             -> decltype(sync_execute_at_helper<
                 typename hpx::traits::executor_execution_category<
-                    typename hpx::util::decay<Executor>::type>::type>::call(0,
+                    typename std::decay<Executor>::type>::type>::call(0,
                 std::forward<Executor>(exec), abs_time, std::forward<F>(f),
                 std::forward<Ts>(ts)...))
         {
             typedef typename hpx::traits::executor_execution_category<
-                typename hpx::util::decay<Executor>::type>::type tag;
+                typename std::decay<Executor>::type>::type tag;
 
             return sync_execute_at_helper<tag>::call(0,
                 std::forward<Executor>(exec), abs_time, std::forward<F>(f),
@@ -231,12 +230,12 @@ namespace hpx { namespace parallel { namespace execution {
             Ts&&... ts)
             -> decltype(async_execute_at_helper<
                 typename hpx::traits::executor_execution_category<
-                    typename hpx::util::decay<Executor>::type>::type>::call(0,
+                    typename std::decay<Executor>::type>::type>::call(0,
                 std::forward<Executor>(exec), abs_time, std::forward<F>(f),
                 std::forward<Ts>(ts)...))
         {
             typedef typename hpx::traits::executor_execution_category<
-                typename hpx::util::decay<Executor>::type>::type tag;
+                typename std::decay<Executor>::type>::type tag;
             return async_execute_at_helper<tag>::call(0,
                 std::forward<Executor>(exec), abs_time, std::forward<F>(f),
                 std::forward<Ts>(ts)...);
@@ -310,7 +309,7 @@ namespace hpx { namespace parallel { namespace execution {
             Ts&&... ts)
         {
             typedef typename hpx::traits::executor_execution_category<
-                typename hpx::util::decay<Executor>::type>::type tag;
+                typename std::decay<Executor>::type>::type tag;
 
             return post_at_helper<tag>::call(0, std::forward<Executor>(exec),
                 abs_time, std::forward<F>(f), std::forward<Ts>(ts)...);

--- a/libs/parallelism/timed_execution/include/hpx/timed_execution/traits/is_timed_executor.hpp
+++ b/libs/parallelism/timed_execution/include/hpx/timed_execution/traits/is_timed_executor.hpp
@@ -8,7 +8,6 @@
 
 #include <hpx/config.hpp>
 #include <hpx/execution/traits/is_executor.hpp>
-#include <hpx/type_support/decay.hpp>
 
 #include <type_traits>
 
@@ -29,7 +28,7 @@ namespace hpx { namespace parallel { namespace execution {
     // Precondition: T is a complete type
     template <typename T>
     struct is_timed_executor
-      : detail::is_timed_executor<typename hpx::util::decay<T>::type>
+      : detail::is_timed_executor<typename std::decay<T>::type>
     {
     };
 

--- a/src/runtime/parcelset/detail/parcel_await.cpp
+++ b/src/runtime/parcelset/detail/parcel_await.cpp
@@ -8,8 +8,8 @@
 
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/actions/actions_fwd.hpp>
+#include <hpx/functional/unique_function.hpp>
 #include <hpx/lcos_local/detail/preprocess_future.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/runtime/parcelset/detail/parcel_await.hpp>
 #include <hpx/runtime/parcelset/parcel.hpp>
 #include <hpx/runtime/parcelset_fwd.hpp>

--- a/src/runtime/threads/thread_pool_suspension_helpers.cpp
+++ b/src/runtime/threads/thread_pool_suspension_helpers.cpp
@@ -6,8 +6,8 @@
 
 #include <hpx/async_local/apply.hpp>
 #include <hpx/async_local/async.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/runtime/threads/thread_pool_suspension_helpers.hpp>
 #include <hpx/threading_base/scheduler_base.hpp>
 #include <hpx/threading_base/thread_data.hpp>

--- a/src/runtime_distributed.cpp
+++ b/src/runtime_distributed.cpp
@@ -18,9 +18,10 @@
 #include <hpx/coroutines/coroutine.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/execution_base/this_thread.hpp>
+#include <hpx/functional/bind.hpp>
+#include <hpx/functional/function.hpp>
 #include <hpx/itt_notify/thread_name.hpp>
 #include <hpx/modules/errors.hpp>
-#include <hpx/modules/functional.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/static_reinit.hpp>
 #include <hpx/modules/threadmanager.hpp>


### PR DESCRIPTION
Replace some internal inclusions of `hpx/module/` headers for the specific headers required for implementation. Reduces number of headers parsed (msvc, windows) from 479'032 to 432'162, roughly 10%. Only looks at replacing the fattest modules.

Fly-by changes:
- Replace some obsolete uses of `util::decay` by `std::decay`.
- Replace some internal uses of `util::invoke` by `HPX_INVOKE`.
- Simplify some expressions with superfluous binds.
- Add missing includes.