### PR TITLE
Allow using noncopyable types with unwrapping

### DIFF
--- a/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_impl.hpp
+++ b/libs/parallelism/pack_traversal/include/hpx/pack_traversal/detail/pack_traversal_impl.hpp
@@ -666,7 +666,7 @@ namespace hpx { namespace util { namespace detail {
     struct mapping_strategy_base
     {
         template <typename T>
-        auto may_void(T&& element) const -> typename std::decay<T>::type
+        decltype(auto) may_void(T&& element) const
         {
             return std::forward<T>(element);
         }

--- a/libs/parallelism/pack_traversal/tests/regressions/CMakeLists.txt
+++ b/libs/parallelism/pack_traversal/tests/regressions/CMakeLists.txt
@@ -23,3 +23,20 @@ foreach(test ${tests})
     "modules.pack_traversal" ${test} ${${test}_PARAMETERS}
   )
 endforeach()
+
+# compile only tests
+if(HPX_WITH_COMPILE_ONLY_TESTS)
+  set(compile_tests unwrapping_noncopyable)
+
+  foreach(compile_test ${compile_tests})
+    set(sources ${compile_test}.cpp)
+
+    source_group("Source Files" FILES ${sources})
+
+    add_hpx_regression_compile_test(
+      "modules.pack_traversal" ${compile_test}
+      SOURCES ${sources} ${${compile_test}_FLAGS}
+      FOLDER "Tests/Regressions/Modules/Parallelism/PackTraversal/CompileOnly"
+    )
+  endforeach()
+endif()

--- a/libs/parallelism/pack_traversal/tests/regressions/unwrapping_noncopyable.cpp
+++ b/libs/parallelism/pack_traversal/tests/regressions/unwrapping_noncopyable.cpp
@@ -1,0 +1,22 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This test checks that unwrapping does not attempt to make copies of
+// noncopyable lvalues.
+
+#include <hpx/pack_traversal/unwrap.hpp>
+
+struct noncopyable
+{
+    noncopyable(noncopyable const&) = delete;
+};
+
+int main()
+{
+    auto f = hpx::util::unwrapping([](noncopyable const&) {});
+    noncopyable n{};
+    f(n);
+}


### PR DESCRIPTION
Avoiding decays at least makes the simple case work. CI will tell me if I've broken something else (unsure if some of the asynchronous cases depend on copies being made; should not if everything is set up correctly...).

Edit: this works for noncopyable lvalues but something breaks trying to make it work for rvalues. There's likely something that depends on having to make copies (e.g. containers). The current fix is enough for me at the moment.