### PR TITLE
Refactor runtime configuration, command line handling, and resource partitioner

### DIFF
--- a/hpx/runtime/agas/addressing_service.hpp
+++ b/hpx/runtime/agas/addressing_service.hpp
@@ -124,10 +124,7 @@ public:
         resolved_localities_type;
     resolved_localities_type resolved_localities_;
 
-    addressing_service(
-        util::runtime_configuration const& ini_
-      , runtime_mode runtime_type_
-        );
+    explicit addressing_service(util::runtime_configuration const& ini_);
 
 #if defined(HPX_HAVE_NETWORKING)
     ~addressing_service()

--- a/libs/core/affinity/include/hpx/affinity/affinity_data.hpp
+++ b/libs/core/affinity/include/hpx/affinity/affinity_data.hpp
@@ -27,7 +27,7 @@ namespace hpx { namespace threads { namespace policies { namespace detail {
         affinity_data();
         ~affinity_data();
 
-        std::size_t init(std::size_t num_threads = 1, std::size_t max_cores = 1,
+        void init(std::size_t num_threads = 1, std::size_t max_cores = 1,
             std::size_t pu_offset = 0, std::size_t pu_step = 1,
             std::size_t used_cores = 0, std::string affinity_domain = "pu",
             std::string const& affinity_description = "balanced",
@@ -79,6 +79,11 @@ namespace hpx { namespace threads { namespace policies { namespace detail {
         void add_punit(std::size_t virt_core, std::size_t thread_num);
         void init_cached_pu_nums(std::size_t hardware_concurrency);
 
+        std::size_t get_num_pus_needed() const
+        {
+            return num_pus_needed_;
+        }
+
     protected:
         std::size_t get_pu_num(
             std::size_t num_thread, std::size_t hardware_concurrency) const;
@@ -96,6 +101,7 @@ namespace hpx { namespace threads { namespace policies { namespace detail {
             no_affinity_;    ///< mask of processing units which have no affinity
         bool
             use_process_mask_;    ///< use the process CPU mask to limit available PUs
+        std::size_t num_pus_needed_;
         static std::atomic<int>
             instance_number_counter_;    ///< counter for instance numbers
     };

--- a/libs/core/affinity/src/affinity_data.cpp
+++ b/libs/core/affinity/src/affinity_data.cpp
@@ -41,6 +41,7 @@ namespace hpx { namespace threads { namespace policies { namespace detail {
       , pu_nums_()
       , no_affinity_()
       , use_process_mask_(false)
+      , num_pus_needed_(0)
     {
         threads::resize(no_affinity_, hardware_concurrency());
     }
@@ -50,9 +51,9 @@ namespace hpx { namespace threads { namespace policies { namespace detail {
         --instance_number_counter_;
     }
 
-    std::size_t affinity_data::init(std::size_t num_threads,
-        std::size_t max_cores, std::size_t pu_offset, std::size_t pu_step,
-        std::size_t used_cores, std::string affinity_domain,    // -V813
+    void affinity_data::init(std::size_t num_threads, std::size_t max_cores,
+        std::size_t pu_offset, std::size_t pu_step, std::size_t used_cores,
+        std::string affinity_domain,    // -V813
         std::string const& affinity_description, bool use_process_mask)
     {
         num_threads_ = num_threads;
@@ -143,7 +144,8 @@ namespace hpx { namespace threads { namespace policies { namespace detail {
         cores.erase(it, cores.end());
 
         std::size_t num_unique_cores = cores.size();
-        return (std::max)(num_unique_cores, max_cores);
+
+        num_pus_needed_ = (std::max)(num_unique_cores, max_cores);
     }
 
     mask_cref_type affinity_data::get_pu_mask(

--- a/libs/full/command_line_handling/include/hpx/command_line_handling/command_line_handling.hpp
+++ b/libs/full/command_line_handling/include/hpx/command_line_handling/command_line_handling.hpp
@@ -21,28 +21,16 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace util {
 
-    struct command_line_handling;
-
-    ///////////////////////////////////////////////////////////////////////////
-    // Helper functions for retrieving command line options (with error
-    // checking)
-    std::size_t get_num_high_priority_queues(
-        util::command_line_handling const& cfg, std::size_t num_threads);
-
-    std::string get_affinity_domain(util::command_line_handling const& cfg);
-
-    std::size_t get_affinity_description(
-        util::command_line_handling const& cfg, std::string& affinity_desc);
-
-    std::size_t get_pu_offset(util::command_line_handling const& cfg);
-
-    std::size_t get_pu_step(util::command_line_handling const& cfg);
-
     ///////////////////////////////////////////////////////////////////////////
     struct command_line_handling
     {
-        command_line_handling()
-          : rtcfg_(nullptr, runtime_mode::default_)
+        command_line_handling(runtime_configuration rtcfg,
+            std::vector<std::string> ini_config,
+            function_nonser<int(hpx::program_options::variables_map& vm)>
+                hpx_main_f)
+          : rtcfg_(rtcfg)
+          , ini_config_(ini_config)
+          , hpx_main_f_(hpx_main_f)
           , node_(std::size_t(-1))
           , num_threads_(1)
           , num_cores_(1)
@@ -54,7 +42,6 @@ namespace hpx { namespace util {
           , cmd_line_parsed_(false)
           , info_printed_(false)
           , version_printed_(false)
-          , parse_result_(0)
         {
         }
 
@@ -84,9 +71,14 @@ namespace hpx { namespace util {
         bool cmd_line_parsed_;
         bool info_printed_;
         bool version_printed_;
-        int parse_result_;
 
     protected:
+        // Helper functions for checking command line options
+        void check_affinity_domain() const;
+        void check_affinity_description() const;
+        void check_pu_offset() const;
+        void check_pu_step() const;
+
         bool handle_arguments(util::manage_config& cfgmap,
             hpx::program_options::variables_map& vm,
             std::vector<std::string>& ini_config, std::size_t& node,

--- a/libs/full/resource_partitioner/CMakeLists.txt
+++ b/libs/full/resource_partitioner/CMakeLists.txt
@@ -39,7 +39,7 @@ add_hpx_module(
   HEADERS ${resource_partitioner_headers}
   COMPAT_HEADERS ${resource_partitioner_compat_headers}
   DEPENDENCIES hpx_core hpx_parallelism
-  MODULE_DEPENDENCIES hpx_command_line_handling hpx_program_options
-                      hpx_runtime_configuration ${MPI_DEPS}
+  MODULE_DEPENDENCIES hpx_command_line_handling hpx_runtime_configuration
+                      ${MPI_DEPS}
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/full/resource_partitioner/include/hpx/resource_partitioner/detail/create_partitioner.hpp
+++ b/libs/full/resource_partitioner/include/hpx/resource_partitioner/detail/create_partitioner.hpp
@@ -14,24 +14,11 @@
 #include <hpx/runtime_configuration/runtime_configuration.hpp>
 #include <hpx/runtime_configuration/runtime_mode.hpp>
 
-#include <hpx/modules/program_options.hpp>
-
 #include <cstddef>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
-
-#if !defined(HPX_EXPORTS)
-// This function must be implemented by the application.
-int hpx_main(hpx::program_options::variables_map& vm);
-typedef int (*hpx_main_type)(hpx::program_options::variables_map&);
-#endif
-
-namespace hpx { namespace detail {
-    HPX_EXPORT int init_helper(hpx::program_options::variables_map&,
-        util::function_nonser<int(int, char**)> const&);
-}}    // namespace hpx::detail
 
 namespace hpx { namespace resource { namespace detail {
     HPX_EXPORT partitioner& create_partitioner(

--- a/libs/full/resource_partitioner/include/hpx/resource_partitioner/detail/create_partitioner.hpp
+++ b/libs/full/resource_partitioner/include/hpx/resource_partitioner/detail/create_partitioner.hpp
@@ -11,6 +11,7 @@
 #include <hpx/functional/function.hpp>
 #include <hpx/prefix/find_prefix.hpp>
 #include <hpx/resource_partitioner/partitioner_fwd.hpp>
+#include <hpx/runtime_configuration/runtime_configuration.hpp>
 #include <hpx/runtime_configuration/runtime_mode.hpp>
 
 #include <hpx/modules/program_options.hpp>
@@ -34,13 +35,8 @@ namespace hpx { namespace detail {
 
 namespace hpx { namespace resource { namespace detail {
     HPX_EXPORT partitioner& create_partitioner(
-        util::function_nonser<int(
-            hpx::program_options::variables_map& vm)> const& f,
-        hpx::program_options::options_description const& desc_cmdline, int argc,
-        char** argv, std::vector<std::string> ini_config,
-        resource::partitioner_mode rpmode, runtime_mode mode, bool check,
-        std::vector<std::shared_ptr<components::component_registry_base>>&
-            component_registries,
-        int* result);
+        resource::partitioner_mode rpmode,
+        hpx::util::runtime_configuration rtcfg,
+        hpx::threads::policies::detail::affinity_data affinity_data);
 
 }}}    // namespace hpx::resource::detail

--- a/libs/full/resource_partitioner/include/hpx/resource_partitioner/detail/partitioner.hpp
+++ b/libs/full/resource_partitioner/include/hpx/resource_partitioner/detail/partitioner.hpp
@@ -10,7 +10,6 @@
 #include <hpx/affinity/affinity_data.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/datastructures/tuple.hpp>
-#include <hpx/modules/program_options.hpp>
 #include <hpx/resource_partitioner/partitioner.hpp>
 #include <hpx/runtime_configuration/runtime_configuration.hpp>
 #include <hpx/runtime_configuration/runtime_mode.hpp>

--- a/libs/full/resource_partitioner/include/hpx/resource_partitioner/detail/partitioner.hpp
+++ b/libs/full/resource_partitioner/include/hpx/resource_partitioner/detail/partitioner.hpp
@@ -9,10 +9,10 @@
 #include <hpx/config.hpp>
 #include <hpx/affinity/affinity_data.hpp>
 #include <hpx/assert.hpp>
-#include <hpx/command_line_handling/command_line_handling.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/modules/program_options.hpp>
 #include <hpx/resource_partitioner/partitioner.hpp>
+#include <hpx/runtime_configuration/runtime_configuration.hpp>
 #include <hpx/runtime_configuration/runtime_mode.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/threading_base/scheduler_mode.hpp>
@@ -117,7 +117,6 @@ namespace hpx { namespace resource { namespace detail {
         void add_resource(const std::vector<hpx::resource::numa_domain>& ndv,
             std::string const& pool_name, bool exclusive = true);
 
-        // called by constructor of scheduler_base
         threads::policies::detail::affinity_data const& get_affinity_data()
             const
         {
@@ -141,9 +140,6 @@ namespace hpx { namespace resource { namespace detail {
         ////////////////////////////////////////////////////////////////////////
         scheduling_policy which_scheduler(std::string const& pool_name);
         threads::topology& get_topology() const;
-        util::command_line_handling& get_command_line_switches();
-
-        std::size_t get_num_distinct_pus() const;
 
         std::size_t get_num_pools() const;
 
@@ -161,26 +157,15 @@ namespace hpx { namespace resource { namespace detail {
         threads::mask_cref_type get_pu_mask(
             std::size_t global_thread_num) const;
 
-        bool cmd_line_parsed() const;
-        int parse(util::function_nonser<int(
-                      hpx::program_options::variables_map& vm)> const& f,
-            hpx::program_options::options_description desc_cmdline, int argc,
-            char** argv, std::vector<std::string> ini_config,
-            resource::partitioner_mode rpmode, runtime_mode mode,
-            std::vector<std::shared_ptr<components::component_registry_base>>&
-                component_registries,
-            bool fill_internal_topology);
+        void init(resource::partitioner_mode rpmode,
+            hpx::util::runtime_configuration cfg,
+            hpx::threads::policies::detail::affinity_data affinity_data);
 
         scheduler_function get_pool_creator(size_t index) const;
 
         std::vector<numa_domain> const& numa_domains() const
         {
             return numa_domains_;
-        }
-
-        int parse_result() const
-        {
-            return cfg_.parse_result_;
         }
 
         std::size_t assign_cores(std::size_t first_core);
@@ -237,7 +222,7 @@ namespace hpx { namespace resource { namespace detail {
         static std::atomic<int> instance_number_counter_;
 
         // holds all of the command line switches
-        util::command_line_handling cfg_;
+        util::runtime_configuration rtcfg_;
         std::size_t first_core_;
         std::size_t pus_needed_;
 

--- a/libs/full/resource_partitioner/include/hpx/resource_partitioner/partitioner.hpp
+++ b/libs/full/resource_partitioner/include/hpx/resource_partitioner/partitioner.hpp
@@ -14,8 +14,6 @@
 #include <hpx/runtime_configuration/runtime_mode.hpp>
 #include <hpx/threading_base/scheduler_mode.hpp>
 
-#include <hpx/modules/program_options.hpp>
-
 #include <cstddef>
 #include <memory>
 #include <string>

--- a/libs/full/resource_partitioner/include/hpx/resource_partitioner/partitioner.hpp
+++ b/libs/full/resource_partitioner/include/hpx/resource_partitioner/partitioner.hpp
@@ -8,9 +8,9 @@
 
 #include <hpx/config.hpp>
 #include <hpx/functional/function.hpp>
-#include <hpx/modules/command_line_handling.hpp>
 #include <hpx/resource_partitioner/detail/create_partitioner.hpp>
 #include <hpx/resource_partitioner/partitioner_fwd.hpp>
+#include <hpx/runtime_configuration/runtime_configuration.hpp>
 #include <hpx/runtime_configuration/runtime_mode.hpp>
 #include <hpx/threading_base/scheduler_mode.hpp>
 
@@ -129,40 +129,24 @@ namespace hpx { namespace resource {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
         inline ::hpx::resource::partitioner make_partitioner(
-            util::function_nonser<int(
-                hpx::program_options::variables_map& vm)> const& f,
-            hpx::program_options::options_description const& desc_cmdline,
-            int argc, char** argv, std::vector<std::string> ini_config,
-            resource::partitioner_mode rpmode, runtime_mode mode, bool check,
-            std::vector<std::shared_ptr<components::component_registry_base>>&
-                component_registries,
-            int* result);
+            resource::partitioner_mode rpmode,
+            hpx::util::runtime_configuration rtcfg,
+            hpx::threads::policies::detail::affinity_data affinity_data);
     }
 
     class partitioner
     {
     private:
         friend ::hpx::resource::partitioner detail::make_partitioner(
-            util::function_nonser<int(
-                hpx::program_options::variables_map& vm)> const& f,
-            hpx::program_options::options_description const& desc_cmdline,
-            int argc, char** argv, std::vector<std::string> ini_config,
-            resource::partitioner_mode rpmode, runtime_mode mode, bool check,
-            std::vector<std::shared_ptr<components::component_registry_base>>&
-                component_registries,
-            int* result);
+            resource::partitioner_mode rpmode,
+            hpx::util::runtime_configuration rtcfg,
+            hpx::threads::policies::detail::affinity_data affinity_data);
 
-        partitioner(util::function_nonser<int(
-                        hpx::program_options::variables_map& vm)> const& f,
-            hpx::program_options::options_description const& desc_cmdline,
-            int argc, char** argv, std::vector<std::string> ini_config,
-            resource::partitioner_mode rpmode, runtime_mode mode, bool check,
-            std::vector<std::shared_ptr<components::component_registry_base>>&
-                component_registries,
-            int* result)
-          : partitioner_(detail::create_partitioner(f, desc_cmdline, argc, argv,
-                std::move(ini_config), rpmode, mode, check,
-                component_registries, result))
+        partitioner(resource::partitioner_mode rpmode,
+            hpx::util::runtime_configuration rtcfg,
+            hpx::threads::policies::detail::affinity_data affinity_data)
+          : partitioner_(
+                detail::create_partitioner(rpmode, rtcfg, affinity_data))
         {
         }
 
@@ -216,15 +200,9 @@ namespace hpx { namespace resource {
         // return the topology object managed by the internal partitioner
         HPX_EXPORT hpx::threads::topology const& get_topology() const;
 
-        // access the command line options
-        HPX_EXPORT util::command_line_handling& get_command_line_switches();
-
         // Does initialization of all resources and internal data of the
         // resource partitioner called in hpx_init
         HPX_EXPORT void configure_pools();
-
-        // Return the initialization result for this resource_partitioner
-        HPX_EXPORT int parse_result() const;
 
     private:
         detail::partitioner& partitioner_;
@@ -232,17 +210,11 @@ namespace hpx { namespace resource {
 
     namespace detail {
         ::hpx::resource::partitioner make_partitioner(
-            util::function_nonser<int(
-                hpx::program_options::variables_map& vm)> const& f,
-            hpx::program_options::options_description const& desc_cmdline,
-            int argc, char** argv, std::vector<std::string> ini_config,
-            resource::partitioner_mode rpmode, runtime_mode mode, bool check,
-            std::vector<std::shared_ptr<components::component_registry_base>>&
-                component_registries,
-            int* result)
+            resource::partitioner_mode rpmode,
+            hpx::util::runtime_configuration rtcfg,
+            hpx::threads::policies::detail::affinity_data affinity_data)
         {
-            return ::hpx::resource::partitioner(f, desc_cmdline, argc, argv,
-                ini_config, rpmode, mode, check, component_registries, result);
+            return ::hpx::resource::partitioner(rpmode, rtcfg, affinity_data);
         }
     }    // namespace detail
 }}       // namespace hpx::resource

--- a/libs/full/resource_partitioner/src/partitioner.cpp
+++ b/libs/full/resource_partitioner/src/partitioner.cpp
@@ -103,10 +103,6 @@ namespace hpx { namespace resource {
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
-    struct partitioner_tag
-    {
-    };
-
     detail::partitioner& get_partitioner()
     {
         std::unique_ptr<detail::partitioner>& rp = detail::get_partitioner();
@@ -121,14 +117,6 @@ namespace hpx { namespace resource {
                 "been initialized and before it has been deleted.");
         }
 
-        if (!rp->cmd_line_parsed())
-        {
-            HPX_THROW_EXCEPTION(invalid_status,
-                "hpx::resource::get_partitioner",
-                "can be called only after the resource partitioner has "
-                "been allowed to parse the command line options.");
-        }
-
         return *rp;
     }
 
@@ -139,48 +127,15 @@ namespace hpx { namespace resource {
 
     namespace detail {
         detail::partitioner& create_partitioner(
-            util::function_nonser<int(
-                hpx::program_options::variables_map& vm)> const& f,
-            hpx::program_options::options_description const& desc_cmdline,
-            int argc, char** argv, std::vector<std::string> ini_config,
-            resource::partitioner_mode rpmode, runtime_mode mode, bool check,
-            std::vector<std::shared_ptr<components::component_registry_base>>&
-                component_registries,
-            int* result)
+            resource::partitioner_mode rpmode,
+            hpx::util::runtime_configuration rtcfg,
+            hpx::threads::policies::detail::affinity_data affinity_data)
         {
             std::unique_ptr<detail::partitioner>& rp =
                 detail::get_partitioner();
 
-            if (rp->cmd_line_parsed())
-            {
-                if (check)
-                {
-                    // if the resource partitioner is not accessed for the
-                    // first time if the command-line parsing has not yet
-                    // been done
-                    HPX_THROW_EXCEPTION(invalid_status,
-                        "hpx::resource::get_partitioner",
-                        "can be called only after the resource partitioner "
-                        "has been allowed to parse the command line "
-                        "options.");
-                }
+            rp->init(rpmode, rtcfg, affinity_data);
 
-                // no need to parse a second time
-                if (result != nullptr)
-                {
-                    *result = 0;
-                }
-            }
-            else
-            {
-                int r = rp->parse(f, desc_cmdline, argc, argv,
-                    std::move(ini_config), rpmode, mode, component_registries,
-                    true);
-                if (result != nullptr)
-                {
-                    *result = r;
-                }
-            }
             return *rp;
         }
     }    // namespace detail
@@ -260,22 +215,10 @@ namespace hpx { namespace resource {
         return partitioner_.threads_needed();
     }
 
-    util::command_line_handling& partitioner::get_command_line_switches()
-    {
-        return partitioner_.get_command_line_switches();
-    }
-
     // Does initialization of all resources and internal data of the
     // resource partitioner called in hpx_init
     void partitioner::configure_pools()
     {
         partitioner_.configure_pools();
     }
-
-    // Return the initialization result for this resource_partitioner
-    int partitioner::parse_result() const
-    {
-        return partitioner_.parse_result();
-    }
-
 }}    // namespace hpx::resource

--- a/libs/full/resource_partitioner/src/partitioner.cpp
+++ b/libs/full/resource_partitioner/src/partitioner.cpp
@@ -9,8 +9,6 @@
 #include <hpx/resource_partitioner/partitioner.hpp>
 #include <hpx/topology/cpu_mask.hpp>
 
-#include <hpx/modules/program_options.hpp>
-
 #include <cstddef>
 #include <memory>
 #include <mutex>

--- a/libs/full/runtime_local/include/hpx/runtime_local/runtime_local.hpp
+++ b/libs/full/runtime_local/include/hpx/runtime_local/runtime_local.hpp
@@ -404,7 +404,7 @@ namespace hpx {
         on_exit_type on_exit_functions_;
         mutable std::mutex mtx_;
 
-        util::runtime_configuration ini_;
+        util::runtime_configuration rtcfg_;
 
         long instance_number_;
         static std::atomic<int> instance_number_counter_;

--- a/libs/full/threadmanager/include/hpx/modules/threadmanager.hpp
+++ b/libs/full/threadmanager/include/hpx/modules/threadmanager.hpp
@@ -14,6 +14,7 @@
 #include <hpx/io_service/io_service_pool.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/resource_partitioner/detail/partitioner.hpp>
+#include <hpx/runtime_configuration/runtime_configuration.hpp>
 #include <hpx/thread_pools/scheduled_thread_pool.hpp>
 #include <hpx/threading_base/scheduler_mode.hpp>
 #include <hpx/threading_base/scheduler_state.hpp>
@@ -56,7 +57,7 @@ namespace hpx { namespace threads {
         typedef threads::policies::scheduler_base scheduler_type;
         typedef std::vector<pool_type> pool_vector;
 
-        threadmanager(
+        threadmanager(util::runtime_configuration& rtcfg_,
 #ifdef HPX_HAVE_TIMER_POOL
             util::io_service_pool& timer_pool,
 #endif
@@ -393,11 +394,7 @@ namespace hpx { namespace threads {
     private:
         mutable mutex_type mtx_;    // mutex protecting the members
 
-        // specified by the user in command line, or all cores by default
-        // represents the total number of OS threads, irrespective of how many
-        // are in which pool.
-        std::size_t num_threads_;
-
+        util::runtime_configuration& rtcfg_;
         std::vector<pool_id_type> threads_lookup_;
 
 #ifdef HPX_HAVE_TIMER_POOL

--- a/libs/full/threadmanager/src/threadmanager.cpp
+++ b/libs/full/threadmanager/src/threadmanager.cpp
@@ -11,7 +11,6 @@
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_combinators/wait_all.hpp>
-#include <hpx/command_line_handling/command_line_handling.hpp>
 #include <hpx/execution_base/this_thread.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/hardware/timestamp.hpp>
@@ -29,7 +28,7 @@
 #include <hpx/threading_base/thread_init_data.hpp>
 #include <hpx/threading_base/thread_queue_init_parameters.hpp>
 #include <hpx/topology/topology.hpp>
-#include <hpx/util/from_string.hpp>
+#include <hpx/util/get_entry_as.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -43,55 +42,33 @@
 #include <utility>
 #include <vector>
 
-///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace detail {
-
-    // helper functions testing option compatibility
-    void ensure_high_priority_compatibility(
-        hpx::program_options::variables_map const& vm)
-    {
-        if (vm.count("hpx:high-priority-threads"))
-        {
-            throw detail::command_line_error(
-                "Invalid command line option "
-                "--hpx:high-priority-threads, valid for "
-                "--hpx:queuing=local-priority and "
-                "--hpx:queuing=abp-priority only");
-        }
-    }
-
-    void ensure_numa_sensitivity_compatibility(
-        hpx::program_options::variables_map const& vm)
-    {
-        if (vm.count("hpx:numa-sensitive"))
-        {
-            throw detail::command_line_error(
-                "Invalid command line option "
-                "--hpx:numa-sensitive, valid for "
-                "--hpx:queuing=local, --hpx:queuing=local-priority, or "
-                "--hpx:queuing=abp-priority only");
-        }
-    }
-
-    void ensure_queuing_option_compatibility(
-        hpx::program_options::variables_map const& vm)
-    {
-        ensure_high_priority_compatibility(vm);
-        ensure_numa_sensitivity_compatibility(vm);
-    }
-}}    // namespace hpx::detail
-
 namespace hpx { namespace threads {
+    namespace detail {
+        void check_num_high_priority_queues(
+            std::size_t num_threads, std::size_t num_high_priority_queues)
+        {
+            if (num_high_priority_queues > num_threads)
+            {
+                throw hpx::detail::command_line_error(
+                    "Invalid command line option: "
+                    "number of high priority threads ("
+                    "--hpx:high-priority-threads), should not be larger "
+                    "than number of threads (--hpx:threads)");
+            }
+        }
+    }    // namespace detail
+
     ///////////////////////////////////////////////////////////////////////////
-    threadmanager::threadmanager(
+    threadmanager::threadmanager(util::runtime_configuration& rtcfg,
 #ifdef HPX_HAVE_TIMER_POOL
         util::io_service_pool& timer_pool,
 #endif
         notification_policy_type& notifier,
         detail::network_background_callback_type network_background_callback)
-      : num_threads_(hpx::resource::get_partitioner().get_num_distinct_pus())
+      : rtcfg_(rtcfg)
+      ,
 #ifdef HPX_HAVE_TIMER_POOL
-      , timer_pool_(timer_pool)
+      timer_pool_(timer_pool)
 #endif
       , notifier_(notifier)
       , network_background_callback_(network_background_callback)
@@ -116,65 +93,62 @@ namespace hpx { namespace threads {
     {
         auto& rp = hpx::resource::get_partitioner();
         size_t num_pools = rp.get_num_pools();
-        util::command_line_handling const& cfg_ =
-            rp.get_command_line_switches();
         std::size_t thread_offset = 0;
 
         std::size_t max_background_threads =
-            hpx::util::from_string<std::size_t>(
-                cfg_.rtcfg_.get_entry("hpx.max_background_threads",
-                    (std::numeric_limits<std::size_t>::max)()));
+            hpx::util::get_entry_as<std::size_t>(rtcfg_,
+                "hpx.max_background_threads",
+                (std::numeric_limits<std::size_t>::max)());
         std::size_t const max_idle_loop_count =
-            hpx::util::from_string<std::int64_t>(cfg_.rtcfg_.get_entry(
-                "hpx.max_idle_loop_count", HPX_IDLE_LOOP_COUNT_MAX));
+            hpx::util::get_entry_as<std::int64_t>(
+                rtcfg_, "hpx.max_idle_loop_count", HPX_IDLE_LOOP_COUNT_MAX);
         std::size_t const max_busy_loop_count =
-            hpx::util::from_string<std::int64_t>(cfg_.rtcfg_.get_entry(
-                "hpx.max_busy_loop_count", HPX_BUSY_LOOP_COUNT_MAX));
+            hpx::util::get_entry_as<std::int64_t>(
+                rtcfg_, "hpx.max_busy_loop_count", HPX_BUSY_LOOP_COUNT_MAX);
 
         std::int64_t const max_thread_count =
-            hpx::util::from_string<std::int64_t>(
-                cfg_.rtcfg_.get_entry("hpx.thread_queue.max_thread_count",
-                    std::to_string(HPX_THREAD_QUEUE_MAX_THREAD_COUNT)));
+            hpx::util::get_entry_as<std::int64_t>(rtcfg_,
+                "hpx.thread_queue.max_thread_count",
+                HPX_THREAD_QUEUE_MAX_THREAD_COUNT);
         std::int64_t const min_tasks_to_steal_pending =
-            hpx::util::from_string<std::int64_t>(cfg_.rtcfg_.get_entry(
+            hpx::util::get_entry_as<std::int64_t>(rtcfg_,
                 "hpx.thread_queue.min_tasks_to_steal_pending",
-                std::to_string(HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_PENDING)));
+                HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_PENDING);
         std::int64_t const min_tasks_to_steal_staged =
-            hpx::util::from_string<std::int64_t>(cfg_.rtcfg_.get_entry(
+            hpx::util::get_entry_as<std::int64_t>(rtcfg_,
                 "hpx.thread_queue.min_tasks_to_steal_staged",
-                std::to_string(HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_STAGED)));
+                HPX_THREAD_QUEUE_MIN_TASKS_TO_STEAL_STAGED);
         std::int64_t const min_add_new_count =
-            hpx::util::from_string<std::int64_t>(
-                cfg_.rtcfg_.get_entry("hpx.thread_queue.min_add_new_count",
-                    std::to_string(HPX_THREAD_QUEUE_MIN_ADD_NEW_COUNT)));
+            hpx::util::get_entry_as<std::int64_t>(rtcfg_,
+                "hpx.thread_queue.min_add_new_count",
+                HPX_THREAD_QUEUE_MIN_ADD_NEW_COUNT);
         std::int64_t const max_add_new_count =
-            hpx::util::from_string<std::int64_t>(
-                cfg_.rtcfg_.get_entry("hpx.thread_queue.max_add_new_count",
-                    std::to_string(HPX_THREAD_QUEUE_MAX_ADD_NEW_COUNT)));
+            hpx::util::get_entry_as<std::int64_t>(rtcfg_,
+                "hpx.thread_queue.max_add_new_count",
+                HPX_THREAD_QUEUE_MAX_ADD_NEW_COUNT);
         std::int64_t const min_delete_count =
-            hpx::util::from_string<std::int64_t>(
-                cfg_.rtcfg_.get_entry("hpx.thread_queue.min_delete_count",
-                    std::to_string(HPX_THREAD_QUEUE_MIN_DELETE_COUNT)));
+            hpx::util::get_entry_as<std::int64_t>(rtcfg_,
+                "hpx.thread_queue.min_delete_count",
+                HPX_THREAD_QUEUE_MIN_DELETE_COUNT);
         std::int64_t const max_delete_count =
-            hpx::util::from_string<std::int64_t>(
-                cfg_.rtcfg_.get_entry("hpx.thread_queue.max_delete_count",
-                    std::to_string(HPX_THREAD_QUEUE_MAX_DELETE_COUNT)));
+            hpx::util::get_entry_as<std::int64_t>(rtcfg_,
+                "hpx.thread_queue.max_delete_count",
+                HPX_THREAD_QUEUE_MAX_DELETE_COUNT);
         std::int64_t const max_terminated_threads =
-            hpx::util::from_string<std::int64_t>(
-                cfg_.rtcfg_.get_entry("hpx.thread_queue.max_terminated_threads",
-                    std::to_string(HPX_THREAD_QUEUE_MAX_TERMINATED_THREADS)));
-        double const max_idle_backoff_time = hpx::util::from_string<double>(
-            cfg_.rtcfg_.get_entry("hpx.max_idle_backoff_time",
-                std::to_string(HPX_IDLE_BACKOFF_TIME_MAX)));
+            hpx::util::get_entry_as<std::int64_t>(rtcfg_,
+                "hpx.thread_queue.max_terminated_threads",
+                HPX_THREAD_QUEUE_MAX_TERMINATED_THREADS);
+        double const max_idle_backoff_time = hpx::util::get_entry_as<double>(
+            rtcfg_, "hpx.max_idle_backoff_time", HPX_IDLE_BACKOFF_TIME_MAX);
 
         std::ptrdiff_t small_stacksize =
-            cfg_.rtcfg_.get_stack_size(thread_stacksize::small_);
+            rtcfg_.get_stack_size(thread_stacksize::small_);
         std::ptrdiff_t medium_stacksize =
-            cfg_.rtcfg_.get_stack_size(thread_stacksize::medium);
+            rtcfg_.get_stack_size(thread_stacksize::medium);
         std::ptrdiff_t large_stacksize =
-            cfg_.rtcfg_.get_stack_size(thread_stacksize::large);
+            rtcfg_.get_stack_size(thread_stacksize::large);
         std::ptrdiff_t huge_stacksize =
-            cfg_.rtcfg_.get_stack_size(thread_stacksize::huge);
+            rtcfg_.get_stack_size(thread_stacksize::huge);
 
         policies::thread_queue_init_parameters thread_queue_init(
             max_thread_count, min_tasks_to_steal_pending,
@@ -183,7 +157,7 @@ namespace hpx { namespace threads {
             max_idle_backoff_time, small_stacksize, medium_stacksize,
             large_stacksize, huge_stacksize);
 
-        if (!cfg_.rtcfg_.enable_networking())
+        if (!rtcfg_.enable_networking())
         {
             max_background_threads = 0;
         }
@@ -203,8 +177,8 @@ namespace hpx { namespace threads {
                 {
                     throw std::invalid_argument("Trying to instantiate pool " +
                         name +
-                        " as first thread pool, but first thread pool must be "
-                        "named " +
+                        " as first thread pool, but first thread pool must "
+                        "be named " +
                         rp.get_default_pool_name());
                 }
             }
@@ -215,9 +189,8 @@ namespace hpx { namespace threads {
                 max_background_threads, max_idle_loop_count,
                 max_busy_loop_count);
 
-            std::string affinity_desc;
-            std::size_t numa_sensitive =
-                hpx::util::get_affinity_description(cfg_, affinity_desc);
+            std::size_t numa_sensitive = hpx::util::get_entry_as<std::size_t>(
+                rtcfg_, "hpx.numa_sensitive", 0);
 
             switch (sched_type)
             {
@@ -238,10 +211,6 @@ namespace hpx { namespace threads {
             case resource::local:
             {
 #if defined(HPX_HAVE_LOCAL_SCHEDULER)
-                // set parameters for scheduler and pool instantiation and
-                // perform compatibility checks
-                hpx::detail::ensure_high_priority_compatibility(cfg_.vm_);
-
                 // instantiate the scheduler
                 using local_sched_type =
                     hpx::threads::policies::local_queue_scheduler<>;
@@ -279,8 +248,11 @@ namespace hpx { namespace threads {
                 // set parameters for scheduler and pool instantiation and
                 // perform compatibility checks
                 std::size_t num_high_priority_queues =
-                    hpx::util::get_num_high_priority_queues(
-                        cfg_, rp.get_num_threads(name));
+                    hpx::util::get_entry_as<std::size_t>(rtcfg_,
+                        "hpx.thread_queue.high_priority_queues",
+                        thread_pool_init.num_threads_);
+                detail::check_num_high_priority_queues(
+                    thread_pool_init.num_threads_, num_high_priority_queues);
 
                 // instantiate the scheduler
                 using local_sched_type =
@@ -316,8 +288,11 @@ namespace hpx { namespace threads {
                 // set parameters for scheduler and pool instantiation and
                 // perform compatibility checks
                 std::size_t num_high_priority_queues =
-                    hpx::util::get_num_high_priority_queues(
-                        cfg_, rp.get_num_threads(name));
+                    hpx::util::get_entry_as<std::size_t>(rtcfg_,
+                        "hpx.thread_queue.high_priority_queues",
+                        thread_pool_init.num_threads_);
+                detail::check_num_high_priority_queues(
+                    thread_pool_init.num_threads_, num_high_priority_queues);
 
                 // instantiate the scheduler
                 using local_sched_type =
@@ -357,10 +332,6 @@ namespace hpx { namespace threads {
             case resource::static_:
             {
 #if defined(HPX_HAVE_STATIC_SCHEDULER)
-                // set parameters for scheduler and pool instantiation and
-                // perform compatibility checks
-                hpx::detail::ensure_high_priority_compatibility(cfg_.vm_);
-
                 // instantiate the scheduler
                 using local_sched_type =
                     hpx::threads::policies::static_queue_scheduler<>;
@@ -399,8 +370,11 @@ namespace hpx { namespace threads {
                 // set parameters for scheduler and pool instantiation and
                 // perform compatibility checks
                 std::size_t num_high_priority_queues =
-                    hpx::util::get_num_high_priority_queues(
-                        cfg_, rp.get_num_threads(name));
+                    hpx::util::get_entry_as<std::size_t>(rtcfg_,
+                        "hpx.thread_queue.high_priority_queues",
+                        thread_pool_init.num_threads_);
+                detail::check_num_high_priority_queues(
+                    thread_pool_init.num_threads_, num_high_priority_queues);
 
                 // instantiate the scheduler
                 using local_sched_type =
@@ -429,7 +403,8 @@ namespace hpx { namespace threads {
                 throw hpx::detail::command_line_error(
                     "Command line option --hpx:queuing=static-priority "
                     "is not configured in this build. Please rebuild with "
-                    "'cmake -DHPX_WITH_THREAD_SCHEDULERS=static-priority'.");
+                    "'cmake "
+                    "-DHPX_WITH_THREAD_SCHEDULERS=static-priority'.");
 #endif
                 break;
             }
@@ -440,8 +415,11 @@ namespace hpx { namespace threads {
                 // set parameters for scheduler and pool instantiation and
                 // perform compatibility checks
                 std::size_t num_high_priority_queues =
-                    hpx::util::get_num_high_priority_queues(
-                        cfg_, rp.get_num_threads(name));
+                    hpx::util::get_entry_as<std::size_t>(rtcfg_,
+                        "hpx.thread_queue.high_priority_queues",
+                        thread_pool_init.num_threads_);
+                detail::check_num_high_priority_queues(
+                    thread_pool_init.num_threads_, num_high_priority_queues);
 
                 // instantiate the scheduler
                 using local_sched_type =
@@ -485,8 +463,11 @@ namespace hpx { namespace threads {
                 // set parameters for scheduler and pool instantiation and
                 // perform compatibility checks
                 std::size_t num_high_priority_queues =
-                    hpx::util::get_num_high_priority_queues(
-                        cfg_, rp.get_num_threads(name));
+                    hpx::util::get_entry_as<std::size_t>(rtcfg_,
+                        "hpx.thread_queue.high_priority_queues",
+                        thread_pool_init.num_threads_);
+                detail::check_num_high_priority_queues(
+                    thread_pool_init.num_threads_, num_high_priority_queues);
 
                 // instantiate the scheduler
                 using local_sched_type =
@@ -552,7 +533,8 @@ namespace hpx { namespace threads {
                 throw hpx::detail::command_line_error(
                     "Command line option --hpx:queuing=shared-priority "
                     "is not configured in this build. Please rebuild with "
-                    "'cmake -DHPX_WITH_THREAD_SCHEDULERS=shared-priority'.");
+                    "'cmake "
+                    "-DHPX_WITH_THREAD_SCHEDULERS=shared-priority'.");
 #endif
                 break;
             }

--- a/src/runtime/agas/addressing_service.cpp
+++ b/src/runtime/agas/addressing_service.cpp
@@ -139,7 +139,7 @@ namespace hpx { namespace agas
     }; // }}}
 
     addressing_service::addressing_service(
-        util::runtime_configuration const& ini_, runtime_mode runtime_type_)
+        util::runtime_configuration const& ini_)
       : gva_cache_(new gva_cache_type)
       , console_cache_(naming::invalid_locality_id)
       , max_refcnt_requests_(ini_.get_agas_max_pending_refcnt_requests())
@@ -147,7 +147,7 @@ namespace hpx { namespace agas
       , enable_refcnt_caching_(true)
       , refcnt_requests_(new refcnt_requests_type)
       , service_type(ini_.get_agas_service_mode())
-      , runtime_type(runtime_type_)
+      , runtime_type(ini_.mode_)
       , caching_(ini_.get_agas_caching_mode())
       , range_caching_(caching_ ? ini_.get_agas_range_caching_mode() : false)
       , action_priority_(threads::thread_priority::boost)

--- a/src/runtime_distributed.cpp
+++ b/src/runtime_distributed.cpp
@@ -14,7 +14,6 @@
 #include <hpx/collectives/barrier.hpp>
 #include <hpx/collectives/detail/barrier_node.hpp>
 #include <hpx/collectives/latch.hpp>
-#include <hpx/command_line_handling/command_line_handling.hpp>
 #include <hpx/coroutines/coroutine.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/execution_base/this_thread.hpp>
@@ -387,18 +386,18 @@ namespace hpx {
             &detail::network_background_callback,
 #endif
             false)
-      , mode_(rtcfg.mode_)
+      , mode_(rtcfg_.mode_)
 #if defined(HPX_HAVE_NETWORKING)
       , parcel_handler_notifier_(runtime_distributed::get_notification_policy(
             "parcel-thread", runtime_local::os_thread_type::parcel_thread))
-      , parcel_handler_(rtcfg, thread_manager_.get(), parcel_handler_notifier_)
-      , agas_client_(ini_, rtcfg.mode_)
+      , parcel_handler_(rtcfg_, thread_manager_.get(), parcel_handler_notifier_)
+      , agas_client_(rtcfg_)
       , applier_(parcel_handler_, *thread_manager_)
 #else
-      , agas_client_(ini_, rtcfg.mode_)
+      , agas_client_(rtcfg_)
       , applier_(*thread_manager_)
 #endif
-      , runtime_support_(new components::server::runtime_support(ini_))
+      , runtime_support_(new components::server::runtime_support(rtcfg_))
     {
         // This needs to happen first
         runtime::init();
@@ -415,9 +414,9 @@ namespace hpx {
         LPROGRESS_;
 
 #if defined(HPX_HAVE_NETWORKING)
-        agas_client_.bootstrap(parcel_handler_, ini_);
+        agas_client_.bootstrap(parcel_handler_, rtcfg_);
 #else
-        agas_client_.bootstrap(ini_);
+        agas_client_.bootstrap(rtcfg_);
 #endif
 
         components::server::get_error_dispatcher().set_error_sink(


### PR DESCRIPTION
Moves command line handling out of the resource partitioner and into `hpx_init.cpp`. This leaves the partitioner only needing the runtime configuration and affinity data to set things up. The command line handling is now also slightly dumber in the sense that it only parses command line options and populates the configuration, but after that configuration options should be accessed through the runtime configuration, not through the command line handling.

This does contain some potentially breaking changes (e.g. command line handling can't be accessed through the partitioner), and we'll have to see how this affects users. My guess is that it's again a very small fraction (like @biddisco) who are affected.

@K-ballo this should also get rid of program options leaking out from the partitioner. If you happen to have the time to check the effect of this I'd appreciate that very much!

Edit: I should add that it should also be possible to not have a partitioner singleton anymore, but I'm leaving that for a separate PR.