### PR TITLE
Replace old init overloads in tests and examples

### DIFF
--- a/components/containers/unordered/tests/regressions/unordered_compilation_4685.cpp
+++ b/components/containers/unordered/tests/regressions/unordered_compilation_4685.cpp
@@ -44,6 +44,9 @@ int main(int argc, char** argv)
 {
     std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
 
-    return hpx::init(argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/components/performance_counters/papi/tests/regressions/papi_counters_active_interface.cpp
+++ b/components/performance_counters/papi/tests/regressions/papi_counters_active_interface.cpp
@@ -124,10 +124,6 @@ int main(int argc, char* argv[])
     if (pipe(pipefd) != 0 || dup2(pipefd[1], STDOUT_FILENO) < 0)
         throw std::runtime_error("could not create pipe to stdout");
 
-    // Configure application-specific options.
-    hpx::program_options::options_description cmdline(
-        "Usage: " HPX_APPLICATION_STRING " [options]");
-
     // Add the required counter command line option.
     char **opt = new char *[argc+2];
     for (int i = 0; i < argc; i++) opt[i] = argv[i];

--- a/components/performance_counters/papi/tests/regressions/papi_counters_basic_functions.cpp
+++ b/components/performance_counters/papi/tests/regressions/papi_counters_basic_functions.cpp
@@ -106,5 +106,8 @@ int main(int argc, char* argv[])
         "Usage: " HPX_APPLICATION_STRING " [options]");
 
     // Initialize and run HPX.
-    return hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/examples/1d_stencil/1d_stencil_1.cpp
+++ b/examples/1d_stencil/1d_stencil_1.cpp
@@ -129,5 +129,8 @@ int main(int argc, char* argv[])
     ;
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/examples/1d_stencil/1d_stencil_2.cpp
+++ b/examples/1d_stencil/1d_stencil_2.cpp
@@ -164,6 +164,9 @@ int main(int argc, char* argv[])
     ;
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 

--- a/examples/1d_stencil/1d_stencil_3.cpp
+++ b/examples/1d_stencil/1d_stencil_3.cpp
@@ -198,5 +198,8 @@ int main(int argc, char* argv[])
     ;
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/examples/1d_stencil/1d_stencil_4.cpp
+++ b/examples/1d_stencil/1d_stencil_4.cpp
@@ -268,5 +268,8 @@ int main(int argc, char* argv[])
     // clang-format on
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/examples/1d_stencil/1d_stencil_4_parallel.cpp
+++ b/examples/1d_stencil/1d_stencil_4_parallel.cpp
@@ -232,5 +232,8 @@ int main(int argc, char* argv[])
     // clang-format on
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/examples/1d_stencil/1d_stencil_4_repart.cpp
+++ b/examples/1d_stencil/1d_stencil_4_repart.cpp
@@ -463,5 +463,8 @@ int main(int argc, char* argv[])
     hpx::register_startup_function(&setup_counters);
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/examples/1d_stencil/1d_stencil_4_throttle.cpp
+++ b/examples/1d_stencil/1d_stencil_4_throttle.cpp
@@ -355,6 +355,9 @@ int main(int argc, char* argv[])
     hpx::register_startup_function(&apex::print_options);
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/examples/1d_stencil/1d_stencil_5.cpp
+++ b/examples/1d_stencil/1d_stencil_5.cpp
@@ -365,6 +365,9 @@ int main(int argc, char* argv[])
     ;
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/examples/1d_stencil/1d_stencil_6.cpp
+++ b/examples/1d_stencil/1d_stencil_6.cpp
@@ -429,6 +429,9 @@ int main(int argc, char* argv[])
     ;
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/examples/1d_stencil/1d_stencil_7.cpp
+++ b/examples/1d_stencil/1d_stencil_7.cpp
@@ -459,6 +459,9 @@ int main(int argc, char* argv[])
     ;
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/examples/1d_stencil/1d_stencil_8.cpp
+++ b/examples/1d_stencil/1d_stencil_8.cpp
@@ -743,6 +743,10 @@ int main(int argc, char* argv[])
         "hpx.run_hpx_main!=1"
     };
 
-    return hpx::init(desc_commandline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/examples/1d_stencil/1d_stencil_channel.cpp
+++ b/examples/1d_stencil/1d_stencil_channel.cpp
@@ -182,6 +182,10 @@ int main(int argc, char* argv[])
         "hpx.run_hpx_main!=1",
     };
 
-    return hpx::init(desc_commandline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/examples/accumulators/accumulator_client.cpp
+++ b/examples/accumulators/accumulator_client.cpp
@@ -101,7 +101,10 @@ int main(int argc, char* argv[])
     };
 
     // Initialize and run HPX.
-    return hpx::init(argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 #endif

--- a/examples/accumulators/template_accumulator_client.cpp
+++ b/examples/accumulators/template_accumulator_client.cpp
@@ -134,7 +134,10 @@ int main(int argc, char* argv[])
     };
 
     // Initialize and run HPX.
-    return hpx::init(argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 #endif

--- a/examples/accumulators/template_function_accumulator_client.cpp
+++ b/examples/accumulators/template_function_accumulator_client.cpp
@@ -113,7 +113,10 @@ int main(int argc, char* argv[])
     };
 
     // Initialize and run HPX.
-    return hpx::init(argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 #endif

--- a/examples/apex/apex_balance.cpp
+++ b/examples/apex/apex_balance.cpp
@@ -131,5 +131,8 @@ int main(int argc, char* argv[])
     hpx::register_startup_function(register_policy);
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/examples/apex/apex_fibonacci.cpp
+++ b/examples/apex/apex_fibonacci.cpp
@@ -131,6 +131,9 @@ int main(int argc, char* argv[])
     });
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 //]

--- a/examples/apex/apex_policy_engine_active_thread_count.cpp
+++ b/examples/apex/apex_policy_engine_active_thread_count.cpp
@@ -152,5 +152,8 @@ int main(int argc, char* argv[])
     hpx::register_startup_function(&register_policies);
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/examples/apex/apex_policy_engine_events.cpp
+++ b/examples/apex/apex_policy_engine_events.cpp
@@ -96,5 +96,8 @@ int main(int argc, char* argv[])
     });
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/examples/apex/apex_policy_engine_periodic.cpp
+++ b/examples/apex/apex_policy_engine_periodic.cpp
@@ -104,5 +104,8 @@ int main(int argc, char* argv[])
     hpx::register_shutdown_function(deregister_policy);
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/examples/balancing/hpx_thread_phase.cpp
+++ b/examples/balancing/hpx_thread_phase.cpp
@@ -44,9 +44,6 @@ using hpx::threads::pending;
 using hpx::threads::suspended;
 using hpx::threads::set_thread_state;
 
-using hpx::init;
-using hpx::finalize;
-
 typedef std::pair<thread_id_type, std::size_t> value_type;
 typedef std::vector<value_type> fifo_type;
 
@@ -150,7 +147,7 @@ int hpx_main(variables_map& vm)
     }
 
     // Initiate shutdown of the runtime system.
-    finalize();
+    hpx::finalize();
     return 0;
 }
 
@@ -173,6 +170,9 @@ int main(int argc, char* argv[])
         ;
 
     // Initialize and run HPX.
-    return init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 

--- a/examples/balancing/os_thread_num.cpp
+++ b/examples/balancing/os_thread_num.cpp
@@ -35,9 +35,6 @@ using hpx::threads::register_work;
 using hpx::threads::thread_init_data;
 using hpx::threads::make_thread_function_nullary;
 
-using hpx::init;
-using hpx::finalize;
-
 using hpx::cout;
 using hpx::flush;
 
@@ -132,7 +129,7 @@ int hpx_main(variables_map& vm)
     }
 
     // initiate shutdown of the runtime system
-    finalize();
+    hpx::finalize();
     return 0;
 }
 
@@ -157,7 +154,10 @@ int main(int argc, char* argv[])
         ;
 
     // Initialize and run HPX
-    return init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 #endif

--- a/examples/heartbeat/heartbeat.cpp
+++ b/examples/heartbeat/heartbeat.cpp
@@ -147,9 +147,12 @@ int main(int argc, char* argv[])
         "hpx.run_hpx_main!=1"
     };
 
-    hpx::util::function_nonser<void()> const empty;
-    return hpx::init(desc_commandline, argc, argv, cfg, empty,
-        empty, hpx::runtime_mode::connect);
+    hpx::init_params init_args;
+    init_args.mode = hpx::runtime_mode::connect;
+    init_args.cfg = cfg;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 #endif

--- a/examples/heartbeat/heartbeat_console.cpp
+++ b/examples/heartbeat/heartbeat_console.cpp
@@ -55,6 +55,10 @@ int main(int argc, char* argv[])
         "hpx.expect_connecting_localities=1"
     };
 
-    return hpx::init(desc_commandline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/examples/jacobi/jacobi.cpp
+++ b/examples/jacobi/jacobi.cpp
@@ -26,9 +26,6 @@ using hpx::program_options::value;
 
 using hpx::chrono::high_resolution_timer;
 
-using hpx::init;
-using hpx::finalize;
-
 using hpx::cout;
 using hpx::flush;
 
@@ -47,7 +44,7 @@ int hpx_main(variables_map & vm)
         solver.run(max_iterations);
     }
 
-    return finalize();
+    return hpx::finalize();
 }
 
 int main(int argc, char **argv)
@@ -83,6 +80,9 @@ int main(int argc, char **argv)
         )
         ;
 
-    return init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/examples/jacobi_smp/jacobi.cpp
+++ b/examples/jacobi_smp/jacobi.cpp
@@ -105,7 +105,10 @@ int main(int argc, char **argv)
     }
     return hpx_main(vm);
 #else
-    return hpx::init(desc_cmd, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_cmd;
+
+    return hpx::init(argc, argv, init_args);
 #endif
 
 }

--- a/examples/jacobi_smp/jacobi_nonuniform.cpp
+++ b/examples/jacobi_smp/jacobi_nonuniform.cpp
@@ -241,7 +241,10 @@ int main(int argc, char **argv)
     }
     return hpx_main(vm);
 #else
-    return hpx::init(desc_cmd, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_cmd;
+
+    return hpx::init(argc, argv, init_args);
 #endif
 
 }

--- a/examples/performance_counters/access_counter_set.cpp
+++ b/examples/performance_counters/access_counter_set.cpp
@@ -75,15 +75,18 @@ int hpx_main(hpx::program_options::variables_map& vm)
 int main(int argc, char* argv[])
 {
     // Define application-specific command-line options.
-    hpx::program_options::options_description opts(
+    hpx::program_options::options_description cmdline(
         "usage: access_counter_set [options]");
 
-    opts.add_options()
+    cmdline.add_options()
         ("counter", hpx::program_options::value<std::string>(),
          "name (pattern) representing the of the performance counter(s) to query")
         ;
 
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
     // Initialize and run HPX.
-    return hpx::init(opts, argc, argv);
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/examples/performance_counters/sine/sine_client.cpp
+++ b/examples/performance_counters/sine/sine_client.cpp
@@ -173,6 +173,10 @@ int main(int argc, char* argv[])
     };
 
     // Initialize and run HPX.
-    return hpx::init(desc_commandline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/examples/quickstart/1d_wave_equation.cpp
+++ b/examples/quickstart/1d_wave_equation.cpp
@@ -51,9 +51,7 @@ using hpx::lcos::wait;
 
 using hpx::chrono::high_resolution_timer;
 
-using hpx::finalize;
 using hpx::find_here;
-using hpx::init;
 
 using hpx::cout;
 using hpx::flush;
@@ -248,7 +246,7 @@ int hpx_main(variables_map& vm)
         hpx::util::format_to(std::cout, fmt, t.elapsed());
     }
 
-    finalize();
+    hpx::finalize();
     return 0;
 }
 
@@ -284,6 +282,9 @@ int main(int argc, char* argv[])
     // clang-format on
 
     // Initialize and run HPX.
-    return init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/examples/quickstart/allow_unknown_options.cpp
+++ b/examples/quickstart/allow_unknown_options.cpp
@@ -31,7 +31,10 @@ int main(int argc, char* argv[])
         "hpx.commandline.allow_unknown=1"   // allow for unknown options
     };
 
-    return hpx::init(argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 #endif

--- a/examples/quickstart/command_line_handling.cpp
+++ b/examples/quickstart/command_line_handling.cpp
@@ -50,6 +50,9 @@ int main(int argc, char* argv[])
          "additional, application-specific option")
     ;
 
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/examples/quickstart/composable_guard.cpp
+++ b/examples/quickstart/composable_guard.cpp
@@ -95,5 +95,8 @@ int main(int argc, char* argv[]) {
         ;
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/examples/quickstart/factorial.cpp
+++ b/examples/quickstart/factorial.cpp
@@ -74,7 +74,10 @@ int main(int argc, char* argv[])
         ;
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 #endif

--- a/examples/quickstart/fibonacci.cpp
+++ b/examples/quickstart/fibonacci.cpp
@@ -90,7 +90,10 @@ int main(int argc, char* argv[])
         ;
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 //]
 #endif

--- a/examples/quickstart/fibonacci_await.cpp
+++ b/examples/quickstart/fibonacci_await.cpp
@@ -248,6 +248,9 @@ int main(int argc, char* argv[])
     ;
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/examples/quickstart/fibonacci_dataflow.cpp
+++ b/examples/quickstart/fibonacci_dataflow.cpp
@@ -149,6 +149,9 @@ int main(int argc, char* argv[])
     ;
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/examples/quickstart/fibonacci_futures.cpp
+++ b/examples/quickstart/fibonacci_futures.cpp
@@ -485,6 +485,9 @@ int main(int argc, char* argv[])
     ;
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/examples/quickstart/fibonacci_futures_distributed.cpp
+++ b/examples/quickstart/fibonacci_futures_distributed.cpp
@@ -262,6 +262,11 @@ int main(int argc, char* argv[])
 {
     // Initialize and run HPX
     hpx::register_startup_function(&init_globals);
-    return hpx::init(get_commandline_options(), argc, argv);
+    hpx::init_params init_args;
+    hpx::program_options::options_description cmdline =
+        get_commandline_options();
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/examples/quickstart/fibonacci_local.cpp
+++ b/examples/quickstart/fibonacci_local.cpp
@@ -74,7 +74,10 @@ int main(int argc, char* argv[])
         ;
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 //main]
 #endif

--- a/examples/quickstart/fibonacci_one.cpp
+++ b/examples/quickstart/fibonacci_one.cpp
@@ -116,7 +116,10 @@ int main(int argc, char* argv[])
         ;
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 //]
 #endif

--- a/examples/quickstart/init_globally.cpp
+++ b/examples/quickstart/init_globally.cpp
@@ -95,8 +95,11 @@ struct manage_global_runtime
         using hpx::util::placeholders::_2;
         hpx::util::function_nonser<int(int, char**)> start_function =
             hpx::util::bind(&manage_global_runtime::hpx_main, this, _1, _2);
+        hpx::init_params init_args;
+        init_args.cfg = cfg;
+        init_args.mode = hpx::runtime_mode::default_;
 
-        if (!hpx::start(start_function, __argc, __argv, cfg, hpx::runtime_mode::default_))
+        if (!hpx::start(start_function, __argc, __argv, init_args))
         {
             // Something went wrong while initializing the runtime.
             // This early we can't generate any output, just bail out.

--- a/examples/quickstart/interest_calculator.cpp
+++ b/examples/quickstart/interest_calculator.cpp
@@ -115,7 +115,10 @@ int main(int argc, char ** argv)
             "The time money is invested [months]")
     ;
 
-    return hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 //]
 #endif

--- a/examples/quickstart/latch_local.cpp
+++ b/examples/quickstart/latch_local.cpp
@@ -56,5 +56,8 @@ int main(int argc, char* argv[])
           "number of threads to synchronize at a local latch (default: 16)")
         ;
 
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/examples/quickstart/latch_remote.cpp
+++ b/examples/quickstart/latch_remote.cpp
@@ -50,6 +50,9 @@ int main(int argc, char* argv[])
         "hpx.run_hpx_main!=1"
     };
 
-    return hpx::init(argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/examples/quickstart/partitioned_vector_spmd_foreach.cpp
+++ b/examples/quickstart/partitioned_vector_spmd_foreach.cpp
@@ -200,6 +200,10 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/examples/quickstart/pingpong.cpp
+++ b/examples/quickstart/pingpong.cpp
@@ -160,7 +160,10 @@ int main(int argc, char* argv[])
          "verbosity of output,if false output is for awk")
         ;
 
