### PR TITLE
Troubleshoot jenkins jobs not starting

### DIFF
--- a/.jenkins/lsu/entry.sh
+++ b/.jenkins/lsu/entry.sh
@@ -39,6 +39,8 @@ sbatch \
     --error="jenkins-hpx-${configuration_name_with_build_type}.err" \
     --wait .jenkins/lsu/batch.sh
 
+echo "last command: $?"
+
 # Print slurm logs
 echo "= stdout =================================================="
 cat jenkins-hpx-${configuration_name_with_build_type}.out


### PR DESCRIPTION
Some jenkins jobs like clang-7-debug do not start on rostam, I'm opening this to try to figure out the pb