### PR TITLE
Change initialization of property CPOs to satisfy older nvcc versions

### DIFF
--- a/libs/core/properties/include/hpx/properties/property.hpp
+++ b/libs/core/properties/include/hpx/properties/property.hpp
@@ -39,5 +39,5 @@ namespace hpx { namespace experimental {
         {
             return std::forward<T0>(t0);
         }
-    } prefer;
+    } prefer{};
 }}    // namespace hpx::experimental

--- a/libs/parallelism/execution/include/hpx/execution/executors/execution_parameters.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/executors/execution_parameters.hpp
@@ -879,10 +879,10 @@ namespace hpx { namespace execution { namespace experimental {
     HPX_INLINE_CONSTEXPR_VARIABLE struct make_with_hint_t
       : hpx::functional::tag<make_with_hint_t>
     {
-    } make_with_hint;
+    } make_with_hint{};
 
     HPX_INLINE_CONSTEXPR_VARIABLE struct get_hint_t
       : hpx::functional::tag<get_hint_t>
     {
-    } get_hint;
+    } get_hint{};
 }}}    // namespace hpx::execution::experimental


### PR DESCRIPTION
Probably fixes compilation on older nvcc's. Not regression test (yet) as I couldn't reproduce this with gcc 8.3 and cuda 10.2. Likely only happens on older cuda versions. Same problem as in #4912.

@G-071 I'd appreciate you trying this out!