### PR TITLE
Replace boost::system::error_code with std::error_code

### DIFF
--- a/components/process/src/util/windows/search_path_w.cpp
+++ b/components/process/src/util/windows/search_path_w.cpp
@@ -24,6 +24,7 @@
 #include <cstdlib>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 
 namespace hpx { namespace components { namespace process { namespace windows
 {

--- a/components/process/src/util/windows/search_path_w.cpp
+++ b/components/process/src/util/windows/search_path_w.cpp
@@ -95,7 +95,7 @@ namespace hpx { namespace components { namespace process { namespace windows
             {
                 filesystem::path p2 = p;
                 p2 += *it2;
-                filesystem::error_code ec;
+                std::error_code ec;
                 bool file = filesystem::is_regular_file(p2, ec);
                 if (!ec && file &&
                     SHGetFileInfoA(p2.string().c_str(), 0, nullptr, 0,

--- a/hpx/plugins/parcelport/mpi/sender_connection.hpp
+++ b/hpx/plugins/parcelport/mpi/sender_connection.hpp
@@ -22,6 +22,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -43,7 +44,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace mpi
         typedef sender sender_type;
 
         typedef util::function_nonser<
-            void(boost::system::error_code const&, parcel const&)
+            void(std::error_code const&, parcel const&)
         > write_handler_type;
 
         typedef std::vector<char> data_type;

--- a/hpx/plugins/parcelport/tcp/connection_handler.hpp
+++ b/hpx/plugins/parcelport/tcp/connection_handler.hpp
@@ -26,6 +26,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <system_error>
 #include <type_traits>
 #include <vector>
 
@@ -107,9 +108,9 @@ namespace hpx { namespace parcelset
             parcelset::locality create_locality() const;
 
         private:
-            void handle_accept(boost::system::error_code const & e,
+            void handle_accept(std::error_code const & e,
                 std::shared_ptr<receiver> receiver_conn);
-            void handle_read_completion(boost::system::error_code const& e,
+            void handle_read_completion(std::error_code const& e,
                 std::shared_ptr<receiver> receiver_conn);
 
             /// Acceptor used to listen for incoming connections.

--- a/hpx/plugins/parcelport/tcp/receiver.hpp
+++ b/hpx/plugins/parcelport/tcp/receiver.hpp
@@ -10,6 +10,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// hpxinspect:nodeprecatedinclude:boost/system/error_code.hpp
+// hpxinspect:nodeprecatedname:boost::system::error_code
+
 #pragma once
 
 #include <hpx/config.hpp>
@@ -33,6 +36,7 @@
 #include <boost/asio/placeholders.hpp>
 #include <boost/asio/read.hpp>
 #include <boost/asio/write.hpp>
+#include <boost/system/error_code.hpp>
 /* The boost asio support includes termios.h.
  * The termios.h file on ppc64le defines these macros, which
  * are also used by blaze, blaze_tensor as Template names.

--- a/hpx/plugins/parcelport/tcp/receiver.hpp
+++ b/hpx/plugins/parcelport/tcp/receiver.hpp
@@ -45,6 +45,7 @@
 #include <memory>
 #include <mutex>
 #include <sstream>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -115,7 +116,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
                 socket_.set_option(quickack);
 #endif
 
-                void (receiver::*f)(boost::system::error_code const&,
+                void (receiver::*f)(std::error_code const&,
                         std::size_t, Handler)
                     = &receiver::handle_read_header<Handler>;
 
@@ -146,7 +147,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
         /// Handle a completed read of the message size from the
         /// message header.
         template <typename Handler>
-        void handle_read_header(boost::system::error_code const& e,
+        void handle_read_header(std::error_code const& e,
             std::size_t bytes_transferred, Handler handler)
         {
             HPX_ASSERT(operation_in_flight_ == 0);
@@ -182,7 +183,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
                     static_cast<std::size_t>(
                         static_cast<std::uint32_t>(buffer_.num_chunks_.second));
 
-                void (receiver::*f)(boost::system::error_code const&,
+                void (receiver::*f)(std::error_code const&,
                         Handler) = nullptr;
 
                 if (num_zero_copy_chunks != 0) {
@@ -240,7 +241,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
 
         /// Handle a completed read of message data.
         template <typename Handler>
-        void handle_read_chunk_data(boost::system::error_code const& e,
+        void handle_read_chunk_data(std::error_code const& e,
             Handler handler)
         {
             if (e) {
@@ -270,7 +271,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
                 }
 
                 // Start an asynchronous call to receive the data.
-                void (receiver::*f)(boost::system::error_code const&,
+                void (receiver::*f)(std::error_code const&,
                         Handler)
                     = &receiver::handle_read_data<Handler>;
 
@@ -299,7 +300,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
 
         /// Handle a completed read of message data.
         template <typename Handler>
-        void handle_read_data(boost::system::error_code const& e,
+        void handle_read_data(std::error_code const& e,
             Handler handler)
         {
             if (e) {
@@ -315,7 +316,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
                     buffer_.data_point_.time_;
 
                 // now send acknowledgment byte
-                void (receiver::*f)(boost::system::error_code const&,
+                void (receiver::*f)(std::error_code const&,
                         Handler)
                     = &receiver::handle_write_ack<Handler>;
 
@@ -344,7 +345,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
         }
 
         template <typename Handler>
-        void handle_write_ack(boost::system::error_code const& e,
+        void handle_write_ack(std::error_code const& e,
             Handler handler)
         {
             HPX_ASSERT(operation_in_flight_ != 0);

--- a/hpx/plugins/parcelport/tcp/sender.hpp
+++ b/hpx/plugins/parcelport/tcp/sender.hpp
@@ -44,6 +44,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -53,7 +54,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
       : public parcelset::parcelport_connection<sender, std::vector<char> >
     {
         using postprocess_handler_type = util::unique_function_nonser<void(
-            boost::system::error_code const&)>;
+            std::error_code const&)>;
 
     public:
         /// Construct a sending parcelport_connection with the given io_service.
@@ -166,7 +167,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
             // this additional wrapping of the handler into a bind object is
             // needed to keep  this parcelport_connection object alive for the whole
             // write operation
-            void (sender::*f)(boost::system::error_code const&, std::size_t)
+            void (sender::*f)(std::error_code const&, std::size_t)
                 = &sender::handle_write;
 
             using util::placeholders::_1;
@@ -182,7 +183,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
         }
 
         /// handle completed write operation
-        void handle_write(boost::system::error_code const& e, std::size_t bytes)
+        void handle_write(std::error_code const& e, std::size_t bytes)
         {
 #if defined(HPX_TRACK_STATE_OF_OUTGOING_TCP_CONNECTION)
             state_ = state_handle_write;
@@ -213,7 +214,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
                 // inform post-processing handler of error as well
                 util::unique_function_nonser<
                     void(
-                        boost::system::error_code const&
+                        std::error_code const&
                       , parcelset::locality const&
                       , std::shared_ptr<sender>
                     )
@@ -235,7 +236,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
             socket_.set_option(quickack);
 #endif
 
-            void (sender::*f)(boost::system::error_code const&)
+            void (sender::*f)(std::error_code const&)
                 = &sender::handle_read_ack;
 
             using util::placeholders::_1;
@@ -244,7 +245,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
                 util::bind(f, shared_from_this(), _1));
         }
 
-        void handle_read_ack(boost::system::error_code const& e)
+        void handle_read_ack(std::error_code const& e)
         {
 #if defined(HPX_TRACK_STATE_OF_OUTGOING_TCP_CONNECTION)
             state_ = state_handle_read_ack;
@@ -255,7 +256,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
             // parcels have to be sent.
             util::unique_function_nonser<
                 void(
-                    boost::system::error_code const&
+                    std::error_code const&
                   , parcelset::locality const&
                   , std::shared_ptr<sender>
                 )
@@ -279,7 +280,7 @@ namespace hpx { namespace parcelset { namespace policies { namespace tcp
         postprocess_handler_type handler_;
         util::unique_function_nonser<
             void(
-                boost::system::error_code const&
+                std::error_code const&
                 , parcelset::locality const&
                 , std::shared_ptr<sender>
                 )

--- a/hpx/plugins/parcelport/tcp/sender.hpp
+++ b/hpx/plugins/parcelport/tcp/sender.hpp
@@ -7,6 +7,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// hpxinspect:nodeprecatedinclude:boost/system/error_code.hpp
+// hpxinspect:nodeprecatedname:boost::system::error_code
+
 #pragma once
 
 #include <hpx/config.hpp>
@@ -35,6 +38,7 @@
 #include <boost/asio/placeholders.hpp>
 #include <boost/asio/read.hpp>
 #include <boost/asio/write.hpp>
+#include <boost/system/error_code.hpp>
 /* The boost asio support includes termios.h.
  * The termios.h file on ppc64le defines these macros, which
  * are also used by blaze, blaze_tensor as Template names.

--- a/hpx/runtime/agas/addressing_service.hpp
+++ b/hpx/runtime/agas/addressing_service.hpp
@@ -40,6 +40,7 @@
 #include <mutex>
 #include <set>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -1135,7 +1136,7 @@ public:
     ///                   destination.
     void route(
         parcelset::parcel p
-      , util::function_nonser<void(boost::system::error_code const&,
+      , util::function_nonser<void(std::error_code const&,
             parcelset::parcel const&)> &&
       , threads::thread_priority local_priority =
             threads::thread_priority_default);

--- a/hpx/runtime/parcelset/decode_parcels.hpp
+++ b/hpx/runtime/parcelset/decode_parcels.hpp
@@ -5,6 +5,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// hpxinspect:nodeprecatedinclude:boost/system/system_error.hpp
+// hpxinspect:nodeprecatedname:boost::system::system_error
+
 #pragma once
 
 #include <hpx/config.hpp>
@@ -26,6 +29,7 @@
 #if BOOST_ASIO_HAS_BOOST_THROW_EXCEPTION != 0
 #include <boost/exception/exception.hpp>
 #endif
+#include <boost/system/system_error.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/hpx/runtime/parcelset/detail/call_for_each.hpp
+++ b/hpx/runtime/parcelset/detail/call_for_each.hpp
@@ -14,6 +14,7 @@
 #include <hpx/runtime/parcelset/parcelport.hpp>
 
 #include <cstddef>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -48,7 +49,7 @@ namespace hpx { namespace parcelset
                 return *this;
             }
 
-            void operator()(boost::system::error_code const& e)
+            void operator()(std::error_code const& e)
             {
                 HPX_ASSERT(parcels_.size() == handlers_.size());
                 for(std::size_t i = 0; i < parcels_.size(); ++i)

--- a/hpx/runtime/parcelset/detail/parcel_route_handler.hpp
+++ b/hpx/runtime/parcelset/detail/parcel_route_handler.hpp
@@ -10,8 +10,9 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/modules/errors.hpp>
 #include <hpx/runtime/parcelset_fwd.hpp>
+
+#include <system_error>
 
 namespace hpx { namespace parcelset { namespace detail
 {
@@ -19,7 +20,7 @@ namespace hpx { namespace parcelset { namespace detail
     // until after the data has been reliably sent (which is needed for zero
     // copy serialization).
     void HPX_EXPORT parcel_route_handler(
-        boost::system::error_code const& ec,
+        std::error_code const& ec,
         parcelset::parcel const& p);
 }}}
 

--- a/hpx/runtime/parcelset/encode_parcels.hpp
+++ b/hpx/runtime/parcelset/encode_parcels.hpp
@@ -8,6 +8,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// hpxinspect:nodeprecatedinclude:boost/system/system_error.hpp
+// hpxinspect:nodeprecatedname:boost::system::system_error
+
 #pragma once
 
 #include <hpx/config.hpp>
@@ -33,6 +36,7 @@
 #if BOOST_ASIO_HAS_BOOST_THROW_EXCEPTION != 0
 #include <boost/exception/exception.hpp>
 #endif
+#include <boost/system/system_error.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/hpx/runtime/parcelset/parcelhandler.hpp
+++ b/hpx/runtime/parcelset/parcelhandler.hpp
@@ -36,6 +36,7 @@
 #include <mutex>
 #include <sstream>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -44,7 +45,7 @@
 namespace hpx { namespace parcelset
 {
     // default callback for put_parcel
-    void default_write_handler(boost::system::error_code const&,
+    void default_write_handler(std::error_code const&,
         parcel const& p);
 
     /// The \a parcelhandler is the representation of the parcelset inside a
@@ -177,7 +178,7 @@ namespace hpx { namespace parcelset
         ///                 function object is expected to be:
         ///
         /// \code
-        ///     void f (boost::system::error_code const& err, std::size_t );
+        ///     void f (std::error_code const& err, std::size_t );
         /// \endcode
         ///
         ///                 where \a err is the status code of the operation and
@@ -209,7 +210,7 @@ namespace hpx { namespace parcelset
         ///                 of these function object are expected to be:
         ///
         /// \code
-        ///     void f (boost::system::error_code const& err, std::size_t );
+        ///     void f (std::error_code const& err, std::size_t );
         /// \endcode
         ///
         ///                 where \a err is the status code of the operation and
@@ -388,7 +389,7 @@ namespace hpx { namespace parcelset
 
         // manage default exception handler
         void invoke_write_handler(
-            boost::system::error_code const& ec, parcel const & p) const;
+            std::error_code const& ec, parcel const & p) const;
 
         write_handler_type set_write_handler(write_handler_type f)
         {

--- a/hpx/runtime/parcelset/parcelport.hpp
+++ b/hpx/runtime/parcelset/parcelport.hpp
@@ -35,6 +35,7 @@
 #include <mutex>
 #include <set>
 #include <string>
+#include <system_error>
 #include <vector>
 
 #include <hpx/config/warnings_prefix.hpp>
@@ -66,7 +67,7 @@ namespace hpx { namespace parcelset
 
     public:
         typedef util::function_nonser<
-            void(boost::system::error_code const&, parcel const&)
+            void(std::error_code const&, parcel const&)
         > write_handler_type;
 
         typedef util::function_nonser<
@@ -125,7 +126,7 @@ namespace hpx { namespace parcelset
         ///                 function object is expected to be:
         ///
         /// \code
-        ///      void handler(boost::system::error_code const& err,
+        ///      void handler(std::error_code const& err,
         ///                   std::size_t bytes_written);
         /// \endcode
         virtual void put_parcel(locality const & dest, parcel p,
@@ -143,7 +144,7 @@ namespace hpx { namespace parcelset
         ///                 these function objects is expected to be:
         ///
         /// \code
-        ///      void handler(boost::system::error_code const& err,
+        ///      void handler(std::error_code const& err,
         ///                   std::size_t bytes_written);
         /// \endcode
         virtual void put_parcels(locality const& dests,
@@ -326,7 +327,7 @@ namespace hpx { namespace parcelset
         }
 
         // callback while bootstrap the parcel layer
-        void early_pending_parcel_handler(boost::system::error_code const& ec,
+        void early_pending_parcel_handler(std::error_code const& ec,
             parcel const & p);
 
     protected:

--- a/hpx/runtime/parcelset/parcelport_impl.hpp
+++ b/hpx/runtime/parcelset/parcelport_impl.hpp
@@ -42,6 +42,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <system_error>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -416,7 +417,7 @@ namespace hpx { namespace parcelset
             put_parcel(
                 dest
               , std::move(p)
-              , [=](boost::system::error_code const& ec, parcel const & p) -> void {
+              , [=](std::error_code const& ec, parcel const & p) -> void {
                     return early_pending_parcel_handler(ec, p);
                 }
             );
@@ -838,7 +839,7 @@ namespace hpx { namespace parcelset
 
 
         void send_pending_parcels_trampoline(
-            boost::system::error_code const& ec,
+            std::error_code const& ec,
             locality const& locality_id,
             std::shared_ptr<connection> sender_connection)
         {

--- a/hpx/runtime/parcelset/policies/message_handler.hpp
+++ b/hpx/runtime/parcelset/policies/message_handler.hpp
@@ -9,9 +9,10 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/modules/errors.hpp>
 #include <hpx/runtime/parcelset_fwd.hpp>
 #include <hpx/functional/function.hpp>
+
+#include <system_error>
 
 namespace hpx { namespace parcelset { namespace policies
 {
@@ -25,7 +26,7 @@ namespace hpx { namespace parcelset { namespace policies
         };
 
         typedef util::function_nonser<
-            void(boost::system::error_code const&, parcel const&)
+            void(std::error_code const&, parcel const&)
         > write_handler_type;
 
         virtual ~message_handler() {}

--- a/hpx/runtime/parcelset_fwd.hpp
+++ b/hpx/runtime/parcelset_fwd.hpp
@@ -13,9 +13,8 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/functional/function.hpp>
 
-#include <boost/system/error_code.hpp>
-
 #include <cstddef>
+#include <system_error>
 
 namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
@@ -88,7 +87,7 @@ namespace hpx {
             parcelport_background_mode mode = parcelport_background_mode_all);
 
         typedef util::function_nonser<
-            void(boost::system::error_code const&, parcel const&)
+            void(std::error_code const&, parcel const&)
         > write_handler_type;
 
         ///////////////////////////////////////////////////////////////////////

--- a/hpx/runtime/set_parcel_write_handler.hpp
+++ b/hpx/runtime/set_parcel_write_handler.hpp
@@ -9,12 +9,10 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/modules/errors.hpp>
 #include <hpx/runtime/parcelset_fwd.hpp>
 #include <hpx/functional/function.hpp>
 
-#include <boost/system/error_code.hpp>
-
+#include <system_error>
 namespace hpx
 {
     /// The type of a function which can be registered as a parcel write handler
@@ -25,7 +23,7 @@ namespace hpx
     ///       networking library and if no explicit parcel handler function was
     ///       specified for the parcel.
     typedef util::function_nonser<
-            void(boost::system::error_code const&, parcelset::parcel const&)
+            void(std::error_code const&, parcelset::parcel const&)
         > parcel_write_handler_type;
 
     /// Set the default parcel write handler which is invoked once a parcel has

--- a/libs/core/asio/src/asio_util.cpp
+++ b/libs/core/asio/src/asio_util.cpp
@@ -5,6 +5,11 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// hpxinspect:nodeprecatedinclude:boost/system/error_code.hpp
+// hpxinspect:nodeprecatedname:boost::system::error_code
+// hpxinspect:nodeprecatedinclude:boost/system/system_error.hpp
+// hpxinspect:nodeprecatedname:boost::system::system_error
+
 #include <hpx/config.hpp>
 #include <hpx/asio/asio_util.hpp>
 #include <hpx/util/from_string.hpp>
@@ -23,6 +28,7 @@
 #include <boost/asio/ip/host_name.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/system/error_code.hpp>
+#include <boost/system/system_error.hpp>
 
 #include <ctime>
 #include <exception>

--- a/libs/core/config/CMakeLists.txt
+++ b/libs/core/config/CMakeLists.txt
@@ -21,6 +21,7 @@ set(config_headers
     hpx/config/constexpr.hpp
     hpx/config/debug.hpp
     hpx/config/deprecation.hpp
+    hpx/config/detail/compat_error_code.hpp
     hpx/config/emulate_deleted.hpp
     hpx/config/export_definitions.hpp
     hpx/config/forceinline.hpp

--- a/libs/core/config/include/hpx/config/detail/compat_error_code.hpp
+++ b/libs/core/config/include/hpx/config/detail/compat_error_code.hpp
@@ -4,6 +4,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// hpxinspect:nodeprecatedinclude:boost/system/error_code.hpp
+// hpxinspect:nodeprecatedname:boost::system::error_code
+
 #pragma once
 
 #include <hpx/config.hpp>

--- a/libs/core/config/include/hpx/config/detail/compat_error_code.hpp
+++ b/libs/core/config/include/hpx/config/detail/compat_error_code.hpp
@@ -1,0 +1,51 @@
+//  Copyright (c) 2020 Agustin Berge
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <boost/system/error_code.hpp>
+
+#include <system_error>
+#include <type_traits>
+
+///////////////////////////////////////////////////////////////////////////////
+/// \cond NODETAIL
+namespace hpx {
+
+    class compat_error_code
+    {
+    public:
+        explicit compat_error_code(std::error_code& ec)
+          : _ec(ec)
+          , _compat()
+        {
+        }
+
+        ~compat_error_code()
+        {
+            _ec = _compat;
+        }
+
+        operator boost::system::error_code&() noexcept
+        {
+            return _compat;
+        }
+
+        template <typename E,
+            typename Enable = typename std::enable_if<
+                boost::system::is_error_code_enum<E>::value>::type>
+        static bool equal(std::error_code const& lhs, E rhs) noexcept
+        {
+            return lhs == std::error_code(make_error_code(rhs));
+        }
+
+    private:
+        std::error_code& _ec;
+        boost::system::error_code _compat;
+    };
+}    // namespace hpx

--- a/libs/core/coroutines/include/hpx/coroutines/detail/context_windows_fibers.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/context_windows_fibers.hpp
@@ -40,12 +40,10 @@
 #include <hpx/type_support/unused.hpp>
 #include <hpx/util/get_and_reset_value.hpp>
 
-#include <boost/system/error_code.hpp>
-#include <boost/system/system_error.hpp>
-
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <system_error>
 
 #if defined(HPX_COROUTINES_HAVE_SWAP_CONTEXT_EMULATION)
 extern "C" void switch_to_fiber(void* lpFiber) noexcept;
@@ -222,8 +220,8 @@ namespace hpx { namespace threads { namespace coroutines {
                     static_cast<LPVOID>(this));
                 if (nullptr == m_ctx)
                 {
-                    throw boost::system::system_error(boost::system::error_code(
-                        GetLastError(), boost::system::system_category()));
+                    throw std::system_error(
+                        GetLastError(), std::system_category());
                 }
             }
 

--- a/libs/core/errors/include/hpx/errors/error.hpp
+++ b/libs/core/errors/include/hpx/errors/error.hpp
@@ -12,9 +12,8 @@
 
 #include <hpx/config.hpp>
 
-#include <boost/system/error_code.hpp>
-
 #include <string>
+#include <system_error>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx {
@@ -215,7 +214,7 @@ namespace hpx {
 }    // namespace hpx
 
 /// \cond NOEXTERNAL
-namespace boost { namespace system {
+namespace std {
     // make sure our errors get recognized by the Boost.System library
     template <>
     struct is_error_code_enum<hpx::error>
@@ -228,5 +227,5 @@ namespace boost { namespace system {
     {
         static const bool value = true;
     };
-}}    // namespace boost::system
+}    // namespace std
 /// \endcond

--- a/libs/core/errors/include/hpx/errors/error_code.hpp
+++ b/libs/core/errors/include/hpx/errors/error_code.hpp
@@ -13,11 +13,10 @@
 #include <hpx/errors/error.hpp>
 #include <hpx/errors/exception_fwd.hpp>
 
-#include <boost/system/error_code.hpp>
-
 #include <exception>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx {
@@ -43,32 +42,27 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Returns generic HPX error category used for new errors.
-    HPX_CORE_EXPORT boost::system::error_category const& get_hpx_category();
+    HPX_CORE_EXPORT std::error_category const& get_hpx_category();
 
     /// \brief Returns generic HPX error category used for errors re-thrown
     ///        after the exception has been de-serialized.
-    HPX_CORE_EXPORT boost::system::error_category const&
-    get_hpx_rethrow_category();
+    HPX_CORE_EXPORT std::error_category const& get_hpx_rethrow_category();
 
     /// \cond NOINTERNAL
-    HPX_CORE_EXPORT boost::system::error_category const&
-    get_lightweight_hpx_category();
+    HPX_CORE_EXPORT std::error_category const& get_lightweight_hpx_category();
 
-    HPX_CORE_EXPORT boost::system::error_category const& get_hpx_category(
-        throwmode mode);
+    HPX_CORE_EXPORT std::error_category const& get_hpx_category(throwmode mode);
 
-    inline boost::system::error_code make_system_error_code(
+    inline std::error_code make_system_error_code(
         error e, throwmode mode = plain)
     {
-        return boost::system::error_code(
-            static_cast<int>(e), get_hpx_category(mode));
+        return std::error_code(static_cast<int>(e), get_hpx_category(mode));
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    inline boost::system::error_condition make_error_condition(
-        error e, throwmode mode)
+    inline std::error_condition make_error_condition(error e, throwmode mode)
     {
-        return boost::system::error_condition(
+        return std::error_condition(
             static_cast<int>(e), get_hpx_category(mode));
     }
     /// \endcond
@@ -83,7 +77,7 @@ namespace hpx {
     /// \note Class hpx::error_code is an adjunct to error reporting by
     /// exception
     ///
-    class error_code : public boost::system::error_code    //-V690
+    class error_code : public std::error_code    //-V690
     {
     public:
         /// Construct an object of type error_code.
@@ -96,7 +90,7 @@ namespace hpx {
         ///
         /// \throws nothing
         explicit error_code(throwmode mode = plain)
-          : boost::system::error_code(make_system_error_code(success, mode))
+          : std::error_code(make_system_error_code(success, mode))
         {
         }
 
@@ -218,8 +212,7 @@ namespace hpx {
         /// * value() == hpx::success and category() == hpx::get_hpx_category()
         void clear()
         {
-            this->boost::system::error_code::assign(
-                success, get_hpx_category());
+            this->std::error_code::assign(success, get_hpx_category());
             exception_ = std::exception_ptr();
         }
 

--- a/libs/core/errors/include/hpx/errors/exception.hpp
+++ b/libs/core/errors/include/hpx/errors/exception.hpp
@@ -15,14 +15,12 @@
 #include <hpx/errors/exception_fwd.hpp>
 #include <hpx/errors/exception_info.hpp>
 
-#include <boost/system/error_code.hpp>
-#include <boost/system/system_error.hpp>
-
 #include <cstddef>
 #include <cstdint>
 #include <exception>
 #include <functional>
 #include <string>
+#include <system_error>
 
 #include <hpx/config/warnings_prefix.hpp>
 
@@ -37,7 +35,7 @@ namespace hpx {
     /// are either of this type or of a type derived from it. This implies that
     /// it is always safe to use this type only in catch statements guarding
     /// HPX library calls.
-    class HPX_CORE_EXPORT exception : public boost::system::system_error
+    class HPX_CORE_EXPORT exception : public std::system_error
     {
     public:
         /// Construct a hpx::exception from a \a hpx::error.
@@ -47,13 +45,13 @@ namespace hpx {
         explicit exception(error e = success);
 
         /// Construct a hpx::exception from a boost#system_error.
-        explicit exception(boost::system::system_error const& e);
+        explicit exception(std::system_error const& e);
 
         /// Construct a hpx::exception from a boost#system#error_code (this is
         /// new for Boost V1.69). This constructor is required to compensate
         /// for the changes introduced as a resolution to LWG3162
         /// (https://cplusplus.github.io/LWG/issue3162).
-        explicit exception(boost::system::error_code const& e);
+        explicit exception(std::error_code const& e);
 
         /// Construct a hpx::exception from a \a hpx::error and an error message.
         ///

--- a/libs/core/errors/include/hpx/errors/exception_list.hpp
+++ b/libs/core/errors/include/hpx/errors/exception_list.hpp
@@ -12,13 +12,12 @@
 #include <hpx/errors/exception.hpp>
 #include <hpx/thread_support/spinlock.hpp>
 
-#include <boost/system/error_code.hpp>
-
 #include <cstddef>
 #include <exception>
 #include <list>
 #include <mutex>
 #include <string>
+#include <system_error>
 
 #include <hpx/config/warnings_prefix.hpp>
 
@@ -91,7 +90,7 @@ namespace hpx {
         }
 
         /// \cond NOINTERNAL
-        boost::system::error_code get_error() const;
+        std::error_code get_error() const;
 
         std::string get_message() const;
         /// \endcond

--- a/libs/core/errors/include/hpx/errors/throw_exception.hpp
+++ b/libs/core/errors/include/hpx/errors/throw_exception.hpp
@@ -17,10 +17,9 @@
 #include <hpx/preprocessor/expand.hpp>
 #include <hpx/preprocessor/nargs.hpp>
 
-#include <boost/system/error_code.hpp>
-
 #include <exception>
 #include <string>
+#include <system_error>
 
 #include <hpx/config/warnings_prefix.hpp>
 
@@ -49,9 +48,9 @@ namespace hpx { namespace detail {
         std::string const& file = "<unknown>", long line = -1,
         std::string const& auxinfo = "");
 
-    HPX_CORE_EXPORT std::exception_ptr get_exception(
-        boost::system::error_code const& ec, std::string const& msg,
-        throwmode mode, std::string const& func = "<unknown>",
+    HPX_CORE_EXPORT std::exception_ptr get_exception(std::error_code const& ec,
+        std::string const& msg, throwmode mode,
+        std::string const& func = "<unknown>",
         std::string const& file = "<unknown>", long line = -1,
         std::string const& auxinfo = "");
 

--- a/libs/core/errors/src/error_code.cpp
+++ b/libs/core/errors/src/error_code.cpp
@@ -9,23 +9,18 @@
 #include <hpx/errors/error_code.hpp>
 #include <hpx/errors/exception.hpp>
 
-#include <boost/system/error_code.hpp>
-
 #include <exception>
 #include <stdexcept>
 #include <string>
-
-#if !defined(BOOST_SYSTEM_NOEXCEPT)
-#define BOOST_SYSTEM_NOEXCEPT noexcept
-#endif
+#include <system_error>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx {
     namespace detail {
-        class hpx_category : public boost::system::error_category
+        class hpx_category : public std::error_category
         {
         public:
-            const char* name() const BOOST_SYSTEM_NOEXCEPT
+            const char* name() const noexcept
             {
                 return "HPX";
             }
@@ -46,10 +41,10 @@ namespace hpx {
         };
 
         // this doesn't add any text to the exception what() message
-        class hpx_category_rethrow : public boost::system::error_category
+        class hpx_category_rethrow : public std::error_category
         {
         public:
-            const char* name() const BOOST_SYSTEM_NOEXCEPT
+            const char* name() const noexcept
             {
                 return "";
             }
@@ -66,25 +61,25 @@ namespace hpx {
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
-    boost::system::error_category const& get_hpx_category()
+    std::error_category const& get_hpx_category()
     {
         static detail::hpx_category hpx_category;
         return hpx_category;
     }
 
-    boost::system::error_category const& get_hpx_rethrow_category()
+    std::error_category const& get_hpx_rethrow_category()
     {
         static detail::hpx_category_rethrow hpx_category_rethrow;
         return hpx_category_rethrow;
     }
 
-    boost::system::error_category const& get_lightweight_hpx_category()
+    std::error_category const& get_lightweight_hpx_category()
     {
         static detail::lightweight_hpx_category lightweight_hpx_category;
         return lightweight_hpx_category;
     }
 
-    boost::system::error_category const& get_hpx_category(throwmode mode)
+    std::error_category const& get_hpx_category(throwmode mode)
     {
         switch (mode)
         {
@@ -104,7 +99,7 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     error_code::error_code(error e, throwmode mode)
-      : boost::system::error_code(make_system_error_code(e, mode))
+      : std::error_code(make_system_error_code(e, mode))
     {
         if (e != success && e != no_success && !(mode & lightweight))
             exception_ = detail::get_exception(e, "", mode);
@@ -112,7 +107,7 @@ namespace hpx {
 
     error_code::error_code(
         error e, char const* func, char const* file, long line, throwmode mode)
-      : boost::system::error_code(make_system_error_code(e, mode))
+      : std::error_code(make_system_error_code(e, mode))
     {
         if (e != success && e != no_success && !(mode & lightweight))
         {
@@ -121,7 +116,7 @@ namespace hpx {
     }
 
     error_code::error_code(error e, char const* msg, throwmode mode)
-      : boost::system::error_code(make_system_error_code(e, mode))
+      : std::error_code(make_system_error_code(e, mode))
     {
         if (e != success && e != no_success && !(mode & lightweight))
             exception_ = detail::get_exception(e, msg, mode);
@@ -129,7 +124,7 @@ namespace hpx {
 
     error_code::error_code(error e, char const* msg, char const* func,
         char const* file, long line, throwmode mode)
-      : boost::system::error_code(make_system_error_code(e, mode))
+      : std::error_code(make_system_error_code(e, mode))
     {
         if (e != success && e != no_success && !(mode & lightweight))
         {
@@ -138,7 +133,7 @@ namespace hpx {
     }
 
     error_code::error_code(error e, std::string const& msg, throwmode mode)
-      : boost::system::error_code(make_system_error_code(e, mode))
+      : std::error_code(make_system_error_code(e, mode))
     {
         if (e != success && e != no_success && !(mode & lightweight))
             exception_ = detail::get_exception(e, msg, mode);
@@ -146,7 +141,7 @@ namespace hpx {
 
     error_code::error_code(error e, std::string const& msg, char const* func,
         char const* file, long line, throwmode mode)
-      : boost::system::error_code(make_system_error_code(e, mode))
+      : std::error_code(make_system_error_code(e, mode))
     {
         if (e != success && e != no_success && !(mode & lightweight))
         {
@@ -156,12 +151,12 @@ namespace hpx {
 
     error_code::error_code(int err, hpx::exception const& e)
     {
-        this->boost::system::error_code::assign(err, get_hpx_category());
+        this->std::error_code::assign(err, get_hpx_category());
         exception_ = std::make_exception_ptr(e);
     }
 
     error_code::error_code(std::exception_ptr const& e)
-      : boost::system::error_code(make_system_error_code(get_error(e), rethrow))
+      : std::error_code(make_system_error_code(get_error(e), rethrow))
       , exception_(e)
     {
     }
@@ -185,7 +180,7 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     error_code::error_code(error_code const& rhs)
-      : boost::system::error_code(rhs.value() == success ?
+      : std::error_code(rhs.value() == success ?
                 make_success_code(
                     (category() == get_lightweight_hpx_category()) ?
                         hpx::lightweight :
@@ -203,14 +198,14 @@ namespace hpx {
             if (rhs.value() == success)
             {
                 // if the rhs is a success code, we maintain our throw mode
-                this->boost::system::error_code::operator=(make_success_code(
+                this->std::error_code::operator=(make_success_code(
                     (category() == get_lightweight_hpx_category()) ?
                         hpx::lightweight :
                         hpx::plain));
             }
             else
             {
-                this->boost::system::error_code::operator=(rhs);
+                this->std::error_code::operator=(rhs);
             }
             exception_ = rhs.exception_;
         }

--- a/libs/core/errors/src/exception.cpp
+++ b/libs/core/errors/src/exception.cpp
@@ -5,6 +5,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// hpxinspect:nodeprecatedinclude:boost/system/system_error.hpp
+// hpxinspect:nodeprecatedname:boost::system::system_error
+
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/errors/error.hpp>

--- a/libs/core/errors/src/exception.cpp
+++ b/libs/core/errors/src/exception.cpp
@@ -20,6 +20,8 @@
 #include <unistd.h>
 #endif
 
+#include <boost/system/system_error.hpp>
+
 #include <algorithm>
 #include <atomic>
 #include <cstddef>
@@ -30,6 +32,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -40,7 +43,7 @@ namespace hpx {
     /// \param e    The parameter \p e holds the hpx::error code the new
     ///             exception should encapsulate.
     exception::exception(error e)
-      : boost::system::system_error(make_error_code(e, plain))
+      : std::system_error(make_error_code(e, plain))
     {
         HPX_ASSERT((e >= success && e < last_error) || (e & system_error_flag));
         if (e != success)
@@ -50,16 +53,16 @@ namespace hpx {
     }
 
     /// Construct a hpx::exception from a boost#system_error.
-    exception::exception(boost::system::system_error const& e)
-      : boost::system::system_error(e)
+    exception::exception(std::system_error const& e)
+      : std::system_error(e)
     {
         LERR_(error) << "created exception: " << this->what();
     }
 
     /// Construct a hpx::exception from a boost#system#error_code (this is
     /// new for Boost V1.69).
-    exception::exception(boost::system::error_code const& e)
-      : boost::system::system_error(e)
+    exception::exception(std::error_code const& e)
+      : std::system_error(e)
     {
         LERR_(error) << "created exception: " << this->what();
     }
@@ -76,7 +79,7 @@ namespace hpx {
     ///               default) or to the category \a hpx_category_rethrow
     ///               (if mode is \a rethrow).
     exception::exception(error e, char const* msg, throwmode mode)
-      : boost::system::system_error(make_system_error_code(e, mode), msg)
+      : std::system_error(make_system_error_code(e, mode), msg)
     {
         HPX_ASSERT((e >= success && e < last_error) || (e & system_error_flag));
         if (e != success)
@@ -97,7 +100,7 @@ namespace hpx {
     ///               default) or to the category \a hpx_category_rethrow
     ///               (if mode is \a rethrow).
     exception::exception(error e, std::string const& msg, throwmode mode)
-      : boost::system::system_error(make_system_error_code(e, mode), msg)
+      : std::system_error(make_system_error_code(e, mode), msg)
     {
         HPX_ASSERT((e >= success && e < last_error) || (e & system_error_flag));
         if (e != success)
@@ -119,8 +122,7 @@ namespace hpx {
     /// \throws nothing
     error exception::get_error() const noexcept
     {
-        return static_cast<error>(
-            this->boost::system::system_error::code().value());
+        return static_cast<error>(this->std::system_error::code().value());
     }
 
     /// The function \a get_error_code() returns a hpx::error_code which
@@ -134,8 +136,7 @@ namespace hpx {
     error_code exception::get_error_code(throwmode mode) const noexcept
     {
         (void) mode;
-        return error_code(
-            this->boost::system::system_error::code().value(), *this);
+        return error_code(this->std::system_error::code().value(), *this);
     }
 
     static custom_exception_info_handler_type custom_exception_info_handler;
@@ -280,6 +281,9 @@ namespace hpx { namespace detail {
     template HPX_CORE_EXPORT std::exception_ptr get_exception(
         boost::system::system_error const&, std::string const&,
         std::string const&, long, std::string const&);
+    template HPX_CORE_EXPORT std::exception_ptr get_exception(
+        std::system_error const&, std::string const&, std::string const&, long,
+        std::string const&);
 
     template HPX_CORE_EXPORT std::exception_ptr get_exception(
         std::exception const&, std::string const&, std::string const&, long,
@@ -331,6 +335,8 @@ namespace hpx { namespace detail {
     template HPX_CORE_EXPORT void throw_exception(
         boost::system::system_error const&, std::string const&,
         std::string const&, long);
+    template HPX_CORE_EXPORT void throw_exception(
+        std::system_error const&, std::string const&, std::string const&, long);
 
     template HPX_CORE_EXPORT void throw_exception(
         std::exception const&, std::string const&, std::string const&, long);
@@ -403,7 +409,7 @@ namespace hpx {
         {
             return he.get_error();
         }
-        catch (boost::system::system_error const& e)
+        catch (std::system_error const& e)
         {
             int code = e.code().value();
             if (code < success || code >= last_error)

--- a/libs/core/errors/src/exception_list.cpp
+++ b/libs/core/errors/src/exception_list.cpp
@@ -9,12 +9,11 @@
 #include <hpx/errors/exception_list.hpp>
 #include <hpx/thread_support/unlock_guard.hpp>
 
-#include <boost/system/system_error.hpp>
-
 #include <exception>
 #include <mutex>
 #include <set>
 #include <string>
+#include <system_error>
 #include <utility>
 
 namespace hpx {
@@ -110,7 +109,7 @@ namespace hpx {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    boost::system::error_code exception_list::get_error() const
+    std::error_code exception_list::get_error() const
     {
         std::lock_guard<mutex_type> l(mtx_);
         if (exceptions_.empty())

--- a/libs/core/errors/src/throw_exception.cpp
+++ b/libs/core/errors/src/throw_exception.cpp
@@ -10,10 +10,9 @@
 #include <hpx/errors/exception.hpp>
 #include <hpx/modules/filesystem.hpp>
 
-#include <boost/system/error_code.hpp>
-
 #include <exception>
 #include <string>
+#include <system_error>
 
 namespace hpx { namespace detail {
     HPX_NORETURN void throw_exception(error errcode, std::string const& msg,
@@ -41,7 +40,7 @@ namespace hpx { namespace detail {
             p.string(), file, line, auxinfo);
     }
 
-    std::exception_ptr get_exception(boost::system::error_code const& ec,
+    std::exception_ptr get_exception(std::error_code const& ec,
         std::string const& /* msg */, throwmode /* mode */,
         std::string const& func, std::string const& file, long line,
         std::string const& auxinfo)

--- a/libs/core/filesystem/include/hpx/modules/filesystem.hpp
+++ b/libs/core/filesystem/include/hpx/modules/filesystem.hpp
@@ -25,7 +25,6 @@
 
 namespace hpx { namespace filesystem {
     using namespace std::filesystem;
-    using std::error_code;
     using std::filesystem::canonical;
 
     inline path initial_path()
@@ -51,7 +50,7 @@ namespace hpx { namespace filesystem {
         }
     }
 
-    inline path canonical(path const& p, path const& base, error_code& ec)
+    inline path canonical(path const& p, path const& base, std::error_code& ec)
     {
         if (p.is_relative())
         {
@@ -65,7 +64,11 @@ namespace hpx { namespace filesystem {
 
 }}    // namespace hpx::filesystem
 #else
+#include <hpx/config/detail/compat_error_code.hpp>
+
 #include <boost/filesystem.hpp>
+
+#include <system_error>
 
 static_assert(BOOST_FILESYSTEM_VERSION == 3,
     "HPX requires Boost.Filesystem version 3 (or support for the C++17 "
@@ -73,6 +76,24 @@ static_assert(BOOST_FILESYSTEM_VERSION == 3,
 
 namespace hpx { namespace filesystem {
     using namespace boost::filesystem;
-    using boost::system::error_code;
+
+    using boost::filesystem::canonical;
+    inline path canonical(path const& p, path const& base, std::error_code& ec)
+    {
+        return canonical(p, base, compat_error_code(ec));
+    }
+
+    using boost::filesystem::exists;
+    inline bool exists(path const& p, std::error_code& ec) noexcept
+    {
+        return exists(p, compat_error_code(ec));
+    }
+
+    using boost::filesystem::is_regular_file;
+    inline bool is_regular_file(path const& p, std::error_code& ec) noexcept
+    {
+        return is_regular_file(p, compat_error_code(ec));
+    }
+
 }}    // namespace hpx::filesystem
 #endif

--- a/libs/core/serialization/include/hpx/serialization/exception_ptr.hpp
+++ b/libs/core/serialization/include/hpx/serialization/exception_ptr.hpp
@@ -38,8 +38,10 @@ namespace hpx { namespace util {
 
 #if BOOST_ASIO_HAS_BOOST_THROW_EXCEPTION != 0
         // boost exceptions
-        boost_exception = 13
+        boost_exception = 13,
 #endif
+
+        std_system_error = 14
     };
 }}    // namespace hpx::util
 

--- a/libs/core/serialization/src/exception_ptr.cpp
+++ b/libs/core/serialization/src/exception_ptr.cpp
@@ -5,6 +5,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// hpxinspect:nodeprecatedinclude:boost/system/system_error.hpp
+// hpxinspect:nodeprecatedname:boost::system::system_error
+
 #include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/serialization/exception_ptr.hpp>

--- a/libs/core/serialization/src/exception_ptr.cpp
+++ b/libs/core/serialization/src/exception_ptr.cpp
@@ -15,6 +15,8 @@
 #include <boost/exception/exception.hpp>
 #endif
 
+#include <boost/system/system_error.hpp>
+
 #include <cstddef>
 #include <cstdint>
 #include <exception>
@@ -251,13 +253,7 @@ namespace hpx { namespace serialization {
             case hpx::util::boost_system_error:
                 e = hpx::detail::get_exception(
                     boost::system::system_error(err_value,
-#if BOOST_VERSION < 106600 && !defined(BOOST_SYSTEM_NO_DEPRECATED)
-                        boost::system::get_system_category()
-#else
-                        boost::system::system_category()
-#endif
-                            ,
-                        err_message),
+                        boost::system::system_category(), err_message),
                     throw_function_, throw_file_, throw_line_);
                 break;
 

--- a/libs/core/serialization/src/exception_ptr.cpp
+++ b/libs/core/serialization/src/exception_ptr.cpp
@@ -25,6 +25,7 @@
 #include <exception>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 #include <typeinfo>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -85,6 +86,13 @@ namespace hpx { namespace serialization {
             catch (boost::system::system_error const& e)
             {
                 type = hpx::util::boost_system_error;
+                what = e.what();
+                err_value = e.code().value();
+                err_message = e.code().message();
+            }
+            catch (std::system_error const& e)
+            {
+                type = hpx::util::std_system_error;
                 what = e.what();
                 err_value = e.code().value();
                 err_message = e.code().message();
@@ -157,7 +165,8 @@ namespace hpx { namespace serialization {
                 ar & err_value;
                 // clang-format on
             }
-            else if (hpx::util::boost_system_error == type)
+            else if (hpx::util::boost_system_error == type ||
+                hpx::util::std_system_error == type)
             {
                 // clang-format off
                 ar & err_value & err_message;
@@ -189,7 +198,8 @@ namespace hpx { namespace serialization {
                 ar & err_value;
                 // clang-format on
             }
-            else if (hpx::util::boost_system_error == type)
+            else if (hpx::util::boost_system_error == type ||
+                hpx::util::std_system_error == type)
             {
                 // clang-format off
                 ar & err_value& err_message;
@@ -257,6 +267,14 @@ namespace hpx { namespace serialization {
                 e = hpx::detail::get_exception(
                     boost::system::system_error(err_value,
                         boost::system::system_category(), err_message),
+                    throw_function_, throw_file_, throw_line_);
+                break;
+
+            // std::system_error
+            case hpx::util::std_system_error:
+                e = hpx::detail::get_exception(
+                    std::system_error(
+                        err_value, std::system_category(), err_message),
                     throw_function_, throw_file_, throw_line_);
                 break;
 

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
@@ -29,8 +29,6 @@
 #include <hpx/threading_base/thread_num_tss.hpp>
 #include <hpx/topology/topology.hpp>
 
-#include <boost/system/system_error.hpp>
-
 #include <algorithm>
 #include <atomic>
 #ifdef HPX_HAVE_MAX_CPU_COUNT
@@ -45,6 +43,7 @@
 #include <mutex>
 #include <numeric>
 #include <string>
+#include <system_error>
 #include <thread>
 #include <type_traits>
 #include <utility>
@@ -533,12 +532,12 @@ namespace hpx { namespace threads { namespace detail {
                 report_error(global_thread_num, std::current_exception());
                 return;
             }
-            catch (boost::system::system_error const& e)
+            catch (std::system_error const& e)
             {
                 LFATAL_    //-V128
                     << "thread_func: " << id_.name()
                     << " thread_num:" << global_thread_num    //-V128
-                    << " : caught boost::system::system_error: " << e.what()
+                    << " : caught std::system_error: " << e.what()
                     << ", aborted thread execution";
 
                 report_error(global_thread_num, std::current_exception());

--- a/libs/core/threading_base/include/hpx/threading_base/set_thread_state.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/set_thread_state.hpp
@@ -28,6 +28,7 @@
 #include <functional>
 #include <memory>
 #include <sstream>
+#include <system_error>
 
 namespace hpx { namespace threads { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
@@ -370,7 +371,7 @@ namespace hpx { namespace threads { namespace detail {
 
         // let the timer invoke the set_state on the new (suspended) thread
         t.async_wait([wake_id, priority, retry_on_active](
-                         const boost::system::error_code& ec) {
+                         const std::error_code& ec) {
             if (ec.value() == boost::system::errc::operation_canceled)
             {
                 detail::set_thread_state(wake_id, pending, wait_abort, priority,

--- a/libs/full/agas/include/hpx/agas/primary_namespace.hpp
+++ b/libs/full/agas/include/hpx/agas/primary_namespace.hpp
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -67,8 +68,8 @@ namespace hpx { namespace agas {
 
 #if defined(HPX_HAVE_NETWORKING)
         void route(parcelset::parcel&& p,
-            util::function_nonser<void(boost::system::error_code const&,
-                parcelset::parcel const&)>&& f);
+            util::function_nonser<void(
+                std::error_code const&, parcelset::parcel const&)>&& f);
 #endif
 
         resolved_type resolve_gid(naming::gid_type const& id);

--- a/libs/full/agas/src/primary_namespace.cpp
+++ b/libs/full/agas/src/primary_namespace.cpp
@@ -20,6 +20,7 @@
 
 #include <cstdint>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -195,7 +196,7 @@ namespace hpx { namespace agas {
 #if defined(HPX_HAVE_NETWORKING)
     void primary_namespace::route(parcelset::parcel&& p,
         util::function_nonser<void(
-            boost::system::error_code const&, parcelset::parcel const&)>&& f)
+            std::error_code const&, parcelset::parcel const&)>&& f)
     {
         // compose request
         naming::gid_type const& id = p.destination();
@@ -206,7 +207,7 @@ namespace hpx { namespace agas {
         {
             hpx::apply(
                 &server::primary_namespace::route, server_.get(), std::move(p));
-            f(boost::system::error_code(), parcelset::parcel());
+            f(std::error_code(), parcelset::parcel());
             return;
         }
 

--- a/libs/full/async_colocated/tests/unit/async_cb_colocated.cpp
+++ b/libs/full/async_colocated/tests/unit/async_cb_colocated.cpp
@@ -15,6 +15,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -76,7 +77,7 @@ struct test_client : hpx::components::client_base<test_client, test_server>
 std::atomic<int> callback_called(0);
 
 #if defined(HPX_HAVE_NETWORKING)
-void cb(boost::system::error_code const& ec, hpx::parcelset::parcel const& p)
+void cb(std::error_code const& ec, hpx::parcelset::parcel const& p)
 {
     ++callback_called;
 }

--- a/libs/full/async_colocated/tests/unit/async_continue_cb_colocated.cpp
+++ b/libs/full/async_colocated/tests/unit/async_continue_cb_colocated.cpp
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -63,7 +64,7 @@ struct test_client : hpx::components::client_base<test_client, test_server>
 std::atomic<int> callback_called(0);
 
 #if defined(HPX_HAVE_NETWORKING)
-void cb(boost::system::error_code const& ec, hpx::parcelset::parcel const& p)
+void cb(std::error_code const& ec, hpx::parcelset::parcel const& p)
 {
     ++callback_called;
 }

--- a/libs/full/async_distributed/include/hpx/async_distributed/applier/apply_callback.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/applier/apply_callback.hpp
@@ -20,6 +20,7 @@
 #include <hpx/async_distributed/applier/apply.hpp>
 
 #include <cstddef>
+#include <system_error>
 #include <type_traits>
 #include <utility>
 
@@ -162,7 +163,7 @@ namespace hpx {
 
             // invoke callback
 #if defined(HPX_HAVE_NETWORKING)
-            cb(boost::system::error_code(), parcelset::parcel());
+            cb(std::error_code(), parcelset::parcel());
 #else
             cb();
 #endif

--- a/libs/full/async_distributed/include/hpx/async_distributed/applier/detail/apply_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/applier/detail/apply_implementations.hpp
@@ -20,6 +20,7 @@
 #include <hpx/traits/action_was_object_migrated.hpp>
 #include <hpx/traits/is_continuation.hpp>
 
+#include <system_error>
 #include <type_traits>
 #include <utility>
 
@@ -273,7 +274,7 @@ namespace hpx { namespace detail {
 
                     // invoke callback
 #if defined(HPX_HAVE_NETWORKING)
-                    cb(boost::system::error_code(), parcelset::parcel());
+                    cb(std::error_code(), parcelset::parcel());
 #else
                     cb();
 #endif
@@ -288,7 +289,7 @@ namespace hpx { namespace detail {
 
                 // invoke callback
 #if defined(HPX_HAVE_NETWORKING)
-                cb(boost::system::error_code(), parcelset::parcel());
+                cb(std::error_code(), parcelset::parcel());
 #else
                 cb();
 #endif
@@ -338,7 +339,7 @@ namespace hpx { namespace detail {
 
                     // invoke callback
 #if defined(HPX_HAVE_NETWORKING)
-                    cb(boost::system::error_code(), parcelset::parcel());
+                    cb(std::error_code(), parcelset::parcel());
 #else
                     cb();
 #endif
@@ -352,7 +353,7 @@ namespace hpx { namespace detail {
 
                 // invoke callback
 #if defined(HPX_HAVE_NETWORKING)
-                cb(boost::system::error_code(), parcelset::parcel());
+                cb(std::error_code(), parcelset::parcel());
 #else
                 cb();
 #endif

--- a/libs/full/async_distributed/tests/regressions/async_callback_with_bound_callback.cpp
+++ b/libs/full/async_distributed/tests/regressions/async_callback_with_bound_callback.cpp
@@ -9,9 +9,11 @@
 #include <hpx/include/async.hpp>
 #include <hpx/modules/testing.hpp>
 
+#include <system_error>
+
 #if defined(HPX_HAVE_NETWORKING)
-void async_callback(uint64_t index, boost::system::error_code const& ec,
-    hpx::parcelset::parcel const& p)
+void async_callback(
+    uint64_t index, std::error_code const& ec, hpx::parcelset::parcel const& p)
 {
 }
 #else

--- a/libs/full/async_distributed/tests/unit/async_cb_remote.cpp
+++ b/libs/full/async_distributed/tests/unit/async_cb_remote.cpp
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <system_error>
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -52,7 +53,7 @@ HPX_REGISTER_ACTION(call_action);
 std::atomic<int> callback_called(0);
 
 #if defined(HPX_HAVE_NETWORKING)
-void cb(boost::system::error_code const& ec, hpx::parcelset::parcel const& p)
+void cb(std::error_code const& ec, hpx::parcelset::parcel const& p)
 {
     ++callback_called;
 }

--- a/libs/full/async_distributed/tests/unit/async_cb_remote_client.cpp
+++ b/libs/full/async_distributed/tests/unit/async_cb_remote_client.cpp
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <system_error>
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -39,7 +40,7 @@ HPX_REGISTER_ACTION(call_action);
 std::atomic<int> callback_called(0);
 
 #if defined(HPX_HAVE_NETWORKING)
-void cb(boost::system::error_code const& ec, hpx::parcelset::parcel const& p)
+void cb(std::error_code const& ec, hpx::parcelset::parcel const& p)
 {
     ++callback_called;
 }

--- a/libs/full/async_distributed/tests/unit/async_continue_cb.cpp
+++ b/libs/full/async_distributed/tests/unit/async_continue_cb.cpp
@@ -13,6 +13,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <system_error>
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -39,7 +40,7 @@ HPX_PLAIN_ACTION(mult2);    // defines mult2_action
 std::atomic<int> callback_called(0);
 
 #if defined(HPX_HAVE_NETWORKING)
-void cb(boost::system::error_code const& ec, hpx::parcelset::parcel const& p)
+void cb(std::error_code const& ec, hpx::parcelset::parcel const& p)
 {
     ++callback_called;
 }

--- a/libs/full/runtime_configuration/src/init_ini_data.cpp
+++ b/libs/full/runtime_configuration/src/init_ini_data.cpp
@@ -26,6 +26,7 @@
 #include <memory>
 #include <random>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -37,7 +38,7 @@ namespace hpx { namespace util {
         try
         {
             namespace fs = filesystem;
-            fs::error_code ec;
+            std::error_code ec;
             if (!fs::exists(loc, ec) || ec)
                 return false;    // avoid exception on missing file
             ini.read(loc);
@@ -147,7 +148,7 @@ namespace hpx { namespace util {
         if (!hpx_ini_file.empty())
         {
             namespace fs = filesystem;
-            fs::error_code ec;
+            std::error_code ec;
             if (!fs::exists(hpx_ini_file, ec) || ec)
             {
                 std::cerr
@@ -200,7 +201,7 @@ namespace hpx { namespace util {
                 fs::directory_iterator nodir;
                 fs::path this_path(*it);
 
-                fs::error_code ec;
+                std::error_code ec;
                 if (!fs::exists(this_path, ec) || ec)
                     continue;
 
@@ -420,7 +421,7 @@ namespace hpx { namespace util {
             fs::directory_iterator nodir;
             fs::path libs_path(libs);
 
-            fs::error_code ec;
+            std::error_code ec;
             if (!fs::exists(libs_path, ec) || ec)
                 return plugin_registries;    // given directory doesn't exist
 
@@ -458,7 +459,7 @@ namespace hpx { namespace util {
                         i - 1, version.length() + 1);    // - 1 for one more dot
 #endif
                 // ensure base directory, remove symlinks, etc.
-                fs::error_code fsec;
+                std::error_code fsec;
                 fs::path canonical_curr =
                     fs::canonical(curr, fs::initial_path(), fsec);
                 if (fsec)

--- a/libs/full/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/full/runtime_configuration/src/runtime_configuration.cpp
@@ -37,6 +37,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -570,7 +571,7 @@ namespace hpx { namespace util {
         if (!path.empty())
         {
             fs::path this_p(path);
-            fs::error_code fsec;
+            std::error_code fsec;
             fs::path canonical_p =
                 fs::canonical(this_p, fs::initial_path(), fsec);
             if (fsec)

--- a/libs/full/runtime_local/include/hpx/runtime_local/custom_exception_info.hpp
+++ b/libs/full/runtime_local/include/hpx/runtime_local/custom_exception_info.hpp
@@ -12,9 +12,6 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/naming_base.hpp>
 
-#include <boost/system/error_code.hpp>
-#include <boost/system/system_error.hpp>
-
 #include <cstddef>
 #include <cstdint>
 #include <exception>

--- a/libs/full/runtime_local/src/custom_exception_info.cpp
+++ b/libs/full/runtime_local/src/custom_exception_info.cpp
@@ -5,6 +5,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// hpxinspect:nodeprecatedinclude:boost/system/system_error.hpp
+// hpxinspect:nodeprecatedname:boost::system::system_error
+
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/command_line_handling/command_line_handling.hpp>
@@ -25,6 +28,8 @@
 #include <hpx/state.hpp>
 #include <hpx/threading_base/thread_helpers.hpp>
 #include <hpx/version.hpp>
+
+#include <boost/system/system_error.hpp>
 
 #if defined(HPX_WINDOWS)
 #include <process.h>

--- a/libs/full/runtime_local/src/custom_exception_info.cpp
+++ b/libs/full/runtime_local/src/custom_exception_info.cpp
@@ -47,6 +47,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -302,6 +303,8 @@ namespace hpx { namespace detail {
         hpx::exception const&, hpx::exception_info info);
     template HPX_EXPORT std::exception_ptr construct_exception(
         boost::system::system_error const&, hpx::exception_info info);
+    template HPX_EXPORT std::exception_ptr construct_exception(
+        std::system_error const&, hpx::exception_info info);
     template HPX_EXPORT std::exception_ptr construct_exception(
         std::exception const&, hpx::exception_info info);
     template HPX_EXPORT std::exception_ptr construct_exception(

--- a/libs/full/runtime_local/src/serialize_exception.cpp
+++ b/libs/full/runtime_local/src/serialize_exception.cpp
@@ -4,6 +4,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// hpxinspect:nodeprecatedinclude:boost/system/system_error.hpp
+// hpxinspect:nodeprecatedname:boost::system::system_error
+
 #include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/runtime_local/custom_exception_info.hpp>

--- a/libs/full/runtime_local/src/serialize_exception.cpp
+++ b/libs/full/runtime_local/src/serialize_exception.cpp
@@ -15,6 +15,8 @@
 #include <boost/exception/exception.hpp>
 #endif
 
+#include <boost/system/system_error.hpp>
+
 #include <cstddef>
 #include <cstdint>
 #include <exception>
@@ -367,14 +369,8 @@ namespace hpx { namespace runtime_local { namespace detail {
         // boost::system::system_error
         case hpx::util::boost_system_error:
             e = hpx::detail::construct_exception(
-                boost::system::system_error(err_value,
-#if BOOST_VERSION < 106600 && !defined(BOOST_SYSTEM_NO_DEPRECATED)
-                    boost::system::get_system_category()
-#else
-                    boost::system::system_category()
-#endif
-                        ,
-                    err_message),
+                boost::system::system_error(
+                    err_value, boost::system::system_category(), err_message),
                 hpx::detail::construct_exception_info(throw_function_,
                     throw_file_, throw_line_, throw_back_trace_,
                     throw_locality_, throw_hostname_, throw_pid_,

--- a/libs/full/runtime_local/src/serialize_exception.cpp
+++ b/libs/full/runtime_local/src/serialize_exception.cpp
@@ -25,6 +25,7 @@
 #include <exception>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 #include <typeinfo>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -151,6 +152,13 @@ namespace hpx { namespace runtime_local { namespace detail {
             err_value = e.code().value();
             err_message = e.code().message();
         }
+        catch (std::system_error const& e)
+        {
+            type = hpx::util::std_system_error;
+            what = e.what();
+            err_value = e.code().value();
+            err_message = e.code().message();
+        }
         catch (std::runtime_error const& e)
         {
             type = hpx::util::std_runtime_error;
@@ -222,7 +230,8 @@ namespace hpx { namespace runtime_local { namespace detail {
             ar & err_value;
             // clang-format on
         }
-        else if (hpx::util::boost_system_error == type)
+        else if (hpx::util::boost_system_error == type ||
+            hpx::util::std_system_error == type)
         {
             // clang-format off
             ar & err_value & err_message;
@@ -268,7 +277,8 @@ namespace hpx { namespace runtime_local { namespace detail {
             ar & err_value;
             // clang-format on
         }
-        else if (hpx::util::boost_system_error == type)
+        else if (hpx::util::boost_system_error == type ||
+            hpx::util::std_system_error == type)
         {
             // clang-format off
             ar & err_value & err_message;
@@ -374,6 +384,18 @@ namespace hpx { namespace runtime_local { namespace detail {
             e = hpx::detail::construct_exception(
                 boost::system::system_error(
                     err_value, boost::system::system_category(), err_message),
+                hpx::detail::construct_exception_info(throw_function_,
+                    throw_file_, throw_line_, throw_back_trace_,
+                    throw_locality_, throw_hostname_, throw_pid_,
+                    throw_shepherd_, throw_thread_id_, throw_thread_name_,
+                    throw_env_, throw_config_, throw_state_, throw_auxinfo_));
+            break;
+
+        // std::system_error
+        case hpx::util::std_system_error:
+            e = hpx::detail::construct_exception(
+                std::system_error(
+                    err_value, std::system_category(), err_message),
                 hpx::detail::construct_exception_info(throw_function_,
                     throw_file_, throw_line_, throw_back_trace_,
                     throw_locality_, throw_hostname_, throw_pid_,

--- a/libs/full/runtime_local/src/thread_mapper.cpp
+++ b/libs/full/runtime_local/src/thread_mapper.cpp
@@ -24,6 +24,7 @@
 #if defined(HPX_HAVE_PAPI) && defined(__linux__) && !defined(__ANDROID) &&     \
     !defined(ANDROID)
 #include <sys/syscall.h>
+#include <unistd.h>
 #endif
 
 namespace hpx { namespace util {

--- a/plugins/parcelport/mpi/parcelport_mpi.cpp
+++ b/plugins/parcelport/mpi/parcelport_mpi.cpp
@@ -37,6 +37,7 @@
 #include <exception>
 #include <memory>
 #include <string>
+#include <system_error>
 #include <type_traits>
 
 #include <hpx/config/warnings_prefix.hpp>
@@ -230,7 +231,7 @@ namespace hpx { namespace parcelset
             }
 
             void early_write_handler(
-                boost::system::error_code const& ec, parcel const & p)
+                std::error_code const& ec, parcel const & p)
             {
                 if (ec) {
                     // all errors during early parcel handling are fatal

--- a/plugins/parcelport/tcp/connection_handler_tcp.cpp
+++ b/plugins/parcelport/tcp/connection_handler_tcp.cpp
@@ -8,6 +8,11 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// hpxinspect:nodeprecatedinclude:boost/system/error_code.hpp
+// hpxinspect:nodeprecatedname:boost::system::error_code
+// hpxinspect:nodeprecatedinclude:boost/system/system_error.hpp
+// hpxinspect:nodeprecatedname:boost::system::system_error
+
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
@@ -25,6 +30,8 @@
 #include <hpx/util/get_entry_as.hpp>
 
 #include <boost/asio/ip/tcp.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/system/system_error.hpp>
 
 #include <thread>
 #include <chrono>

--- a/plugins/parcelport/tcp/connection_handler_tcp.cpp
+++ b/plugins/parcelport/tcp/connection_handler_tcp.cpp
@@ -42,6 +42,7 @@
 #include <mutex>
 #include <sstream>
 #include <string>
+#include <system_error>
 
 namespace hpx { namespace parcelset { namespace policies { namespace tcp
 {

--- a/plugins/parcelport/verbs/sender_connection.hpp
+++ b/plugins/parcelport/verbs/sender_connection.hpp
@@ -12,6 +12,7 @@
 //
 #include <memory>
 #include <cstdint>
+#include <system_error>
 #include <utility>
 //
 #include <plugins/parcelport/verbs/rdma/verbs_endpoint.hpp>
@@ -37,7 +38,7 @@ namespace verbs
     {
     private:
         typedef util::function_nonser<
-            void(boost::system::error_code const&, parcel const&)
+            void(std::error_code const&, parcel const&)
             > write_handler_type;
 
     public:

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -66,6 +66,7 @@
 #include <mutex>
 #include <sstream>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -1499,7 +1500,7 @@ bool addressing_service::resolve_cached(
 ///////////////////////////////////////////////////////////////////////////////
 void addressing_service::route(
     parcelset::parcel p
-  , util::function_nonser<void(boost::system::error_code const&,
+  , util::function_nonser<void(std::error_code const&,
         parcelset::parcel const&)> && f
   , threads::thread_priority local_priority
     )
@@ -1509,7 +1510,7 @@ void addressing_service::route(
         // reschedule this call as an HPX thread
         void (addressing_service::*route_ptr)(
             parcelset::parcel,
-            util::function_nonser<void(boost::system::error_code const&,
+            util::function_nonser<void(std::error_code const&,
                 parcelset::parcel const&)> &&,
             threads::thread_priority
         ) = &addressing_service::route;

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -70,6 +70,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <system_error>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -1518,7 +1519,7 @@ namespace hpx { namespace components { namespace server {
                 typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
                 boost::char_separator<char> sep(HPX_INI_PATH_DELIMITER);
                 tokenizer tokens(component_path, sep);
-                fs::error_code fsec;
+                std::error_code fsec;
                 for (tokenizer::iterator it = tokens.begin();
                      it != tokens.end(); ++it)
                 {
@@ -1992,7 +1993,7 @@ namespace hpx { namespace components { namespace server {
                 typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
                 boost::char_separator<char> sep(HPX_INI_PATH_DELIMITER);
                 tokenizer tokens(component_path, sep);
-                fs::error_code fsec;
+                std::error_code fsec;
                 for (tokenizer::iterator it = tokens.begin();
                      it != tokens.end(); ++it)
                 {

--- a/src/runtime/parcelset/detail/parcel_route_handler.cpp
+++ b/src/runtime/parcelset/detail/parcel_route_handler.cpp
@@ -15,6 +15,8 @@
 #include <hpx/runtime/runtime_fwd.hpp>
 #include <hpx/runtime_distributed.hpp>
 
+#include <system_error>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace detail
 {
@@ -24,7 +26,7 @@ namespace hpx { namespace detail
 namespace hpx { namespace parcelset { namespace detail
 {
     void parcel_route_handler(
-        boost::system::error_code const& ec,
+        std::error_code const& ec,
         parcelset::parcel const& p)
     {
         parcelhandler& ph = hpx::get_runtime_distributed().get_parcel_handler();

--- a/src/runtime/parcelset/parcelport.cpp
+++ b/src/runtime/parcelset/parcelport.cpp
@@ -27,6 +27,7 @@
 #include <cstdint>
 #include <exception>
 #include <string>
+#include <system_error>
 #include <utility>
 
 namespace hpx { namespace parcelset
@@ -269,7 +270,7 @@ namespace hpx { namespace parcelset
     ///////////////////////////////////////////////////////////////////////////
     // the code below is needed to bootstrap the parcel layer
     void parcelport::early_pending_parcel_handler(
-        boost::system::error_code const& ec, parcel const & p)
+        std::error_code const& ec, parcel const & p)
     {
         if (ec) {
             // all errors during early parcel handling are fatal

--- a/src/util/pool_timer.cpp
+++ b/src/util/pool_timer.cpp
@@ -18,12 +18,12 @@
 #include <hpx/util/pool_timer.hpp>
 
 #include <boost/asio/basic_waitable_timer.hpp>
-#include <boost/system/error_code.hpp>
 
 #include <chrono>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <system_error>
 
 namespace hpx { namespace util { namespace detail
 {
@@ -51,7 +51,7 @@ namespace hpx { namespace util { namespace detail
 
         bool is_started() const { return is_started_; }
         bool is_terminated() const { return is_terminated_; }
-        void timer_handler(const boost::system::error_code&);
+        void timer_handler(const std::error_code&);
 
         void terminate();             // handle system shutdown
         bool stop_locked();
@@ -95,7 +95,7 @@ namespace hpx { namespace util { namespace detail
         )
     {}
 
-    void pool_timer::timer_handler(const boost::system::error_code& err)
+    void pool_timer::timer_handler(const std::error_code& err)
     {
         if(!is_stopped_ || !is_terminated_)
         {

--- a/tests/performance/network/network_storage/network_storage.cpp
+++ b/tests/performance/network/network_storage/network_storage.cpp
@@ -30,6 +30,7 @@
 #include <mutex>
 #include <random>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -307,7 +308,7 @@ mutex_type keep_alive_mutex;
 alive_map  keep_alive_buffers;
 
 //
-void async_callback(const uint64_t index, boost::system::error_code const& ec,
+void async_callback(const uint64_t index, std::error_code const& ec,
     hpx::parcelset::parcel const& p)
 {
     scoped_lock lock(keep_alive_mutex);

--- a/tests/unit/parcelset/set_parcel_write_handler.cpp
+++ b/tests/unit/parcelset/set_parcel_write_handler.cpp
@@ -11,6 +11,7 @@
 #include <atomic>
 #include <cstddef>
 #include <memory>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -34,8 +35,8 @@ bool is_test_action(hpx::parcelset::parcel const& p)
 #endif
 }
 
-void write_handler(
-    boost::system::error_code const&, hpx::parcelset::parcel const& p)
+void write_handler(std::error_code const&,
+    hpx::parcelset::parcel const& p)
 {
     if (is_test_action(p))
         ++write_handler_called;

--- a/tools/inspect/deprecated_include_check.cpp
+++ b/tools/inspect/deprecated_include_check.cpp
@@ -56,6 +56,7 @@ namespace boost
       { "boost/program_options([^\\s]*)\\.hpp", "hpx/program_options\\2.hpp" },
       { "boost/filesystem([^\\s]*)\\.hpp", "hpx/modules/filesystem.hpp" },
       { "boost/lexical_cast\\.hpp", "hpx/util/((from_string)|(to_string)).hpp" },
+      { "boost/system([^\\s]*)\\.hpp", "system_error" },
       { nullptr, nullptr }
     };
 

--- a/tools/inspect/deprecated_name_check.cpp
+++ b/tools/inspect/deprecated_name_check.cpp
@@ -81,6 +81,10 @@ namespace boost
       { "(\\bboost\\s*::\\s*format\\b)", "hpx::util::format[_to]" },
       { "(\\bboost\\s*::\\s*(regex[^\\s]*)\\b)", "std::\\2" },
       { "(\\bboost\\s*::\\s*lexical_cast\\b)", "hpx::util::((from_string)|(to_string))" },
+      { "(\\bboost\\s*::\\s*system\\s*::\\s*error_code\\b)", "std::error_code" },
+      { "(\\bboost\\s*::\\s*system\\s*::\\s*error_condition\\b)", "std::error_condition" },
+      { "(\\bboost\\s*::\\s*system\\s*::\\s*error_category\\b)", "std::error_category" },
+      { "(\\bboost\\s*::\\s*system\\s*::\\s*system_error\\b)", "std::system_error" },
       /////////////////////////////////////////////////////////////////////////
       { "((\\bhpx::\\b)?\\btraits\\s*::\\bis_callable\\b)", "\\2traits::is_invocable[_r]" },
       { "((\\bhpx::\\b)?\\butil\\s*::\\bresult_of\\b)", "\\2util::invoke_result" },

--- a/tools/inspect/include_check.cpp
+++ b/tools/inspect/include_check.cpp
@@ -232,6 +232,14 @@ namespace boost
             "std::uniform_real_distribution", "random"},
         {"(\\bstd\\s*::\\s*exponential_distribution\\b)",
             "std::exponential_distribution", "random"},
+        // system_error
+        {"(\\bstd\\s*::\\s*error_code\\b)", "std::error_code", "system_error"},
+        {"(\\bstd\\s*::\\s*error_condition\\b)", "std::error_condition",
+            "system_error"},
+        {"(\\bstd\\s*::\\s*error_category\\b)", "std::error_category",
+            "system_error"},
+        {"(\\bstd\\s*::\\s*system_error\\b)", "std::system_error",
+            "system_error"},
         // boost
         {"(\\bhpx\\s*::\\s*intrusive_ptr\\b)", "hpx::intrusive_ptr",
             "hpx/modules/memory.hpp"},


### PR DESCRIPTION
Since Boost 1.65.0, `boost::system::error_code` is implicitly convertible to `std::error_code`. This takes care of compatibility when the error_code is taken by value or const ref; functions taking the error_code by mutable ref need to be manually mapped.