### PR TITLE
Allow mixing debug and release builds

### DIFF
--- a/.github/workflows/windows_debug.yml
+++ b/.github/workflows/windows_debug.yml
@@ -39,33 +39,29 @@ jobs:
       run: |
           cmake --build build --config Debug \
           --target ALL_BUILD \
-            cmake_debug_build_dir_targets_test \
-            cmake_minsizerel_build_dir_targets_test \
-            cmake_release_build_dir_targets_test \
-            cmake_relwithdebinfo_build_dir_targets_test \
-            cmake_debug_build_dir_macros_test \
-            cmake_minsizerel_build_dir_macros_test \
-            cmake_release_build_dir_macros_test \
-            cmake_relwithdebinfo_build_dir_macros_test \
-          -- -maxcpucount -verbosity:detailed -nologo
+            cmake_debug_build_dir_targets_test.make_build_dir \
+            cmake_debug_build_dir_targets_test.make_configure \
+            cmake_debug_build_dir_targets_test.make_compile   \
+            cmake_debug_build_dir_macros_test.make_build_dir \
+            cmake_debug_build_dir_macros_test.make_configure \
+            cmake_debug_build_dir_macros_test.make_compile   \
+          -- -maxcpucount -verbosity:minimal -nologo
     - name: Install
       shell: bash
       run: |
-          cmake --install build
+          cmake --install build --config Debug
     - name: Build External
       shell: bash
       run: |
-          cmake --build build --config Release \
+          cmake --build build --config Debug \
             --target \
-              cmake_debug_install_dir_targets_test \
-              cmake_minsizerel_install_dir_targets_test \
-              cmake_release_install_dir_targets_test \
-              cmake_relwithdebinfo_install_dir_targets_test \
-              cmake_debug_install_dir_macros_test \
-              cmake_minsizerel_install_dir_macros_test \
-              cmake_release_install_dir_macros_test \
-              cmake_relwithdebinfo_install_dir_macros_test \
-            -- -maxcpucount -verbosity:detailed -nologo
+              cmake_debug_install_dir_targets_test.make_build_dir \
+              cmake_debug_install_dir_targets_test.make_configure \
+              cmake_debug_install_dir_targets_test.make_compile   \
+              cmake_debug_install_dir_macros_test.make_build_dir \
+              cmake_debug_install_dir_macros_test.make_configure \
+              cmake_debug_install_dir_macros_test.make_compile   \
+            -- -maxcpucount -verbosity:minimal -nologo
     - name: Test
       shell: bash
       run: |

--- a/.github/workflows/windows_debug.yml
+++ b/.github/workflows/windows_debug.yml
@@ -39,9 +39,33 @@ jobs:
       run: |
           cmake --build build --config Debug \
           --target ALL_BUILD \
-            cmake_build_dir_targets_test.make_compile \
-            cmake_build_dir_macros_test.make_compile \
+            cmake_debug_build_dir_targets_test \
+            cmake_minsizerel_build_dir_targets_test \
+            cmake_release_build_dir_targets_test \
+            cmake_relwithdebinfo_build_dir_targets_test \
+            cmake_debug_build_dir_macros_test \
+            cmake_minsizerel_build_dir_macros_test \
+            cmake_release_build_dir_macros_test \
+            cmake_relwithdebinfo_build_dir_macros_test \
           -- -maxcpucount -verbosity:minimal -nologo
+    - name: Install
+      shell: bash
+      run: |
+          cmake --install build
+    - name: Build External
+      shell: bash
+      run: |
+          cmake --build build --config Release \
+            --target \
+              cmake_debug_install_dir_targets_test \
+              cmake_minsizerel_install_dir_targets_test \
+              cmake_release_install_dir_targets_test \
+              cmake_relwithdebinfo_install_dir_targets_test \
+              cmake_debug_install_dir_macros_test \
+              cmake_minsizerel_install_dir_macros_test \
+              cmake_release_install_dir_macros_test \
+              cmake_relwithdebinfo_install_dir_macros_test \
+            -- -maxcpucount -verbosity:minimal -nologo
     - name: Test
       shell: bash
       run: |

--- a/.github/workflows/windows_debug.yml
+++ b/.github/workflows/windows_debug.yml
@@ -47,7 +47,7 @@ jobs:
             cmake_minsizerel_build_dir_macros_test \
             cmake_release_build_dir_macros_test \
             cmake_relwithdebinfo_build_dir_macros_test \
-          -- -maxcpucount -verbosity:minimal -nologo
+          -- -maxcpucount -verbosity:detailed -nologo
     - name: Install
       shell: bash
       run: |
@@ -65,7 +65,7 @@ jobs:
               cmake_minsizerel_install_dir_macros_test \
               cmake_release_install_dir_macros_test \
               cmake_relwithdebinfo_install_dir_macros_test \
