### PR TITLE
Limit jenkins hipcc to the reno node

### DIFF
--- a/.jenkins/lsu/slurm-configuration-hipcc.sh
+++ b/.jenkins/lsu/slurm-configuration-hipcc.sh
@@ -4,5 +4,6 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-configuration_slurm_partition="fury"
+# The partition k40 contains the reno node with both Nvidia and AMD
+configuration_slurm_partition="k40"
 configuration_slurm_num_nodes="1"


### PR DESCRIPTION
Paired with #5047

Limit the hipcc jenkins to only the reno nodes, will revert it once the main work on hipcc is done.