### PR TITLE
Fix regeneration of two files that trigger unnecessary rebuilds

### DIFF
--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -232,7 +232,8 @@ function(add_hpx_module libname modulename)
        ${CMAKE_CURRENT_BINARY_DIR}/include_compatibility/*.hpp
   )
   list(REMOVE_ITEM zombie_generated_headers ${generated_headers}
-       ${compat_headers} ${CMAKE_CURRENT_BINARY_DIR}/include/hpx/config/modules_enabled.hpp
+       ${compat_headers}
+       ${CMAKE_CURRENT_BINARY_DIR}/include/hpx/config/modules_enabled.hpp
   )
   foreach(zombie_header IN LISTS zombie_generated_headers)
     hpx_warn("Removing zombie generated header: ${zombie_header}")

--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -232,7 +232,7 @@ function(add_hpx_module libname modulename)
        ${CMAKE_CURRENT_BINARY_DIR}/include_compatibility/*.hpp
   )
   list(REMOVE_ITEM zombie_generated_headers ${generated_headers}
-       ${compat_headers}
+       ${compat_headers} ${CMAKE_CURRENT_BINARY_DIR}/include/hpx/config/modules_enabled.hpp
   )
   foreach(zombie_header IN LISTS zombie_generated_headers)
     hpx_warn("Removing zombie generated header: ${zombie_header}")

--- a/cmake/TargetArch.cmake
+++ b/cmake/TargetArch.cmake
@@ -113,18 +113,18 @@ function(target_architecture output_var)
       list(APPEND ARCH ppc64)
     endif()
   else()
-    if (NOT HPX_INTERNAL_ARCH_DETECT)
+    if(NOT HPX_INTERNAL_ARCH_DETECT)
       file(WRITE "${PROJECT_BINARY_DIR}/arch.cpp" "${archdetect_cpp_code}")
 
-      # Detect the architecture in a rather creative way... This compiles a small
-      # C++ program which is a series of ifdefs that selects a particular #error
-      # preprocessor directive whose message string contains the target
+      # Detect the architecture in a rather creative way... This compiles a
+      # small C++ program which is a series of ifdefs that selects a particular
+      # #error preprocessor directive whose message string contains the target
       # architecture. The program will always fail to compile (both because file
       # is not a valid C program, and obviously because of the presence of the
       # #error preprocessor directives... but by exploiting the preprocessor in
       # this way, we can detect the correct target architecture even when
-      # cross-compiling, since the program itself never needs to be run (only the
-      # compiler/preprocessor)
+      # cross-compiling, since the program itself never needs to be run (only
+      # the compiler/preprocessor)
       try_run(
         run_result_unused compile_result_unused "${PROJECT_BINARY_DIR}"
         "${PROJECT_BINARY_DIR}/arch.cpp"
@@ -139,12 +139,15 @@ function(target_architecture output_var)
       string(REPLACE "cmake_ARCH " "" ARCH "${ARCH}")
 
       # If we are compiling with an unknown architecture this variable should
-      # already be set to "unknown" but in the case that it's empty (i.e. due to a
-      # typo in the code), then set it to unknown
+      # already be set to "unknown" but in the case that it's empty (i.e. due to
+      # a typo in the code), then set it to unknown
       if(NOT ARCH)
         set(ARCH unknown)
       endif()
-      set(HPX_INTERNAL_ARCH_DETECT ${ARCH} CACHE INTERNAL "")
+      set(HPX_INTERNAL_ARCH_DETECT
+          ${ARCH}
+          CACHE INTERNAL ""
+      )
     else()
       set(ARCH ${HPX_INTERNAL_ARCH_DETECT})
     endif()

--- a/cmake/TargetArch.cmake
+++ b/cmake/TargetArch.cmake
@@ -113,35 +113,40 @@ function(target_architecture output_var)
       list(APPEND ARCH ppc64)
     endif()
   else()
-    file(WRITE "${PROJECT_BINARY_DIR}/arch.cpp" "${archdetect_cpp_code}")
+    if (NOT HPX_INTERNAL_ARCH_DETECT)
+      file(WRITE "${PROJECT_BINARY_DIR}/arch.cpp" "${archdetect_cpp_code}")
 
-    # Detect the architecture in a rather creative way... This compiles a small
-    # C++ program which is a series of ifdefs that selects a particular #error
-    # preprocessor directive whose message string contains the target
-    # architecture. The program will always fail to compile (both because file
-    # is not a valid C program, and obviously because of the presence of the
-    # #error preprocessor directives... but by exploiting the preprocessor in
-    # this way, we can detect the correct target architecture even when
-    # cross-compiling, since the program itself never needs to be run (only the
-    # compiler/preprocessor)
-    try_run(
-      run_result_unused compile_result_unused "${PROJECT_BINARY_DIR}"
-      "${PROJECT_BINARY_DIR}/arch.cpp"
-      COMPILE_OUTPUT_VARIABLE ARCH
-      CMAKE_FLAGS CMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}
-    )
+      # Detect the architecture in a rather creative way... This compiles a small
+      # C++ program which is a series of ifdefs that selects a particular #error
+      # preprocessor directive whose message string contains the target
+      # architecture. The program will always fail to compile (both because file
+      # is not a valid C program, and obviously because of the presence of the
+      # #error preprocessor directives... but by exploiting the preprocessor in
+      # this way, we can detect the correct target architecture even when
+      # cross-compiling, since the program itself never needs to be run (only the
+      # compiler/preprocessor)
+      try_run(
+        run_result_unused compile_result_unused "${PROJECT_BINARY_DIR}"
+        "${PROJECT_BINARY_DIR}/arch.cpp"
+        COMPILE_OUTPUT_VARIABLE ARCH
+        CMAKE_FLAGS CMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}
+      )
 
-    # Parse the architecture name from the compiler output
-    string(REGEX MATCH "cmake_ARCH ([a-zA-Z0-9_]+)" ARCH "${ARCH}")
+      # Parse the architecture name from the compiler output
+      string(REGEX MATCH "cmake_ARCH ([a-zA-Z0-9_]+)" ARCH "${ARCH}")
 
-    # Get rid of the value marker leaving just the architecture name
-    string(REPLACE "cmake_ARCH " "" ARCH "${ARCH}")
+      # Get rid of the value marker leaving just the architecture name
+      string(REPLACE "cmake_ARCH " "" ARCH "${ARCH}")
 
-    # If we are compiling with an unknown architecture this variable should
-    # already be set to "unknown" but in the case that it's empty (i.e. due to a
-    # typo in the code), then set it to unknown
-    if(NOT ARCH)
-      set(ARCH unknown)
+      # If we are compiling with an unknown architecture this variable should
+      # already be set to "unknown" but in the case that it's empty (i.e. due to a
+      # typo in the code), then set it to unknown
+      if(NOT ARCH)
+        set(ARCH unknown)
+      endif()
+      set(HPX_INTERNAL_ARCH_DETECT ${ARCH} CACHE INTERNAL "")
+    else()
+      set(ARCH ${HPX_INTERNAL_ARCH_DETECT})
     endif()
   endif()
 


### PR DESCRIPTION
The modules_enabled.hpp file was being wiped by a cleanup step
in the module creation script.

Architecture detection generated a file on every configure
step and only needs to be done once, so cache the result fo
reuse on subsequent runs.