-            -- -maxcpucount -verbosity:minimal -nologo
+            -- -maxcpucount -verbosity:detailed -nologo
     - name: Test
       shell: bash
       run: |

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -38,33 +38,29 @@ jobs:
       run: |
           cmake --build build --config Release \
           --target ALL_BUILD \
-            cmake_debug_build_dir_targets_test \
-            cmake_minsizerel_build_dir_targets_test \
-            cmake_release_build_dir_targets_test \
-            cmake_relwithdebinfo_build_dir_targets_test \
-            cmake_debug_build_dir_macros_test \
-            cmake_minsizerel_build_dir_macros_test \
-            cmake_release_build_dir_macros_test \
-            cmake_relwithdebinfo_build_dir_macros_test \
-          -- -maxcpucount -verbosity:detailed -nologo
+            cmake_release_build_dir_targets_test.make_build_dir \
+            cmake_release_build_dir_targets_test.make_configure \
+            cmake_release_build_dir_targets_test.make_compile   \
+            cmake_release_build_dir_macros_test.make_build_dir \
+            cmake_release_build_dir_macros_test.make_configure \
+            cmake_release_build_dir_macros_test.make_compile   \
+          -- -maxcpucount -verbosity:minimal -nologo
     - name: Install
       shell: bash
       run: |
-          cmake --install build
+          cmake --install build --config Release
     - name: Build External
       shell: bash
       run: |
           cmake --build build --config Release \
             --target \
-              cmake_debug_install_dir_targets_test \
-              cmake_minsizerel_install_dir_targets_test \
-              cmake_release_install_dir_targets_test \
-              cmake_relwithdebinfo_install_dir_targets_test \
-              cmake_debug_install_dir_macros_test \
-              cmake_minsizerel_install_dir_macros_test \
-              cmake_release_install_dir_macros_test \
-              cmake_relwithdebinfo_install_dir_macros_test \
-            -- -maxcpucount -verbosity:detailed -nologo
+              cmake_release_install_dir_targets_test.make_build_dir \
+              cmake_release_install_dir_targets_test.make_configure \
+              cmake_release_install_dir_targets_test.make_compile   \
+              cmake_release_install_dir_macros_test.make_build_dir \
+              cmake_release_install_dir_macros_test.make_configure \
+              cmake_release_install_dir_macros_test.make_compile   \
+            -- -maxcpucount -verbosity:minimal -nologo
     - name: Test
       shell: bash
       run: |

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -38,8 +38,14 @@ jobs:
       run: |
           cmake --build build --config Release \
           --target ALL_BUILD \
-            cmake_build_dir_targets_test.make_compile \
-            cmake_build_dir_macros_test.make_compile \
+            cmake_debug_build_dir_targets_test \
+            cmake_minsizerel_build_dir_targets_test \
+            cmake_release_build_dir_targets_test \
+            cmake_relwithdebinfo_build_dir_targets_test \
+            cmake_debug_build_dir_macros_test \
+            cmake_minsizerel_build_dir_macros_test \
+            cmake_release_build_dir_macros_test \
+            cmake_relwithdebinfo_build_dir_macros_test \
           -- -maxcpucount -verbosity:minimal -nologo
     - name: Install
       shell: bash
@@ -49,8 +55,15 @@ jobs:
       shell: bash
       run: |
           cmake --build build --config Release \
-            --target cmake_install_dir_targets_test.make_compile \
-              cmake_install_dir_macros_test.make_compile \
+            --target \
+              cmake_debug_install_dir_targets_test \
+              cmake_minsizerel_install_dir_targets_test \
+              cmake_release_install_dir_targets_test \
+              cmake_relwithdebinfo_install_dir_targets_test \
+              cmake_debug_install_dir_macros_test \
+              cmake_minsizerel_install_dir_macros_test \
+              cmake_release_install_dir_macros_test \
+              cmake_relwithdebinfo_install_dir_macros_test \
             -- -maxcpucount -verbosity:minimal -nologo
     - name: Test
       shell: bash

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -46,7 +46,7 @@ jobs:
             cmake_minsizerel_build_dir_macros_test \
             cmake_release_build_dir_macros_test \
             cmake_relwithdebinfo_build_dir_macros_test \
-          -- -maxcpucount -verbosity:minimal -nologo
+          -- -maxcpucount -verbosity:detailed -nologo
     - name: Install
       shell: bash
       run: |
@@ -64,7 +64,7 @@ jobs:
               cmake_minsizerel_install_dir_macros_test \
               cmake_release_install_dir_macros_test \
               cmake_relwithdebinfo_install_dir_macros_test \
-            -- -maxcpucount -verbosity:minimal -nologo
+            -- -maxcpucount -verbosity:detailed -nologo
     - name: Test
       shell: bash
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1731,23 +1731,6 @@ hpx_option(
 )
 
 # ##############################################################################
