### PR TITLE
Fix typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,7 @@ We would also like to thank the following organizations for granting us
 allocations of their compute resources: LSU HPC, LONI, XSEDE, NERSC, ORNL,
 CSCS/ETHZ, and the Gauss Center for Supercomputing.
 
-HPX is has been funded by:
+HPX has been funded by:
 
 * The National Science Foundation through awards 1117470 (APX), 1160602 (PXGL),
   1240655 (STAR), 1447831 (PXFS), 1339782 (STORM), and 1737785 (Phylanx).

--- a/README.rst
+++ b/README.rst
@@ -136,63 +136,8 @@ to the latest release of HPX please use: |zenodo_doi|.
 Acknowledgements
 ================
 
-We would like to acknowledge the NSF, DoE, DTIC, DARPA, the Center for
-Computation and Technology (CCT) at Louisiana State University, the Swiss
-National Supercomputing Centre (CSCS), and the
-Department of Computer Science 3 - Computer Architecture at the University of
-Erlangen Nuremberg who fund and support our work.
-
-We would also like to thank the following organizations for granting us
-allocations of their compute resources: LSU HPC, LONI, XSEDE, NERSC, ORNL,
-CSCS/ETHZ, and the Gauss Center for Supercomputing.
-
-HPX has been funded by:
-
-* The National Science Foundation through awards 1117470 (APX), 1160602 (PXGL),
-  1240655 (STAR), 1447831 (PXFS), 1339782 (STORM), and 1737785 (Phylanx).
-
-  Any opinions, findings, and conclusions or recommendations expressed in this
-  material are those of the author(s) and do not necessarily reflect the views
-  of the National Science Foundation.
-
-* The Department of Energy (DoE) through the awards DE-SC0008714 (XPRESS),
-  DE-AC52-06NA25396 (FLeCSI), and DE-NA0003525 (Resilience).
-
-  This work is partially supported by the Scientific Discovery through Advanced
-  Computing (SciDAC) program funded by U.S. DOE, Office of Science, Advanced
-  Computing Scientific Computing Research (ASCR) and Basic Energy Sciences (BES),
-  Division of Materials Science and Engineering.
-
-  This research used resources of the Oak Ridge Leadership Computing Facility
-  at the Oak Ridge National Laboratory, which is supported by the Office of
-  Science of the U.S. Department of Energy under Contract No. DE-AC05-00OR22725.
-
-  Neither the United States Government nor any agency thereof, nor any of their
-  employees makes any warranty, express or implied, or assumes any legal
-  liability or responsibility for the accuracy, completeness, or usefulness of
-  any information, apparatus, product, or process disclosed, or represents that
-  its use would not infringe privately owned rights. Reference herein to any
-  specific commercial product, process, or service by trade name, trademark,
-  manufacturer, or otherwise does not necessarily constitute or imply its
-  endorsement, recommendation, or favoring by the United States Government or
-  any agency thereof. The views and opinions of authors expressed herein do not
-  necessarily state or reflect those of the United States Government or any
-  agency thereof.
-
-* The Defense Technical Information Center (DTIC) under contract
-  FA8075-14-D-0002/0007
-
-  Neither the United States Government nor any agency thereof, nor any of their
-  employees makes any warranty, express or implied, or assumes any legal
-  liability or responsibility for the accuracy, completeness, or usefulness of
-  any information, apparatus, product, or process disclosed, or represents that
-  its use would not infringe privately owned rights.
-
-* The Bavarian Research Foundation (Bayerische Forschungsstiftung) through the
-  grant AZ-987-11.
-
-* The European Commission's Horizon 2020 programme through the grant
-  H2020-EU.1.2.2. 671603 (AllScale).
+Past and current funding and support for HPX is listed `here
+<https://hpx.stellar-group.org/funding-acknowledgements>`_
 
 .. |circleci_status| image:: https://circleci.com/gh/STEllAR-GROUP/hpx/tree/master.svg?style=svg
      :target: https://circleci.com/gh/STEllAR-GROUP/hpx/tree/master

--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -196,7 +196,9 @@ rst_prolog += '''
 .. |cpplang_slack| replace:: Cpplang Slack
 .. _cpplang_slack: https://cpplang.slack.com
 .. |stellar_hpx_download| replace:: |hpx| Downloads
-.. _stellar_hpx_download: https://stellar-group.org/downloads/
+.. _stellar_hpx_download: https://hpx.stellar-group.org/downloads/
+.. |stellar_hpx_funding| replace:: |hpx| Funding Acknowledgements
+.. _stellar_hpx_funding: https://hpx.stellar-group.org/funding-acknowledgements/
 .. |hpx_github| replace:: Github
 .. _hpx_github: https://github.com/STEllAR-GROUP/hpx/
 .. |hpx_github_issues| replace:: |hpx| Issues

--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -199,6 +199,8 @@ rst_prolog += '''
 .. _stellar_hpx_download: https://hpx.stellar-group.org/downloads/
 .. |stellar_hpx_funding| replace:: |hpx| Funding Acknowledgements
 .. _stellar_hpx_funding: https://hpx.stellar-group.org/funding-acknowledgements/
