### PR TITLE
Relax iterator requirements for sequential versions of set algorithms

### DIFF
--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
@@ -371,12 +371,12 @@ namespace hpx {
             FwdIter1 last1, FwdIter2 first2, FwdIter2 last2, FwdIter3 dest,
             Pred&& op = Pred())
         {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_input_iterator<FwdIter1>::value),
+                "Requires at least input iterator.");
+            static_assert((hpx::traits::is_input_iterator<FwdIter2>::value),
+                "Requires at least input iterator.");
+            static_assert((hpx::traits::is_output_iterator<FwdIter3>::value),
+                "Requires at least output iterator.");
 
             using result_type =
                 hpx::parallel::util::in_out_result<FwdIter1, FwdIter3>;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_intersection.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_intersection.hpp
@@ -349,12 +349,12 @@ namespace hpx {
             FwdIter1 last1, FwdIter2 first2, FwdIter2 last2, FwdIter3 dest,
             Pred&& op = Pred())
         {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_input_iterator<FwdIter1>::value),
+                "Requires at least input iterator.");
+            static_assert((hpx::traits::is_input_iterator<FwdIter2>::value),
+                "Requires at least input iterator.");
+            static_assert((hpx::traits::is_output_iterator<FwdIter3>::value),
+                "Requires at least output iterator.");
 
             using result_type = hpx::parallel::util::in_in_out_result<FwdIter1,
                 FwdIter2, FwdIter3>;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
@@ -387,12 +387,12 @@ namespace hpx {
             FwdIter1 last1, FwdIter2 first2, FwdIter2 last2, FwdIter3 dest,
             Pred&& op = Pred())
         {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_input_iterator<FwdIter1>::value),
+                "Requires at least input iterator.");
+            static_assert((hpx::traits::is_input_iterator<FwdIter2>::value),
+                "Requires at least input iterator.");
+            static_assert((hpx::traits::is_output_iterator<FwdIter3>::value),
+                "Requires at least output iterator.");
 
             using result_type = hpx::parallel::util::in_in_out_result<FwdIter1,
                 FwdIter2, FwdIter3>;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_union.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_union.hpp
