### PR TITLE
Add install lib directory to list of component search paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2330,7 +2330,7 @@ endif()
 # Note: on windows systems the ':' will be converted to a ';' at runtime
 hpx_add_config_cond_define(
   HPX_DEFAULT_COMPONENT_PATH_SUFFIXES
-  "\"/${CMAKE_INSTALL_BINDIR}/hpx:/lib/hpx:/bin/hpx\""
+  "\"/${CMAKE_INSTALL_LIBDIR}/hpx:/${CMAKE_INSTALL_BINDIR}/hpx:/lib/hpx:/bin/hpx\""
 )
 
 # ##############################################################################


### PR DESCRIPTION
Might fix #5077. Completely untested, but I'm pretty sure the reason the plugins are not found is simply because we don't add the GNUInstallDirs-enabled lib64 directory to the list of search paths. @shahrzad I'd appreciate if you could give this a try.