### PR TITLE
Remove hipcc guards in examples and tests

### DIFF
--- a/components/iostreams/include/hpx/iostream.hpp
+++ b/components/iostreams/include/hpx/iostream.hpp
@@ -9,7 +9,5 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/components/iostreams/standard_streams.hpp>
 #include <hpx/include/components.hpp>
-#endif

--- a/examples/async_io/async_io_external.cpp
+++ b/examples/async_io/async_io_external.cpp
@@ -8,8 +8,6 @@
 // schedule an IO task onto an external OS-thread in HPX and how to
 // synchronize the result of this IO task with a waiting HPX thread.
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/runtime.hpp>
 #include <hpx/iostream.hpp>
@@ -110,5 +108,3 @@ int main(int argc, char* argv[])
 {
     return hpx::init(argc, argv); // Initialize and run HPX.
 }
-
-#endif

--- a/examples/async_io/async_io_low_level.cpp
+++ b/examples/async_io/async_io_low_level.cpp
@@ -8,8 +8,6 @@
 // schedule an IO task onto one of the IO-threads in HPX (which are OS-threads)
 // and how to synchronize the result of this IO task with a waiting HPX thread.
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/runtime.hpp>
 #include <hpx/include/util.hpp>
@@ -70,4 +68,3 @@ int main(int argc, char* argv[])
 {
     return hpx::init(argc, argv); // Initialize and run HPX.
 }
-#endif

--- a/examples/async_io/async_io_simple.cpp
+++ b/examples/async_io/async_io_simple.cpp
@@ -8,8 +8,6 @@
 // schedule an IO task onto one of the IO-threads in HPX (which are OS-threads)
 // and how to synchronize the result of this IO task with a waiting HPX thread.
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_init.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/include/parallel_executors.hpp>
@@ -68,4 +66,3 @@ int main(int argc, char* argv[])
 {
     return hpx::init(argc, argv);    // Initialize and run HPX.
 }
-#endif

--- a/examples/balancing/os_thread_num.cpp
+++ b/examples/balancing/os_thread_num.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 
@@ -159,5 +157,3 @@ int main(int argc, char* argv[])
 
     return hpx::init(argc, argv, init_args);
 }
-
-#endif

--- a/examples/future_reduce/rnd_future_reduce.cpp
+++ b/examples/future_reduce/rnd_future_reduce.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_init.hpp>
 
 #include <hpx/future.hpp>
@@ -122,5 +120,3 @@ int main(int argc, char* argv[])
   // Initialize and run HPX.
   return hpx::init(argc, argv);
 }
-
-#endif

--- a/examples/quickstart/allow_unknown_options.cpp
+++ b/examples/quickstart/allow_unknown_options.cpp
@@ -8,8 +8,6 @@
 // line alias handling and to allow for unknown options to be passed through
 // to hpx_main.
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_init.hpp>
 #include <hpx/iostream.hpp>
 
@@ -36,5 +34,3 @@ int main(int argc, char* argv[])
 
     return hpx::init(argc, argv, init_args);
 }
-
-#endif

--- a/examples/quickstart/command_line_handling.cpp
+++ b/examples/quickstart/command_line_handling.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_init.hpp>
 #include <hpx/iostream.hpp>
 
@@ -55,4 +53,3 @@ int main(int argc, char* argv[])
 
     return hpx::init(argc, argv, init_args);
 }
-#endif

--- a/examples/quickstart/customize_async.cpp
+++ b/examples/quickstart/customize_async.cpp
@@ -9,8 +9,6 @@
 // processing unit) for a thread which is created by calling hpx::apply() or
 // hpx::async().
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_main.hpp>
 #include <hpx/iostream.hpp>
@@ -84,5 +82,3 @@ int main(int argc, char* argv[])
 
     return 0;
 }
-
-#endif

--- a/examples/quickstart/enumerate_threads.cpp
+++ b/examples/quickstart/enumerate_threads.cpp
@@ -58,5 +58,4 @@ int main()
     return 0;
 }
 
-
 #endif

--- a/examples/quickstart/enumerate_threads.cpp
+++ b/examples/quickstart/enumerate_threads.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_main.hpp>
 #include <hpx/iostream.hpp>
 #include <hpx/include/lcos.hpp>
