### PR TITLE
Fix unused variable and typedef warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1936,11 +1936,6 @@ if(HPX_WITH_COMPILER_WARNINGS)
   else() # Trial and error approach for any other compiler ...
     hpx_add_compile_flag_if_available(-Wall LANGUAGES CXX C Fortran)
     hpx_add_compile_flag_if_available(-Wextra LANGUAGES CXX C Fortran)
-    # This is a new warning popping up from the boost headers with no particular
-    # meaning
-    hpx_add_compile_flag_if_available(
-      -Wno-unused-local-typedefs LANGUAGES CXX C Fortran
-    )
     hpx_add_compile_flag_if_available(
       -Wno-strict-aliasing LANGUAGES CXX C Fortran
     )

--- a/components/containers/partitioned_vector/tests/unit/partitioned_vector_view_iterator.cpp
+++ b/components/containers/partitioned_vector/tests/unit/partitioned_vector_view_iterator.cpp
@@ -34,10 +34,6 @@ void bulk_test( hpx::lcos::spmd_block block,
         = hpx::partitioned_vector<double>;
     using view_type
         = hpx::partitioned_vector_view<double,3>;
-    using view_type_iterator
-        = typename view_type::iterator;
-    using const_view_type_iterator
-        = typename view_type::const_iterator;
 
     vector_type my_vector;
     my_vector.connect_to(hpx::launch::sync, vec_name);

--- a/libs/core/coroutines/CMakeLists.txt
+++ b/libs/core/coroutines/CMakeLists.txt
@@ -109,8 +109,14 @@ add_hpx_module(
   SOURCES ${coroutines_sources}
   HEADERS ${coroutines_headers} OBJECTS "${switch_to_fiber_object}"
   COMPAT_HEADERS ${coroutines_compat_headers}
-  MODULE_DEPENDENCIES hpx_assertion hpx_config hpx_errors hpx_format
-                      hpx_functional hpx_util
+  MODULE_DEPENDENCIES
+    hpx_assertion
+    hpx_config
+    hpx_errors
+    hpx_format
+    hpx_functional
+    hpx_type_support
+    hpx_util
   CMAKE_SUBDIRS examples tests
 )
 

--- a/libs/core/coroutines/src/detail/tss.cpp
+++ b/libs/core/coroutines/src/detail/tss.cpp
@@ -15,6 +15,7 @@
 #include <hpx/coroutines/detail/coroutine_self.hpp>
 #include <hpx/coroutines/detail/tss.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/type_support/unused.hpp>
 
 #include <cstddef>
 #include <map>
@@ -31,6 +32,8 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         }
         func_.reset();
         value_ = nullptr;
+#else
+        HPX_UNUSED(cleanup_existing);
 #endif
     }
 
@@ -52,6 +55,8 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
 #ifdef HPX_HAVE_THREAD_LOCAL_STORAGE
         delete storage;
         storage = nullptr;
+#else
+        HPX_UNUSED(storage);
 #endif
     }
 
@@ -77,6 +82,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
 
         return node->get_data<std::size_t>();
 #else
+        HPX_UNUSED(storage);
         throw std::runtime_error(
             "thread local storage has been disabled at configuration time, "
             "please specify HPX_WITH_THREAD_LOCAL_STORAGE=ON to cmake");
@@ -115,6 +121,8 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
 
         return prev_val;
 #else
+        HPX_UNUSED(storage);
+        HPX_UNUSED(data);
         throw std::runtime_error(
             "thread local storage has been disabled at configuration time, "
             "please specify HPX_WITH_THREAD_LOCAL_STORAGE=ON to cmake");
@@ -141,6 +149,7 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
 
         return tss_map->find(key);
 #else
+        HPX_UNUSED(key);
         throw std::runtime_error(
             "thread local storage has been disabled at configuration time, "
             "please specify HPX_WITH_THREAD_LOCAL_STORAGE=ON to cmake");
@@ -153,6 +162,8 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
 #ifdef HPX_HAVE_THREAD_LOCAL_STORAGE
         if (tss_data_node* const current_node = find_tss_data(key))
             return current_node->get_value();
+#else
+        HPX_UNUSED(key);
 #endif
         return nullptr;
     }
@@ -178,6 +189,10 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         }
 
         tss_map->insert(key, func, tss_data);
+#else
+        HPX_UNUSED(key);
+        HPX_UNUSED(func);
+        HPX_UNUSED(tss_data);
 #endif
     }
 
@@ -196,6 +211,9 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         detail::tss_storage* tss_map = self->get_thread_tss_data();
         if (nullptr != tss_map)
             tss_map->erase(key, cleanup_existing);
+#else
+        HPX_UNUSED(key);
+        HPX_UNUSED(cleanup_existing);
 #endif
     }
 
@@ -215,6 +233,11 @@ namespace hpx { namespace threads { namespace coroutines { namespace detail {
         {
             add_new_tss_node(key, func, tss_data);
         }
+#else
+        HPX_UNUSED(key);
+        HPX_UNUSED(func);
+        HPX_UNUSED(tss_data);
+        HPX_UNUSED(cleanup_existing);
 #endif
     }
 }}}}    // namespace hpx::threads::coroutines::detail

