### PR TITLE
Limit cuda jenkins run to nodes with exclusively Nvidia GPUs 

### DIFF
--- a/.jenkins/lsu/slurm-configuration-gcc-9-cuda-11.sh
+++ b/.jenkins/lsu/slurm-configuration-gcc-9-cuda-11.sh
@@ -4,5 +4,5 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-configuration_slurm_partition="cuda"
+configuration_slurm_partition="sc15"
 configuration_slurm_num_nodes="1"


### PR DESCRIPTION
Both nodes with AMD GPUs are used for jenkins, one for the cuda run and the other for the hip run.
This limit the cuda jenkins run to partitions which contains exclusively NVIDIA GPUs.