-# Add necessary compiler flags. Flags added here include flags to disable/enable
-# certain warnings, enabling C++11 mode and disabling asserts. Setting of
-# optimization flags is not handled here and is left to the responsibility of
-# the user to avoid conflicts in the resulting binaries
-
-hpx_add_target_compile_definition(_DEBUG PUBLIC CONFIGURATIONS Debug)
-hpx_add_target_compile_definition(DEBUG PUBLIC CONFIGURATIONS Debug)
-hpx_add_target_compile_definition(
-  HPX_DISABLE_ASSERTS PUBLIC CONFIGURATIONS Release RelWithDebInfo
-                                            MinSizeRelease
-)
-hpx_add_target_compile_definition(
-  BOOST_DISABLE_ASSERTS PUBLIC CONFIGURATIONS Release RelWithDebInfo
-                                              MinSizeRelease
-)
-
-# ##############################################################################
 # C++ feature tests
 # ##############################################################################
 include(HPX_PerformCxxFeatureTests)
@@ -1853,7 +1836,7 @@ if(WIN32)
     # non-referenced functions and data (-Zc:inline)
     hpx_add_target_compile_option(-Zc:inline PUBLIC)
     hpx_add_target_compile_option(
-      -Gw PUBLIC CONFIGURATIONS Release RelWithDebInfo MinSizeRelease
+      -Gw PUBLIC CONFIGURATIONS Release RelWithDebInfo MinSizeRel
     )
     hpx_add_target_compile_option(-Zo PUBLIC CONFIGURATIONS RelWithDebInfo)
     if(HPX_WITH_DATAPAR_VC)

--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -319,9 +319,7 @@ function(add_hpx_module libname modulename)
   endif()
 
   target_compile_definitions(
-    hpx_${modulename}
-    PRIVATE $<$<CONFIG:Debug>:DEBUG> $<$<CONFIG:Debug>:_DEBUG>
-            HPX_${libname_upper}_EXPORTS
+    hpx_${modulename} PRIVATE HPX_${libname_upper}_EXPORTS
   )
 
   # This is a temporary solution until all of HPX has been modularized as it

--- a/cmake/HPX_CompilerFlagsTargets.cmake
+++ b/cmake/HPX_CompilerFlagsTargets.cmake
@@ -21,6 +21,13 @@ target_compile_definitions(
   hpx_public_flags INTERFACE $<$<CONFIG:Debug>:HPX_DEBUG>
 )
 
+target_compile_definitions(
+  hpx_private_flags
+  INTERFACE $<$<CONFIG:MinSizeRel>:NDEBUG>
+  INTERFACE $<$<CONFIG:Release>:NDEBUG>
+  INTERFACE $<$<CONFIG:RelWithDebInfo>:NDEBUG>
+)
+
 # Remaining flags are set through the macros in cmake/HPX_AddCompileFlag.cmake
 
 include(HPX_ExportTargets)

--- a/cmake/templates/HPXConfig.cmake.in
+++ b/cmake/templates/HPXConfig.cmake.in
@@ -98,7 +98,6 @@ if(NOT HPX_CMAKE_LOGLEVEL)
   set(HPX_CMAKE_LOGLEVEL "WARN")
 endif()
 
-hpx_check_cmake_build_type()
 hpx_check_compiler_compatibility()
 hpx_check_boost_compatibility()
 hpx_check_allocator_compatibility()

--- a/cmake/templates/HPXMacros.cmake.in
+++ b/cmake/templates/HPXMacros.cmake.in
@@ -95,25 +95,3 @@ function(hpx_check_allocator_compatibility)
       "informational purposes to dependent projects and should not be changed.")
   endif()
 endfunction()
