### PR TITLE
Use versioned container image on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,8 +153,8 @@ jobs:
           name: Check that the modules are well clang-formatted
           command: |
               cd /hpx/source/libs && shopt -s globstar # to activate the ** globbing
-              clang-format --version
-              clang-format -i **/*.{cpp,hpp}
+              clang-format-9 --version
+              clang-format-9 -i **/*.{cpp,hpp}
               git diff --exit-code > /tmp/modified_clang_format_files.txt
       - store_artifacts:
           path: /tmp/modified_clang_format_files.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@
 defaults: &defaults
     working_directory: /hpx/build
     docker:
-      - image: stellargroup/build_env:ubuntu
+      - image: stellargroup/build_env:1
 
 convert_xml: &convert_xml
     name: Converting XML
@@ -74,7 +74,7 @@ version: 2
 jobs:
   checkout_code:
     docker:
-      - image: stellargroup/build_env:ubuntu
+      - image: stellargroup/build_env:1
     working_directory: /hpx
     steps:
       - checkout:
@@ -473,7 +473,7 @@ jobs:
 
   install:
     docker:
-      - image: stellargroup/build_env:ubuntu
+      - image: stellargroup/build_env:1
     environment:
       TARGET_IMAGE_NAME: stellargroup/hpx:dev
     steps:
@@ -545,7 +545,7 @@ jobs:
   # here again to be able to push the new tag.
   push_stable_tag:
     docker:
-      - image: stellargroup/build_env:ubuntu
+      - image: stellargroup/build_env:1
     steps:
       - checkout:
           path: /hpx/source

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -491,8 +491,6 @@ jobs:
           name: Testing build unit tests
           command: |
               ninja -j2 tests.unit.build
-              ulimit -c unlimited
-              ctest --timeout 60 -T test --no-compress-output --output-on-failure -R tests.unit.build
           working_directory: /hpx/build
           when: always
       - run:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -460,11 +460,31 @@ if(NOT HPX_WITH_TESTS)
     VALUE OFF
     FORCE
   )