@@ -57,5 +55,3 @@ int main()
 
     return 0;
 }
-
-#endif

--- a/examples/quickstart/error_handling.cpp
+++ b/examples/quickstart/error_handling.cpp
@@ -7,7 +7,6 @@
 //
 //  This example is documented in the Manual under the title "Error Handling"
 #include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 
@@ -182,4 +181,3 @@ int main(int argc, char* argv[])
 {
     return hpx::init(argc, argv);       // Initialize and run HPX.
 }
-#endif

--- a/examples/quickstart/event_synchronization.cpp
+++ b/examples/quickstart/event_synchronization.cpp
@@ -6,8 +6,6 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_main.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/iostream.hpp>
@@ -58,5 +56,3 @@ int main()
 
     return 0;
 }
-
-#endif

--- a/examples/quickstart/fibonacci_await.cpp
+++ b/examples/quickstart/fibonacci_await.cpp
@@ -9,10 +9,7 @@
 // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3564.pdf). The
 // necessary transformations are performed by hand.
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/actions.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
 
@@ -253,4 +250,3 @@ int main(int argc, char* argv[])
 
     return hpx::init(argc, argv, init_args);
 }
-#endif

--- a/examples/quickstart/fibonacci_dataflow.cpp
+++ b/examples/quickstart/fibonacci_dataflow.cpp
@@ -10,8 +10,6 @@
 // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3564.pdf). The
 // necessary transformations are performed by hand.
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/actions.hpp>
 #include <hpx/include/lcos.hpp>
@@ -154,4 +152,3 @@ int main(int argc, char* argv[])
 
     return hpx::init(argc, argv, init_args);
 }
-#endif

--- a/examples/quickstart/fibonacci_futures.cpp
+++ b/examples/quickstart/fibonacci_futures.cpp
@@ -7,10 +7,7 @@
 // This is a purely local version demonstrating different versions of making
 // the calculation of a fibonacci asynchronous.
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/actions.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
 
@@ -490,4 +487,3 @@ int main(int argc, char* argv[])
 
     return hpx::init(argc, argv, init_args);
 }
-#endif

--- a/examples/quickstart/fibonacci_local.cpp
+++ b/examples/quickstart/fibonacci_local.cpp
@@ -11,8 +11,6 @@
 // fibonacci_futures.cpp. This example is mainly intended to demonstrate async,
 // futures and get for the documentation.
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/async.hpp>
 #include <hpx/include/util.hpp>
@@ -80,4 +78,3 @@ int main(int argc, char* argv[])
     return hpx::init(argc, argv, init_args);
 }
 //main]
-#endif

--- a/examples/quickstart/hello_world_1.cpp
+++ b/examples/quickstart/hello_world_1.cpp
@@ -11,8 +11,6 @@
 //[hello_world_1_getting_started
 // Including 'hpx/hpx_main.hpp' instead of the usual 'hpx/hpx_init.hpp' enables
 // to use the plain C-main below as the direct main HPX entry point.
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_main.hpp>
 #include <hpx/iostream.hpp>
 
@@ -23,5 +21,3 @@ int main()
     return 0;
 }
 //]
-
-#endif

--- a/examples/quickstart/hello_world_2.cpp
+++ b/examples/quickstart/hello_world_2.cpp
@@ -9,8 +9,6 @@
 // execute a HPX-thread printing "Hello World!" once. That's all.
 
 //[hello_world_2_getting_started
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_init.hpp>
 #include <hpx/iostream.hpp>
 
@@ -26,4 +24,3 @@ int main(int argc, char* argv[])
     return hpx::init(argc, argv);
 }
 //]
-#endif

--- a/examples/quickstart/interest_calculator.cpp
+++ b/examples/quickstart/interest_calculator.cpp
@@ -16,8 +16,6 @@
 // $134.01 and will have made $34.01 in interest.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 
@@ -121,4 +119,3 @@ int main(int argc, char ** argv)
     return hpx::init(argc, argv, init_args);
 }
 //]
-#endif

