### PR TITLE
Adapt transform to C++20

### DIFF
--- a/libs/full/compute_cuda/tests/unit/transform_compute.cu
+++ b/libs/full/compute_cuda/tests/unit/transform_compute.cu
@@ -45,8 +45,8 @@ struct transform_test
 void test_transform(executor_type& exec, target_vector& d_A, target_vector& d_B,
     target_vector& d_C, std::vector<int> const& ref)
 {
-    hpx::parallel::transform(hpx::execution::par.on(exec), d_A.begin(),
-        d_A.end(), d_B.begin(), d_C.begin(), transform_test());
+    hpx::transform(hpx::execution::par.on(exec), d_A.begin(), d_A.end(),
+        d_B.begin(), d_C.begin(), transform_test());
 
     std::vector<int> h_C(d_C.size());
     hpx::copy(hpx::execution::par, d_C.begin(), d_C.end(), h_C.begin());

--- a/libs/full/include/include/hpx/algorithm.hpp
+++ b/libs/full/include/include/hpx/algorithm.hpp
@@ -36,7 +36,6 @@ namespace hpx {
     using hpx::parallel::stable_partition;
     using hpx::parallel::stable_sort;
     using hpx::parallel::swap_ranges;
-    using hpx::parallel::transform;
     using hpx::parallel::unique;
     using hpx::parallel::unique_copy;
 }    // namespace hpx

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -125,7 +126,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     };
 
     template <typename Iterator1, typename Iterator2, typename Iterator3>
-    struct algorithm_result_helper<util::in_in_out_result<Iterator1, Iterator2, Iterator3>,
+    struct algorithm_result_helper<
+        util::in_in_out_result<Iterator1, Iterator2, Iterator3>,
         typename std::enable_if<
             hpx::traits::is_segmented_local_iterator<Iterator1>::value ||
             hpx::traits::is_segmented_local_iterator<Iterator2>::value ||
@@ -135,8 +137,9 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         typedef hpx::traits::segmented_local_iterator_traits<Iterator2> traits2;
         typedef hpx::traits::segmented_local_iterator_traits<Iterator3> traits3;
 
-        static HPX_FORCEINLINE util::in_in_out_result<typename traits1::local_iterator,
-            typename traits2::local_iterator, typename traits3::local_iterator>
+        static HPX_FORCEINLINE util::in_in_out_result<
+            typename traits1::local_iterator, typename traits2::local_iterator,
+            typename traits3::local_iterator>
         call(util::in_in_out_result<typename traits1::local_raw_iterator,
             typename traits2::local_raw_iterator,
             typename traits3::local_raw_iterator>&& p)

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
@@ -124,6 +124,32 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         }
     };
 
+    template <typename Iterator1, typename Iterator2, typename Iterator3>
+    struct algorithm_result_helper<util::in_in_out_result<Iterator1, Iterator2, Iterator3>,
+        typename std::enable_if<
+            hpx::traits::is_segmented_local_iterator<Iterator1>::value ||
+            hpx::traits::is_segmented_local_iterator<Iterator2>::value ||
+            hpx::traits::is_segmented_local_iterator<Iterator3>::value>::type>
+    {
+        typedef hpx::traits::segmented_local_iterator_traits<Iterator1> traits1;
+        typedef hpx::traits::segmented_local_iterator_traits<Iterator2> traits2;
+        typedef hpx::traits::segmented_local_iterator_traits<Iterator3> traits3;
+
+        static HPX_FORCEINLINE util::in_in_out_result<typename traits1::local_iterator,
+            typename traits2::local_iterator, typename traits3::local_iterator>
+        call(util::in_in_out_result<typename traits1::local_raw_iterator,
+            typename traits2::local_raw_iterator,
+            typename traits3::local_raw_iterator>&& p)
+        {
+            return util::in_in_out_result<typename traits1::local_raw_iterator,
+                typename traits2::local_raw_iterator, 
+                typename traits3::local_raw_iterator>{
+                traits1::remote(std::move(p.in1)),
+                traits2::remote(std::move(p.in2)),
+                traits3::remote(std::move(p.out))};
+        }
+    };
+
     template <typename Iterator>
     struct algorithm_result_helper<future<Iterator>,
         typename std::enable_if<
@@ -239,6 +265,47 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                         traits1::remote(std::move(hpx::get<0>(p))),
                         traits2::remote(std::move(hpx::get<1>(p))),
                         traits3::remote(std::move(hpx::get<2>(p))));
+                });
+            // clang-format on
+        }
+    };
+
+    template <typename Iterator1, typename Iterator2, typename Iterator3>
+    struct algorithm_result_helper<
+        future<util::in_in_out_result<Iterator1, Iterator2, Iterator3>>,
+        typename std::enable_if<
+            hpx::traits::is_segmented_local_iterator<Iterator1>::value ||
+            hpx::traits::is_segmented_local_iterator<Iterator2>::value ||
+            hpx::traits::is_segmented_local_iterator<Iterator3>::value>::type>
+    {
+        typedef hpx::traits::segmented_local_iterator_traits<Iterator1> traits1;
+        typedef hpx::traits::segmented_local_iterator_traits<Iterator2> traits2;
+        typedef hpx::traits::segmented_local_iterator_traits<Iterator3> traits3;
+
+        typedef util::in_in_out_result<typename traits1::local_raw_iterator,
+            typename traits2::local_raw_iterator,
+            typename traits3::local_raw_iterator>
+            arg_type;
+
+        static HPX_FORCEINLINE future<util::in_in_out_result<
+            typename traits1::local_iterator, typename traits2::local_iterator,
+            typename traits3::local_iterator>>
+        call(future<arg_type>&& f)
+        {
+            // different versions of clang-format produce different results
+            // clang-format off
+            return f.then(hpx::launch::sync,
+                [](future<arg_type>&& f)
+                    -> util::in_in_out_result<typename traits1::local_iterator,
+                        typename traits2::local_iterator,
+                        typename traits3::local_iterator> {
+                    auto&& p = f.get();
+                    return  util::in_in_out_result<typename traits1::local_iterator,
+                        typename traits2::local_iterator,
+                        typename traits3::local_iterator>{
+                        traits1::remote(p.in1),
+                        traits2::remote(p.in2),
+                        traits3::remote(p.out)};
                 });
             // clang-format on
         }

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
@@ -141,9 +141,9 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             typename traits2::local_raw_iterator,
             typename traits3::local_raw_iterator>&& p)
         {
-            return util::in_in_out_result<typename traits1::local_raw_iterator,
-                typename traits2::local_raw_iterator, 
-                typename traits3::local_raw_iterator>{
+            return util::in_in_out_result<typename traits1::local_iterator,
+                typename traits2::local_iterator,
+                typename traits3::local_iterator>{
                 traits1::remote(std::move(p.in1)),
                 traits2::remote(std::move(p.in2)),
                 traits3::remote(std::move(p.out))};
@@ -303,9 +303,9 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                     return  util::in_in_out_result<typename traits1::local_iterator,
                         typename traits2::local_iterator,
                         typename traits3::local_iterator>{
-                        traits1::remote(p.in1),
-                        traits2::remote(p.in2),
-                        traits3::remote(p.out)};
+                        traits1::remote(std::move(p.in1)),
+                        traits2::remote(std::move(p.in2)),
+                        traits3::remote(std::move(p.out))};
                 });
             // clang-format on
         }

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform.hpp
@@ -9,9 +9,9 @@
 #include <hpx/config.hpp>
 #include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
 #include <hpx/datastructures/tuple.hpp>
+#include <hpx/parallel/util/result_types.hpp>
 #include <hpx/parallel/util/tagged_pair.hpp>
 #include <hpx/parallel/util/tagged_tuple.hpp>
-#include <hpx/parallel/util/result_types.hpp>
 
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
@@ -68,8 +68,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type2 ldest = traits2::begin(sdest);
                 if (beg != end)
                 {
-                    util::in_out_result<local_iterator_type1, local_iterator_type2> out =
-                        dispatch(traits2::get_id(sdest), algo, policy,
+                    util::in_out_result<local_iterator_type1,
+                        local_iterator_type2>
+                        out = dispatch(traits2::get_id(sdest), algo, policy,
                             std::true_type(), beg, end, ldest, f, proj);
                     last = traits1::compose(send, out.in);
                     dest = traits2::compose(sdest, out.out);
@@ -81,7 +82,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type1 beg = traits1::local(first);
                 local_iterator_type1 end = traits1::end(sit);
                 local_iterator_type2 ldest = traits2::begin(sdest);
-                util::in_out_result<local_iterator_type1, local_iterator_type2> out;
+                util::in_out_result<local_iterator_type1, local_iterator_type2>
+                    out;
                 if (beg != end)
                 {
                     out = dispatch(traits2::get_id(sdest), algo, policy,
@@ -113,7 +115,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 last = traits1::compose(send, out.in);
                 dest = traits2::compose(sdest, out.out);
             }
-            return result::get(util::in_out_result<SegIter, OutIter>{std::move(last), std::move(dest)});
+            return result::get(util::in_out_result<SegIter, OutIter>{
+                std::move(last), std::move(dest)});
         }
 
         // parallel remote implementation
@@ -143,8 +146,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             segment_iterator1 send = traits1::segment(last);
             segment_iterator2 sdest = traits2::segment(dest);
 
-            typedef std::vector<
-                future<util::in_out_result<local_iterator_type1, local_iterator_type2>>>
+            typedef std::vector<future<util::in_out_result<local_iterator_type1,
+                local_iterator_type2>>>
                 segment_type;
             segment_type segments;
             segments.reserve(std::distance(sit, send));
@@ -227,7 +230,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             if (first == last)
             {
-                return result::get(util::in_out_result<SegIter, OutIter>{std::move(last), std::move(dest)});
+                return result::get(util::in_out_result<SegIter, OutIter>{
+                    std::move(last), std::move(dest)});
             }
 
             typedef hpx::traits::segmented_iterator_traits<SegIter>
@@ -236,7 +240,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 iterator_traits2;
 
             return segmented_transform(
-                transform<util::in_out_result<typename iterator_traits1::local_iterator,
+                transform<util::in_out_result<
+                    typename iterator_traits1::local_iterator,
                     typename iterator_traits2::local_iterator>>(),
                 std::forward<ExPolicy>(policy), first, last, dest,
                 std::forward<F>(f), std::forward<Proj>(proj), is_seq());
@@ -293,8 +298,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type3 ldest = traits3::begin(sdest);
                 if (beg1 != end1)
                 {
-                    util::in_in_out_result<local_iterator_type1, local_iterator_type2,
-                        local_iterator_type3>
+                    util::in_in_out_result<local_iterator_type1,
+                        local_iterator_type2, local_iterator_type3>
                         out = dispatch(traits1::get_id(sit1), algo, policy,
                             std::true_type(), beg1, end1, beg2, ldest, f, proj1,
                             proj2);
@@ -310,8 +315,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type1 end1 = traits1::end(sit1);
                 local_iterator_type2 beg2 = traits2::local(first2);
                 local_iterator_type3 ldest = traits3::begin(sdest);
-                util::in_in_out_result<local_iterator_type1, local_iterator_type2,
-                    local_iterator_type3>
+                util::in_in_out_result<local_iterator_type1,
+                    local_iterator_type2, local_iterator_type3>
                     out;
                 if (beg1 != end1)
                 {
@@ -351,8 +356,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 last2 = traits2::compose(send2, out.in2);
                 dest = traits3::compose(sdest, out.out);
             }
-            return result::get(util::in_in_out_result<InIter1, InIter2, OutIter>{
-                std::move(last1), std::move(last2), std::move(dest)});
+            return result::get(
+                util::in_in_out_result<InIter1, InIter2, OutIter>{
+                    std::move(last1), std::move(last2), std::move(dest)});
         }
 
         // parallel remote implementation
@@ -393,8 +399,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
             segment_iterator2 send2 = traits2::segment(last2);
             segment_iterator3 sdest = traits3::segment(dest);
 
-            typedef std::vector<future<util::in_in_out_result<local_iterator_type1,
-                local_iterator_type2, local_iterator_type3>>>
+            typedef std::vector<
+                future<util::in_in_out_result<local_iterator_type1,
+                    local_iterator_type2, local_iterator_type3>>>
                 segment_type;
             segment_type segments;
             segments.reserve(std::distance(sit1, send1));
@@ -457,7 +464,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             }
 
             return result::get(dataflow(
-                [=](segment_type&& r) -> util::in_in_out_result<InIter1, InIter2, OutIter> {
+                [=](segment_type&& r)
+                    -> util::in_in_out_result<InIter1, InIter2, OutIter> {
                     // handle any remote exceptions, will throw on error
                     std::list<std::exception_ptr> errors;
                     parallel::util::detail::handle_remote_exceptions<
@@ -466,7 +474,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     auto olast1 = traits1::compose(send1, rl.in1);
                     auto olast2 = traits2::compose(send2, rl.in2);
                     auto odest = traits3::compose(sdest, rl.out);
-                    return util::in_in_out_result<InIter1, InIter2, OutIter>{olast1, olast2, odest};
+                    return util::in_in_out_result<InIter1, InIter2, OutIter>{
+                        olast1, olast2, odest};
                 },
                 std::move(segments)));
         }
@@ -490,8 +499,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             if (first1 == last1)
             {
-                return result::get(util::in_in_out_result<InIter1, InIter2, OutIter>{
-                    std::move(last1), std::move(last2), std::move(dest)});
+                return result::get(
+                    util::in_in_out_result<InIter1, InIter2, OutIter>{
+                        std::move(last1), std::move(last2), std::move(dest)});
             }
 
             typedef hpx::traits::segmented_iterator_traits<InIter1>
@@ -501,13 +511,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef hpx::traits::segmented_iterator_traits<OutIter>
                 iterator3_traits;
             return segmented_transform(
-                    transform_binary<
-                        util::in_in_out_result<typename iterator1_traits::local_iterator,
-                            typename iterator2_traits::local_iterator,
-                            typename iterator3_traits::local_iterator>>(),
-                    std::forward<ExPolicy>(policy), first1, last1, first2, dest,
-                    std::forward<F>(f), std::forward<Proj1>(proj1),
-                    std::forward<Proj2>(proj2), is_seq());
+                transform_binary<util::in_in_out_result<
+                    typename iterator1_traits::local_iterator,
+                    typename iterator2_traits::local_iterator,
+                    typename iterator3_traits::local_iterator>>(),
+                std::forward<ExPolicy>(policy), first1, last1, first2, dest,
+                std::forward<F>(f), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2), is_seq());
         }
 
         // forward declare the non-segmented version of this algorithm
@@ -561,14 +571,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type3 ldest = traits3::begin(sdest);
                 if (beg1 != end1 && beg2 != end2)
                 {
-                    util::in_in_out_result<local_iterator_type1, local_iterator_type2,
-                        local_iterator_type3>
+                    util::in_in_out_result<local_iterator_type1,
+                        local_iterator_type2, local_iterator_type3>
                         out = dispatch(traits1::get_id(sit1), algo, policy,
                             std::true_type(), beg1, end1, beg2, end2, ldest, f,
                             proj1, proj2);
-                    last1 = traits1::compose(send1, hpx::get<0>(out));
-                    last2 = traits2::compose(send2, hpx::get<1>(out));
-                    dest = traits3::compose(sdest, hpx::get<2>(out));
+                    last1 = traits1::compose(send1, out.in1);
+                    last2 = traits2::compose(send2, out.in2);
+                    dest = traits3::compose(sdest, out.out);
                 }
             }
             else
@@ -579,8 +589,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type2 beg2 = traits2::local(first2);
                 local_iterator_type2 end2 = traits2::end(sit2);
                 local_iterator_type3 ldest = traits3::begin(sdest);
-                util::in_in_out_result<local_iterator_type1, local_iterator_type2,
-                    local_iterator_type3>
+                util::in_in_out_result<local_iterator_type1,
+                    local_iterator_type2, local_iterator_type3>
                     out;
                 if (beg1 != end1 && beg2 != end2)
                 {
@@ -622,8 +632,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 last2 = traits2::compose(send2, out.in2);
                 dest = traits3::compose(sdest, out.out);
             }
-            return result::get(util::in_in_out_result<InIter1, InIter2, OutIter>{
-                std::move(last1), std::move(last2), std::move(dest)});
+            return result::get(
+                util::in_in_out_result<InIter1, InIter2, OutIter>{
+                    std::move(last1), std::move(last2), std::move(dest)});
         }
 
         // parallel remote implementation
@@ -661,8 +672,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
             segment_iterator2 send2 = traits2::segment(last2);
             segment_iterator3 sdest = traits3::segment(dest);
 
-            typedef std::vector<future<util::in_in_out_result<local_iterator_type1,
-                local_iterator_type2, local_iterator_type3>>>
+            typedef std::vector<
+                future<util::in_in_out_result<local_iterator_type1,
+                    local_iterator_type2, local_iterator_type3>>>
                 segment_type;
             segment_type segments;
             segments.reserve(std::distance(sit1, send1));
@@ -729,7 +741,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             }
 
             return result::get(dataflow(
-                [=](segment_type&& r) -> util::in_in_out_result<InIter1, InIter2, OutIter> {
+                [=](segment_type&& r)
+                    -> util::in_in_out_result<InIter1, InIter2, OutIter> {
                     // handle any remote exceptions, will throw on error
                     std::list<std::exception_ptr> errors;
                     parallel::util::detail::handle_remote_exceptions<
@@ -738,7 +751,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     auto olast1 = traits1::compose(send1, rl.in1);
                     auto olast2 = traits2::compose(send2, rl.in2);
                     auto odest = traits3::compose(sdest, rl.out);
-                    return util::in_in_out_result<InIter1, InIter2, OutIter>(olast1, olast2, odest);
+                    return util::in_in_out_result<InIter1, InIter2, OutIter>{
+                        olast1, olast2, odest};
                 },
                 std::move(segments)));
         }
@@ -759,8 +773,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             if (first1 == last1)
             {
-                return result::get(util::in_in_out_result<InIter1, InIter2, OutIter>{
-                    std::move(last1), std::move(last2), std::move(dest)});
+                return result::get(
+                    util::in_in_out_result<InIter1, InIter2, OutIter>{
+                        std::move(last1), std::move(last2), std::move(dest)});
             }
 
             typedef hpx::traits::segmented_iterator_traits<InIter1>
@@ -771,13 +786,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 iterator3_traits;
 
             return segmented_transform(
-                    transform_binary2<
-                        util::in_in_out_result<typename iterator1_traits::local_iterator,
-                            typename iterator2_traits::local_iterator,
-                            typename iterator3_traits::local_iterator>>(),
-                    std::forward<ExPolicy>(policy), first1, last1, first2,
-                    last2, dest, std::forward<F>(f), std::forward<Proj1>(proj1),
-                    std::forward<Proj2>(proj2), is_seq());
+                transform_binary2<util::in_in_out_result<
+                    typename iterator1_traits::local_iterator,
+                    typename iterator2_traits::local_iterator,
+                    typename iterator3_traits::local_iterator>>(),
+                std::forward<ExPolicy>(policy), first1, last1, first2, last2,
+                dest, std::forward<F>(f), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2), is_seq());
         }
 
         // forward declare the non-segmented version of this algorithm

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform.hpp
@@ -10,8 +10,6 @@
 #include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/parallel/util/result_types.hpp>
-#include <hpx/parallel/util/tagged_pair.hpp>
-#include <hpx/parallel/util/tagged_tuple.hpp>
 
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/transform.hpp
@@ -11,6 +11,7 @@
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/parallel/util/tagged_pair.hpp>
 #include <hpx/parallel/util/tagged_tuple.hpp>
+#include <hpx/parallel/util/result_types.hpp>
 
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
@@ -40,7 +41,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename Algo, typename ExPolicy, typename SegIter,
             typename OutIter, typename F, typename Proj>
         static typename util::detail::algorithm_result<ExPolicy,