+.. |stellar_hpx_users| replace:: |hpx| Users
+.. _stellar_hpx_users: https://hpx.stellar-group.org/hpx-users/
 .. |hpx_github| replace:: Github
 .. _hpx_github: https://github.com/STEllAR-GROUP/hpx/
 .. |hpx_github_issues| replace:: |hpx| Issues

--- a/docs/sphinx/about_hpx/people.rst
+++ b/docs/sphinx/about_hpx/people.rst
@@ -257,40 +257,4 @@ the project through discussions, pull requests, documentation patches, etc.
   Jeff Trull, Yuri Victorovich, and Gregor Daiß who contributed to the general
   improvement of |hpx|.
 
-In addition to the people who worked directly with |hpx| development we would
-like to acknowledge the NSF, DoE, DARPA, |cct|_, |inf3|_, and |cscs|_ who fund
-and support our work. We would also like to thank the following organizations
-for granting us allocations of their compute resources: LSU HPC, LONI, XSEDE,
-NERSC, and the Gauss Center for Supercomputing.
-
-|hpx| is currently funded by the following grants:
-
-* The National Science Foundation through awards 1240655 (STAR),
-  1339782 (STORM), and 1737785 (Phylanx). Any opinions,
-  findings, and conclusions or recommendations expressed in this material are
-  those of the author(s) and do not necessarily reflect the views of the
-  National Science Foundation.
-* The Department of Energy (DoE) through the awards
-  DE-AC52-06NA25396 (FLeCSI) and DE-NA0003525 (Resilience).
-  Neither the United States Government nor any agency thereof, nor any of their
-  employees, makes any warranty, express or implied, or assumes any legal
-  liability or responsibility for the accuracy, completeness, or usefulness of
-  any information, apparatus, product, or process disclosed, or represents that
-  its use would not infringe privately owned rights. Reference herein to any
-  specific commercial product, process, or service by trade name, trademark,
-  manufacturer, or otherwise does not necessarily constitute or imply its
-  endorsement, recommendation, or favoring by the United States Government or
-  any agency thereof. The views and opinions of authors expressed herein do not
-  necessarily state or reflect those of the United States Government or any
-  agency thereof.
-* The Defense Technical Information Center (DTIC) under contract
-  FA8075-14-D-0002/0007.
-  Neither the United States Government nor any agency thereof, nor any of
-  their employees makes any warranty, express or implied, or assumes any
-  legal liability or responsibility for the accuracy, completeness, or
-  usefulness of any information, apparatus, product, or process disclosed,
-  or represents that its use would not infringe privately owned rights.
-* The Bavarian Research Foundation (Bayerische Forschungsstfitung) through the
-  grant AZ-987-11.
-* The European Commission's Horizon 2020 programme through the grant
-  H2020-EU.1.2.2. 671603 (AllScale).
+|stellar_hpx_funding|_ lists current and past funding sources for |hpx|.

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -25,7 +25,8 @@ If you can't find what you're looking for in the documentation, please:
 * read or ask questions tagged with |hpx| on `StackOverflow
   <hpx_stackoverflow_>`_.
 
-See :ref:`citing_hpx` for details on how to cite |hpx| in publications.
+See :ref:`citing_hpx` for details on how to cite |hpx| in publications. See
+:ref:`hpx_users` for a list of institutions and projects using |hpx|.
 
 What is |hpx|?
 ==============
@@ -106,6 +107,7 @@ What's so special about |hpx|?
 
    releases
    citing
+   users
    about_hpx
 
 

--- a/docs/sphinx/users.rst
+++ b/docs/sphinx/users.rst
@@ -1,0 +1,15 @@
+..
+    Copyright (C) 2020 ETH Zurich
+
+    SPDX-License-Identifier: BSL-1.0
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+.. _hpx_users:
+
+===========
+|hpx| users
+===========
+
+A list of institutions and projects using |hpx| can be found on the
+|stellar_hpx_users|_ page.


### PR DESCRIPTION
` HPX is has been funded by`

Should read

`HPX has been funded by`