@@ -372,12 +372,12 @@ namespace hpx {
         friend FwdIter3 tag_invoke(set_union_t, FwdIter1 first1, FwdIter1 last1,
             FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, Pred&& op = Pred())
         {
-            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_input_iterator<FwdIter1>::value),
+                "Requires at least input iterator.");
+            static_assert((hpx::traits::is_input_iterator<FwdIter2>::value),
+                "Requires at least input iterator.");
+            static_assert((hpx::traits::is_output_iterator<FwdIter3>::value),
+                "Requires at least output iterator.");
 
             using result_type = hpx::parallel::util::in_in_out_result<FwdIter1,
                 FwdIter3, FwdIter3>;

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_difference.hpp
@@ -394,12 +394,12 @@ namespace hpx { namespace ranges {
             Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
         {
-            static_assert((hpx::traits::is_forward_iterator<Iter1>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_input_iterator<Iter1>::value),
+                "Requires at least input iterator.");
+            static_assert((hpx::traits::is_input_iterator<Iter2>::value),
+                "Requires at least input iterator.");
+            static_assert((hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least output iterator.");
 
             using result_type = set_difference_result<Iter1, Iter3>;
 
@@ -439,13 +439,13 @@ namespace hpx { namespace ranges {
                 typename hpx::traits::range_iterator<Rng2>::type;
 
             static_assert(
-                (hpx::traits::is_forward_iterator<iterator_type1>::value),
-                "Requires at least forward iterator.");
+                (hpx::traits::is_input_iterator<iterator_type1>::value),
+                "Requires at least input iterator.");
             static_assert(
-                (hpx::traits::is_forward_iterator<iterator_type2>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+                (hpx::traits::is_input_iterator<iterator_type2>::value),
+                "Requires at least input iterator.");
+            static_assert((hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least output iterator.");
 
             using result_type = set_difference_result<iterator_type1, Iter3>;
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_intersection.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_intersection.hpp
@@ -397,12 +397,12 @@ namespace hpx { namespace ranges {
             Sent2 last2, Iter3 dest, Pred&& op = Pred(),
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
-            static_assert((hpx::traits::is_forward_iterator<Iter1>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_input_iterator<Iter1>::value),
+                "Requires at least input iterator.");
+            static_assert((hpx::traits::is_input_iterator<Iter2>::value),
+                "Requires at least input iterator.");
+            static_assert((hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least output iterator.");
 
             using result_type = set_intersection_result<Iter1, Iter2, Iter3>;
 
@@ -443,13 +443,13 @@ namespace hpx { namespace ranges {
                 typename hpx::traits::range_iterator<Rng2>::type;
 
             static_assert(
-                (hpx::traits::is_forward_iterator<iterator_type1>::value),
-                "Requires at least forward iterator.");
+                (hpx::traits::is_input_iterator<iterator_type1>::value),
+                "Requires at least input iterator.");
             static_assert(
-                (hpx::traits::is_forward_iterator<iterator_type2>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+                (hpx::traits::is_input_iterator<iterator_type2>::value),
+                "Requires at least input iterator.");
+            static_assert((hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least out iterator.");
 
             using result_type =
                 set_intersection_result<iterator_type1, iterator_type2, Iter3>;

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_symmetric_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_symmetric_difference.hpp
@@ -408,12 +408,12 @@ namespace hpx { namespace ranges {
             Sent2 last2, Iter3 dest, Pred&& op = Pred(),
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
-            static_assert((hpx::traits::is_forward_iterator<Iter1>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_input_iterator<Iter1>::value),
+                "Requires at least input iterator.");
+            static_assert((hpx::traits::is_input_iterator<Iter2>::value),
+                "Requires at least input iterator.");
+            static_assert((hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least output iterator.");
 
             using result_type =
                 set_symmetric_difference_result<Iter1, Iter2, Iter3>;
@@ -456,13 +456,13 @@ namespace hpx { namespace ranges {
                 typename hpx::traits::range_iterator<Rng2>::type;
 
             static_assert(
-                (hpx::traits::is_forward_iterator<iterator_type1>::value),
-                "Requires at least forward iterator.");
+                (hpx::traits::is_input_iterator<iterator_type1>::value),
+                "Requires at least input iterator.");
             static_assert(
-                (hpx::traits::is_forward_iterator<iterator_type2>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+                (hpx::traits::is_input_iterator<iterator_type2>::value),
+                "Requires at least input iterator.");
+            static_assert((hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least output iterator.");
 
             using result_type = set_symmetric_difference_result<iterator_type1,
                 iterator_type2, Iter3>;

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_union.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_union.hpp
@@ -395,12 +395,12 @@ namespace hpx { namespace ranges {
             Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
         {
-            static_assert((hpx::traits::is_forward_iterator<Iter1>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_input_iterator<Iter1>::value),
+                "Requires at least input iterator.");
+            static_assert((hpx::traits::is_input_iterator<Iter2>::value),
+                "Requires at least input iterator.");
+            static_assert((hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least output iterator.");
 
             using result_type = set_union_result<Iter1, Iter2, Iter3>;
 
@@ -441,13 +441,13 @@ namespace hpx { namespace ranges {
                 typename hpx::traits::range_iterator<Rng2>::type;
 
             static_assert(
-                (hpx::traits::is_forward_iterator<iterator_type1>::value),
-                "Requires at least forward iterator.");
+                (hpx::traits::is_input_iterator<iterator_type1>::value),
+                "Requires at least input iterator.");
             static_assert(
-                (hpx::traits::is_forward_iterator<iterator_type2>::value),
-                "Requires at least forward iterator.");
-            static_assert((hpx::traits::is_forward_iterator<Iter3>::value),
-                "Requires at least forward iterator.");
+                (hpx::traits::is_input_iterator<iterator_type2>::value),
+                "Requires at least input iterator.");
+            static_assert((hpx::traits::is_output_iterator<Iter3>::value),
+                "Requires at least output iterator.");
 
             using result_type =
                 set_union_result<iterator_type1, iterator_type2, Iter3>;


### PR DESCRIPTION
This is a partial duplicate of #5027 and has been merged over there.