### PR TITLE
Update APEX tag for 1.6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -988,7 +988,7 @@ if(HPX_WITH_APEX)
     "Do not update code from remote APEX repository." OFF CATEGORY "Profiling"
   )
   hpx_option(
-    HPX_WITH_APEX_TAG STRING "APEX repository tag or branch" "v2.2.0"
+    HPX_WITH_APEX_TAG STRING "APEX repository tag or branch" "v2.3.0"
     CATEGORY "Profiling"
   )
 endif()


### PR DESCRIPTION
Currently updated to the develop branch while we wait for a real tag for APEX.