### PR TITLE
Fix string split function

### DIFF
--- a/libs/core/string_util/include/hpx/string_util/split.hpp
+++ b/libs/core/string_util/include/hpx/string_util/split.hpp
@@ -59,7 +59,7 @@ namespace hpx { namespace string_util {
             if (compress_mode == token_compress_mode::on)
             {
                 // Skip contiguous separators
-                while (token_end != std::end(str) && pred(int(*token_begin)))
+                while (token_begin != std::end(str) && pred(int(*token_begin)))
                 {
                     ++token_begin;
                 }

--- a/libs/core/string_util/tests/unit/string_split.cpp
+++ b/libs/core/string_util/tests/unit/string_split.cpp
@@ -15,16 +15,6 @@
 #include <string>
 #include <vector>
 
-template <typename T1, typename T2>
-void deep_compare(const T1& X, const T2& Y)
-{
-    HPX_TEST_EQ(X.size(), Y.size());
-    for (unsigned int nIndex = 0; nIndex < X.size(); ++nIndex)
-    {
-        HPX_TEST_EQ(X[nIndex], Y[nIndex]);
-    }
-}
-
 int main()
 {
     std::string str2("Xx-abc--xX-abb-xx");


### PR DESCRIPTION
The implementation could dereference the end or past the end of the input. Fixes #5067.