### PR TITLE
Properly reset pointer tracking data in output_archive

### DIFF
--- a/hpx/runtime/serialization/detail/preprocess_gid_types.hpp
+++ b/hpx/runtime/serialization/detail/preprocess_gid_types.hpp
@@ -127,8 +127,9 @@ namespace hpx { namespace serialization { namespace detail {
     // This is explicitly instantiated to ensure that the id is stable across
     // shared libraries.
     template <>
-    struct extra_archive_data_id_helper<preprocess_gid_types>
+    struct extra_archive_data_helper<preprocess_gid_types>
     {
         HPX_EXPORT static void id() noexcept;
+        static constexpr void reset(preprocess_gid_types*) noexcept {}
     };
 }}}    // namespace hpx::serialization::detail

--- a/libs/core/serialization/include/hpx/serialization/basic_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/basic_archive.hpp
@@ -136,6 +136,7 @@ namespace hpx { namespace serialization {
         void reset()
         {
             size_ = 0;
+            extra_data_.reset();
         }
 
         // access extra data stored

--- a/libs/core/serialization/include/hpx/serialization/detail/pointer.hpp
+++ b/libs/core/serialization/include/hpx/serialization/detail/pointer.hpp
@@ -45,15 +45,17 @@ namespace hpx { namespace serialization {
         // This is explicitly instantiated to ensure that the id is stable across
         // shared libraries.
         template <>
-        struct extra_archive_data_id_helper<input_pointer_tracker>
+        struct extra_archive_data_helper<input_pointer_tracker>
         {
             HPX_CORE_EXPORT static void id() noexcept;
+            static constexpr void reset(input_pointer_tracker*) noexcept {}
         };
 
         template <>
-        struct extra_archive_data_id_helper<output_pointer_tracker>
+        struct extra_archive_data_helper<output_pointer_tracker>
         {
             HPX_CORE_EXPORT static void id() noexcept;
+            HPX_CORE_EXPORT static void reset(output_pointer_tracker* data);
         };
     }    // namespace detail
 

--- a/libs/core/serialization/src/detail/pointer.cpp
+++ b/libs/core/serialization/src/detail/pointer.cpp
@@ -21,12 +21,14 @@ namespace hpx { namespace serialization {
     namespace detail {
         // This is explicitly instantiated to ensure that the id is stable across
         // shared libraries.
-        void extra_archive_data_id_helper<input_pointer_tracker>::id() noexcept
-        {
-        }
+        void extra_archive_data_helper<input_pointer_tracker>::id() noexcept {}
 
-        void extra_archive_data_id_helper<output_pointer_tracker>::id() noexcept
+        void extra_archive_data_helper<output_pointer_tracker>::id() noexcept {}
+
+        void extra_archive_data_helper<output_pointer_tracker>::reset(
+            output_pointer_tracker* data)
         {
+            data->clear();
         }
     }    // namespace detail
 

--- a/libs/full/checkpoint_base/include/hpx/checkpoint_base/checkpoint_data.hpp
+++ b/libs/full/checkpoint_base/include/hpx/checkpoint_base/checkpoint_data.hpp
@@ -136,8 +136,9 @@ namespace hpx { namespace serialization { namespace detail {
     // This is explicitly instantiated to ensure that the id is stable across
     // shared libraries.
     template <>
-    struct extra_archive_data_id_helper<hpx::util::checkpointing_tag>
+    struct extra_archive_data_helper<hpx::util::checkpointing_tag>
     {
         HPX_EXPORT static void id() noexcept;
+        static constexpr void reset(hpx::util::checkpointing_tag*) noexcept {}
     };
 }}}    // namespace hpx::serialization::detail

--- a/libs/full/checkpoint_base/src/checkpoint_data.cpp
+++ b/libs/full/checkpoint_base/src/checkpoint_data.cpp
@@ -12,8 +12,7 @@ namespace hpx { namespace serialization { namespace detail {
 
     // This is explicitly instantiated to ensure that the id is stable across
     // shared libraries.
-    void
-    extra_archive_data_id_helper<hpx::util::checkpointing_tag>::id() noexcept
+    void extra_archive_data_helper<hpx::util::checkpointing_tag>::id() noexcept
     {
     }
 }}}    // namespace hpx::serialization::detail

--- a/libs/parallelism/lcos_local/include/hpx/lcos_local/detail/preprocess_future.hpp
+++ b/libs/parallelism/lcos_local/include/hpx/lcos_local/detail/preprocess_future.hpp
@@ -188,8 +188,9 @@ namespace hpx { namespace serialization { namespace detail {
     // This is explicitly instantiated to ensure that the id is stable across
     // shared libraries.
     template <>
-    struct extra_archive_data_id_helper<preprocess_futures>
+    struct extra_archive_data_helper<preprocess_futures>
     {
         HPX_PARALLELISM_EXPORT static void id() noexcept;
+        static constexpr void reset(preprocess_futures*) noexcept {}
     };
 }}}    // namespace hpx::serialization::detail

--- a/libs/parallelism/lcos_local/src/preprocess_future.cpp
+++ b/libs/parallelism/lcos_local/src/preprocess_future.cpp
@@ -13,8 +13,7 @@ namespace hpx { namespace serialization { namespace detail {
 
     // This is explicitly instantiated to ensure that the id is stable across
     // shared libraries.
-    void extra_archive_data_id_helper<preprocess_futures>::id() noexcept {}
-
+    void extra_archive_data_helper<preprocess_futures>::id() noexcept {}
 }}}    // namespace hpx::serialization::detail
 
 namespace hpx { namespace lcos { namespace detail {

--- a/src/runtime/serialization/detail/preprocess_gid_types.cpp
+++ b/src/runtime/serialization/detail/preprocess_gid_types.cpp
@@ -12,6 +12,5 @@ namespace hpx { namespace serialization { namespace detail {
 
     // This is explicitly instantiated to ensure that the id is stable across
     // shared libraries.
-    void extra_archive_data_id_helper<preprocess_gid_types>::id() noexcept {}
-
+    void extra_archive_data_helper<preprocess_gid_types>::id() noexcept {}
 }}}    // namespace hpx::serialization::detail


### PR DESCRIPTION
- This fixes an issue that is caused by not cleaning out the pointer
  tracking data in output archives during serialization preprocessing
  while repeatedly serializing the data because of futures not being
  ready
