### PR TITLE
Remove default runtime mode argument from init overload, again

### DIFF
--- a/libs/full/init_runtime/include/hpx/hpx_init.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_init.hpp
@@ -705,7 +705,7 @@ namespace hpx {
     ///                     executed in console or worker mode depending on the
     ///                     command line arguments passed in `argc`/`argv`.
     inline int init(int (*f)(hpx::program_options::variables_map& vm), int argc,
-        char** argv, hpx::runtime_mode mode = hpx::runtime_mode::default_);
+        char** argv, hpx::runtime_mode mode);
 
     /// \brief Main entry point for launching the HPX runtime system.
     ///

--- a/libs/full/init_runtime/include/hpx/hpx_init.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_init.hpp
@@ -668,7 +668,7 @@ namespace hpx {
     ///                     command line arguments passed in `argc`/`argv`.
     inline int init(int (*f)(hpx::program_options::variables_map& vm),
         std::string const& app_name, int argc, char** argv,
-        hpx::runtime_mode mode);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main entry point for launching the HPX runtime system.
     ///

--- a/libs/full/init_runtime/include/hpx/hpx_start.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_start.hpp
@@ -693,7 +693,7 @@ namespace hpx {
     ///                     command line arguments passed in `argc`/`argv`.
     inline bool start(int (*f)(hpx::program_options::variables_map& vm),
         std::string const& app_name, int argc, char** argv,
-        hpx::runtime_mode mode);
+        hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main non-blocking entry point for launching the HPX runtime system.
     ///


### PR DESCRIPTION
Apologies, I was off by one in #5103. On top of that `hpx::start` did not need any change...