-    return hpx::init(description, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = description;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 #endif

--- a/examples/quickstart/sierpinski.cpp
+++ b/examples/quickstart/sierpinski.cpp
@@ -135,6 +135,9 @@ int main(int argc, char* argv[])
           "side-length of the original triangle")
         ;
 
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/examples/quickstart/timed_wake.cpp
+++ b/examples/quickstart/timed_wake.cpp
@@ -19,9 +19,6 @@ using hpx::program_options::value;
 
 using std::chrono::seconds;
 
-using hpx::init;
-using hpx::finalize;
-
 using hpx::threads::pending;
 using hpx::threads::suspended;
 using hpx::threads::get_self_id;
@@ -47,7 +44,7 @@ int hpx_main(variables_map& vm)
         std::cout << "woke up after " << t.elapsed() << " seconds\n";
     }
 
-    finalize();
+    hpx::finalize();
     return 0;
 }
 
@@ -59,6 +56,9 @@ int main(int argc, char* argv[])
        desc_commandline("Usage: " HPX_APPLICATION_STRING " [options]");
 
     // Initialize and run HPX.
-    return init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 

--- a/examples/quickstart/vector_counting_dotproduct.cpp
+++ b/examples/quickstart/vector_counting_dotproduct.cpp
@@ -53,6 +53,9 @@ int main(int argc, char* argv[])
     };
 
     // Initialize and run HPX
-    return hpx::init(argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/examples/quickstart/vector_zip_dotproduct.cpp
+++ b/examples/quickstart/vector_zip_dotproduct.cpp
@@ -55,7 +55,10 @@ int main(int argc, char* argv[])
     };
 
     // Initialize and run HPX
-    return hpx::init(argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 

--- a/examples/random_mem_access/random_mem_access_client.cpp
+++ b/examples/random_mem_access/random_mem_access_client.cpp
@@ -86,7 +86,10 @@ int main(int argc, char* argv[])
             "the number of lookups to perform")
         ;
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 #endif

--- a/examples/sheneos/sheneos_client.cpp
+++ b/examples/sheneos/sheneos_client.cpp
@@ -95,6 +95,9 @@ int main(int argc, char* argv[])
         ;
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 

--- a/examples/sheneos/sheneos_test.cpp
+++ b/examples/sheneos/sheneos_test.cpp
@@ -434,7 +434,10 @@ int main(int argc, char* argv[])
     ;
 
     // Initialize and run HPX.
-    return hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 #endif

--- a/examples/throttle/spin.cpp
+++ b/examples/throttle/spin.cpp
@@ -84,7 +84,11 @@ int main(int argc, char* argv[])
     };
 
     // Initialize and run HPX.
-    return init(desc_commandline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 #endif

--- a/examples/throttle/throttle_client.cpp
+++ b/examples/throttle/throttle_client.cpp
@@ -100,8 +100,12 @@ int main(int argc, char* argv[])
         "hpx.run_hpx_main!=1"
     };
 
-    hpx::util::function_nonser<void()> const empty;
-    return hpx::init(cmdline, argc, argv, cfg, empty, empty, hpx::runtime_mode::connect);
+    hpx::init_params init_args;
+    init_args.mode = hpx::runtime_mode::connect;
+    init_args.cfg = cfg;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 #endif

--- a/examples/transpose/transpose_await.cpp
+++ b/examples/transpose/transpose_await.cpp
@@ -395,7 +395,11 @@ int main(int argc, char* argv[])
     // localities
     std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
 
-    return hpx::init(desc_commandline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 void transpose(sub_block const A, sub_block B, std::uint64_t block_order,

--- a/examples/transpose/transpose_block.cpp
+++ b/examples/transpose/transpose_block.cpp
@@ -412,7 +412,11 @@ int main(int argc, char* argv[])
     // localities
     std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
 
-    return hpx::init(desc_commandline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 void transpose(hpx::future<sub_block> Af, hpx::future<sub_block> Bf,

--- a/examples/transpose/transpose_block_numa.cpp
+++ b/examples/transpose/transpose_block_numa.cpp
@@ -601,7 +601,11 @@ int main(int argc, char* argv[])
     //    cfg.push_back(bind_desc);
 
     //    return hpx::init();
-    return hpx::init(desc_commandline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 void transpose(hpx::future<sub_block> Af, hpx::future<sub_block> Bf,

--- a/examples/transpose/transpose_serial.cpp
+++ b/examples/transpose/transpose_serial.cpp
@@ -158,7 +158,11 @@ int main(int argc, char* argv[])
         "hpx.os_threads!=1"
     };
 
-    return hpx::init(desc_commandline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 double test_results(std::uint64_t order, std::vector<double> const & trans)

--- a/examples/transpose/transpose_serial_block.cpp
+++ b/examples/transpose/transpose_serial_block.cpp
@@ -163,7 +163,11 @@ int main(int argc, char* argv[])
         "hpx.os_threads!=1"
     };
 
-    return hpx::init(desc_commandline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 void transpose(sub_block A, sub_block B, std::uint64_t block_order,

--- a/examples/transpose/transpose_serial_vector.cpp
+++ b/examples/transpose/transpose_serial_vector.cpp
@@ -165,7 +165,11 @@ int main(int argc, char* argv[])
         "hpx.os_threads!=1"
     };
 
-    return hpx::init(desc_commandline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 double test_results(std::uint64_t order,

--- a/examples/transpose/transpose_smp.cpp
+++ b/examples/transpose/transpose_smp.cpp
@@ -164,7 +164,10 @@ int main(int argc, char* argv[])
     ;
     // clang-format on
 
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 double test_results(std::uint64_t order, std::vector<double> const& trans)

--- a/examples/transpose/transpose_smp_block.cpp
+++ b/examples/transpose/transpose_smp_block.cpp
@@ -173,7 +173,10 @@ int main(int argc, char* argv[])
     ;
     // clang-format on
 
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 void transpose(sub_block A, sub_block B, std::uint64_t block_order,

--- a/examples/tuplespace/simple_central_tuplespace_client.cpp
+++ b/examples/tuplespace/simple_central_tuplespace_client.cpp
@@ -168,6 +168,9 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=2"};
 
     // Initialize and run HPX.
-    return hpx::init(argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/hpx/lcos/packaged_action.hpp
+++ b/hpx/lcos/packaged_action.hpp
@@ -206,9 +206,8 @@ namespace hpx { namespace lcos {
                         << hpx::actions::detail::get_action_name<action_type>()
                         << ", " << id << ") args(" << sizeof...(Ts) << ")";
 
-            using callback_type = typename std::decay<Callback>::type;
-
 #if defined(HPX_HAVE_NETWORKING)
+            using callback_type = typename std::decay<Callback>::type;
             auto&& f = detail::parcel_write_handler_cb<Result, callback_type>{
                 this->shared_state_, std::forward<Callback>(cb)};
 #else
@@ -248,9 +247,9 @@ namespace hpx { namespace lcos {
                         << hpx::actions::detail::get_action_name<action_type>()
                         << ", " << id << ") args(" << sizeof...(Ts) << ")";
 
-            using callback_type = typename std::decay<Callback>::type;
 
 #if defined(HPX_HAVE_NETWORKING)
+            using callback_type = typename std::decay<Callback>::type;
             auto&& f = detail::parcel_write_handler_cb<Result, callback_type>{
                 this->shared_state_, std::forward<Callback>(cb)};
 #else
@@ -382,9 +381,8 @@ namespace hpx { namespace lcos {
                         << hpx::actions::detail::get_action_name<action_type>()
                         << ", " << id << ") args(" << sizeof...(Ts) << ")";
 
-            using callback_type = typename std::decay<Callback>::type;
-
 #if defined(HPX_HAVE_NETWORKING)
+            using callback_type = typename std::decay<Callback>::type;
             auto&& f = detail::parcel_write_handler_cb<Result, callback_type>{
                 this->shared_state_, std::forward<Callback>(cb)};
 #else

--- a/init/include/hpx/hpx_main_impl.hpp
+++ b/init/include/hpx/hpx_main_impl.hpp
@@ -33,7 +33,10 @@ int HPX_CDECL main(int argc, char** argv)
         "hpx.commandline.aliasing=0"
     };
 
-    return hpx::init(argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 // Make sure header testing code does not redefine main()

--- a/libs/core/affinity/tests/unit/parse_affinity_options.cpp
+++ b/libs/core/affinity/tests/unit/parse_affinity_options.cpp
@@ -1127,6 +1127,9 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=4"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ(0, hpx::init(argc, argv, cfg));
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(0, hpx::init(argc, argv, init_args));
     return hpx::util::report_errors();
 }

--- a/libs/core/functional/tests/regressions/function_argument.cpp
+++ b/libs/core/functional/tests/regressions/function_argument.cpp
@@ -82,6 +82,9 @@ int main(int argc, char** argv)
 {
     options_description cmdline("usage: " HPX_APPLICATION_STRING " [options]");
 
-    return hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/libs/core/functional/tests/regressions/function_serialization_728.cpp
+++ b/libs/core/functional/tests/regressions/function_serialization_728.cpp
@@ -96,7 +96,10 @@ int main(int argc, char* argv[])
     options_description cmdline("Usage: " HPX_APPLICATION_STRING " [options]");
 
     // Initialize and run HPX
-    HPX_TEST_EQ(hpx::init(cmdline, argc, argv), 0);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
     return 0;
 }
 #endif

--- a/libs/core/iterator_support/tests/performance/stencil3_iterators.cpp
+++ b/libs/core/iterator_support/tests/performance/stencil3_iterators.cpp
@@ -577,6 +577,9 @@ int main(int argc, char* argv[])
         ;
     // clang-format on
 
-    return hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/libs/core/iterator_support/tests/unit/counting_iterator.cpp
+++ b/libs/core/iterator_support/tests/unit/counting_iterator.cpp
@@ -355,7 +355,10 @@ int main(int argc, char* argv[])
         "the random number generator seed to use for this run");
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/core/serialization/tests/performance/serialization_overhead.cpp
+++ b/libs/core/serialization/tests/performance/serialization_overhead.cpp
@@ -222,6 +222,9 @@ int main(int argc, char* argv[])
         ;
     // clang-format on
 
-    return hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/libs/core/serialization/tests/unit/any_serialization.cpp
+++ b/libs/core/serialization/tests/unit/any_serialization.cpp
@@ -33,9 +33,6 @@ using hpx::program_options::variables_map;
 
 using hpx::util::basic_any;
 
-using hpx::finalize;
-using hpx::init;
-
 // note: version can be assigned only to objects whose implementation
 // level is object_class_info.  So, doing the following will result in
 // a static assertion
@@ -94,7 +91,7 @@ int hpx_main(variables_map& vm)
             hpx::any_cast<big_object>(any), hpx::any_cast<big_object>(any_in));
     }
 
-    return finalize();
+    return hpx::finalize();
 }
 
 int main(int argc, char* argv[])
@@ -103,7 +100,10 @@ int main(int argc, char* argv[])
     options_description cmdline("Usage: " HPX_APPLICATION_STRING " [options]");
 
     // Initialize and run HPX
-    init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    hpx::init(argc, argv, init_args);
 
     return EXIT_SUCCESS;
 }

--- a/libs/core/synchronization/tests/unit/condition_variable.cpp
+++ b/libs/core/synchronization/tests/unit/condition_variable.cpp
@@ -733,5 +733,9 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/core/synchronization/tests/unit/counting_semaphore.cpp
+++ b/libs/core/synchronization/tests/unit/counting_semaphore.cpp
@@ -48,8 +48,10 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/core/synchronization/tests/unit/local_barrier.cpp
+++ b/libs/core/synchronization/tests/unit/local_barrier.cpp
@@ -97,7 +97,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
     return report_errors();
 }

--- a/libs/core/synchronization/tests/unit/local_barrier_count_up.cpp
+++ b/libs/core/synchronization/tests/unit/local_barrier_count_up.cpp
@@ -101,7 +101,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
     return report_errors();
 }

--- a/libs/core/synchronization/tests/unit/local_barrier_reset.cpp
+++ b/libs/core/synchronization/tests/unit/local_barrier_reset.cpp
@@ -153,7 +153,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
     return report_errors();
 }

--- a/libs/core/synchronization/tests/unit/local_event.cpp
+++ b/libs/core/synchronization/tests/unit/local_event.cpp
@@ -101,7 +101,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
     return report_errors();
 }

--- a/libs/core/synchronization/tests/unit/local_mutex.cpp
+++ b/libs/core/synchronization/tests/unit/local_mutex.cpp
@@ -329,5 +329,9 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/core/synchronization/tests/unit/shared_mutex/shared_mutex1.cpp
+++ b/libs/core/synchronization/tests/unit/shared_mutex/shared_mutex1.cpp
@@ -363,8 +363,10 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/core/synchronization/tests/unit/shared_mutex/shared_mutex2.cpp
+++ b/libs/core/synchronization/tests/unit/shared_mutex/shared_mutex2.cpp
@@ -311,8 +311,10 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/core/synchronization/tests/unit/sliding_semaphore.cpp
+++ b/libs/core/synchronization/tests/unit/sliding_semaphore.cpp
@@ -46,8 +46,10 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/core/threading_base/tests/unit/set_thread_state.cpp
+++ b/libs/core/threading_base/tests/unit/set_thread_state.cpp
@@ -43,9 +43,7 @@ using hpx::threads::wait_signaled;
 using hpx::threads::wait_terminate;
 using hpx::threads::wait_timeout;
 
-using hpx::finalize;
 using hpx::find_here;
-using hpx::init;
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace detail {
@@ -198,7 +196,7 @@ int hpx_main(variables_map& vm)
         set_thread_state(thread, pending, wait_terminate);
     }
 
-    finalize();
+    hpx::finalize();
 
     return 0;
 }
@@ -222,6 +220,9 @@ int main(int argc, char* argv[])
     // clang-format on
 
     // Initialize and run HPX
-    return init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/libs/full/async_cuda/tests/performance/cuda_executor_throughput.cpp
+++ b/libs/full/async_cuda/tests/performance/cuda_executor_throughput.cpp
@@ -209,6 +209,9 @@ int main(int argc, char** argv)
         "iterations");
     // clang-format on
 
-    auto result = hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    auto result = hpx::init(argc, argv, init_args);
     return result || hpx::util::report_errors();
 }

--- a/libs/full/async_cuda/tests/unit/cublas_matmul.cpp
+++ b/libs/full/async_cuda/tests/unit/cublas_matmul.cpp
@@ -350,6 +350,9 @@ int main(int argc, char** argv)
         hpx::program_options::value<unsigned int>(),
         "the random number generator seed to use for this run");
     // clang-format on
-    auto result = hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    auto result = hpx::init(argc, argv, init_args);
     return result || hpx::util::report_errors();
 }

--- a/libs/full/async_cuda/tests/unit/cuda_future.cpp
+++ b/libs/full/async_cuda/tests/unit/cuda_future.cpp
@@ -194,6 +194,9 @@ int main(int argc, char** argv)
         "iterations")("seed,s", hpx::program_options::value<unsigned int>(),
         "the random number generator seed to use for this run");
 
-    auto result = hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    auto result = hpx::init(argc, argv, init_args);
     return result || hpx::util::report_errors();
 }

--- a/libs/full/async_distributed/tests/regressions/async_callback_non_deduced_context.cpp
+++ b/libs/full/async_distributed/tests/regressions/async_callback_non_deduced_context.cpp
@@ -58,6 +58,9 @@ int main(int argc, char* argv[])
         "Usage: " HPX_APPLICATION_STRING " [options]");
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/libs/full/async_distributed/tests/regressions/dataflow_791.cpp
+++ b/libs/full/async_distributed/tests/regressions/dataflow_791.cpp
@@ -120,7 +120,10 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    return hpx::init(argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 void LU(int numBlocks)

--- a/libs/full/async_distributed/tests/unit/remote_dataflow.cpp
+++ b/libs/full/async_distributed/tests/unit/remote_dataflow.cpp
@@ -140,8 +140,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
     return hpx::util::report_errors();
 }
 #endif

--- a/libs/full/async_mpi/tests/unit/mpi_ring_async_executor.cpp
+++ b/libs/full/async_mpi/tests/unit/mpi_ring_async_executor.cpp
@@ -198,7 +198,11 @@ int main(int argc, char* argv[])
     // clang-format on
 
     // Initialize and run HPX.
-    auto result = hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    auto result = hpx::init(argc, argv, init_args);
 
     // Finalize MPI
     MPI_Finalize();

--- a/libs/full/checkpoint/examples/1d_stencil_4_checkpoint.cpp
+++ b/libs/full/checkpoint/examples/1d_stencil_4_checkpoint.cpp
@@ -477,6 +477,9 @@ int main(int argc, char* argv[])
         "Base name of archive file");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/libs/full/collectives/tests/performance/lcos/barrier_performance.cpp