--- a/libs/core/datastructures/include/hpx/datastructures/optional.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/optional.hpp
@@ -372,7 +372,7 @@ namespace hpx { namespace util {
     }
 
     template <typename T>
-    constexpr bool operator<(optional<T> const& opt, nullopt_t) noexcept
+    constexpr bool operator<(optional<T> const&, nullopt_t) noexcept
     {
         return false;
     }
@@ -384,7 +384,7 @@ namespace hpx { namespace util {
     }
 
     template <typename T>
-    constexpr bool operator>=(optional<T> const& opt, nullopt_t) noexcept
+    constexpr bool operator>=(optional<T> const&, nullopt_t) noexcept
     {
         return true;
     }
@@ -402,7 +402,7 @@ namespace hpx { namespace util {
     }
 
     template <typename T>
-    constexpr bool operator>(nullopt_t, optional<T> const& opt) noexcept
+    constexpr bool operator>(nullopt_t, optional<T> const&) noexcept
     {
         return false;
     }
@@ -414,7 +414,7 @@ namespace hpx { namespace util {
     }
 
     template <typename T>
-    constexpr bool operator<=(nullopt_t, optional<T> const& opt) noexcept
+    constexpr bool operator<=(nullopt_t, optional<T> const&) noexcept
     {
         return true;
     }

--- a/libs/core/datastructures/include/hpx/datastructures/tuple.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/tuple.hpp
@@ -11,9 +11,7 @@
 #include <hpx/config.hpp>
 #include <hpx/datastructures/config/defines.hpp>
 #include <hpx/datastructures/member_pack.hpp>
-#include <hpx/type_support/always_void.hpp>
-#include <hpx/type_support/decay.hpp>
-#include <hpx/type_support/pack.hpp>
+#include <hpx/modules/type_support.hpp>
 
 #include <algorithm>
 #include <array>
@@ -162,7 +160,7 @@ namespace hpx {
         struct ignore_type
         {
             template <typename T>
-            void operator=(T&& t) const
+            void operator=(T&&) const
             {
             }
         };
@@ -935,7 +933,7 @@ namespace hpx {
         {
             template <typename TTuple, typename UTuple>
             static constexpr HPX_HOST_DEVICE HPX_FORCEINLINE bool call(
-                TTuple const& t, UTuple const& u)
+                TTuple const&, UTuple const&)
             {
                 return false;
             }

--- a/libs/core/debugging/include/hpx/debugging/demangle_helper.hpp
+++ b/libs/core/debugging/include/hpx/debugging/demangle_helper.hpp
@@ -100,7 +100,7 @@ namespace hpx { namespace util { namespace debug {
     // separator is appended if the number of types > 1
     // --------------------------------------------------------------------
     template <typename T = void>
-    inline std::string print_type(const char* delim = "")
+    inline std::string print_type(const char* = "")
     {
         return std::string(cxx_type_id<T>::typeid_.type_id());
     }

--- a/libs/core/debugging/include/hpx/debugging/print.hpp
+++ b/libs/core/debugging/include/hpx/debugging/print.hpp
@@ -513,25 +513,22 @@ namespace hpx { namespace debug {
         }
 
         template <typename T>
-        constexpr void array(
-            std::string const& name, std::vector<T> const&) const
+        constexpr void array(std::string const&, std::vector<T> const&) const
         {
         }
 
         template <typename T, std::size_t N>
-        constexpr void array(
-            std::string const& name, std::array<T, N> const&) const
+        constexpr void array(std::string const&, std::array<T, N> const&) const
         {
         }
 
         template <typename T>
-        constexpr void array(
-            std::string const& name, T const* data, std::size_t size) const
+        constexpr void array(std::string const&, T const*, std::size_t) const
         {
         }
 
         template <typename... Args>
-        constexpr bool scope(Args const&... args)
+        constexpr bool scope(Args const&...)
         {
             return true;
         }
@@ -543,7 +540,7 @@ namespace hpx { namespace debug {
         }
 
         template <typename T, typename V>
-        constexpr void set(T& var, V const& val)
+        constexpr void set(T&, V const&)
         {
         }
 

--- a/libs/core/errors/src/exception.cpp
+++ b/libs/core/errors/src/exception.cpp
@@ -231,7 +231,7 @@ namespace hpx { namespace detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Exception>
-    inline bool is_of_lightweight_hpx_category(Exception const& e)
+    inline bool is_of_lightweight_hpx_category(Exception const&)
     {
         return false;
     }

--- a/libs/core/errors/src/throw_exception.cpp
+++ b/libs/core/errors/src/throw_exception.cpp
@@ -33,7 +33,7 @@ namespace hpx { namespace detail {
     }
 
     std::exception_ptr get_exception(error errcode, std::string const& msg,
-        throwmode mode, std::string const& func, std::string const& file,
+        throwmode mode, std::string const& /* func */, std::string const& file,
         long line, std::string const& auxinfo)
     {
         filesystem::path p(file);
@@ -42,8 +42,9 @@ namespace hpx { namespace detail {
     }
 
     std::exception_ptr get_exception(boost::system::error_code const& ec,
-        std::string const& msg, throwmode mode, std::string const& func,
-        std::string const& file, long line, std::string const& auxinfo)
+        std::string const& /* msg */, throwmode /* mode */,
+        std::string const& func, std::string const& file, long line,
+        std::string const& auxinfo)
     {
         return hpx::detail::get_exception(
             hpx::exception(ec), func, file, line, auxinfo);

--- a/libs/core/execution_base/src/agent_ref.cpp
+++ b/libs/core/execution_base/src/agent_ref.cpp
@@ -27,7 +27,7 @@ namespace hpx { namespace execution_base {
         impl_->yield(desc);
     }
 
-    void agent_ref::yield_k(std::size_t k, const char* desc)
+    void agent_ref::yield_k(std::size_t /* k */, const char* desc)
     {
         HPX_ASSERT(*this == hpx::execution_base::this_thread::agent());
         // verify that there are no more registered locks for this OS-thread

--- a/libs/core/execution_base/src/register_locks.cpp
+++ b/libs/core/execution_base/src/register_locks.cpp
@@ -379,9 +379,9 @@ namespace hpx { namespace util {
 
     void trace_depth_lock_detection(std::size_t) {}
 
-    void ignore_lock(void const* lock) {}
+    void ignore_lock(void const* /* lock */) {}
 
-    void reset_ignored(void const* lock) {}
+    void reset_ignored(void const* /* lock */) {}
 
     void ignore_all_locks() {}
 
@@ -392,6 +392,6 @@ namespace hpx { namespace util {
         return std::unique_ptr<held_locks_data>();
     }
 
-    void set_held_locks_data(std::unique_ptr<held_locks_data>&& data) {}
+    void set_held_locks_data(std::unique_ptr<held_locks_data>&& /* data */) {}
 #endif
 }}    // namespace hpx::util

--- a/libs/core/execution_base/src/this_thread.cpp
+++ b/libs/core/execution_base/src/this_thread.cpp
@@ -90,7 +90,7 @@ namespace hpx { namespace execution_base {
         {
         }
 
-        void default_agent::yield(char const* desc)
+        void default_agent::yield(char const* /* desc */)
         {
 #if defined(HPX_SMT_PAUSE)
             HPX_SMT_PAUSE;
@@ -103,7 +103,7 @@ namespace hpx { namespace execution_base {
 #endif
         }
 
-        void default_agent::yield_k(std::size_t k, char const* desc)
+        void default_agent::yield_k(std::size_t k, char const* /* desc */)
         {
             if (k < 4)    //-V112
             {
@@ -141,7 +141,7 @@ namespace hpx { namespace execution_base {
             }
         }
 
-        void default_agent::suspend(char const* desc)
+        void default_agent::suspend(char const* /* desc */)
         {
             std::unique_lock<std::mutex> l(mtx_);
             HPX_ASSERT(running_);
@@ -163,7 +163,7 @@ namespace hpx { namespace execution_base {
             }
         }
 
-        void default_agent::resume(char const* desc)
+        void default_agent::resume(char const* /* desc */)
         {
             {
                 std::unique_lock<std::mutex> l(mtx_);
@@ -176,7 +176,7 @@ namespace hpx { namespace execution_base {
             suspend_cv_.notify_one();
         }
 
-        void default_agent::abort(char const* desc)
+        void default_agent::abort(char const* /* desc */)
         {
             {
                 std::unique_lock<std::mutex> l(mtx_);
@@ -192,13 +192,14 @@ namespace hpx { namespace execution_base {
 
         void default_agent::sleep_for(
             hpx::chrono::steady_duration const& sleep_duration,
-            char const* desc)
+            char const* /* desc */)
         {
             std::this_thread::sleep_for(sleep_duration.value());
         }
 
         void default_agent::sleep_until(
-            hpx::chrono::steady_time_point const& sleep_time, char const* desc)
+            hpx::chrono::steady_time_point const& sleep_time,
+            char const* /* desc */)
         {
             std::this_thread::sleep_until(sleep_time.value());
         }

--- a/libs/core/format/CMakeLists.txt
+++ b/libs/core/format/CMakeLists.txt
@@ -32,6 +32,6 @@ add_hpx_module(
   SOURCES ${format_sources}
   HEADERS ${format_headers}
   COMPAT_HEADERS ${format_compat_headers}
-  MODULE_DEPENDENCIES hpx_assertion hpx_config
+  MODULE_DEPENDENCIES hpx_assertion hpx_config hpx_type_support
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/format/src/format.cpp
+++ b/libs/core/format/src/format.cpp
@@ -7,6 +7,7 @@
 
 #include <hpx/assert.hpp>
 #include <hpx/modules/format.hpp>
+#include <hpx/type_support/unused.hpp>
 
 #include <boost/utility/string_ref.hpp>
 
@@ -96,6 +97,7 @@ namespace hpx { namespace util { namespace detail {
                     std::size_t const id =
                         field.arg_id ? field.arg_id - 1 : index;
                     HPX_ASSERT(id < count);
+                    HPX_UNUSED(count);
                     args[id](os, field.spec);
                     ++index;
                 }

--- a/libs/core/functional/include/hpx/functional/bind.hpp
+++ b/libs/core/functional/include/hpx/functional/bind.hpp
@@ -310,7 +310,7 @@ namespace hpx { namespace serialization {
 
     // serialization of placeholders is trivial, just provide empty functions
     template <typename Archive, std::size_t I>
-    void serialize(Archive& ar,
+    void serialize(Archive& /* ar */,
         ::hpx::util::detail::placeholder<I>& /*placeholder*/
         ,
         unsigned int const /*version*/ = 0)

--- a/libs/core/functional/include/hpx/functional/function_ref.hpp
+++ b/libs/core/functional/include/hpx/functional/function_ref.hpp
@@ -56,7 +56,7 @@ namespace hpx { namespace util {
         }
 
         template <typename F>
-        constexpr bool is_empty_function_ptr(F const& f) noexcept
+        constexpr bool is_empty_function_ptr(F const&) noexcept
         {
             return false;
         }

--- a/libs/core/functional/src/basic_function.cpp
+++ b/libs/core/functional/src/basic_function.cpp
@@ -27,7 +27,7 @@
 namespace hpx { namespace util { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     function_base::function_base(
-        function_base const& other, vtable const* empty_vtable)
+        function_base const& other, vtable const* /* empty_vtable */)
       : vptr(other.vptr)
       , object(other.object)
     {
@@ -58,7 +58,7 @@ namespace hpx { namespace util { namespace detail {
     }
 
     void function_base::op_assign(
-        function_base const& other, vtable const* empty_vtable)
+        function_base const& other, vtable const* /* empty_vtable */)
     {
         if (vptr == other.vptr)
         {

--- a/libs/core/serialization/include/hpx/serialization/detail/non_default_constructible.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/non_default_constructible.hpp
@@ -21,7 +21,7 @@ namespace hpx { namespace serialization { namespace detail {
 
     // by default fall back to in-place default construction
     template <typename Archive, typename T>
-    void load_construct_data(Archive& ar, T* t, unsigned)
+    void load_construct_data(Archive&, T* t, unsigned)
     {
         ::new (t) T;
     }

--- a/libs/core/serialization/include/hpx/serialization/detail/polymorphic_id_factory.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/polymorphic_id_factory.hpp
@@ -16,6 +16,7 @@
 #include <hpx/serialization/serialization_fwd.hpp>
 #include <hpx/serialization/traits/polymorphic_traits.hpp>
 #include <hpx/type_support/static.hpp>
+#include <hpx/type_support/unused.hpp>
 
 #include <cstdint>
 #include <map>
@@ -104,6 +105,8 @@ namespace hpx { namespace serialization { namespace detail {
                     msg += ", for typename " + *name + "\n";
                     msg += collect_registered_typenames();
                 }
+#else
+                HPX_UNUSED(name);
 #endif
                 HPX_THROW_EXCEPTION(
                     serialization_error, "polymorphic_id_factory::create", msg);

--- a/libs/core/serialization/include/hpx/serialization/output_container.hpp
+++ b/libs/core/serialization/include/hpx/serialization/output_container.hpp
@@ -198,7 +198,7 @@ namespace hpx { namespace serialization {
             access_traits::reset(cont_);
         }
 
-        void set_filter(binary_filter* filter) override
+        void set_filter(binary_filter* /* filter */) override
         {
             HPX_ASSERT(chunker_.get_num_chunks() == 1 &&
                 chunker_.get_chunk_size() == 0);

--- a/libs/core/serialization/include/hpx/serialization/serializable_any.hpp
+++ b/libs/core/serialization/include/hpx/serialization/serializable_any.hpp
@@ -63,7 +63,7 @@ namespace hpx { namespace util { namespace detail { namespace any {
         virtual void load_object(void**, IArch& ar, unsigned) = 0;
 
         template <typename Arch>
-        void serialize(Arch& ar, unsigned)
+        void serialize(Arch&, unsigned)
         {
         }
 

--- a/libs/core/serialization/include/hpx/serialization/traits/serialization_access_data.hpp
+++ b/libs/core/serialization/include/hpx/serialization/traits/serialization_access_data.hpp
@@ -29,32 +29,35 @@ namespace hpx { namespace traits {
         }
 
         // functions related to output operations
-        static constexpr void write(Container& cont, std::size_t count,
-            std::size_t current, void const* address)
+        static constexpr void write(Container& /* cont */,
+            std::size_t /* count */, std::size_t /* current */,
+            void const* /* address */)
         {
         }
 
-        static bool flush(serialization::binary_filter* filter, Container& cont,
-            std::size_t current, std::size_t size, std::size_t& written)
+        static bool flush(serialization::binary_filter* /* filter */,
+            Container& /* cont */, std::size_t /* current */, std::size_t size,
+            std::size_t& written)
         {
             written = size;
             return true;
         }
 
         // functions related to input operations
-        static constexpr void read(Container const& cont, std::size_t count,
-            std::size_t current, void* address)
+        static constexpr void read(Container const& /* cont */,
+            std::size_t /* count */, std::size_t /* current */,
+            void* /* address */)
         {
         }
 
-        static constexpr std::size_t init_data(Container const& cont,
-            serialization::binary_filter* filter, std::size_t current,
-            std::size_t decompressed_size)
+        static constexpr std::size_t init_data(Container const& /* cont */,
+            serialization::binary_filter* /* filter */,
+            std::size_t /* current */, std::size_t decompressed_size)
         {
             return decompressed_size;
         }
 
-        static constexpr void reset(Container& cont) {}
+        static constexpr void reset(Container& /* cont */) {}
     };
 
     ///////////////////////////////////////////////////////////////////////

--- a/libs/core/serialization/src/exception_ptr.cpp
+++ b/libs/core/serialization/src/exception_ptr.cpp
@@ -28,7 +28,7 @@ namespace hpx { namespace serialization {
         ///////////////////////////////////////////////////////////////////////////
         // TODO: This is not scalable, and painful to update.
         void save(output_archive& ar, std::exception_ptr const& ep,
-            unsigned int version)
+            unsigned int /* version */)
         {
             hpx::util::exception_type type(hpx::util::unknown_exception);
             std::string what;
@@ -162,8 +162,8 @@ namespace hpx { namespace serialization {
 
         ///////////////////////////////////////////////////////////////////////////
         // TODO: This is not scalable, and painful to update.
-        void load(
-            input_archive& ar, std::exception_ptr& e, unsigned int version)
+        void load(input_archive& ar, std::exception_ptr& e,
+            unsigned int /* version */)
         {
             hpx::util::exception_type type(hpx::util::unknown_exception);
             std::string what;

--- a/libs/core/serialization/src/serializable_any.cpp
+++ b/libs/core/serialization/src/serializable_any.cpp
@@ -37,25 +37,26 @@ namespace hpx { namespace util {
             }
 
             // compression API
-            void set_max_length(std::size_t size) {}
+            void set_max_length(std::size_t /* size */) {}
             void save(void const* src, std::size_t src_count)
             {
                 char const* data = static_cast<char const*>(src);
                 boost::hash_range(hash, data, data + src_count);
             }
-            bool flush(void* dst, std::size_t dst_count, std::size_t& written)
+            bool flush(
+                void* /* dst */, std::size_t dst_count, std::size_t& written)
             {
                 written = dst_count;
                 return true;
             }
 
             // decompression API
-            std::size_t init_data(
-                char const* buffer, std::size_t size, std::size_t buffer_size)
+            std::size_t init_data(char const* /* buffer */,
+                std::size_t /* size */, std::size_t /* buffer_size */)
             {
                 return 0;
             }
-            void load(void* dst, std::size_t dst_count) {}
+            void load(void* /* dst */, std::size_t /* dst_count */) {}
 
             template <class T>
             void serialize(T&, unsigned)

--- a/libs/core/threading_base/src/execution_agent.cpp
+++ b/libs/core/threading_base/src/execution_agent.cpp
@@ -189,7 +189,7 @@ namespace hpx { namespace threads {
     }
 
     void execution_agent::do_resume(
-        const char* desc, hpx::threads::thread_state_ex_enum statex)
+        const char* /* desc */, hpx::threads::thread_state_ex_enum statex)
     {
         thread_id_type id = self_.get_thread_id();
 

--- a/libs/core/threading_base/src/thread_description.cpp
+++ b/libs/core/threading_base/src/thread_description.cpp
@@ -8,6 +8,7 @@
 #include <hpx/assert.hpp>
 #include <hpx/threading_base/thread_data.hpp>
 #include <hpx/threading_base/thread_description.hpp>
+#include <hpx/type_support/unused.hpp>
 #include <hpx/util/to_string.hpp>
 
 #include <iostream>
@@ -28,6 +29,7 @@ namespace hpx { namespace util {
             os << d.get_address();    //-V128
         }
 #else
+        HPX_UNUSED(d);
         os << "<unknown>";
 #endif
         return os;
@@ -44,6 +46,7 @@ namespace hpx { namespace util {
              << util::to_string(desc.get_address());
         return strm.str();
 #else
+        HPX_UNUSED(desc);
         return "<unknown>";
 #endif
     }
@@ -82,6 +85,8 @@ namespace hpx { namespace util {
             type_ = data_type_description;
             data_.desc_ = "<unknown>";
         }
+#else
+        HPX_UNUSED(altname);
 #endif
     }
 }}    // namespace hpx::util

--- a/libs/core/topology/include/hpx/topology/cpu_mask.hpp
+++ b/libs/core/topology/include/hpx/topology/cpu_mask.hpp
@@ -180,6 +180,8 @@ namespace hpx { namespace threads {
     {
 #  if defined(HPX_HAVE_MAX_CPU_COUNT)
         HPX_ASSERT(s <= mask.size());
+        HPX_UNUSED(mask);
+        HPX_UNUSED(s);
 #  else
         return mask.resize(s);
 #  endif

--- a/libs/core/topology/src/topology.cpp
+++ b/libs/core/topology/src/topology.cpp
@@ -169,6 +169,7 @@ namespace hpx { namespace threads {
 
     bool topology::reduce_thread_priority(error_code& ec) const
     {
+        HPX_UNUSED(ec);
 #ifdef HPX_HAVE_NICE_THREADLEVEL
 #if defined(__linux__) && !defined(__ANDROID__) && !defined(__bgq__)
         pid_t tid;

--- a/libs/full/collectives/include/hpx/collectives/broadcast.hpp
+++ b/libs/full/collectives/include/hpx/collectives/broadcast.hpp
@@ -369,8 +369,6 @@ namespace hpx { namespace lcos {
             this_site = static_cast<std::size_t>(hpx::get_locality_id());
         }
 
-        using arg_type = typename util::decay<T>::type;
-
         auto broadcast_data_direct =
             [this_site](hpx::future<hpx::id_type>&& fid) -> hpx::future<T> {
             using action_type = typename detail::communicator_server::

--- a/libs/full/collectives/tests/performance/osu/osu_bibw.cpp
+++ b/libs/full/collectives/tests/performance/osu/osu_bibw.cpp
@@ -74,8 +74,6 @@ HPX_PLAIN_DIRECT_ACTION(irecv);
 ///////////////////////////////////////////////////////////////////////////////
 void recv_async(hpx::id_type dest, std::size_t size, std::size_t window_size)
 {
-    using buffer_type = hpx::serialization::serialize_buffer<char>;
-
     using hpx::for_loop;
     using hpx::execution::par;
 

--- a/libs/full/resiliency/include/hpx/resiliency/async_replay.hpp
+++ b/libs/full/resiliency/include/hpx/resiliency/async_replay.hpp
@@ -153,8 +153,6 @@ namespace hpx { namespace resiliency { namespace experimental {
             std::tuple<typename std::decay<Ts>::type...>>>
         make_async_replay_helper(Pred&& pred, F&& f, Ts&&... ts)
         {
-            using tuple_type = std::tuple<typename std::decay<Ts>::type...>;
-
             using return_type = async_replay_helper<Result,
                 typename std::decay<Pred>::type, typename std::decay<F>::type,
                 std::tuple<typename std::decay<Ts>::type...>>;

--- a/libs/full/resiliency/include/hpx/resiliency/async_replay_executor.hpp
+++ b/libs/full/resiliency/include/hpx/resiliency/async_replay_executor.hpp
@@ -210,8 +210,6 @@ namespace hpx { namespace resiliency { namespace experimental {
             std::tuple<typename std::decay<Ts>::type...>>>
         make_async_replay_executor_helper(Pred&& pred, F&& f, Ts&&... ts)
         {
-            using tuple_type = std::tuple<typename std::decay<Ts>::type...>;
-
             using return_type = async_replay_executor_helper<Result,
                 typename std::decay<Pred>::type, typename std::decay<F>::type,
                 std::tuple<typename std::decay<Ts>::type...>>;

--- a/libs/full/runtime_configuration/src/init_ini_data.cpp
+++ b/libs/full/runtime_configuration/src/init_ini_data.cpp
@@ -408,9 +408,6 @@ namespace hpx { namespace util {
     {
         namespace fs = filesystem;
 
-        typedef std::vector<std::pair<fs::path, std::string>>::iterator
-            iterator_type;
-
         typedef std::vector<std::shared_ptr<plugins::plugin_registry_base>>
             plugin_list_type;
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
@@ -216,8 +216,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     typename std::iterator_traits<Iter2>::difference_type;
 
                 using result_type = util::in_in_out_result<Iter1, Iter2, Iter3>;
-                using result =
-                    util::detail::algorithm_result<ExPolicy, result_type>;
 
                 if (first1 == last1)
                 {

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_union.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_union.hpp
@@ -206,8 +206,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     typename std::iterator_traits<Iter2>::difference_type;
 
                 using result_type = util::in_in_out_result<Iter1, Iter2, Iter3>;
-                using result =
-                    util::detail::algorithm_result<ExPolicy, result_type>;
 
                 if (first1 == last1)
                 {

--- a/libs/parallelism/algorithms/include/hpx/parallel/spmd_block.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/spmd_block.hpp
@@ -180,8 +180,6 @@ namespace hpx { namespace lcos { namespace local {
 
         using ftype = typename std::decay<F>::type;
         using first_type = typename hpx::util::first_argument<ftype>::type;
-        using executor_type =
-            typename hpx::util::decay<ExPolicy>::type::executor_type;
 
         using barrier_type = hpx::lcos::local::barrier;
         using table_type =
@@ -216,8 +214,6 @@ namespace hpx { namespace lcos { namespace local {
 
         using ftype = typename std::decay<F>::type;
         using first_type = typename hpx::util::first_argument<ftype>::type;
-        using executor_type =
-            typename hpx::util::decay<ExPolicy>::type::executor_type;
 
         using barrier_type = hpx::lcos::local::barrier;
         using table_type =

--- a/libs/parallelism/algorithms/tests/regressions/scan_shortlength.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/scan_shortlength.cpp
@@ -48,7 +48,6 @@ void test_async_zero()
 {
     using namespace hpx::execution;
     typedef std::vector<int>::iterator Iter;
-    typedef hpx::future<std::pair<Iter, Iter>> Fut_Iter;
     std::vector<int> a;
     std::vector<int> b, c, d;
 
@@ -73,7 +72,6 @@ void test_async_zero()
 void test_one(std::vector<int> a)
 {
     using namespace hpx::execution;
-    typedef std::vector<int>::iterator Iter;
     std::size_t n = a.size();
     std::vector<int> b(n), c(n), d(n);
     std::vector<int> b_ans(n), c_ans(n), d_ans(n);
@@ -111,8 +109,6 @@ void print(std::vector<int> const& result, std::vector<int> const& correct)
 void test_async_one(std::vector<int> a)
 {
     using namespace hpx::execution;
-    typedef std::vector<int>::iterator Iter;
-    typedef hpx::future<std::pair<Iter, Iter>> Fut_Iter;
     std::size_t n = a.size();
     std::vector<int> b(n), c(n), d(n);
     std::vector<int> b_ans(n), c_ans(n), d_ans(n);

--- a/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_parallel_stable_sort.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_parallel_stable_sort.cpp
@@ -43,9 +43,6 @@ struct xk
 
 void test3()
 {
-    typedef typename std::vector<xk>::iterator iter_t;
-    typedef std::less<xk> compare;
-
     std::mt19937_64 my_rand(std::rand());
 
     constexpr std::uint32_t NMAX = NUMELEMS;
@@ -76,9 +73,6 @@ void test3()
 
 void test4()
 {
-    typedef typename std::vector<std::uint64_t>::iterator iter_t;
-    typedef std::less<std::uint64_t> compare;
-
     constexpr std::uint32_t NElem = NUMELEMS;
 
     std::vector<std::uint64_t> V1;
@@ -126,9 +120,6 @@ void test4()
 
 void test5()
 {
-    typedef typename std::vector<std::uint64_t>::iterator iter_t;
-    typedef std::less<std::uint64_t> compare;
-
     constexpr std::uint32_t NELEM = NUMELEMS;
     std::mt19937_64 my_rand(std::rand());
 
@@ -153,9 +144,6 @@ void test5()
 
 void test6(void)
 {
-    typedef typename std::vector<std::uint64_t>::iterator iter_t;
-    typedef std::less<std::uint64_t> compare;
-
     constexpr std::uint32_t NELEM = NUMELEMS;
     std::vector<std::uint64_t> A;
     A.reserve(NELEM);

--- a/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_sample_sort.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_sample_sort.cpp
@@ -44,9 +44,6 @@ struct xk
 
 void test3()
 {
-    typedef typename std::vector<xk>::iterator iter_t;
-    typedef std::less<xk> compare;
-
     std::mt19937_64 my_rand(std::rand());
 
     constexpr std::uint32_t NMAX = NUMELEMS;
@@ -77,9 +74,6 @@ void test3()
 
 void test4()
 {
-    typedef typename std::vector<std::uint64_t>::iterator iter_t;
-    typedef std::less<std::uint64_t> compare;
-
     constexpr std::uint32_t NElem = NUMELEMS;
     std::vector<std::uint64_t> V1;
     std::mt19937_64 my_rand(std::rand());
@@ -126,8 +120,6 @@ void test4()
 
 void test5()
 {
-    typedef typename std::vector<std::uint64_t>::iterator iter_t;
-    typedef std::less<std::uint64_t> compare;
     constexpr std::uint32_t KMax = NUMELEMS;
 
     std::vector<std::uint64_t> K, M;
@@ -163,7 +155,6 @@ void test5()
 
 void test6()
 {
-    typedef typename std::vector<std::uint64_t>::iterator iter_t;
     std::vector<std::uint64_t> V;
 
     for (std::uint32_t i = 0; i < 2083333; ++i)

--- a/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_spin_sort.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_spin_sort.cpp
@@ -157,10 +157,8 @@ void test4()
 
 void test5()
 {
-    typedef std::vector<std::uint64_t>::iterator iter_t;
     typedef std::less<std::uint64_t> compare;
     constexpr std::uint32_t KMax = NUMELEMS;
-    typedef std::vector<std::uint64_t>::iterator iter_t;
     std::vector<std::uint64_t> K, M;
     std::mt19937_64 my_rand(std::rand());
     compare comp;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_validate.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_validate.cpp
@@ -49,7 +49,6 @@ void test_exclusive_scan_validate(
     ExPolicy p, std::vector<int>& a, std::vector<int>& b)
 {
     using namespace hpx::execution;
-    typedef std::vector<int>::iterator Iter;
 
     // test 1, fill array with numbers counting from 0, then run scan algorithm
     a.clear();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop.cpp
@@ -114,8 +114,6 @@ void test_for_loop_idx(ExPolicy&& policy)
 template <typename ExPolicy>
 void test_for_loop_idx_async(ExPolicy&& p)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_exception.cpp
@@ -271,8 +271,6 @@ void test_for_loop_idx_exception(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_loop_idx_exception_async(ExPolicy&& p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
@@ -338,8 +336,6 @@ void test_for_loop_idx_bad_alloc(ExPolicy&& policy)
 template <typename ExPolicy>
 void test_for_loop_idx_bad_alloc_async(ExPolicy&& p)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_n.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_n.cpp
@@ -114,8 +114,6 @@ void test_for_loop_n_idx(ExPolicy&& policy)
 template <typename ExPolicy>
 void test_for_loop_n_idx_async(ExPolicy&& p)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_n_strided.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_n_strided.cpp
@@ -162,8 +162,6 @@ void test_for_loop_n_strided_idx(ExPolicy&& policy)
 template <typename ExPolicy>
 void test_for_loop_n_strided_idx_async(ExPolicy&& p)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_strided.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_strided.cpp
@@ -162,8 +162,6 @@ void test_for_loop_strided_idx(ExPolicy&& policy)
 template <typename ExPolicy>
 void test_for_loop_strided_idx_async(ExPolicy&& p)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreach_tests_prefetching.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreach_tests_prefetching.hpp
@@ -51,10 +51,6 @@ void test_for_each_prefetching(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_prefetching_async(ExPolicy&& p, IteratorTag)
 {
-    typedef typename hpx::parallel::util::detail::prefetching_iterator<
-        std::vector<double>::iterator, double>
-        iterator;
-
     std::size_t prefetch_distance_factor = 2;
     std::vector<double> c(10007, 1.0);
 
@@ -83,10 +79,6 @@ void test_for_each_prefetching_exception(ExPolicy policy, IteratorTag)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
-
-    typedef typename hpx::parallel::util::detail::prefetching_iterator<
-        std::vector<double>::iterator, double>
-        iterator;
 
     std::size_t prefetch_distance_factor = 2;
     std::vector<double> c(10007, 1.0);
@@ -121,10 +113,6 @@ void test_for_each_prefetching_exception(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_prefetching_exception_async(ExPolicy p, IteratorTag)
 {
-    typedef typename hpx::parallel::util::detail::prefetching_iterator<
-        std::vector<double>::iterator, double>
-        iterator;
-
     std::size_t prefetch_distance_factor = 2;
     std::vector<double> c(10007, 1.0);
 
@@ -166,10 +154,6 @@ void test_for_each_prefetching_bad_alloc(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef typename hpx::parallel::util::detail::prefetching_iterator<
-        std::vector<double>::iterator, double>
-        iterator;
-
     std::size_t prefetch_distance_factor = 2;
     std::vector<double> c(10007, 1.0);
 
@@ -202,10 +186,6 @@ void test_for_each_prefetching_bad_alloc(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_for_each_prefetching_bad_alloc_async(ExPolicy p, IteratorTag)
 {
-    typedef typename hpx::parallel::util::detail::prefetching_iterator<
-        std::vector<double>::iterator, double>
-        iterator;
-
     std::size_t prefetch_distance_factor = 2;
     std::vector<double> c(10007, 1.0);
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/inclusive_scan_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/inclusive_scan_tests.hpp
@@ -429,7 +429,6 @@ void test_inclusive_scan_validate(
     ExPolicy p, std::vector<int>& a, std::vector<int>& b)
 {
     using namespace hpx::execution;
-    typedef std::vector<int>::iterator Iter;
 
     // test 1, fill array with numbers counting from 0, then run scan algorithm
     a.clear();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/move.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/move.cpp
@@ -133,7 +133,6 @@ void test_move_exception(ExPolicy policy, IteratorTag)
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
@@ -167,7 +166,6 @@ template <typename ExPolicy, typename IteratorTag>
 void test_move_exception_async(ExPolicy p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
@@ -231,7 +229,6 @@ void test_move_bad_alloc(ExPolicy policy, IteratorTag)
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
@@ -263,7 +260,6 @@ template <typename ExPolicy, typename IteratorTag>
 void test_move_bad_alloc_async(ExPolicy p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/all_of_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/all_of_range.cpp
@@ -24,9 +24,6 @@ template <typename IteratorTag,
     typename Proj = hpx::parallel::util::projection_identity>
 void test_all_of_seq(IteratorTag, Proj proj = Proj())
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {
@@ -51,9 +48,6 @@ void test_all_of(ExPolicy&& policy, IteratorTag, Proj proj = Proj())
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {
@@ -75,9 +69,6 @@ template <typename ExPolicy, typename IteratorTag,
     typename Proj = hpx::parallel::util::projection_identity>
 void test_all_of_async(ExPolicy p, IteratorTag, Proj proj = Proj())
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {
@@ -162,9 +153,6 @@ void all_of_test()
 template <typename IteratorTag>
 void test_all_of_exception(IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {
@@ -201,9 +189,6 @@ void test_all_of_exception(ExPolicy&& policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {
@@ -236,9 +221,6 @@ void test_all_of_exception(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_all_of_exception_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {
@@ -302,9 +284,6 @@ void test_all_of_bad_alloc(ExPolicy&& policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {
@@ -335,9 +314,6 @@ void test_all_of_bad_alloc(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_all_of_bad_alloc_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/any_of_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/any_of_range.cpp
@@ -24,9 +24,6 @@ template <typename IteratorTag,
     typename Proj = hpx::parallel::util::projection_identity>
 void test_any_of_seq(IteratorTag, Proj proj = Proj())
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {
@@ -51,9 +48,6 @@ void test_any_of(ExPolicy&& policy, IteratorTag, Proj proj = Proj())
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {
@@ -75,9 +69,6 @@ template <typename ExPolicy, typename IteratorTag,
     typename Proj = hpx::parallel::util::projection_identity>
 void test_any_of_async(ExPolicy p, IteratorTag, Proj proj = Proj())
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {
@@ -162,9 +153,6 @@ void any_of_test()
 template <typename IteratorTag>
 void test_any_of_exception(IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {
@@ -201,9 +189,6 @@ void test_any_of_exception(ExPolicy&& policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {
@@ -236,9 +221,6 @@ void test_any_of_exception(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_any_of_exception_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {
@@ -302,9 +284,6 @@ void test_any_of_bad_alloc(ExPolicy&& policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {
@@ -335,9 +314,6 @@ void test_any_of_bad_alloc(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_any_of_bad_alloc_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/copy_range.cpp
@@ -24,9 +24,6 @@
 template <typename IteratorTag>
 void test_copy(IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
 
     test_vector c(10007);
@@ -50,9 +47,6 @@ void test_copy(ExPolicy&& policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
 
     test_vector c(10007);
@@ -73,9 +67,6 @@ void test_copy(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_copy_async(ExPolicy&& p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
 
     test_vector c(10007);

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/copyif_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/copyif_range.cpp
@@ -22,10 +22,6 @@
 ////////////////////////////////////////////////////////////////////////////
 void test_copy_if_seq()
 {
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, std::random_access_iterator_tag>
-        iterator;
-
     std::vector<int> c(10007);
     std::vector<int> d(c.size());
     auto middle = std::begin(c) + c.size() / 2;
@@ -58,10 +54,6 @@ void test_copy_if(ExPolicy&& policy)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, std::random_access_iterator_tag>
-        iterator;
-
     std::vector<int> c(10007);
     std::vector<int> d(c.size());
     auto middle = std::begin(c) + c.size() / 2;
@@ -92,10 +84,6 @@ void test_copy_if(ExPolicy&& policy)
 template <typename ExPolicy>
 void test_copy_if_async(ExPolicy&& p)
 {
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, std::random_access_iterator_tag>
-        iterator;
-
     std::vector<int> c(10007);
     std::vector<int> d(c.size());
     auto middle = std::begin(c) + c.size() / 2;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/generate_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/generate_range.cpp
@@ -25,9 +25,6 @@
 template <typename IteratorTag>
 void test_generate(IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 
@@ -52,9 +49,6 @@ void test_generate(ExPolicy&& policy, IteratorTag)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
-
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/minmax_element_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/minmax_element_range.cpp
@@ -28,7 +28,6 @@ void test_minmax_element(ExPolicy policy, IteratorTag)
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
@@ -61,7 +60,6 @@ template <typename ExPolicy, typename IteratorTag>
 void test_minmax_element_async(ExPolicy p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/mismatch_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/mismatch_range.cpp
@@ -29,9 +29,7 @@ template <typename IteratorTag>
 void test_mismatch1(IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -75,9 +73,7 @@ void test_mismatch1(ExPolicy&& policy, IteratorTag)
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -118,9 +114,7 @@ template <typename ExPolicy, typename IteratorTag>
 void test_mismatch1_async(ExPolicy&& p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -187,9 +181,7 @@ template <typename IteratorTag>
 void test_mismatch2(IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -233,9 +225,7 @@ void test_mismatch2(ExPolicy&& policy, IteratorTag)
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -276,9 +266,7 @@ template <typename ExPolicy, typename IteratorTag>
 void test_mismatch2_async(ExPolicy&& p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -345,9 +333,7 @@ template <typename IteratorTag>
 void test_mismatch_exception(IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -387,9 +373,7 @@ void test_mismatch_exception(ExPolicy&& policy, IteratorTag)
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -426,9 +410,7 @@ template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_exception_async(ExPolicy&& p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -494,9 +476,7 @@ void test_mismatch_bad_alloc(ExPolicy&& policy, IteratorTag)
         "hpx::is_execution_policy<ExPolicy>::value");
 
     typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());
@@ -532,9 +512,7 @@ template <typename ExPolicy, typename IteratorTag>
 void test_mismatch_bad_alloc_async(ExPolicy&& p, IteratorTag)
 {
     typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef hpx::util::iterator_range<base_iterator> base_range;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-    typedef hpx::util::iterator_range<iterator> range;
 
     std::vector<std::size_t> c1(10007);
     std::vector<std::size_t> c2(c1.size());

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/move_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/move_range.cpp
@@ -25,9 +25,6 @@
 template <typename IteratorTag>
 void test_move(IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 
@@ -56,9 +53,6 @@ void test_move(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 
@@ -83,9 +77,6 @@ void test_move(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_move_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/none_of_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/none_of_range.cpp
@@ -24,9 +24,6 @@ template <typename IteratorTag,
     typename Proj = hpx::parallel::util::projection_identity>
 void test_none_of_seq(IteratorTag, Proj proj = Proj())
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 1, 3};
     for (std::size_t i : iseq)
     {
@@ -50,9 +47,6 @@ void test_none_of(ExPolicy&& policy, IteratorTag, Proj proj = Proj())
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 1, 3};
     for (std::size_t i : iseq)
     {
@@ -73,9 +67,6 @@ template <typename ExPolicy, typename IteratorTag,
     typename Proj = hpx::parallel::util::projection_identity>
 void test_none_of_async(ExPolicy p, IteratorTag, Proj proj = Proj())
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {
@@ -160,9 +151,6 @@ void none_of_test()
 template <typename IteratorTag>
 void test_none_of_exception(IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {
@@ -199,9 +187,6 @@ void test_none_of_exception(ExPolicy&& policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {
@@ -234,9 +219,6 @@ void test_none_of_exception(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_none_of_exception_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {
@@ -300,9 +282,6 @@ void test_none_of_bad_alloc(ExPolicy&& policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {
@@ -333,9 +312,6 @@ void test_none_of_bad_alloc(ExPolicy&& policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_none_of_bad_alloc_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::size_t iseq[] = {0, 23, 10007};
     for (std::size_t i : iseq)
     {

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/reduce_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/reduce_range.cpp
@@ -29,9 +29,6 @@ void test_reduce1(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
@@ -48,9 +45,6 @@ void test_reduce1(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce1_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
@@ -91,9 +85,6 @@ void test_reduce2(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
@@ -108,9 +99,6 @@ void test_reduce2(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce2_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
@@ -149,9 +137,6 @@ void test_reduce3(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
@@ -166,9 +151,6 @@ void test_reduce3(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce3_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
@@ -207,9 +189,6 @@ void test_reduce_exception(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
@@ -239,9 +218,6 @@ void test_reduce_exception(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce_exception_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
@@ -300,9 +276,6 @@ void test_reduce_bad_alloc(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 
@@ -331,9 +304,6 @@ void test_reduce_bad_alloc(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_reduce_bad_alloc_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
     std::iota(std::begin(c), std::end(c), gen());
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_if_range.cpp
@@ -25,9 +25,6 @@ void test_remove_copy_if(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
 
     test_vector c(10007);
@@ -63,9 +60,6 @@ void test_remove_copy_if(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_if_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
 
     test_vector c(10007);
@@ -105,9 +99,6 @@ void test_remove_copy_if_outiter(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
 
     test_vector c(10007);
@@ -134,9 +125,6 @@ void test_remove_copy_if_outiter(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_if_outiter_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
 
     test_vector c(10007);
@@ -187,9 +175,6 @@ void test_remove_copy_if_exception(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
 
     test_vector c(10007);
@@ -221,9 +206,6 @@ void test_remove_copy_if_exception(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_if_exception_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
 
     test_vector c(10007);
@@ -286,9 +268,6 @@ void test_remove_copy_if_bad_alloc(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
 
     test_vector c(10007);
@@ -318,9 +297,6 @@ void test_remove_copy_if_bad_alloc(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_if_bad_alloc_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
 
     test_vector c(10007);

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_range.cpp
@@ -26,9 +26,6 @@ void test_remove_copy(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 
@@ -55,9 +52,6 @@ void test_remove_copy(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 
@@ -88,9 +82,6 @@ void test_remove_copy_outiter(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 
@@ -120,9 +111,6 @@ void test_remove_copy_outiter(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_outiter_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_if_range.cpp
@@ -41,9 +41,6 @@ void test_replace_copy_if(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 
@@ -74,9 +71,6 @@ void test_replace_copy_if(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_if_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_range.cpp
@@ -26,9 +26,6 @@ void test_replace_copy(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 
@@ -58,9 +55,6 @@ void test_replace_copy(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_if_range.cpp
@@ -41,9 +41,6 @@ void test_replace_if(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 
@@ -71,9 +68,6 @@ void test_replace_if(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_if_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_range.cpp
@@ -26,9 +26,6 @@ void test_replace(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 
@@ -56,9 +53,6 @@ void test_replace(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/reverse_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/reverse_copy_range.cpp
@@ -26,9 +26,6 @@ void test_reverse_copy(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 
@@ -55,9 +52,6 @@ void test_reverse_copy(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse_copy_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/reverse_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/reverse_range.cpp
@@ -26,9 +26,6 @@ void test_reverse(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 
@@ -55,9 +52,6 @@ void test_reverse(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_reverse_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/search_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/search_range.cpp
@@ -126,9 +126,6 @@ void test_search2(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_search2_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
     // fill vector with random values above 2
     std::fill(std::begin(c), std::end(c), (std::rand() % 100) + 3);

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/searchn_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/searchn_range.cpp
@@ -127,9 +127,6 @@ void test_search_n2(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_search_n2_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     std::vector<std::size_t> c(10007);
     // fill vector with random values above 2
     std::fill(std::begin(c), std::end(c), (std::rand() % 100) + 3);

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range.cpp
@@ -26,9 +26,6 @@ void test_transform(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
 
     test_vector c(10007);
@@ -55,9 +52,6 @@ void test_transform(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<std::size_t>, IteratorTag>
         test_vector;
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary.cpp
@@ -26,9 +26,6 @@ void test_transform_binary(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
 
     test_vector c1(10007);
@@ -64,9 +61,6 @@ void test_transform_binary(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
 
     test_vector c1(10007);

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary2.cpp
@@ -26,9 +26,6 @@ void test_transform_binary(ExPolicy policy, IteratorTag)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
 
     test_vector c1(10007);
@@ -63,9 +60,6 @@ void test_transform_binary(ExPolicy policy, IteratorTag)
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary_async(ExPolicy p, IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
 
     test_vector c1(10007);

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -2839,8 +2839,6 @@ void addressing_service::unmark_as_migrated(
 hpx::future<std::pair<naming::id_type, naming::address>>
 addressing_service::begin_migration(naming::id_type const& id)
 {
-    typedef std::pair<naming::id_type, naming::address> result_type;
-
     if (!id)
     {
         HPX_THROW_EXCEPTION(bad_parameter,

--- a/tests/performance/local/partitioned_vector_foreach.cpp
+++ b/tests/performance/local/partitioned_vector_foreach.cpp
@@ -47,8 +47,6 @@ struct wait_op
 template <typename Policy, typename Vector>
 std::uint64_t foreach_vector(Policy&& policy, Vector const& v)
 {
-    typedef typename Vector::value_type value_type;
-
     std::uint64_t start = hpx::chrono::high_resolution_clock::now();
 
     for (int i = 0; i != test_count; ++i)

--- a/tests/regressions/lcos/call_promise_get_gid_more_than_once.cpp
+++ b/tests/regressions/lcos/call_promise_get_gid_more_than_once.cpp
@@ -16,9 +16,6 @@ void dummy() {}
 int hpx_main()
 {
     {
-        typedef hpx::lcos::promise<void> promise_type;
-        typedef hpx::lcos::detail::promise_data<void> shared_state_type;
-
         hpx::lcos::promise<void> promise;
         hpx::future<void> future = promise.get_future();
 


### PR DESCRIPTION
Removes all unused typedefs and some unused variables. I'm leaving the rest of the unused variables for another PR as there are a lot of them...