### PR TITLE
Lessen constraints on certain algorithm arguments

### DIFF
--- a/libs/core/iterator_support/include/hpx/iterator_support/traits/is_iterator.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/traits/is_iterator.hpp
@@ -392,9 +392,11 @@ namespace hpx { namespace traits {
     template <typename Iter, typename Enable = void>
     struct is_output_iterator
       : std::integral_constant<bool,
-            detail::has_category<typename std::decay<Iter>::type,
+            detail::belongs_to_iterator_category<
+                typename std::decay<Iter>::type,
                 std::output_iterator_tag>::value ||
-                detail::has_traversal<typename std::decay<Iter>::type,
+                detail::belongs_to_iterator_traversal<
+                    typename std::decay<Iter>::type,
                     boost::incrementable_traversal_tag>::value>
     {
     };

--- a/libs/core/iterator_support/tests/unit/iterator_tests.hpp
+++ b/libs/core/iterator_support/tests/unit/iterator_tests.hpp
@@ -173,7 +173,7 @@ namespace tests {
 
         // I think we don't really need this as it checks the same things as
         // the above code.
-        HPX_TEST(!hpx::traits::is_output_iterator<Iterator>::value);
+        HPX_TEST(hpx::traits::is_input_iterator<Iterator>::value);
     }
 
     template <typename Iterator, typename T>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -696,8 +696,10 @@ namespace hpx {
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
                 "Required at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
-                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value ||
+                    (hpx::is_sequenced_execution_policy<ExPolicy>::value &&
+                        hpx::traits::is_output_iterator<FwdIter2>::value),
+                "Requires at least forward iterator or sequential execution.");
 
             // if count is representing a negative value, we do nothing
             if (hpx::parallel::v1::detail::is_negative(count))
@@ -727,8 +729,8 @@ namespace hpx {
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
                 "Required at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_output_iterator<FwdIter2>::value),
+                "Requires at least output iterator.");
 
             // if count is representing a negative value, we do nothing
             if (hpx::parallel::v1::detail::is_negative(count))
@@ -771,8 +773,10 @@ namespace hpx {
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
                 "Required at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
-                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value ||
+                    (hpx::is_sequenced_execution_policy<ExPolicy>::value &&
+                        hpx::traits::is_output_iterator<FwdIter2>::value),
+                "Requires at least forward iterator or sequential execution.");
 
             using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 
@@ -799,8 +803,8 @@ namespace hpx {
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
                 "Required at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_output_iterator<FwdIter2>::value),
+                "Requires at least output iterator.");
 
             return hpx::parallel::util::get_second_element(
                 hpx::parallel::v1::detail::copy_if<

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/transfer.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/transfer.hpp
@@ -127,8 +127,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
                 "Required at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
-                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value ||
+                    (hpx::is_sequenced_execution_policy<ExPolicy>::value &&
+                        hpx::traits::is_output_iterator<FwdIter2>::value),
+                "Requires at least forward iterator or sequential execution.");
 
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             return transfer_<Algo>(std::forward<ExPolicy>(policy), first, last,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
@@ -335,8 +335,10 @@ namespace hpx {
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
-                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter3>::value ||
+                    (hpx::is_sequenced_execution_policy<ExPolicy>::value &&
+                        hpx::traits::is_output_iterator<FwdIter3>::value),
+                "Requires at least forward iterator or sequential execution.");
 
             using is_seq = std::integral_constant<bool,
                 hpx::is_sequenced_execution_policy<ExPolicy>::value ||
@@ -375,8 +377,8 @@ namespace hpx {
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_output_iterator<FwdIter3>::value),
+                "Requires at least output iterator.");
 
             using result_type =
                 hpx::parallel::util::in_out_result<FwdIter1, FwdIter3>;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_intersection.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_intersection.hpp
@@ -313,8 +313,10 @@ namespace hpx {
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
-                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter3>::value ||
+                    (hpx::is_sequenced_execution_policy<ExPolicy>::value &&
+                        hpx::traits::is_output_iterator<FwdIter3>::value),
+                "Requires at least forward iterator or sequential execution.");
 
             using is_seq = std::integral_constant<bool,
                 hpx::is_sequenced_execution_policy<ExPolicy>::value ||
@@ -353,8 +355,8 @@ namespace hpx {
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_output_iterator<FwdIter3>::value),
+                "Requires at least output iterator.");
 
             using result_type = hpx::parallel::util::in_in_out_result<FwdIter1,
                 FwdIter2, FwdIter3>;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
@@ -350,8 +350,10 @@ namespace hpx {
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
-                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter3>::value ||
+                    (hpx::is_sequenced_execution_policy<ExPolicy>::value &&
+                        hpx::traits::is_output_iterator<FwdIter3>::value),
+                "Requires at least forward iterator or sequential execution.");
 
             using is_seq = std::integral_constant<bool,
                 hpx::is_sequenced_execution_policy<ExPolicy>::value ||
@@ -391,8 +393,8 @@ namespace hpx {
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_output_iterator<FwdIter3>::value),
+                "Requires at least output iterator.");
 
             using result_type = hpx::parallel::util::in_in_out_result<FwdIter1,
                 FwdIter2, FwdIter3>;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_union.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_union.hpp