-
-# Check we are using the same build type as HPX
-function(hpx_check_cmake_build_type)
-  get_property(_GENERATOR_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-  if (NOT _GENERATOR_IS_MULTI_CONFIG AND
-      NOT "${HPX_BUILD_TYPE}" STREQUAL "${CMAKE_BUILD_TYPE}" AND
-      ("${HPX_BUILD_TYPE}" STREQUAL "Debug" OR "${CMAKE_BUILD_TYPE}" STREQUAL "Debug"))
-    if(HPX_IGNORE_CMAKE_BUILD_TYPE_COMPATIBILITY)
-      hpx_warn("CMAKE_BUILD_TYPE does not match ${HPX_BUILD_TYPE}: "
-        "this project uses '${CMAKE_BUILD_TYPE}', HPX uses '${HPX_BUILD_TYPE}'. "
-        "HPX is not ABI compatible between release and debug modes and it is "
-        "recommended that you use the same build type for HPX and your project.")
-    else()
-      hpx_error("CMAKE_BUILD_TYPE does not match ${HPX_BUILD_TYPE}: "
-        "this project uses '${CMAKE_BUILD_TYPE}', HPX uses '${HPX_BUILD_TYPE}'. "
-        "Please add -DCMAKE_BUILD_TYPE=${HPX_BUILD_TYPE} to your cmake command "
-        "or add -DHPX_IGNORE_CMAKE_BUILD_TYPE_COMPATIBILITY=ON to ignore this "
-        "check (not recommended; HPX is not ABI compatible between release and "
-        "debug modes).")
-    endif()
-  endif()
-endfunction()

--- a/examples/hello_world_component/CMakeLists.txt
+++ b/examples/hello_world_component/CMakeLists.txt
@@ -15,7 +15,6 @@ if(EXISTS "${HPX_DIR}")
 
   add_executable(hello_world_client hello_world_client.cpp)
   target_include_directories(hello_world_client PRIVATE ${test_SOURCE_DIR})
-  target_include_directories(hello_world_client PRIVATE HPX_DEBUG)
 
   if("${SETUP_TYPE}" STREQUAL "TARGETS")
     target_link_libraries(
@@ -35,9 +34,6 @@ if(EXISTS "${HPX_DIR}")
       add_executable(hello_world_client_only_hpx_init hello_world_client.cpp)
       target_include_directories(
         hello_world_client_only_hpx_init PRIVATE ${test_SOURCE_DIR}
-      )
-      target_include_directories(
-        hello_world_client_only_hpx_init PRIVATE HPX_DEBUG
       )
 
       target_link_libraries(

--- a/hpx/runtime/components/server/component_base.hpp
+++ b/hpx/runtime/components/server/component_base.hpp
@@ -77,14 +77,6 @@ namespace hpx { namespace components
             HPX_EXPORT naming::id_type get_unmanaged_id(
                 naming::gid_type const& gid) const;
 
-#if defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) || defined(NDEBUG)
-            static constexpr void mark_as_migrated()
-            {
-            }
-            static constexpr void on_migrated()
-            {
-            }
-#else
             static void mark_as_migrated()
             {
                 // If this assertion is triggered then this component instance is
@@ -100,7 +92,6 @@ namespace hpx { namespace components
                 // migration.
                 HPX_ASSERT(false);
             }
-#endif
 
         protected:
             // Create a new GID (if called for the first time), assign this

--- a/hpx/runtime/components/server/fixed_component_base.hpp
+++ b/hpx/runtime/components/server/fixed_component_base.hpp
@@ -156,14 +156,6 @@ public:
         }
     }
 
-#if defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) || defined(NDEBUG)
-    static constexpr void mark_as_migrated()
-    {
-    }
-    static constexpr void on_migrated()
-    {
-    }
-#else
     void mark_as_migrated()
     {
         // If this assertion is triggered then this component instance is being
@@ -179,7 +171,6 @@ public:
         // migration.
         HPX_ASSERT(false);
     }
-#endif
 
 private:
     mutable naming::gid_type gid_;
@@ -192,15 +183,6 @@ namespace detail
     ///////////////////////////////////////////////////////////////////////
     struct fixed_heap
     {
-#if defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) || defined(NDEBUG)
-        static constexpr void* alloc(std::size_t /*count*/)
-        {
-            return nullptr;
-        }
-        static constexpr void free(void* /*p*/, std::size_t /*count*/)
-        {
-        }
-#else
         static void* alloc(std::size_t /*count*/)
         {
             HPX_ASSERT(false);        // this shouldn't ever be called
@@ -210,7 +192,6 @@ namespace detail
         {
             HPX_ASSERT(false);        // this shouldn't ever be called
         }
-#endif
     };
 }
 
@@ -224,17 +205,6 @@ class fixed_component : public Component
     typedef component_type derived_type;
     typedef detail::fixed_heap heap_type;
 
-#if defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) || defined(NDEBUG)
-    static constexpr Component* create(std::size_t /* count */)
-    {
-        return nullptr;
-    }
-
-    static constexpr void destroy(
-        Component* /* p */, std::size_t /* count */ = 1)
-    {
-    }
-#else
     /// \brief  The function \a create is used for allocation and
     ///         initialization of instances of the derived components.
     static Component* create(std::size_t /* count */)
@@ -249,9 +219,6 @@ class fixed_component : public Component
     {
         HPX_ASSERT(false);        // this shouldn't ever be called
     }
-#endif
 };
 
 }}
-
-

--- a/hpx/runtime/components/server/managed_component_base.hpp
+++ b/hpx/runtime/components/server/managed_component_base.hpp
@@ -171,14 +171,6 @@ namespace hpx { namespace components
             ///        destructed
             static constexpr void finalize() {}
 
-#if defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) || defined(NDEBUG)
-            static constexpr void mark_as_migrated()
-            {
-            }
-            static constexpr void on_migrated()
-            {
-            }
-#else
             static void mark_as_migrated()
             {
                 // If this assertion is triggered then this component instance is
@@ -194,7 +186,6 @@ namespace hpx { namespace components
                 // migration.
                 HPX_ASSERT(false);
             }
-#endif
         };
     }
 

