### PR TITLE
Fix unused variables warnings in hipcc

### DIFF
--- a/components/component_storage/include/hpx/components/component_storage/server/migrate_to_storage.hpp
+++ b/components/component_storage/include/hpx/components/component_storage/server/migrate_to_storage.hpp
@@ -12,6 +12,7 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/naming_base/address.hpp>
 #include <hpx/naming_base/id_type.hpp>
+#include <hpx/type_support/unused.hpp>
 
 #include <hpx/components/component_storage/export_definitions.hpp>
 #include <hpx/components/component_storage/server/component_storage.hpp>
@@ -122,6 +123,9 @@ namespace hpx { namespace components { namespace server
                     ptr, to_migrate));
 #else
             HPX_ASSERT(false);
+            HPX_UNUSED(ptr);
+            HPX_UNUSED(to_migrate);
+            HPX_UNUSED(target_storage);
             return hpx::make_ready_future(naming::id_type{});
 #endif
         }
@@ -207,6 +211,8 @@ namespace hpx { namespace components { namespace server
                 });
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(to_migrate);
+        HPX_UNUSED(target_storage);
         return hpx::make_ready_future(naming::id_type{});
 #endif
     }

--- a/components/component_storage/src/component_storage.cpp
+++ b/components/component_storage/src/component_storage.cpp
@@ -8,6 +8,7 @@
 #include <hpx/assert.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/runtime/components/new.hpp>
+#include <hpx/type_support/unused.hpp>
 
 #include <hpx/components/component_storage/component_storage.hpp>
 
@@ -35,6 +36,9 @@ namespace hpx { namespace components
         return hpx::async<action_type>(this->get_id(), data, id, addr);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(data);
+        HPX_UNUSED(id);
+        HPX_UNUSED(addr);
         return hpx::make_ready_future(naming::id_type{});
 #endif
     }
@@ -55,6 +59,7 @@ namespace hpx { namespace components
         return hpx::async<action_type>(this->get_id(), id);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(id);
         return hpx::make_ready_future(std::vector<char>{});
 #endif
     }

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_component_impl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_component_impl.hpp
@@ -9,6 +9,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/async_base/launch_policy.hpp>
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/preprocessor/expand.hpp>
 #include <hpx/preprocessor/nargs.hpp>
@@ -18,7 +19,7 @@
 #include <hpx/runtime/components/server/component_base.hpp>
 #include <hpx/runtime/components/server/locking_hook.hpp>
 #include <hpx/runtime/get_ptr.hpp>
-#include <hpx/async_base/launch_policy.hpp>
+#include <hpx/type_support/unused.hpp>
 
 #include <hpx/components/containers/partitioned_vector/partitioned_vector_decl.hpp>
 
@@ -401,6 +402,8 @@ namespace hpx
             this->get_id(), n, val);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(n);
+        HPX_UNUSED(val);
         return hpx::make_ready_future();
 #endif
     }
@@ -423,6 +426,7 @@ namespace hpx
             this->get_id(), pos);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(pos);
         return hpx::future<T>{};
 #endif
     }
@@ -446,6 +450,7 @@ namespace hpx
             this->get_id(), pos);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(pos);
         return hpx::make_ready_future(std::vector<T>{});
 #endif
     }
@@ -476,6 +481,8 @@ namespace hpx
             this->get_id(), pos, std::move(val));
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(pos);
+        HPX_UNUSED(val);
         return hpx::make_ready_future();
 #endif
     }
@@ -490,6 +497,8 @@ namespace hpx
             this->get_id(), pos, val);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(pos);
+        HPX_UNUSED(val);
         return hpx::make_ready_future();
 #endif
     }
@@ -513,6 +522,8 @@ namespace hpx
             this->get_id(), pos, val);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(pos);
+        HPX_UNUSED(val);
         return hpx::make_ready_future();
 #endif
     }
@@ -561,6 +572,7 @@ namespace hpx
             this->get_id(), std::move(other));
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(other);
         return hpx::make_ready_future();
 #endif
     }

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
@@ -22,6 +22,7 @@
 #include <hpx/runtime/components/server/distributed_metadata_base.hpp>
 #include <hpx/runtime/get_ptr.hpp>
 #include <hpx/traits/is_distribution_policy.hpp>
+#include <hpx/type_support/unused.hpp>
 
 #include <hpx/components/containers/container_distribution_policy.hpp>
 #include <hpx/components/containers/partitioned_vector/partitioned_vector_decl.hpp>
@@ -107,6 +108,7 @@ namespace hpx
             });
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(id);
         return hpx::make_ready_future();
 #endif
     }

