### PR TITLE
Test all schedulers in cross_pool_injection test except shared_priority_queue_scheduler

### DIFF
--- a/cmake/HPX_AddTest.cmake
+++ b/cmake/HPX_AddTest.cmake
@@ -6,7 +6,9 @@
 
 function(add_hpx_test category name)
   set(options FAILURE_EXPECTED RUN_SERIAL)
-  set(one_value_args EXECUTABLE LOCALITIES THREADS_PER_LOCALITY RUNWRAPPER)
+  set(one_value_args EXECUTABLE LOCALITIES THREADS_PER_LOCALITY TIMEOUT
+                     RUNWRAPPER
+  )
   set(multi_value_args ARGS PARCELPORTS)
   cmake_parse_arguments(
     ${name} "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN}
@@ -113,6 +115,11 @@ function(add_hpx_test category name)
     if(${run_serial})
       set_tests_properties("${_full_name}" PROPERTIES RUN_SERIAL TRUE)
     endif()
+    if(${name}_TIMEOUT)
+      set_tests_properties(
+        "${_full_name}" PROPERTIES TIMEOUT ${${name}_TIMEOUT}
+      )
+    endif()
   else()
     if(HPX_WITH_PARCELPORT_VERBS)
       set(_add_test FALSE)
@@ -129,6 +136,11 @@ function(add_hpx_test category name)
         set(_full_name "${category}.distributed.verbs.${name}")
         add_test(NAME "${_full_name}" COMMAND ${cmd} "-p" "verbs" ${args})
         set_tests_properties("${_full_name}" PROPERTIES RUN_SERIAL TRUE)
+        if(${name}_TIMEOUT)
+          set_tests_properties(
+            "${_full_name}" PROPERTIES TIMEOUT ${${name}_TIMEOUT}
+          )
+        endif()
       endif()
     endif()
     if(HPX_WITH_PARCELPORT_MPI)
@@ -148,6 +160,11 @@ function(add_hpx_test category name)
                                               ${args}
         )
         set_tests_properties("${_full_name}" PROPERTIES RUN_SERIAL TRUE)
+        if(${name}_TIMEOUT)
+          set_tests_properties(
+            "${_full_name}" PROPERTIES TIMEOUT ${${name}_TIMEOUT}
+          )
+        endif()
       endif()
     endif()
     if(HPX_WITH_PARCELPORT_TCP)
@@ -165,10 +182,14 @@ function(add_hpx_test category name)
         set(_full_name "${category}.distributed.tcp.${name}")
         add_test(NAME "${_full_name}" COMMAND ${cmd} "-p" "tcp" ${args})
         set_tests_properties("${_full_name}" PROPERTIES RUN_SERIAL TRUE)
+        if(${name}_TIMEOUT)
+          set_tests_properties(
+            "${_full_name}" PROPERTIES TIMEOUT ${${name}_TIMEOUT}
+          )
+        endif()
       endif()
     endif()
   endif()
-
 endfunction(add_hpx_test)
 
 function(add_hpx_test_target_dependencies category name)

--- a/libs/full/include/include/hpx/include/resource_partitioner.hpp
+++ b/libs/full/include/include/hpx/include/resource_partitioner.hpp
@@ -8,3 +8,4 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/resource_partitioner.hpp>
+#include <hpx/runtime_local/thread_pool_helpers.hpp>

--- a/tests/unit/resource/CMakeLists.txt
+++ b/tests/unit/resource/CMakeLists.txt
@@ -18,7 +18,7 @@ set(tests
 
 if(HPX_WITH_SHARED_PRIORITY_SCHEDULER)
   set(tests ${tests} cross_pool_injection scheduler_binding_check)
-  set(cross_pool_injection_PARAMETERS THREADS_PER_LOCALITY -1)
+  set(cross_pool_injection_PARAMETERS THREADS_PER_LOCALITY -1 TIMEOUT 300)
   set(scheduler_binding_check_PARAMETERS THREADS_PER_LOCALITY -1)
 endif()
 


### PR DESCRIPTION
I could get reliable hangs with the shared priority scheduler, and none with the other schedulers. This does not mean that the others are fault free, but at least I could not reproduce the issue with them. The other schedulers also don't use exactly the same flags as the shared priority scheduler, so it's not a 100% fair comparison. Time will tell if the test will keep failing.