--- a/examples/quickstart/interval_timer.cpp
+++ b/examples/quickstart/interval_timer.cpp
@@ -8,8 +8,6 @@
 // make_ready_future_after to orchestrate timed operations with 'normal'
 // asynchronous work.
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/threads.hpp>
 #include <hpx/include/util.hpp>
@@ -43,5 +41,3 @@ int main()
 
     return hpx::finalize();
 }
-
-#endif

--- a/examples/quickstart/local_channel.cpp
+++ b/examples/quickstart/local_channel.cpp
@@ -7,8 +7,6 @@
 // This example demonstrates the use of a channel which is very similar to the
 // equally named feature in the Go language.
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/apply.hpp>
 #include <hpx/iostream.hpp>
@@ -170,4 +168,3 @@ int main(int argc, char* argv[])
 
     return 0;
 }
-#endif

--- a/examples/quickstart/local_channel_docs.cpp
+++ b/examples/quickstart/local_channel_docs.cpp
@@ -6,8 +6,6 @@
 
 // This example is meant for inclusion in the documentation.
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_main.hpp>
 
 #include <hpx/assert.hpp>
@@ -65,4 +63,3 @@ int main(int argc, char* argv[])
 
     return 0;
 }
-#endif

--- a/examples/quickstart/potpourri.cpp
+++ b/examples/quickstart/potpourri.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/parallel_generate.hpp>
@@ -80,4 +78,3 @@ int main(int, char**)
 
     return hpx::finalize();
 }
-#endif

--- a/examples/quickstart/simple_future_continuation.cpp
+++ b/examples/quickstart/simple_future_continuation.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_main.hpp>
 #include <hpx/iostream.hpp>
 #include <hpx/execution.hpp>
@@ -67,5 +65,3 @@ int main(int argc, char* argv[])
 
     return 0;
 }
-
-#endif

--- a/examples/quickstart/sort_by_key_demo.cpp
+++ b/examples/quickstart/sort_by_key_demo.cpp
@@ -7,8 +7,6 @@
 // This example demonstrates how a parallel::sort_by_key algorithm could be
 // implemented based on the existing algorithm hpx::parallel::sort.
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/parallel_sort.hpp>
@@ -66,5 +64,3 @@ int main(int argc, char* argv[])
 {
     return hpx::init(argc, argv);   // Initialize and run HPX
 }
-
-#endif

--- a/examples/quickstart/timed_futures.cpp
+++ b/examples/quickstart/timed_futures.cpp
@@ -8,8 +8,6 @@
 // make_ready_future_after to orchestrate timed operations with 'normal'
 // asynchronous work.
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_init.hpp>
 #include <hpx/iostream.hpp>
 #include <hpx/modules/timing.hpp>
@@ -73,5 +71,3 @@ int main(int argc, char* argv[])
     // Initialize and run HPX.
     return hpx::init(argc, argv);
 }
-
-#endif

--- a/examples/quickstart/vector_counting_dotproduct.cpp
+++ b/examples/quickstart/vector_counting_dotproduct.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/numeric.hpp>
@@ -58,4 +56,3 @@ int main(int argc, char* argv[])
 
     return hpx::init(argc, argv, init_args);
 }
-#endif

--- a/examples/quickstart/vector_zip_dotproduct.cpp
+++ b/examples/quickstart/vector_zip_dotproduct.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/numeric.hpp>
@@ -60,5 +58,3 @@ int main(int argc, char* argv[])
 
     return hpx::init(argc, argv, init_args);
 }
-
-#endif

--- a/examples/quickstart/vector_zip_dotproduct.cpp
+++ b/examples/quickstart/vector_zip_dotproduct.cpp
@@ -61,5 +61,4 @@ int main(int argc, char* argv[])
     return hpx::init(argc, argv, init_args);
 }
 
-
 #endif

--- a/examples/thread_aware_timer/thread_aware_timer.cpp
+++ b/examples/thread_aware_timer/thread_aware_timer.cpp
@@ -6,8 +6,6 @@
 
 // Including 'hpx/hpx_main.hpp' instead of the usual 'hpx/hpx_init.hpp' enables
 // to use the plain C-main below as the direct main HPX entry point.
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_main.hpp>
 #include <hpx/iostream.hpp>
 #include <hpx/include/util.hpp>