--- a/libs/core/config/include/hpx/config/debug.hpp
+++ b/libs/core/config/include/hpx/config/debug.hpp
@@ -14,20 +14,9 @@
 #define HPX_BUILD_TYPE
 #else
 
-// clang-format off
-// Make sure DEBUG macro is defined consistently across platforms
-#if defined(_DEBUG) && !defined(DEBUG)
-#  define DEBUG
-#endif
-
-#if defined(DEBUG) && !defined(HPX_DEBUG)
-#  define HPX_DEBUG
-#endif
-
 #if defined(HPX_DEBUG)
-#  define HPX_BUILD_TYPE debug
+#define HPX_BUILD_TYPE debug
 #else
-#  define HPX_BUILD_TYPE release
+#define HPX_BUILD_TYPE release
 #endif
 #endif
-// clang-format on

--- a/libs/core/functional/include/hpx/functional/one_shot.hpp
+++ b/libs/core/functional/include/hpx/functional/one_shot.hpp
@@ -25,10 +25,11 @@ namespace hpx { namespace util {
         class one_shot_wrapper    //-V690
         {
         public:
-#if !defined(HPX_DISABLE_ASSERTS)
             // default constructor is needed for serialization
             constexpr one_shot_wrapper()
+#if defined(HPX_DEBUG)
               : _called(false)
+#endif
             {
             }
 
@@ -37,42 +38,30 @@ namespace hpx { namespace util {
                     std::is_constructible<F, F_>::value>::type>
             constexpr explicit one_shot_wrapper(F_&& f)
               : _f(std::forward<F_>(f))
+#if defined(HPX_DEBUG)
               , _called(false)
+#endif
             {
             }
 
             constexpr one_shot_wrapper(one_shot_wrapper&& other)
               : _f(std::move(other._f))
+#if defined(HPX_DEBUG)
               , _called(other._called)
+#endif
             {
+#if defined(HPX_DEBUG)
                 other._called = true;
+#endif
             }
 
             void check_call()
             {
+#if defined(HPX_DEBUG)
                 HPX_ASSERT(!_called);
-
                 _called = true;
-            }
-#else
-            // default constructor is needed for serialization
-            constexpr one_shot_wrapper() {}
-
-            template <typename F_,
-                typename = typename std::enable_if<
-                    std::is_constructible<F, F_>::value>::type>
-            constexpr explicit one_shot_wrapper(F_&& f)
-              : _f(std::forward<F_>(f))
-            {
-            }
-
-            constexpr one_shot_wrapper(one_shot_wrapper&& other)
-              : _f(std::move(other._f))
-            {
-            }
-
-            void check_call() {}
 #endif
+            }
 
             template <typename... Ts>
             constexpr HPX_HOST_DEVICE
@@ -118,7 +107,7 @@ namespace hpx { namespace util {
 
         public:    // exposition-only
             F _f;
-#if !defined(HPX_DISABLE_ASSERTS)
+#if defined(HPX_DEBUG)
             bool _called;
 #endif
         };

--- a/libs/core/functional/include/hpx/functional/tag_invoke.hpp
+++ b/libs/core/functional/include/hpx/functional/tag_invoke.hpp
@@ -149,7 +149,7 @@ namespace hpx { namespace functional {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Tag, typename... Args>
     using is_tag_invocable =
-        hpx::is_invocable<decltype(tag_invoke), Tag, Args...>;
+        hpx::is_invocable<decltype(hpx::functional::tag_invoke), Tag, Args...>;
 
     template <typename Tag, typename... Args>
     constexpr bool is_tag_invocable_v = is_tag_invocable<Tag, Args...>::value;

--- a/libs/core/preprocessor/include/hpx/preprocessor/config.hpp
+++ b/libs/core/preprocessor/include/hpx/preprocessor/config.hpp
@@ -70,10 +70,10 @@
 #/* HPX_PP_CONFIG_ERRORS */
 #
 #if !defined(HPX_PP_CONFIG_ERRORS)
-#ifdef NDEBUG
-#define HPX_PP_CONFIG_ERRORS 0
-#else
+#ifdef HPX_DEBUG
 #define HPX_PP_CONFIG_ERRORS 1
+#else
+#define HPX_PP_CONFIG_ERRORS 0
 #endif
 #endif
 #

--- a/libs/core/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#if !defined(NDEBUG)
+#if defined(HPX_DEBUG)
 //# define SHARED_PRIORITY_SCHEDULER_DEBUG 1
 #endif
 

--- a/libs/core/thread_support/include/hpx/thread_support/assert_owns_lock.hpp
+++ b/libs/core/thread_support/include/hpx/thread_support/assert_owns_lock.hpp
@@ -9,6 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/concepts/has_member_xxx.hpp>
+#include <hpx/type_support/unused.hpp>
 
 #include <type_traits>
 
@@ -26,14 +27,12 @@ namespace hpx { namespace util { namespace detail {
     {
     }
 
-#if !defined(HPX_DISABLE_ASSERTS) && !defined(BOOST_DISABLE_ASSERTS) &&        \
-    !defined(NDEBUG)
-
     template <typename Lock>
     typename std::enable_if<has_owns_lock<Lock>::value>::type assert_owns_lock(
         Lock const& l, long)
     {
         HPX_ASSERT(l.owns_lock());
+        HPX_UNUSED(l);
     }
 
     template <typename Lock>
@@ -41,9 +40,8 @@ namespace hpx { namespace util { namespace detail {
     assert_doesnt_own_lock(Lock const& l, long)
     {
         HPX_ASSERT(!l.owns_lock());
+        HPX_UNUSED(l);
     }
-
-#endif
 }}}    // namespace hpx::util::detail
 
 #define HPX_ASSERT_OWNS_LOCK(l) ::hpx::util::detail::assert_owns_lock(l, 0L)

--- a/libs/full/actions/include/hpx/actions/transfer_base_action.hpp
+++ b/libs/full/actions/include/hpx/actions/transfer_base_action.hpp
@@ -84,19 +84,11 @@ namespace hpx { namespace actions {
                 return *data_;
             }
 
-#if defined(HPX_DISABLE_ASSERTS) || defined(BOOST_DISABLE_ASSERTS) ||          \
-    defined(NDEBUG)
-            constexpr HPX_HOST_DEVICE HPX_FORCEINLINE Args const& data() const
-            {
-                return *data_;
-            }
-#else
             HPX_HOST_DEVICE HPX_FORCEINLINE Args const& data() const
             {
                 HPX_ASSERT(!!data_);
                 return *data_;
             }
-#endif
 
         private:
             std::unique_ptr<Args> data_;

--- a/libs/full/runtime_local/src/runtime_local.cpp
+++ b/libs/full/runtime_local/src/runtime_local.cpp
@@ -1119,7 +1119,7 @@ namespace hpx {
     }
 }    // namespace hpx
 
-#if defined(_WIN64) && defined(_DEBUG) &&                                      \
+#if defined(_WIN64) && defined(HPX_DEBUG) &&                                   \
     !defined(HPX_HAVE_FIBER_BASED_COROUTINES)
 #include <io.h>
 #endif
@@ -1296,7 +1296,7 @@ namespace hpx {
         util::function_nonser<hpx_main_function_type> const& func,
         bool blocking)
     {
-#if defined(_WIN64) && defined(_DEBUG) &&                                      \
+#if defined(_WIN64) && defined(HPX_DEBUG) &&                                   \
     !defined(HPX_HAVE_FIBER_BASED_COROUTINES)
         // needs to be called to avoid problems at system startup
         // see: http://connect.microsoft.com/VisualStudio/feedback/ViewFeedback.aspx?FeedbackID=100319

--- a/libs/parallelism/algorithms/include/hpx/algorithms/traits/projected_range.hpp
+++ b/libs/parallelism/algorithms/include/hpx/algorithms/traits/projected_range.hpp
@@ -54,7 +54,7 @@ namespace hpx { namespace parallel { namespace traits {
     struct projected_range<Proj, Rng,
         typename std::enable_if<hpx::traits::is_range<Rng>::value>::type>
     {
-        typedef typename std::decay<Proj>::type projector_type;
-        typedef typename hpx::traits::range_iterator<Rng>::type iterator_type;
+        using projector_type = typename std::decay<Proj>::type;
+        using iterator_type = typename hpx::traits::range_iterator<Rng>::type;
     };
 }}}    // namespace hpx::parallel::traits

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/make_heap.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/make_heap.hpp
@@ -179,7 +179,7 @@ namespace hpx { namespace ranges {
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy, Comp,
                     hpx::parallel::traits::projected_range<Proj, Rng>,
                     hpx::parallel::traits::projected_range<Proj, Rng>
@@ -240,7 +240,7 @@ namespace hpx { namespace ranges {
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
                 hpx::parallel::traits::is_indirect_callable<ExPolicy,
                     std::less<typename std::iterator_traits<
                         typename hpx::traits::range_iterator<Rng>::type
@@ -299,7 +299,7 @@ namespace hpx { namespace ranges {
         template <typename Rng, typename Comp,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
                 hpx::parallel::traits::is_indirect_callable<
                     hpx::execution::sequenced_policy, Comp,
                     hpx::parallel::traits::projected_range<Proj, Rng>,
@@ -353,7 +353,7 @@ namespace hpx { namespace ranges {
         template <typename Rng,
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
                 hpx::parallel::traits::is_indirect_callable<
                     hpx::execution::sequenced_policy,
                     std::less<typename std::iterator_traits<

--- a/src/runtime_distributed.cpp
+++ b/src/runtime_distributed.cpp
@@ -81,7 +81,7 @@
 #include <utility>
 #include <vector>
 
-#if defined(_WIN64) && defined(_DEBUG) &&                                      \
+#if defined(_WIN64) && defined(HPX_DEBUG) &&                                   \
     !defined(HPX_HAVE_FIBER_BASED_COROUTINES)
 #include <io.h>
 #endif
@@ -543,7 +543,7 @@ namespace hpx {
         util::function_nonser<hpx_main_function_type> const& func,
         bool blocking)
     {
-#if defined(_WIN64) && defined(_DEBUG) &&                                      \
+#if defined(_WIN64) && defined(HPX_DEBUG) &&                                   \
     !defined(HPX_HAVE_FIBER_BASED_COROUTINES)
         // needs to be called to avoid problems at system startup
         // see: http://connect.microsoft.com/VisualStudio/feedback/ViewFeedback.aspx?FeedbackID=100319

--- a/tests/unit/build/CMakeLists.txt
+++ b/tests/unit/build/CMakeLists.txt
@@ -15,7 +15,15 @@ if(NOT HPX_WITH_DISTRIBUTED_RUNTIME)
 endif()
 
 # Try building an external cmake based project ...
-function(create_cmake_test name using_install_dir hpx_dir setup_type test_dir)
+function(
+  create_cmake_test
+  name
+  using_install_dir
+  hpx_dir
+  setup_type
+  build_type
+  test_dir
+)
   set(build_dir "${CMAKE_CURRENT_BINARY_DIR}/${name}")
   add_custom_target(
     ${name}.make_build_dir
@@ -56,7 +64,7 @@ function(create_cmake_test name using_install_dir hpx_dir setup_type test_dir)
       "${CMAKE_COMMAND}" -E chdir "${build_dir}" "${CMAKE_COMMAND}" ${test_dir}
       -DHPX_DIR=${hpx_dir} -DBOOST_ROOT=${BOOST_ROOT}
       ${ADDITIONAL_CMAKE_OPTIONS} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS_SAFE}
-      -DCMAKE_BUILD_TYPE=$<CONFIGURATION>
+      -DCMAKE_BUILD_TYPE=${build_type}
     VERBATIM
   )
   add_dependencies(
@@ -65,7 +73,7 @@ function(create_cmake_test name using_install_dir hpx_dir setup_type test_dir)
   )
   add_custom_target(
     ${name}.make_compile
-    COMMAND "${CMAKE_COMMAND}" --build "${build_dir}" --config $<CONFIGURATION>
+    COMMAND "${CMAKE_COMMAND}" --build "${build_dir}" --config ${build_type}
     VERBATIM
   )
   add_dependencies(${name}.make_compile ${name}.make_configure)
@@ -113,44 +121,60 @@ function(create_pkgconfig_test name hpx_dir)
 
 endfunction()
 
-create_cmake_test(
-  cmake_build_dir_targets_test FALSE
-  "${PROJECT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}" TARGETS
-  "examples/hello_world_component"
-)
-
-create_cmake_test(
-  cmake_build_dir_macros_test FALSE
-  "${PROJECT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}" MACROS
-  "examples/hello_world_component"
-)
-
-create_cmake_test(
-  cmake_install_dir_targets_test TRUE
-  "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}" TARGETS
-  "examples/hello_world_component"
-)
-
-create_cmake_test(
-  cmake_install_dir_macros_test TRUE
-  "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}" MACROS
-  "examples/hello_world_component"
-)
-
-if(HPX_WITH_DYNAMIC_HPX_MAIN)
-  # Google test emulation
-  create_cmake_test(
-    cmake_build_dir_gtest_emulation_test FALSE
-    "${PROJECT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}" TARGETS
-    "examples/gtest_emulation"
-  )
-
-  create_cmake_test(
-    cmake_install_dir_gtest_emulation_test TRUE
-    "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}" TARGETS
-    "examples/gtest_emulation"
-  )
+if(MSVC)
+  set(build_types ${CMAKE_BUILD_TYPE})
+else()
+  set(build_types Debug Release RelWithDebInfo)
+  # lld (which HIP uses) does not support the -Os flags in older versions. We do
+  # not attempt to detect the linker in the general case, but disable the
+  # MinSizeRel test here since we know that HIP only uses lld.
+  if(NOT HPX_WITH_HIP OR (HIP_VERSION VERSION_GREATER_EQUAL "4.0.0"))
+    list(APPEND build_types MinSizeRel)
+  endif()
 endif()
+
+foreach(build_type ${build_types})
+  string(TOLOWER "${build_type}" build_type_lc)
+
+  create_cmake_test(
+    cmake_${build_type_lc}_build_dir_targets_test FALSE
+    "${PROJECT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}" TARGETS ${build_type}
+    "examples/hello_world_component"
+  )
+
+  create_cmake_test(
+    cmake_${build_type_lc}_build_dir_macros_test FALSE
+    "${PROJECT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}" MACROS ${build_type}
+    "examples/hello_world_component"
+  )
+
+  create_cmake_test(
+    cmake_${build_type_lc}_install_dir_targets_test TRUE
+    "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}" TARGETS
+    ${build_type} "examples/hello_world_component"
+  )
+
+  create_cmake_test(
+    cmake_${build_type_lc}_install_dir_macros_test TRUE
+    "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}" MACROS
+    ${build_type} "examples/hello_world_component"
+  )
+
+  if(HPX_WITH_DYNAMIC_HPX_MAIN)
+    # Google test emulation
+    create_cmake_test(
+      cmake_${build_type_lc}_build_dir_gtest_emulation_test FALSE
+      "${PROJECT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}" TARGETS
+      ${build_type} "examples/gtest_emulation"
+    )
+
+    create_cmake_test(
+      cmake_${build_type_lc}_install_dir_gtest_emulation_test TRUE
+      "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}" TARGETS
+      ${build_type} "examples/gtest_emulation"
+    )
+  endif()
+endforeach()
 
 # PkgConfig
 if(NOT MSVC
@@ -189,17 +213,37 @@ if(NOT CMAKE_TOOLCHAIN_FILE
   set(pkgconfig_tests build_dir install_dir)
 endif()
 
-foreach(system ${build_systems})
-  add_hpx_pseudo_target(tests.unit.build.${system})
+set(system cmake)
+add_hpx_pseudo_target(tests.unit.build.${system})
+foreach(build_type ${build_types})
+  string(TOLOWER "${build_type}" build_type_lc)
+  add_hpx_pseudo_target(tests.unit.build.${system}.${build_type_lc})
   foreach(test ${${system}_tests})
-    add_hpx_pseudo_target(tests.unit.build.${system}.${test})
+    add_hpx_pseudo_target(tests.unit.build.${system}.${build_type_lc}.${test})
     add_hpx_pseudo_dependencies(
-      tests.unit.build.${system}.${test} ${system}_${test}_test
+      tests.unit.build.${system}.${build_type_lc}.${test}
+      ${system}_${build_type_lc}_${test}_test
     )
     add_hpx_pseudo_dependencies(
-      tests.unit.build.${system} tests.unit.build.${system}.${test}
+      tests.unit.build.${system}.${build_type_lc}
+      tests.unit.build.${system}.${build_type_lc}.${test}
     )
   endforeach()
-
-  add_hpx_pseudo_dependencies(tests.unit.build tests.unit.build.${system})
+  add_hpx_pseudo_dependencies(
+    tests.unit.build.${system} tests.unit.build.${system}.${build_type_lc}
+  )
 endforeach()
+add_hpx_pseudo_dependencies(tests.unit.build tests.unit.build.${system})
+
+set(system pkgconfig)
+add_hpx_pseudo_target(tests.unit.build.${system})
+foreach(test ${${system}_tests})
+  add_hpx_pseudo_target(tests.unit.build.${system}.${test})
+  add_hpx_pseudo_dependencies(
+    tests.unit.build.${system}.${test} ${system}_${test}_test
+  )
+  add_hpx_pseudo_dependencies(
+    tests.unit.build.${system} tests.unit.build.${system}.${test}
+  )
+endforeach()
+add_hpx_pseudo_dependencies(tests.unit.build tests.unit.build.${system})


### PR DESCRIPTION
Fixes #5013.

Testing if this is feasible. In principle it is, but I'd appreciate feedback on if there are any pitfalls that I'm not aware of, especially on Windows. Ideally we only use `HPX_DEBUG` determine if parts of the code should be conditionally compiled/disabled/etc. However, there are a few additional macros that we use:

- `DEBUG`: I could find no reference to anything using this, does anyone know what it's doing in HPX?
- `_DEBUG`: Windows specific, added automatically in debug mode, correct? There are a couple of uses of this one. Can we replace them with `HPX_DEBUG`? (https://github.com/STEllAR-GROUP/hpx/blob/8cb1829d7ae94d1cc078a7ed1a6014c212406a09/src/runtime_distributed.cpp#L546-L551)
- `NDEBUG`: Disables `assert`. We have a few uses of `assert` which are fine, but as far as I can tell there is no reason for us to rely on this macro.
- `HPX_DISABLE_ASSERTIONS`/`BOOST_DISABLE_ASSERTIONS`: Used to disable a few assertions, but not `HPX_ASSERT`. Used together with `NDEBUG` in some cases. I'd at most leave `HPX_DISABLE_ASSERTIONS`.

Is there a use case for debug builds with assertions disabled? If yes, should it get a CMake option instead of needing to be manually added to the compile flags?

