### PR TITLE
Remove default runtime mode argument from start/init overloads

### DIFF
--- a/libs/full/init_runtime/include/hpx/hpx_init.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_init.hpp
@@ -668,7 +668,7 @@ namespace hpx {
     ///                     command line arguments passed in `argc`/`argv`.
     inline int init(int (*f)(hpx::program_options::variables_map& vm),
         std::string const& app_name, int argc, char** argv,
-        hpx::runtime_mode mode = hpx::runtime_mode::default_);
+        hpx::runtime_mode mode);
 
     /// \brief Main entry point for launching the HPX runtime system.
     ///

--- a/libs/full/init_runtime/include/hpx/hpx_start.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_start.hpp
@@ -693,7 +693,7 @@ namespace hpx {
     ///                     command line arguments passed in `argc`/`argv`.
     inline bool start(int (*f)(hpx::program_options::variables_map& vm),
         std::string const& app_name, int argc, char** argv,
-        hpx::runtime_mode mode = hpx::runtime_mode::default_);
+        hpx::runtime_mode mode);
 
     /// \brief Main non-blocking entry point for launching the HPX runtime system.
     ///


### PR DESCRIPTION
These overloads may take precedence over the non-deprecated overloads
using `hpx::init_params` when the mode has a default value. Since these
overloads are deprecated, we don't want them to take precedence.