@@ -35,5 +33,3 @@ int main(int argc, char* argv[])
     hpx::cout << "min: " << min_sample << ", max: " << max_sample << "\n" << hpx::flush;
     return 0;
 }
-
-#endif

--- a/examples/throttle/spin.cpp
+++ b/examples/throttle/spin.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/include/util.hpp>
@@ -90,5 +88,3 @@ int main(int argc, char* argv[])
 
     return hpx::init(argc, argv, init_args);
 }
-
-#endif

--- a/libs/core/iterator_support/tests/performance/stencil3_iterators.cpp
+++ b/libs/core/iterator_support/tests/performance/stencil3_iterators.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 
@@ -582,4 +580,3 @@ int main(int argc, char* argv[])
 
     return hpx::init(argc, argv, init_args);
 }
-#endif

--- a/libs/core/threading_base/tests/unit/set_thread_state.cpp
+++ b/libs/core/threading_base/tests/unit/set_thread_state.cpp
@@ -6,8 +6,6 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/modules/testing.hpp>
@@ -225,4 +223,3 @@ int main(int argc, char* argv[])
 
     return hpx::init(argc, argv, init_args);
 }
-#endif

--- a/libs/full/checkpoint/examples/1d_stencil_4_checkpoint.cpp
+++ b/libs/full/checkpoint/examples/1d_stencil_4_checkpoint.cpp
@@ -21,8 +21,6 @@
 // every n time steps.
 //
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 
@@ -482,4 +480,3 @@ int main(int argc, char* argv[])
 
     return hpx::init(argc, argv, init_args);
 }
-#endif

--- a/libs/full/checkpoint/tests/unit/checkpoint.cpp
+++ b/libs/full/checkpoint/tests/unit/checkpoint.cpp
@@ -8,8 +8,6 @@
 // restore_checkpoint.
 //
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx_main.hpp>
 
 #include <hpx/modules/checkpoint.hpp>
@@ -272,4 +270,3 @@ int main()
 
     return hpx::util::report_errors();
 }
-#endif

--- a/libs/full/naming_base/tests/unit/gid_type.cpp
+++ b/libs/full/naming_base/tests/unit/gid_type.cpp
@@ -6,8 +6,6 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx.hpp>
 #include <hpx/modules/naming.hpp>
 #include <hpx/modules/testing.hpp>
@@ -643,4 +641,3 @@ int main()
 
     return hpx::util::report_errors();
 }
-#endif

--- a/libs/parallelism/algorithms/tests/performance/transform_reduce_scaling.cpp
+++ b/libs/parallelism/algorithms/tests/performance/transform_reduce_scaling.cpp
@@ -5,8 +5,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 
@@ -131,4 +129,3 @@ int main(int argc, char* argv[])
 
     return hpx::init(argc, argv, init_args);
 }
-#endif

--- a/libs/parallelism/algorithms/tests/unit/block/spmd_block.cpp
+++ b/libs/parallelism/algorithms/tests/unit/block/spmd_block.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_main.hpp>
@@ -119,4 +117,3 @@ int main()
 
     return 0;
 }
-#endif

--- a/libs/parallelism/algorithms/tests/unit/block/task_block.cpp
+++ b/libs/parallelism/algorithms/tests/unit/block/task_block.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 
@@ -275,4 +273,3 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
-#endif

--- a/libs/parallelism/algorithms/tests/unit/block/task_block_executor.cpp
+++ b/libs/parallelism/algorithms/tests/unit/block/task_block_executor.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 
@@ -430,4 +428,3 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
-#endif

--- a/libs/parallelism/algorithms/tests/unit/block/task_block_par.cpp
+++ b/libs/parallelism/algorithms/tests/unit/block/task_block_par.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 
@@ -154,4 +152,3 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
-#endif


### PR DESCRIPTION
Remove the hipcc guards in some of the examples and tests, following #5055

The remaining guards are due to the fact that the actions are undefined in device code so all tests using actions/components still need the guard. A potential solution would be to define the actions to be normal functions in device code but I'm not sure how much work it would require.