+++ b/libs/full/collectives/tests/performance/lcos/barrier_performance.cpp
@@ -53,7 +53,10 @@ int main(int argc, char* argv[])
         "hpx.run_hpx_main!=1", "hpx.os_threads!=all"};
 
     double startup_start = hpx::chrono::high_resolution_timer::now();
-    return hpx::init(argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
     double shutdown_end = hpx::chrono::high_resolution_timer::now();
 
     if (startup_end > 1e-10)

--- a/libs/full/collectives/tests/performance/osu/osu_base.cpp
+++ b/libs/full/collectives/tests/performance/osu/osu_base.cpp
@@ -49,6 +49,9 @@ int main(int argc, char* argv[])
          "Maximum size of message to send");
     // clang-format ON
 
-    return hpx::init(desc, argc, argv);
+hpx::init_params init_args;
+init_args.desc_cmdline = desc;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/libs/full/collectives/tests/performance/osu/osu_bcast.cpp
+++ b/libs/full/collectives/tests/performance/osu/osu_bcast.cpp
@@ -150,6 +150,9 @@ int main(int argc, char* argv[])
 {
     hpx::program_options::options_description desc(params_desc());
 
-    return hpx::init(desc, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/libs/full/collectives/tests/performance/osu/osu_scatter.cpp
+++ b/libs/full/collectives/tests/performance/osu/osu_scatter.cpp
@@ -119,6 +119,9 @@ int main(int argc, char* argv[])
 {
     hpx::program_options::options_description desc(params_desc());
 
-    return hpx::init(desc, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/libs/full/collectives/tests/regressions/barrier_3792.cpp
+++ b/libs/full/collectives/tests/regressions/barrier_3792.cpp
@@ -66,6 +66,9 @@ int main(int argc, char* argv[])
 {
     // We force hpx_main to run on all processes
     std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
-    return hpx::init(argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/libs/full/collectives/tests/regressions/multiple_gather_ops_2001.cpp
+++ b/libs/full/collectives/tests/regressions/multiple_gather_ops_2001.cpp
@@ -59,6 +59,9 @@ int hpx_main(int argc, char* argv[])
 int main(int argc, char* argv[])
 {
     std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
-    return hpx::init(argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/libs/full/collectives/tests/unit/all_gather.cpp
+++ b/libs/full/collectives/tests/unit/all_gather.cpp
@@ -69,7 +69,10 @@ int main(int argc, char* argv[])
 {
     std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
 
-    HPX_TEST_EQ(hpx::init(argc, argv, cfg), 0);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
     return hpx::util::report_errors();
 }
 #endif

--- a/libs/full/collectives/tests/unit/all_reduce.cpp
+++ b/libs/full/collectives/tests/unit/all_reduce.cpp
@@ -67,7 +67,10 @@ int main(int argc, char* argv[])
 {
     std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
 
-    HPX_TEST_EQ(hpx::init(argc, argv, cfg), 0);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
     return hpx::util::report_errors();
 }
 #endif

--- a/libs/full/collectives/tests/unit/all_to_all.cpp
+++ b/libs/full/collectives/tests/unit/all_to_all.cpp
@@ -75,7 +75,10 @@ int main(int argc, char* argv[])
 {
     std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
 
-    HPX_TEST_EQ(hpx::init(argc, argv, cfg), 0);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
     return hpx::util::report_errors();
 }
 #endif

--- a/libs/full/collectives/tests/unit/barrier.cpp
+++ b/libs/full/collectives/tests/unit/barrier.cpp
@@ -132,7 +132,11 @@ int main(int argc, char* argv[])
         "hpx.os_threads=all", "hpx.run_hpx_main!=1"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/full/collectives/tests/unit/broadcast.cpp
+++ b/libs/full/collectives/tests/unit/broadcast.cpp
@@ -72,7 +72,10 @@ int main(int argc, char* argv[])
 {
     std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
 
-    HPX_TEST_EQ(hpx::init(argc, argv, cfg), 0);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
     return hpx::util::report_errors();
 }
 #endif

--- a/libs/full/collectives/tests/unit/gather.cpp
+++ b/libs/full/collectives/tests/unit/gather.cpp
@@ -82,7 +82,10 @@ int main(int argc, char* argv[])
 {
     std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
 
-    HPX_TEST_EQ(hpx::init(argc, argv, cfg), 0);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
     return hpx::util::report_errors();
 }
 #endif

--- a/libs/full/collectives/tests/unit/remote_latch.cpp
+++ b/libs/full/collectives/tests/unit/remote_latch.cpp
@@ -88,8 +88,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/full/collectives/tests/unit/scatter.cpp
+++ b/libs/full/collectives/tests/unit/scatter.cpp
@@ -81,7 +81,10 @@ int main(int argc, char* argv[])
 {
     std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
 
-    HPX_TEST_EQ(hpx::init(argc, argv, cfg), 0);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
     return hpx::util::report_errors();
 }
 #endif

--- a/libs/full/compute/tests/unit/block_allocator.cpp
+++ b/libs/full/compute/tests/unit/block_allocator.cpp
@@ -113,7 +113,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/full/compute_cuda/examples/data_copy.cu
+++ b/libs/full/compute_cuda/examples/data_copy.cu
@@ -69,5 +69,8 @@ int main(int argc, char* argv[])
         "the random number generator seed to use for this run");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/compute_cuda/examples/hello_compute.cu
+++ b/libs/full/compute_cuda/examples/hello_compute.cu
@@ -95,5 +95,8 @@ int main(int argc, char* argv[])
         "the random number generator seed to use for this run");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/compute_cuda/examples/partitioned_vector.cu
+++ b/libs/full/compute_cuda/examples/partitioned_vector.cu
@@ -65,5 +65,8 @@ int main(int argc, char* argv[])
         "Usage: " HPX_APPLICATION_STRING " [options]");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/compute_cuda/tests/performance/synchronize.cu
+++ b/libs/full/compute_cuda/tests/performance/synchronize.cu
@@ -91,5 +91,8 @@ int main(int argc, char* argv[])
     cmdline.add_options()("iterations",
         hpx::program_options::value<std::size_t>()->default_value(1024),
         "number of iterations (default: 1024)");
-    return hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/compute_cuda/tests/unit/for_each_compute.cu
+++ b/libs/full/compute_cuda/tests/unit/for_each_compute.cu
@@ -96,7 +96,10 @@ int main(int argc, char* argv[])
     // clang-format on
 
     // Initialize and run HPX
-    hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    hpx::init(argc, argv, init_args);
 
     return hpx::util::report_errors();
 }

--- a/libs/full/compute_cuda/tests/unit/for_loop_compute.cu
+++ b/libs/full/compute_cuda/tests/unit/for_loop_compute.cu
@@ -114,7 +114,10 @@ int main(int argc, char* argv[])
         "the random number generator seed to use for this run");
 
     // Initialize and run HPX
-    hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    hpx::init(argc, argv, init_args);
 
     return hpx::util::report_errors();
 }

--- a/libs/full/compute_cuda/tests/unit/transform_compute.cu
+++ b/libs/full/compute_cuda/tests/unit/transform_compute.cu
@@ -121,7 +121,10 @@ int main(int argc, char* argv[])
         "the random number generator seed to use for this run");
 
     // Initialize and run HPX
-    hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    hpx::init(argc, argv, init_args);
 
     return hpx::util::report_errors();
 }

