### PR TITLE
Attempt to fix MacOS Github action error

### DIFF
--- a/libs/core/debugging/src/print.cpp
+++ b/libs/core/debugging/src/print.cpp
@@ -137,6 +137,12 @@ namespace hpx { namespace debug {
 
         template HPX_CORE_EXPORT void print_bin(
             std::ostream&, std::uint64_t, int);
+
+#if defined(__APPLE__)
+        // Explicit instantiation necessary to solve undefined symbol for MacOS
+        template HPX_CORE_EXPORT void print_bin(
+            std::ostream&, unsigned long, int);
+#endif
     }    // namespace detail
 
     // ------------------------------------------------------------------

--- a/tests/unit/build/CMakeLists.txt
+++ b/tests/unit/build/CMakeLists.txt
@@ -157,7 +157,7 @@ if(HPX_WITH_DYNAMIC_HPX_MAIN)
 endif()
 
 # PkgConfig
-if(NOT MSVC)
+if(NOT MSVC AND NOT APPLE)
   find_package(PkgConfig)
   if(PKGCONFIG_FOUND)
     create_pkgconfig_test(
@@ -180,6 +180,7 @@ endif()
 if(NOT CMAKE_TOOLCHAIN_FILE
    AND PKGCONFIG_FOUND
    AND NOT MSVC
+   AND NOT APPLE
 )
   set(build_systems ${build_systems} pkgconfig)
   set(pkgconfig_tests build_dir install_dir)


### PR DESCRIPTION
Add explicit template instanciation to fix undefined symbol when `print_bin` with `unsigned long` use