-            std::pair<SegIter, OutIter>>::type
+            util::in_out_result<SegIter, OutIter>>::type
         segmented_transform(Algo&& algo, ExPolicy const& policy, SegIter first,
             SegIter last, OutIter dest, F&& f, Proj&& proj, std::true_type)
         {
@@ -52,7 +53,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef typename traits2::local_iterator local_iterator_type2;
 
             typedef util::detail::algorithm_result<ExPolicy,
-                std::pair<SegIter, OutIter>>
+                util::in_out_result<SegIter, OutIter>>
                 result;
 
             segment_iterator1 sit = traits1::segment(first);
@@ -67,11 +68,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type2 ldest = traits2::begin(sdest);
                 if (beg != end)
                 {
-                    std::pair<local_iterator_type1, local_iterator_type2> out =
+                    util::in_out_result<local_iterator_type1, local_iterator_type2> out =
                         dispatch(traits2::get_id(sdest), algo, policy,
                             std::true_type(), beg, end, ldest, f, proj);
-                    last = traits1::compose(send, std::get<0>(out));
-                    dest = traits2::compose(sdest, std::get<1>(out));
+                    last = traits1::compose(send, out.in);
+                    dest = traits2::compose(sdest, out.out);
                 }
             }
             else
@@ -80,7 +81,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type1 beg = traits1::local(first);
                 local_iterator_type1 end = traits1::end(sit);
                 local_iterator_type2 ldest = traits2::begin(sdest);
-                std::pair<local_iterator_type1, local_iterator_type2> out;
+                util::in_out_result<local_iterator_type1, local_iterator_type2> out;
                 if (beg != end)
                 {
                     out = dispatch(traits2::get_id(sdest), algo, policy,
@@ -109,18 +110,17 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     out = dispatch(traits2::get_id(sdest), algo, policy,
                         std::true_type(), beg, end, ldest, f, proj);
                 }
-                last = traits1::compose(send, std::get<0>(out));
-                dest = traits2::compose(sdest, std::get<1>(out));
+                last = traits1::compose(send, out.in);
+                dest = traits2::compose(sdest, out.out);
             }
-            return result::get(
-                std::make_pair(std::move(last), std::move(dest)));
+            return result::get(util::in_out_result<SegIter, OutIter>{std::move(last), std::move(dest)});
         }
 
         // parallel remote implementation
         template <typename Algo, typename ExPolicy, typename SegIter,
             typename OutIter, typename F, typename Proj>
         static typename util::detail::algorithm_result<ExPolicy,
-            std::pair<SegIter, OutIter>>::type
+            util::in_out_result<SegIter, OutIter>>::type
         segmented_transform(Algo&& algo, ExPolicy const& policy, SegIter first,
             SegIter last, OutIter dest, F&& f, Proj&& proj, std::false_type)
         {
@@ -132,7 +132,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef typename traits2::local_iterator local_iterator_type2;
 
             typedef util::detail::algorithm_result<ExPolicy,
-                std::pair<SegIter, OutIter>>
+                util::in_out_result<SegIter, OutIter>>
                 result;
 
             typedef std::integral_constant<bool,
@@ -144,7 +144,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             segment_iterator2 sdest = traits2::segment(dest);
 
             typedef std::vector<
-                future<std::pair<local_iterator_type1, local_iterator_type2>>>
+                future<util::in_out_result<local_iterator_type1, local_iterator_type2>>>
                 segment_type;
             segment_type segments;
             segments.reserve(std::distance(sit, send));
@@ -199,15 +199,15 @@ namespace hpx { namespace parallel { inline namespace v1 {
             }
 
             return result::get(dataflow(
-                [=](segment_type&& r) -> std::pair<SegIter, OutIter> {
+                [=](segment_type&& r) -> util::in_out_result<SegIter, OutIter> {
                     // handle any remote exceptions, will throw on error
                     std::list<std::exception_ptr> errors;
                     parallel::util::detail::handle_remote_exceptions<
                         ExPolicy>::call(r, errors);
                     auto ft = r.back().get();
-                    auto olast = traits1::compose(send, std::get<0>(ft));
-                    auto odest = traits2::compose(sdest, std::get<1>(ft));
-                    return std::make_pair(olast, odest);
+                    auto olast = traits1::compose(send, ft.in);
+                    auto odest = traits2::compose(sdest, ft.out);
+                    return util::in_out_result<SegIter, OutIter>{olast, odest};
                 },
                 std::move(segments)));
         }
@@ -217,18 +217,17 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename ExPolicy, typename SegIter, typename OutIter,
             typename F, typename Proj>
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_pair<tag::in(SegIter), tag::out(OutIter)>>::type
+            util::in_out_result<SegIter, OutIter>>::type
         transform_(ExPolicy&& policy, SegIter first, SegIter last, OutIter dest,
             F&& f, Proj&& proj, std::true_type)
         {
             using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
             using result = util::detail::algorithm_result<ExPolicy,
-                hpx::util::tagged_pair<tag::in(SegIter), tag::out(OutIter)>>;
+                util::in_out_result<SegIter, OutIter>>;
 
             if (first == last)
             {
-                return result::get(
-                    std::make_pair(std::move(last), std::move(dest)));
+                return result::get(util::in_out_result<SegIter, OutIter>{std::move(last), std::move(dest)});
             }
 
             typedef hpx::traits::segmented_iterator_traits<SegIter>
@@ -236,19 +235,18 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef hpx::traits::segmented_iterator_traits<OutIter>
                 iterator_traits2;
 
-            return hpx::util::make_tagged_pair<tag::in,
-                tag::out>(segmented_transform(
-                transform<std::pair<typename iterator_traits1::local_iterator,
+            return segmented_transform(
+                transform<util::in_out_result<typename iterator_traits1::local_iterator,
                     typename iterator_traits2::local_iterator>>(),
                 std::forward<ExPolicy>(policy), first, last, dest,
-                std::forward<F>(f), std::forward<Proj>(proj), is_seq()));
+                std::forward<F>(f), std::forward<Proj>(proj), is_seq());
         }
 
         // forward declare the non-segmented version of this algorithm
         template <typename ExPolicy, typename InIter, typename OutIter,
             typename F, typename Proj>
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_pair<tag::in(InIter), tag::out(OutIter)>>::type
+            util::in_out_result<InIter, OutIter>>::type
         transform_(ExPolicy&& policy, InIter first, InIter last, OutIter dest,
             F&& f, Proj&& proj, std::false_type);
 
@@ -259,7 +257,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typename InIter2, typename OutIter, typename F, typename Proj1,
             typename Proj2>
         static typename util::detail::algorithm_result<ExPolicy,
-            hpx::tuple<InIter1, InIter2, OutIter>>::type
+            util::in_in_out_result<InIter1, InIter2, OutIter>>::type
         segmented_transform(Algo&& algo, ExPolicy&& policy, InIter1 first1,
             InIter1 last1, InIter2 first2, OutIter dest, F&& f, Proj1&& proj1,
             Proj2&& proj2, std::true_type)
@@ -275,7 +273,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef typename traits3::local_iterator local_iterator_type3;
 
             typedef util::detail::algorithm_result<ExPolicy,
-                hpx::tuple<InIter1, InIter2, OutIter>>
+                util::in_in_out_result<InIter1, InIter2, OutIter>>
                 result;
 
             auto last2 = first2;
@@ -295,14 +293,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type3 ldest = traits3::begin(sdest);
                 if (beg1 != end1)
                 {
-                    hpx::tuple<local_iterator_type1, local_iterator_type2,
+                    util::in_in_out_result<local_iterator_type1, local_iterator_type2,
                         local_iterator_type3>
                         out = dispatch(traits1::get_id(sit1), algo, policy,
                             std::true_type(), beg1, end1, beg2, ldest, f, proj1,
                             proj2);
-                    last1 = traits1::compose(send1, hpx::get<0>(out));
-                    last2 = traits2::compose(send2, hpx::get<1>(out));
-                    dest = traits3::compose(sdest, hpx::get<2>(out));
+                    last1 = traits1::compose(send1, out.in1);
+                    last2 = traits2::compose(send2, out.in2);
+                    dest = traits3::compose(sdest, out.out);
                 }
             }
             else
@@ -312,7 +310,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type1 end1 = traits1::end(sit1);
                 local_iterator_type2 beg2 = traits2::local(first2);
                 local_iterator_type3 ldest = traits3::begin(sdest);
-                hpx::tuple<local_iterator_type1, local_iterator_type2,
+                util::in_in_out_result<local_iterator_type1, local_iterator_type2,
                     local_iterator_type3>
                     out;
                 if (beg1 != end1)
@@ -349,12 +347,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         std::true_type(), beg1, end1, beg2, ldest, f, proj1,
                         proj2);
                 }
-                last1 = traits1::compose(send1, hpx::get<0>(out));
-                last2 = traits2::compose(send2, hpx::get<1>(out));
-                dest = traits3::compose(sdest, hpx::get<2>(out));
+                last1 = traits1::compose(send1, out.in1);
+                last2 = traits2::compose(send2, out.in2);
+                dest = traits3::compose(sdest, out.out);
             }
-            return result::get(hpx::make_tuple<InIter1, InIter2, OutIter>(
-                std::move(last1), std::move(last2), std::move(dest)));
+            return result::get(util::in_in_out_result<InIter1, InIter2, OutIter>{
+                std::move(last1), std::move(last2), std::move(dest)});
         }
 
         // parallel remote implementation
@@ -362,7 +360,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typename InIter2, typename OutIter, typename F, typename Proj1,
             typename Proj2>
         static typename util::detail::algorithm_result<ExPolicy,
-            hpx::tuple<InIter1, InIter2, OutIter>>::type
+            util::in_in_out_result<InIter1, InIter2, OutIter>>::type
         segmented_transform(Algo&& algo, ExPolicy&& policy, InIter1 first1,
             InIter1 last1, InIter2 first2, OutIter dest, F&& f, Proj1&& proj1,
             Proj2&& proj2, std::false_type)
@@ -378,7 +376,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef typename traits3::local_iterator local_iterator_type3;
 
             typedef util::detail::algorithm_result<ExPolicy,
-                hpx::tuple<InIter1, InIter2, OutIter>>
+                util::in_in_out_result<InIter1, InIter2, OutIter>>
                 result;
 
             typedef std::integral_constant<bool,
@@ -395,7 +393,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             segment_iterator2 send2 = traits2::segment(last2);
             segment_iterator3 sdest = traits3::segment(dest);
 
-            typedef std::vector<future<hpx::tuple<local_iterator_type1,
+            typedef std::vector<future<util::in_in_out_result<local_iterator_type1,
                 local_iterator_type2, local_iterator_type3>>>
                 segment_type;
             segment_type segments;
@@ -459,16 +457,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
             }
 
             return result::get(dataflow(
-                [=](segment_type&& r) -> hpx::tuple<InIter1, InIter2, OutIter> {
+                [=](segment_type&& r) -> util::in_in_out_result<InIter1, InIter2, OutIter> {
                     // handle any remote exceptions, will throw on error
                     std::list<std::exception_ptr> errors;
                     parallel::util::detail::handle_remote_exceptions<
                         ExPolicy>::call(r, errors);
                     auto rl = r.back().get();
-                    auto olast1 = traits1::compose(send1, hpx::get<0>(rl));
-                    auto olast2 = traits2::compose(send2, hpx::get<1>(rl));
-                    auto odest = traits3::compose(sdest, hpx::get<2>(rl));
-                    return hpx::make_tuple(olast1, olast2, odest);
+                    auto olast1 = traits1::compose(send1, rl.in1);
+                    auto olast2 = traits2::compose(send2, rl.in2);
+                    auto odest = traits3::compose(sdest, rl.out);
+                    return util::in_in_out_result<InIter1, InIter2, OutIter>{olast1, olast2, odest};
                 },
                 std::move(segments)));
         }
@@ -478,24 +476,22 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename ExPolicy, typename InIter1, typename InIter2,
             typename OutIter, typename F, typename Proj1, typename Proj2>
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_tuple<tag::in1(InIter1), tag::in2(InIter2),
-                tag::out(OutIter)>>::type
+            util::in_in_out_result<InIter1, InIter2, OutIter>>::type
         transform_(ExPolicy&& policy, InIter1 first1, InIter1 last1,
             InIter2 first2, OutIter dest, F&& f, Proj1&& proj1, Proj2&& proj2,
             std::true_type)
         {
             using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
             using result = util::detail::algorithm_result<ExPolicy,
-                hpx::util::tagged_tuple<tag::in1(InIter1), tag::in2(InIter2),
-                    tag::out(OutIter)>>;
+                util::in_in_out_result<InIter1, InIter2, OutIter>>;
 
             auto last2 = first2;
             detail::advance(last2, std::distance(first1, last1));
 
             if (first1 == last1)
             {
-                return result::get(hpx::make_tuple<InIter1, InIter2, OutIter>(
-                    std::move(last1), std::move(last2), std::move(dest)));
+                return result::get(util::in_in_out_result<InIter1, InIter2, OutIter>{
+                    std::move(last1), std::move(last2), std::move(dest)});
             }
 
             typedef hpx::traits::segmented_iterator_traits<InIter1>
@@ -504,23 +500,21 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 iterator2_traits;
             typedef hpx::traits::segmented_iterator_traits<OutIter>
                 iterator3_traits;
-            return hpx::util::make_tagged_tuple<tag::in1, tag::in2, tag::out>(
-                segmented_transform(
+            return segmented_transform(
                     transform_binary<
-                        hpx::tuple<typename iterator1_traits::local_iterator,
+                        util::in_in_out_result<typename iterator1_traits::local_iterator,
                             typename iterator2_traits::local_iterator,
                             typename iterator3_traits::local_iterator>>(),
                     std::forward<ExPolicy>(policy), first1, last1, first2, dest,
                     std::forward<F>(f), std::forward<Proj1>(proj1),
-                    std::forward<Proj2>(proj2), is_seq()));
+                    std::forward<Proj2>(proj2), is_seq());
         }
 
         // forward declare the non-segmented version of this algorithm
         template <typename ExPolicy, typename InIter1, typename InIter2,
             typename OutIter, typename F, typename Proj1, typename Proj2>
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_tuple<tag::in1(InIter1), tag::in2(InIter2),
-                tag::out(OutIter)>>::type
+            util::in_in_out_result<InIter1, InIter2, OutIter>>::type
         transform_(ExPolicy&& policy, InIter1 first1, InIter1 last1,
             InIter2 first2, OutIter dest, F&& f, Proj1&& proj1, Proj2&& proj2,
             std::false_type);
@@ -532,7 +526,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typename InIter2, typename OutIter, typename F, typename Proj1,
             typename Proj2>
         static typename util::detail::algorithm_result<ExPolicy,
-            hpx::tuple<InIter1, InIter2, OutIter>>::type
+            util::in_in_out_result<InIter1, InIter2, OutIter>>::type
         segmented_transform(Algo&& algo, ExPolicy&& policy, InIter1 first1,
             InIter1 last1, InIter2 first2, InIter2 last2, OutIter dest, F&& f,
             Proj1&& proj1, Proj2&& proj2, std::true_type)
@@ -548,7 +542,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef typename traits3::local_iterator local_iterator_type3;
 
             typedef util::detail::algorithm_result<ExPolicy,
-                hpx::tuple<InIter1, InIter2, OutIter>>
+                util::in_in_out_result<InIter1, InIter2, OutIter>>
                 result;
 
             segment_iterator1 sit1 = traits1::segment(first1);
@@ -567,7 +561,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type3 ldest = traits3::begin(sdest);
                 if (beg1 != end1 && beg2 != end2)
                 {
-                    hpx::tuple<local_iterator_type1, local_iterator_type2,
+                    util::in_in_out_result<local_iterator_type1, local_iterator_type2,
                         local_iterator_type3>
                         out = dispatch(traits1::get_id(sit1), algo, policy,
                             std::true_type(), beg1, end1, beg2, end2, ldest, f,
@@ -585,7 +579,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 local_iterator_type2 beg2 = traits2::local(first2);
                 local_iterator_type2 end2 = traits2::end(sit2);
                 local_iterator_type3 ldest = traits3::begin(sdest);
-                hpx::tuple<local_iterator_type1, local_iterator_type2,
+                util::in_in_out_result<local_iterator_type1, local_iterator_type2,
                     local_iterator_type3>
                     out;
                 if (beg1 != end1 && beg2 != end2)
@@ -624,12 +618,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         std::true_type(), beg1, end1, beg2, end2, ldest, f,
                         proj1, proj2);
                 }
-                last1 = traits1::compose(send1, hpx::get<0>(out));
-                last2 = traits2::compose(send2, hpx::get<1>(out));
-                dest = traits3::compose(sdest, hpx::get<2>(out));
+                last1 = traits1::compose(send1, out.in1);
+                last2 = traits2::compose(send2, out.in2);
+                dest = traits3::compose(sdest, out.out);
             }
-            return result::get(hpx::make_tuple<InIter1, InIter2, OutIter>(
-                std::move(last1), std::move(last2), std::move(dest)));
+            return result::get(util::in_in_out_result<InIter1, InIter2, OutIter>{
+                std::move(last1), std::move(last2), std::move(dest)});
         }
 
         // parallel remote implementation
@@ -637,7 +631,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typename InIter2, typename OutIter, typename F, typename Proj1,
             typename Proj2>
         static typename util::detail::algorithm_result<ExPolicy,
-            hpx::tuple<InIter1, InIter2, OutIter>>::type
+            util::in_in_out_result<InIter1, InIter2, OutIter>>::type
         segmented_transform(Algo&& algo, ExPolicy&& policy, InIter1 first1,
             InIter1 last1, InIter2 first2, InIter2 last2, OutIter dest, F&& f,
             Proj1&& proj1, Proj2&& proj2, std::false_type)
@@ -653,7 +647,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef typename traits3::local_iterator local_iterator_type3;
 
             typedef util::detail::algorithm_result<ExPolicy,
-                hpx::tuple<InIter1, InIter2, OutIter>>
+                util::in_in_out_result<InIter1, InIter2, OutIter>>
                 result;
 
             typedef std::integral_constant<bool,
@@ -667,7 +661,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             segment_iterator2 send2 = traits2::segment(last2);
             segment_iterator3 sdest = traits3::segment(dest);
 
-            typedef std::vector<future<hpx::tuple<local_iterator_type1,
+            typedef std::vector<future<util::in_in_out_result<local_iterator_type1,
                 local_iterator_type2, local_iterator_type3>>>
                 segment_type;
             segment_type segments;
@@ -735,16 +729,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
             }
 
             return result::get(dataflow(
-                [=](segment_type&& r) -> hpx::tuple<InIter1, InIter2, OutIter> {
+                [=](segment_type&& r) -> util::in_in_out_result<InIter1, InIter2, OutIter> {
                     // handle any remote exceptions, will throw on error
                     std::list<std::exception_ptr> errors;
                     parallel::util::detail::handle_remote_exceptions<
                         ExPolicy>::call(r, errors);
                     auto rl = r.back().get();
-                    auto olast1 = traits1::compose(send1, hpx::get<0>(rl));
-                    auto olast2 = traits2::compose(send2, hpx::get<1>(rl));
-                    auto odest = traits3::compose(sdest, hpx::get<2>(rl));
-                    return hpx::make_tuple(olast1, olast2, odest);
+                    auto olast1 = traits1::compose(send1, rl.in1);
+                    auto olast2 = traits2::compose(send2, rl.in2);
+                    auto odest = traits3::compose(sdest, rl.out);
+                    return util::in_in_out_result<InIter1, InIter2, OutIter>(olast1, olast2, odest);
                 },
                 std::move(segments)));
         }