--- a/libs/full/init_runtime/include/hpx/hpx_init_impl.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_init_impl.hpp
@@ -147,6 +147,9 @@ namespace hpx {
     /// (or one of its overloads below) should be called from the users `main()`
     /// function. It will set up the HPX runtime environment and schedule the
     /// function given by \p f as a HPX thread.
+    HPX_DEPRECATED_V(1, 6,
+        "The init overload used is deprecated. Please use"
+        "the init overloads using the hpx::init_params struct.")
     inline int init(util::function_nonser<int(
                         hpx::program_options::variables_map& vm)> const& f,
         hpx::program_options::options_description const& desc_cmdline, int argc,
@@ -169,6 +172,9 @@ namespace hpx {
     /// (or one of its overloads below) should be called from the users `main()`
     /// function. It will set up the HPX runtime environment and schedule the
     /// function given by \p f as a HPX thread.
+    HPX_DEPRECATED_V(1, 6,
+        "The init overload used is deprecated. Please use"
+        "the init overloads using the hpx::init_params struct.")
     inline int init(int (*f)(hpx::program_options::variables_map& vm),
         hpx::program_options::options_description const& desc_cmdline, int argc,
         char** argv, startup_function_type startup,
@@ -190,6 +196,9 @@ namespace hpx {
     ///
     /// In console mode it will execute the user supplied function `hpx_main`,
     /// in worker mode it will execute an empty `hpx_main`.
+    HPX_DEPRECATED_V(1, 6,
+        "The init overload used is deprecated. Please use"
+        "the init overloads using the hpx::init_params struct.")
     inline int init(
         hpx::program_options::options_description const& desc_cmdline, int argc,
         char** argv, startup_function_type startup,
@@ -211,6 +220,9 @@ namespace hpx {
     ///
     /// In console mode it will execute the user supplied function `hpx_main`,
     /// in worker mode it will execute an empty `hpx_main`.
+    HPX_DEPRECATED_V(1, 6,
+        "The init overload used is deprecated. Please use"
+        "the init overloads using the hpx::init_params struct.")
     inline int init(
         hpx::program_options::options_description const& desc_cmdline, int argc,
         char** argv, std::vector<std::string> const& cfg,
@@ -234,6 +246,9 @@ namespace hpx {
     ///
     /// In console mode it will execute the user supplied function `hpx_main`,
     /// in worker mode it will execute an empty `hpx_main`.
+    HPX_DEPRECATED_V(1, 6,
+        "The init overload used is deprecated. Please use"
+        "the init overloads using the hpx::init_params struct.")
     inline int init(int argc, char** argv, std::vector<std::string> const& cfg,
         hpx::runtime_mode mode)
     {
@@ -251,6 +266,9 @@ namespace hpx {
     ///
     /// In console mode it will execute the user supplied function `hpx_main`,
     /// in worker mode it will execute an empty `hpx_main`.
+    HPX_DEPRECATED_V(1, 6,
+        "The init overload used is deprecated. Please use"
+        "the init overloads using the hpx::init_params struct.")
     inline int init(
         hpx::program_options::options_description const& desc_cmdline, int argc,
         char** argv, hpx::runtime_mode mode)
@@ -269,6 +287,9 @@ namespace hpx {
     ///
     /// In console mode it will execute the user supplied function `hpx_main`,
     /// in worker mode it will execute an empty `hpx_main`.
+    HPX_DEPRECATED_V(1, 6,
+        "The init overload used is deprecated. Please use"
+        "the init overloads using the hpx::init_params struct.")
     inline int init(
         hpx::program_options::options_description const& desc_cmdline, int argc,
         char** argv, std::vector<std::string> const& cfg,
@@ -288,6 +309,9 @@ namespace hpx {
     /// This is a simplified main entry point, which can be used to set up the
     /// runtime for an HPX application (the runtime system will be set up in
     /// console mode or worker mode depending on the command line settings).
+    HPX_DEPRECATED_V(1, 6,
+        "The init overload used is deprecated. Please use"
+        "the init overloads using the hpx::init_params struct.")
     inline int init(std::string const& app_name, int argc, char** argv,
         hpx::runtime_mode mode)
     {
@@ -305,6 +329,9 @@ namespace hpx {
     /// This is a simplified main entry point, which can be used to set up the
     /// runtime for an HPX application (the runtime system will be set up in
     /// console mode or worker mode depending on the command line settings).
+    HPX_DEPRECATED_V(1, 6,
+        "The init overload used is deprecated. Please use"
+        "the init overloads using the hpx::init_params struct.")
     inline int init(std::vector<std::string> const& cfg, hpx::runtime_mode mode)
     {
         hpx::init_params iparams;
@@ -318,6 +345,9 @@ namespace hpx {
     /// This is a simplified main entry point, which can be used to set up the
     /// runtime for an HPX application (the runtime system will be set up in
     /// console mode or worker mode depending on the command line settings).
+    HPX_DEPRECATED_V(1, 6,
+        "The init overload used is deprecated. Please use"
+        "the init overloads using the hpx::init_params struct.")
     inline int init(int (*f)(hpx::program_options::variables_map&),
         std::string const& app_name, int argc, char** argv,
         hpx::runtime_mode mode)
@@ -339,6 +369,9 @@ namespace hpx {
     }
 
     // Main entry point for launching the HPX runtime system.
+    HPX_DEPRECATED_V(1, 6,
+        "The init overload used is deprecated. Please use"
+        "the init overloads using the hpx::init_params struct.")
     inline int init(int (*f)(hpx::program_options::variables_map&), int argc,
         char** argv, hpx::runtime_mode mode)
     {
@@ -358,6 +391,9 @@ namespace hpx {
     /// This is a simplified main entry point, which can be used to set up the
     /// runtime for an HPX application (the runtime system will be set up in
     /// console mode or worker mode depending on the command line settings).
+    HPX_DEPRECATED_V(1, 6,
+        "The init overload used is deprecated. Please use"
+        "the init overloads using the hpx::init_params struct.")
     inline int init(util::function_nonser<int(int, char**)> const& f,
         std::string const& app_name, int argc, char** argv,
         hpx::runtime_mode mode)
@@ -373,6 +409,9 @@ namespace hpx {
         return init(f, argc, argv, iparams);
     }
 
+    HPX_DEPRECATED_V(1, 6,
+        "The init overload used is deprecated. Please use"
+        "the init overloads using the hpx::init_params struct.")
     inline int init(util::function_nonser<int(int, char**)> const& f, int argc,
         char** argv, std::vector<std::string> const& cfg,
         hpx::runtime_mode mode)
@@ -385,6 +424,9 @@ namespace hpx {
         return init(f, argc, argv, iparams);
     }
 
+    HPX_DEPRECATED_V(1, 6,
+        "The init overload used is deprecated. Please use"
+        "the init overloads using the hpx::init_params struct.")
     inline int init(util::function_nonser<int(int, char**)> const& f,
         std::vector<std::string> const& cfg, hpx::runtime_mode mode)
     {
@@ -394,6 +436,9 @@ namespace hpx {
         return init(f, detail::dummy_argc, detail::dummy_argv, iparams);
     }
 
+    HPX_DEPRECATED_V(1, 6,
+        "The init overload used is deprecated. Please use"
+        "the init overloads using the hpx::init_params struct.")
     inline int init(std::nullptr_t, std::string const& app_name, int argc,
         char** argv, hpx::runtime_mode mode)
     {
@@ -410,6 +455,9 @@ namespace hpx {
         return init(main_f, argc, argv, iparams);
     }
 
+    HPX_DEPRECATED_V(1, 6,
+        "The init overload used is deprecated. Please use"
+        "the init overloads using the hpx::init_params struct.")
     inline int init(
         std::nullptr_t, int argc, char** argv, hpx::runtime_mode mode)
     {
@@ -422,6 +470,9 @@ namespace hpx {
         return init(main_f, argc, argv, iparams);
     }
 
+    HPX_DEPRECATED_V(1, 6,
+        "The init overload used is deprecated. Please use"
+        "the init overloads using the hpx::init_params struct.")
     inline int init(std::nullptr_t, int argc, char** argv,
         std::vector<std::string> const& cfg, hpx::runtime_mode mode)
     {
@@ -435,6 +486,9 @@ namespace hpx {
         return init(main_f, argc, argv, iparams);
     }
 
+    HPX_DEPRECATED_V(1, 6,
+        "The init overload used is deprecated. Please use"
+        "the init overloads using the hpx::init_params struct.")
     inline int init(std::nullptr_t, std::vector<std::string> const& cfg,
         hpx::runtime_mode mode)
     {

--- a/libs/full/init_runtime/include/hpx/hpx_start_impl.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_start_impl.hpp
@@ -161,6 +161,9 @@ namespace hpx {
     /// schedule the function given by \p f as an HPX thread. It will return
     /// immediately after that. Use `hpx::wait` and `hpx::stop` to synchronize
     /// with the runtime system's execution.
+    HPX_DEPRECATED_V(1, 6,
+        "The start overload used is deprecated. Please use"
+        "the start overloads using the hpx::init_params struct.")
     inline bool start(util::function_nonser<int(
                           hpx::program_options::variables_map& vm)> const& f,
         hpx::program_options::options_description const& desc_cmdline, int argc,
@@ -186,6 +189,9 @@ namespace hpx {
     /// schedule the function given by \p f as an HPX thread. It will return
     /// immediately after that. Use `hpx::wait` and `hpx::stop` to synchronize
     /// with the runtime system's execution.
+    HPX_DEPRECATED_V(1, 6,
+        "The start overload used is deprecated. Please use"
+        "the start overloads using the hpx::init_params struct.")
     inline bool start(int (*f)(hpx::program_options::variables_map& vm),
         hpx::program_options::options_description const& desc_cmdline, int argc,
         char** argv, startup_function_type startup,
@@ -210,6 +216,9 @@ namespace hpx {
     /// set up in console mode or worker mode depending on the command line
     /// settings). It will return immediately after that. Use `hpx::wait` and
     /// `hpx::stop` to synchronize with the runtime system's execution.
+    HPX_DEPRECATED_V(1, 6,
+        "The start overload used is deprecated. Please use"
+        "the start overloads using the hpx::init_params struct.")
     inline bool start(
         hpx::program_options::options_description const& desc_cmdline, int argc,
         char** argv, startup_function_type startup,
@@ -232,6 +241,9 @@ namespace hpx {
     /// be set up in console mode or worker mode depending on the command line
     /// settings). It will return immediately after that. Use `hpx::wait` and
     /// `hpx::stop` to synchronize with the runtime system's execution.
+    HPX_DEPRECATED_V(1, 6,
+        "The start overload used is deprecated. Please use"
+        "the start overloads using the hpx::init_params struct.")
     inline bool start(
         hpx::program_options::options_description const& desc_cmdline, int argc,
         char** argv, std::vector<std::string> const& cfg,
@@ -256,6 +268,9 @@ namespace hpx {
     /// be set up in console mode or worker mode depending on the command line
     /// settings). It will return immediately after that. Use `hpx::wait` and
     /// `hpx::stop` to synchronize with the runtime system's execution.
+    HPX_DEPRECATED_V(1, 6,
+        "The start overload used is deprecated. Please use"
+        "the start overloads using the hpx::init_params struct.")
     inline bool start(int argc, char** argv,
         std::vector<std::string> const& cfg, hpx::runtime_mode mode)
     {
@@ -272,6 +287,9 @@ namespace hpx {
     /// be set up in console mode or worker mode depending on the command line
     /// settings). It will return immediately after that. Use `hpx::wait` and
     /// `hpx::stop` to synchronize with the runtime system's execution.
+    HPX_DEPRECATED_V(1, 6,
+        "The start overload used is deprecated. Please use"
+        "the start overloads using the hpx::init_params struct.")
     inline bool start(
         hpx::program_options::options_description const& desc_cmdline, int argc,
         char** argv, hpx::runtime_mode mode)
@@ -291,6 +309,9 @@ namespace hpx {
     /// be set up in console mode or worker mode depending on the command line
     /// settings). It will return immediately after that. Use `hpx::wait` and
     /// `hpx::stop` to synchronize with the runtime system's execution.
+    HPX_DEPRECATED_V(1, 6,
+        "The start overload used is deprecated. Please use"
+        "the start overloads using the hpx::init_params struct.")
     inline bool start(
         hpx::program_options::options_description const& desc_cmdline, int argc,
         char** argv, std::vector<std::string> const& cfg,
@@ -312,6 +333,9 @@ namespace hpx {
     /// be set up in console mode or worker mode depending on the command line
     /// settings). It will return immediately after that. Use `hpx::wait` and
     /// `hpx::stop` to synchronize with the runtime system's execution.
+    HPX_DEPRECATED_V(1, 6,
+        "The start overload used is deprecated. Please use"
+        "the start overloads using the hpx::init_params struct.")
     inline bool start(std::string const& app_name, int argc, char** argv,
         hpx::runtime_mode mode)
     {
@@ -331,6 +355,9 @@ namespace hpx {
     /// be set up in console mode or worker mode depending on the command line
     /// settings). It will return immediately after that. Use `hpx::wait` and
     /// `hpx::stop` to synchronize with the runtime system's execution.
+    HPX_DEPRECATED_V(1, 6,
+        "The start overload used is deprecated. Please use"
+        "the start overloads using the hpx::init_params struct.")
     inline bool start(int argc, char** argv, hpx::runtime_mode mode)
     {
         hpx::init_params iparams;
@@ -345,6 +372,9 @@ namespace hpx {
     /// be set up in console mode or worker mode depending on the command line
     /// settings). It will return immediately after that. Use `hpx::wait` and
     /// `hpx::stop` to synchronize with the runtime system's execution.
+    HPX_DEPRECATED_V(1, 6,
+        "The start overload used is deprecated. Please use"
+        "the start overloads using the hpx::init_params struct.")
     inline bool start(
         std::vector<std::string> const& cfg, hpx::runtime_mode mode)
     {
@@ -361,6 +391,9 @@ namespace hpx {
     /// be set up in console mode or worker mode depending on the command line
     /// settings). It will return immediately after that. Use `hpx::wait` and
     /// `hpx::stop` to synchronize with the runtime system's execution.
+    HPX_DEPRECATED_V(1, 6,
+        "The start overload used is deprecated. Please use"
+        "the start overloads using the hpx::init_params struct.")
     inline bool start(int (*f)(hpx::program_options::variables_map& vm),
         std::string const& app_name, int argc, char** argv,
         hpx::runtime_mode mode)
@@ -383,6 +416,9 @@ namespace hpx {
     }
 
     // Main non-blocking entry point for launching the HPX runtime system.
+    HPX_DEPRECATED_V(1, 6,
+        "The start overload used is deprecated. Please use"
+        "the start overloads using the hpx::init_params struct.")
     inline bool start(util::function_nonser<int(int, char**)> const& f,
         std::string const& app_name, int argc, char** argv,
         hpx::runtime_mode mode)
@@ -399,6 +435,9 @@ namespace hpx {
         return start(f, argc, argv, iparams);
     }
 
+    HPX_DEPRECATED_V(1, 6,
+        "The start overload used is deprecated. Please use"
+        "the start overloads using the hpx::init_params struct.")
     inline bool start(util::function_nonser<int(int, char**)> const& f,
         int argc, char** argv, std::vector<std::string> const& cfg,
         hpx::runtime_mode mode)
@@ -411,6 +450,9 @@ namespace hpx {
         return start(f, argc, argv, iparams);
     }
 
+    HPX_DEPRECATED_V(1, 6,
+        "The start overload used is deprecated. Please use"
+        "the start overloads using the hpx::init_params struct.")
     inline bool start(util::function_nonser<int(int, char**)> const& f,
         std::vector<std::string> const& cfg, hpx::runtime_mode mode)
     {
@@ -420,6 +462,9 @@ namespace hpx {
         return start(f, detail::dummy_argc, detail::dummy_argv, iparams);
     }
 
+    HPX_DEPRECATED_V(1, 6,
+        "The start overload used is deprecated. Please use"
+        "the start overloads using the hpx::init_params struct.")
     inline bool start(std::nullptr_t f, std::string const& app_name, int argc,
         char** argv, hpx::runtime_mode mode)
     {
@@ -435,6 +480,9 @@ namespace hpx {
         return start(f, argc, argv, iparams);
     }
 
+    HPX_DEPRECATED_V(1, 6,
+        "The start overload used is deprecated. Please use"
+        "the start overloads using the hpx::init_params struct.")
     inline bool start(std::nullptr_t f, int argc, char** argv,
         std::vector<std::string> const& cfg, hpx::runtime_mode mode)
     {
@@ -446,6 +494,9 @@ namespace hpx {
         return start(f, argc, argv, iparams);
     }
 
+    HPX_DEPRECATED_V(1, 6,
+        "The start overload used is deprecated. Please use"
+        "the start overloads using the hpx::init_params struct.")
     inline bool start(std::nullptr_t f, std::vector<std::string> const& cfg,
         hpx::runtime_mode mode)
     {

--- a/libs/full/performance_counters/tests/unit/counter_raw_values.cpp
+++ b/libs/full/performance_counters/tests/unit/counter_raw_values.cpp
@@ -76,7 +76,10 @@ int main(int argc, char* argv[])
 
     // Initialize and run HPX.
     std::vector<std::string> const cfg = {"hpx.os_threads=1"};
-    HPX_TEST_EQ(hpx::init(argc, argv, cfg), 0);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
 
     return hpx::util::report_errors();
 }

--- a/libs/full/performance_counters/tests/unit/path_elements.cpp
+++ b/libs/full/performance_counters/tests/unit/path_elements.cpp
@@ -542,7 +542,6 @@ int hpx_main(hpx::program_options::variables_map& vm)
 ///////////////////////////////////////////////////////////////////////////////
 int main(int argc, char* argv[])
 {
-    return hpx::init(
-        HPX_APPLICATION_STRING, argc, argv);    // Initialize and run HPX.
+    return hpx::init(argc, argv);    // Initialize and run HPX.
 }
 #endif

--- a/libs/full/performance_counters/tests/unit/reinit_counters.cpp
+++ b/libs/full/performance_counters/tests/unit/reinit_counters.cpp
@@ -181,7 +181,11 @@ int main(int argc, char* argv[])
 
     // Initialize and run HPX.
     std::vector<std::string> const cfg = {"hpx.os_threads=1"};
-    HPX_TEST_EQ(hpx::init(desc_commandline, argc, argv, cfg), 0);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
 
     return hpx::util::report_errors();
 }

--- a/libs/full/program_options/tests/regressions/command_line_required_arguments_2990.cpp
+++ b/libs/full/program_options/tests/regressions/command_line_required_arguments_2990.cpp
@@ -38,14 +38,18 @@ int main(int argc, char* argv[])
     newargv.push_back(help_option);
     newargv.push_back(nullptr);
 
-    options_description op("Issue #2990\n\nUsage: issue2990 [options]");
+    options_description cmdline("Issue #2990\n\nUsage: issue2990 [options]");
 
     // clang-format off
-    op.add_options()
+    cmdline.add_options()
         ("reqopt1", value<int>()->required(), "Required option 1")
         ("reqopt2", value<double>()->required(), "Required option 2")
         ("reqopt3", value<std::string>()->required(), "Required option 3");
     // clang-format on
 
-    return hpx::init(op, argc + 1, newargv.data(), cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc + 1, newargv.data(), init_args);
 }

--- a/libs/full/program_options/tests/regressions/commandline_options_1437.cpp
+++ b/libs/full/program_options/tests/regressions/commandline_options_1437.cpp
@@ -25,7 +25,7 @@ int main(int argc, char** argv)
 {
     HPX_TEST_LT(1, argc);
 
-    HPX_TEST_EQ(hpx::init(&my_hpx_main, "testapp", argc, argv), 0);
+    HPX_TEST_EQ(hpx::init(&my_hpx_main, argc, argv), 0);
     HPX_TEST(invoked_main);
 
     return hpx::util::report_errors();

--- a/libs/full/program_options/tests/unit/boost_program_options.cpp
+++ b/libs/full/program_options/tests/unit/boost_program_options.cpp
@@ -34,5 +34,9 @@ int main(int argc, char* argv[])
     ;
     // clang-format on
 
-    return hpx::init(desc, argc, argv);
+    hpx::program_options::options_description cmdline(desc);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/examples/1d_stencil_replay_exception.cpp
+++ b/libs/full/resiliency/examples/1d_stencil_replay_exception.cpp
@@ -209,5 +209,8 @@ int main(int argc, char* argv[])
         "Maximum number of repeat launches for a function f");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/examples/1d_stencil_replay_validate.cpp
+++ b/libs/full/resiliency/examples/1d_stencil_replay_validate.cpp
@@ -228,5 +228,8 @@ int main(int argc, char* argv[])
         "Maximum number of repeat launches for a function f");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/examples/async_replay.cpp
+++ b/libs/full/resiliency/examples/async_replay.cpp
@@ -149,5 +149,8 @@ int main(int argc, char* argv[])
         "example)");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/examples/async_replicate.cpp
+++ b/libs/full/resiliency/examples/async_replicate.cpp
@@ -148,5 +148,8 @@ int main(int argc, char* argv[])
         "replicate example)");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/examples/async_replicate_vote.cpp
+++ b/libs/full/resiliency/examples/async_replicate_vote.cpp
@@ -88,5 +88,8 @@ int main(int argc, char* argv[])
         "replicate example)");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/examples/dataflow_replicate.cpp
+++ b/libs/full/resiliency/examples/dataflow_replicate.cpp
@@ -130,5 +130,8 @@ int main(int argc, char* argv[])
         "Number of repeat launches for aborted dataflow replicate");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/tests/performance/replay/1d_stencil.cpp
+++ b/libs/full/resiliency/tests/performance/replay/1d_stencil.cpp
@@ -282,5 +282,8 @@ int main(int argc, char* argv[])
         value<std::uint64_t>()->default_value(10), "Number of partitions");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/tests/performance/replay/1d_stencil_checksum.cpp
+++ b/libs/full/resiliency/tests/performance/replay/1d_stencil_checksum.cpp
@@ -383,5 +383,8 @@ int main(int argc, char* argv[])
         value<std::uint64_t>()->default_value(10), "Number of partitions");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/tests/performance/replay/1d_stencil_replay.cpp
+++ b/libs/full/resiliency/tests/performance/replay/1d_stencil_replay.cpp
@@ -334,5 +334,8 @@ int main(int argc, char* argv[])
         value<std::uint64_t>()->default_value(10), "Number of partitions");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/tests/performance/replay/async_replay.cpp
+++ b/libs/full/resiliency/tests/performance/replay/async_replay.cpp
@@ -147,5 +147,8 @@ int main(int argc, char* argv[])
         "Time in us taken by a thread to execute before it terminates");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/tests/performance/replay/async_replay_validate.cpp
+++ b/libs/full/resiliency/tests/performance/replay/async_replay_validate.cpp
@@ -151,5 +151,8 @@ int main(int argc, char* argv[])
         "Time in us taken by a thread to execute before it terminates");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/tests/performance/replay/dataflow_replay.cpp
+++ b/libs/full/resiliency/tests/performance/replay/dataflow_replay.cpp
@@ -370,5 +370,8 @@ int main(int argc, char* argv[])
         value<std::uint64_t>()->default_value(10), "Number of partitions");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/tests/performance/replay/dataflow_replay_validate.cpp
+++ b/libs/full/resiliency/tests/performance/replay/dataflow_replay_validate.cpp
@@ -374,5 +374,8 @@ int main(int argc, char* argv[])
         value<std::uint64_t>()->default_value(10), "Number of partitions");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/tests/performance/replay/pure_async_for_replay.cpp
+++ b/libs/full/resiliency/tests/performance/replay/pure_async_for_replay.cpp
@@ -142,5 +142,8 @@ int main(int argc, char* argv[])
         "Time in us taken by a thread to execute before it terminates");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/tests/performance/replay/pure_dataflow.cpp
+++ b/libs/full/resiliency/tests/performance/replay/pure_dataflow.cpp
@@ -287,5 +287,8 @@ int main(int argc, char* argv[])
         value<std::uint64_t>()->default_value(10), "Number of partitions");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/tests/performance/replicate/1d_stencil_replicate.cpp
+++ b/libs/full/resiliency/tests/performance/replicate/1d_stencil_replicate.cpp
@@ -333,5 +333,8 @@ int main(int argc, char* argv[])
         value<std::uint64_t>()->default_value(10), "Number of partitions");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/tests/performance/replicate/1d_stencil_replicate_checksum.cpp
+++ b/libs/full/resiliency/tests/performance/replicate/1d_stencil_replicate_checksum.cpp
@@ -379,5 +379,8 @@ int main(int argc, char* argv[])
         value<std::uint64_t>()->default_value(10), "Number of partitions");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/tests/performance/replicate/async_replicate.cpp
+++ b/libs/full/resiliency/tests/performance/replicate/async_replicate.cpp
@@ -145,5 +145,8 @@ int main(int argc, char* argv[])
         "Time in us taken by a thread to execute before it terminates");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/tests/performance/replicate/async_replicate_validate.cpp
+++ b/libs/full/resiliency/tests/performance/replicate/async_replicate_validate.cpp
@@ -154,5 +154,8 @@ int main(int argc, char* argv[])
         "Time in us taken by a thread to execute before it terminates");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/tests/performance/replicate/async_replicate_vote.cpp
+++ b/libs/full/resiliency/tests/performance/replicate/async_replicate_vote.cpp
@@ -154,5 +154,8 @@ int main(int argc, char* argv[])
         "Time in us taken by a thread to execute before it terminates");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/tests/performance/replicate/async_replicate_vote_validate.cpp
+++ b/libs/full/resiliency/tests/performance/replicate/async_replicate_vote_validate.cpp
@@ -151,5 +151,8 @@ int main(int argc, char* argv[])
         "Time in us taken by a thread to execute before it terminates");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resiliency/tests/performance/replicate/pure_async_for_replicate.cpp
+++ b/libs/full/resiliency/tests/performance/replicate/pure_async_for_replicate.cpp
@@ -147,5 +147,8 @@ int main(int argc, char* argv[])
         "Time in us taken by a thread to execute before it terminates");
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/full/resource_partitioner/tests/regressions/help_exit_4317_2.cpp
+++ b/libs/full/resource_partitioner/tests/regressions/help_exit_4317_2.cpp
@@ -24,7 +24,10 @@ int main(int argc, char** argv)
 {
     std::vector<std::string> cfg = {"--hpx:help"};
 
-    HPX_TEST_EQ(hpx::init(argc, argv, cfg), 0);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
 
     HPX_TEST(!main_executed);
 

--- a/libs/full/runtime_local/tests/unit/thread_mapper.cpp
+++ b/libs/full/runtime_local/tests/unit/thread_mapper.cpp
@@ -100,7 +100,10 @@ int main(int argc, char* argv[])
     // make sure networking is enabled
     std::vector<std::string> cfg = {"hpx.expect_connecting_localities=1"};
 
-    HPX_TEST_EQ(hpx::init(argc, argv, cfg), 0);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
 
     return hpx::util::report_errors();
 }

--- a/libs/full/segmented_algorithms/tests/performance/minmax_element_performance.cpp
+++ b/libs/full/segmented_algorithms/tests/performance/minmax_element_performance.cpp
@@ -162,6 +162,10 @@ int main(int argc, char* argv[])
         hpx::program_options::value<unsigned int>(),
         "the random number generator seed to use for this run");
 
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/libs/full/thread_executors/tests/unit/resource_manager.cpp
+++ b/libs/full/thread_executors/tests/unit/resource_manager.cpp
@@ -234,8 +234,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> cfg;
     cfg.push_back("hpx.os_threads=all");
 
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/full/thread_executors/tests/unit/thread_pool_executors.cpp
+++ b/libs/full/thread_executors/tests/unit/thread_pool_executors.cpp
@@ -181,8 +181,10 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/full/thread_executors/tests/unit/thread_pool_os_executors.cpp
+++ b/libs/full/thread_executors/tests/unit/thread_pool_os_executors.cpp
@@ -187,8 +187,10 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=1"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/full/thread_executors/tests/unit/timed_this_thread_executors.cpp
+++ b/libs/full/thread_executors/tests/unit/timed_this_thread_executors.cpp
@@ -93,8 +93,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/full/thread_executors/tests/unit/timed_thread_pool_executors.cpp
+++ b/libs/full/thread_executors/tests/unit/timed_thread_pool_executors.cpp
@@ -98,8 +98,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/algorithms/tests/performance/benchmark_inplace_merge.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_inplace_merge.cpp
@@ -229,7 +229,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/performance/benchmark_is_heap.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_is_heap.cpp
@@ -211,7 +211,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/performance/benchmark_is_heap_until.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_is_heap_until.cpp
@@ -219,7 +219,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/performance/benchmark_merge.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_merge.cpp
@@ -222,7 +222,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/performance/benchmark_partial_sort.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_partial_sort.cpp
@@ -143,5 +143,9 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/parallelism/algorithms/tests/performance/benchmark_partial_sort_parallel.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_partial_sort_parallel.cpp
@@ -203,5 +203,9 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/parallelism/algorithms/tests/performance/benchmark_partition.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_partition.cpp
@@ -240,7 +240,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/performance/benchmark_partition_copy.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_partition_copy.cpp
@@ -215,7 +215,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/performance/benchmark_remove.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_remove.cpp
@@ -298,7 +298,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/performance/benchmark_remove_if.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_remove_if.cpp
@@ -297,7 +297,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/performance/benchmark_unique.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_unique.cpp
@@ -304,7 +304,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/performance/benchmark_unique_copy.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_unique_copy.cpp
@@ -208,7 +208,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/performance/transform_reduce_scaling.cpp
+++ b/libs/parallelism/algorithms/tests/performance/transform_reduce_scaling.cpp
@@ -125,6 +125,10 @@ int main(int argc, char* argv[])
                 hpx::program_options::value<int>()->default_value(100),
                 "number of tests to take average from");
 
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/libs/parallelism/algorithms/tests/regressions/for_each_annotated_function.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/for_each_annotated_function.cpp
@@ -43,8 +43,11 @@ int main(int argc, char* argv[])
 {
     std::vector<std::string> const cfg = {"hpx.os_threads=4"};
 
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/algorithms/tests/regressions/for_loop_2281.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/for_loop_2281.cpp
@@ -45,8 +45,11 @@ int main(int argc, char* argv[])
 {
     std::vector<std::string> const cfg = {"hpx.os_threads=4"};
 
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/algorithms/tests/regressions/minimal_findend.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/minimal_findend.cpp
@@ -101,8 +101,11 @@ int main(int argc, char* argv[])
 {
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/algorithms/tests/regressions/scan_different_inits.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/scan_different_inits.cpp
@@ -251,7 +251,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/regressions/scan_non_commutative.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/scan_non_commutative.cpp
@@ -64,7 +64,11 @@ int main(int argc, char* argv[])
     // By default this test should run on all available cores
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/regressions/scan_shortlength.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/scan_shortlength.cpp
@@ -197,7 +197,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/regressions/search_zerolength.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/search_zerolength.cpp
@@ -45,8 +45,11 @@ int main(int argc, char* argv[])
 {
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exted with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exted with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/algorithms/tests/regressions/set_operations_3442.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/set_operations_3442.cpp
@@ -161,8 +161,11 @@ int main(int argc, char* argv[])
 {
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exted with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exted with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/algorithms/tests/regressions/stable_merge_2964.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/stable_merge_2964.cpp
@@ -107,7 +107,10 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=1"};
 
     // Initialize and run HPX
-    return hpx::init(argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 int hpx_main(int argc, char** argv)

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentdifference.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentdifference.cpp
@@ -98,7 +98,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentdifference_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentdifference_bad_alloc.cpp
@@ -141,7 +141,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentdifference_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentdifference_exception.cpp
@@ -144,7 +144,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind.cpp
@@ -120,7 +120,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_bad_alloc.cpp
@@ -141,7 +141,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_binary.cpp
@@ -119,7 +119,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_binary_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_binary_bad_alloc.cpp
@@ -141,7 +141,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_binary_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_binary_exception.cpp
@@ -144,7 +144,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/adjacentfind_exception.cpp
@@ -144,7 +144,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/all_of.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/all_of.cpp
@@ -499,7 +499,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/any_of.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/any_of.cpp
@@ -489,7 +489,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/copy.cpp
@@ -365,7 +365,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/copyif_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/copyif_bad_alloc.cpp
@@ -140,7 +140,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/copyif_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/copyif_exception.cpp
@@ -178,7 +178,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/copyif_forward.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/copyif_forward.cpp
@@ -167,7 +167,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/copyif_random.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/copyif_random.cpp
@@ -167,7 +167,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/copyn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/copyn.cpp
@@ -366,7 +366,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/count.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/count.cpp
@@ -109,7 +109,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/countif.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/countif.cpp
@@ -110,7 +110,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/destroy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/destroy.cpp
@@ -110,7 +110,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/destroyn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/destroyn.cpp
@@ -496,7 +496,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_insertion_sort.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_insertion_sort.cpp
@@ -154,7 +154,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_parallel_stable_sort.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_parallel_stable_sort.cpp
@@ -189,7 +189,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize && run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_sample_sort.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_sample_sort.cpp
@@ -279,7 +279,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize && run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_spin_sort.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/detail/test_spin_sort.cpp
@@ -307,7 +307,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/equal.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/equal.cpp
@@ -583,7 +583,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/equal_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/equal_binary.cpp
@@ -583,7 +583,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan.cpp
@@ -172,7 +172,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan2.cpp
@@ -113,7 +113,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_bad_alloc.cpp
@@ -141,7 +141,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_exception.cpp
@@ -143,7 +143,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_validate.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/exclusive_scan_validate.cpp
@@ -199,7 +199,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/fill.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/fill.cpp
@@ -353,7 +353,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/filln.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/filln.cpp
@@ -353,7 +353,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/find.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/find.cpp
@@ -356,7 +356,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findend.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findend.cpp
@@ -704,7 +704,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findfirstof.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findfirstof.cpp
@@ -376,7 +376,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findfirstof_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findfirstof_binary.cpp
@@ -393,7 +393,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findif.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findif.cpp
@@ -359,7 +359,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findifnot.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findifnot.cpp
@@ -135,7 +135,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findifnot_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findifnot_bad_alloc.cpp
@@ -140,7 +140,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/findifnot_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/findifnot_exception.cpp
@@ -177,7 +177,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop.cpp
@@ -171,7 +171,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_exception.cpp
@@ -418,7 +418,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_induction.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_induction.cpp
@@ -283,7 +283,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_induction_async.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_induction_async.cpp
@@ -283,7 +283,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_n.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_n.cpp
@@ -172,7 +172,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_n_strided.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_n_strided.cpp
@@ -235,7 +235,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_reduction.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_reduction.cpp
@@ -205,7 +205,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_reduction_async.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_reduction_async.cpp
@@ -208,7 +208,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_strided.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/for_loop_strided.cpp
@@ -235,7 +235,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreach.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreach.cpp
@@ -113,7 +113,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreach_executors.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreach_executors.cpp
@@ -85,7 +85,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreach_prefetching.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreach_prefetching.cpp
@@ -97,7 +97,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreachn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreachn.cpp
@@ -64,7 +64,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_bad_alloc.cpp
@@ -168,7 +168,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreachn_exception.cpp
@@ -170,7 +170,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/generate.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/generate.cpp
@@ -366,7 +366,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/generaten.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/generaten.cpp
@@ -357,7 +357,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/includes.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/includes.cpp
@@ -803,7 +803,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/inclusive_scan.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/inclusive_scan.cpp
@@ -168,7 +168,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/inplace_merge.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/inplace_merge.cpp
@@ -72,7 +72,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/is_heap.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/is_heap.cpp
@@ -68,7 +68,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/is_heap_until.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/is_heap_until.cpp
@@ -68,7 +68,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/is_partitioned.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/is_partitioned.cpp
@@ -452,7 +452,11 @@ int main(int argc, char* argv[])
 
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/is_sorted.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/is_sorted.cpp
@@ -142,7 +142,11 @@ int main(int argc, char* argv[])
 
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/is_sorted_until.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/is_sorted_until.cpp
@@ -602,7 +602,11 @@ int main(int argc, char* argv[])
 
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/lexicographical_compare.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/lexicographical_compare.cpp
@@ -450,7 +450,11 @@ int main(int argc, char* argv[])
 
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/make_heap.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/make_heap.cpp
@@ -437,7 +437,10 @@ int main(int argc, char* argv[])
     desc_commandline.add_options()("seed,s", value<unsigned int>(),
         "the random number generator seed to use for this run");
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with a non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/max_element.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/max_element.cpp
@@ -433,7 +433,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/merge.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/merge.cpp
@@ -75,7 +75,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/min_element.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/min_element.cpp
@@ -434,7 +434,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/minmax_element.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/minmax_element.cpp
@@ -443,7 +443,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/mismatch.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/mismatch.cpp
@@ -597,7 +597,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/mismatch_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/mismatch_binary.cpp
@@ -602,7 +602,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/move.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/move.cpp
@@ -341,7 +341,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/none_of.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/none_of.cpp
@@ -494,7 +494,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/parallel_sort.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/parallel_sort.cpp
@@ -401,7 +401,11 @@ int main(int argc, char* argv[])
     // By default this test should run on all available cores
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/partial_sort.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/partial_sort.cpp
@@ -104,7 +104,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/partial_sort_parallel.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/partial_sort_parallel.cpp
@@ -105,7 +105,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/partition.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/partition.cpp
@@ -73,7 +73,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/partition_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/partition_copy.cpp
@@ -73,7 +73,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/reduce_.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/reduce_.cpp
@@ -424,7 +424,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/reduce_by_key.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/reduce_by_key.cpp
@@ -513,7 +513,11 @@ int main(int argc, char* argv[])
     // By default this test should run on all available cores
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove.cpp
@@ -68,7 +68,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove1.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove1.cpp
@@ -68,7 +68,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove2.cpp
@@ -68,7 +68,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy.cpp
@@ -381,7 +381,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy_if.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy_if.cpp
@@ -398,7 +398,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove_if.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove_if.cpp
@@ -71,7 +71,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove_if1.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove_if1.cpp
@@ -68,7 +68,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/replace.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/replace.cpp
@@ -310,7 +310,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/replace_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/replace_copy.cpp
@@ -322,7 +322,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/replace_copy_if.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/replace_copy_if.cpp
@@ -336,7 +336,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/replace_if.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/replace_if.cpp
@@ -325,7 +325,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/reverse.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/reverse.cpp
@@ -306,7 +306,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/reverse_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/reverse_copy.cpp
@@ -314,7 +314,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/rotate.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/rotate.cpp
@@ -349,7 +349,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/rotate_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/rotate_copy.cpp
@@ -350,7 +350,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/search.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/search.cpp
@@ -534,7 +534,11 @@ int main(int argc, char* argv[])
 
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/searchn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/searchn.cpp
@@ -603,7 +603,11 @@ int main(int argc, char* argv[])
 
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/set_difference.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/set_difference.cpp
@@ -555,7 +555,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/set_intersection.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/set_intersection.cpp
@@ -556,7 +556,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/set_symmetric_difference.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/set_symmetric_difference.cpp
@@ -558,7 +558,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/set_union.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/set_union.cpp
@@ -554,7 +554,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/sort.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/sort.cpp
@@ -173,7 +173,11 @@ int main(int argc, char* argv[])
     // By default this test should run on all available cores
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/sort_by_key.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/sort_by_key.cpp
@@ -311,7 +311,11 @@ int main(int argc, char* argv[])
     // By default this test should run on all available cores
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/sort_exceptions.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/sort_exceptions.cpp
@@ -68,7 +68,11 @@ int main(int argc, char* argv[])
     // By default this test should run on all available cores
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/stable_partition.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/stable_partition.cpp
@@ -107,7 +107,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/stable_sort.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/stable_sort.cpp
@@ -174,7 +174,11 @@ int main(int argc, char* argv[])
     // By default this test should run on all available cores
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/stable_sort_exceptions.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/stable_sort_exceptions.cpp
@@ -68,7 +68,11 @@ int main(int argc, char* argv[])
     // By default this test should run on all available cores
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/swapranges.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/swapranges.cpp
@@ -328,7 +328,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform.cpp
@@ -106,7 +106,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary.cpp
@@ -106,7 +106,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary2.cpp
@@ -106,7 +106,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_exclusive_scan.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_exclusive_scan.cpp
@@ -342,7 +342,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_inclusive_scan.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_inclusive_scan.cpp
@@ -430,7 +430,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce.cpp
@@ -436,7 +436,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce_binary.cpp
@@ -65,7 +65,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce_binary_bad_alloc.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce_binary_bad_alloc.cpp
@@ -175,7 +175,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce_binary_exception.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_reduce_binary_exception.cpp
@@ -176,7 +176,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_copy.cpp
@@ -105,7 +105,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_copyn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_copyn.cpp
@@ -339,7 +339,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_default_construct.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_default_construct.cpp
@@ -118,7 +118,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_default_constructn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_default_constructn.cpp
@@ -453,7 +453,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_fill.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_fill.cpp
@@ -330,7 +330,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_filln.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_filln.cpp
@@ -330,7 +330,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_move.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_move.cpp
@@ -105,7 +105,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_moven.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_moven.cpp
@@ -339,7 +339,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_value_construct.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_value_construct.cpp
@@ -111,7 +111,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_value_constructn.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/uninitialized_value_constructn.cpp
@@ -382,7 +382,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/unique.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/unique.cpp
@@ -74,7 +74,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/unique_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/unique_copy.cpp
@@ -74,7 +74,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/block/task_block.cpp
+++ b/libs/parallelism/algorithms/tests/unit/block/task_block.cpp
@@ -268,8 +268,10 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/algorithms/tests/unit/block/task_block_executor.cpp
+++ b/libs/parallelism/algorithms/tests/unit/block/task_block_executor.cpp
@@ -422,8 +422,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/algorithms/tests/unit/block/task_block_par.cpp
+++ b/libs/parallelism/algorithms/tests/unit/block/task_block_par.cpp
@@ -146,8 +146,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/adjacentfind_bad_alloc_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/adjacentfind_bad_alloc_range.cpp
@@ -141,7 +141,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/adjacentfind_binary_bad_alloc_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/adjacentfind_binary_bad_alloc_range.cpp
@@ -141,7 +141,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/adjacentfind_binary_exception_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/adjacentfind_binary_exception_range.cpp
@@ -144,7 +144,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/adjacentfind_binary_projection_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/adjacentfind_binary_projection_range.cpp
@@ -185,7 +185,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/adjacentfind_binary_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/adjacentfind_binary_range.cpp
@@ -175,7 +175,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/adjacentfind_exception_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/adjacentfind_exception_range.cpp
@@ -144,7 +144,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/adjacentfind_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/adjacentfind_range.cpp
@@ -119,7 +119,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/all_of_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/all_of_range.cpp
@@ -396,7 +396,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/any_of_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/any_of_range.cpp
@@ -396,7 +396,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/copy_range.cpp
@@ -369,7 +369,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/copyif_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/copyif_range.cpp
@@ -153,7 +153,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/copyn_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/copyn_range.cpp
@@ -371,7 +371,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/count_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/count_range.cpp
@@ -154,7 +154,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/countif_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/countif_range.cpp
@@ -159,7 +159,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/destroy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/destroy_range.cpp
@@ -110,7 +110,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/destroyn_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/destroyn_range.cpp
@@ -497,7 +497,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/equal_binary_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/equal_binary_range.cpp
@@ -625,7 +625,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/equal_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/equal_range.cpp
@@ -587,7 +587,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/fill_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/fill_range.cpp
@@ -126,7 +126,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/filln_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/filln_range.cpp
@@ -125,7 +125,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_end_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_end_range.cpp
@@ -795,7 +795,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_end_range2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_end_range2.cpp
@@ -746,7 +746,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_first_of_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_first_of_range.cpp
@@ -218,7 +218,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_first_of_range2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_first_of_range2.cpp
@@ -386,7 +386,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_if_not_exception_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_if_not_exception_range.cpp
@@ -178,7 +178,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_if_not_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_if_not_range.cpp
@@ -135,7 +135,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_if_range.cpp
@@ -359,7 +359,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/find_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/find_range.cpp
@@ -356,7 +356,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/for_loop_exception_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/for_loop_exception_range.cpp
@@ -240,7 +240,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/for_loop_induction_async_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/for_loop_induction_async_range.cpp
@@ -195,7 +195,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/for_loop_induction_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/for_loop_induction_range.cpp
@@ -201,7 +201,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/for_loop_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/for_loop_range.cpp
@@ -106,7 +106,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/for_loop_reduction_async_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/for_loop_reduction_async_range.cpp
@@ -140,7 +140,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/for_loop_reduction_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/for_loop_reduction_range.cpp
@@ -138,7 +138,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/for_loop_strided_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/for_loop_strided_range.cpp
@@ -138,7 +138,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_range.cpp
@@ -113,7 +113,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_range_projection.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_range_projection.cpp
@@ -130,7 +130,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/generate_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/generate_range.cpp
@@ -384,7 +384,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/includes_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/includes_range.cpp
@@ -803,7 +803,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/inplace_merge_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/inplace_merge_range.cpp
@@ -410,7 +410,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/is_heap_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/is_heap_range.cpp
@@ -162,7 +162,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/is_heap_until_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/is_heap_until_range.cpp
@@ -162,7 +162,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/is_partitioned_projection_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/is_partitioned_projection_range.cpp
@@ -677,7 +677,11 @@ int main(int argc, char* argv[])
 
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/is_partitioned_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/is_partitioned_range.cpp
@@ -617,7 +617,11 @@ int main(int argc, char* argv[])
 
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/is_sorted_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/is_sorted_range.cpp
@@ -195,7 +195,11 @@ int main(int argc, char* argv[])
 
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/is_sorted_until_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/is_sorted_until_range.cpp
@@ -1604,7 +1604,11 @@ int main(int argc, char* argv[])
 
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/make_heap_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/make_heap_range.cpp
@@ -443,7 +443,10 @@ int main(int argc, char* argv[])
     desc_commandline.add_options()("seed,s", value<unsigned int>(),
         "the random number generator seed to use for this run");
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with a non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/max_element_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/max_element_range.cpp
@@ -442,7 +442,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/merge_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/merge_range.cpp
@@ -465,7 +465,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/min_element_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/min_element_range.cpp
@@ -444,7 +444,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/minmax_element_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/minmax_element_range.cpp
@@ -454,7 +454,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/mismatch_binary_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/mismatch_binary_range.cpp
@@ -648,7 +648,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/mismatch_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/mismatch_range.cpp
@@ -599,7 +599,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/move_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/move_range.cpp
@@ -349,7 +349,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/none_of_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/none_of_range.cpp
@@ -393,7 +393,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/partition_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/partition_copy_range.cpp
@@ -197,7 +197,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/partition_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/partition_range.cpp
@@ -207,7 +207,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/reduce_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/reduce_range.cpp
@@ -386,7 +386,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_if_range.cpp
@@ -378,7 +378,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_range.cpp
@@ -383,7 +383,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_if_range.cpp
@@ -160,7 +160,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_range.cpp
@@ -160,7 +160,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_if_range.cpp
@@ -343,7 +343,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_range.cpp
@@ -328,7 +328,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_if_range.cpp
@@ -334,7 +334,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_range.cpp
@@ -319,7 +319,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/reverse_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/reverse_copy_range.cpp
@@ -317,7 +317,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/reverse_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/reverse_range.cpp
@@ -309,7 +309,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/rotate_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/rotate_copy_range.cpp
@@ -373,7 +373,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/rotate_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/rotate_range.cpp
@@ -364,7 +364,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/search_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/search_range.cpp
@@ -399,7 +399,11 @@ int main(int argc, char* argv[])
 
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/searchn_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/searchn_range.cpp
@@ -403,7 +403,11 @@ int main(int argc, char* argv[])
 
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/set_difference_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/set_difference_range.cpp
@@ -558,7 +558,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/set_intersection_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/set_intersection_range.cpp
@@ -558,7 +558,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/set_symmetric_difference_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/set_symmetric_difference_range.cpp
@@ -559,7 +559,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/set_union_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/set_union_range.cpp
@@ -556,7 +556,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/sort_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/sort_range.cpp
@@ -141,7 +141,11 @@ int main(int argc, char* argv[])
     // By default this test should run on all available cores
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/stable_sort_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/stable_sort_range.cpp
@@ -142,7 +142,11 @@ int main(int argc, char* argv[])
     // By default this test should run on all available cores
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range.cpp
@@ -319,7 +319,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary.cpp
@@ -347,7 +347,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary2.cpp
@@ -349,7 +349,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_binary_bad_alloc_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_binary_bad_alloc_range.cpp
@@ -175,7 +175,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_binary_exception_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_binary_exception_range.cpp
@@ -177,7 +177,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_binary_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_binary_range.cpp
@@ -65,7 +65,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_reduce_range.cpp
@@ -438,7 +438,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_copy_range.cpp
@@ -162,7 +162,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/unique_range.cpp
@@ -156,7 +156,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/count_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/count_datapar.cpp
@@ -99,7 +99,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/countif_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/countif_datapar.cpp
@@ -100,7 +100,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_datapar.cpp
@@ -101,7 +101,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_datapar_zipiter.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_datapar_zipiter.cpp
@@ -130,7 +130,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreachn_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreachn_datapar.cpp
@@ -62,7 +62,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_binary2_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_binary2_datapar.cpp
@@ -104,7 +104,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_binary_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_binary_datapar.cpp
@@ -104,7 +104,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_datapar.cpp
@@ -100,7 +100,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_reduce_binary_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_reduce_binary_datapar.cpp
@@ -62,7 +62,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/async_combinators/tests/unit/split_shared_future.cpp
+++ b/libs/parallelism/async_combinators/tests/unit/split_shared_future.cpp
@@ -174,5 +174,8 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    return hpx::init(argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/parallelism/async_combinators/tests/unit/when_all.cpp
+++ b/libs/parallelism/async_combinators/tests/unit/when_all.cpp
@@ -293,5 +293,9 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/parallelism/async_combinators/tests/unit/when_all_std_array.cpp
+++ b/libs/parallelism/async_combinators/tests/unit/when_all_std_array.cpp
@@ -71,5 +71,9 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/parallelism/async_combinators/tests/unit/when_any.cpp
+++ b/libs/parallelism/async_combinators/tests/unit/when_any.cpp
@@ -728,5 +728,9 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/parallelism/async_combinators/tests/unit/when_any_std_array.cpp
+++ b/libs/parallelism/async_combinators/tests/unit/when_any_std_array.cpp
@@ -74,5 +74,9 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/parallelism/async_combinators/tests/unit/when_each.cpp
+++ b/libs/parallelism/async_combinators/tests/unit/when_each.cpp
@@ -610,5 +610,9 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/parallelism/async_combinators/tests/unit/when_some.cpp
+++ b/libs/parallelism/async_combinators/tests/unit/when_some.cpp
@@ -376,5 +376,9 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/parallelism/async_combinators/tests/unit/when_some_std_array.cpp
+++ b/libs/parallelism/async_combinators/tests/unit/when_some_std_array.cpp
@@ -75,5 +75,9 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/parallelism/execution/tests/regressions/chunk_size_4118.cpp
+++ b/libs/parallelism/execution/tests/regressions/chunk_size_4118.cpp
@@ -18,7 +18,10 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=2"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ(hpx::init(argc, argv, cfg), 0);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/execution/tests/unit/bulk_async.cpp
+++ b/libs/parallelism/execution/tests/unit/bulk_async.cpp
@@ -84,8 +84,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/execution/tests/unit/created_executor.cpp
+++ b/libs/parallelism/execution/tests/unit/created_executor.cpp
@@ -234,7 +234,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/execution/tests/unit/executor_parameters.cpp
+++ b/libs/parallelism/execution/tests/unit/executor_parameters.cpp
@@ -208,7 +208,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/execution/tests/unit/executor_parameters_dispatching.cpp
+++ b/libs/parallelism/execution/tests/unit/executor_parameters_dispatching.cpp
@@ -466,8 +466,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/execution/tests/unit/executor_parameters_timer_hooks.cpp
+++ b/libs/parallelism/execution/tests/unit/executor_parameters_timer_hooks.cpp
@@ -137,7 +137,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/execution/tests/unit/future_then_executor.cpp
+++ b/libs/parallelism/execution/tests/unit/future_then_executor.cpp
@@ -200,5 +200,9 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/parallelism/execution/tests/unit/minimal_async_executor.cpp
+++ b/libs/parallelism/execution/tests/unit/minimal_async_executor.cpp
@@ -313,8 +313,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/execution/tests/unit/minimal_sync_executor.cpp
+++ b/libs/parallelism/execution/tests/unit/minimal_sync_executor.cpp
@@ -359,8 +359,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/execution/tests/unit/parallel_executor.cpp
+++ b/libs/parallelism/execution/tests/unit/parallel_executor.cpp
@@ -190,8 +190,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/execution/tests/unit/parallel_fork_executor.cpp
+++ b/libs/parallelism/execution/tests/unit/parallel_fork_executor.cpp
@@ -189,8 +189,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/execution/tests/unit/parallel_policy_executor.cpp
+++ b/libs/parallelism/execution/tests/unit/parallel_policy_executor.cpp
@@ -236,8 +236,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/execution/tests/unit/persistent_executor_parameters.cpp
+++ b/libs/parallelism/execution/tests/unit/persistent_executor_parameters.cpp
@@ -118,7 +118,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/execution/tests/unit/polymorphic_executor.cpp
+++ b/libs/parallelism/execution/tests/unit/polymorphic_executor.cpp
@@ -197,8 +197,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/execution/tests/unit/shared_parallel_executor.cpp
+++ b/libs/parallelism/execution/tests/unit/shared_parallel_executor.cpp
@@ -156,8 +156,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/executors/tests/unit/limiting_executor.cpp
+++ b/libs/parallelism/executors/tests/unit/limiting_executor.cpp
@@ -114,8 +114,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=cores"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/executors/tests/unit/sequenced_executor.cpp
+++ b/libs/parallelism/executors/tests/unit/sequenced_executor.cpp
@@ -185,8 +185,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/executors/tests/unit/thread_pool_attached_executors.cpp
+++ b/libs/parallelism/executors/tests/unit/thread_pool_attached_executors.cpp
@@ -182,8 +182,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=1"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/futures/tests/regressions/future_hang_on_get_629.cpp
+++ b/libs/parallelism/futures/tests/regressions/future_hang_on_get_629.cpp
@@ -193,6 +193,9 @@ int main(int argc, char* argv[])
     // clang-format on
 
     // Initialize and run HPX.
-    return hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/libs/parallelism/futures/tests/regressions/future_hang_on_then_629.cpp
+++ b/libs/parallelism/futures/tests/regressions/future_hang_on_then_629.cpp
@@ -209,6 +209,9 @@ int main(int argc, char* argv[])
     // clang-format on
 
     // Initialize and run HPX.
-    return hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/libs/parallelism/futures/tests/regressions/future_hang_on_wait_with_callback_629.cpp
+++ b/libs/parallelism/futures/tests/regressions/future_hang_on_wait_with_callback_629.cpp
@@ -180,6 +180,9 @@ int main(int argc, char* argv[])
     // clang-format on
 
     // Initialize and run HPX.
-    return hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/libs/parallelism/futures/tests/regressions/future_timed_wait_1025.cpp
+++ b/libs/parallelism/futures/tests/regressions/future_timed_wait_1025.cpp
@@ -115,5 +115,8 @@ int main(int argc, char* argv[])
     options_description cmdline("Usage: " HPX_APPLICATION_STRING " [options]");
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/parallelism/futures/tests/unit/future.cpp
+++ b/libs/parallelism/futures/tests/unit/future.cpp
@@ -615,5 +615,9 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/parallelism/futures/tests/unit/future_then.cpp
+++ b/libs/parallelism/futures/tests/unit/future_then.cpp
@@ -241,5 +241,8 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    return hpx::init(argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/parallelism/futures/tests/unit/make_ready_future.cpp
+++ b/libs/parallelism/futures/tests/unit/make_ready_future.cpp
@@ -138,6 +138,9 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ(hpx::init(argc, argv, cfg), 0);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/futures/tests/unit/shared_future.cpp
+++ b/libs/parallelism/futures/tests/unit/shared_future.cpp
@@ -1585,5 +1585,9 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=4"};
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/parallelism/lcos_local/tests/unit/local_dataflow.cpp
+++ b/libs/parallelism/lcos_local/tests/unit/local_dataflow.cpp
@@ -417,7 +417,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
     return report_errors();
 }

--- a/libs/parallelism/lcos_local/tests/unit/local_dataflow_executor.cpp
+++ b/libs/parallelism/lcos_local/tests/unit/local_dataflow_executor.cpp
@@ -354,7 +354,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
     return report_errors();
 }

--- a/libs/parallelism/lcos_local/tests/unit/local_dataflow_std_array.cpp
+++ b/libs/parallelism/lcos_local/tests/unit/local_dataflow_std_array.cpp
@@ -211,7 +211,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
     return report_errors();
 }

--- a/libs/parallelism/lcos_local/tests/unit/run_guarded.cpp
+++ b/libs/parallelism/lcos_local/tests/unit/run_guarded.cpp
@@ -87,7 +87,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/lcos_local/tests/unit/split_future.cpp
+++ b/libs/parallelism/lcos_local/tests/unit/split_future.cpp
@@ -194,5 +194,8 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    return hpx::init(argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/parallelism/pack_traversal/tests/unit/unwrap.cpp
+++ b/libs/parallelism/pack_traversal/tests/unit/unwrap.cpp
@@ -597,7 +597,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    if (int result = hpx::init(cmdline, argc, argv, cfg))
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    if (int result = hpx::init(argc, argv, init_args))
     {
         return result;
     }

--- a/libs/parallelism/threading/tests/unit/stack_check.cpp
+++ b/libs/parallelism/threading/tests/unit/stack_check.cpp
@@ -97,7 +97,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/threading/tests/unit/thread.cpp
+++ b/libs/parallelism/threading/tests/unit/thread.cpp
@@ -378,5 +378,8 @@ int main(int argc, char* argv[])
     options_description cmdline("Usage: " HPX_APPLICATION_STRING " [options]");
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/parallelism/threading/tests/unit/thread_affinity.cpp
+++ b/libs/parallelism/threading/tests/unit/thread_affinity.cpp
@@ -184,6 +184,9 @@ int main(int argc, char* argv[])
         "usage: " HPX_APPLICATION_STRING " [options]");
 
     // Initialize and run HPX.
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/libs/parallelism/threading/tests/unit/thread_id.cpp
+++ b/libs/parallelism/threading/tests/unit/thread_id.cpp
@@ -195,5 +195,8 @@ int main(int argc, char* argv[])
     options_description cmdline("Usage: " HPX_APPLICATION_STRING " [options]");
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/parallelism/threading/tests/unit/thread_launching.cpp
+++ b/libs/parallelism/threading/tests/unit/thread_launching.cpp
@@ -251,5 +251,8 @@ int main(int argc, char* argv[])
     options_description cmdline("Usage: " HPX_APPLICATION_STRING " [options]");
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/parallelism/threading/tests/unit/thread_mf.cpp
+++ b/libs/parallelism/threading/tests/unit/thread_mf.cpp
@@ -232,5 +232,8 @@ int main(int argc, char* argv[])
     options_description cmdline("Usage: " HPX_APPLICATION_STRING " [options]");
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/libs/parallelism/threading/tests/unit/thread_yield.cpp
+++ b/libs/parallelism/threading/tests/unit/thread_yield.cpp
@@ -43,6 +43,9 @@ int main(int argc, char* argv[])
     // By default this test should run on all available cores
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    HPX_TEST_EQ(hpx::init(argc, argv, cfg), 0);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/timed_execution/tests/unit/minimal_timed_async_executor.cpp
+++ b/libs/parallelism/timed_execution/tests/unit/minimal_timed_async_executor.cpp
@@ -291,8 +291,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/timed_execution/tests/unit/minimal_timed_sync_executor.cpp
+++ b/libs/parallelism/timed_execution/tests/unit/minimal_timed_sync_executor.cpp
@@ -243,8 +243,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/libs/parallelism/timed_execution/tests/unit/timed_parallel_executor.cpp
+++ b/libs/parallelism/timed_execution/tests/unit/timed_parallel_executor.cpp
@@ -77,8 +77,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(
-        hpx::init(argc, argv, cfg), 0, "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/tests/performance/local/agas_cache_timings.cpp
+++ b/tests/performance/local/agas_cache_timings.cpp
@@ -274,6 +274,9 @@ int main(int argc, char* argv[])
         ;
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/performance/local/async_overheads.cpp
+++ b/tests/performance/local/async_overheads.cpp
@@ -139,5 +139,8 @@ int main(int argc, char* argv[])
         ;
 
     // Initialize and run HPX
-    return hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/tests/performance/local/coroutines_call_overhead.cpp
+++ b/tests/performance/local/coroutines_call_overhead.cpp
@@ -301,5 +301,8 @@ int main(
         ;
 
     // Initialize and run HPX.
-    return hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/tests/performance/local/foreach_scaling.cpp
+++ b/tests/performance/local/foreach_scaling.cpp
@@ -576,6 +576,10 @@ int main(int argc, char* argv[])
         ;
     // clang-format on
 
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -43,9 +43,6 @@ using hpx::program_options::options_description;
 using hpx::program_options::value;
 using hpx::program_options::variables_map;
 
-using hpx::finalize;
-using hpx::init;
-
 using hpx::apply;
 using hpx::async;
 using hpx::future;
@@ -606,6 +603,9 @@ int main(int argc, char* argv[])
     // clang-format on
 
     // Initialize and run HPX.
-    return init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/performance/local/hpx_heterogeneous_timed_task_spawn.cpp
+++ b/tests/performance/local/hpx_heterogeneous_timed_task_spawn.cpp
@@ -29,8 +29,6 @@ using hpx::program_options::variables_map;
 using hpx::program_options::options_description;
 using hpx::program_options::value;
 
-using hpx::init;
-using hpx::finalize;
 using hpx::get_os_thread_count;
 
 using hpx::threads::register_work;
@@ -232,7 +230,7 @@ int hpx_main(
         print_results(get_os_thread_count(), t.elapsed());
     }
 
-    finalize();
+    hpx::finalize();
     return 0;
 }
 
@@ -272,6 +270,9 @@ int main(
         ;
 
     // Initialize and run HPX.
-    return init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/performance/local/hpx_homogeneous_timed_task_spawn_executors.cpp
+++ b/tests/performance/local/hpx_homogeneous_timed_task_spawn_executors.cpp
@@ -23,8 +23,6 @@ using hpx::program_options::variables_map;
 using hpx::program_options::options_description;
 using hpx::program_options::value;
 
-using hpx::init;
-using hpx::finalize;
 using hpx::get_os_thread_count;
 
 using hpx::this_thread::suspend;
@@ -120,7 +118,7 @@ int hpx_main(
 
     print_results(num_os_threads, t.elapsed());
 
-    return finalize();
+    return hpx::finalize();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -154,6 +152,9 @@ int main(
         ;
 
     // Initialize and run HPX.
-    return init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 

--- a/tests/performance/local/htts_v2/htts2_hpx.cpp
+++ b/tests/performance/local/htts_v2/htts2_hpx.cpp
@@ -43,9 +43,13 @@ struct hpx_driver : htts2::driver
         hpx::util::function_nonser<int(hpx::program_options::variables_map& vm)> f;
         hpx::program_options::options_description desc;
 
+        hpx::init_params init_args;
+        init_args.cfg = cfg;
+        init_args.desc_cmdline = desc;
+
         using hpx::util::placeholders::_1;
         hpx::init(hpx::util::bind(&hpx_driver::run_impl, std::ref(*this), _1),
-            desc, argc_, argv_, cfg);
+            argc_, argv_, init_args);
     }
 
   private:

--- a/tests/performance/local/libcds_hazard_pointer_overhead.cpp
+++ b/tests/performance/local/libcds_hazard_pointer_overhead.cpp
@@ -40,9 +40,6 @@ using hpx::program_options::options_description;
 using hpx::program_options::value;
 using hpx::program_options::variables_map;
 
-using hpx::finalize;
-using hpx::init;
-
 using hpx::find_here;
 using hpx::naming::id_type;
 
@@ -349,5 +346,8 @@ int main(int argc, char* argv[])
     // clang-format on
 
     // Initialize and run HPX.
-    return init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/tests/performance/local/parent_vs_child_stealing.cpp
+++ b/tests/performance/local/parent_vs_child_stealing.cpp
@@ -126,6 +126,9 @@ int main(int argc, char* argv[])
         ("no-parent", "do not test child-stealing (launch::async only)")
         ;
 
-    return hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/performance/local/partitioned_vector_foreach.cpp
+++ b/tests/performance/local/partitioned_vector_foreach.cpp
@@ -172,6 +172,10 @@ int main(int argc, char* argv[])
         ;
     // clang-format on
 
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/performance/local/resume_suspend.cpp
+++ b/tests/performance/local/resume_suspend.cpp
@@ -38,7 +38,10 @@ int main(int argc, char ** argv)
 
     std::uint64_t repetitions = vm["repetitions"].as<std::uint64_t>();
 
-    hpx::start(nullptr, desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    hpx::start(nullptr, argc, argv, init_args);
     hpx::suspend();
 
     std::uint64_t threads = hpx::resource::get_num_threads("default");
@@ -85,5 +88,3 @@ int main(int argc, char ** argv)
     hpx::apply([]() { hpx::finalize(); });
     hpx::stop();
 }
-
-

--- a/tests/performance/local/sizeof.cpp
+++ b/tests/performance/local/sizeof.cpp
@@ -17,9 +17,6 @@ using hpx::program_options::variables_map;
 using hpx::program_options::options_description;
 using hpx::program_options::value;
 
-using hpx::init;
-using hpx::finalize;
-
 using hpx::find_here;
 
 using hpx::cout;
@@ -45,7 +42,7 @@ int hpx_main(
 #       undef HPX_SIZEOF
     }
 
-    finalize();
+    hpx::finalize();
     return 0;
 }
 
@@ -59,6 +56,9 @@ int main(
     options_description cmdline("usage: " HPX_APPLICATION_STRING " [options]");
 
     // Initialize and run HPX.
-    return init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/performance/local/sizeof.cpp
+++ b/tests/performance/local/sizeof.cpp
@@ -52,13 +52,7 @@ int main(
   , char* argv[]
     )
 {
-    // Configure application-specific options.
-    options_description cmdline("usage: " HPX_APPLICATION_STRING " [options]");
-
     // Initialize and run HPX.
-    hpx::init_params init_args;
-    init_args.desc_cmdline = cmdline;
-
-    return hpx::init(argc, argv, init_args);
+    return hpx::init(argc, argv);
 }
 #endif

--- a/tests/performance/local/spinlock_overhead1.cpp
+++ b/tests/performance/local/spinlock_overhead1.cpp
@@ -29,9 +29,6 @@ using hpx::program_options::variables_map;
 using hpx::program_options::options_description;
 using hpx::program_options::value;
 
-using hpx::init;
-using hpx::finalize;
-
 using hpx::find_here;
 
 using hpx::naming::id_type;
@@ -251,7 +248,7 @@ int hpx_main(
         }
     }
 
-    finalize();
+    hpx::finalize();
     return 0;
 }
 
@@ -286,6 +283,9 @@ int main(
         ;
 
     // Initialize and run HPX.
-    return init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/performance/local/spinlock_overhead2.cpp
+++ b/tests/performance/local/spinlock_overhead2.cpp
@@ -29,9 +29,6 @@ using hpx::program_options::variables_map;
 using hpx::program_options::options_description;
 using hpx::program_options::value;
 
-using hpx::init;
-using hpx::finalize;
-
 using hpx::find_here;
 
 using hpx::naming::id_type;
@@ -279,7 +276,7 @@ int hpx_main(
         }
     }
 
-    finalize();
+    hpx::finalize();
     return 0;
 }
 
@@ -318,6 +315,9 @@ int main(
         ;
 
     // Initialize and run HPX.
-    return init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/performance/local/start_stop.cpp
+++ b/tests/performance/local/start_stop.cpp
@@ -41,7 +41,10 @@ int main(int argc, char ** argv)
 
     std::uint64_t repetitions = vm["repetitions"].as<std::uint64_t>();
 
-    hpx::start(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    hpx::start(argc, argv, init_args);
     std::uint64_t threads = hpx::resource::get_num_threads("default");
     hpx::stop();
 
@@ -57,7 +60,10 @@ int main(int argc, char ** argv)
     {
         timer.restart();
 
-        hpx::start(desc_commandline, argc, argv);
+        hpx::init_params init_args;
+        init_args.desc_cmdline = desc_commandline;
+
+        hpx::start(argc, argv, init_args);
         auto t_start = timer.elapsed();
         start_time += t_start;
 

--- a/tests/performance/local/stream.cpp
+++ b/tests/performance/local/stream.cpp
@@ -611,5 +611,9 @@ int main(int argc, char* argv[])
         "hpx.numa_sensitive=2"    // no-cross NUMA stealing
     };
 
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/tests/performance/local/timed_task_spawn.cpp
+++ b/tests/performance/local/timed_task_spawn.cpp
@@ -41,9 +41,7 @@ using hpx::program_options::options_description;
 using hpx::program_options::value;
 using hpx::program_options::variables_map;
 
-using hpx::finalize;
 using hpx::get_os_thread_count;
-using hpx::init;
 
 using hpx::threads::register_work;
 using hpx::threads::thread_init_data;
@@ -505,7 +503,7 @@ int hpx_main(variables_map& vm)
         // Force termination of all suspended tasks.
         hpx::get_runtime().get_thread_manager().abort_all_suspended_threads();
 
-    return finalize();
+    return hpx::finalize();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -557,5 +555,8 @@ int main(int argc, char* argv[])
     // clang-format on
 
     // Initialize and run HPX.
-    return init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/tests/performance/local/transform_reduce_binary_scaling.cpp
+++ b/tests/performance/local/transform_reduce_binary_scaling.cpp
@@ -148,7 +148,10 @@ int main(int argc, char* argv[])
         , "the random number generator seed to use for this run")
         ;
 
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
 
+    return hpx::init(argc, argv, init_args);
 }
 

--- a/tests/performance/local/wait_all_timings.cpp
+++ b/tests/performance/local/wait_all_timings.cpp
@@ -149,21 +149,24 @@ int main(int argc, char* argv[])
     namespace po = hpx::program_options;
 
     // Configure application-specific options.
-    po::options_description opts("usage: " HPX_APPLICATION_STRING " [options]");
-    opts.add_options()
-        ("samples,s", po::value<std::uint64_t>()->default_value(1000),
-         "number of tasks to concurrently wait for (default: 1000)")
-        ("futures,f", po::value<std::uint64_t>()->default_value(100),
-         "number of tasks to concurrently wait for (default: 100)")
-        ("chunks,c", po::value<std::uint64_t>()->default_value(1),
-         "number of chunks to split tasks into (default: 1)")
-        ("delay,d", po::value<std::uint64_t>()->default_value(0),
-         "number of iterations in the delay loop")
-        ("no-header,n", po::value<bool>()->default_value(true),
-         "do not print out the csv header row")
-        ;
+    po::options_description cmdline(
+        "usage: " HPX_APPLICATION_STRING " [options]");
+    cmdline.add_options()("samples,s",
+        po::value<std::uint64_t>()->default_value(1000),
+        "number of tasks to concurrently wait for (default: 1000)")("futures,f",
+        po::value<std::uint64_t>()->default_value(100),
+        "number of tasks to concurrently wait for (default: 100)")("chunks,c",
+        po::value<std::uint64_t>()->default_value(1),
+        "number of chunks to split tasks into (default: 1)")("delay,d",
+        po::value<std::uint64_t>()->default_value(0),
+        "number of iterations in the delay loop")("no-header,n",
+        po::value<bool>()->default_value(true),
+        "do not print out the csv header row");
 
     // Initialize and run HPX.
-    return hpx::init(opts, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/performance/network/network_storage/network_storage.cpp
+++ b/tests/performance/network/network_storage/network_storage.cpp
@@ -1087,6 +1087,10 @@ int main(int argc, char* argv[])
     };
 
     DEBUG_OUTPUT(3,"Calling hpx::init");
-    return hpx::init(desc_commandline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/performance/network/pingpong_performance.cpp
+++ b/tests/performance/network/pingpong_performance.cpp
@@ -88,6 +88,11 @@ int main(int argc, char* argv[])
     // Initialize and run HPX
     std::vector<std::string> cfg;
     cfg.push_back("hpx.run_hpx_main!=1");
-    return hpx::init(cmdline,argc, argv, cfg);
+
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/regressions/actions/component_action_move_semantics.cpp
+++ b/tests/regressions/actions/component_action_move_semantics.cpp
@@ -317,6 +317,10 @@ int main(int argc, char* argv[])
         "hpx.components.action_move_semantics.enabled! = 1"};
 
     // Initialize and run HPX.
-    return hpx::init(desc_commandline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/regressions/actions/plain_action_move_semantics.cpp
+++ b/tests/regressions/actions/plain_action_move_semantics.cpp
@@ -34,9 +34,7 @@ using hpx::actions::direct_action;
 
 using hpx::async;
 
-using hpx::finalize;
 using hpx::find_here;
-using hpx::init;
 
 using hpx::test::movable_object;
 using hpx::test::non_movable_object;
@@ -833,7 +831,7 @@ int hpx_main(variables_map&)
     test_object_actions();
     test_object_direct_actions();
 
-    finalize();
+    hpx::finalize();
 
     return hpx::util::report_errors();
 }
@@ -846,6 +844,9 @@ int main(int argc, char* argv[])
         "Usage: " HPX_APPLICATION_STRING " [options]");
 
     // Initialize and run HPX.
-    return init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/regressions/agas/pass_by_value_id_type_action.cpp
+++ b/tests/regressions/agas/pass_by_value_id_type_action.cpp
@@ -73,6 +73,9 @@ int main(int argc, char* argv[])
         "Usage: " HPX_APPLICATION_STRING " [options]");
 
     // Initialize and run HPX.
-    return hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/regressions/agas/pass_by_value_id_type_action.cpp
+++ b/tests/regressions/agas/pass_by_value_id_type_action.cpp
@@ -68,14 +68,7 @@ int hpx_main(hpx::program_options::variables_map&)
 ///////////////////////////////////////////////////////////////////////////////
 int main(int argc, char* argv[])
 {
-    // Configure application-specific options.
-    hpx::program_options::options_description cmdline(
-        "Usage: " HPX_APPLICATION_STRING " [options]");
-
     // Initialize and run HPX.
-    hpx::init_params init_args;
-    init_args.desc_cmdline = cmdline;
-
-    return hpx::init(argc, argv, init_args);
+    return hpx::init(argc, argv);
 }
 #endif

--- a/tests/regressions/agas/register_with_basename_1804.cpp
+++ b/tests/regressions/agas/register_with_basename_1804.cpp
@@ -120,7 +120,10 @@ int main(int argc, char **argv)
     // all other localities:
     std::vector<std::string> config(1, "hpx.run_hpx_main!=1");
 
-    HPX_TEST_EQ(hpx::init(argc, argv, config), 0);
+    hpx::init_params init_args;
+    init_args.cfg = config;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
     return hpx::util::report_errors();
 }
 #endif

--- a/tests/regressions/block_matrix/main.cpp
+++ b/tests/regressions/block_matrix/main.cpp
@@ -99,6 +99,9 @@ int main(int argc, char** argv)
   hpx::program_options::options_description
     desc_commandline("usage: " HPX_APPLICATION_STRING " [options]");
 
-  return hpx::init(desc_commandline, argc, argv);
+  hpx::init_params init_args;
+  init_args.desc_cmdline = desc_commandline;
+
+  return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/regressions/block_matrix/main.cpp
+++ b/tests/regressions/block_matrix/main.cpp
@@ -95,13 +95,6 @@ int hpx_main(hpx::program_options::variables_map&)
 
 int main(int argc, char** argv)
 {
-  // Configure application-specific options
-  hpx::program_options::options_description
-    desc_commandline("usage: " HPX_APPLICATION_STRING " [options]");
-
-  hpx::init_params init_args;
-  init_args.desc_cmdline = desc_commandline;
-
-  return hpx::init(argc, argv, init_args);
+  return hpx::init(argc, argv);
 }
 #endif

--- a/tests/regressions/build/client_1950.cpp
+++ b/tests/regressions/build/client_1950.cpp
@@ -32,7 +32,10 @@ int main(int argc, char **argv)
     hpx::program_options::options_description
         desc_commandline("USAGE: " HPX_APPLICATION_STRING " [options]");
 
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX exited with exit status != 0");
 }
 #endif

--- a/tests/regressions/component/new_4369.cpp
+++ b/tests/regressions/component/new_4369.cpp
@@ -66,6 +66,9 @@ int hpx_main(int argc, char* argv[])
 int main(int argc, char* argv[])
 {
     std::vector<std::string> cfg = {"hpx.commandline.allow_unknown=1"};
-    hpx::init(argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/regressions/lcos/after_588.cpp
+++ b/tests/regressions/lcos/after_588.cpp
@@ -91,6 +91,9 @@ int main(int argc, char **argv)
           "number of times to repeat the test")
         ;
 
-    return hpx::init(desc, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/regressions/lcos/promise_leak_996.cpp
+++ b/tests/regressions/lcos/promise_leak_996.cpp
@@ -48,6 +48,9 @@ int main(int argc, char **argv)
     hpx::program_options::options_description desc(
         "usage: " HPX_APPLICATION_STRING " [options]");
 
-    return hpx::init(desc, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/regressions/lcos/promise_leak_996.cpp
+++ b/tests/regressions/lcos/promise_leak_996.cpp
@@ -45,12 +45,6 @@ int hpx_main(hpx::program_options::variables_map & vm)
 
 int main(int argc, char **argv)
 {
-    hpx::program_options::options_description desc(
-        "usage: " HPX_APPLICATION_STRING " [options]");
-
-    hpx::init_params init_args;
-    init_args.desc_cmdline = desc;
-
-    return hpx::init(argc, argv, init_args);
+    return hpx::init(argc, argv);
 }
 #endif

--- a/tests/regressions/lcos/receive_buffer_1733.cpp
+++ b/tests/regressions/lcos/receive_buffer_1733.cpp
@@ -164,7 +164,10 @@ int main(int argc, char* argv[])
         "hpx.run_hpx_main!=1"
     };
 
-    HPX_TEST_EQ_MSG(hpx::init(argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
     return hpx::util::report_errors();
 }

--- a/tests/regressions/options_as_config_3339.cpp
+++ b/tests/regressions/options_as_config_3339.cpp
@@ -21,7 +21,10 @@ int main(int argc, char* argv[])
         "--hpx:cores=3"
     };
 
-    HPX_TEST_EQ(hpx::init(argc, argv, cfg), 0);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
 
     return hpx::util::report_errors();
 }

--- a/tests/regressions/threads/block_os_threads_1036.cpp
+++ b/tests/regressions/threads/block_os_threads_1036.cpp
@@ -141,7 +141,11 @@ int main(
     };
 
     // Initialize and run HPX.
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 

--- a/tests/regressions/threads/thread_rescheduling.cpp
+++ b/tests/regressions/threads/thread_rescheduling.cpp
@@ -40,8 +40,6 @@ using hpx::threads::suspended;
 using hpx::threads::wait_signaled;
 using hpx::threads::wait_terminate;
 
-using hpx::init;
-using hpx::finalize;
 using hpx::find_here;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -183,7 +181,7 @@ int hpx_main(variables_map& vm)
         set_thread_state(thread_id, pending, wait_terminate);
     }
 
-    finalize();
+    hpx::finalize();
 
     return 0;
 }
@@ -205,7 +203,10 @@ int main(int argc, char* argv[])
     ;
 
     // Initialize and run HPX
-    HPX_TEST_EQ(0, init(cmdline, argc, argv));
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    HPX_TEST_EQ(0, hpx::init(argc, argv, init_args));
 
     HPX_TEST(woken);
 

--- a/tests/regressions/threads/thread_suspend_duration.cpp
+++ b/tests/regressions/threads/thread_suspend_duration.cpp
@@ -106,8 +106,12 @@ int main(int argc, char* argv[])
     };
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(init(desc_commandline, argc, argv, cfg), 0,
-      "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
     return report_errors();
 }
 

--- a/tests/regressions/threads/thread_suspend_pending.cpp
+++ b/tests/regressions/threads/thread_suspend_pending.cpp
@@ -98,8 +98,12 @@ int main(int argc, char* argv[])
     };
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(init(desc_commandline, argc, argv, cfg), 0,
-      "HPX main exited with non-zero status");
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
     return report_errors();
 }
 

--- a/tests/regressions/threads/threads_all_1422.cpp
+++ b/tests/regressions/threads/threads_all_1422.cpp
@@ -41,7 +41,10 @@ int main(int argc, char **argv)
     };
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
     return hpx::util::report_errors();
 }

--- a/tests/regressions/util/use_all_cores_2262.cpp
+++ b/tests/regressions/util/use_all_cores_2262.cpp
@@ -35,7 +35,11 @@ char* argv[] =
 int main()
 {
     std::vector<std::string> cfg = { "hpx.os_threads=all" };
-    HPX_TEST_EQ(hpx::init(1, argv, cfg), 0);
+
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(1, argv, init_args), 0);
     return hpx::util::report_errors();
 }
 #endif

--- a/tests/unit/agas/credit_exhaustion.cpp
+++ b/tests/unit/agas/credit_exhaustion.cpp
@@ -191,6 +191,10 @@ int main(
     };
 
     // Initialize and run HPX.
-    return init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/unit/agas/find_clients_from_prefix.cpp
+++ b/tests/unit/agas/find_clients_from_prefix.cpp
@@ -192,7 +192,10 @@ int main(int argc, char* argv[])
     };
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/tests/unit/agas/find_ids_from_prefix.cpp
+++ b/tests/unit/agas/find_ids_from_prefix.cpp
@@ -206,7 +206,10 @@ int main(int argc, char* argv[])
     };
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/tests/unit/agas/local_address_rebind.cpp
+++ b/tests/unit/agas/local_address_rebind.cpp
@@ -97,6 +97,10 @@ int main(int argc, char* argv[])
     };
 
     // Initialize and run HPX.
-    return init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/unit/agas/local_embedded_ref_to_local_object.cpp
+++ b/tests/unit/agas/local_embedded_ref_to_local_object.cpp
@@ -140,7 +140,11 @@ int main(
     };
 
     // Initialize and run HPX.
-    return init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 #endif

--- a/tests/unit/agas/local_embedded_ref_to_remote_object.cpp
+++ b/tests/unit/agas/local_embedded_ref_to_remote_object.cpp
@@ -157,6 +157,10 @@ int main(
     };
 
     // Initialize and run HPX.
-    return init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/unit/agas/refcnted_symbol_to_local_object.cpp
+++ b/tests/unit/agas/refcnted_symbol_to_local_object.cpp
@@ -152,6 +152,10 @@ int main(
     };
 
     // Initialize and run HPX.
-    return init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/unit/agas/refcnted_symbol_to_remote_object.cpp
+++ b/tests/unit/agas/refcnted_symbol_to_remote_object.cpp
@@ -168,6 +168,10 @@ int main(
     };
 
     // Initialize and run HPX.
-    return init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/unit/agas/remote_embedded_ref_to_local_object.cpp
+++ b/tests/unit/agas/remote_embedded_ref_to_local_object.cpp
@@ -157,6 +157,10 @@ int main(
     };
 
     // Initialize and run HPX.
-    return init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/unit/agas/remote_embedded_ref_to_remote_object.cpp
+++ b/tests/unit/agas/remote_embedded_ref_to_remote_object.cpp
@@ -156,6 +156,10 @@ int main(
     };
 
     // Initialize and run HPX.
-    return init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/unit/agas/scoped_ref_to_local_object.cpp
+++ b/tests/unit/agas/scoped_ref_to_local_object.cpp
@@ -127,6 +127,10 @@ int main(
     };
 
     // Initialize and run HPX.
-    return init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/unit/agas/scoped_ref_to_remote_object.cpp
+++ b/tests/unit/agas/scoped_ref_to_remote_object.cpp
@@ -142,6 +142,10 @@ int main(
         "hpx.components.managed_refcnt_checker.enabled! = 1"
     };
     // Initialize and run HPX.
-    return init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/unit/agas/split_credit.cpp
+++ b/tests/unit/agas/split_credit.cpp
@@ -178,6 +178,10 @@ int main(
     };
 
     // Initialize and run HPX.
-    return init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/unit/agas/uncounted_symbol_to_local_object.cpp
+++ b/tests/unit/agas/uncounted_symbol_to_local_object.cpp
@@ -148,6 +148,10 @@ int main(
     };
 
     // Initialize and run HPX.
-    return init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/unit/agas/uncounted_symbol_to_remote_object.cpp
+++ b/tests/unit/agas/uncounted_symbol_to_remote_object.cpp
@@ -171,6 +171,10 @@ int main(
     };
 
     // Initialize and run HPX.
-    return init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/unit/apex/apex_action_count.cpp
+++ b/tests/unit/apex/apex_action_count.cpp
@@ -95,7 +95,10 @@ int main(int argc, char* argv[])
         ;
 
     // Initialize and run HPX
-    int status =  hpx::init(desc_commandline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    int status = hpx::init(argc, argv, init_args);
     HPX_TEST_EQ(status, 0);
 
     std::cout << "Calls to fibonacci_action: " << count << std::endl;

--- a/tests/unit/component/launch_process.cpp
+++ b/tests/unit/component/launch_process.cpp
@@ -171,10 +171,12 @@ int main(int argc, char* argv[])
         "hpx.components.launch_process_test_server.enabled!=1"
     };
 
-    HPX_TEST_EQ_MSG(
-        hpx::init(desc_commandline, argc, argv, cfg), 0,
-        "HPX main exited with non-zero status"
-    );
+    HPX_TEST_EQ_MSG(hpx::init_params init_args;
+                    init_args.desc_cmdline = desc_commandline;
+                    init_args.cfg = cfg;
+
+                    hpx::init(argc, argv, init_args), 0,
+                    "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/component/launch_process.cpp
+++ b/tests/unit/component/launch_process.cpp
@@ -171,12 +171,12 @@ int main(int argc, char* argv[])
         "hpx.components.launch_process_test_server.enabled!=1"
     };
 
-    HPX_TEST_EQ_MSG(hpx::init_params init_args;
-                    init_args.desc_cmdline = desc_commandline;
-                    init_args.cfg = cfg;
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
 
-                    hpx::init(argc, argv, init_args), 0,
-                    "HPX main exited with non-zero status");
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/component/launched_process.cpp
+++ b/tests/unit/component/launched_process.cpp
@@ -85,6 +85,11 @@ int main(int argc, char* argv[])
 
     // Note: this uses runtime_mode::connect to instruct this locality to
     // connect to the existing HPX applications
-    return hpx::init(desc_commandline, argc, argv, cfg, hpx::runtime_mode::connect);
+    hpx::init_params init_args;
+    init_args.mode = hpx::runtime_mode::connect;
+    init_args.cfg = cfg;
+    init_args.desc_cmdline = desc_commandline;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/unit/lcos/await.cpp
+++ b/tests/unit/lcos/await.cpp
@@ -198,5 +198,8 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    return hpx::init(argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }

--- a/tests/unit/lcos/future_wait.cpp
+++ b/tests/unit/lcos/future_wait.cpp
@@ -232,6 +232,10 @@ int main(
     };
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/unit/lcos/packaged_action.cpp
+++ b/tests/unit/lcos/packaged_action.cpp
@@ -110,6 +110,10 @@ int main(int argc, char* argv[])
     };
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/unit/lcos/promise.cpp
+++ b/tests/unit/lcos/promise.cpp
@@ -240,6 +240,10 @@ int main(int argc, char* argv[])
     };
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv, cfg);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
 }
 #endif

--- a/tests/unit/lcos/promise_emplace.cpp
+++ b/tests/unit/lcos/promise_emplace.cpp
@@ -199,7 +199,10 @@ int main(int argc, char* argv[])
     };
 
     // Initialize and run HPX
-    HPX_TEST_EQ(hpx::init(argc, argv, cfg), 0);
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
     return hpx::util::report_errors();
 }
 

--- a/tests/unit/parcelset/put_parcels.cpp
+++ b/tests/unit/parcelset/put_parcels.cpp
@@ -257,7 +257,11 @@ int main(int argc, char* argv[])
     };
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/tests/unit/parcelset/put_parcels_with_coalescing.cpp
+++ b/tests/unit/parcelset/put_parcels_with_coalescing.cpp
@@ -283,7 +283,11 @@ int main(int argc, char* argv[])
     };
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/tests/unit/parcelset/put_parcels_with_compression.cpp
+++ b/tests/unit/parcelset/put_parcels_with_compression.cpp
@@ -318,7 +318,10 @@ int main(int argc, char* argv[])
         ;
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/tests/unit/resource/cross_pool_injection.cpp
+++ b/tests/unit/resource/cross_pool_injection.cpp
@@ -257,10 +257,10 @@ void init_resource_partitioner_handler(
 void test_scheduler(
     int argc, char* argv[], hpx::resource::scheduling_policy scheduler)
 {
-    hpx::init_params p;
-    p.rp_callback =
+    hpx::init_params init_args;
+    init_args.rp_callback =
         hpx::bind_back(init_resource_partitioner_handler, scheduler);
-    HPX_TEST_EQ(hpx::init(argc, argv, p), 0);
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/util/bind_action.cpp
+++ b/tests/unit/util/bind_action.cpp
@@ -373,7 +373,10 @@ int main(int argc, char* argv[])
         "Usage: " HPX_APPLICATION_STRING " [options]");
 
     // Initialize and run HPX
-    return hpx::init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 
 #endif

--- a/tests/unit/util/bind_action.cpp
+++ b/tests/unit/util/bind_action.cpp
@@ -368,15 +368,8 @@ int hpx_main(hpx::program_options::variables_map&)
 ///////////////////////////////////////////////////////////////////////////////
 int main(int argc, char* argv[])
 {
-    // Configure application-specific options
-    hpx::program_options::options_description cmdline(
-        "Usage: " HPX_APPLICATION_STRING " [options]");
-
     // Initialize and run HPX
-    hpx::init_params init_args;
-    init_args.desc_cmdline = cmdline;
-
-    return hpx::init(argc, argv, init_args);
+    return hpx::init(argc, argv);
 }
 
 #endif

--- a/tests/unit/util/function/function_object_size.cpp
+++ b/tests/unit/util/function/function_object_size.cpp
@@ -20,9 +20,6 @@ using hpx::program_options::options_description;
 
 using hpx::util::function;
 
-using hpx::init;
-using hpx::finalize;
-
 ///////////////////////////////////////////////////////////////////////////////
 struct small_object
 {
@@ -269,7 +266,7 @@ int hpx_main(variables_map& vm)
         }
     }
 
-    finalize();
+    hpx::finalize();
 
     return 0;
 }
@@ -281,6 +278,9 @@ int main(int argc, char* argv[])
     options_description cmdline("Usage: " HPX_APPLICATION_STRING " [options]");
 
     // Initialize and run HPX
-    return init(cmdline, argc, argv);
+    hpx::init_params init_args;
+    init_args.desc_cmdline = cmdline;
+
+    return hpx::init(argc, argv, init_args);
 }
 

--- a/tests/unit/util/function/function_object_size.cpp
+++ b/tests/unit/util/function/function_object_size.cpp
@@ -274,13 +274,7 @@ int hpx_main(variables_map& vm)
 ///////////////////////////////////////////////////////////////////////////////
 int main(int argc, char* argv[])
 {
-    // Configure application-specific options
-    options_description cmdline("Usage: " HPX_APPLICATION_STRING " [options]");
-
     // Initialize and run HPX
-    hpx::init_params init_args;
-    init_args.desc_cmdline = cmdline;
-
-    return hpx::init(argc, argv, init_args);
+    return hpx::init(argc, argv);
 }
 


### PR DESCRIPTION
- Change the  old `hpx::init` overloads to the one using the `struct init_params`
- Add deprecated messages for the old `init` overloads
- Unify the indentation/name of variables for some `init` calls to facilitate the use of scripts