-  hpx_set_option(HPX_WITH_TESTS_REGRESSIONS VALUE OFF FORCE)
-  hpx_set_option(HPX_WITH_TESTS_UNIT VALUE OFF FORCE)
-  hpx_set_option(HPX_WITH_TESTS_HEADERS VALUE OFF FORCE)
-  hpx_set_option(HPX_WITH_TESTS_EXTERNAL_BUILD VALUE OFF FORCE)
-  hpx_set_option(HPX_WITH_TESTS_EXAMPLES VALUE OFF FORCE)
+  hpx_set_option(
+    HPX_WITH_TESTS_REGRESSIONS
+    VALUE OFF
+    FORCE
+  )
+  hpx_set_option(
+    HPX_WITH_TESTS_UNIT
+    VALUE OFF
+    FORCE
+  )
+  hpx_set_option(
+    HPX_WITH_TESTS_HEADERS
+    VALUE OFF
+    FORCE
+  )
+  hpx_set_option(
+    HPX_WITH_TESTS_EXTERNAL_BUILD
+    VALUE OFF
+    FORCE
+  )
+  hpx_set_option(
+    HPX_WITH_TESTS_EXAMPLES
+    VALUE OFF
+    FORCE
+  )
 endif()
 
 hpx_option(
@@ -472,7 +492,8 @@ hpx_option(
   BOOL
   "Enable the distributed runtime (default: ON). Turning off the distributed runtime completely disallows the creation and use of components and actions. Turning this option off is experimental!"
   ON
-  CATEGORY "Build Targets" ADVANCED
+  CATEGORY "Build Targets"
+  ADVANCED
 )
 
 if(HPX_WITH_DISTRIBUTED_RUNTIME)
@@ -695,7 +716,8 @@ hpx_option(
   STRING
   "HPX applications will not use more that this number of OS-Threads (empty string means dynamic) (default: ${HPX_MAX_CPU_COUNT_DEFAULT})"
   "${HPX_MAX_CPU_COUNT_DEFAULT}"
-  CATEGORY "Thread Manager" ADVANCED
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 if(HPX_WITH_MAX_CPU_COUNT)
   hpx_add_config_define(HPX_HAVE_MAX_CPU_COUNT ${HPX_WITH_MAX_CPU_COUNT})
@@ -710,7 +732,8 @@ hpx_option(
   STRING
   "HPX applications will not run on machines with more NUMA domains (default: ${HPX_MAX_NUMA_DOMAIN_COUNT_DEFAULT})"
   ${HPX_MAX_NUMA_DOMAIN_COUNT_DEFAULT}
-  CATEGORY "Thread Manager" ADVANCED
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 hpx_add_config_define(
   HPX_HAVE_MAX_NUMA_DOMAIN_COUNT ${HPX_WITH_MAX_NUMA_DOMAIN_COUNT}
@@ -722,7 +745,8 @@ hpx_option(
   BOOL
   "HPX applications will be able to run on more than 64 cores (This variable is deprecated. The value is derived from HPX_WITH_MAX_CPU_COUNT instead.)"
   ""
-  CATEGORY "Thread Manager" ADVANCED
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 if(HPX_WITH_MORE_THAN_64_THREADS)
   hpx_warn(
@@ -732,24 +756,30 @@ endif()
 hpx_option(
   HPX_WITH_THREAD_STACK_MMAP BOOL
   "Use mmap for stack allocation on appropriate platforms" ON
-  CATEGORY "Thread Manager" ADVANCED
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 
 hpx_option(
   HPX_WITH_THREAD_MANAGER_IDLE_BACKOFF BOOL
   "HPX scheduler threads do exponential backoff on idle queues (default: ON)" ON
-  CATEGORY "Thread Manager" ADVANCED
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 
 hpx_option(
   HPX_WITH_STACKTRACES BOOL "Attach backtraces to HPX exceptions (default: ON)"
-  ON CATEGORY "Thread Manager" ADVANCED
+  ON
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 
 hpx_option(
   HPX_WITH_THREAD_BACKTRACE_ON_SUSPENSION BOOL
   "Enable thread stack back trace being captured on suspension (default: OFF)"
-  OFF CATEGORY "Thread Manager" ADVANCED
+  OFF
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 
 # We create a target to contain libraries like rt, dl etc. in order to remove
@@ -770,7 +800,8 @@ if(HPX_WITH_STACKTRACES OR HPX_WITH_THREAD_BACKTRACE_ON_SUSPENSION)
   hpx_option(
     HPX_WITH_THREAD_BACKTRACE_DEPTH STRING
     "Thread stack back trace depth being captured (default: 20)" "20"
-    CATEGORY "Thread Manager" ADVANCED
+    CATEGORY "Thread Manager"
+    ADVANCED
   )
   hpx_add_config_define(
     HPX_HAVE_THREAD_BACKTRACE_DEPTH ${HPX_WITH_THREAD_BACKTRACE_DEPTH}
@@ -786,7 +817,8 @@ if(HPX_WITH_STACKTRACES OR HPX_WITH_THREAD_BACKTRACE_ON_SUSPENSION)
     hpx_option(
       HPX_WITH_STACKTRACES_STATIC_SYMBOLS BOOL
       "Thread stack back trace will resolve static symbols (default: OFF)" OFF
-      CATEGORY "Thread Manager" ADVANCED
+      CATEGORY "Thread Manager"
+      ADVANCED
     )
     hpx_add_config_define(
       HPX_HAVE_STACKTRACES_STATIC_SYMBOLS
@@ -797,7 +829,8 @@ if(HPX_WITH_STACKTRACES OR HPX_WITH_THREAD_BACKTRACE_ON_SUSPENSION)
     hpx_option(
       HPX_WITH_STACKTRACES_DEMANGLE_SYMBOLS BOOL
       "Thread stack back trace symbols will be demangled (default: ON)" ON
-      CATEGORY "Thread Manager" ADVANCED
+      CATEGORY "Thread Manager"
+      ADVANCED
     )
     if(HPX_WITH_STACKTRACES_DEMANGLE_SYMBOLS)
       hpx_add_config_define(HPX_HAVE_STACKTRACES_DEMANGLE_SYMBOLS)
@@ -811,7 +844,9 @@ if(HPX_WITH_THREAD_BACKTRACE_ON_SUSPENSION)
   hpx_option(
     HPX_WITH_THREAD_FULLBACKTRACE_ON_SUSPENSION BOOL
     "Enable thread stack back trace being captured on suspension (default: OFF)"
-    OFF CATEGORY "Thread Manager" ADVANCED
+    OFF
+    CATEGORY "Thread Manager"
+    ADVANCED
   )
   if(HPX_WITH_THREAD_FULLBACKTRACE_ON_SUSPENSION)
     hpx_add_config_define(HPX_HAVE_THREAD_FULLBACKTRACE_ON_SUSPENSION)
@@ -821,7 +856,9 @@ endif()
 hpx_option(
   HPX_WITH_THREAD_TARGET_ADDRESS BOOL
   "Enable storing target address in thread for NUMA awareness (default: OFF)"
-  OFF CATEGORY "Thread Manager" ADVANCED
+  OFF
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 
 if(HPX_WITH_THREAD_TARGET_ADDRESS)
@@ -831,7 +868,8 @@ endif()
 hpx_option(
   HPX_WITH_THREAD_QUEUE_WAITTIME BOOL
   "Enable collecting queue wait times for threads (default: OFF)" OFF
-  CATEGORY "Thread Manager" ADVANCED
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 
 if(HPX_WITH_THREAD_QUEUE_WAITTIME)
@@ -843,13 +881,15 @@ hpx_option(
   BOOL
   "Enable measuring the percentage of overhead times spent in the scheduler (default: OFF)"
   OFF
-  CATEGORY "Thread Manager" ADVANCED
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 
 hpx_option(
   HPX_WITH_THREAD_CREATION_AND_CLEANUP_RATES BOOL
   "Enable measuring thread creation and cleanup times (default: OFF)" OFF
-  CATEGORY "Thread Manager" ADVANCED
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 
 if(HPX_WITH_THREAD_IDLE_RATES)
@@ -864,7 +904,8 @@ hpx_option(
   BOOL
   "Enable keeping track of cumulative thread counts in the schedulers (default: ON)"
   ON
-  CATEGORY "Thread Manager" ADVANCED
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 
 if(HPX_WITH_THREAD_CUMULATIVE_COUNTS)
@@ -876,7 +917,8 @@ hpx_option(
   BOOL
   "Enable keeping track of counts of thread stealing incidents in the schedulers (default: OFF)"
   OFF
-  CATEGORY "Thread Manager" ADVANCED
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 
 if(HPX_WITH_THREAD_STEALING_COUNTS)
@@ -886,7 +928,9 @@ endif()
 hpx_option(
   HPX_WITH_COROUTINE_COUNTERS BOOL
   "Enable keeping track of coroutine creation and rebind counts (default: OFF)"
-  OFF CATEGORY "Thread Manager" ADVANCED
+  OFF
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 if(HPX_WITH_COROUTINE_COUNTERS)
   hpx_add_config_define(HPX_HAVE_COROUTINE_COUNTERS)
@@ -895,7 +939,8 @@ endif()
 hpx_option(
   HPX_WITH_THREAD_LOCAL_STORAGE BOOL
   "Enable thread local storage for all HPX threads (default: OFF)" OFF
-  CATEGORY "Thread Manager" ADVANCED
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 
 if(HPX_WITH_THREAD_LOCAL_STORAGE)
@@ -905,7 +950,8 @@ endif()
 hpx_option(
   HPX_WITH_SCHEDULER_LOCAL_STORAGE BOOL
   "Enable scheduler local storage for all HPX schedulers (default: OFF)" OFF
-  CATEGORY "Thread Manager" ADVANCED
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 
 if(HPX_WITH_SCHEDULER_LOCAL_STORAGE)
@@ -915,7 +961,8 @@ endif()
 hpx_option(
   HPX_WITH_SPINLOCK_POOL_NUM STRING
   "Number of elements a spinlock pool manages (default: 128)" 128
-  CATEGORY "Thread Manager" ADVANCED
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 
 hpx_add_config_define(HPX_HAVE_SPINLOCK_POOL_NUM ${HPX_WITH_SPINLOCK_POOL_NUM})
@@ -926,7 +973,8 @@ hpx_option(
   STRING
   "[Deprecated] Maximum number of terminated threads collected before those are cleaned up (default: 100)"
   "0"
-  CATEGORY "Thread Manager" ADVANCED
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 
 if(HPX_SCHEDULER_MAX_TERMINATED_THREADS GREATER 0)
@@ -942,7 +990,8 @@ endif()
 hpx_option(
   HPX_WITH_SPINLOCK_DEADLOCK_DETECTION BOOL
   "Enable spinlock deadlock detection (default: OFF)" OFF
-  CATEGORY "Thread Manager" ADVANCED
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 
 if(HPX_WITH_SPINLOCK_DEADLOCK_DETECTION)
@@ -1057,7 +1106,8 @@ hpx_option(
   STRING
   "Which thread schedulers are built. Options are: all, abp-priority, local, static-priority, static, shared-priority. For multiple enabled schedulers, separate with a semicolon (default: all)"
   "all"
-  CATEGORY "Thread Manager" ADVANCED
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 
 string(TOUPPER "${HPX_WITH_THREAD_SCHEDULERS}" HPX_WITH_THREAD_SCHEDULERS_UC)
@@ -1113,7 +1163,8 @@ hpx_option(
   BOOL
   "Disable internal IO thread pool, do not change if not absolutely necessary (default: ON)"
   ON
-  CATEGORY "Thread Manager" ADVANCED
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 if(HPX_WITH_IO_POOL)
   hpx_add_config_define(HPX_HAVE_IO_POOL)
@@ -1124,7 +1175,8 @@ hpx_option(
   BOOL
   "Disable internal timer thread pool, do not change if not absolutely necessary (default: ON)"
   ON
-  CATEGORY "Thread Manager" ADVANCED
+  CATEGORY "Thread Manager"
+  ADVANCED
 )
 if(HPX_WITH_TIMER_POOL)
   hpx_add_config_define(HPX_HAVE_TIMER_POOL)
@@ -1134,7 +1186,8 @@ endif()
 hpx_option(
   HPX_WITH_AGAS_DUMP_REFCNT_ENTRIES BOOL
   "Enable dumps of the AGAS refcnt tables to logs (default: OFF)" OFF
-  CATEGORY "AGAS" ADVANCED
+  CATEGORY "AGAS"
+  ADVANCED
 )
 if(HPX_WITH_AGAS_DUMP_REFCNT_ENTRIES)
   hpx_add_config_define(HPX_HAVE_AGAS_DUMP_REFCNT_ENTRIES)
@@ -1170,7 +1223,9 @@ if(HPX_WITH_NETWORKING)
 
   hpx_option(
     HPX_WITH_PARCEL_PROFILING BOOL "Enable profiling data for parcels"
-    ${_parcel_profiling_default} CATEGORY "Parcelport" ADVANCED
+    ${_parcel_profiling_default}
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   if(HPX_WITH_PARCEL_PROFILING)
@@ -1183,7 +1238,8 @@ if(HPX_WITH_NETWORKING)
     BOOL
     "Enable the libfabric based parcelport. This is currently an experimental feature"
     OFF
-    CATEGORY "Parcelport" ADVANCED
+    CATEGORY "Parcelport"
+    ADVANCED
   )
   if(HPX_WITH_PARCELPORT_LIBFABRIC)
     hpx_add_config_define(HPX_HAVE_PARCELPORT_LIBFABRIC)
@@ -1194,7 +1250,8 @@ if(HPX_WITH_NETWORKING)
     BOOL
     "Enable the ibverbs based parcelport. This is currently an experimental feature"
     OFF
-    CATEGORY "Parcelport" ADVANCED
+    CATEGORY "Parcelport"
+    ADVANCED
   )
   if(HPX_WITH_PARCELPORT_VERBS)
     hpx_warn(
@@ -1256,7 +1313,8 @@ if((HPX_WITH_NETWORKING AND HPX_WITH_PARCELPORT_MPI) OR HPX_WITH_ASYNC_MPI)
     STRING
     "List of environment variables checked to detect MPI (default: MV2_COMM_WORLD_RANK;PMI_RANK;OMPI_COMM_WORLD_SIZE;ALPS_APP_PE;PMIX_RANK)."
     "MV2_COMM_WORLD_RANK;PMI_RANK;OMPI_COMM_WORLD_SIZE;ALPS_APP_PE;PMIX_RANK"
-    CATEGORY "Parcelport" ADVANCED
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   # This list is to detect whether we run inside an mpi environment. If one of
@@ -1274,8 +1332,9 @@ if((HPX_WITH_NETWORKING AND HPX_WITH_PARCELPORT_MPI) OR HPX_WITH_ASYNC_MPI)
 
   hpx_option(
     HPX_WITH_PARCELPORT_MPI_MULTITHREADED BOOL
-    "Turn on MPI multithreading support (default: ON)." ON CATEGORY "Parcelport"
-                                                                    ADVANCED
+    "Turn on MPI multithreading support (default: ON)." ON
+    CATEGORY "Parcelport"
+    ADVANCED
   )
   if(HPX_WITH_PARCELPORT_MPI_MULTITHREADED)
     hpx_add_config_define(HPX_HAVE_PARCELPORT_MPI_MULTITHREADED)
@@ -1293,7 +1352,8 @@ endif()
 hpx_option(
   HPX_WITH_EXAMPLES_OPENMP BOOL
   "Enable examples requiring OpenMP support (default: OFF)." OFF
-  CATEGORY "Build Targets" ADVANCED
+  CATEGORY "Build Targets"
+  ADVANCED
 )
 if(HPX_WITH_EXAMPLES_OPENMP)
   find_package(OpenMP)
@@ -1304,7 +1364,8 @@ endif()
 hpx_option(
   HPX_WITH_EXAMPLES_TBB BOOL
   "Enable examples requiring TBB support (default: OFF)." OFF
-  CATEGORY "Build Targets" ADVANCED
+  CATEGORY "Build Targets"
+  ADVANCED
 )
 if(HPX_WITH_EXAMPLES_TBB)
   find_package(TBB)
@@ -1315,7 +1376,8 @@ endif()
 hpx_option(
   HPX_WITH_EXAMPLES_QTHREADS BOOL
   "Enable examples requiring QThreads support (default: OFF)." OFF
-  CATEGORY "Build Targets" ADVANCED
+  CATEGORY "Build Targets"
+  ADVANCED
 )
 if(HPX_WITH_EXAMPLES_QTHREADS)
   find_package(QThreads)
@@ -1326,7 +1388,8 @@ endif()
 hpx_option(
   HPX_WITH_EXAMPLES_HDF5 BOOL
   "Enable examples requiring HDF5 support (default: OFF)." OFF
-  CATEGORY "Build Targets" ADVANCED
+  CATEGORY "Build Targets"
+  ADVANCED
 )
 if(HPX_WITH_EXAMPLES_HDF5)
   enable_language(Fortran)
@@ -1341,7 +1404,8 @@ if(NOT "${HPX_PLATFORM_UC}" STREQUAL "BLUEGENEQ")
   hpx_option(
     HPX_WITH_EXAMPLES_QT4 BOOL
     "Enable examples requiring Qt4 support (default: OFF)." OFF
-    CATEGORY "Build Targets" ADVANCED
+    CATEGORY "Build Targets"
+    ADVANCED
   )
   if(HPX_WITH_EXAMPLES_QT4)
     find_package(Qt4)
@@ -1367,32 +1431,37 @@ hpx_option(
   BOOL
   "Enable lock verification code (default: OFF, implicitly enabled in debug builds)"
   OFF
-  CATEGORY "Debugging" ADVANCED
+  CATEGORY "Debugging"
+  ADVANCED
 )
 hpx_option(
   HPX_WITH_VERIFY_LOCKS_GLOBALLY
   BOOL
   "Enable global lock verification code (default: OFF, implicitly enabled in debug builds)"
   OFF
-  CATEGORY "Debugging" ADVANCED
+  CATEGORY "Debugging"
+  ADVANCED
 )
 hpx_option(
   HPX_WITH_VERIFY_LOCKS_BACKTRACE
   BOOL
   "Enable thread stack back trace being captured on lock registration (to be used in combination with HPX_WITH_VERIFY_LOCKS=ON, default: OFF)"
   OFF
-  CATEGORY "Debugging" ADVANCED
+  CATEGORY "Debugging"
+  ADVANCED
 )
 hpx_option(
   HPX_WITH_THREAD_DEBUG_INFO
   BOOL
   "Enable thread debugging information (default: OFF, implicitly enabled in debug builds)"
   OFF
-  CATEGORY "Debugging" ADVANCED
+  CATEGORY "Debugging"
+  ADVANCED
 )
 hpx_option(
   HPX_WITH_THREAD_GUARD_PAGE BOOL "Enable thread guard page (default: ON)" ON
-  CATEGORY "Debugging" ADVANCED
+  CATEGORY "Debugging"
+  ADVANCED
 )
 
 if(HPX_WITH_VERIFY_LOCKS)
@@ -1421,13 +1490,15 @@ endif()
 hpx_option(
   HPX_WITH_THREAD_DESCRIPTION_FULL BOOL
   "Use function address for thread description (default: OFF)" OFF
-  CATEGORY "Debugging" ADVANCED
+  CATEGORY "Debugging"
+  ADVANCED
 )
 
 hpx_option(
   HPX_WITH_ATTACH_DEBUGGER_ON_TEST_FAILURE BOOL
   "Break the debugger if a test has failed  (default: OFF)" OFF
-  CATEGORY "Debugging" ADVANCED
+  CATEGORY "Debugging"
+  ADVANCED
 )
 if(HPX_WITH_ATTACH_DEBUGGER_ON_TEST_FAILURE)
   hpx_add_config_define(HPX_HAVE_ATTACH_DEBUGGER_ON_TEST_FAILURE)
@@ -1436,13 +1507,15 @@ endif()
 hpx_option(
   HPX_WITH_TESTS_DEBUG_LOG BOOL
   "Turn on debug logs (--hpx:debug-hpx-log) for tests (default: OFF)" OFF
-  CATEGORY "Debugging" ADVANCED
+  CATEGORY "Debugging"
+  ADVANCED
 )
 
 hpx_option(
   HPX_WITH_TESTS_DEBUG_LOG_DESTINATION STRING
-  "Destination for test debug logs (default: cout)" "cout" CATEGORY "Debugging"
-                                                                    ADVANCED
+  "Destination for test debug logs (default: cout)" "cout"
+  CATEGORY "Debugging"
+  ADVANCED
 )
 
 hpx_option(
@@ -1450,7 +1523,8 @@ hpx_option(
   STRING
   "Maximum number of threads to use for tests (default: 0, use the number of threads specified by the test)"
   0
-  CATEGORY "Debugging" ADVANCED
+  CATEGORY "Debugging"
+  ADVANCED
 )
 
 hpx_option(
@@ -1458,7 +1532,8 @@ hpx_option(
   BOOL
   "Pass --hpx:bind=none to tests that may run in parallel (cmake -j flag) (default: OFF)"
   OFF
-  CATEGORY "Debugging" ADVANCED
+  CATEGORY "Debugging"
+  ADVANCED
 )
 
 # If APEX is defined, the action timers need thread debug info.
@@ -1549,7 +1624,8 @@ hpx_option(
   BOOL
   "Enable swapping of rvalue tuples (needed for parallel::sort_by_key, default: ON)."
   ON
-  CATEGORY "Utility" ADVANCED
+  CATEGORY "Utility"
+  ADVANCED
 )
 if(HPX_WITH_TUPLE_RVALUE_SWAP)
   hpx_add_config_define(HPX_HAVE_TUPLE_RVALUE_SWAP)

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -252,7 +252,8 @@ function(hpx_cpuid target variable)
   add_hpx_config_test(
     ${variable}
     SOURCE cmake/tests/cpuid.cpp
-    COMPILE_DEFINITIONS "${boost_include_dir}" "${include_dir}" FILE EXECUTE
+    COMPILE_DEFINITIONS "${boost_include_dir}" "${include_dir}"
+    FILE EXECUTE
     ARGS "${target}" ${ARGN}
   )
 endfunction()
@@ -260,7 +261,9 @@ endfunction()
 # ##############################################################################
 function(hpx_check_for_unistd_h)
   add_hpx_config_test(
-    HPX_WITH_UNISTD_H SOURCE cmake/tests/unistd_h.cpp FILE ${ARGN}
+    HPX_WITH_UNISTD_H
+    SOURCE cmake/tests/unistd_h.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -268,7 +271,8 @@ endfunction()
 function(hpx_check_for_libfun_std_experimental_optional)
   add_hpx_config_test(
     HPX_WITH_LIBFUN_EXPERIMENTAL_OPTIONAL
-    SOURCE cmake/tests/libfun_std_experimental_optional.cpp FILE ${ARGN}
+    SOURCE cmake/tests/libfun_std_experimental_optional.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -295,7 +299,8 @@ function(hpx_check_for_cxx11_std_atomic)
   add_hpx_config_test(
     HPX_WITH_CXX11_ATOMIC
     SOURCE cmake/tests/cxx11_std_atomic.cpp
-    LIBRARIES ${HPX_CXX11_STD_ATOMIC_LIBRARIES} FILE ${ARGN}
+    LIBRARIES ${HPX_CXX11_STD_ATOMIC_LIBRARIES}
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -304,7 +309,8 @@ function(hpx_check_for_cxx11_std_atomic_128bit)
   add_hpx_config_test(
     HPX_WITH_CXX11_ATOMIC_128BIT
     SOURCE cmake/tests/cxx11_std_atomic_128bit.cpp
-    LIBRARIES ${HPX_CXX11_STD_ATOMIC_LIBRARIES} FILE ${ARGN}
+    LIBRARIES ${HPX_CXX11_STD_ATOMIC_LIBRARIES}
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -312,15 +318,17 @@ endfunction()
 function(hpx_check_for_cxx11_std_shared_ptr_lwg3018)
   add_hpx_config_test(
     HPX_WITH_CXX11_SHARED_PTR_LWG3018
-    SOURCE cmake/tests/cxx11_std_shared_ptr_lwg3018.cpp FILE ${ARGN}
+    SOURCE cmake/tests/cxx11_std_shared_ptr_lwg3018.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
 # ##############################################################################
 function(hpx_check_for_cxx11_std_quick_exit)
   add_hpx_config_test(
-    HPX_WITH_CXX11_STD_QUICK_EXIT SOURCE cmake/tests/cxx11_std_quick_exit.cpp
-                                         FILE ${ARGN}
+    HPX_WITH_CXX11_STD_QUICK_EXIT
+    SOURCE cmake/tests/cxx11_std_quick_exit.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -328,7 +336,8 @@ endfunction()
 function(hpx_check_for_cxx17_aligned_new)
   add_hpx_config_test(
     HPX_WITH_CXX17_ALIGNED_NEW
-    SOURCE cmake/tests/cxx17_aligned_new.cpp FILE ${ARGN}
+    SOURCE cmake/tests/cxx17_aligned_new.cpp
+    FILE ${ARGN}
     REQUIRED
   )
 endfunction()
@@ -336,8 +345,9 @@ endfunction()
 # ##############################################################################
 function(hpx_check_for_cxx17_filesystem)
   add_hpx_config_test(
-    HPX_WITH_CXX17_FILESYSTEM SOURCE cmake/tests/cxx17_filesystem.cpp FILE
-                                     ${ARGN}
+    HPX_WITH_CXX17_FILESYSTEM
+    SOURCE cmake/tests/cxx17_filesystem.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -345,7 +355,8 @@ endfunction()
 function(hpx_check_for_cxx17_fold_expressions)
   add_hpx_config_test(
     HPX_WITH_CXX17_FOLD_EXPRESSIONS
-    SOURCE cmake/tests/cxx17_fold_expressions.cpp FILE ${ARGN}
+    SOURCE cmake/tests/cxx17_fold_expressions.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -353,7 +364,8 @@ endfunction()
 function(hpx_check_for_cxx17_fallthrough_attribute)
   add_hpx_config_test(
     HPX_WITH_CXX17_FALLTHROUGH_ATTRIBUTE
-    SOURCE cmake/tests/cxx17_fallthrough_attribute.cpp FILE ${ARGN}
+    SOURCE cmake/tests/cxx17_fallthrough_attribute.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -361,7 +373,8 @@ endfunction()
 function(hpx_check_for_cxx17_nodiscard_attribute)
   add_hpx_config_test(
     HPX_WITH_CXX17_NODISCARD_ATTRIBUTE
-    SOURCE cmake/tests/cxx17_nodiscard_attribute.cpp FILE ${ARGN}
+    SOURCE cmake/tests/cxx17_nodiscard_attribute.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -369,8 +382,8 @@ endfunction()
 function(hpx_check_for_cxx17_hardware_destructive_interference_size)
   add_hpx_config_test(
     HPX_WITH_CXX17_HARDWARE_DESTRUCTIVE_INTERFERENCE_SIZE
-    SOURCE cmake/tests/cxx17_hardware_destructive_interference_size.cpp FILE
-           ${ARGN}
+    SOURCE cmake/tests/cxx17_hardware_destructive_interference_size.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -378,15 +391,17 @@ endfunction()
 function(hpx_check_for_cxx17_std_in_place_type_t)
   add_hpx_config_test(
     HPX_WITH_CXX17_STD_IN_PLACE_TYPE_T
-    SOURCE cmake/tests/cxx17_std_in_place_type_t.cpp FILE ${ARGN}
+    SOURCE cmake/tests/cxx17_std_in_place_type_t.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
 # ##############################################################################
 function(hpx_check_for_cxx17_maybe_unused)
   add_hpx_config_test(
-    HPX_WITH_CXX17_MAYBE_UNUSED SOURCE cmake/tests/cxx17_maybe_unused.cpp FILE
-                                       ${ARGN}
+    HPX_WITH_CXX17_MAYBE_UNUSED
+    SOURCE cmake/tests/cxx17_maybe_unused.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -394,7 +409,8 @@ endfunction()
 function(hpx_check_for_cxx17_deduction_guides)
   add_hpx_config_test(
     HPX_WITH_CXX17_DEDUCTION_GUIDES
-    SOURCE cmake/tests/cxx17_deduction_guides.cpp FILE ${ARGN}
+    SOURCE cmake/tests/cxx17_deduction_guides.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -402,15 +418,17 @@ endfunction()
 function(hpx_check_for_cxx17_structured_bindings)
   add_hpx_config_test(
     HPX_WITH_CXX17_STRUCTURED_BINDINGS
-    SOURCE cmake/tests/cxx17_structured_bindings.cpp FILE ${ARGN}
+    SOURCE cmake/tests/cxx17_structured_bindings.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
 # ##############################################################################
 function(hpx_check_for_cxx17_if_constexpr)
   add_hpx_config_test(
-    HPX_WITH_CXX17_IF_CONSTEXPR SOURCE cmake/tests/cxx17_if_constexpr.cpp FILE
-                                       ${ARGN}
+    HPX_WITH_CXX17_IF_CONSTEXPR
+    SOURCE cmake/tests/cxx17_if_constexpr.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -418,7 +436,8 @@ endfunction()
 function(hpx_check_for_cxx17_inline_constexpr_variable)
   add_hpx_config_test(
     HPX_WITH_CXX17_INLINE_CONSTEXPR_VALUE
-    SOURCE cmake/tests/cxx17_inline_constexpr_variable.cpp FILE ${ARGN}
+    SOURCE cmake/tests/cxx17_inline_constexpr_variable.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -426,15 +445,17 @@ endfunction()
 function(hpx_check_for_cxx17_noexcept_functions_as_nontype_template_arguments)
   add_hpx_config_test(
     HPX_WITH_CXX17_NOEXCEPT_FUNCTIONS_AS_NONTYPE_TEMPLATE_ARGUMENTS
-    SOURCE cmake/tests/cxx17_noexcept_function.cpp FILE ${ARGN}
+    SOURCE cmake/tests/cxx17_noexcept_function.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
 # ##############################################################################
 function(hpx_check_for_cxx17_std_variant)
   add_hpx_config_test(
-    HPX_WITH_CXX17_STD_VARIANT SOURCE cmake/tests/cxx17_std_variant.cpp FILE
-                                      ${ARGN}
+    HPX_WITH_CXX17_STD_VARIANT
+    SOURCE cmake/tests/cxx17_std_variant.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -442,7 +463,8 @@ endfunction()
 function(hpx_check_for_cxx17_std_transform_scan)
   add_hpx_config_test(
     HPX_WITH_CXX17_STD_TRANSFORM_SCAN_ALGORITHMS
-    SOURCE cmake/tests/cxx17_std_transform_scan_algorithms.cpp FILE ${ARGN}
+    SOURCE cmake/tests/cxx17_std_transform_scan_algorithms.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -450,7 +472,8 @@ endfunction()
 function(hpx_check_for_cxx17_std_scan)
   add_hpx_config_test(
     HPX_WITH_CXX17_STD_SCAN_ALGORITHMS
-    SOURCE cmake/tests/cxx17_std_scan_algorithms.cpp FILE ${ARGN}
+    SOURCE cmake/tests/cxx17_std_scan_algorithms.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -458,7 +481,8 @@ endfunction()
 function(hpx_check_for_cxx17_shared_ptr_array)
   add_hpx_config_test(
     HPX_WITH_CXX17_SHARED_PTR_ARRAY
-    SOURCE cmake/tests/cxx17_shared_ptr_array.cpp FILE ${ARGN}
+    SOURCE cmake/tests/cxx17_shared_ptr_array.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -466,16 +490,17 @@ endfunction()
 function(hpx_check_for_cxx17_std_nontype_template_parameter_auto)
   add_hpx_config_test(
     HPX_WITH_CXX17_NONTYPE_TEMPLATE_PARAMETER_AUTO
-    SOURCE cmake/tests/cxx17_std_nontype_template_parameter_auto.cpp FILE
-           ${ARGN}
+    SOURCE cmake/tests/cxx17_std_nontype_template_parameter_auto.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
 # ##############################################################################
 function(hpx_check_for_cxx20_coroutines)
   add_hpx_config_test(
-    HPX_WITH_CXX20_COROUTINES SOURCE cmake/tests/cxx20_coroutines.cpp FILE
-                                     ${ARGN}
+    HPX_WITH_CXX20_COROUTINES
+    SOURCE cmake/tests/cxx20_coroutines.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -483,7 +508,8 @@ endfunction()
 function(hpx_check_for_cxx20_std_disable_sized_sentinel_for)
   add_hpx_config_test(
     HPX_WITH_CXX20_STD_DISABLE_SIZED_SENTINEL_FOR
-    SOURCE cmake/tests/cxx20_std_disable_sized_sentinel_for.cpp FILE ${ARGN}
+    SOURCE cmake/tests/cxx20_std_disable_sized_sentinel_for.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -491,15 +517,17 @@ endfunction()
 function(hpx_check_for_cxx20_no_unique_address_attribute)
   add_hpx_config_test(
     HPX_WITH_CXX20_NO_UNIQUE_ADDRESS_ATTRIBUTE
-    SOURCE cmake/tests/cxx20_no_unique_address_attribute.cpp FILE ${ARGN}
+    SOURCE cmake/tests/cxx20_no_unique_address_attribute.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
 # ##############################################################################
 function(hpx_check_for_builtin_integer_pack)
   add_hpx_config_test(
-    HPX_WITH_BUILTIN_INTEGER_PACK SOURCE cmake/tests/builtin_integer_pack.cpp
-                                         FILE ${ARGN}
+    HPX_WITH_BUILTIN_INTEGER_PACK
+    SOURCE cmake/tests/builtin_integer_pack.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -507,7 +535,8 @@ endfunction()
 function(hpx_check_for_builtin_make_integer_seq)
   add_hpx_config_test(
     HPX_WITH_BUILTIN_MAKE_INTEGER_SEQ
-    SOURCE cmake/tests/builtin_make_integer_seq.cpp FILE ${ARGN}
+    SOURCE cmake/tests/builtin_make_integer_seq.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
@@ -515,21 +544,25 @@ endfunction()
 function(hpx_check_for_builtin_type_pack_element)
   add_hpx_config_test(
     HPX_WITH_BUILTIN_TYPE_PACK_ELEMENT
-    SOURCE cmake/tests/builtin_type_pack_element.cpp FILE ${ARGN}
+    SOURCE cmake/tests/builtin_type_pack_element.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
 # ##############################################################################
 function(hpx_check_for_mm_prefetch)
   add_hpx_config_test(
-    HPX_WITH_MM_PREFETCH SOURCE cmake/tests/mm_prefetch.cpp FILE ${ARGN}
+    HPX_WITH_MM_PREFETCH
+    SOURCE cmake/tests/mm_prefetch.cpp
+    FILE ${ARGN}
   )
 endfunction()
 
 # ##############################################################################
 function(hpx_check_for_stable_inplace_merge)
   add_hpx_config_test(
-    HPX_WITH_STABLE_INPLACE_MERGE SOURCE cmake/tests/stable_inplace_merge.cpp
-                                         FILE ${ARGN}
+    HPX_WITH_STABLE_INPLACE_MERGE
+    SOURCE cmake/tests/stable_inplace_merge.cpp
+    FILE ${ARGN}
   )
 endfunction()

--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -126,17 +126,11 @@ function(add_hpx_module libname modulename)
   set(all_headers ${${modulename}_HEADERS})
 
   # Write full path for the sources files
-  list(
-    TRANSFORM ${modulename}_SOURCES
-    PREPEND ${SOURCE_ROOT}/
-            OUTPUT_VARIABLE
-            sources
+  list(TRANSFORM ${modulename}_SOURCES PREPEND ${SOURCE_ROOT}/ OUTPUT_VARIABLE
+                                                               sources
   )
-  list(
-    TRANSFORM ${modulename}_HEADERS
-    PREPEND ${HEADER_ROOT}/
-            OUTPUT_VARIABLE
-            headers
+  list(TRANSFORM ${modulename}_HEADERS PREPEND ${HEADER_ROOT}/ OUTPUT_VARIABLE
+                                                               headers
   )
   if(${_have_compatibility_headers_option}
      AND HPX_${modulename_upper}_WITH_COMPATIBILITY_HEADERS

--- a/cmake/HPX_AddParcelport.cmake
+++ b/cmake/HPX_AddParcelport.cmake
@@ -51,7 +51,8 @@ function(add_parcelport name)
   target_compile_options(${parcelport_name} PUBLIC ${${name}_COMPILE_FLAGS})
   set_target_properties(
     ${parcelport_name}
-    PROPERTIES FOLDER "${${name}_FOLDER}" LINK_FLAGS "${${name}_LINK_FLAGS}"
+    PROPERTIES FOLDER "${${name}_FOLDER}"
+               LINK_FLAGS "${${name}_LINK_FLAGS}"
                POSITION_INDEPENDENT_CODE ON
   )
 

--- a/cmake/HPX_SetupLibfabric.cmake
+++ b/cmake/HPX_SetupLibfabric.cmake
@@ -66,7 +66,8 @@ if(HPX_WITH_PARCELPORT_LIBFABRIC AND NOT TARGET Libfabric::libfabric)
     BOOL
     "Enables some extra logging and debug features in the libfabric parcelport (default: OFF - Warning - severely impacts usability when enabled)"
     OFF
-    CATEGORY "Parcelport" ADVANCED
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   if(HPX_PARCELPORT_LIBFABRIC_WITH_DEV_MODE)
@@ -93,8 +94,9 @@ if(HPX_WITH_PARCELPORT_LIBFABRIC AND NOT TARGET Libfabric::libfabric)
   # ------------------------------------------------------------------------------
   hpx_option(
     HPX_PARCELPORT_LIBFABRIC_PROVIDER STRING
-    "The provider (verbs/gni/psm2/sockets)" "verbs" CATEGORY "Parcelport"
-                                                             ADVANCED
+    "The provider (verbs/gni/psm2/sockets)" "verbs"
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   hpx_add_config_define_namespace(
@@ -123,8 +125,9 @@ if(HPX_WITH_PARCELPORT_LIBFABRIC AND NOT TARGET Libfabric::libfabric)
 
   hpx_option(
     HPX_PARCELPORT_LIBFABRIC_DOMAIN STRING
-    "The libfabric domain (leave blank for default" "" CATEGORY "Parcelport"
-                                                                ADVANCED
+    "The libfabric domain (leave blank for default" ""
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   hpx_add_config_define_namespace(
@@ -136,7 +139,8 @@ if(HPX_WITH_PARCELPORT_LIBFABRIC AND NOT TARGET Libfabric::libfabric)
   hpx_option(
     HPX_PARCELPORT_LIBFABRIC_ENDPOINT STRING
     "The libfabric endpoint type (leave blank for default" "rdm"
-    CATEGORY "Parcelport" ADVANCED
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   hpx_add_config_define_namespace(
@@ -153,7 +157,8 @@ if(HPX_WITH_PARCELPORT_LIBFABRIC AND NOT TARGET Libfabric::libfabric)
     BOOL
     "Configure the parcelport to enable bootstrap capabilities (default: OFF, enabled if PMI was found)"
     ${PMI_FOUND}
-    CATEGORY "Parcelport" ADVANCED
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   if(HPX_PARCELPORT_LIBFABRIC_WITH_BOOTSTRAPPING)
@@ -176,7 +181,8 @@ if(HPX_WITH_PARCELPORT_LIBFABRIC AND NOT TARGET Libfabric::libfabric)
   hpx_option(
     HPX_PARCELPORT_LIBFABRIC_WITH_PERFORMANCE_COUNTERS BOOL
     "Enable libfabric parcelport performance counters (default: OFF)" OFF
-    CATEGORY "Parcelport" ADVANCED
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   if(HPX_PARCELPORT_LIBFABRIC_WITH_PERFORMANCE_COUNTERS)
@@ -192,7 +198,9 @@ if(HPX_WITH_PARCELPORT_LIBFABRIC AND NOT TARGET Libfabric::libfabric)
   hpx_option(
     HPX_PARCELPORT_LIBFABRIC_THROTTLE_SENDS STRING
     "Threshold of active sends at which throttling is enabled (default: 16)"
-    "16" CATEGORY "Parcelport" ADVANCED
+    "16"
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   hpx_add_config_define_namespace(
@@ -209,7 +217,8 @@ if(HPX_WITH_PARCELPORT_LIBFABRIC AND NOT TARGET Libfabric::libfabric)
     BOOL
     "Configure the parcelport to use a custom scheduler (default: OFF - Warning, experimental, may cause serious program errors)"
     OFF
-    CATEGORY "Parcelport" ADVANCED
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   if(HPX_PARCELPORT_LIBFABRIC_USE_CUSTOM_SCHEDULER)
@@ -226,7 +235,8 @@ if(HPX_WITH_PARCELPORT_LIBFABRIC AND NOT TARGET Libfabric::libfabric)
     BOOL
     "Turn on extra log messages for lock/unlock  (default: OFF - Warning, severely impacts performance when enabled)"
     OFF
-    CATEGORY "Parcelport" ADVANCED
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   if(HPX_PARCELPORT_LIBFABRIC_DEBUG_LOCKS)
@@ -241,13 +251,17 @@ if(HPX_WITH_PARCELPORT_LIBFABRIC AND NOT TARGET Libfabric::libfabric)
   hpx_option(
     HPX_PARCELPORT_LIBFABRIC_MEMORY_CHUNK_SIZE STRING
     "Number of bytes a default chunk in the memory pool can hold (default: 4K)"
-    "4096" CATEGORY "Parcelport" ADVANCED
+    "4096"
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   hpx_option(
     HPX_PARCELPORT_LIBFABRIC_64K_PAGES STRING
     "Number of 64K pages we reserve for default message buffers (default: 10)"
-    "10" CATEGORY "Parcelport" ADVANCED
+    "10"
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   hpx_option(
@@ -255,7 +269,8 @@ if(HPX_WITH_PARCELPORT_LIBFABRIC AND NOT TARGET Libfabric::libfabric)
     STRING
     "Cutoff size over which data is never copied into existing buffers (default: 4K)"
     "4096"
-    CATEGORY "Parcelport" ADVANCED
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   hpx_add_config_define_namespace(
@@ -289,7 +304,8 @@ if(HPX_WITH_PARCELPORT_LIBFABRIC AND NOT TARGET Libfabric::libfabric)
   hpx_option(
     HPX_PARCELPORT_LIBFABRIC_MAX_PREPOSTS STRING
     "The number of pre-posted receive buffers (default: 512)" "512"
-    CATEGORY "Parcelport" ADVANCED
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   hpx_add_config_define_namespace(

--- a/cmake/HPX_SetupVerbs.cmake
+++ b/cmake/HPX_SetupVerbs.cmake
@@ -42,7 +42,8 @@ if(HPX_WITH_PARCELPORT_VERBS AND NOT TARGET Verbs::verbs)
     HPX_PARCELPORT_VERBS_WITH_DEV_MODE BOOL
     "Enables some extra logging and debug features in the verbs parcelport \
      (default: OFF - Warning - severely impacts usability when enabled)" OFF
-    CATEGORY "Parcelport" ADVANCED
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   if(HPX_PARCELPORT_VERBS_WITH_DEV_MODE)
@@ -68,13 +69,17 @@ if(HPX_WITH_PARCELPORT_VERBS AND NOT TARGET Verbs::verbs)
   hpx_option(
     HPX_PARCELPORT_VERBS_DEVICE STRING
     "The device name of the ibverbs capable network adapter (default: mlx5_0)"
-    "mlx5_0" CATEGORY "Parcelport" ADVANCED
+    "mlx5_0"
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   hpx_option(
     HPX_PARCELPORT_VERBS_INTERFACE STRING
     "The interface name of the ibverbs capable network adapter (default: ib0)"
-    "ib0" CATEGORY "Parcelport" ADVANCED
+    "ib0"
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   hpx_add_config_define_namespace(
@@ -95,7 +100,8 @@ if(HPX_WITH_PARCELPORT_VERBS AND NOT TARGET Verbs::verbs)
   hpx_option(
     HPX_PARCELPORT_VERBS_WITH_BOOTSTRAPPING BOOL
     "Configure the parcelport to enable bootstrap capabilities (default: ON)" ON
-    CATEGORY "Parcelport" ADVANCED
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   if(HPX_PARCELPORT_VERBS_WITH_BOOTSTRAPPING)
@@ -118,7 +124,8 @@ if(HPX_WITH_PARCELPORT_VERBS AND NOT TARGET Verbs::verbs)
   hpx_option(
     HPX_PARCELPORT_VERBS_WITH_PERFORMANCE_COUNTERS BOOL
     "Enable verbs parcelport performance counters (default: OFF)" OFF
-    CATEGORY "Parcelport" ADVANCED
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   if(HPX_PARCELPORT_VERBS_WITH_PERFORMANCE_COUNTERS)
@@ -134,7 +141,9 @@ if(HPX_WITH_PARCELPORT_VERBS AND NOT TARGET Verbs::verbs)
   hpx_option(
     HPX_PARCELPORT_VERBS_THROTTLE_SENDS STRING
     "Threshold of active sends at which throttling is enabled (default: 16)"
-    "16" CATEGORY "Parcelport" ADVANCED
+    "16"
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   hpx_add_config_define_namespace(
@@ -152,7 +161,8 @@ if(HPX_WITH_PARCELPORT_VERBS AND NOT TARGET Verbs::verbs)
     "Configure the parcelport to use a custom scheduler \
      (default: OFF - Warning, experimental, may cause serious program errors)"
     OFF
-    CATEGORY "Parcelport" ADVANCED
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   if(HPX_PARCELPORT_VERBS_USE_CUSTOM_SCHEDULER)
@@ -168,7 +178,8 @@ if(HPX_WITH_PARCELPORT_VERBS AND NOT TARGET Verbs::verbs)
     HPX_PARCELPORT_VERBS_DEBUG_LOCKS BOOL
     "Turn on extra log messages for lock/unlock \
      (default: OFF - Warning, severely impacts performance when enabled)" OFF
-    CATEGORY "Parcelport" ADVANCED
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   if(HPX_PARCELPORT_VERBS_DEBUG_LOCKS)
@@ -183,13 +194,17 @@ if(HPX_WITH_PARCELPORT_VERBS AND NOT TARGET Verbs::verbs)
   hpx_option(
     HPX_PARCELPORT_VERBS_MEMORY_CHUNK_SIZE STRING
     "Number of bytes a default chunk in the memory pool can hold (default: 4K)"
-    "4096" CATEGORY "Parcelport" ADVANCED
+    "4096"
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   hpx_option(
     HPX_PARCELPORT_VERBS_64K_PAGES STRING
     "Number of 64K pages we reserve for default message buffers (default: 10)"
-    "10" CATEGORY "Parcelport" ADVANCED
+    "10"
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   hpx_option(
@@ -197,7 +212,8 @@ if(HPX_WITH_PARCELPORT_VERBS AND NOT TARGET Verbs::verbs)
     STRING
     "Cutoff size over which data is never copied into existing buffers (default: 4K)"
     "4096"
-    CATEGORY "Parcelport" ADVANCED
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   hpx_add_config_define_namespace(
@@ -231,7 +247,8 @@ if(HPX_WITH_PARCELPORT_VERBS AND NOT TARGET Verbs::verbs)
   hpx_option(
     HPX_PARCELPORT_VERBS_MAX_PREPOSTS STRING
     "The number of pre-posted receive buffers (default: 512)" "512"
-    CATEGORY "Parcelport" ADVANCED
+    CATEGORY "Parcelport"
+    ADVANCED
   )
 
   hpx_add_config_define_namespace(

--- a/cmake/installed_hpx.cmake
+++ b/cmake/installed_hpx.cmake
@@ -59,11 +59,31 @@ if(NOT HPX_WITH_TESTS)
     VALUE OFF
     FORCE
   )
-  hpx_set_option(HPX_WITH_TESTS_REGRESSIONS VALUE OFF FORCE)
-  hpx_set_option(HPX_WITH_TESTS_UNIT VALUE OFF FORCE)
-  hpx_set_option(HPX_WITH_TESTS_HEADERS VALUE OFF FORCE)
-  hpx_set_option(HPX_WITH_TESTS_EXTERNAL_BUILD VALUE OFF FORCE)
-  hpx_set_option(HPX_WITH_TESTS_EXAMPLES VALUE OFF FORCE)
+  hpx_set_option(
+    HPX_WITH_TESTS_REGRESSIONS
+    VALUE OFF
+    FORCE
+  )
+  hpx_set_option(
+    HPX_WITH_TESTS_UNIT
+    VALUE OFF
+    FORCE
+  )
+  hpx_set_option(
+    HPX_WITH_TESTS_HEADERS
+    VALUE OFF
+    FORCE
+  )
+  hpx_set_option(
+    HPX_WITH_TESTS_EXTERNAL_BUILD
+    VALUE OFF
+    FORCE
+  )
+  hpx_set_option(
+    HPX_WITH_TESTS_EXAMPLES
+    VALUE OFF
+    FORCE
+  )
 endif()
 
 if(HPX_WITH_TESTS)

--- a/docs/sphinx/contributing/docker_image.rst
+++ b/docs/sphinx/contributing/docker_image.rst
@@ -24,7 +24,7 @@ environment, run:
 
 .. code-block:: bash
 
-   docker run --interactive --tty stellargroup/build_env:ubuntu bash
+   docker run --interactive --tty stellargroup/build_env:latest bash
 
 You are now in an environment where all the |hpx| build and runtime dependencies
 are present. You can install additional packages according to your own needs.

--- a/examples/interpolate1d/CMakeLists.txt
+++ b/examples/interpolate1d/CMakeLists.txt
@@ -45,7 +45,8 @@ if(HPX_WITH_EXAMPLES_HDF5)
 
   add_hpx_executable(
     create_1d_testdata INTERNAL_FLAGS
-    SOURCES create_testdata.cpp NOLIBS
+    SOURCES create_testdata.cpp
+    NOLIBS
     FOLDER "Examples/Interpolate1D"
   )
 

--- a/libs/core/datastructures/include/hpx/datastructures/tuple.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/tuple.hpp
@@ -347,7 +347,8 @@ namespace hpx {
         {
             int const _sequencer[] = {
                 ((_members.template get<Is>() =
-                         hpx::get<Is>(std::forward<UTuple>(other))),
+                         // NOLINTNEXTLINE(bugprone-signed-char-misuse)
+                     hpx::get<Is>(std::forward<UTuple>(other))),
                     0)...};
             (void) _sequencer;
         }

--- a/libs/core/serialization/tests/unit/CMakeLists.txt
+++ b/libs/core/serialization/tests/unit/CMakeLists.txt
@@ -77,7 +77,8 @@ foreach(test ${full_tests})
   # add example executable
   add_hpx_executable(
     ${test}_test INTERNAL_FLAGS
-    SOURCES ${sources} ${${test}_FLAGS} EXCLUDE_FROM_ALL
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
     FOLDER ${folder_name}
   )
 

--- a/libs/core/synchronization/tests/regressions/ignore_while_locked_1485.cpp
+++ b/libs/core/synchronization/tests/regressions/ignore_while_locked_1485.cpp
@@ -69,6 +69,7 @@ void test_condition_with_mutex()
     // wait for the thread to run
     {
         std::unique_lock<hpx::lcos::local::spinlock> lk(local_mutex);
+        // NOLINTNEXTLINE(bugprone-infinite-loop)
         while (!running)
             local_cond_var.wait(lk);
     }

--- a/libs/core/synchronization/tests/unit/shared_mutex/shared_mutex1.cpp
+++ b/libs/core/synchronization/tests/unit/shared_mutex/shared_mutex1.cpp
@@ -59,6 +59,7 @@ void test_multiple_readers()
 
         {
             std::unique_lock<mutex_type> lk(unblocked_count_mutex);
+            // NOLINTNEXTLINE(bugprone-infinite-loop)
             while (unblocked_count < number_of_threads)
             {
                 unblocked_condition.wait(lk);
@@ -157,6 +158,7 @@ void test_reader_blocks_writer()
 
         {
             std::unique_lock<mutex_type> lk(unblocked_count_mutex);
+            // NOLINTNEXTLINE(bugprone-infinite-loop)
             while (unblocked_count < 1)
             {
                 unblocked_condition.wait(lk);
@@ -228,6 +230,7 @@ void test_unlocking_writer_unblocks_all_readers()
 
         {
             std::unique_lock<mutex_type> lk(unblocked_count_mutex);
+            // NOLINTNEXTLINE(bugprone-infinite-loop)
             while (unblocked_count < reader_count)
             {
                 unblocked_condition.wait(lk);
@@ -298,6 +301,7 @@ void test_unlocking_last_reader_only_unblocks_one_writer()
 
         {
             std::unique_lock<mutex_type> lk(unblocked_count_mutex);
+            // NOLINTNEXTLINE(bugprone-infinite-loop)
             while (unblocked_count < reader_count)
             {
                 unblocked_condition.wait(lk);
@@ -313,6 +317,7 @@ void test_unlocking_last_reader_only_unblocks_one_writer()
 
         {
             std::unique_lock<mutex_type> lk(unblocked_count_mutex);
+            // NOLINTNEXTLINE(bugprone-infinite-loop)
             while (unblocked_count < (reader_count + 1))
             {
                 unblocked_condition.wait(lk);

--- a/libs/core/synchronization/tests/unit/shared_mutex/shared_mutex2.cpp
+++ b/libs/core/synchronization/tests/unit/shared_mutex/shared_mutex2.cpp
@@ -115,6 +115,7 @@ void test_can_lock_upgrade_if_currently_locked_shared()
 
         {
             std::unique_lock<mutex_type> lk(unblocked_count_mutex);
+            // NOLINTNEXTLINE(bugprone-infinite-loop)
             while (unblocked_count < (reader_count + 1))
             {
                 unblocked_condition.wait(lk);

--- a/libs/full/collectives/tests/performance/osu/CMakeLists.txt
+++ b/libs/full/collectives/tests/performance/osu/CMakeLists.txt
@@ -38,7 +38,8 @@ foreach(benchmark ${coll_benchmarks})
   # add example executable
   add_hpx_executable(
     ${benchmark}_test INTERNAL_FLAGS
-    SOURCES ${sources} ${${benchmark}_FLAGS} EXCLUDE_FROM_ALL
+    SOURCES ${sources} ${${benchmark}_FLAGS}
+    EXCLUDE_FROM_ALL
     FOLDER "Benchmarks/Modules/Full/Collectives/OSU"
   )
 

--- a/libs/full/runtime_local/src/runtime_local.cpp
+++ b/libs/full/runtime_local/src/runtime_local.cpp
@@ -1456,6 +1456,7 @@ namespace hpx {
         // wait for the thread to run
         {
             std::unique_lock<std::mutex> lk(mtx);
+            // NOLINTNEXTLINE(bugprone-infinite-loop)
             while (!running)    // -V776 // -V1044
                 cond.wait(lk);
         }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -391,12 +391,19 @@ endif()
 
 if("${HPX_PLATFORM_UC}" STREQUAL "ANDROID")
   set_target_properties(
-    hpx_full PROPERTIES CLEAN_DIRECT_OUTPUT 1 OUTPUT_NAME hpx FOLDER "Core"
+    hpx_full
+    PROPERTIES CLEAN_DIRECT_OUTPUT 1
+               OUTPUT_NAME hpx
+               FOLDER "Core"
   )
 else()
   set_target_properties(
-    hpx_full PROPERTIES VERSION ${HPX_VERSION} SOVERSION ${HPX_SOVERSION}
-                        CLEAN_DIRECT_OUTPUT 1 OUTPUT_NAME hpx FOLDER "Core"
+    hpx_full
+    PROPERTIES VERSION ${HPX_VERSION}
+               SOVERSION ${HPX_SOVERSION}
+               CLEAN_DIRECT_OUTPUT 1
+               OUTPUT_NAME hpx
+               FOLDER "Core"
   )
 endif()
 

--- a/src/runtime_distributed.cpp
+++ b/src/runtime_distributed.cpp
@@ -694,6 +694,7 @@ namespace hpx {
         // wait for the thread to run
         {
             std::unique_lock<std::mutex> lk(mtx);
+            // NOLINTNEXTLINE(bugprone-infinite-loop)
             while (!running)    // -V776 // -V1044
                 cond.wait(lk);
         }

--- a/tests/unit/agas/components/CMakeLists.txt
+++ b/tests/unit/agas/components/CMakeLists.txt
@@ -21,12 +21,14 @@ add_hpx_component(
   DEPENDENCIES iostreams_component
   HEADER_GLOB "${root}/managed_refcnt_checker.h*"
   SOURCE_GLOB "${root}/managed_refcnt_checker.c*"
-  FOLDER "Tests/Unit/AGAS" EXCLUDE_FROM_ALL AUTOGLOB
+  FOLDER "Tests/Unit/AGAS"
+  EXCLUDE_FROM_ALL AUTOGLOB
 )
 
 add_hpx_component(
   simple_mobile_object INTERNAL_FLAGS
   HEADER_GLOB "${root}/simple_mobile_object.h*"
   SOURCE_GLOB "${root}/simple_mobile_object.c*"
-  FOLDER "Tests/Unit/AGAS" EXCLUDE_FROM_ALL AUTOGLOB
+  FOLDER "Tests/Unit/AGAS"
+  EXCLUDE_FROM_ALL AUTOGLOB
 )

--- a/tests/unit/component/CMakeLists.txt
+++ b/tests/unit/component/CMakeLists.txt
@@ -106,7 +106,8 @@ foreach(test ${tests})
   # add example executable
   add_hpx_executable(
     ${test}_test INTERNAL_FLAGS
-    SOURCES ${sources} ${${test}_FLAGS} EXCLUDE_FROM_ALL
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
     HPX_PREFIX ${HPX_BUILD_PREFIX}
     FOLDER ${folder_name}
   )

--- a/tests/unit/resource/suspend_pool_external.cpp
+++ b/tests/unit/resource/suspend_pool_external.cpp
@@ -13,9 +13,9 @@
 #include <hpx/include/threads.hpp>
 #include <hpx/modules/schedulers.hpp>
 #include <hpx/modules/testing.hpp>
+#include <hpx/modules/timing.hpp>
 #include <hpx/threading_base/scheduler_mode.hpp>
 #include <hpx/threading_base/thread_helpers.hpp>
-#include <hpx/modules/timing.hpp>
 
 #include <atomic>
 #include <cstddef>
@@ -55,6 +55,7 @@ void test_scheduler(
         hpx::threads::suspend_pool_cb(
             default_pool, [&suspended]() { suspended = true; });
 
+        // NOLINTNEXTLINE(bugprone-infinite-loop)
         while (!suspended)
         {
             std::this_thread::yield();
@@ -64,6 +65,7 @@ void test_scheduler(
         hpx::threads::resume_pool_cb(
             default_pool, [&resumed]() { resumed = true; });
 
+        // NOLINTNEXTLINE(bugprone-infinite-loop)
         while (!resumed)
         {
             std::this_thread::yield();

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -3,7 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-FROM stellargroup/build_env:ubuntu
+FROM stellargroup/build_env:1
 
 # docker build needs to be run in /usr/local
 COPY . /usr/local


### PR DESCRIPTION
I've updated the base image for CI to Ubuntu 20.04 (20.10 is still a bit too recent, and not all packages worked there). At the same time I started tagging the pushed images with a simple incrementing number. That means that we can update the image without having all CI builds use the new image immediately. A PR on the HPX side (like this one) is required to actually update to the new version. The versioning is completely manual for the moment, as e.g. installing a single new package in the image doesn't necessarily require a new version. We can improve this later if needed. The `latest` tag always refers to the latest image.

With the move to Ubuntu 20.04 clang is updated to 10, but I've kept clang-format on 9 for now. Ubuntu helpfully provides a few versions of clang-format so we can in the future update the base image a bit more aggressively without changing the clang-format version.

@K-ballo this new tag also includes IWYU, so if you'd like to try things out on CircleCI you can base your IWYU work on this branch.