### PR TITLE
Fix hpx::util::get

### DIFF
--- a/libs/core/datastructures/include/hpx/datastructures/tuple.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/tuple.hpp
@@ -142,7 +142,7 @@ namespace hpx {
                                         UTuple>::type>::value ==
                 util::pack<Ts...>::size>::type>
           : util::all_of<std::is_convertible<
-                decltype(get<Is>(std::declval<UTuple>())), Ts>...>
+                decltype(hpx::get<Is>(std::declval<UTuple>())), Ts>...>
         {
         };
 
@@ -1072,13 +1072,13 @@ namespace hpx { namespace util {
         return hpx::tuple_cat(std::forward<Ts>(vs)...);
     }
 
-    template <typename... Ts>
+    template <std::size_t I, typename Tuple>
     HPX_DEPRECATED_V(1, 6,
         "hpx::util::get is deprecated. Use hpx::get "
         "instead.")
-    constexpr HPX_HOST_DEVICE HPX_FORCEINLINE auto get(Ts&&... vs)
+    constexpr HPX_HOST_DEVICE HPX_FORCEINLINE auto get(Tuple&& tuple)
     {
-        return hpx::get(std::forward<Ts>(vs)...);
+        return hpx::get<I>(std::forward<Tuple>(tuple));
     }
 }}    // namespace hpx::util
 

--- a/libs/core/datastructures/include/hpx/datastructures/variant_helper.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/variant_helper.hpp
@@ -16,7 +16,7 @@
 #include <utility>
 #include <variant>
 
-namespace hpx { namespace util {
+namespace hpx {
 
     // This is put into the same embedded namespace as the implementations in
     // tuple.hpp
@@ -55,7 +55,7 @@ namespace hpx { namespace util {
         }
     }    // namespace adl_barrier
 
-    using hpx::util::adl_barrier::get;
-}}    // namespace hpx::util
+    using hpx::adl_barrier::get;
+}    // namespace hpx
 
 #endif


### PR DESCRIPTION
The deprecated forwarding definition was... not right.