@@ -754,21 +748,19 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename ExPolicy, typename InIter1, typename InIter2,
             typename OutIter, typename F, typename Proj1, typename Proj2>
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_tuple<tag::in1(InIter1), tag::in2(InIter2),
-                tag::out(OutIter)>>::type
+            util::in_in_out_result<InIter1, InIter2, OutIter>>::type
         transform_(ExPolicy&& policy, InIter1 first1, InIter1 last1,
             InIter2 first2, InIter2 last2, OutIter dest, F&& f, Proj1&& proj1,
             Proj2&& proj2, std::true_type)
         {
             using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
             using result = util::detail::algorithm_result<ExPolicy,
-                hpx::util::tagged_tuple<tag::in1(InIter1), tag::in2(InIter2),
-                    tag::out(OutIter)>>;
+                util::in_in_out_result<InIter1, InIter2, OutIter>>;
 
             if (first1 == last1)
             {
-                return result::get(hpx::make_tuple<InIter1, InIter2, OutIter>(
-                    std::move(last1), std::move(last2), std::move(dest)));
+                return result::get(util::in_in_out_result<InIter1, InIter2, OutIter>{
+                    std::move(last1), std::move(last2), std::move(dest)});
             }
 
             typedef hpx::traits::segmented_iterator_traits<InIter1>
@@ -778,23 +770,21 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef hpx::traits::segmented_iterator_traits<OutIter>
                 iterator3_traits;
 
-            return hpx::util::make_tagged_tuple<tag::in1, tag::in2, tag::out>(
-                segmented_transform(
+            return segmented_transform(
                     transform_binary2<
-                        hpx::tuple<typename iterator1_traits::local_iterator,
+                        util::in_in_out_result<typename iterator1_traits::local_iterator,
                             typename iterator2_traits::local_iterator,
                             typename iterator3_traits::local_iterator>>(),
                     std::forward<ExPolicy>(policy), first1, last1, first2,
                     last2, dest, std::forward<F>(f), std::forward<Proj1>(proj1),
-                    std::forward<Proj2>(proj2), is_seq()));
+                    std::forward<Proj2>(proj2), is_seq());
         }
 
         // forward declare the non-segmented version of this algorithm
         template <typename ExPolicy, typename InIter1, typename InIter2,
             typename OutIter, typename F, typename Proj1, typename Proj2>
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_tuple<tag::in1(InIter1), tag::in2(InIter2),
-                tag::out(OutIter)>>::type
+            util::in_in_out_result<InIter1, InIter2, OutIter>>::type
         transform_(ExPolicy&& policy, InIter1 first1, InIter1 last1,
             InIter2 first2, InIter2 last2, OutIter dest, F&& f, Proj1&& proj1,
             Proj2&& proj2, std::false_type);

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform1.cpp
@@ -98,7 +98,7 @@ void test_transform(ExPolicy&& policy, hpx::partitioned_vector<T>& v,
     verify_values(policy, v, val);
     verify_values_count(policy, v, val);
 
-    hpx::parallel::transform(policy, v.begin(), v.end(), w.begin(), pfo<U>());
+    hpx::transform(policy, v.begin(), v.end(), w.begin(), pfo<U>());
 
     verify_values(policy, w, 2 * val);
     verify_values_count(policy, w, 2 * val);
@@ -123,7 +123,7 @@ void test_transform_async(ExPolicy&& policy, hpx::partitioned_vector<T>& v,
     verify_values(policy, v, val);
     verify_values_count_async(policy, v, val);
 
-    hpx::parallel::transform(policy, v.begin(), v.end(), w.begin(), pfo<U>())
+    hpx::transform(policy, v.begin(), v.end(), w.begin(), pfo<U>())
         .get();
 
     verify_values(policy, w, 2 * val);
@@ -139,14 +139,14 @@ void transform_tests(std::vector<hpx::id_type>& localities)
     {
         hpx::partitioned_vector<T> v;
         hpx::partitioned_vector<U> w;
-        hpx::parallel::transform(
+        hpx::transform(
             hpx::execution::seq, v.begin(), v.end(), w.begin(), pfo<U>());
-        hpx::parallel::transform(
+        hpx::transform(
             hpx::execution::par, v.begin(), v.end(), w.begin(), pfo<U>());
-        hpx::parallel::transform(hpx::execution::seq(hpx::execution::task),
+        hpx::transform(hpx::execution::seq(hpx::execution::task),
             v.begin(), v.end(), w.begin(), pfo<U>())
             .get();
-        hpx::parallel::transform(hpx::execution::par(hpx::execution::task),
+        hpx::transform(hpx::execution::par(hpx::execution::task),
             v.begin(), v.end(), w.begin(), pfo<U>())
             .get();
     }

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform1.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform1.cpp
@@ -123,8 +123,7 @@ void test_transform_async(ExPolicy&& policy, hpx::partitioned_vector<T>& v,
     verify_values(policy, v, val);
     verify_values_count_async(policy, v, val);
 
-    hpx::transform(policy, v.begin(), v.end(), w.begin(), pfo<U>())
-        .get();
+    hpx::transform(policy, v.begin(), v.end(), w.begin(), pfo<U>()).get();
 
     verify_values(policy, w, 2 * val);
     verify_values_count_async(policy, w, 2 * val);
@@ -143,11 +142,11 @@ void transform_tests(std::vector<hpx::id_type>& localities)
             hpx::execution::seq, v.begin(), v.end(), w.begin(), pfo<U>());
         hpx::transform(
             hpx::execution::par, v.begin(), v.end(), w.begin(), pfo<U>());
-        hpx::transform(hpx::execution::seq(hpx::execution::task),
-            v.begin(), v.end(), w.begin(), pfo<U>())
+        hpx::transform(hpx::execution::seq(hpx::execution::task), v.begin(),
+            v.end(), w.begin(), pfo<U>())
             .get();
-        hpx::transform(hpx::execution::par(hpx::execution::task),
-            v.begin(), v.end(), w.begin(), pfo<U>())
+        hpx::transform(hpx::execution::par(hpx::execution::task), v.begin(),
+            v.end(), w.begin(), pfo<U>())
             .get();
     }
 

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform2.cpp
@@ -102,7 +102,7 @@ void test_transform(ExPolicy&& policy, hpx::partitioned_vector<T>& v,
     verify_values(policy, v, val);
     verify_values_count(policy, v, val);
 
-    hpx::parallel::transform(policy, v.begin(), v.end(), w.begin(), pfo<U>());
+    hpx::transform(policy, v.begin(), v.end(), w.begin(), pfo<U>());
 
     verify_values(policy, w, 2 * val);
     verify_values_count(policy, w, 2 * val);
@@ -127,7 +127,7 @@ void test_transform_async(ExPolicy&& policy, hpx::partitioned_vector<T>& v,
     verify_values(policy, v, val);
     verify_values_count_async(policy, v, val);
 
-    hpx::parallel::transform(policy, v.begin(), v.end(), w.begin(), pfo<U>())
+    hpx::transform(policy, v.begin(), v.end(), w.begin(), pfo<U>())
         .get();
 
     verify_values(policy, w, 2 * val);
@@ -143,14 +143,14 @@ void transform_tests(std::vector<hpx::id_type>& localities)
     {
         hpx::partitioned_vector<T> v;
         hpx::partitioned_vector<U> w;
-        hpx::parallel::transform(
+        hpx::transform(
             hpx::execution::seq, v.begin(), v.end(), w.begin(), pfo<U>());
-        hpx::parallel::transform(
+        hpx::transform(
             hpx::execution::par, v.begin(), v.end(), w.begin(), pfo<U>());
-        hpx::parallel::transform(hpx::execution::seq(hpx::execution::task),
+        hpx::transform(hpx::execution::seq(hpx::execution::task),
             v.begin(), v.end(), w.begin(), pfo<U>())
             .get();
-        hpx::parallel::transform(hpx::execution::par(hpx::execution::task),
+        hpx::transform(hpx::execution::par(hpx::execution::task),
             v.begin(), v.end(), w.begin(), pfo<U>())
             .get();
     }

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_transform2.cpp
@@ -127,8 +127,7 @@ void test_transform_async(ExPolicy&& policy, hpx::partitioned_vector<T>& v,
     verify_values(policy, v, val);
     verify_values_count_async(policy, v, val);
 
-    hpx::transform(policy, v.begin(), v.end(), w.begin(), pfo<U>())
-        .get();
+    hpx::transform(policy, v.begin(), v.end(), w.begin(), pfo<U>()).get();
 
     verify_values(policy, w, 2 * val);
     verify_values_count_async(policy, w, 2 * val);
@@ -147,11 +146,11 @@ void transform_tests(std::vector<hpx::id_type>& localities)
             hpx::execution::seq, v.begin(), v.end(), w.begin(), pfo<U>());
         hpx::transform(
             hpx::execution::par, v.begin(), v.end(), w.begin(), pfo<U>());
-        hpx::transform(hpx::execution::seq(hpx::execution::task),
-            v.begin(), v.end(), w.begin(), pfo<U>())
+        hpx::transform(hpx::execution::seq(hpx::execution::task), v.begin(),
+            v.end(), w.begin(), pfo<U>())
             .get();
-        hpx::transform(hpx::execution::par(hpx::execution::task),
-            v.begin(), v.end(), w.begin(), pfo<U>())
+        hpx::transform(hpx::execution::par(hpx::execution::task), v.begin(),
+            v.end(), w.begin(), pfo<U>())
             .get();
     }
 

--- a/libs/full/segmented_algorithms/tests/unit/test_transform_binary.hpp
+++ b/libs/full/segmented_algorithms/tests/unit/test_transform_binary.hpp
@@ -99,7 +99,7 @@ void test_transform_binary(ExPolicy&& policy, hpx::partitioned_vector<T>& v,
     verify_values(policy, w, val);
     verify_values_count(policy, w, val);
 
-    hpx::parallel::transform(
+    hpx::transform(
         policy, v.begin(), v.end(), w.begin(), x.begin(), add<V>());
 
     verify_values(policy, x, 2 * val);
@@ -128,7 +128,7 @@ void test_transform_binary_async(ExPolicy&& policy,
     verify_values(policy, w, val);
     verify_values_count_async(policy, w, val);
 
-    hpx::parallel::transform(
+    hpx::transform(
         policy, v.begin(), v.end(), w.begin(), x.begin(), add<V>())
         .get();
 
@@ -145,14 +145,14 @@ void transform_binary_tests(std::vector<hpx::id_type>& localities)
         hpx::partitioned_vector<T> v;
         hpx::partitioned_vector<U> w;
         hpx::partitioned_vector<V> x;
-        hpx::parallel::transform(hpx::execution::seq, v.begin(), v.end(),
+        hpx::transform(hpx::execution::seq, v.begin(), v.end(),
             w.begin(), x.begin(), add<V>());
-        hpx::parallel::transform(hpx::execution::par, v.begin(), v.end(),
+        hpx::transform(hpx::execution::par, v.begin(), v.end(),
             w.begin(), x.begin(), add<V>());
-        hpx::parallel::transform(hpx::execution::seq(hpx::execution::task),
+        hpx::transform(hpx::execution::seq(hpx::execution::task),
             v.begin(), v.end(), w.begin(), x.begin(), add<V>())
             .get();
-        hpx::parallel::transform(hpx::execution::par(hpx::execution::task),
+        hpx::transform(hpx::execution::par(hpx::execution::task),
             v.begin(), v.end(), w.begin(), x.begin(), add<V>())
             .get();
     }

--- a/libs/full/segmented_algorithms/tests/unit/test_transform_binary.hpp
+++ b/libs/full/segmented_algorithms/tests/unit/test_transform_binary.hpp
@@ -99,8 +99,7 @@ void test_transform_binary(ExPolicy&& policy, hpx::partitioned_vector<T>& v,
     verify_values(policy, w, val);
     verify_values_count(policy, w, val);
 
-    hpx::transform(
-        policy, v.begin(), v.end(), w.begin(), x.begin(), add<V>());
+    hpx::transform(policy, v.begin(), v.end(), w.begin(), x.begin(), add<V>());
 
     verify_values(policy, x, 2 * val);
     verify_values_count(policy, x, 2 * val);
@@ -128,8 +127,7 @@ void test_transform_binary_async(ExPolicy&& policy,
     verify_values(policy, w, val);
     verify_values_count_async(policy, w, val);
 
-    hpx::transform(
-        policy, v.begin(), v.end(), w.begin(), x.begin(), add<V>())
+    hpx::transform(policy, v.begin(), v.end(), w.begin(), x.begin(), add<V>())
         .get();
 
     verify_values(policy, x, 2 * val);
@@ -145,15 +143,15 @@ void transform_binary_tests(std::vector<hpx::id_type>& localities)
         hpx::partitioned_vector<T> v;
         hpx::partitioned_vector<U> w;
         hpx::partitioned_vector<V> x;
-        hpx::transform(hpx::execution::seq, v.begin(), v.end(),
-            w.begin(), x.begin(), add<V>());
-        hpx::transform(hpx::execution::par, v.begin(), v.end(),
-            w.begin(), x.begin(), add<V>());
-        hpx::transform(hpx::execution::seq(hpx::execution::task),
-            v.begin(), v.end(), w.begin(), x.begin(), add<V>())
+        hpx::transform(hpx::execution::seq, v.begin(), v.end(), w.begin(),
+            x.begin(), add<V>());
+        hpx::transform(hpx::execution::par, v.begin(), v.end(), w.begin(),
+            x.begin(), add<V>());
+        hpx::transform(hpx::execution::seq(hpx::execution::task), v.begin(),
+            v.end(), w.begin(), x.begin(), add<V>())
             .get();
-        hpx::transform(hpx::execution::par(hpx::execution::task),
-            v.begin(), v.end(), w.begin(), x.begin(), add<V>())
+        hpx::transform(hpx::execution::par(hpx::execution::task), v.begin(),
+            v.end(), w.begin(), x.begin(), add<V>())
             .get();
     }
 

--- a/libs/full/segmented_algorithms/tests/unit/test_transform_binary2.hpp
+++ b/libs/full/segmented_algorithms/tests/unit/test_transform_binary2.hpp
@@ -111,7 +111,7 @@ void test_transform_binary2(ExPolicy&& policy, hpx::partitioned_vector<T>& v,
     verify_values(policy, w, val);
     verify_values_count(policy, w, val);
 
-    hpx::parallel::transform(
+    hpx::ranges::transform(
         policy, v.begin(), v.end(), w.begin(), w.end(), x.begin(), add<V>());
 
     verify_values(policy, x, 2 * val);
@@ -128,7 +128,7 @@ void test_transform_binary2_async(ExPolicy&& policy,
     verify_values(policy, w, val);
     verify_values_count_async(policy, w, val);
 
-    hpx::parallel::transform(
+    hpx::ranges::transform(
         policy, v.begin(), v.end(), w.begin(), w.end(), x.begin(), add<V>())
         .get();
 
@@ -144,14 +144,14 @@ void transform_binary2_tests(std::vector<hpx::id_type>& localities)
         hpx::partitioned_vector<T> v;
         hpx::partitioned_vector<U> w;
         hpx::partitioned_vector<V> x;
-        hpx::parallel::transform(hpx::execution::seq, v.begin(), v.end(),
+        hpx::ranges::transform(hpx::execution::seq, v.begin(), v.end(),
             w.begin(), w.end(), x.begin(), add<V>());
-        hpx::parallel::transform(hpx::execution::par, v.begin(), v.end(),
+        hpx::ranges::transform(hpx::execution::par, v.begin(), v.end(),
             w.begin(), w.end(), x.begin(), add<V>());
-        hpx::parallel::transform(hpx::execution::seq(hpx::execution::task),
+        hpx::ranges::transform(hpx::execution::seq(hpx::execution::task),
             v.begin(), v.end(), w.begin(), w.end(), x.begin(), add<V>())
             .get();
-        hpx::parallel::transform(hpx::execution::par(hpx::execution::task),
+        hpx::ranges::transform(hpx::execution::par(hpx::execution::task),
             v.begin(), v.end(), w.begin(), w.end(), x.begin(), add<V>())
             .get();
     }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -68,6 +68,19 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         typedef hpx::tuple<type1, type2, type3> type;
     };
 
+    template <typename Result1, typename Result2, typename Result3>
+    struct local_algorithm_result<util::in_in_out_result<Result1, Result2, Result3>>
+    {
+        typedef typename hpx::traits::segmented_local_iterator_traits<
+            Result1>::local_raw_iterator type1;
+        typedef typename hpx::traits::segmented_local_iterator_traits<
+            Result2>::local_raw_iterator type2;
+        typedef typename hpx::traits::segmented_local_iterator_traits<
+            Result3>::local_raw_iterator type3;
+
+        typedef util::in_in_out_result<type1, type2, type3> type;
+    };
+
     template <>
     struct local_algorithm_result<void>
     {

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -69,7 +70,8 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     };
 
     template <typename Result1, typename Result2, typename Result3>
-    struct local_algorithm_result<util::in_in_out_result<Result1, Result2, Result3>>
+    struct local_algorithm_result<
+        util::in_in_out_result<Result1, Result2, Result3>>
     {
         typedef typename hpx::traits::segmented_local_iterator_traits<
             Result1>::local_raw_iterator type1;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
@@ -361,7 +361,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename F, typename Proj>
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)>>::type
+            util::in_out_result<FwdIter1, FwdIter2>>::type
         transform_(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
             FwdIter2 dest, F&& f, Proj&& proj, std::true_type);
         /// \endcond
@@ -493,7 +493,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename ExPolicy, typename InIter1, typename InIter2,
                 typename OutIter, typename F, typename Proj1, typename Proj2>
-            static hpx::tuple<InIter1, InIter2, OutIter> sequential(ExPolicy&&,
+            static util::in_in_out_result<InIter1, InIter2, OutIter> sequential(ExPolicy&&,
                 InIter1 first1, InIter1 last1, InIter2 first2, OutIter dest,
                 F&& f, Proj1&& proj1, Proj2&& proj2)
             {
@@ -565,8 +565,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename FwdIter3, typename F, typename Proj1, typename Proj2>
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2),
-                tag::out(FwdIter3)>>::type
+            util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
         transform_(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
             FwdIter2 first2, FwdIter3 dest, F&& f, Proj1&& proj1, Proj2&& proj2,
             std::true_type);
@@ -620,7 +619,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename ExPolicy, typename InIter1, typename InIter2,
                 typename OutIter, typename F, typename Proj1, typename Proj2>
-            static hpx::tuple<InIter1, InIter2, OutIter> sequential(ExPolicy&&,
+            static util::in_in_out_result<InIter1, InIter2, OutIter> sequential(ExPolicy&&,
                 InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
                 OutIter dest, F&& f, Proj1&& proj1, Proj2&& proj2)
             {
@@ -692,8 +691,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename FwdIter3, typename F, typename Proj1, typename Proj2>
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2),
-                tag::out(FwdIter3)>>::type
+            util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
         transform_(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
             FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, F&& f,
             Proj1&& proj1, Proj2&& proj2, std::true_type);

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
@@ -839,8 +839,8 @@ namespace hpx {
             return parallel::util::get_third_element(
                 parallel::v1::detail::transform_(hpx::execution::seq,
                     first1, last1, first2, dest, std::forward<F>(f),
-                    hpx::parallel::util::projection_identity(),
-                    hpx::parallel::util::projection_identity(),
+                    proj_id(),
+                    proj_id(),
                     std::false_type{}));
         }
 
@@ -867,8 +867,8 @@ namespace hpx {
             return parallel::util::get_third_element(
                 parallel::v1::detail::transform_(std::forward<ExPolicy>(policy),
                     first1, last1, first2, dest, std::forward<F>(f),
-                    hpx::parallel::util::projection_identity(),
-                    hpx::parallel::util::projection_identity(),
+                    proj_id(),
+                    proj_id(),
                     is_segmented()));
         }
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
@@ -8,6 +8,168 @@
 
 #pragma once
 
+#if defined(DOXYGEN)
+namespace hpx {
+
+    /// Applies the given function \a f to the range [first, last) and stores
+    /// the result in another range, beginning at dest.
+    ///
+    /// \note   Complexity: Exactly \a last - \a first applications of \a f
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the invocations of \a f.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a transform requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&.
+    ///                     The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to \a Type. The type \a Ret
+    ///                     must be such that an object of type \a FwdIter2 can
+    ///                     be dereferenced and assigned a value of type
+    ///                     \a Ret.
+    ///
+    /// The invocations of \a f in the parallel \a transform algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The invocations of \a f in the parallel \a transform algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a transform algorithm returns a
+    /// \a hpx::future<in_out_result<FwdIter1, FwdIter2> >
+    ///           if the execution policy is of type \a parallel_task_policy
+    ///           and returns
+    /// \a in_out_result<FwdIter1, FwdIter2> otherwise.
+    ///           The \a transform algorithm returns a tuple holding an iterator
+    ///           referring to the first element after the input sequence and
+    ///           the output iterator to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename F>
+    typename util::detail::algorithm_result<ExPolicy,
+        util::in_out_result<FwdIter1, FwdIter2>>::type
+    transform(
+        ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest, F&& f);
+
+    /// Applies the given function \a f to pairs of elements from two ranges:
+    /// one defined by [first1, last1) and the other beginning at first2, and
+    /// stores the result in another range, beginning at dest.
+    ///
+    /// \note   Complexity: Exactly \a last - \a first applications of \a f
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the invocations of \a f.
+    /// \tparam FwdIter1    The type of the source iterators for the first
+    ///                     range used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the source iterators for the second
+    ///                     range used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter3    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a transform requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first1       Refers to the beginning of the first sequence of
+    ///                     elements the algorithm will be applied to.
+    /// \param last1        Refers to the end of the first sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the second sequence of
+    ///                     elements the algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is a
+    ///                     binary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type1 &a, const Type2 &b);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&.
+    ///                     The types \a Type1 and \a Type2 must be such that
+    ///                     objects of types FwdIter1 and FwdIter2 can be
+    ///                     dereferenced and then implicitly converted to
+    ///                     \a Type1 and \a Type2 respectively. The type \a Ret
+    ///                     must be such that an object of type \a FwdIter3 can
+    ///                     be dereferenced and assigned a value of type
+    ///                     \a Ret.
+    ///
+    /// The invocations of \a f in the parallel \a transform algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The invocations of \a f in the parallel \a transform algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a transform algorithm returns a
+    /// \a hpx::future<in_in_out_result<FwdIter1, FwdIter2, FwdIter3> >
+    ///           if the execution policy is of type \a parallel_task_policy
+    ///           and returns
+    /// \a in_in_out_result<FwdIter1, FwdIter2, FwdIter3>
+    ///           otherwise.
+    ///           The \a transform algorithm returns a tuple holding an iterator
+    ///           referring to the first element after the first input sequence,
+    ///           an iterator referring to the first element after the second
+    ///           input sequence, and the output iterator referring to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename FwdIter3, typename F>
+    typename util::detail::algorithm_result<ExPolicy,
+        util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
+    transform(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+        FwdIter2 first2, FwdIter3 dest, F&& f);
+
+}    // namespace hpx
+
+#else    // DOXYGEN
+
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
@@ -19,6 +181,7 @@
 #include <hpx/functional/invoke.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/util/result_types.hpp>
 #include <hpx/parallel/util/tagged_pair.hpp>
 #include <hpx/parallel/util/tagged_tuple.hpp>
 #include <hpx/threading_base/annotated_function.hpp>
@@ -26,6 +189,7 @@
 #include <hpx/algorithms/traits/projected.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/tagspec.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>
@@ -135,21 +299,21 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
             }
 
-            template <typename ExPolicy, typename InIter, typename OutIter,
-                typename F, typename Proj>
-            HPX_HOST_DEVICE static std::pair<InIter, OutIter> sequential(
-                ExPolicy&& policy, InIter first, InIter last, OutIter dest,
-                F&& f, Proj&& proj)
+            template <typename ExPolicy, typename InIterB, typename InIterE,
+                typename OutIter, typename F, typename Proj>
+            HPX_HOST_DEVICE static util::in_out_result<InIterB, OutIter>
+            sequential(ExPolicy&& policy, InIterB first, InIterE last,
+                OutIter dest, F&& f, Proj&& proj)
             {
                 return util::transform_loop(std::forward<ExPolicy>(policy),
                     first, last, dest, transform_projected<F, Proj>{f, proj});
             }
 
-            template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-                typename F, typename Proj>
+            template <typename ExPolicy, typename FwdIter1B, typename FwdIter1E,
+                typename FwdIter2, typename F, typename Proj>
             static typename util::detail::algorithm_result<ExPolicy,
-                std::pair<FwdIter1, FwdIter2>>::type
-            parallel(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+                util::in_out_result<FwdIter1B, FwdIter2>>::type
+            parallel(ExPolicy&& policy, FwdIter1B first, FwdIter1E last,
                 FwdIter2 dest, F&& f, Proj&& proj)
             {
                 if (first != last)
@@ -157,39 +321,40 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     auto f1 = transform_iteration<ExPolicy, F, Proj>(
                         std::forward<F>(f), std::forward<Proj>(proj));
 
-                    return get_iter_pair(
+                    return util::detail::get_in_out_result(
                         util::foreach_partitioner<ExPolicy>::call(
                             std::forward<ExPolicy>(policy),
                             hpx::util::make_zip_iterator(first, dest),
-                            std::distance(first, last), std::move(f1),
+                            detail::distance(first, last), std::move(f1),
                             util::projection_identity()));
                 }
 
+                using result_type = util::in_out_result<FwdIter1B, FwdIter2>;
+
                 return util::detail::algorithm_result<ExPolicy,
-                    std::pair<FwdIter1, FwdIter2>>::
-                    get(std::make_pair(std::move(first), std::move(dest)));
+                    result_type>::get(result_type{
+                    std::move(first), std::move(dest)});
             }
         };
 
         /// non_segmented version
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename F, typename Proj>
+        template <typename ExPolicy, typename FwdIter1B, typename FwdIter1E,
+            typename FwdIter2, typename F, typename Proj>
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)>>::type
-        transform_(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+            util::in_out_result<FwdIter1B, FwdIter2>>::type
+        transform_(ExPolicy&& policy, FwdIter1B first, FwdIter1E last,
             FwdIter2 dest, F&& f, Proj&& proj, std::false_type)
         {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1B>::value),
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
             typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
-            return hpx::util::make_tagged_pair<tag::in, tag::out>(
-                detail::transform<std::pair<FwdIter1, FwdIter2>>().call(
-                    std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
-                    std::forward<F>(f), std::forward<Proj>(proj)));
+            return detail::transform<util::in_out_result<FwdIter1B, FwdIter2>>()
+                .call(std::forward<ExPolicy>(policy), is_seq(), first, last,
+                    dest, std::forward<F>(f), std::forward<Proj>(proj));
         }
 
         /// forward declare the segmented version
@@ -202,89 +367,24 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Applies the given function \a f to the range [first, last) and stores
-    /// the result in another range, beginning at dest.
-    ///
-    /// \note   Complexity: Exactly \a last - \a first applications of \a f
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the invocations of \a f.
-    /// \tparam FwdIter1    The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam F           The type of the function/function object to use
-    ///                     (deduced). Unlike its sequential form, the parallel
-    ///                     overload of \a transform requires \a F to meet the
-    ///                     requirements of \a CopyConstructible.
-    /// \tparam Proj        The type of an optional projection function. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param f            Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last).This is an
-    ///                     unary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     Ret fun(const Type &a);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&.
-    ///                     The type \a Type must be such that an object of
-    ///                     type \a FwdIter can be dereferenced and then
-    ///                     implicitly converted to \a Type. The type \a Ret
-    ///                     must be such that an object of type \a FwdIter2 can
-    ///                     be dereferenced and assigned a value of type
-    ///                     \a Ret.
-    /// \param proj         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements as a
-    ///                     projection operation before the actual predicate
-    ///                     \a f is invoked.
-    ///
-    /// The invocations of \a f in the parallel \a transform algorithm invoked
-    /// with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The invocations of \a f in the parallel \a transform algorithm invoked
-    /// with an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a transform algorithm returns a
-    /// \a hpx::future<tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)> >
-    ///           if the execution policy is of type \a parallel_task_policy
-    ///           and returns
-    /// \a tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)> otherwise.
-    ///           The \a transform algorithm returns a tuple holding an iterator
-    ///           referring to the first element after the input sequence and
-    ///           the output iterator to the
-    ///           element in the destination range, one past the last element
-    ///           copied.
-    ///
+    // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename F, typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<FwdIter1>::value&&
-                    hpx::traits::is_iterator<FwdIter2>::value&&
-                        traits::is_projected<Proj, FwdIter1>::value&&
-                            traits::is_indirect_callable<ExPolicy, F,
-                                traits::projected<Proj, FwdIter1>>::value)>
-    typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)>>::type
-    transform(ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest,
-        F&& f, Proj&& proj = Proj())
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<FwdIter1>::value &&
+            hpx::traits::is_iterator<FwdIter2>::value &&
+            traits::is_projected<Proj, FwdIter1>::value &&
+            traits::is_indirect_callable<ExPolicy, F,
+                traits::projected<Proj, FwdIter1>>::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::transform is deprecated, use hpx::transform instead")
+        typename util::detail::algorithm_result<ExPolicy,
+            hpx::util::tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)>>::type
+        transform(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+            FwdIter2 dest, F&& f, Proj&& proj = Proj())
     {
         typedef hpx::traits::is_segmented_iterator<FwdIter1> is_segmented;
         return detail::transform_(std::forward<ExPolicy>(policy), first, last,
@@ -403,11 +503,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         f, proj1, proj2});
             }
 
-            template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-                typename FwdIter3, typename F, typename Proj1, typename Proj2>
+            template <typename ExPolicy, typename FwdIter1B, typename FwdIter1E,
+                typename FwdIter2, typename FwdIter3, typename F,
+                typename Proj1, typename Proj2>
             static typename util::detail::algorithm_result<ExPolicy,
-                hpx::tuple<FwdIter1, FwdIter2, FwdIter3>>::type
-            parallel(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+                util::in_in_out_result<FwdIter1B, FwdIter2, FwdIter3>>::type
+            parallel(ExPolicy&& policy, FwdIter1B first1, FwdIter1E last1,
                 FwdIter2 first2, FwdIter3 dest, F&& f, Proj1&& proj1,
                 Proj2&& proj2)
             {
@@ -418,31 +519,33 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             std::forward<F>(f), std::forward<Proj1>(proj1),
                             std::forward<Proj2>(proj2));
 
-                    return get_iter_tuple(
+                    return util::detail::get_in_in_out_result(
                         util::foreach_partitioner<ExPolicy>::call(
                             std::forward<ExPolicy>(policy),
                             hpx::util::make_zip_iterator(first1, first2, dest),
-                            std::distance(first1, last1), std::move(f1),
+                            detail::distance(first1, last1), std::move(f1),
                             util::projection_identity()));
                 }
 
+                using result_type =
+                    util::in_in_out_result<FwdIter1B, FwdIter2, FwdIter3>;
+
                 return util::detail::algorithm_result<ExPolicy,
-                    hpx::tuple<FwdIter1, FwdIter2,
-                        FwdIter3>>::get(hpx::make_tuple(std::move(first1),
-                    std::move(first2), std::move(dest)));
+                    result_type>::get(result_type{
+                    std::move(first1), std::move(first2), std::move(dest)});
             }
         };
 
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename FwdIter3, typename F, typename Proj1, typename Proj2>
+        template <typename ExPolicy, typename FwdIter1B, typename FwdIter1E,
+            typename FwdIter2, typename FwdIter3, typename F, typename Proj1,
+            typename Proj2>
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2),
-                tag::out(FwdIter3)>>::type
-        transform_(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+            util::in_in_out_result<FwdIter1B, FwdIter2, FwdIter3>>::type
+        transform_(ExPolicy&& policy, FwdIter1B first1, FwdIter1E last1,
             FwdIter2 first2, FwdIter3 dest, F&& f, Proj1&& proj1, Proj2&& proj2,
             std::false_type)
         {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1B>::value),
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
@@ -450,13 +553,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 "Requires at least forward iterator.");
 
             typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-            typedef hpx::tuple<FwdIter1, FwdIter2, FwdIter3> result_type;
+            typedef util::in_in_out_result<FwdIter1B, FwdIter2, FwdIter3>
+                result_type;
 
-            return hpx::util::make_tagged_tuple<tag::in1, tag::in2, tag::out>(
-                detail::transform_binary<result_type>().call(
-                    std::forward<ExPolicy>(policy), is_seq(), first1, last1,
-                    first2, dest, std::forward<F>(f),
-                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2)));
+            return detail::transform_binary<result_type>().call(
+                std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
+                dest, std::forward<F>(f), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
         }
 
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
@@ -470,115 +573,30 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Applies the given function \a f to pairs of elements from two ranges:
-    /// one defined by [first1, last1) and the other beginning at first2, and
-    /// stores the result in another range, beginning at dest.
-    ///
-    /// \note   Complexity: Exactly \a last - \a first applications of \a f
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the invocations of \a f.
-    /// \tparam FwdIter1    The type of the source iterators for the first
-    ///                     range used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the source iterators for the second
-    ///                     range used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter3    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam F           The type of the function/function object to use
-    ///                     (deduced). Unlike its sequential form, the parallel
-    ///                     overload of \a transform requires \a F to meet the
-    ///                     requirements of \a CopyConstructible.
-    /// \tparam Proj1       The type of an optional projection function to be
-    ///                     used for elements of the first sequence. This
-    ///                     defaults to \a util::projection_identity
-    /// \tparam Proj2       The type of an optional projection function to be
-    ///                     used for elements of the second sequence. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first1       Refers to the beginning of the first sequence of
-    ///                     elements the algorithm will be applied to.
-    /// \param last1        Refers to the end of the first sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param first2       Refers to the beginning of the second sequence of
-    ///                     elements the algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param f            Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last).This is a
-    ///                     binary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     Ret fun(const Type1 &a, const Type2 &b);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&.
-    ///                     The types \a Type1 and \a Type2 must be such that
-    ///                     objects of types FwdIter1 and FwdIter2 can be
-    ///                     dereferenced and then implicitly converted to
-    ///                     \a Type1 and \a Type2 respectively. The type \a Ret
-    ///                     must be such that an object of type \a FwdIter3 can
-    ///                     be dereferenced and assigned a value of type
-    ///                     \a Ret.
-    /// \param proj1        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the
-    ///                     first sequence as a projection operation before the
-    ///                     actual predicate \a f is invoked.
-    /// \param proj2        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the
-    ///                     second sequence as a projection operation before
-    ///                     the actual predicate \a f is invoked.
-    ///
-    /// The invocations of \a f in the parallel \a transform algorithm invoked
-    /// with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The invocations of \a f in the parallel \a transform algorithm invoked
-    /// with an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a transform algorithm returns a
-    /// \a hpx::future<tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2), tag::out(FwdIter3)> >
-    ///           if the execution policy is of type \a parallel_task_policy
-    ///           and returns
-    /// \a tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2), tag::out(FwdIter3)>
-    ///           otherwise.
-    ///           The \a transform algorithm returns a tuple holding an iterator
-    ///           referring to the first element after the first input sequence,
-    ///           an iterator referring to the first element after the second
-    ///           input sequence, and the output iterator referring to the
-    ///           element in the destination range, one past the last element
-    ///           copied.
-    ///
+    // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename FwdIter3, typename F,
         typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<
-            ExPolicy>::value&& hpx::traits::is_iterator<FwdIter1>::value&&
-                hpx::traits::is_iterator<FwdIter2>::value&&
-                    hpx::traits::is_iterator<FwdIter3>::value&&
-                        traits::is_projected<Proj1, FwdIter1>::value&&
-                            traits::is_projected<Proj2, FwdIter2>::value&&
-                                traits::is_indirect_callable<ExPolicy, F,
-                                    traits::projected<Proj1, FwdIter1>,
-                                    traits::projected<Proj2, FwdIter2>>::value)>
-    typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2),
-            tag::out(FwdIter3)>>::type
-    transform(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
-        FwdIter2 first2, FwdIter3 dest, F&& f, Proj1&& proj1 = Proj1(),
-        Proj2&& proj2 = Proj2())
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<
+                ExPolicy>::value&& hpx::traits::is_iterator<FwdIter1>::value &&
+            hpx::traits::is_iterator<FwdIter2>::value &&
+            hpx::traits::is_iterator<FwdIter3>::value &&
+            traits::is_projected<Proj1, FwdIter1>::value &&
+            traits::is_projected<Proj2, FwdIter2>::value &&
+            traits::is_indirect_callable<ExPolicy, F,
+                traits::projected<Proj1, FwdIter1>,
+                traits::projected<Proj2, FwdIter2>>::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::transform is deprecated, use hpx::transform instead")
+        typename util::detail::algorithm_result<ExPolicy,
+            hpx::util::tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2),
+                tag::out(FwdIter3)>>::type transform(ExPolicy&& policy,
+            FwdIter1 first1, FwdIter1 last1, FwdIter2 first2, FwdIter3 dest,
+            F&& f, Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
     {
         typedef hpx::traits::is_segmented_iterator<FwdIter1> is_segmented;
 
@@ -612,12 +630,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         f, proj1, proj2});
             }
 
-            template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-                typename FwdIter3, typename F, typename Proj1, typename Proj2>
+            template <typename ExPolicy, typename FwdIter1B, typename FwdIter1E,
+                typename FwdIter2B, typename FwdIter2E, typename FwdIter3,
+                typename F, typename Proj1, typename Proj2>
             static typename util::detail::algorithm_result<ExPolicy,
-                hpx::tuple<FwdIter1, FwdIter2, FwdIter3>>::type
-            parallel(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
-                FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, F&& f,
+                util::in_in_out_result<FwdIter1B, FwdIter2B, FwdIter3>>::type
+            parallel(ExPolicy&& policy, FwdIter1B first1, FwdIter1E last1,
+                FwdIter2B first2, FwdIter2E last2, FwdIter3 dest, F&& f,
                 Proj1&& proj1, Proj2&& proj2)
             {
                 if (first1 != last1 && first2 != last2)
@@ -627,46 +646,48 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             std::forward<F>(f), std::forward<Proj1>(proj1),
                             std::forward<Proj2>(proj2));
 
-                    return get_iter_tuple(
+                    return util::detail::get_in_in_out_result(
                         util::foreach_partitioner<ExPolicy>::call(
                             std::forward<ExPolicy>(policy),
                             hpx::util::make_zip_iterator(first1, first2, dest),
-                            (std::min)(std::distance(first1, last1),
-                                std::distance(first2, last2)),
+                            (std::min)(detail::distance(first1, last1),
+                                detail::distance(first2, last2)),
                             std::move(f1), util::projection_identity()));
                 }
 
+                using result_type =
+                    util::in_in_out_result<FwdIter1B, FwdIter2B, FwdIter3>;
+
                 return util::detail::algorithm_result<ExPolicy,
-                    hpx::tuple<FwdIter1, FwdIter2,
-                        FwdIter3>>::get(hpx::make_tuple(std::move(first1),
-                    std::move(first2), std::move(dest)));
+                    result_type>::get(result_type{
+                    std::move(first1), std::move(first2), std::move(dest)});
             }
         };
 
-        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-            typename FwdIter3, typename F, typename Proj1, typename Proj2>
+        template <typename ExPolicy, typename FwdIter1B, typename FwdIter1E,
+            typename FwdIter2B, typename FwdIter2E, typename FwdIter3,
+            typename F, typename Proj1, typename Proj2>
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2),
-                tag::out(FwdIter3)>>::type
-        transform_(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
-            FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, F&& f,
+            util::in_in_out_result<FwdIter1B, FwdIter2B, FwdIter3>>::type
+        transform_(ExPolicy&& policy, FwdIter1B first1, FwdIter1E last1,
+            FwdIter2B first2, FwdIter2E last2, FwdIter3 dest, F&& f,
             Proj1&& proj1, Proj2&& proj2, std::false_type)
         {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1B>::value),
                 "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2E>::value),
                 "Requires at least forward iterator.");
             static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
                 "Requires at least forward iterator.");
 
             typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-            typedef hpx::tuple<FwdIter1, FwdIter2, FwdIter3> result_type;
+            typedef util::in_in_out_result<FwdIter1B, FwdIter2E, FwdIter3>
+                result_type;
 
-            return hpx::util::make_tagged_tuple<tag::in1, tag::in2, tag::out>(
-                detail::transform_binary2<result_type>().call(
-                    std::forward<ExPolicy>(policy), is_seq(), first1, last1,
-                    first2, last2, dest, std::forward<F>(f),
-                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2)));
+            return detail::transform_binary2<result_type>().call(
+                std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
+                last2, dest, std::forward<F>(f), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
         }
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
             typename FwdIter3, typename F, typename Proj1, typename Proj2>
@@ -679,121 +700,31 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Applies the given function \a f to pairs of elements from two ranges:
-    /// one defined by [first1, last1) and the other beginning at first2, and
-    /// stores the result in another range, beginning at dest.
-    ///
-    /// \note   Complexity: Exactly min(last2-first2, last1-first1)
-    ///         applications of \a f
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the invocations of \a f.
-    /// \tparam FwdIter1    The type of the source iterators for the first
-    ///                     range used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the source iterators for the second
-    ///                     range used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter3    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam F           The type of the function/function object to use
-    ///                     (deduced). Unlike its sequential form, the parallel
-    ///                     overload of \a transform requires \a F to meet the
-    ///                     requirements of \a CopyConstructible.
-    /// \tparam Proj1       The type of an optional projection function to be
-    ///                     used for elements of the first sequence. This
-    ///                     defaults to \a util::projection_identity
-    /// \tparam Proj2       The type of an optional projection function to be
-    ///                     used for elements of the second sequence. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first1       Refers to the beginning of the first sequence of
-    ///                     elements the algorithm will be applied to.
-    /// \param last1        Refers to the end of the first sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param first2       Refers to the beginning of the second sequence of
-    ///                     elements the algorithm will be applied to.
-    /// \param last2        Refers to the end of the second sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param f            Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last).This is a
-    ///                     binary predicate. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     Ret fun(const Type1 &a, const Type2 &b);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&.
-    ///                     The types \a Type1 and \a Type2 must be such that
-    ///                     objects of types FwdIter1 and FwdIter2 can be
-    ///                     dereferenced and then implicitly converted to
-    ///                     \a Type1 and \a Type2 respectively. The type \a Ret
-    ///                     must be such that an object of type \a FwdIter3 can
-    ///                     be dereferenced and assigned a value of type
-    ///                     \a Ret.
-    /// \param proj1        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the
-    ///                     first sequence as a projection operation before the
-    ///                     actual predicate \a f is invoked.
-    /// \param proj2        Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements of the
-    ///                     second sequence as a projection operation before
-    ///                     the actual predicate \a f is invoked.
-    ///
-    /// The invocations of \a f in the parallel \a transform algorithm invoked
-    /// with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The invocations of \a f in the parallel \a transform algorithm invoked
-    /// with an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \note The algorithm will invoke the binary predicate until it reaches
-    ///       the end of the shorter of the two given input sequences
-    ///
-    /// \returns  The \a transform algorithm returns a
-    /// \a hpx::future<tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2), tag::out(FwdIter3)> >
-    ///           if the execution policy is of type \a parallel_task_policy
-    ///           and returns
-    /// \a tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2), tag::out(FwdIter3)>
-    ///           otherwise.
-    ///           The \a transform algorithm returns a tuple holding an iterator
-    ///           referring to the first element after the first input sequence,
-    ///           an iterator referring to the first element after the second
-    ///           input sequence, and the output iterator referring to the
-    ///           element in the destination range, one past the last element
-    ///           copied.
-    ///
+    // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename FwdIter3, typename F,
         typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<
-            ExPolicy>::value&& hpx::traits::is_iterator<FwdIter1>::value&&
-                hpx::traits::is_iterator<FwdIter2>::value&&
-                    hpx::traits::is_iterator<FwdIter3>::value&&
-                        traits::is_projected<Proj1, FwdIter1>::value&&
-                            traits::is_projected<Proj2, FwdIter2>::value&&
-                                traits::is_indirect_callable<ExPolicy, F,
-                                    traits::projected<Proj1, FwdIter1>,
-                                    traits::projected<Proj2, FwdIter2>>::value)>
-    typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2),
-            tag::out(FwdIter3)>>::type
-    transform(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
-        FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, F&& f,
-        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<
+                ExPolicy>::value&& hpx::traits::is_iterator<FwdIter1>::value &&
+            hpx::traits::is_iterator<FwdIter2>::value &&
+            hpx::traits::is_iterator<FwdIter3>::value &&
+            traits::is_projected<Proj1, FwdIter1>::value &&
+            traits::is_projected<Proj2, FwdIter2>::value &&
+            traits::is_indirect_callable<ExPolicy, F,
+                traits::projected<Proj1, FwdIter1>,
+                traits::projected<Proj2, FwdIter2>>::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::transform is deprecated, use hpx::transform instead")
+        typename util::detail::algorithm_result<ExPolicy,
+            hpx::util::tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2),
+                tag::out(FwdIter3)>>::type
+        transform(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+            FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, F&& f,
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
     {
         typedef hpx::traits::is_segmented_iterator<FwdIter1> is_segmented;
 
@@ -847,3 +778,103 @@ namespace hpx { namespace traits {
 #endif
 }}    // namespace hpx::traits
 #endif
+
+namespace hpx {
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::transform
+    HPX_INLINE_CONSTEXPR_VARIABLE struct transform_t final
+      : hpx::functional::tag<transform_t>
+    {
+    private:
+        // clang-format off
+        template <typename FwdIter1, typename FwdIter2,
+            typename F, HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value
+            )>
+        // clang-format on
+        friend FwdIter2 tag_invoke(hpx::transform_t, FwdIter1 first,
+            FwdIter1 last, FwdIter2 dest, F&& f)
+        {
+            return parallel::util::get_second_element(
+                parallel::v1::detail::transform_(hpx::execution::seq,
+                    first, last, dest, std::forward<F>(f),
+                    hpx::parallel::util::projection_identity(),
+                    std::false_type{}));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+            typename F, HPX_CONCEPT_REQUIRES_(
+                parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter2>::type
+        tag_invoke(hpx::transform_t, ExPolicy&& policy, FwdIter1 first,
+            FwdIter1 last, FwdIter2 dest, F&& f)
+        {
+            typedef hpx::traits::is_segmented_iterator<FwdIter1> is_segmented;
+
+            return parallel::util::get_second_element(
+                parallel::v1::detail::transform_(std::forward<ExPolicy>(policy),
+                    first, last, dest, std::forward<F>(f),
+                    hpx::parallel::util::projection_identity(),
+                    is_segmented()));
+        }
+
+        // clang-format off
+        template <typename FwdIter1, typename FwdIter2, typename FwdIter3,
+            typename F, HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_iterator<FwdIter3>::value
+            )>
+        // clang-format on
+        friend FwdIter3 tag_invoke(hpx::transform_t, FwdIter1 first1,
+            FwdIter1 last1, FwdIter2 first2, FwdIter3 dest, F&& f)
+        {
+            using proj_id = hpx::parallel::util::projection_identity;
+
+            return parallel::util::get_third_element(
+                parallel::v1::detail::transform_(hpx::execution::seq,
+                    first1, last1, first2, dest, std::forward<F>(f),
+                    hpx::parallel::util::projection_identity(),
+                    hpx::parallel::util::projection_identity(),
+                    std::false_type{}));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1,
+            typename FwdIter2, typename FwdIter3,
+            typename F, HPX_CONCEPT_REQUIRES_(
+                parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_iterator<FwdIter3>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter3>::type
+        tag_invoke(hpx::transform_t, ExPolicy&& policy, FwdIter1 first1,
+            FwdIter1 last1, FwdIter2 first2, FwdIter3 dest, F&& f)
+        {
+            using is_segmented = std::integral_constant<bool,
+                hpx::traits::is_segmented_iterator<FwdIter1>::value ||
+                    hpx::traits::is_segmented_iterator<FwdIter2>::value>;
+            using proj_id = hpx::parallel::util::projection_identity;
+
+            return parallel::util::get_third_element(
+                parallel::v1::detail::transform_(std::forward<ExPolicy>(policy),
+                    first1, last1, first2, dest, std::forward<F>(f),
+                    hpx::parallel::util::projection_identity(),
+                    hpx::parallel::util::projection_identity(),
+                    is_segmented()));
+        }
+
+    } transform{};
+}    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -182,8 +183,6 @@ namespace hpx {
 #include <hpx/functional/traits/is_invocable.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/parallel/util/result_types.hpp>
-#include <hpx/parallel/util/tagged_pair.hpp>
-#include <hpx/parallel/util/tagged_tuple.hpp>
 #include <hpx/threading_base/annotated_function.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>
@@ -382,7 +381,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     HPX_DEPRECATED_V(1, 6,
         "hpx::parallel::transform is deprecated, use hpx::transform instead")
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)>>::type
+            util::in_out_result<FwdIter1, FwdIter2>>::type
         transform(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
             FwdIter2 dest, F&& f, Proj&& proj = Proj())
     {
@@ -493,9 +492,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename ExPolicy, typename InIter1, typename InIter2,
                 typename OutIter, typename F, typename Proj1, typename Proj2>
-            static util::in_in_out_result<InIter1, InIter2, OutIter> sequential(ExPolicy&&,
-                InIter1 first1, InIter1 last1, InIter2 first2, OutIter dest,
-                F&& f, Proj1&& proj1, Proj2&& proj2)
+            static util::in_in_out_result<InIter1, InIter2, OutIter> sequential(
+                ExPolicy&&, InIter1 first1, InIter1 last1, InIter2 first2,
+                OutIter dest, F&& f, Proj1&& proj1, Proj2&& proj2)
             {
                 return util::transform_binary_loop<ExPolicy>(first1, last1,
                     first2, dest,
@@ -592,10 +591,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
     HPX_DEPRECATED_V(1, 6,
         "hpx::parallel::transform is deprecated, use hpx::transform instead")
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2),
-                tag::out(FwdIter3)>>::type transform(ExPolicy&& policy,
-            FwdIter1 first1, FwdIter1 last1, FwdIter2 first2, FwdIter3 dest,
-            F&& f, Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+            util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
+        transform(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
+            FwdIter2 first2, FwdIter3 dest, F&& f, Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
     {
         typedef hpx::traits::is_segmented_iterator<FwdIter1> is_segmented;
 
@@ -619,9 +618,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
             template <typename ExPolicy, typename InIter1, typename InIter2,
                 typename OutIter, typename F, typename Proj1, typename Proj2>
-            static util::in_in_out_result<InIter1, InIter2, OutIter> sequential(ExPolicy&&,
-                InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
-                OutIter dest, F&& f, Proj1&& proj1, Proj2&& proj2)
+            static util::in_in_out_result<InIter1, InIter2, OutIter> sequential(
+                ExPolicy&&, InIter1 first1, InIter1 last1, InIter2 first2,
+                InIter2 last2, OutIter dest, F&& f, Proj1&& proj1,
+                Proj2&& proj2)
             {
                 return util::transform_binary_loop<ExPolicy>(first1, last1,
                     first2, last2, dest,
@@ -718,8 +718,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     HPX_DEPRECATED_V(1, 6,
         "hpx::parallel::transform is deprecated, use hpx::transform instead")
         typename util::detail::algorithm_result<ExPolicy,
-            hpx::util::tagged_tuple<tag::in1(FwdIter1), tag::in2(FwdIter2),
-                tag::out(FwdIter3)>>::type
+            util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>>::type
         transform(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
             FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, F&& f,
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
@@ -795,8 +794,8 @@ namespace hpx {
             FwdIter1 last, FwdIter2 dest, F&& f)
         {
             return parallel::util::get_second_element(
-                parallel::v1::detail::transform_(hpx::execution::seq,
-                    first, last, dest, std::forward<F>(f),
+                parallel::v1::detail::transform_(hpx::execution::seq, first,
+                    last, dest, std::forward<F>(f),
                     hpx::parallel::util::projection_identity(),
                     std::false_type{}));
         }
@@ -837,11 +836,9 @@ namespace hpx {
             using proj_id = hpx::parallel::util::projection_identity;
 
             return parallel::util::get_third_element(
-                parallel::v1::detail::transform_(hpx::execution::seq,
-                    first1, last1, first2, dest, std::forward<F>(f),
-                    proj_id(),
-                    proj_id(),
-                    std::false_type{}));
+                parallel::v1::detail::transform_(hpx::execution::seq, first1,
+                    last1, first2, dest, std::forward<F>(f), proj_id(),
+                    proj_id(), std::false_type{}));
         }
 
         // clang-format off
@@ -866,10 +863,8 @@ namespace hpx {
 
             return parallel::util::get_third_element(
                 parallel::v1::detail::transform_(std::forward<ExPolicy>(policy),
-                    first1, last1, first2, dest, std::forward<F>(f),
-                    proj_id(),
-                    proj_id(),
-                    is_segmented()));
+                    first1, last1, first2, dest, std::forward<F>(f), proj_id(),
+                    proj_id(), is_segmented()));
         }
 
     } transform{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2015 Hartmut Kaiser
+//  Copyright (c) 2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -396,8 +397,6 @@ namespace hpx {
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
 #include <hpx/parallel/util/result_types.hpp>
-#include <hpx/parallel/util/tagged_pair.hpp>
-#include <hpx/parallel/util/tagged_tuple.hpp>
 
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/parallel/algorithms/transform.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
@@ -84,9 +84,9 @@ namespace hpx {
         typename Proj = util::projection_identity>
     typename util::detail::algorithm_result<ExPolicy,
         ranges::unary_transform_result<
-            typename hpx::traits::range_iterator<Rng>::type,
-            OutIter>>::type
-    transform(ExPolicy&& policy, Rng&& rng, OutIter dest, F&& f, Proj&& proj = Proj());
+            typename hpx::traits::range_iterator<Rng>::type, OutIter>>::type
+    transform(ExPolicy&& policy, Rng&& rng, OutIter dest, F&& f,
+        Proj&& proj = Proj());
 
     /// Applies the given function \a f to the given range \a rng and stores
     /// the result in another range, beginning at dest.
@@ -164,12 +164,12 @@ namespace hpx {
     ///           copied.
     ///
     template <typename ExPolicy, typename FwdIter1, typename Sent1,
-            typename FwdIter2, typename F,
-            typename Proj = hpx::parallel::util::projection_identity>
+        typename FwdIter2, typename F,
+        typename Proj = hpx::parallel::util::projection_identity>
     typename parallel::util::detail::algorithm_result<ExPolicy,
-            ranges::unary_transform_result<FwdIter1, FwdIter2>>::type
-    transform(ExPolicy&& policy, FwdIter1 first,
-            Sent1 last, FwdIter2 dest, F&& f, Proj&& proj = Proj());
+        ranges::unary_transform_result<FwdIter1, FwdIter2>>::type
+    transform(ExPolicy&& policy, FwdIter1 first, Sent1 last, FwdIter2 dest,
+        F&& f, Proj&& proj = Proj());
 
     /// Applies the given function \a f to pairs of elements from two ranges:
     /// one defined by \a rng and the other beginning at first2, and
@@ -275,9 +275,9 @@ namespace hpx {
         typename Proj2 = hpx::parallel::util::projection_identity>
     typename parallel::util::detail::algorithm_result<ExPolicy,
         ranges::binary_transform_result<FwdIter1, FwdIter2, FwdIter3>>::type
-    transform(ExPolicy&& policy, FwdIter1 first1,
-        Sent1 last1, FwdIter2 first2, Sent2 last2, FwdIter3 dest, F&& f,
-        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+    transform(ExPolicy&& policy, FwdIter1 first1, Sent1 last1, FwdIter2 first2,
+        Sent2 last2, FwdIter3 dest, F&& f, Proj1&& proj1 = Proj1(),
+        Proj2&& proj2 = Proj2());
 
     /// Applies the given function \a f to pairs of elements from two ranges:
     /// one defined by [first1, last1) and the other beginning at first2, and
@@ -382,8 +382,7 @@ namespace hpx {
     typename parallel::util::detail::algorithm_result<ExPolicy,
         ranges::binary_transform_result<
             typename hpx::traits::range_iterator<Rng1>::type,
-            typename hpx::traits::range_iterator<Rng2>::type,
-            FwdIter>>::type
+            typename hpx::traits::range_iterator<Rng2>::type, FwdIter>>::type
     tag_invoke(hpx::ranges::transform_t, ExPolicy&& policy, Rng1&& rng1,
         Rng2&& rng2, FwdIter dest, F&& f, Proj1&& proj1 = Proj1(),
         Proj2&& proj2 = Proj2())
@@ -413,14 +412,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
     // clang format-off
     template <typename ExPolicy, typename Rng, typename OutIter, typename F,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(
-            execution::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_range<Rng>::value &&
-            hpx::traits::is_iterator<OutIter>::value &&
-            traits::is_projected_range<Proj,Rng>::value &&
-            traits::is_indirect_callable<ExPolicy, F,
-                traits::projected_range<Proj, Rng>>::value
-        )>
+        HPX_CONCEPT_REQUIRES_(execution::is_execution_policy<ExPolicy>::value&&
+                hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
+                    OutIter>::value&& traits::is_projected_range<Proj,
+                    Rng>::value&& traits::is_indirect_callable<ExPolicy, F,
+                    traits::projected_range<Proj, Rng>>::value)>
     // clang format-on
     HPX_DEPRECATED_V(1, 6,
         "hpx::parallel::transform is deprecated, use hpx::ranges::transform "
@@ -640,9 +636,8 @@ namespace hpx { namespace ranges {
             hpx::ranges::transform_t, FwdIter1 first, Sent1 last, FwdIter2 dest,
             F&& f, Proj&& proj = Proj())
         {
-            return parallel::v1::detail::transform_(
-                hpx::execution::seq, first, last, dest,
-                std::forward<F>(f), std::forward<Proj>(proj),
+            return parallel::v1::detail::transform_(hpx::execution::seq, first,
+                last, dest, std::forward<F>(f), std::forward<Proj>(proj),
                 std::false_type{});
         }
 
@@ -659,10 +654,10 @@ namespace hpx { namespace ranges {
         tag_invoke(hpx::ranges::transform_t, Rng&& rng, FwdIter dest, F&& f,
             Proj&& proj = Proj())
         {
-            return parallel::v1::detail::transform_(
-                hpx::parallel::execution::seq, hpx::util::begin(rng),
-                hpx::util::end(rng), dest, std::forward<F>(f),
-                std::forward<Proj>(proj), std::false_type{});
+            return parallel::v1::detail::transform_(hpx::execution::seq,
+                hpx::util::begin(rng), hpx::util::end(rng), dest,
+                std::forward<F>(f), std::forward<Proj>(proj),
+                std::false_type{});
         }
 
         // clang-format off
@@ -683,10 +678,10 @@ namespace hpx { namespace ranges {
             FwdIter2 first2, Sent2 last2, FwdIter3 dest, F&& f,
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
-            return parallel::v1::detail::transform_(
-                hpx::parallel::execution::seq, first1, last1, first2, last2,
-                dest, std::forward<F>(f), std::forward<Proj1>(proj1),
-                std::forward<Proj2>(proj2), std::false_type{});
+            return parallel::v1::detail::transform_(hpx::execution::seq, first1,
+                last1, first2, last2, dest, std::forward<F>(f),
+                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2),
+                std::false_type{});
         }
 
         // clang-format off
@@ -706,12 +701,11 @@ namespace hpx { namespace ranges {
             FwdIter dest, F&& f, Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
         {
-            return parallel::v1::detail::transform_(
-                hpx::parallel::execution::seq, hpx::util::begin(rng1),
-                hpx::util::end(rng1), hpx::util::begin(rng2),
-                hpx::util::end(rng2), dest, std::forward<F>(f),
-                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2),
-                std::false_type{});
+            return parallel::v1::detail::transform_(hpx::execution::seq,
+                hpx::util::begin(rng1), hpx::util::end(rng1),
+                hpx::util::begin(rng2), hpx::util::end(rng2), dest,
+                std::forward<F>(f), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2), std::false_type{});
         }
 
     } transform{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
@@ -8,23 +8,9 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/concepts/concepts.hpp>
-#include <hpx/iterator_support/range.hpp>
-#include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/iterator_support/traits/is_range.hpp>
-#include <hpx/parallel/util/tagged_pair.hpp>
-#include <hpx/parallel/util/tagged_tuple.hpp>
+#if defined(DOXYGEN)
+namespace hpx {
 
-#include <hpx/algorithms/traits/projected_range.hpp>
-#include <hpx/parallel/algorithms/transform.hpp>
-#include <hpx/parallel/tagspec.hpp>
-#include <hpx/parallel/util/projection_identity.hpp>
-
-#include <type_traits>
-#include <utility>
-
-namespace hpx { namespace parallel { inline namespace v1 {
     /// Applies the given function \a f to the given range \a rng and stores
     /// the result in another range, beginning at dest.
     ///
@@ -63,7 +49,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///                     \endcode \n
     ///                     The signature does not need to have const&.
     ///                     The type \a Type must be such that an object of
-    ///                     type \a InIter can be dereferenced and then
+    ///                     type \a range_iterator<Rng>::type can be dereferenced and then
     ///                     implicitly converted to \a Type. The type \a Ret
     ///                     must be such that an object of type \a OutIter can
     ///                     be dereferenced and assigned a value of type
@@ -84,9 +70,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// within each thread.
     ///
     /// \returns  The \a transform algorithm returns a
-    ///           \a hpx::future<tagged_pair<tag::in(InIter), tag::out(OutIter)> >
+    ///           \a hpx::future<ranges::unary_transform_result<range_iterator<Rng>::type, OutIter> >
     ///           if the execution policy is of type \a parallel_task_policy
-    ///           and returns \a tagged_pair<tag::in(InIter), tag::out(OutIter)>
+    ///           and returns \a ranges::unary_transform_result<range_iterator<Rng>::type, OutIter>
     ///           otherwise.
     ///           The \a transform algorithm returns a tuple holding an iterator
     ///           referring to the first element after the input sequence and
@@ -95,23 +81,95 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           copied.
     ///
     template <typename ExPolicy, typename Rng, typename OutIter, typename F,
-        typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
-                    OutIter>::value&& traits::is_projected_range<Proj,
-                    Rng>::value&& traits::is_indirect_callable<ExPolicy, F,
-                    traits::projected_range<Proj, Rng>>::value)>
+        typename Proj = util::projection_identity>
     typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_pair<
-            tag::in(typename hpx::traits::range_iterator<Rng>::type),
-            tag::out(OutIter)>>::type
-    transform(
-        ExPolicy&& policy, Rng&& rng, OutIter dest, F&& f, Proj&& proj = Proj())
-    {
-        return transform(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
-            hpx::util::end(rng), std::move(dest), std::forward<F>(f),
-            std::forward<Proj>(proj));
-    }
+        ranges::unary_transform_result<
+            typename hpx::traits::range_iterator<Rng>::type,
+            OutIter>>::type
+    transform(ExPolicy&& policy, Rng&& rng, OutIter dest, F&& f, Proj&& proj = Proj());
+
+    /// Applies the given function \a f to the given range \a rng and stores
+    /// the result in another range, beginning at dest.
+    ///
+    /// \note   Complexity: Exactly size(rng) applications of \a f
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the invocations of \a f.
+    /// \tparam FwdIter1    The type of the source iterators for the first
+    ///                     range used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent1       The type of the end source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     sentinel for FwdIter1.
+    /// \tparam FwdIter2    The type of the source iterators for the first
+    ///                     range used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam F           The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a transform requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the first sequence of
+    ///                     elements the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param f            Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     Ret fun(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&.
+    ///                     The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to \a Type. The type \a Ret
+    ///                     must be such that an object of type \a FwdIter2 can
+    ///                     be dereferenced and assigned a value of type
+    ///                     \a Ret.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a f is invoked.
+    ///
+    /// The invocations of \a f in the parallel \a transform algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The invocations of \a f in the parallel \a transform algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a transform algorithm returns a
+    ///           \a hpx::future<ranges::unary_transform_result<FwdIter1, FwdIter2> >
+    ///           if the execution policy is of type \a parallel_task_policy
+    ///           and returns \a ranges::unary_transform_result<FwdIter1, FwdIter2>
+    ///           otherwise.
+    ///           The \a transform algorithm returns a tuple holding an iterator
+    ///           referring to the first element after the input sequence and
+    ///           the output iterator to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename Sent1,
+            typename FwdIter2, typename F,
+            typename Proj = hpx::parallel::util::projection_identity>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+            ranges::unary_transform_result<FwdIter1, FwdIter2>>::type
+    transform(ExPolicy&& policy, FwdIter1 first,
+            Sent1 last, FwdIter2 dest, F&& f, Proj&& proj = Proj());
 
     /// Applies the given function \a f to pairs of elements from two ranges:
     /// one defined by \a rng and the other beginning at first2, and
@@ -123,17 +181,24 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///                     It describes the manner in which the execution
     ///                     of the algorithm may be parallelized and the manner
     ///                     in which it executes the invocations of \a f.
-    /// \tparam Rng         The type of the source range used (deduced).
-    ///                     The iterators extracted from this range type must
-    ///                     meet the requirements of an input iterator.
-    /// \tparam InIter2     The type of the source iterators for the second
+    /// \tparam FwdIter1    The type of the source iterators for the first
     ///                     range used (deduced).
     ///                     This iterator type must meet the requirements of an
-    ///                     input iterator.
-    /// \tparam OutIter     The type of the iterator representing the
-    ///                     destination range (deduced).
+    ///                     forward iterator.
+    /// \tparam Sent1       The type of the end source iterators used (deduced).
     ///                     This iterator type must meet the requirements of an
-    ///                     output iterator.
+    ///                     sentinel for FwdIter1.
+    /// \tparam FwdIter2    The type of the source iterators for the first
+    ///                     range used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent2       The type of the end source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     sentinel for FwdIter2.
+    /// \tparam FwdIter3    The type of the source iterators for the first
+    ///                     range used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
     /// \tparam F           The type of the function/function object to use
     ///                     (deduced). Unlike its sequential form, the parallel
     ///                     overload of \a transform requires \a F to meet the
@@ -147,10 +212,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
-    /// \param rng          Refers to the sequence of elements the algorithm
-    ///                     will be applied to.
+    /// \param first1       Refers to the beginning of the first sequence of
+    ///                     elements the algorithm will be applied to.
+    /// \param last1        Refers to the end of the first sequence of elements
+    ///                     the algorithm will be applied to.
     /// \param first2       Refers to the beginning of the second sequence of
     ///                     elements the algorithm will be applied to.
+    /// \param last2        Refers to the end of the second sequence of elements
+    ///                     the algorithm will be applied to.
     /// \param dest         Refers to the beginning of the destination range.
     /// \param f            Specifies the function (or function object) which
     ///                     will be invoked for each of the elements in the
@@ -162,10 +231,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///                     \endcode \n
     ///                     The signature does not need to have const&.
     ///                     The types \a Type1 and \a Type2 must be such that
-    ///                     objects of types InIter1 and InIter2 can be
+    ///                     objects of types FwdIter1 and FwdIter2 can be
     ///                     dereferenced and then implicitly converted to
     ///                     \a Type1 and \a Type2 respectively. The type \a Ret
-    ///                     must be such that an object of type \a OutIter can
+    ///                     must be such that an object of type \a FwdIter3 can
     ///                     be dereferenced and assigned a value of type
     ///                     \a Ret.
     /// \param proj1        Specifies the function (or function object) which
@@ -188,10 +257,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// within each thread.
     ///
     /// \returns  The \a transform algorithm returns a
-    /// \a hpx::future<tagged_tuple<tag::in1(InIter1), tag::in2(InIter2), tag::out(OutIter)> >
+    /// \a hpx::future<ranges::binary_transform_result<FwdIter1, FwdIter2, FwdIter3> >
     ///           if the execution policy is of type \a parallel_task_policy
     ///           and returns
-    /// \a tagged_tuple<tag::in1(InIter1), tag::in2(InIter2), tag::out(OutIter)>
+    /// \a ranges::binary_transform_result<FwdIter1, FwdIter2, FwdIter3>
     ///           otherwise.
     ///           The \a transform algorithm returns a tuple holding an iterator
     ///           referring to the first element after the first input sequence,
@@ -200,30 +269,15 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           element in the destination range, one past the last element
     ///           copied.
     ///
-    template <typename ExPolicy, typename Rng, typename InIter2,
-        typename OutIter, typename F,
-        typename Proj1 = util::projection_identity,
-        typename Proj2 = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
-                    InIter2>::value&& hpx::traits::is_iterator<OutIter>::value&&
-                    traits::is_projected_range<Proj1, Rng>::value&&
-                        traits::is_projected<Proj2, InIter2>::value&&
-                            traits::is_indirect_callable<ExPolicy, F,
-                                traits::projected_range<Proj1, Rng>,
-                                traits::projected<Proj2, InIter2>>::value)>
-    typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_tuple<
-            tag::in1(typename hpx::traits::range_iterator<Rng>::type),
-            tag::in2(InIter2), tag::out(OutIter)>>::type
-    transform(ExPolicy&& policy, Rng&& rng, InIter2 first2, OutIter dest, F&& f,
-        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
-    {
-        return transform(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
-            hpx::util::end(rng), std::move(first2), std::move(dest),
-            std::forward<F>(f), std::forward<Proj1>(proj1),
-            std::forward<Proj2>(proj2));
-    }
+    template <typename ExPolicy, typename FwdIter1, typename Sent1,
+        typename FwdIter2, typename Sent2, typename FwdIter3, typename F,
+        typename Proj1 = hpx::parallel::util::projection_identity,
+        typename Proj2 = hpx::parallel::util::projection_identity>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        ranges::binary_transform_result<FwdIter1, FwdIter2, FwdIter3>>::type
+    transform(ExPolicy&& policy, FwdIter1 first1,
+        Sent1 last1, FwdIter2 first2, Sent2 last2, FwdIter3 dest, F&& f,
+        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
 
     /// Applies the given function \a f to pairs of elements from two ranges:
     /// one defined by [first1, last1) and the other beginning at first2, and
@@ -242,7 +296,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// \tparam Rng2        The type of the second source range used (deduced).
     ///                     The iterators extracted from this range type must
     ///                     meet the requirements of an input iterator.
-    /// \tparam OutIter     The type of the iterator representing the
+    /// \tparam FwdIter     The type of the iterator representing the
     ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     output iterator.
@@ -274,10 +328,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///                     \endcode \n
     ///                     The signature does not need to have const&.
     ///                     The types \a Type1 and \a Type2 must be such that
-    ///                     objects of types InIter1 and InIter2 can be
+    ///                     objects of types range_iterator<Rng1>::type and
+    ///                     range_iterator<Rng2>::type can be
     ///                     dereferenced and then implicitly converted to
     ///                     \a Type1 and \a Type2 respectively. The type \a Ret
-    ///                     must be such that an object of type \a OutIter can
+    ///                     must be such that an object of type \a FwdIter can
     ///                     be dereferenced and assigned a value of type
     ///                     \a Ret.
     /// \param proj1        Specifies the function (or function object) which
@@ -303,36 +358,136 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///       the end of the shorter of the two given input sequences
     ///
     /// \returns  The \a transform algorithm returns a
-    /// \a hpx::future<tagged_tuple<tag::in1(InIter1), tag::in2(InIter2), tag::out(OutIter)> >
+    /// \a hpx::future<ranges::binary_transform_result<
+    ///           typename hpx::traits::range_iterator<Rng1>::type,
+    ///           typename hpx::traits::range_iterator<Rng2>::type,
+    ///           FwdIter> >
     ///           if the execution policy is of type \a parallel_task_policy
     ///           and returns
-    /// \a tagged_tuple<tag::in1(InIter1), tag::in2(InIter2), tag::out(OutIter)>
+    /// \a ranges::binary_transform_result<
+    ///           typename hpx::traits::range_iterator<Rng1>::type,
+    ///           typename hpx::traits::range_iterator<Rng2>::type,
+    ///           FwdIter>
     ///           otherwise.
     ///           The \a transform algorithm returns a tuple holding an iterator
-    ///           referring to the first element         r the first input sequence,
+    ///           referring to the first element after the first input sequence,
     ///           an iterator referring to the first element after the second
     ///           input sequence, and the output iterator referring to the
     ///           element in the destination range, one past the last element
     ///           copied.
     ///
+    template <typename ExPolicy, typename Rng1, typename Rng2, typename FwdIter,
+        typename F, typename Proj1 = hpx::parallel::util::projection_identity,
+        typename Proj2 = hpx::parallel::util::projection_identity>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        ranges::binary_transform_result<
+            typename hpx::traits::range_iterator<Rng1>::type,
+            typename hpx::traits::range_iterator<Rng2>::type,
+            FwdIter>>::type
+    tag_invoke(hpx::ranges::transform_t, ExPolicy&& policy, Rng1&& rng1,
+        Rng2&& rng2, FwdIter dest, F&& f, Proj1&& proj1 = Proj1(),
+        Proj2&& proj2 = Proj2())
+
+}    // namespace hpx
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/iterator_support/traits/is_range.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+#include <hpx/parallel/util/tagged_pair.hpp>
+#include <hpx/parallel/util/tagged_tuple.hpp>
+
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/parallel/algorithms/transform.hpp>
+#include <hpx/parallel/tagspec.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1 {
+
+    // clang format-off
+    template <typename ExPolicy, typename Rng, typename OutIter, typename F,
+        typename Proj = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value &&
+            hpx::traits::is_iterator<OutIter>::value &&
+            traits::is_projected_range<Proj,Rng>::value &&
+            traits::is_indirect_callable<ExPolicy, F,
+                traits::projected_range<Proj, Rng>>::value
+        )>
+    // clang format-on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::transform is deprecated, use hpx::ranges::transform "
+        "instead") typename util::detail::algorithm_result<ExPolicy,
+        util::in_out_result<typename hpx::traits::range_iterator<Rng>::type,
+            OutIter>>::type transform(ExPolicy&& policy, Rng&& rng,
+        OutIter dest, F&& f, Proj&& proj = Proj())
+    {
+        return transform(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+            hpx::util::end(rng), std::move(dest), std::forward<F>(f),
+            std::forward<Proj>(proj));
+    }
+
+    // clang-format off
+    template <typename ExPolicy, typename Rng, typename InIter2,
+        typename OutIter, typename F,
+        typename Proj1 = util::projection_identity,
+        typename Proj2 = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
+                InIter2>::value &&
+            hpx::traits::is_iterator<OutIter>::value &&
+            traits::is_projected_range<Proj1, Rng>::value &&
+            traits::is_projected<Proj2, InIter2>::value &&
+            traits::is_indirect_callable<ExPolicy, F,
+                traits::projected_range<Proj1, Rng>,
+                traits::projected<Proj2, InIter2>>::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::transform is deprecated, use hpx::ranges::transform "
+        "instead") typename util::detail::algorithm_result<ExPolicy,
+        util::in_in_out_result<typename hpx::traits::range_iterator<Rng>::type,
+            InIter2, OutIter>>::type
+        transform(ExPolicy&& policy, Rng&& rng, InIter2 first2, OutIter dest,
+            F&& f, Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+    {
+        return transform(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+            hpx::util::end(rng), std::move(first2), std::move(dest),
+            std::forward<F>(f), std::forward<Proj1>(proj1),
+            std::forward<Proj2>(proj2));
+    }
+
+    // clang-format off
     template <typename ExPolicy, typename Rng1, typename Rng2, typename OutIter,
         typename F, typename Proj1 = util::projection_identity,
         typename Proj2 = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng1>::value&& hpx::traits::is_range<
-                    Rng2>::value&& hpx::traits::is_iterator<OutIter>::value&&
-                    traits::is_projected_range<Proj1, Rng1>::value&&
-                        traits::is_projected_range<Proj2, Rng2>::value&&
-                            traits::is_indirect_callable<ExPolicy, F,
-                                traits::projected_range<Proj1, Rng1>,
-                                traits::projected_range<Proj2, Rng2>>::value)>
-    typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_tuple<
-            tag::in1(typename hpx::traits::range_iterator<Rng1>::type),
-            tag::in2(typename hpx::traits::range_iterator<Rng2>::type),
-            tag::out(OutIter)>>::type
-    transform(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2, OutIter dest, F&& f,
-        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        HPX_CONCEPT_REQUIRES_(
+            execution::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng1>::value &&
+            hpx::traits::is_range<Rng2>::value &&
+            hpx::traits::is_iterator<OutIter>::value &&
+            traits::is_projected_range<Proj1, Rng1>::value &&
+            traits::is_projected_range<Proj2, Rng2>::value &&
+                traits::is_indirect_callable<ExPolicy, F,
+                traits::projected_range<Proj1, Rng1>,
+                traits::projected_range<Proj2, Rng2>>::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::transform is deprecated, use hpx::ranges::transform "
+        "instead") typename util::detail::algorithm_result<ExPolicy,
+        util::in_in_out_result<typename hpx::traits::range_iterator<Rng1>::type,
+            typename hpx::traits::range_iterator<Rng2>::type, OutIter>>::type
+        transform(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2, OutIter dest,
+            F&& f, Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
     {
         return transform(std::forward<ExPolicy>(policy), hpx::util::begin(rng1),
             hpx::util::end(rng1), hpx::util::begin(rng2), hpx::util::end(rng2),
@@ -340,3 +495,226 @@ namespace hpx { namespace parallel { inline namespace v1 {
             std::forward<Proj2>(proj2));
     }
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx { namespace ranges {
+
+    template <typename I, typename O>
+    using unary_transform_result = parallel::util::in_out_result<I, O>;
+
+    template <typename I1, typename I2, typename O>
+    using binary_transform_result = parallel::util::in_in_out_result<I1, I2, O>;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::transform
+    HPX_INLINE_CONSTEXPR_VARIABLE struct transform_t final
+      : hpx::functional::tag<transform_t>
+    {
+    private:
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename Sent1,
+            typename FwdIter2, typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            ranges::unary_transform_result<FwdIter1, FwdIter2>>::type
+        tag_invoke(hpx::ranges::transform_t, ExPolicy&& policy, FwdIter1 first,
+            Sent1 last, FwdIter2 dest, F&& f, Proj&& proj = Proj())
+        {
+            typedef hpx::traits::is_segmented_iterator<FwdIter1> is_segmented;
+
+            return parallel::v1::detail::transform_(
+                std::forward<ExPolicy>(policy), first, last, dest,
+                std::forward<F>(f), std::forward<Proj>(proj), is_segmented());
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng, typename FwdIter,
+            typename F, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::traits::is_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            ranges::unary_transform_result<
+                typename hpx::traits::range_iterator<Rng>::type, FwdIter>>::type
+        tag_invoke(hpx::ranges::transform_t, ExPolicy&& policy, Rng&& rng,
+            FwdIter dest, F&& f, Proj&& proj = Proj())
+        {
+            using iterator_type =
+                typename hpx::traits::range_traits<Rng>::iterator_type;
+            using is_segmented =
+                hpx::traits::is_segmented_iterator<iterator_type>;
+
+            return parallel::v1::detail::transform_(
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                hpx::util::end(rng), dest, std::forward<F>(f),
+                std::forward<Proj>(proj), is_segmented());
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename Sent1,
+            typename FwdIter2, typename Sent2, typename FwdIter3, typename F,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_sentinel_for<Sent2, FwdIter2>::value &&
+                hpx::traits::is_iterator<FwdIter3>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            ranges::binary_transform_result<FwdIter1, FwdIter2, FwdIter3>>::type
+        tag_invoke(hpx::ranges::transform_t, ExPolicy&& policy, FwdIter1 first1,
+            Sent1 last1, FwdIter2 first2, Sent2 last2, FwdIter3 dest, F&& f,
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        {
+            using is_segmented = std::integral_constant<bool,
+                hpx::traits::is_segmented_iterator<FwdIter1>::value ||
+                    hpx::traits::is_segmented_iterator<FwdIter2>::value>;
+
+            return parallel::v1::detail::transform_(
+                std::forward<ExPolicy>(policy), first1, last1, first2, last2,
+                dest, std::forward<F>(f), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2), is_segmented());
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng1, typename Rng2, typename FwdIter,
+            typename F, typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value &&
+                hpx::traits::is_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            ranges::binary_transform_result<
+                typename hpx::traits::range_iterator<Rng1>::type,
+                typename hpx::traits::range_iterator<Rng2>::type,
+                FwdIter>>::type
+        tag_invoke(hpx::ranges::transform_t, ExPolicy&& policy, Rng1&& rng1,
+            Rng2&& rng2, FwdIter dest, F&& f, Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_traits<Rng1>::iterator_type;
+            using iterator_type2 =
+                typename hpx::traits::range_traits<Rng2>::iterator_type;
+
+            using is_segmented = std::integral_constant<bool,
+                hpx::traits::is_segmented_iterator<iterator_type1>::value ||
+                    hpx::traits::is_segmented_iterator<iterator_type2>::value>;
+
+            return parallel::v1::detail::transform_(
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng1),
+                hpx::util::end(rng1), hpx::util::begin(rng2),
+                hpx::util::end(rng2), dest, std::forward<F>(f),
+                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2),
+                is_segmented());
+        }
+
+        // clang-format off
+        template <typename FwdIter1, typename Sent1, typename FwdIter2,
+            typename F,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value
+            )>
+        // clang-format on
+        friend ranges::unary_transform_result<FwdIter1, FwdIter2> tag_invoke(
+            hpx::ranges::transform_t, FwdIter1 first, Sent1 last, FwdIter2 dest,
+            F&& f, Proj&& proj = Proj())
+        {
+            return parallel::v1::detail::transform_(
+                hpx::execution::seq, first, last, dest,
+                std::forward<F>(f), std::forward<Proj>(proj),
+                std::false_type{});
+        }
+
+        // clang-format off
+        template <typename Rng, typename FwdIter,
+            typename F, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value &&
+                hpx::traits::is_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend ranges::unary_transform_result<
+            typename hpx::traits::range_iterator<Rng>::type, FwdIter>
+        tag_invoke(hpx::ranges::transform_t, Rng&& rng, FwdIter dest, F&& f,
+            Proj&& proj = Proj())
+        {
+            return parallel::v1::detail::transform_(
+                hpx::parallel::execution::seq, hpx::util::begin(rng),
+                hpx::util::end(rng), dest, std::forward<F>(f),
+                std::forward<Proj>(proj), std::false_type{});
+        }
+
+        // clang-format off
+        template <typename FwdIter1, typename Sent1,
+            typename FwdIter2, typename Sent2, typename FwdIter3, typename F,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_sentinel_for<Sent2, FwdIter2>::value &&
+                hpx::traits::is_iterator<FwdIter3>::value
+            )>
+        // clang-format on
+        friend ranges::binary_transform_result<FwdIter1, FwdIter2, FwdIter3>
+        tag_invoke(hpx::ranges::transform_t, FwdIter1 first1, Sent1 last1,
+            FwdIter2 first2, Sent2 last2, FwdIter3 dest, F&& f,
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        {
+            return parallel::v1::detail::transform_(
+                hpx::parallel::execution::seq, first1, last1, first2, last2,
+                dest, std::forward<F>(f), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2), std::false_type{});
+        }
+
+        // clang-format off
+        template <typename Rng1, typename Rng2, typename FwdIter,
+            typename F, typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value &&
+                hpx::traits::is_iterator<FwdIter>::value
+            )>
+        // clang-format on
+        friend ranges::binary_transform_result<
+            typename hpx::traits::range_iterator<Rng1>::type,
+            typename hpx::traits::range_iterator<Rng2>::type, FwdIter>
+        tag_invoke(hpx::ranges::transform_t, Rng1&& rng1, Rng2&& rng2,
+            FwdIter dest, F&& f, Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            return parallel::v1::detail::transform_(
+                hpx::parallel::execution::seq, hpx::util::begin(rng1),
+                hpx::util::end(rng1), hpx::util::begin(rng2),
+                hpx::util::end(rng2), dest, std::forward<F>(f),
+                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2),
+                std::false_type{});
+        }
+
+    } transform{};
+}}    // namespace hpx::ranges
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -224,6 +224,49 @@ namespace hpx { namespace parallel { namespace util {
                     return get_in_out_result(std::move(zipiter));
                 });
         }
+
+        template <typename ZipIter>
+        in_in_out_result<typename hpx::tuple_element<0,
+                             typename ZipIter::iterator_tuple_type>::type,
+            typename hpx::tuple_element<1,
+                typename ZipIter::iterator_tuple_type>::type,
+            typename hpx::tuple_element<2,
+                typename ZipIter::iterator_tuple_type>::type>
+        get_in_in_out_result(ZipIter&& zipiter)
+        {
+            using iterator_tuple_type = typename ZipIter::iterator_tuple_type;
+
+            using result_type = in_in_out_result<
+                typename hpx::tuple_element<0, iterator_tuple_type>::type,
+                typename hpx::tuple_element<1, iterator_tuple_type>::type,
+                typename hpx::tuple_element<2, iterator_tuple_type>::type>;
+
+            iterator_tuple_type t = zipiter.get_iterator_tuple();
+            return result_type{hpx::get<0>(t), hpx::get<1>(t), hpx::get<2>(t)};
+        }
+
+        template <typename ZipIter>
+        hpx::future<
+            in_in_out_result<typename hpx::tuple_element<0,
+                                 typename ZipIter::iterator_tuple_type>::type,
+                typename hpx::tuple_element<1,
+                    typename ZipIter::iterator_tuple_type>::type,
+                typename hpx::tuple_element<2,
+                    typename ZipIter::iterator_tuple_type>::type>>
+        get_in_in_out_result(hpx::future<ZipIter>&& zipiter)
+        {
+            using iterator_tuple_type = typename ZipIter::iterator_tuple_type;
+
+            using result_type = in_in_out_result<
+                typename hpx::tuple_element<0, iterator_tuple_type>::type,
+                typename hpx::tuple_element<1, iterator_tuple_type>::type,
+                typename hpx::tuple_element<2, iterator_tuple_type>::type>;
+
+            return lcos::make_future<result_type>(
+                std::move(zipiter), [](ZipIter zipiter) {
+                    return get_in_in_out_result(std::move(zipiter));
+                });
+        }
     }    // namespace detail
 }}}      // namespace hpx::parallel::util
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/transform_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/transform_loop.hpp
@@ -11,6 +11,7 @@
 #include <hpx/execution/traits/is_execution_policy.hpp>
 #include <hpx/functional/detail/invoke.hpp>
 #include <hpx/parallel/util/cancellation_token.hpp>
+#include <hpx/parallel/util/result_types.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -24,24 +25,28 @@ namespace hpx { namespace parallel { namespace util {
         template <typename Iter>
         struct transform_loop
         {
-            template <typename InIter, typename OutIter, typename F>
-            HPX_HOST_DEVICE HPX_FORCEINLINE static std::pair<InIter, OutIter>
-            call(InIter first, InIter last, OutIter dest, F&& f)
+            template <typename InIterB, typename InIterE, typename OutIter,
+                typename F>
+            HPX_HOST_DEVICE
+                HPX_FORCEINLINE static util::in_out_result<InIterB, OutIter>
+                call(InIterB first, InIterE last, OutIter dest, F&& f)
             {
                 for (/* */; first != last; (void) ++first, ++dest)
                 {
                     *dest = HPX_INVOKE(std::forward<F>(f), first);
                 }
-                return std::make_pair(std::move(first), std::move(dest));
+                return util::in_out_result<InIterB, OutIter>{
+                    std::move(first), std::move(dest)};
             }
         };
     }    // namespace detail
 
-    template <typename ExPolicy, typename Iter, typename OutIter, typename F>
-    HPX_HOST_DEVICE HPX_FORCEINLINE std::pair<Iter, OutIter> transform_loop(
-        ExPolicy&&, Iter it, Iter end, OutIter dest, F&& f)
+    template <typename ExPolicy, typename IterB, typename IterE,
+        typename OutIter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE util::in_out_result<IterB, OutIter>
+    transform_loop(ExPolicy&&, IterB it, IterE end, OutIter dest, F&& f)
     {
-        return detail::transform_loop<Iter>::call(
+        return detail::transform_loop<IterB>::call(
             it, end, dest, std::forward<F>(f));
     }
 
@@ -50,59 +55,60 @@ namespace hpx { namespace parallel { namespace util {
         template <typename Iter1, typename Iter2>
         struct transform_binary_loop
         {
-            template <typename InIter1, typename InIter2, typename OutIter,
-                typename F>
-            HPX_HOST_DEVICE
-                HPX_FORCEINLINE static hpx::tuple<InIter1, InIter2, OutIter>
-                call(InIter1 first1, InIter1 last1, InIter2 first2,
-                    OutIter dest, F&& f)
+            template <typename InIter1B, typename InIter1E, typename InIter2,
+                typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static util::in_in_out_result<
+                InIter1B, InIter2, OutIter>
+            call(InIter1B first1, InIter1E last1, InIter2 first2, OutIter dest,
+                F&& f)
             {
                 for (/* */; first1 != last1; (void) ++first1, ++first2, ++dest)
                 {
                     *dest = HPX_INVOKE(std::forward<F>(f), first1, first2);
                 }
-                return hpx::make_tuple(
-                    std::move(first1), std::move(first2), std::move(dest));
+                return util::in_in_out_result<InIter1B, InIter2, OutIter>{
+                    std::move(first1), std::move(first2), std::move(dest)};
             }
 
-            template <typename InIter1, typename InIter2, typename OutIter,
-                typename F>
-            HPX_HOST_DEVICE
-                HPX_FORCEINLINE static hpx::tuple<InIter1, InIter2, OutIter>
-                call(InIter1 first1, InIter1 last1, InIter2 first2,
-                    InIter2 last2, OutIter dest, F&& f)
+            template <typename InIter1B, typename InIter1E, typename InIter2,
+                typename OutIter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static util::in_in_out_result<
+                InIter1B, InIter2, OutIter>
+            call(InIter1B first1, InIter1E last1, InIter2 first2, InIter2 last2,
+                OutIter dest, F&& f)
             {
                 for (/* */; first1 != last1 && first2 != last2;
                      (void) ++first1, ++first2, ++dest)
                 {
                     *dest = HPX_INVOKE(std::forward<F>(f), first1, first2);
                 }
-                return hpx::make_tuple(first1, first2, dest);
+                return util::in_in_out_result<InIter1B, InIter2, OutIter>{
+                    first1, first2, dest};
             }
         };
     }    // namespace detail
 
-    template <typename ExPolicy, typename InIter1, typename InIter2,
-        typename OutIter, typename F>
+    template <typename ExPolicy, typename InIter1B, typename InIter1E,
+        typename InIter2, typename OutIter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
-        !hpx::is_vectorpack_execution_policy<ExPolicy>::value,
-        hpx::tuple<InIter1, InIter2, OutIter>>::type
+        !execution::is_vectorpack_execution_policy<ExPolicy>::value,
+        util::in_in_out_result<InIter1B, InIter2, OutIter>>::type
     transform_binary_loop(
-        InIter1 first1, InIter1 last1, InIter2 first2, OutIter dest, F&& f)
+        InIter1B first1, InIter1E last1, InIter2 first2, OutIter dest, F&& f)
     {
-        return detail::transform_binary_loop<InIter1, InIter2>::call(
+        return detail::transform_binary_loop<InIter1B, InIter2>::call(
             first1, last1, first2, dest, std::forward<F>(f));
     }
 
-    template <typename ExPolicy, typename InIter1, typename InIter2,
-        typename OutIter, typename F>
+    template <typename ExPolicy, typename InIter1B, typename InIter1E,
+        typename InIter2B, typename InIter2E, typename OutIter, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
-        !hpx::is_vectorpack_execution_policy<ExPolicy>::value,
-        hpx::tuple<InIter1, InIter2, OutIter>>::type
-    transform_binary_loop(InIter1 first1, InIter1 last1, InIter2 first2,
-        InIter2 last2, OutIter dest, F&& f)
+        !execution::is_vectorpack_execution_policy<ExPolicy>::value,
+        util::in_in_out_result<InIter1B, InIter2B, OutIter>>::type
+    transform_binary_loop(InIter1B first1, InIter1E last1, InIter2B first2,
+        InIter2E last2, OutIter dest, F&& f)
     {
-        return detail::transform_binary_loop<InIter1, InIter2>::call(
+        return detail::transform_binary_loop<InIter1B, InIter2B>::call(
             first1, last1, first2, last2, dest, std::forward<F>(f));
     }
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform.cpp
@@ -19,6 +19,7 @@ void test_transform()
 {
     using namespace hpx::execution;
 
+    test_transform(IteratorTag());
     test_transform(seq, IteratorTag());
     test_transform(par, IteratorTag());
     test_transform(par_unseq, IteratorTag());
@@ -41,6 +42,7 @@ void test_transform_exception()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_transform_exception(IteratorTag());
     test_transform_exception(seq, IteratorTag());
     test_transform_exception(par, IteratorTag());
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary.cpp
@@ -19,6 +19,7 @@ void test_transform_binary()
 {
     using namespace hpx::execution;
 
+    test_transform_binary(IteratorTag());
     test_transform_binary(seq, IteratorTag());
     test_transform_binary(par, IteratorTag());
     test_transform_binary(par_unseq, IteratorTag());
@@ -42,6 +43,7 @@ void test_transform_binary_exception()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_transform_binary_exception(IteratorTag());
     test_transform_binary_exception(seq, IteratorTag());
     test_transform_binary_exception(par, IteratorTag());
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary2.cpp
@@ -19,6 +19,7 @@ void test_transform_binary2()
 {
     using namespace hpx::execution;
 
+    test_transform_binary2(IteratorTag());
     test_transform_binary2(seq, IteratorTag());
     test_transform_binary2(par, IteratorTag());
     test_transform_binary2(par_unseq, IteratorTag());
@@ -42,6 +43,7 @@ void test_transform_binary2_exception()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_transform_binary2_exception(IteratorTag());
     test_transform_binary2_exception(seq, IteratorTag());
     test_transform_binary2_exception(par, IteratorTag());
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary2_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary2_tests.hpp
@@ -46,6 +46,43 @@ struct throw_bad_alloc
 };
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_binary2(IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c1(10007);
+    std::vector<int> c2(c1.size());
+    std::vector<int> d1(c1.size());    //-V656
+    std::iota(std::begin(c1), std::end(c1),
+        std::rand() % ((std::numeric_limits<int>::max)() / 2));
+    std::iota(std::begin(c2), std::end(c2),
+        std::rand() % ((std::numeric_limits<int>::max)() / 2));
+
+    auto result =
+        hpx::ranges::transform(iterator(std::begin(c1)), iterator(std::end(c1)),
+            std::begin(c2), std::end(c2), std::begin(d1), add());
+
+    HPX_TEST(result.in1 == iterator(std::end(c1)));
+    HPX_TEST(result.in2 == std::end(c2));
+    HPX_TEST(result.out == std::end(d1));
+
+    // verify values
+    std::vector<int> d2(c1.size());
+    std::transform(
+        std::begin(c1), std::end(c1), std::begin(c2), std::begin(d2), add());
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(d1), std::end(d1), std::begin(d2),
+        [&count](int v1, int v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d2.size());
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary2(ExPolicy policy, IteratorTag)
 {
@@ -63,13 +100,13 @@ void test_transform_binary2(ExPolicy policy, IteratorTag)
     std::iota(std::begin(c2), std::end(c2),
         std::rand() % ((std::numeric_limits<int>::max)() / 2));
 
-    auto result = hpx::parallel::transform(policy, iterator(std::begin(c1)),
+    auto result = hpx::ranges::transform(policy, iterator(std::begin(c1)),
         iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(d1),
         add());
 
-    HPX_TEST(hpx::get<0>(result) == iterator(std::end(c1)));
-    HPX_TEST(hpx::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::get<2>(result) == std::end(d1));
+    HPX_TEST(result.in1 == iterator(std::end(c1)));
+    HPX_TEST(result.in2 == std::end(c2));
+    HPX_TEST(result.out == std::end(d1));
 
     // verify values
     std::vector<int> d2(c1.size());
@@ -100,15 +137,15 @@ void test_transform_binary2_async(ExPolicy p, IteratorTag)
     std::iota(std::begin(c2), std::end(c2),
         std::rand() % ((std::numeric_limits<int>::max)() / 2));
 
-    auto f = hpx::parallel::transform(p, iterator(std::begin(c1)),
+    auto f = hpx::ranges::transform(p, iterator(std::begin(c1)),
         iterator(std::end(c1)), std::begin(c2), std::end(c2), std::begin(d1),
         add());
     f.wait();
 
-    hpx::tuple<iterator, base_iterator, base_iterator> result = f.get();
-    HPX_TEST(hpx::get<0>(result) == iterator(std::end(c1)));
-    HPX_TEST(hpx::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::get<2>(result) == std::end(d1));
+    auto result = f.get();
+    HPX_TEST(result.in1 == iterator(std::end(c1)));
+    HPX_TEST(result.in2 == std::end(c2));
+    HPX_TEST(result.out == std::end(d1));
 
     // verify values
     std::vector<int> d2(c1.size());
@@ -126,6 +163,40 @@ void test_transform_binary2_async(ExPolicy p, IteratorTag)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_binary2_exception(IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c1(10007);
+    std::vector<int> c2(c1.size());
+    std::vector<int> d1(c1.size());    //-V656
+    std::iota(std::begin(c1), std::end(c1), std::rand());
+    std::iota(std::begin(c2), std::end(c2), std::rand());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::ranges::transform(iterator(std::begin(c1)), iterator(std::end(c1)),
+            std::begin(c2), std::end(c2), std::begin(d1), throw_always());
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary2_exception(ExPolicy policy, IteratorTag)
 {
@@ -144,7 +215,7 @@ void test_transform_binary2_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::transform(policy, iterator(std::begin(c1)),
+        hpx::ranges::transform(policy, iterator(std::begin(c1)),
             iterator(std::end(c1)), std::begin(c2), std::end(c2),
             std::begin(d1), throw_always());
 
@@ -179,7 +250,7 @@ void test_transform_binary2_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::transform(p, iterator(std::begin(c1)),
+        auto f = hpx::ranges::transform(p, iterator(std::begin(c1)),
             iterator(std::end(c1)), std::begin(c2), std::end(c2),
             std::begin(d1), throw_always());
         returned_from_algorithm = true;
@@ -220,7 +291,7 @@ void test_transform_binary2_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::transform(policy, iterator(std::begin(c1)),
+        hpx::ranges::transform(policy, iterator(std::begin(c1)),
             iterator(std::end(c1)), std::begin(c2), std::end(c2),
             std::begin(d1), throw_bad_alloc());
 
@@ -254,7 +325,7 @@ void test_transform_binary2_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::transform(p, iterator(std::begin(c1)),
+        auto f = hpx::ranges::transform(p, iterator(std::begin(c1)),
             iterator(std::end(c1)), std::begin(c2), std::end(c2),
             std::begin(d1), throw_bad_alloc());
         returned_from_algorithm = true;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary2_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary2_tests.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2016 Hartmut Kaiser
+//  Copyright (c) 2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary_tests.hpp
@@ -46,6 +46,40 @@ struct throw_bad_alloc
 };
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_binary(IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c1(10007);
+    std::vector<int> c2(c1.size());
+    std::vector<int> d1(c1.size());    //-V656
+    std::iota(std::begin(c1), std::end(c1),
+        std::rand() % ((std::numeric_limits<int>::max)() / 2));
+    std::iota(std::begin(c2), std::end(c2),
+        std::rand() % ((std::numeric_limits<int>::max)() / 2));
+
+    auto result = hpx::transform(iterator(std::begin(c1)),
+        iterator(std::end(c1)), std::begin(c2), std::begin(d1), add());
+
+    HPX_TEST(result == std::end(d1));
+
+    // verify values
+    std::vector<int> d2(c1.size());
+    std::transform(
+        std::begin(c1), std::end(c1), std::begin(c2), std::begin(d2), add());
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(d1), std::end(d1), std::begin(d2),
+        [&count](int v1, int v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d2.size());
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary(ExPolicy policy, IteratorTag)
 {
@@ -63,12 +97,10 @@ void test_transform_binary(ExPolicy policy, IteratorTag)
     std::iota(std::begin(c2), std::end(c2),
         std::rand() % ((std::numeric_limits<int>::max)() / 2));
 
-    auto result = hpx::parallel::transform(policy, iterator(std::begin(c1)),
+    auto result = hpx::transform(policy, iterator(std::begin(c1)),
         iterator(std::end(c1)), std::begin(c2), std::begin(d1), add());
 
-    HPX_TEST(hpx::get<0>(result) == iterator(std::end(c1)));
-    HPX_TEST(hpx::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::get<2>(result) == std::end(d1));
+    HPX_TEST(result == std::end(d1));
 
     // verify values
     std::vector<int> d2(c1.size());
@@ -99,14 +131,12 @@ void test_transform_binary_async(ExPolicy p, IteratorTag)
     std::iota(std::begin(c2), std::end(c2),
         std::rand() % ((std::numeric_limits<int>::max)() / 2));
 
-    auto f = hpx::parallel::transform(p, iterator(std::begin(c1)),
-        iterator(std::end(c1)), std::begin(c2), std::begin(d1), add());
+    auto f = hpx::transform(p, iterator(std::begin(c1)), iterator(std::end(c1)),
+        std::begin(c2), std::begin(d1), add());
     f.wait();
 
-    hpx::tuple<iterator, base_iterator, base_iterator> result = f.get();
-    HPX_TEST(hpx::get<0>(result) == iterator(std::end(c1)));
-    HPX_TEST(hpx::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::get<2>(result) == std::end(d1));
+    auto result = f.get();
+    HPX_TEST(result == std::end(d1));
 
     // verify values
     std::vector<int> d2(c1.size());
@@ -124,6 +154,40 @@ void test_transform_binary_async(ExPolicy p, IteratorTag)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_binary_exception(IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c1(10007);
+    std::vector<int> c2(c1.size());
+    std::vector<int> d1(c1.size());    //-V656
+    std::iota(std::begin(c1), std::end(c1), std::rand());
+    std::iota(std::begin(c2), std::end(c2), std::rand());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::transform(iterator(std::begin(c1)), iterator(std::end(c1)),
+            std::begin(c2), std::begin(d1), throw_always());
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary_exception(ExPolicy policy, IteratorTag)
 {
@@ -142,9 +206,8 @@ void test_transform_binary_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::transform(policy, iterator(std::begin(c1)),
-            iterator(std::end(c1)), std::begin(c2), std::begin(d1),
-            throw_always());
+        hpx::transform(policy, iterator(std::begin(c1)), iterator(std::end(c1)),
+            std::begin(c2), std::begin(d1), throw_always());
 
         HPX_TEST(false);
     }
@@ -177,9 +240,9 @@ void test_transform_binary_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::transform(p, iterator(std::begin(c1)),
-            iterator(std::end(c1)), std::begin(c2), std::begin(d1),
-            throw_always());
+        auto f =
+            hpx::transform(p, iterator(std::begin(c1)), iterator(std::end(c1)),
+                std::begin(c2), std::begin(d1), throw_always());
         returned_from_algorithm = true;
         f.get();
 
@@ -218,9 +281,8 @@ void test_transform_binary_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::transform(policy, iterator(std::begin(c1)),
-            iterator(std::end(c1)), std::begin(c2), std::begin(d1),
-            throw_bad_alloc());
+        hpx::transform(policy, iterator(std::begin(c1)), iterator(std::end(c1)),
+            std::begin(c2), std::begin(d1), throw_bad_alloc());
 
         HPX_TEST(false);
     }
@@ -252,9 +314,9 @@ void test_transform_binary_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::transform(p, iterator(std::begin(c1)),
-            iterator(std::end(c1)), std::begin(c2), std::begin(d1),
-            throw_bad_alloc());
+        auto f =
+            hpx::transform(p, iterator(std::begin(c1)), iterator(std::end(c1)),
+                std::begin(c2), std::begin(d1), throw_bad_alloc());
         returned_from_algorithm = true;
         f.get();
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_binary_tests.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2016 Hartmut Kaiser
+//  Copyright (c) 2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_tests.hpp
@@ -46,6 +46,31 @@ struct throw_bad_alloc
 };
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform(IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c(10007);
+    std::vector<int> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    auto result = hpx::transform(iterator(std::begin(c)), iterator(std::end(c)),
+        std::begin(d), add_one());
+    HPX_TEST(result == std::end(d));
+
+    // verify values
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1 + 1, v2);
+            ++count;
+            return v1 + 1 == v2;
+        }));
+    HPX_TEST_EQ(count, d.size());
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_transform(ExPolicy policy, IteratorTag)
 {
@@ -59,11 +84,10 @@ void test_transform(ExPolicy policy, IteratorTag)
     std::vector<int> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
 
-    auto result = hpx::parallel::transform(policy, iterator(std::begin(c)),
+    auto result = hpx::transform(policy, iterator(std::begin(c)),
         iterator(std::end(c)), std::begin(d), add_one());
 
-    HPX_TEST(hpx::get<0>(result) == iterator(std::end(c)));
-    HPX_TEST(hpx::get<1>(result) == std::end(d));
+    HPX_TEST(result == std::end(d));
 
     // verify values
     std::size_t count = 0;
@@ -86,13 +110,12 @@ void test_transform_async(ExPolicy p, IteratorTag)
     std::vector<int> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
 
-    auto f = hpx::parallel::transform(p, iterator(std::begin(c)),
-        iterator(std::end(c)), std::begin(d), add_one());
+    auto f = hpx::transform(p, iterator(std::begin(c)), iterator(std::end(c)),
+        std::begin(d), add_one());
     f.wait();
 
-    hpx::tuple<iterator, base_iterator> result = f.get();
-    HPX_TEST(hpx::get<0>(result) == iterator(std::end(c)));
-    HPX_TEST(hpx::get<1>(result) == std::end(d));
+    auto result = f.get();
+    HPX_TEST(result == std::end(d));
 
     // verify values
     std::size_t count = 0;
@@ -106,6 +129,38 @@ void test_transform_async(ExPolicy p, IteratorTag)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_exception(IteratorTag)
+{
+    typedef std::vector<int>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<int> c(10007);
+    std::vector<int> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::transform(iterator(std::begin(c)), iterator(std::end(c)),
+            std::begin(d), throw_always());
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_exception(ExPolicy policy, IteratorTag)
 {
@@ -122,8 +177,8 @@ void test_transform_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::transform(policy, iterator(std::begin(c)),
-            iterator(std::end(c)), std::begin(d), throw_always());
+        hpx::transform(policy, iterator(std::begin(c)), iterator(std::end(c)),
+            std::begin(d), throw_always());
 
         HPX_TEST(false);
     }
@@ -154,7 +209,7 @@ void test_transform_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::transform(p, iterator(std::begin(c)),
+        auto f = hpx::transform(p, iterator(std::begin(c)),
             iterator(std::end(c)), std::begin(d), throw_always());
         returned_from_algorithm = true;
         f.get();
@@ -192,8 +247,8 @@ void test_transform_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::transform(policy, iterator(std::begin(c)),
-            iterator(std::end(c)), std::begin(d), throw_bad_alloc());
+        hpx::transform(policy, iterator(std::begin(c)), iterator(std::end(c)),
+            std::begin(d), throw_bad_alloc());
 
         HPX_TEST(false);
     }
@@ -223,7 +278,7 @@ void test_transform_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::transform(p, iterator(std::begin(c)),
+        auto f = hpx::transform(p, iterator(std::begin(c)),
             iterator(std::end(c)), std::begin(d), throw_bad_alloc());
         returned_from_algorithm = true;
         f.get();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/transform_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/transform_tests.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2016 Hartmut Kaiser
+//  Copyright (c) 2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -85,7 +85,7 @@ set(tests
     sort_range
     stable_sort_range
     transform_range
-    transform_range_binary
+    transform_range2
     transform_range_binary2
     transform_reduce_binary_bad_alloc_range
     transform_reduce_binary_exception_range

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -85,6 +85,7 @@ set(tests
     sort_range
     stable_sort_range
     transform_range
+    transform_range_binary
     transform_range2
     transform_range_binary2
     transform_reduce_binary_bad_alloc_range
@@ -95,11 +96,13 @@ set(tests
     unique_copy_range
 )
 
+set(transform_range_binary_FLAGS COMPILE_FLAGS
+                                 -DHPX_HAVE_DEPRECATION_WARNINGS_V1_6=0
+)
 foreach(test ${tests})
   set(sources ${test}.cpp)
 
   set(${test}_PARAMETERS THREADS_PER_LOCALITY 4)
-
   source_group("Source Files" FILES ${sources})
 
   # add example executable

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range.cpp
@@ -23,9 +23,6 @@
 template <typename IteratorTag>
 void test_transform(IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
 
     test_vector c(10007);

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range2.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2020 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -32,8 +32,8 @@ void test_transform(IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
 
-    auto result = hpx::ranges::transform(
-        c, std::begin(d), [](std::size_t v) { return v + 1; });
+    auto result = hpx::ranges::transform(std::begin(c), std::end(c),
+        std::begin(d), [](std::size_t v) { return v + 1; });
 
     HPX_TEST(result.in == std::end(c));
     HPX_TEST(result.out == std::end(d));
@@ -61,8 +61,8 @@ void test_transform(ExPolicy policy, IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
 
-    auto result = hpx::ranges::transform(
-        policy, c, std::begin(d), [](std::size_t v) { return v + 1; });
+    auto result = hpx::ranges::transform(policy, std::begin(c), std::end(c),
+        std::begin(d), [](std::size_t v) { return v + 1; });
 
     HPX_TEST(result.in == std::end(c));
     HPX_TEST(result.out == std::end(d));
@@ -88,8 +88,8 @@ void test_transform_async(ExPolicy p, IteratorTag)
     std::vector<std::size_t> d(c.size());
     std::iota(std::begin(c), std::end(c), std::rand());
 
-    auto f = hpx::ranges::transform(
-        p, c, std::begin(d), [](std::size_t& v) { return v + 1; });
+    auto f = hpx::ranges::transform(p, std::begin(c), std::end(c),
+        std::begin(d), [](std::size_t& v) { return v + 1; });
     f.wait();
 
     auto result = f.get();
@@ -385,11 +385,7 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    hpx::init_params init_args;
-    init_args.desc_cmdline = desc_commandline;
-    init_args.cfg = cfg;
-
-    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range2.cpp
@@ -23,9 +23,6 @@
 template <typename IteratorTag>
 void test_transform(IteratorTag)
 {
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
     typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
 
     test_vector c(10007);
@@ -385,7 +382,11 @@ int main(int argc, char* argv[])
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
     // Initialize and run HPX
-    HPX_TEST_EQ_MSG(hpx::init(desc_commandline, argc, argv, cfg), 0,
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
         "HPX main exited with non-zero status");
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary.cpp
@@ -39,9 +39,9 @@ void test_transform_binary(ExPolicy policy, IteratorTag)
     auto result = hpx::parallel::transform(
         policy, c1, std::begin(c2), std::begin(d1), add);
 
-    HPX_TEST(result.in1() == std::end(c1));
-    HPX_TEST(result.in2() == std::end(c2));
-    HPX_TEST(result.out() == std::end(d1));
+    HPX_TEST(result.in1 == std::end(c1));
+    HPX_TEST(result.in2 == std::end(c2));
+    HPX_TEST(result.out == std::end(d1));
 
     // verify values
     std::vector<std::size_t> d2(c1.size());
@@ -76,9 +76,10 @@ void test_transform_binary_async(ExPolicy p, IteratorTag)
     f.wait();
 
     auto result = f.get();
-    HPX_TEST(hpx::get<0>(result) == std::end(c1));
-    HPX_TEST(hpx::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::get<2>(result) == std::end(d1));
+
+    HPX_TEST(result.in1 == std::end(c1));
+    HPX_TEST(result.in2 == std::end(c2));
+    HPX_TEST(result.out == std::end(d1));
 
     // verify values
     std::vector<std::size_t> d2(c1.size());

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary2.cpp
@@ -20,6 +20,40 @@
 #include "test_utils.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_binary(IteratorTag)
+{
+    typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
+
+    test_vector c1(10007);
+    test_vector c2(10007);
+    std::vector<std::size_t> d1(c1.size());    //-V656
+    std::iota(std::begin(c1), std::end(c1), std::rand());
+    std::iota(std::begin(c2), std::end(c2), std::rand());
+
+    auto add = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
+
+    auto result = hpx::ranges::transform(c1, c2, std::begin(d1), add);
+
+    HPX_TEST(result.in1 == std::end(c1));
+    HPX_TEST(result.in2 == std::end(c2));
+    HPX_TEST(result.out == std::end(d1));
+
+    // verify values
+    std::vector<std::size_t> d2(c1.size());
+    std::transform(
+        std::begin(c1), std::end(c1), std::begin(c2), std::begin(d2), add);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(d1), std::end(d1), std::begin(d2),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d2.size());
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary(ExPolicy policy, IteratorTag)
 {
@@ -36,11 +70,11 @@ void test_transform_binary(ExPolicy policy, IteratorTag)
 
     auto add = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
 
-    auto result = hpx::parallel::transform(policy, c1, c2, std::begin(d1), add);
+    auto result = hpx::ranges::transform(policy, c1, c2, std::begin(d1), add);
 
-    HPX_TEST(hpx::get<0>(result) == std::end(c1));
-    HPX_TEST(hpx::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::get<2>(result) == std::end(d1));
+    HPX_TEST(result.in1 == std::end(c1));
+    HPX_TEST(result.in2 == std::end(c2));
+    HPX_TEST(result.out == std::end(d1));
 
     // verify values
     std::vector<std::size_t> d2(c1.size());
@@ -70,13 +104,13 @@ void test_transform_binary_async(ExPolicy p, IteratorTag)
 
     auto add = [](std::size_t v1, std::size_t v2) { return v1 + v2; };
 
-    auto f = hpx::parallel::transform(p, c1, c2, std::begin(d1), add);
+    auto f = hpx::ranges::transform(p, c1, c2, std::begin(d1), add);
     f.wait();
 
     auto result = f.get();
-    HPX_TEST(hpx::get<0>(result) == std::end(c1));
-    HPX_TEST(hpx::get<1>(result) == std::end(c2));
-    HPX_TEST(hpx::get<2>(result) == std::end(d1));
+    HPX_TEST(result.in1 == std::end(c1));
+    HPX_TEST(result.in2 == std::end(c2));
+    HPX_TEST(result.out == std::end(d1));
 
     // verify values
     std::vector<std::size_t> d2(c1.size());
@@ -98,6 +132,7 @@ void test_transform_binary()
 {
     using namespace hpx::execution;
 
+    test_transform_binary(IteratorTag());
     test_transform_binary(seq, IteratorTag());
     test_transform_binary(par, IteratorTag());
     test_transform_binary(par_unseq, IteratorTag());
@@ -113,6 +148,44 @@ void transform_binary_test()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_transform_binary_exception(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c1(10007);
+    std::vector<std::size_t> c2(c1.size());
+    std::vector<std::size_t> d1(c1.size());    //-V656
+    std::iota(std::begin(c1), std::end(c1), std::rand());
+    std::iota(std::begin(c2), std::end(c2), std::rand());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::ranges::transform(
+            hpx::util::make_iterator_range(
+                iterator(std::begin(c1)), iterator(std::end(c1))),
+            c2, std::begin(d1), [](std::size_t v1, std::size_t v2) {
+                return throw std::runtime_error("test"), v1 + v2;
+            });
+
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_transform_binary_exception(ExPolicy policy, IteratorTag)
 {
@@ -131,7 +204,7 @@ void test_transform_binary_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::transform(policy,
+        hpx::ranges::transform(policy,
             hpx::util::make_iterator_range(
                 iterator(std::begin(c1)), iterator(std::end(c1))),
             hpx::util::make_iterator_range(std::begin(c2), std::end(c2)),
@@ -170,7 +243,7 @@ void test_transform_binary_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::transform(p,
+        auto f = hpx::ranges::transform(p,
             hpx::util::make_iterator_range(
                 iterator(std::begin(c1)), iterator(std::end(c1))),
             hpx::util::make_iterator_range(std::begin(c2), std::end(c2)),
@@ -204,6 +277,7 @@ void test_transform_binary_exception()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_transform_binary_exception(IteratorTag());
     test_transform_binary_exception(seq, IteratorTag());
     test_transform_binary_exception(par, IteratorTag());
 
@@ -236,7 +310,7 @@ void test_transform_binary_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::transform(policy,
+        hpx::ranges::transform(policy,
             hpx::util::make_iterator_range(
                 iterator(std::begin(c1)), iterator(std::end(c1))),
             hpx::util::make_iterator_range(std::begin(c2), std::end(c2)),
@@ -274,7 +348,7 @@ void test_transform_binary_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::transform(p,
+        auto f = hpx::ranges::transform(p,
             hpx::util::make_iterator_range(
                 iterator(std::begin(c1)), iterator(std::end(c1))),
             hpx::util::make_iterator_range(std::begin(c2), std::end(c2)),

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary2.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/transform_range_binary2.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/tests/performance/local/stream.cpp
+++ b/tests/performance/local/stream.cpp
@@ -327,7 +327,7 @@ std::vector<std::vector<double>> run_benchmark(std::size_t iterations,
 
     // Check clock ticks ...
     double t = mysecond();
-    hpx::parallel::transform(
+    hpx::transform(
         policy, a.begin(), a.end(), a.begin(), multiply_step<STREAM_TYPE>(2.0));
     t = 1.0E6 * (mysecond() - t);
 
@@ -387,19 +387,19 @@ std::vector<std::vector<double>> run_benchmark(std::size_t iterations,
 
         // Scale
         timing[1][iteration] = mysecond();
-        hpx::parallel::transform(policy, c.begin(), c.end(), b.begin(),
+        hpx::transform(policy, c.begin(), c.end(), b.begin(),
             multiply_step<STREAM_TYPE>(scalar));
         timing[1][iteration] = mysecond() - timing[1][iteration];
 
         // Add
         timing[2][iteration] = mysecond();
-        hpx::parallel::transform(policy, a.begin(), a.end(), b.begin(), b.end(),
+        hpx::ranges::transform(policy, a.begin(), a.end(), b.begin(), b.end(),
             c.begin(), add_step<STREAM_TYPE>());
         timing[2][iteration] = mysecond() - timing[2][iteration];
 
         // Triad
         timing[3][iteration] = mysecond();
-        hpx::parallel::transform(policy, b.begin(), b.end(), c.begin(), c.end(),
+        hpx::ranges::transform(policy, b.begin(), b.end(), c.begin(), c.end(),
             a.begin(), triad_step<STREAM_TYPE>(scalar));
         timing[3][iteration] = mysecond() - timing[3][iteration];
     }


### PR DESCRIPTION
This adapts `transform` to C++20 (all overloads according to [the Standard](http://eel.is/c++draft/alg.transform)) and adds unit tests. It deprecates the `hpx::parallel::transform` overloads.

flyby: it adds `get_in_in_out_result`. 