--- a/components/containers/unordered/include/hpx/components/containers/unordered/partition_unordered_map_component.hpp
+++ b/components/containers/unordered/include/hpx/components/containers/unordered/partition_unordered_map_component.hpp
@@ -35,6 +35,7 @@
 #include <hpx/runtime/components/server/locking_hook.hpp>
 #include <hpx/runtime/components/server/simple_component_base.hpp>
 #include <hpx/runtime/get_ptr.hpp>
+#include <hpx/type_support/unused.hpp>
 
 #include <cstddef>
 #include <iostream>
@@ -549,6 +550,8 @@ namespace hpx
                 this->get_id(), pos, erase);
 #else
             HPX_ASSERT(false);
+            HPX_UNUSED(pos);
+            HPX_UNUSED(erase);
             return hpx::future<T>{};
 #endif
         }
@@ -610,6 +613,8 @@ namespace hpx
                 this->get_id(), pos, std::forward<T_>(val));
 #else
             HPX_ASSERT(false);
+            HPX_UNUSED(pos);
+            HPX_UNUSED(val);
             return hpx::make_ready_future();
 #endif
         }

--- a/components/containers/unordered/include/hpx/components/containers/unordered/unordered_map.hpp
+++ b/components/containers/unordered/include/hpx/components/containers/unordered/unordered_map.hpp
@@ -22,6 +22,7 @@
 #include <hpx/serialization/unordered_map.hpp>
 #include <hpx/serialization/vector.hpp>
 #include <hpx/traits/is_distribution_policy.hpp>
+#include <hpx/type_support/unused.hpp>
 
 #include <hpx/components/containers/container_distribution_policy.hpp>
 #include <hpx/components/containers/unordered/partition_unordered_map_component.hpp>
@@ -305,6 +306,7 @@ namespace hpx
                 return hpx::async<action_type>(this->partition_.get(), std::move(d));
 #else
                 HPX_ASSERT(false);
+                HPX_UNUSED(d);
                 return hpx::make_ready_future();
 #endif
             }

--- a/components/iostreams/include/hpx/components/iostreams/ostream.hpp
+++ b/components/iostreams/include/hpx/components/iostreams/ostream.hpp
@@ -16,6 +16,7 @@
 #include <hpx/execution_base/register_locks.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/runtime/components/client_base.hpp>
+#include <hpx/type_support/unused.hpp>
 
 #include <boost/iostreams/stream.hpp>
 
@@ -207,6 +208,8 @@ namespace hpx { namespace iostreams
             }
 #else
             HPX_ASSERT(false);
+            HPX_UNUSED(subject);
+            HPX_UNUSED(l);
 #endif
             return *this;
 
@@ -236,6 +239,8 @@ namespace hpx { namespace iostreams
 
 #else
             HPX_ASSERT(false);
+            HPX_UNUSED(subject);
+            HPX_UNUSED(l);
 #endif
             return *this;
         }    // }}}

--- a/libs/full/agas/src/primary_namespace.cpp
+++ b/libs/full/agas/src/primary_namespace.cpp
@@ -17,6 +17,7 @@
 #include <hpx/runtime/actions/continuation.hpp>
 #include <hpx/runtime/components/component_factory.hpp>
 #include <hpx/serialization/vector.hpp>
+#include <hpx/type_support/unused.hpp>
 
 #include <cstdint>
 #include <string>
