### PR TITLE
Relax dataflow internals

### DIFF
--- a/libs/parallelism/executors/include/hpx/executors/dataflow.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/dataflow.hpp
@@ -112,9 +112,7 @@ namespace hpx { namespace lcos { namespace detail {
     template <typename Policy, typename F, typename Args>
     struct dataflow_return_impl<
         /*IsAction=*/false, Policy, F, Args,
-        typename std::enable_if<traits::is_launch_policy<Policy>::value,
-            typename hpx::util::always_void<typename hpx::util::detail::
-                    invoke_fused_result<F, Args>::type>::type>::type>
+        typename std::enable_if<traits::is_launch_policy<Policy>::value>::type>
     {
         using type = hpx::lcos::future<
             typename util::detail::invoke_fused_result<F, Args>::type>;

--- a/libs/parallelism/lcos_local/tests/unit/local_dataflow_executor_additional_arguments.cpp
+++ b/libs/parallelism/lcos_local/tests/unit/local_dataflow_executor_additional_arguments.cpp
@@ -356,6 +356,25 @@ void plain_deferred_arguments(Executor& exec)
     }
 }
 
+HPX_INLINE_CONSTEXPR_VARIABLE struct void_f_wrapper
+{
+    // This should not be instantiated by the dataflow internals for launch
+    // policies, since that would not add an additional argument and compilation
+    // would fail.
+    template <typename... Ts>
+    auto operator()(Ts&&... ts)
+    {
+        return void_f(std::forward<Ts>(ts)...);
+    }
+} void_f_wrapper_instance{};
+
+template <typename Executor>
+void function_wrapper(Executor& exec)
+{
+    hpx::dataflow(exec, void_f_wrapper{});
+    hpx::dataflow(exec, void_f_wrapper_instance);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(variables_map&)
 {
@@ -365,6 +384,7 @@ int hpx_main(variables_map&)
         future_function_pointers(exec);
         plain_arguments(exec);
         plain_deferred_arguments(exec);
+        function_wrapper(exec);
     }
 
     return hpx::finalize();


### PR DESCRIPTION
Removes a `typename hpx::util::always_void<typename hpx::util::detail::invoke_fused_result<F, Args>::type>::type` from the `dataflow_return_impl` specialization as it can in certain cases trigger errors where none should be triggered. There is an added test case which triggers this problem.

Regarding the test case, a trailing `-> decltype(void_f(std::forward<Ts>(ts)...))` on the wrapper does also avoid the error, but I don't see a need for the `always_void<...>` in the specialization so I've removed that. Might I be missing some corner case that requires it?