### PR TITLE
Fixing broken backwards compatibility for hpx::parallel::fill

### DIFF
--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/fill.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/fill.hpp
@@ -221,7 +221,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format on
     HPX_DEPRECATED_V(
         1, 6, "hpx::parallel::fill is deprecated, use hpx::fill instead")
-        typename util::detail::algorithm_result<ExPolicy>::type
+        typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
         fill(ExPolicy&& policy, FwdIter first, FwdIter last, T const& value)
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),

--- a/libs/parallelism/algorithms/tests/regressions/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/regressions/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 set(tests
     count_3646
+    fill_executor_5016
     for_each_annotated_function
     for_loop_2281
     minimal_findend

--- a/libs/parallelism/algorithms/tests/regressions/fill_executor_5016.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/fill_executor_5016.cpp
@@ -1,0 +1,44 @@
+//  Copyright (c) 2020 Steven R. Brandt
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// #5016: hpx::parallel::fill fails compiling
+
+// suppress deprecation warnings for algorithms
+#define HPX_HAVE_DEPRECATION_WARNINGS_V1_6 0
+
+#include <hpx/hpx_main.hpp>
+
+#include <hpx/include/compute.hpp>
+#include <hpx/include/parallel_executors.hpp>
+#include <hpx/include/parallel_fill.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <vector>
+
+void fill_example()
+{
+    hpx::execution::parallel_executor exec;
+
+    std::vector<float> vd(5);
+    hpx::parallel::fill(
+        hpx::execution::par.on(exec), vd.begin(), vd.end(), 2.0f);
+
+    std::vector<float> vd1(5);
+    hpx::fill(hpx::execution::par.on(exec), vd1.begin(), vd1.end(), 2.0f);
+
+    std::vector<float> expected(5);
+    std::fill(expected.begin(), expected.end(), 2.0f);
+
+    HPX_TEST(vd == expected);
+    HPX_TEST(vd1 == expected);
+}
+
+int main()
+{
+    fill_example();
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Fixes #5016

@stevenrbrandt please verify whether this fixes your issue.

Please note that `hpx::parallel::fill` was deprecated and will be removed in the future, use `hpx::fill` instead (which also is not affected by this issue).