@@ -337,8 +337,10 @@ namespace hpx {
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
-                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter3>::value ||
+                    (hpx::is_sequenced_execution_policy<ExPolicy>::value &&
+                        hpx::traits::is_output_iterator<FwdIter3>::value),
+                "Requires at least forward iterator or sequential execution.");
 
             using is_seq = std::integral_constant<bool,
                 hpx::is_sequenced_execution_policy<ExPolicy>::value ||
@@ -376,8 +378,8 @@ namespace hpx {
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_output_iterator<FwdIter3>::value),
+                "Requires at least output iterator.");
 
             using result_type = hpx::parallel::util::in_in_out_result<FwdIter1,
                 FwdIter3, FwdIter3>;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
@@ -304,7 +304,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     typename std::iterator_traits<Iter>::value_type;
 
                 return detail::accumulate(first, last, std::forward<T_>(init),
-                    [&r, &conv](T const& res, value_type const& next) -> T {
+                    [&r, &conv](T const& res, value_type&& next) -> T {
                         return hpx::util::invoke(
                             r, res, hpx::util::invoke(conv, next));
                     });
@@ -493,7 +493,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 // this is to support vectorization, it will call op1 for each
                 // of the elements of a value-pack
                 auto result = util::detail::accumulate_values<ExPolicy>(
-                    [&op1](T const& sum, T const& val) -> T {
+                    [&op1](T const& sum, T&& val) -> T {
                         return hpx::util::invoke(op1, sum, val);
                     },
                     std::move(part_sum), std::move(init));
@@ -569,7 +569,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     // this is to support vectorization, it will call op1
                     // for each of the elements of a value-pack
                     auto result = util::detail::accumulate_values<ExPolicy>(
-                        [&op1](T const& sum, T const& val) -> T {
+                        [&op1](T const& sum, T&& val) -> T {
                             return hpx::util::invoke(op1, sum, val);
                         },
                         part_sum);

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
@@ -304,7 +304,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     typename std::iterator_traits<Iter>::value_type;
 
                 return detail::accumulate(first, last, std::forward<T_>(init),
-                    [&r, &conv](T const& res, value_type&& next) -> T {
+                    [&r, &conv](T const& res, value_type const& next) -> T {
                         return hpx::util::invoke(
                             r, res, hpx::util::invoke(conv, next));
                     });

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/all_any_none.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/all_any_none.hpp
@@ -267,9 +267,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename Rng, typename F,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<ExPolicy>::value&&
-            hpx::traits::is_range<Rng>::value&&
-            traits::is_projected_range<Proj, Rng>::value&&
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value &&
+            traits::is_projected_range<Proj, Rng>::value &&
             traits::is_indirect_callable<ExPolicy, F,
                 traits::projected_range<Proj, Rng>
             >::value
@@ -291,9 +291,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename Rng, typename F,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<ExPolicy>::value&&
-            hpx::traits::is_range<Rng>::value&&
-            traits::is_projected_range<Proj, Rng>::value&&
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value &&
+            traits::is_projected_range<Proj, Rng>::value &&
             traits::is_indirect_callable<ExPolicy, F,
                 traits::projected_range<Proj, Rng>
             >::value
@@ -430,9 +430,9 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Rng, typename F,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&&
-                hpx::parallel::traits::is_projected_range<Proj, Rng>::value&&
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
                     hpx::parallel::traits::projected_range<Proj, Rng>
                 >::value
@@ -458,10 +458,10 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Iter, typename Sent, typename F,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<Iter>::value&&
-                hpx::traits::is_sentinel_for<Sent, Iter>::value&&
-                hpx::parallel::traits::is_projected<Proj, Iter>::value&&
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<Iter>::value &&
+                hpx::traits::is_sentinel_for<Sent, Iter>::value &&
+                hpx::parallel::traits::is_projected<Proj, Iter>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
                     hpx::parallel::traits::projected<Proj, Iter>
                 >::value
@@ -507,9 +507,9 @@ namespace hpx { namespace ranges {
         template <typename Iter, typename Sent, typename F,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<Iter>::value&&
-                hpx::traits::is_sentinel_for<Sent, Iter>::value&&
-                hpx::parallel::traits::is_projected<Proj, Iter>::value&&
+                hpx::traits::is_iterator<Iter>::value &&
+                hpx::traits::is_sentinel_for<Sent, Iter>::value &&
+                hpx::parallel::traits::is_projected<Proj, Iter>::value &&
                 hpx::parallel::traits::is_indirect_callable<
                 hpx::execution::sequenced_policy, F,
                     hpx::parallel::traits::projected<Proj, Iter>
@@ -537,9 +537,9 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Rng, typename F,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&&
-                hpx::parallel::traits::is_projected_range<Proj, Rng>::value&&
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
                     hpx::parallel::traits::projected_range<Proj, Rng>
                 >::value
@@ -565,10 +565,10 @@ namespace hpx { namespace ranges {
         template <typename ExPolicy, typename Iter, typename Sent, typename F,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<Iter>::value&&
-                hpx::traits::is_sentinel_for<Sent, Iter>::value&&
-                hpx::parallel::traits::is_projected<Proj, Iter>::value&&
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<Iter>::value &&
+                hpx::traits::is_sentinel_for<Sent, Iter>::value &&
+                hpx::parallel::traits::is_projected<Proj, Iter>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
                     hpx::parallel::traits::projected<Proj, Iter>
                 >::value
@@ -590,8 +590,8 @@ namespace hpx { namespace ranges {
         template <typename Rng, typename F,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_range<Rng>::value&&
-                hpx::parallel::traits::is_projected_range<Proj, Rng>::value&&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
                 hpx::parallel::traits::is_indirect_callable<
                 hpx::execution::sequenced_policy, F,
                     hpx::parallel::traits::projected_range<Proj, Rng>
@@ -614,9 +614,9 @@ namespace hpx { namespace ranges {
         template <typename Iter, typename Sent, typename F,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<Iter>::value&&
-                hpx::traits::is_sentinel_for<Sent, Iter>::value&&
-                hpx::parallel::traits::is_projected<Proj, Iter>::value&&
+                hpx::traits::is_iterator<Iter>::value &&
+                hpx::traits::is_sentinel_for<Sent, Iter>::value &&
+                hpx::parallel::traits::is_projected<Proj, Iter>::value &&
                 hpx::parallel::traits::is_indirect_callable<
                 hpx::execution::sequenced_policy, F,
                     hpx::parallel::traits::projected<Proj, Iter>

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/copy.hpp
@@ -430,8 +430,8 @@ namespace hpx { namespace ranges {
         // clang-format off
         template <typename FwdIter1, typename Sent1, typename FwdIter,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<FwdIter1>::value&&
-                hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value&&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
@@ -448,7 +448,7 @@ namespace hpx { namespace ranges {
         // clang-format off
         template <typename Rng, typename FwdIter,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_range<Rng>::value&&
+                hpx::traits::is_range<Rng>::value &&
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
@@ -487,8 +487,9 @@ namespace hpx { namespace ranges {
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
                 "Required at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
-                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value ||
+                    hpx::is_sequenced_execution_policy<ExPolicy>::value,
+                "Requires at least forward iterator or sequential execution.");
 
             // if count is representing a negative value, we do nothing
             if (hpx::parallel::v1::detail::is_negative(count))
@@ -518,8 +519,8 @@ namespace hpx { namespace ranges {
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
                 "Required at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_output_iterator<FwdIter2>::value),
+                "Requires at least output iterator.");
 
             // if count is representing a negative value, we do nothing
             if (hpx::parallel::v1::detail::is_negative(count))
@@ -564,8 +565,10 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
                 "Required at least forward iterator.");
 
-            static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
-                "Required at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value ||
+                    (hpx::is_sequenced_execution_policy<ExPolicy>::value &&
+                        hpx::traits::is_output_iterator<FwdIter>::value),
+                "Requires at least forward iterator or sequential execution.");
 
             using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 
@@ -596,8 +599,10 @@ namespace hpx { namespace ranges {
         tag_invoke(hpx::ranges::copy_if_t, ExPolicy&& policy, Rng&& rng,
             FwdIter dest, Pred&& pred, Proj&& proj = Proj())
         {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
-                "Required at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter>::value ||
+                    (hpx::is_sequenced_execution_policy<ExPolicy>::value &&
+                        hpx::traits::is_output_iterator<FwdIter>::value),
+                "Requires at least forward iterator or sequential execution.");
 
             using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 
@@ -632,8 +637,8 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
                 "Required at least forward iterator.");
 
-            static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
-                "Required at least forward iterator.");
+            static_assert((hpx::traits::is_output_iterator<FwdIter>::value),
+                "Required at least output iterator.");
 
             return hpx::parallel::v1::detail::copy_if<
                 hpx::parallel::util::in_out_result<FwdIter1, FwdIter>>()
@@ -659,8 +664,8 @@ namespace hpx { namespace ranges {
         tag_invoke(hpx::ranges::copy_if_t, Rng&& rng, FwdIter dest, Pred&& pred,
             Proj&& proj = Proj())
         {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
-                "Required at least forward iterator.");
+            static_assert((hpx::traits::is_output_iterator<FwdIter>::value),
+                "Required at least output iterator.");
 
             return hpx::parallel::v1::detail::copy_if<
                 hpx::parallel::util::in_out_result<
@@ -681,9 +686,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename FwdIter1, typename Sent1,
         typename FwdIter,
         HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<ExPolicy>::value&&
-            hpx::traits::is_iterator<FwdIter1>::value&&
-            hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value&&
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<FwdIter1>::value &&
+            hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
             hpx::traits::is_iterator<FwdIter>::value
         )>
     // clang-format on
@@ -708,8 +713,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang-format off
     template <typename ExPolicy, typename Rng, typename FwdIter,
         HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<ExPolicy>::value&&
-            hpx::traits::is_range<Rng>::value&&
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value &&
             hpx::traits::is_iterator<FwdIter>::value
         )>
     // clang-format on
@@ -738,10 +743,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
     template <typename ExPolicy, typename Rng, typename OutIter, typename F,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<ExPolicy>::value&&
-            hpx::traits::is_range<Rng>::value&&
-            traits::is_projected_range<Proj, Rng>::value&&
-            hpx::traits::is_iterator<OutIter>::value&&
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value &&
+            traits::is_projected_range<Proj, Rng>::value &&
+            hpx::traits::is_iterator<OutIter>::value &&
             traits::is_indirect_callable<ExPolicy, F,
                 traits::projected_range<Proj, Rng>
             >::value

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_difference.hpp
@@ -299,8 +299,10 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<Iter3>::value ||
+                    (hpx::is_sequenced_execution_policy<ExPolicy>::value &&
+                        hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least forward iterator or sequential execution.");
 
             using is_seq = std::integral_constant<bool,
                 hpx::is_sequenced_execution_policy<ExPolicy>::value ||
@@ -351,8 +353,10 @@ namespace hpx { namespace ranges {
             static_assert(
                 (hpx::traits::is_forward_iterator<iterator_type2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<Iter3>::value ||
+                    (hpx::is_sequenced_execution_policy<ExPolicy>::value &&
+                        hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least forward iterator or sequential execution.");
 
             using is_seq = std::integral_constant<bool,
                 hpx::is_sequenced_execution_policy<ExPolicy>::value ||
@@ -398,8 +402,8 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least output iterator.");
 
             using result_type = set_difference_result<Iter1, Iter3>;
 
@@ -444,8 +448,8 @@ namespace hpx { namespace ranges {
             static_assert(
                 (hpx::traits::is_forward_iterator<iterator_type2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least output iterator.");
 
             using result_type = set_difference_result<iterator_type1, Iter3>;
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_intersection.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_intersection.hpp
@@ -300,8 +300,10 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<Iter3>::value ||
+                    (hpx::is_sequenced_execution_policy<ExPolicy>::value &&
+                        hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least forward iterator or sequential execution.");
 
             using is_seq = std::integral_constant<bool,
                 hpx::is_sequenced_execution_policy<ExPolicy>::value ||
@@ -353,8 +355,10 @@ namespace hpx { namespace ranges {
             static_assert(
                 (hpx::traits::is_forward_iterator<iterator_type2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<Iter3>::value ||
+                    (hpx::is_sequenced_execution_policy<ExPolicy>::value &&
+                        hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least forward iterator or sequential execution.");
 
             using is_seq = std::integral_constant<bool,
                 hpx::is_sequenced_execution_policy<ExPolicy>::value ||
@@ -401,8 +405,8 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least output iterator.");
 
             using result_type = set_intersection_result<Iter1, Iter2, Iter3>;
 
@@ -448,8 +452,8 @@ namespace hpx { namespace ranges {
             static_assert(
                 (hpx::traits::is_forward_iterator<iterator_type2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least output iterator.");
 
             using result_type =
                 set_intersection_result<iterator_type1, iterator_type2, Iter3>;

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_symmetric_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_symmetric_difference.hpp
@@ -308,8 +308,10 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<Iter3>::value ||
+                    (hpx::is_sequenced_execution_policy<ExPolicy>::value &&
+                        hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least forward iterator or sequential execution.");
 
             using is_seq = std::integral_constant<bool,
                 hpx::is_sequenced_execution_policy<ExPolicy>::value ||
@@ -363,8 +365,10 @@ namespace hpx { namespace ranges {
             static_assert(
                 (hpx::traits::is_forward_iterator<iterator_type2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<Iter3>::value ||
+                    (hpx::is_sequenced_execution_policy<ExPolicy>::value &&
+                        hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least forward iterator or sequential execution.");
 
             using is_seq = std::integral_constant<bool,
                 hpx::is_sequenced_execution_policy<ExPolicy>::value ||
@@ -412,8 +416,8 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least output iterator.");
 
             using result_type =
                 set_symmetric_difference_result<Iter1, Iter2, Iter3>;
@@ -461,8 +465,8 @@ namespace hpx { namespace ranges {
             static_assert(
                 (hpx::traits::is_forward_iterator<iterator_type2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least output iterator.");
 
             using result_type = set_symmetric_difference_result<iterator_type1,
                 iterator_type2, Iter3>;

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_union.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_union.hpp
@@ -299,8 +299,10 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<Iter3>::value ||
+                    (hpx::is_sequenced_execution_policy<ExPolicy>::value &&
+                        hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least forward iterator or sequential execution.");
 
             using is_seq = std::integral_constant<bool,
                 hpx::is_sequenced_execution_policy<ExPolicy>::value ||
@@ -351,8 +353,10 @@ namespace hpx { namespace ranges {
             static_assert(
                 (hpx::traits::is_forward_iterator<iterator_type2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<Iter3>::value ||
+                    (hpx::is_sequenced_execution_policy<ExPolicy>::value &&
+                        hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least forward iterator or sequential execution.");
 
             using is_seq = std::integral_constant<bool,
                 hpx::is_sequenced_execution_policy<ExPolicy>::value ||
@@ -399,8 +403,8 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least output iterator.");
 
             using result_type = set_union_result<Iter1, Iter2, Iter3>;
 
@@ -446,8 +450,8 @@ namespace hpx { namespace ranges {
             static_assert(
                 (hpx::traits::is_forward_iterator<iterator_type2>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least output iterator.");
 
             using result_type =
                 set_union_result<iterator_type1, iterator_type2, Iter3>;

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_reduce.hpp
@@ -502,10 +502,10 @@ namespace hpx { namespace ranges {
         template <typename Rng, typename T, typename Reduce, typename Convert,
             HPX_CONCEPT_REQUIRES_(
                 hpx::traits::is_range<Rng>::value &&
-                hpx::traits::is_invocable<Convert,
+                hpx::is_invocable_v<Convert,
                     typename hpx::traits::range_traits<Rng>::value_type
-                >::value &&
-                hpx::traits::is_invocable<Reduce,
+                > &&
+                hpx::is_invocable_v<Reduce,
                     typename hpx::util::invoke_result<Convert,
                         typename hpx::traits::range_traits<Rng>::value_type
                     >::type,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_reduce.hpp
@@ -464,14 +464,14 @@ namespace hpx { namespace ranges {
                 hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value &&
                 hpx::is_invocable_v<Convert,
-                    typename hpx::traits::range_iterator<Rng>::type
+                    typename hpx::traits::range_traits<Rng>::value_type
                 > &&
                 hpx::is_invocable_v<Reduce,
                     typename hpx::util::invoke_result<Convert,
-                        typename hpx::traits::range_iterator<Rng>::type
+                        typename hpx::traits::range_traits<Rng>::value_type
                     >::type,
                     typename hpx::util::invoke_result<Convert,
-                        typename hpx::traits::range_iterator<Rng>::type
+                        typename hpx::traits::range_traits<Rng>::value_type
                     >::type
                 >
             )>
@@ -502,15 +502,16 @@ namespace hpx { namespace ranges {
         template <typename Rng, typename T, typename Reduce, typename Convert,
             HPX_CONCEPT_REQUIRES_(
                 hpx::traits::is_range<Rng>::value &&
-                hpx::is_invocable_v<Convert,
-                   typename hpx::traits::range_iterator<Rng>::type> &&
-                hpx::is_invocable_v<Reduce,
-                   typename hpx::util::invoke_result<Convert,
-                       typename hpx::traits::range_iterator<Rng>::type
-                   >::type,
-                   typename hpx::util::invoke_result<Convert,
-                       typename hpx::traits::range_iterator<Rng>::type
-                   >::type
+                hpx::traits::is_invocable<Convert,
+                    typename hpx::traits::range_traits<Rng>::value_type
+                >::value &&
+                hpx::traits::is_invocable<Reduce,
+                    typename hpx::util::invoke_result<Convert,
+                        typename hpx::traits::range_traits<Rng>::value_type
+                    >::type,
+                    typename hpx::util::invoke_result<Convert,
+                        typename hpx::traits::range_traits<Rng>::value_type
+                    >::type
                 >
             )>
         // clang-format on
@@ -586,16 +587,16 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_range<Rng>::value &&
                 hpx::traits::is_iterator<Iter2>::value &&
                 hpx::is_invocable_v<Convert,
-                    typename hpx::traits::range_iterator<Rng>::type,
+                    typename hpx::traits::range_traits<Rng>::value_type,
                     typename std::iterator_traits<Iter2>::value_type
                 > &&
                 hpx::is_invocable_v<Reduce,
                     typename hpx::util::invoke_result<Convert,
-                        typename hpx::traits::range_iterator<Rng>::type,
+                        typename hpx::traits::range_traits<Rng>::value_type,
                         typename std::iterator_traits<Iter2>::value_type
                     >::type,
                     typename hpx::util::invoke_result<Convert,
-                        typename hpx::traits::range_iterator<Rng>::type,
+                        typename hpx::traits::range_traits<Rng>::value_type,
                         typename std::iterator_traits<Iter2>::value_type
                     >::type
                 >
@@ -625,16 +626,16 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_range<Rng>::value &&
                 hpx::traits::is_iterator<Iter2>::value &&
                 hpx::is_invocable_v<Convert,
-                    typename hpx::traits::range_iterator<Rng>::type,
+                    typename hpx::traits::range_traits<Rng>::value_type,
                     typename std::iterator_traits<Iter2>::value_type
                 > &&
                 hpx::is_invocable_v<Reduce,
                     typename hpx::util::invoke_result<Convert,
-                        typename hpx::traits::range_iterator<Rng>::type,
+                        typename hpx::traits::range_traits<Rng>::value_type,
                         typename std::iterator_traits<Iter2>::value_type
                     >::type,
                     typename hpx::util::invoke_result<Convert,
-                        typename hpx::traits::range_iterator<Rng>::type,
+                        typename hpx::traits::range_traits<Rng>::value_typee,
                         typename std::iterator_traits<Iter2>::value_type
                     >::type
                 >


### PR DESCRIPTION
- some sequential algorithms (copy, etc.) are fully functional if - when used sequentially - the destination is just an output iterator
- fixing is_output_iterator
- fixing `transform_reduce` implementation to properly handle constant input sequences
- flyby: minor formatting changes