@@ -167,6 +168,7 @@ namespace hpx { namespace agas {
         return hpx::async(action, std::move(dest), id);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(id);
         return hpx::make_ready_future(
             std::pair<naming::id_type, naming::address>{});
 #endif

--- a/libs/full/collectives/src/latch.cpp
+++ b/libs/full/collectives/src/latch.cpp
@@ -17,6 +17,7 @@
 #include <hpx/runtime/components/derived_component_factory.hpp>
 #include <hpx/runtime/components/new.hpp>
 #include <hpx/runtime_local/detail/serialize_exception.hpp>
+#include <hpx/type_support/unused.hpp>
 
 #include <cstddef>
 #include <exception>
@@ -47,6 +48,7 @@ namespace hpx { namespace lcos {
         return hpx::async(act, get_id(), std::move(n));
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(n);
         return hpx::make_ready_future();
 #endif
     }
@@ -80,6 +82,7 @@ namespace hpx { namespace lcos {
         return hpx::async(act, get_id(), e);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(e);
         return hpx::make_ready_future();
 #endif
     }

--- a/libs/full/performance_counters/src/counter_creators.cpp
+++ b/libs/full/performance_counters/src/counter_creators.cpp
@@ -17,6 +17,7 @@
 #include <hpx/runtime/agas/server/component_namespace.hpp>
 #include <hpx/runtime/agas/server/locality_namespace.hpp>
 #include <hpx/runtime/agas/server/symbol_namespace.hpp>
+#include <hpx/type_support/unused.hpp>
 
 #include <cstdint>
 #include <string>
@@ -543,6 +544,9 @@ namespace hpx { namespace performance_counters {
             return id;
 #else
             HPX_ASSERT(false);
+            HPX_UNUSED(name);
+            HPX_UNUSED(agas_id);
+            HPX_UNUSED(ec);
             return id;
 #endif
         }

--- a/libs/full/performance_counters/src/performance_counter.cpp
+++ b/libs/full/performance_counters/src/performance_counter.cpp
@@ -10,6 +10,7 @@
 #include <hpx/functional/bind.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/type_support/unused.hpp>
 
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/performance_counter.hpp>
@@ -69,6 +70,7 @@ namespace hpx { namespace performance_counters {
         return hpx::async<action_type>(get_id(), reset);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(reset);
         return hpx::make_ready_future(counter_value{});
 #endif
     }
@@ -104,6 +106,7 @@ namespace hpx { namespace performance_counters {
         return hpx::async<action_type>(get_id(), reset);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(reset);
         return hpx::make_ready_future(counter_values_array{});
 #endif
     }
@@ -185,6 +188,7 @@ namespace hpx { namespace performance_counters {
         return hpx::async<action_type>(get_id(), reset);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(reset);
         return hpx::make_ready_future();
 #endif
     }

--- a/src/runtime/components/server/runtime_support_server.cpp
+++ b/src/runtime/components/server/runtime_support_server.cpp
@@ -43,6 +43,7 @@
 #include <hpx/runtime_local/startup_function.hpp>
 #include <hpx/serialization/serialize.hpp>
 #include <hpx/serialization/vector.hpp>
+#include <hpx/type_support/unused.hpp>
 
 #include <hpx/lcos_local/packaged_task.hpp>
 #include <hpx/modules/collectives.hpp>
@@ -306,6 +307,7 @@ namespace hpx { namespace components { namespace server {
         }
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(respond_to);
 #endif
         std::abort();
     }
@@ -339,6 +341,8 @@ namespace hpx { namespace components { namespace server {
         lcos::broadcast(act, localities, pre_shutdown).get();
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(localities);
+        HPX_UNUSED(pre_shutdown);
 #endif
     }
 
@@ -393,6 +397,10 @@ namespace hpx { namespace components { namespace server {
             id, initiating_locality_id, num_localities, dijkstra_token);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(target_locality_id);
+        HPX_UNUSED(initiating_locality_id);
+        HPX_UNUSED(num_localities);
+        HPX_UNUSED(dijkstra_token);
 #endif
     }
 
@@ -778,9 +786,11 @@ namespace hpx { namespace components { namespace server {
                 if (respond_to)
                 {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
+#if defined(HPX_HAVE_NETWORKING)
                     // respond synchronously
                     using void_lco_type = lcos::base_lco_with_value<void>;
                     using action_type = void_lco_type::set_event_action;
+#endif
 #else
                     HPX_ASSERT(false);
 #endif

--- a/src/runtime/components/stubs/runtime_support_stubs.cpp
+++ b/src/runtime/components/stubs/runtime_support_stubs.cpp
@@ -19,6 +19,7 @@
 #include <hpx/runtime_configuration/ini.hpp>
 #include <hpx/runtime_local/runtime_local.hpp>
 #include <hpx/traits/action_was_object_migrated.hpp>
+#include <hpx/type_support/unused.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -35,6 +36,7 @@ namespace hpx { namespace components { namespace stubs
         return hpx::async<action_type>(gid);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(gid);
         return hpx::make_ready_future(0);
 #endif
     }
@@ -53,6 +55,8 @@ namespace hpx { namespace components { namespace stubs
         return hpx::async<action_type>(gid, pre_startup);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(gid);
+        HPX_UNUSED(pre_startup);
         return ::hpx::make_ready_future();
 #endif
     }
@@ -84,6 +88,8 @@ namespace hpx { namespace components { namespace stubs
         return f;
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(targetgid);
+        HPX_UNUSED(timeout);
         return ::hpx::make_ready_future();
 #endif
     }
@@ -105,6 +111,8 @@ namespace hpx { namespace components { namespace stubs
             targetgid, timeout);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(targetgid);
+        HPX_UNUSED(timeout);
 #endif
     }
 
@@ -117,6 +125,7 @@ namespace hpx { namespace components { namespace stubs
                 hpx::naming::id_type::unmanaged), timeout);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(timeout);
 #endif
     }
 
@@ -139,6 +148,7 @@ namespace hpx { namespace components { namespace stubs
         return f;
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(targetgid);
         return ::hpx::make_ready_future();
 #endif
     }
@@ -158,6 +168,7 @@ namespace hpx { namespace components { namespace stubs
             targetgid);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(targetgid);
 #endif
     }
 
@@ -183,6 +194,7 @@ namespace hpx { namespace components { namespace stubs
         hpx::apply<action_type>(targetgid);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(targetgid);
 #endif
     }
 
@@ -195,6 +207,7 @@ namespace hpx { namespace components { namespace stubs
         return hpx::async<action_type>(targetgid);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(targetgid);
         return ::hpx::make_ready_future();
 #endif
     }
@@ -207,6 +220,7 @@ namespace hpx { namespace components { namespace stubs
         hpx::async<action_type>(targetgid).get();
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(targetgid);
 #endif
     }
 
@@ -230,6 +244,8 @@ namespace hpx { namespace components { namespace stubs
         return hpx::async<action_type>(targetgid, info);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(targetgid);
+        HPX_UNUSED(info);
         return ::hpx::make_ready_future(naming::invalid_id);
 #endif
     }
@@ -255,6 +271,7 @@ namespace hpx { namespace components { namespace stubs
         return hpx::async<action_type>(targetgid);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(targetgid);
         return ::hpx::make_ready_future(util::section{});
 #endif
     }
@@ -278,6 +295,9 @@ namespace hpx { namespace components { namespace stubs
         hpx::apply<action_type>(target, gid, endpoints);
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(target);
+        HPX_UNUSED(gid);
+        HPX_UNUSED(endpoints);
 #endif
     }
 }}}

--- a/src/runtime/trigger_lco.cpp
+++ b/src/runtime/trigger_lco.cpp
@@ -10,6 +10,7 @@
 #include <hpx/naming_base/address.hpp>
 #include <hpx/naming_base/id_type.hpp>
 #include <hpx/runtime/trigger_lco.hpp>
+#include <hpx/type_support/unused.hpp>
 #if defined(HPX_MSVC) && !defined(HPX_DEBUG)
 #include <hpx/lcos/base_lco_with_value.hpp>
 #endif
@@ -19,7 +20,7 @@
 
 namespace hpx
 {
-    void trigger_lco_event(naming::id_type const& id, naming::address && addr,
+    void trigger_lco_event(naming::id_type const& id, naming::address&& addr,
         bool move_credits)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
@@ -40,6 +41,9 @@ namespace hpx
         }
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(id);
+        HPX_UNUSED(addr);
+        HPX_UNUSED(move_credits);
 #endif
     }
 
@@ -74,6 +78,10 @@ namespace hpx
         }
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(id);
+        HPX_UNUSED(cont);
+        HPX_UNUSED(addr);
+        HPX_UNUSED(move_credits);
 #endif
     }
 
@@ -98,6 +106,10 @@ namespace hpx
         }
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(id);
+        HPX_UNUSED(addr);
+        HPX_UNUSED(e);
+        HPX_UNUSED(move_credits);
 #endif
     }
 
@@ -124,6 +136,10 @@ namespace hpx
         }
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(id);
+        HPX_UNUSED(addr);
+        HPX_UNUSED(e);
+        HPX_UNUSED(move_credits);
 #endif
     }
 
@@ -159,6 +175,11 @@ namespace hpx
         }
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(id);
+        HPX_UNUSED(addr);
+        HPX_UNUSED(e);
+        HPX_UNUSED(cont);
+        HPX_UNUSED(move_credits);
 #endif
     }
 
@@ -196,6 +217,11 @@ namespace hpx
         }
 #else
         HPX_ASSERT(false);
+        HPX_UNUSED(id);
+        HPX_UNUSED(addr);
+        HPX_UNUSED(e);
+        HPX_UNUSED(cont);
+        HPX_UNUSED(move_credits);
 #endif
     }
 

--- a/src/runtime_distributed.cpp
+++ b/src/runtime_distributed.cpp
@@ -60,6 +60,7 @@
 #include <hpx/threading_base/external_timer.hpp>
 #include <hpx/threading_base/scheduler_mode.hpp>
 #include <hpx/timing/high_resolution_clock.hpp>
+#include <hpx/type_support/unused.hpp>
 #include <hpx/util/from_string.hpp>
 #include <hpx/util/query_counters.hpp>
 #include <hpx/version.hpp>
@@ -782,8 +783,10 @@ namespace hpx {
         // will be ignored
         apply<components::server::runtime_support::shutdown_all_action>(
             hpx::find_root_locality(), shutdown_timeout);
+#else
+        HPX_ASSERT(false);
+        HPX_UNUSED(shutdown_timeout);
 #endif
-
         return 0;
     }
 


### PR DESCRIPTION
Fix unused variables warnings in hipcc after #5057