### PR TITLE
Refactor iter_sent.hpp to make structs lowercase

### DIFF
--- a/libs/core/iterator_support/tests/unit/is_sentinel_for.cpp
+++ b/libs/core/iterator_support/tests/unit/is_sentinel_for.cpp
@@ -14,7 +14,7 @@
 
 void is_sentinel_for()
 {
-    HPX_TEST_MSG((hpx::traits::is_sentinel_for<Sentinel<int64_t>,
+    HPX_TEST_MSG((hpx::traits::is_sentinel_for<sentinel<int64_t>,
                       iterator<std::int64_t>>::value == true),
         "Sentinel value is not proper for given iterator");
 

--- a/libs/core/iterator_support/tests/unit/is_sentinel_for.cpp
+++ b/libs/core/iterator_support/tests/unit/is_sentinel_for.cpp
@@ -15,7 +15,7 @@
 void is_sentinel_for()
 {
     HPX_TEST_MSG((hpx::traits::is_sentinel_for<Sentinel<int64_t>,
-                      Iterator<std::int64_t>>::value == true),
+                      iterator<std::int64_t>>::value == true),
         "Sentinel value is not proper for given iterator");
 
     HPX_TEST_MSG(

--- a/libs/core/iterator_support/tests/unit/is_sized_sentinel_for.cpp
+++ b/libs/core/iterator_support/tests/unit/is_sized_sentinel_for.cpp
@@ -14,7 +14,7 @@
 
 void is_sized_sentinel_for()
 {
-    HPX_TEST_MSG((hpx::traits::is_sized_sentinel_for<Sentinel<int64_t>,
+    HPX_TEST_MSG((hpx::traits::is_sized_sentinel_for<sentinel<int64_t>,
                       iterator<std::int64_t>>::value == false),
         "Sentinel falsely marked as sized for particular iterator");
 

--- a/libs/core/iterator_support/tests/unit/is_sized_sentinel_for.cpp
+++ b/libs/core/iterator_support/tests/unit/is_sized_sentinel_for.cpp
@@ -9,14 +9,13 @@
 #include "iter_sent.hpp"
 
 #include <cstdint>
-#include <iterator>
 #include <string>
 #include <vector>
 
 void is_sized_sentinel_for()
 {
     HPX_TEST_MSG((hpx::traits::is_sized_sentinel_for<Sentinel<int64_t>,
-                      Iterator<std::int64_t>>::value == false),
+                      iterator<std::int64_t>>::value == false),
         "Sentinel falsely marked as sized for particular iterator");
 
     HPX_TEST_MSG((hpx::traits::is_sized_sentinel_for<std::vector<int>::iterator,

--- a/libs/core/iterator_support/tests/unit/iter_sent.hpp
+++ b/libs/core/iterator_support/tests/unit/iter_sent.hpp
@@ -12,9 +12,9 @@
 #include <iterator>
 
 template <typename ValueType>
-struct Sentinel
+struct sentinel
 {
-    explicit Sentinel(ValueType stop_value)
+    explicit sentinel(ValueType stop_value)
       : stop(stop_value)
     {
     }
@@ -109,11 +109,11 @@ struct iterator
         return this->state == that.state;
     }
 
-    friend bool operator==(iterator i, Sentinel<Value> s)
+    friend bool operator==(iterator i, sentinel<Value> s)
     {
         return i.state == s.get_stop();
     }
-    friend bool operator==(Sentinel<Value> s, iterator i)
+    friend bool operator==(sentinel<Value> s, iterator i)
     {
         return i.state == s.get_stop();
     }
@@ -123,11 +123,11 @@ struct iterator
         return this->state != that.state;
     }
 
-    friend bool operator!=(iterator i, Sentinel<Value> s)
+    friend bool operator!=(iterator i, sentinel<Value> s)
     {
         return i.state != s.get_stop();
     }
-    friend bool operator!=(Sentinel<Value> s, iterator i)
+    friend bool operator!=(sentinel<Value> s, iterator i)
     {
         return i.state != s.get_stop();
     }

--- a/libs/core/iterator_support/tests/unit/iter_sent.hpp
+++ b/libs/core/iterator_support/tests/unit/iter_sent.hpp
@@ -29,7 +29,7 @@ private:
 };
 
 template <typename Value>
-struct Iterator
+struct iterator
 {
     using difference_type = std::ptrdiff_t;
     using value_type = Value;
@@ -37,7 +37,7 @@ struct Iterator
     using pointer = Value const*;
     using reference = Value const&;
 
-    explicit Iterator(Value initialState)
+    explicit iterator(Value initialState)
       : state(initialState)
     {
     }
@@ -49,26 +49,26 @@ struct Iterator
 
     virtual Value operator->() const = delete;
 
-    Iterator& operator++()
+    iterator& operator++()
     {
         ++(this->state);
         return *this;
     }
 
-    Iterator operator++(int)
+    iterator operator++(int)
     {
         auto copy = *this;
         ++(*this);
         return copy;
     }
 
-    Iterator& operator--()
+    iterator& operator--()
     {
         --(this->state);
         return *this;
     }
 
-    Iterator operator--(int)
+    iterator operator--(int)
     {
         auto copy = *this;
         --(*this);
@@ -80,74 +80,74 @@ struct Iterator
         return this->state + n;
     }
 
-    Iterator& operator+=(difference_type n)
+    iterator& operator+=(difference_type n)
     {
         this->state += n;
         return *this;
     }
 
-    Iterator operator+(difference_type n) const
+    iterator operator+(difference_type n) const
     {
-        Iterator copy = *this;
+        iterator copy = *this;
         return copy += n;
     }
 
-    Iterator& operator-=(difference_type n)
+    iterator& operator-=(difference_type n)
     {
         this->state -= n;
         return *this;
     }
 
-    Iterator operator-(difference_type n) const
+    iterator operator-(difference_type n) const
     {
-        Iterator copy = *this;
+        iterator copy = *this;
         return copy -= n;
     }
 
-    bool operator==(const Iterator& that) const
+    bool operator==(const iterator& that) const
     {
         return this->state == that.state;
     }
 
-    friend bool operator==(Iterator i, Sentinel<Value> s)
+    friend bool operator==(iterator i, Sentinel<Value> s)
     {
         return i.state == s.get_stop();
     }
-    friend bool operator==(Sentinel<Value> s, Iterator i)
+    friend bool operator==(Sentinel<Value> s, iterator i)
     {
         return i.state == s.get_stop();
     }
 
-    bool operator!=(const Iterator& that) const
+    bool operator!=(const iterator& that) const
     {
         return this->state != that.state;
     }
 
-    friend bool operator!=(Iterator i, Sentinel<Value> s)
+    friend bool operator!=(iterator i, Sentinel<Value> s)
     {
         return i.state != s.get_stop();
     }
-    friend bool operator!=(Sentinel<Value> s, Iterator i)
+    friend bool operator!=(Sentinel<Value> s, iterator i)
     {
         return i.state != s.get_stop();
     }
 
-    bool operator<(const Iterator& that) const
+    bool operator<(const iterator& that) const
     {
         return this->state < that.state;
     }
 
-    bool operator<=(const Iterator& that) const
+    bool operator<=(const iterator& that) const
     {
         return this->state <= that.state;
     }
 
-    bool operator>(const Iterator& that) const
+    bool operator>(const iterator& that) const
     {
         return this->state > that.state;
     }
 
-    bool operator>=(const Iterator& that) const
+    bool operator>=(const iterator& that) const
     {
         return this->state >= that.state;
     }

--- a/libs/parallelism/algorithms/tests/regressions/count_3646.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/count_3646.cpp
@@ -16,7 +16,7 @@
 
 #include "iter_sent.hpp"
 
-struct BitCountingIterator : public iterator<std::int64_t>
+struct bit_counting_iterator : public iterator<std::int64_t>
 {
     using difference_type = std::ptrdiff_t;
     using value_type = std::int64_t;
@@ -24,7 +24,7 @@ struct BitCountingIterator : public iterator<std::int64_t>
     using pointer = std::int64_t const*;
     using reference = std::int64_t const&;
 
-    explicit BitCountingIterator(int64_t initialState)
+    explicit bit_counting_iterator(int64_t initialState)
       : iterator<int64_t>(initialState)
     {
     }
@@ -39,26 +39,26 @@ struct BitCountingIterator : public iterator<std::int64_t>
         return countBits(this->state + n);
     }
 
-    BitCountingIterator& operator++()
+    bit_counting_iterator& operator++()
     {
         ++(this->state);
         return *this;
     }
 
-    BitCountingIterator operator++(int)
+    bit_counting_iterator operator++(int)
     {
         auto copy = *this;
         ++(*this);
         return copy;
     }
 
-    BitCountingIterator& operator--()
+    bit_counting_iterator& operator--()
     {
         --(this->state);
         return *this;
     }
 
-    BitCountingIterator operator--(int)
+    bit_counting_iterator operator--(int)
     {
         auto copy = *this;
         --(*this);
@@ -81,7 +81,7 @@ private:
 
 void test_count()
 {
-    using Iter = BitCountingIterator;
+    using Iter = bit_counting_iterator;
     using Sent = sentinel<std::int64_t>;
 
     auto stdResult = std::count(Iter{0}, Iter{33}, std::int64_t{1});
@@ -99,7 +99,7 @@ void test_count()
 
 void test_count_if()
 {
-    using Iter = BitCountingIterator;
+    using Iter = bit_counting_iterator;
     using Sent = sentinel<std::int64_t>;
 
     auto predicate = [](std::int64_t v) { return v == 1; };

--- a/libs/parallelism/algorithms/tests/regressions/count_3646.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/count_3646.cpp
@@ -82,7 +82,7 @@ private:
 void test_count()
 {
     using Iter = BitCountingIterator;
-    using Sent = Sentinel<std::int64_t>;
+    using Sent = sentinel<std::int64_t>;
 
     auto stdResult = std::count(Iter{0}, Iter{33}, std::int64_t{1});
 
@@ -100,7 +100,7 @@ void test_count()
 void test_count_if()
 {
     using Iter = BitCountingIterator;
-    using Sent = Sentinel<std::int64_t>;
+    using Sent = sentinel<std::int64_t>;
 
     auto predicate = [](std::int64_t v) { return v == 1; };
     auto stdResult = std::count_if(Iter{0}, Iter{33}, predicate);

--- a/libs/parallelism/algorithms/tests/regressions/count_3646.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/count_3646.cpp
@@ -16,7 +16,7 @@
 
 #include "iter_sent.hpp"
 
-struct BitCountingIterator : public Iterator<std::int64_t>
+struct BitCountingIterator : public iterator<std::int64_t>
 {
     using difference_type = std::ptrdiff_t;
     using value_type = std::int64_t;
@@ -25,7 +25,7 @@ struct BitCountingIterator : public Iterator<std::int64_t>
     using reference = std::int64_t const&;
 
     explicit BitCountingIterator(int64_t initialState)
-      : Iterator<int64_t>(initialState)
+      : iterator<int64_t>(initialState)
     {
     }
 

--- a/libs/parallelism/algorithms/tests/regressions/iter_sent.hpp
+++ b/libs/parallelism/algorithms/tests/regressions/iter_sent.hpp
@@ -12,9 +12,9 @@
 #include <iterator>
 
 template <typename ValueType>
-struct Sentinel
+struct sentinel
 {
-    explicit Sentinel(ValueType stop_value)
+    explicit sentinel(ValueType stop_value)
       : stop(stop_value)
     {
     }
@@ -109,11 +109,11 @@ struct iterator
         return this->state == that.state;
     }
 
-    friend bool operator==(iterator i, Sentinel<Value> s)
+    friend bool operator==(iterator i, sentinel<Value> s)
     {
         return i.state == s.get_stop();
     }
-    friend bool operator==(Sentinel<Value> s, iterator i)
+    friend bool operator==(sentinel<Value> s, iterator i)
     {
         return i.state == s.get_stop();
     }
@@ -123,11 +123,11 @@ struct iterator
         return this->state != that.state;
     }
 
-    friend bool operator!=(iterator i, Sentinel<Value> s)
+    friend bool operator!=(iterator i, sentinel<Value> s)
     {
         return i.state != s.get_stop();
     }
-    friend bool operator!=(Sentinel<Value> s, iterator i)
+    friend bool operator!=(sentinel<Value> s, iterator i)
     {
         return i.state != s.get_stop();
     }

--- a/libs/parallelism/algorithms/tests/regressions/iter_sent.hpp
+++ b/libs/parallelism/algorithms/tests/regressions/iter_sent.hpp
@@ -29,7 +29,7 @@ private:
 };
 
 template <typename Value>
-struct Iterator
+struct iterator
 {
     using difference_type = std::ptrdiff_t;
     using value_type = Value;
@@ -37,7 +37,7 @@ struct Iterator
     using pointer = Value const*;
     using reference = Value const&;
 
-    explicit Iterator(Value initialState)
+    explicit iterator(Value initialState)
       : state(initialState)
     {
     }
@@ -49,26 +49,26 @@ struct Iterator
 
     virtual Value operator->() const = delete;
 
-    Iterator& operator++()
+    iterator& operator++()
     {
         ++(this->state);
         return *this;
     }
 
-    Iterator operator++(int)
+    iterator operator++(int)
     {
         auto copy = *this;
         ++(*this);
         return copy;
     }
 
-    Iterator& operator--()
+    iterator& operator--()
     {
         --(this->state);
         return *this;
     }
 
-    Iterator operator--(int)
+    iterator operator--(int)
     {
         auto copy = *this;
         --(*this);
@@ -80,74 +80,74 @@ struct Iterator
         return this->state + n;
     }
 
-    Iterator& operator+=(difference_type n)
+    iterator& operator+=(difference_type n)
     {
         this->state += n;
         return *this;
     }
 
-    Iterator operator+(difference_type n) const
+    iterator operator+(difference_type n) const
     {
-        Iterator copy = *this;
+        iterator copy = *this;
         return copy += n;
     }
 
-    Iterator& operator-=(difference_type n)
+    iterator& operator-=(difference_type n)
     {
         this->state -= n;
         return *this;
     }
 
-    Iterator operator-(difference_type n) const
+    iterator operator-(difference_type n) const
     {
-        Iterator copy = *this;
+        iterator copy = *this;
         return copy -= n;
     }
 
-    bool operator==(const Iterator& that) const
+    bool operator==(const iterator& that) const
     {
         return this->state == that.state;
     }
 
-    friend bool operator==(Iterator i, Sentinel<Value> s)
+    friend bool operator==(iterator i, Sentinel<Value> s)
     {
         return i.state == s.get_stop();
     }
-    friend bool operator==(Sentinel<Value> s, Iterator i)
+    friend bool operator==(Sentinel<Value> s, iterator i)
     {
         return i.state == s.get_stop();
     }
 
-    bool operator!=(const Iterator& that) const
+    bool operator!=(const iterator& that) const
     {
         return this->state != that.state;
     }
 
-    friend bool operator!=(Iterator i, Sentinel<Value> s)
+    friend bool operator!=(iterator i, Sentinel<Value> s)
     {
         return i.state != s.get_stop();
     }
-    friend bool operator!=(Sentinel<Value> s, Iterator i)
+    friend bool operator!=(Sentinel<Value> s, iterator i)
     {
         return i.state != s.get_stop();
     }
 
-    bool operator<(const Iterator& that) const
+    bool operator<(const iterator& that) const
     {
         return this->state < that.state;
     }
 
-    bool operator<=(const Iterator& that) const
+    bool operator<=(const iterator& that) const
     {
         return this->state <= that.state;
     }
 
-    bool operator>(const Iterator& that) const
+    bool operator>(const iterator& that) const
     {
         return this->state > that.state;
     }
 
-    bool operator>=(const Iterator& that) const
+    bool operator>=(const iterator& that) const
     {
         return this->state >= that.state;
     }

--- a/libs/parallelism/algorithms/tests/regressions/reduce_3641.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/reduce_3641.cpp
@@ -8,23 +8,20 @@
 // #3641: Trouble with using ranges-v3 and hpx::parallel::reduce
 // #3646: Parallel algorithms should accept iterator/sentinel pairs
 
-#include <hpx/hpx_main.hpp>
 #include <hpx/include/parallel_reduce.hpp>
 #include <hpx/modules/testing.hpp>
 #include "iter_sent.hpp"
 
-#include <cstddef>
 #include <cstdint>
-#include <iterator>
 
 int main()
 {
     std::int64_t result = hpx::ranges::reduce(hpx::execution::seq,
-        Iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, std::int64_t(0));
+        iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, std::int64_t(0));
 
     HPX_TEST_EQ(result, std::int64_t(4950));
 
-    result = hpx::ranges::reduce(hpx::execution::par, Iterator<std::int64_t>{0},
+    result = hpx::ranges::reduce(hpx::execution::par, iterator<std::int64_t>{0},
         Sentinel<int64_t>{100}, std::int64_t(0));
 
     HPX_TEST_EQ(result, std::int64_t(4950));

--- a/libs/parallelism/algorithms/tests/regressions/reduce_3641.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/reduce_3641.cpp
@@ -8,6 +8,7 @@
 // #3641: Trouble with using ranges-v3 and hpx::parallel::reduce
 // #3646: Parallel algorithms should accept iterator/sentinel pairs
 
+#include <hpx/hpx_main.hpp>
 #include <hpx/include/parallel_reduce.hpp>
 #include <hpx/modules/testing.hpp>
 #include "iter_sent.hpp"

--- a/libs/parallelism/algorithms/tests/regressions/reduce_3641.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/reduce_3641.cpp
@@ -17,12 +17,12 @@
 int main()
 {
     std::int64_t result = hpx::ranges::reduce(hpx::execution::seq,
-        iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, std::int64_t(0));
+        iterator<std::int64_t>{0}, sentinel<int64_t>{100}, std::int64_t(0));
 
     HPX_TEST_EQ(result, std::int64_t(4950));
 
     result = hpx::ranges::reduce(hpx::execution::par, iterator<std::int64_t>{0},
-        Sentinel<int64_t>{100}, std::int64_t(0));
+        sentinel<int64_t>{100}, std::int64_t(0));
 
     HPX_TEST_EQ(result, std::int64_t(4950));
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/distance.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/distance.cpp
@@ -14,7 +14,7 @@
 int main()
 {
     HPX_TEST_EQ(hpx::parallel::v1::detail::distance(
-                    Iterator<std::int64_t>{0}, Sentinel<int64_t>{100}),
+                    iterator<std::int64_t>{0}, Sentinel<int64_t>{100}),
         100);
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/distance.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/distance.cpp
@@ -14,7 +14,7 @@
 int main()
 {
     HPX_TEST_EQ(hpx::parallel::v1::detail::distance(
-                    iterator<std::int64_t>{0}, Sentinel<int64_t>{100}),
+                    iterator<std::int64_t>{0}, sentinel<int64_t>{100}),
         100);
 
     return hpx::util::report_errors();

--- a/libs/parallelism/algorithms/tests/unit/algorithms/iter_sent.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/iter_sent.hpp
@@ -12,9 +12,9 @@
 #include <iterator>
 
 template <typename ValueType>
-struct Sentinel
+struct sentinel
 {
-    explicit Sentinel(ValueType stop_value)
+    explicit sentinel(ValueType stop_value)
       : stop(stop_value)
     {
     }
@@ -109,11 +109,11 @@ struct iterator
         return this->state == that.state;
     }
 
-    friend bool operator==(iterator i, Sentinel<Value> s)
+    friend bool operator==(iterator i, sentinel<Value> s)
     {
         return i.state == s.get_stop();
     }
-    friend bool operator==(Sentinel<Value> s, iterator i)
+    friend bool operator==(sentinel<Value> s, iterator i)
     {
         return i.state == s.get_stop();
     }
@@ -123,11 +123,11 @@ struct iterator
         return this->state != that.state;
     }
 
-    friend bool operator!=(iterator i, Sentinel<Value> s)
+    friend bool operator!=(iterator i, sentinel<Value> s)
     {
         return i.state != s.get_stop();
     }
-    friend bool operator!=(Sentinel<Value> s, iterator i)
+    friend bool operator!=(sentinel<Value> s, iterator i)
     {
         return i.state != s.get_stop();
     }

--- a/libs/parallelism/algorithms/tests/unit/algorithms/iter_sent.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/iter_sent.hpp
@@ -29,7 +29,7 @@ private:
 };
 
 template <typename Value>
-struct Iterator
+struct iterator
 {
     using difference_type = std::ptrdiff_t;
     using value_type = Value;
@@ -37,7 +37,7 @@ struct Iterator
     using pointer = Value const*;
     using reference = Value const&;
 
-    explicit Iterator(Value initialState)
+    explicit iterator(Value initialState)
       : state(initialState)
     {
     }
@@ -49,26 +49,26 @@ struct Iterator
 
     virtual Value operator->() const = delete;
 
-    Iterator& operator++()
+    iterator& operator++()
     {
         ++(this->state);
         return *this;
     }
 
-    Iterator operator++(int)
+    iterator operator++(int)
     {
         auto copy = *this;
         ++(*this);
         return copy;
     }
 
-    Iterator& operator--()
+    iterator& operator--()
     {
         --(this->state);
         return *this;
     }
 
-    Iterator operator--(int)
+    iterator operator--(int)
     {
         auto copy = *this;
         --(*this);
@@ -80,74 +80,74 @@ struct Iterator
         return this->state + n;
     }
 
-    Iterator& operator+=(difference_type n)
+    iterator& operator+=(difference_type n)
     {
         this->state += n;
         return *this;
     }
 
-    Iterator operator+(difference_type n) const
+    iterator operator+(difference_type n) const
     {
-        Iterator copy = *this;
+        iterator copy = *this;
         return copy += n;
     }
 
-    Iterator& operator-=(difference_type n)
+    iterator& operator-=(difference_type n)
     {
         this->state -= n;
         return *this;
     }
 
-    Iterator operator-(difference_type n) const
+    iterator operator-(difference_type n) const
     {
-        Iterator copy = *this;
+        iterator copy = *this;
         return copy -= n;
     }
 
-    bool operator==(const Iterator& that) const
+    bool operator==(const iterator& that) const
     {
         return this->state == that.state;
     }
 
-    friend bool operator==(Iterator i, Sentinel<Value> s)
+    friend bool operator==(iterator i, Sentinel<Value> s)
     {
         return i.state == s.get_stop();
     }
-    friend bool operator==(Sentinel<Value> s, Iterator i)
+    friend bool operator==(Sentinel<Value> s, iterator i)
     {
         return i.state == s.get_stop();
     }
 
-    bool operator!=(const Iterator& that) const
+    bool operator!=(const iterator& that) const
     {
         return this->state != that.state;
     }
 
-    friend bool operator!=(Iterator i, Sentinel<Value> s)
+    friend bool operator!=(iterator i, Sentinel<Value> s)
     {
         return i.state != s.get_stop();
     }
-    friend bool operator!=(Sentinel<Value> s, Iterator i)
+    friend bool operator!=(Sentinel<Value> s, iterator i)
     {
         return i.state != s.get_stop();
     }
 
-    bool operator<(const Iterator& that) const
+    bool operator<(const iterator& that) const
     {
         return this->state < that.state;
     }
 
-    bool operator<=(const Iterator& that) const
+    bool operator<=(const iterator& that) const
     {
         return this->state <= that.state;
     }
 
-    bool operator>(const Iterator& that) const
+    bool operator>(const iterator& that) const
     {
         return this->state > that.state;
     }
 
-    bool operator>=(const Iterator& that) const
+    bool operator>=(const iterator& that) const
     {
         return this->state >= that.state;
     }

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_adapt.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_adapt.cpp
@@ -4,6 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/hpx_main.hpp>
 #include <hpx/include/parallel_for_each.hpp>
 #include <hpx/modules/testing.hpp>
 #include "iter_sent.hpp"

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_adapt.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_adapt.cpp
@@ -19,12 +19,12 @@ void myfunction(int i)
 void test_invoke_projected()
 {
     iterator<std::int64_t> iter = hpx::ranges::for_each(hpx::execution::seq,
-        iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, myfunction);
+        iterator<std::int64_t>{0}, sentinel<int64_t>{100}, myfunction);
 
     HPX_TEST_EQ(*iter, std::int64_t(100));
 
     iter = hpx::ranges::for_each(hpx::execution::par, iterator<std::int64_t>{0},
-        Sentinel<int64_t>{100}, myfunction);
+        sentinel<int64_t>{100}, myfunction);
 
     HPX_TEST_EQ(*iter, std::int64_t(100));
 }
@@ -32,12 +32,12 @@ void test_invoke_projected()
 void test_begin_end_iterator()
 {
     iterator<std::int64_t> iter = hpx::ranges::for_each(hpx::execution::seq,
-        iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, &myfunction);
+        iterator<std::int64_t>{0}, sentinel<int64_t>{100}, &myfunction);
 
     HPX_TEST_EQ(*iter, std::int64_t(100));
 
     iter = hpx::ranges::for_each(hpx::execution::par, iterator<std::int64_t>{0},
-        Sentinel<int64_t>{100}, &myfunction);
+        sentinel<int64_t>{100}, &myfunction);
 
     HPX_TEST_EQ(*iter, std::int64_t(100));
 }

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_adapt.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_adapt.cpp
@@ -4,16 +4,12 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/hpx_main.hpp>
 #include <hpx/include/parallel_for_each.hpp>
 #include <hpx/modules/testing.hpp>
 #include "iter_sent.hpp"
 
-#include <cstddef>
 #include <cstdint>
 #include <iostream>
-#include <iterator>
-#include <vector>
 
 void myfunction(int i)
 {
@@ -22,12 +18,12 @@ void myfunction(int i)
 
 void test_invoke_projected()
 {
-    Iterator<std::int64_t> iter = hpx::ranges::for_each(hpx::execution::seq,
-        Iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, myfunction);
+    iterator<std::int64_t> iter = hpx::ranges::for_each(hpx::execution::seq,
+        iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, myfunction);
 
     HPX_TEST_EQ(*iter, std::int64_t(100));
 
-    iter = hpx::ranges::for_each(hpx::execution::par, Iterator<std::int64_t>{0},
+    iter = hpx::ranges::for_each(hpx::execution::par, iterator<std::int64_t>{0},
         Sentinel<int64_t>{100}, myfunction);
 
     HPX_TEST_EQ(*iter, std::int64_t(100));
@@ -35,12 +31,12 @@ void test_invoke_projected()
 
 void test_begin_end_iterator()
 {
-    Iterator<std::int64_t> iter = hpx::ranges::for_each(hpx::execution::seq,
-        Iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, &myfunction);
+    iterator<std::int64_t> iter = hpx::ranges::for_each(hpx::execution::seq,
+        iterator<std::int64_t>{0}, Sentinel<int64_t>{100}, &myfunction);
 
     HPX_TEST_EQ(*iter, std::int64_t(100));
 
-    iter = hpx::ranges::for_each(hpx::execution::par, Iterator<std::int64_t>{0},
+    iter = hpx::ranges::for_each(hpx::execution::par, iterator<std::int64_t>{0},
         Sentinel<int64_t>{100}, &myfunction);
 
     HPX_TEST_EQ(*iter, std::int64_t(100));

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/iter_sent.hpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/iter_sent.hpp
@@ -12,9 +12,9 @@
 #include <iterator>
 
 template <typename ValueType>
-struct Sentinel
+struct sentinel
 {
-    explicit Sentinel(ValueType stop_value)
+    explicit sentinel(ValueType stop_value)
       : stop(stop_value)
     {
     }
@@ -109,11 +109,11 @@ struct iterator
         return this->state == that.state;
     }
 
-    friend bool operator==(iterator i, Sentinel<Value> s)
+    friend bool operator==(iterator i, sentinel<Value> s)
     {
         return i.state == s.get_stop();
     }
-    friend bool operator==(Sentinel<Value> s, iterator i)
+    friend bool operator==(sentinel<Value> s, iterator i)
     {
         return i.state == s.get_stop();
     }
@@ -123,11 +123,11 @@ struct iterator
         return this->state != that.state;
     }
 
-    friend bool operator!=(iterator i, Sentinel<Value> s)
+    friend bool operator!=(iterator i, sentinel<Value> s)
     {
         return i.state != s.get_stop();
     }
-    friend bool operator!=(Sentinel<Value> s, iterator i)
+    friend bool operator!=(sentinel<Value> s, iterator i)
     {
         return i.state != s.get_stop();
     }

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/iter_sent.hpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/iter_sent.hpp
@@ -29,7 +29,7 @@ private:
 };
 
 template <typename Value>
-struct Iterator
+struct iterator
 {
     using difference_type = std::ptrdiff_t;
     using value_type = Value;
@@ -37,7 +37,7 @@ struct Iterator
     using pointer = Value const*;
     using reference = Value const&;
 
-    explicit Iterator(Value initialState)
+    explicit iterator(Value initialState)
       : state(initialState)
     {
     }
@@ -49,26 +49,26 @@ struct Iterator
 
     virtual Value operator->() const = delete;
 
-    Iterator& operator++()
+    iterator& operator++()
     {
         ++(this->state);
         return *this;
     }
 
-    Iterator operator++(int)
+    iterator operator++(int)
     {
         auto copy = *this;
         ++(*this);
         return copy;
     }
 
-    Iterator& operator--()
+    iterator& operator--()
     {
         --(this->state);
         return *this;
     }
 
-    Iterator operator--(int)
+    iterator operator--(int)
     {
         auto copy = *this;
         --(*this);
@@ -80,74 +80,74 @@ struct Iterator
         return this->state + n;
     }
 
-    Iterator& operator+=(difference_type n)
+    iterator& operator+=(difference_type n)
     {
         this->state += n;
         return *this;
     }
 
-    Iterator operator+(difference_type n) const
+    iterator operator+(difference_type n) const
     {
-        Iterator copy = *this;
+        iterator copy = *this;
         return copy += n;
     }
 
-    Iterator& operator-=(difference_type n)
+    iterator& operator-=(difference_type n)
     {
         this->state -= n;
         return *this;
     }
 
-    Iterator operator-(difference_type n) const
+    iterator operator-(difference_type n) const
     {
-        Iterator copy = *this;
+        iterator copy = *this;
         return copy -= n;
     }
 
-    bool operator==(const Iterator& that) const
+    bool operator==(const iterator& that) const
     {
         return this->state == that.state;
     }
 
-    friend bool operator==(Iterator i, Sentinel<Value> s)
+    friend bool operator==(iterator i, Sentinel<Value> s)
     {
         return i.state == s.get_stop();
     }
-    friend bool operator==(Sentinel<Value> s, Iterator i)
+    friend bool operator==(Sentinel<Value> s, iterator i)
     {
         return i.state == s.get_stop();
     }
 
-    bool operator!=(const Iterator& that) const
+    bool operator!=(const iterator& that) const
     {
         return this->state != that.state;
     }
 
-    friend bool operator!=(Iterator i, Sentinel<Value> s)
+    friend bool operator!=(iterator i, Sentinel<Value> s)
     {
         return i.state != s.get_stop();
     }
-    friend bool operator!=(Sentinel<Value> s, Iterator i)
+    friend bool operator!=(Sentinel<Value> s, iterator i)
     {
         return i.state != s.get_stop();
     }
 
-    bool operator<(const Iterator& that) const
+    bool operator<(const iterator& that) const
     {
         return this->state < that.state;
     }
 
-    bool operator<=(const Iterator& that) const
+    bool operator<=(const iterator& that) const
     {
         return this->state <= that.state;
     }
 
-    bool operator>(const Iterator& that) const
+    bool operator>(const iterator& that) const
     {
         return this->state > that.state;
     }
 
-    bool operator>=(const Iterator& that) const
+    bool operator>=(const iterator& that) const
     {
         return this->state >= that.state;
     }


### PR DESCRIPTION
Fixes #5075 

### Changes
- Change Iterator struct to iterator
- Change Sentinel struct to sentinel
- Cleanup in files that had unnecessary includes

