### PR TITLE
Add checks to make sure that MPI/CUDA polling is enabled/not disabled too early

### DIFF
--- a/libs/full/async_cuda/include/hpx/async_cuda/cuda_future.hpp
+++ b/libs/full/async_cuda/include/hpx/async_cuda/cuda_future.hpp
@@ -302,8 +302,9 @@ namespace hpx { namespace cuda { namespace experimental {
         HPX_EXPORT hpx::future<void> get_future_with_event(cudaStream_t);
 
         // -------------------------------------------------------------
-        void register_polling(hpx::threads::thread_pool_base& pool);
-        void unregister_polling(hpx::threads::thread_pool_base& pool);
+        HPX_EXPORT void register_polling(hpx::threads::thread_pool_base& pool);
+        HPX_EXPORT void unregister_polling(
+            hpx::threads::thread_pool_base& pool);
 
         // -------------------------------------------------------------
     }    // namespace detail


### PR DESCRIPTION
Adds a check to make sure that polling has been registered at least once before getting MPI/CUDA futures, and another that checks that there are no more unprocessed events/requests/futures when polling is disabled. `HPX_NODISCARD` helps if one actually remembers to try to enable polling, but doesn't help one hasn't even remembered to do that. In those cases the application just hangs without any indication of what is wrong. These checks are intended to help debugging those situations.

The reason for the currently vague "registered at least once" is that the polling could be enabled on *any* pool, and I didn't want to look through every pool to see if at least one of them has polling enabled. This may be necessary in the end, but this should already catch most cases of not enabling polling.

I'm at the same time benchmarking the overhead of enabling polling (both CUDA and MPI). Another possibility is to simply enable polling whenever it's needed and leave it enabled. Perhaps simply using the normal `register_polling` functions would be easier than using the RAII wrappers. The RAII wrappers can also not be nested now. I'm leaving this PR as it is, but ideas on how to make this slightly less error prone are welcome.