### PR TITLE
Fixing template specializations that make extra archive data types unique across module boundaries

### DIFF
--- a/hpx/runtime/serialization/detail/preprocess_gid_types.hpp
+++ b/hpx/runtime/serialization/detail/preprocess_gid_types.hpp
@@ -125,12 +125,10 @@ namespace hpx { namespace serialization { namespace detail {
     };
 
     // This is explicitly instantiated to ensure that the id is stable across
-    // shared libraries. MSVC and gcc/clang require different handling of
-    // exported explicitly instantiated templates.
-#if defined(HPX_MSVC)
-    extern template struct extra_archive_data_id_helper<preprocess_gid_types>;
-#else
-    extern template struct HPX_EXPORT
-        extra_archive_data_id_helper<preprocess_gid_types>;
-#endif
+    // shared libraries.
+    template <>
+    struct extra_archive_data_id_helper<preprocess_gid_types>
+    {
+        HPX_EXPORT static void id() noexcept;
+    };
 }}}    // namespace hpx::serialization::detail

--- a/libs/core/serialization/include/hpx/serialization/detail/extra_archive_data.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/extra_archive_data.hpp
@@ -17,7 +17,9 @@ namespace hpx { namespace serialization { namespace detail {
     template <typename T>
     struct extra_archive_data_id_helper
     {
-        static void dummy() noexcept {}
+        // this is intentionally left unimplemented, will lead to linker errors
+        // if used with unknown data type
+        static void id() noexcept;
     };
 
     using extra_archive_data_id_type = void (*)();
@@ -25,7 +27,7 @@ namespace hpx { namespace serialization { namespace detail {
     template <typename T>
     constexpr extra_archive_data_id_type extra_archive_data_id()
     {
-        return &extra_archive_data_id_helper<T>::dummy;
+        return &extra_archive_data_id_helper<T>::id;
     }
 
     struct extra_archive_data_member_base;

--- a/libs/core/serialization/include/hpx/serialization/detail/pointer.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/pointer.hpp
@@ -43,19 +43,18 @@ namespace hpx { namespace serialization {
         using output_pointer_tracker = std::map<void const*, std::uint64_t>;
 
         // This is explicitly instantiated to ensure that the id is stable across
-        // shared libraries. MSVC and gcc/clang require different handling of
-        // exported explicitly instantiated templates.
-#if defined(HPX_MSVC)
-        extern template struct extra_archive_data_id_helper<
-            input_pointer_tracker>;
-        extern template struct extra_archive_data_id_helper<
-            output_pointer_tracker>;
-#else
-        extern template struct HPX_CORE_EXPORT
-            extra_archive_data_id_helper<input_pointer_tracker>;
-        extern template struct HPX_CORE_EXPORT
-            extra_archive_data_id_helper<output_pointer_tracker>;
-#endif
+        // shared libraries.
+        template <>
+        struct extra_archive_data_id_helper<input_pointer_tracker>
+        {
+            HPX_CORE_EXPORT static void id() noexcept;
+        };
+
+        template <>
+        struct extra_archive_data_id_helper<output_pointer_tracker>
+        {
+            HPX_CORE_EXPORT static void id() noexcept;
+        };
     }    // namespace detail
 
     ////////////////////////////////////////////////////////////////////////////

--- a/libs/core/serialization/src/detail/pointer.cpp
+++ b/libs/core/serialization/src/detail/pointer.cpp
@@ -20,17 +20,14 @@ namespace hpx { namespace serialization {
 
     namespace detail {
         // This is explicitly instantiated to ensure that the id is stable across
-        // shared libraries. MSVC and gcc/clang require different handling of
-        // exported explicitly instantiated templates.
-#if defined(HPX_MSVC)
-        template struct HPX_CORE_EXPORT
-            extra_archive_data_id_helper<input_pointer_tracker>;
-        template struct HPX_CORE_EXPORT
-            extra_archive_data_id_helper<output_pointer_tracker>;
-#else
-        template struct extra_archive_data_id_helper<input_pointer_tracker>;
-        template struct extra_archive_data_id_helper<output_pointer_tracker>;
-#endif
+        // shared libraries.
+        void extra_archive_data_id_helper<input_pointer_tracker>::id() noexcept
+        {
+        }
+
+        void extra_archive_data_id_helper<output_pointer_tracker>::id() noexcept
+        {
+        }
     }    // namespace detail
 
     void register_pointer(

--- a/libs/full/checkpoint_base/include/hpx/checkpoint_base/checkpoint_data.hpp
+++ b/libs/full/checkpoint_base/include/hpx/checkpoint_base/checkpoint_data.hpp
@@ -134,13 +134,10 @@ namespace hpx { namespace util {
 
 namespace hpx { namespace serialization { namespace detail {
     // This is explicitly instantiated to ensure that the id is stable across
-    // shared libraries. MSVC and gcc/clang require different handling of
-    // exported explicitly instantiated templates.
-#if defined(HPX_MSVC)
-    extern template struct extra_archive_data_id_helper<
-        hpx::util::checkpointing_tag>;
-#else
-    extern template struct HPX_EXPORT
-        extra_archive_data_id_helper<hpx::util::checkpointing_tag>;
-#endif
+    // shared libraries.
+    template <>
+    struct extra_archive_data_id_helper<hpx::util::checkpointing_tag>
+    {
+        HPX_EXPORT static void id() noexcept;
+    };
 }}}    // namespace hpx::serialization::detail

--- a/libs/full/checkpoint_base/src/checkpoint_data.cpp
+++ b/libs/full/checkpoint_base/src/checkpoint_data.cpp
@@ -11,12 +11,9 @@
 namespace hpx { namespace serialization { namespace detail {
 
     // This is explicitly instantiated to ensure that the id is stable across
-    // shared libraries. MSVC and gcc/clang require different handling of
-    // exported explicitly instantiated templates.
-#if defined(HPX_MSVC)
-    template struct HPX_EXPORT
-        extra_archive_data_id_helper<hpx::util::checkpointing_tag>;
-#else
-    template struct extra_archive_data_id_helper<hpx::util::checkpointing_tag>;
-#endif
+    // shared libraries.
+    void
+    extra_archive_data_id_helper<hpx::util::checkpointing_tag>::id() noexcept
+    {
+    }
 }}}    // namespace hpx::serialization::detail

--- a/libs/parallelism/lcos_local/include/hpx/lcos_local/detail/preprocess_future.hpp
+++ b/libs/parallelism/lcos_local/include/hpx/lcos_local/detail/preprocess_future.hpp
@@ -186,12 +186,10 @@ namespace hpx { namespace serialization { namespace detail {
     };
 
     // This is explicitly instantiated to ensure that the id is stable across
-    // shared libraries. MSVC and gcc/clang require different handling of
-    // exported explicitly instantiated templates.
-#if defined(HPX_MSVC)
-    extern template struct extra_archive_data_id_helper<preprocess_futures>;
-#else
-    extern template struct HPX_PARALLELISM_EXPORT
-        extra_archive_data_id_helper<preprocess_futures>;
-#endif
+    // shared libraries.
+    template <>
+    struct extra_archive_data_id_helper<preprocess_futures>
+    {
+        HPX_PARALLELISM_EXPORT static void id() noexcept;
+    };
 }}}    // namespace hpx::serialization::detail

--- a/libs/parallelism/lcos_local/src/preprocess_future.cpp
+++ b/libs/parallelism/lcos_local/src/preprocess_future.cpp
@@ -9,6 +9,14 @@
 #include <hpx/serialization/detail/extra_archive_data.hpp>
 #include <hpx/serialization/output_archive.hpp>
 
+namespace hpx { namespace serialization { namespace detail {
+
+    // This is explicitly instantiated to ensure that the id is stable across
+    // shared libraries.
+    void extra_archive_data_id_helper<preprocess_futures>::id() noexcept {}
+
+}}}    // namespace hpx::serialization::detail
+
 namespace hpx { namespace lcos { namespace detail {
 
     void preprocess_future(serialization::output_archive& ar,
@@ -20,16 +28,3 @@ namespace hpx { namespace lcos { namespace detail {
         handle_futures.await_future(state);
     }
 }}}    // namespace hpx::lcos::detail
-
-namespace hpx { namespace serialization { namespace detail {
-
-    // This is explicitly instantiated to ensure that the id is stable across
-    // shared libraries. MSVC and gcc/clang require different handling of
-    // exported explicitly instantiated templates.
-#if defined(HPX_MSVC)
-    template struct HPX_PARALLELISM_EXPORT
-        extra_archive_data_id_helper<preprocess_futures>;
-#else
-    template struct extra_archive_data_id_helper<preprocess_futures>;
-#endif
-}}}    // namespace hpx::serialization::detail

--- a/src/runtime/parcelset/detail/parcel_await.cpp
+++ b/src/runtime/parcelset/detail/parcel_await.cpp
@@ -53,7 +53,7 @@ namespace hpx { namespace parcelset { namespace detail {
 
             archive_ << p;
 
-            auto handle_futures = archive_.try_get_extra_data<
+            auto* handle_futures = archive_.try_get_extra_data<
                 serialization::detail::preprocess_futures>();
 
             // We are doing a fixed point iteration until we are sure that the

--- a/src/runtime/serialization/detail/preprocess_gid_types.cpp
+++ b/src/runtime/serialization/detail/preprocess_gid_types.cpp
@@ -11,12 +11,7 @@
 namespace hpx { namespace serialization { namespace detail {
 
     // This is explicitly instantiated to ensure that the id is stable across
-    // shared libraries. MSVC and gcc/clang require different handling of
-    // exported explicitly instantiated templates.
-#if defined(HPX_MSVC)
-    template struct HPX_EXPORT
-        extra_archive_data_id_helper<preprocess_gid_types>;
-#else
-    template struct extra_archive_data_id_helper<preprocess_gid_types>;
-#endif
+    // shared libraries.
+    void extra_archive_data_id_helper<preprocess_gid_types>::id() noexcept {}
+
 }}}    // namespace hpx::serialization::detail


### PR DESCRIPTION
- this was broken on Windows, not sure if it was broken on other platforms as well

This fixes a serious issue and if it turns out that this was broken on non-Windows platforms as well then this would be a candidate for another point release. 
