### PR TITLE
Disambiguation of fs::directory_iterator due to a parameter by adding…

### DIFF
--- a/libs/full/runtime_configuration/src/init_ini_data.cpp
+++ b/libs/full/runtime_configuration/src/init_ini_data.cpp
@@ -201,11 +201,14 @@ namespace hpx { namespace util {
                 fs::directory_iterator nodir;
                 fs::path this_path(*it);
 
+                boost::system::error_code dir_ec;
                 std::error_code ec;
+
                 if (!fs::exists(this_path, ec) || ec)
                     continue;
 
-                for (fs::directory_iterator dir(this_path); dir != nodir; ++dir)
+                for (fs::directory_iterator dir(this_path, dir_ec);
+                     dir != nodir; ++dir)
                 {
                     if ((*dir).path().extension() != ".ini")
                         continue;
@@ -422,7 +425,9 @@ namespace hpx { namespace util {
             fs::directory_iterator nodir;
             fs::path libs_path(libs);
 
+            boost::system::error_code dir_ec;
             std::error_code ec;
+
             if (!fs::exists(libs_path, ec) || ec)
                 return plugin_registries;    // given directory doesn't exist
 
@@ -439,7 +444,8 @@ namespace hpx { namespace util {
             // generate component sections for all found shared libraries
             // this will create too many sections, but the non-components will
             // be filtered out during loading
-            for (fs::directory_iterator dir(libs_path); dir != nodir; ++dir)
+            for (fs::directory_iterator dir(libs_path, dir_ec); dir != nodir;
+                 ++dir)
             {
                 fs::path curr(*dir);
                 if (curr.extension() != HPX_SHARED_LIB_EXTENSION)
@@ -452,7 +458,7 @@ namespace hpx { namespace util {
                 if (0 == name.find("lib"))
                     name = name.substr(3);
 #endif
-#if defined(__APPLE__)    // shared library version is added berfore extension
+#if defined(__APPLE__)    // shared library version is added before extension
                 const std::string version = hpx::full_version_as_string();
                 std::string::size_type i = name.find(version);
                 if (i != std::string::npos)


### PR DESCRIPTION
… a boost::system::error_code parameter to the ctor.

After successfully building HPX in my macos system I faced an issue with the dynamic libraries showing two different constructors for `fs::directory_iterator` and the `hello_world.cpp` binary failing to find the correct ctor. By adding a `boost::system::error_code` variable to the ctor the application now finds the correct version.

Fixes #

## Proposed Changes

Addition of a error code variable to the `fs::directory_iterator` constructor.

## Any background context you want to provide?

The `hello_world.cpp` binary was not starting displaying the following message:

```
dyld: lazy symbol binding failed: Symbol not found: __ZN5boost10filesystem6detail28directory_iterator_constructERNS0_18directory_iteratorERKNS0_4pathEPNS_6system10error_codeE
  Referenced from: /usr/local/lib/libhpx.1.dylib
  Expected in: /usr/local/lib/libboost_filesystem-mt.dylib

dyld: Symbol not found: __ZN5boost10filesystem6detail28directory_iterator_constructERNS0_18directory_iteratorERKNS0_4pathEPNS_6system10error_codeE
  Referenced from: /usr/local/lib/libhpx.1.dylib
  Expected in: /usr/local/lib/libboost_filesystem-mt.dylib

Trace/BPT trap: 5
```

and by using gcc's `c++filt` I was able to see that, since Boost 1.72, there are two overloads of the constructor. Adding the error code variable solved the ambiguous instantiation.