### PR TITLE
Fix 5112 - make sure libatomic is used when needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1784,8 +1784,8 @@ if(NOT WIN32)
   # ############################################################################
   if(NOT MSVC)
     hpx_add_compile_flag_if_available(-pthread)
-    if(HPX_HAVE_LIBATOMIC)
-      target_link_libraries(hpx_base_libraries INTERFACE atomic)
+    if(HPX_CXX11_STD_ATOMIC_LIBRARIES)
+      target_link_libraries(hpx_base_libraries INTERFACE ${HPX_CXX11_STD_ATOMIC_LIBRARIES})
     endif()
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1785,7 +1785,9 @@ if(NOT WIN32)
   if(NOT MSVC)
     hpx_add_compile_flag_if_available(-pthread)
     if(HPX_CXX11_STD_ATOMIC_LIBRARIES)
-      target_link_libraries(hpx_base_libraries INTERFACE ${HPX_CXX11_STD_ATOMIC_LIBRARIES})
+      target_link_libraries(
+        hpx_base_libraries INTERFACE ${HPX_CXX11_STD_ATOMIC_LIBRARIES}
+      )
     endif()
   endif()
 

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -297,7 +297,7 @@ function(hpx_check_for_cxx11_std_atomic)
     if(NOT HPX_WITH_CXX11_ATOMIC)
       set(HPX_CXX11_STD_ATOMIC_LIBRARIES
           atomic
-          CACHE BOOL "std::atomics need separate library" FORCE
+          CACHE STRING "std::atomics need separate library" FORCE
       )
       unset(HPX_WITH_CXX11_ATOMIC CACHE)
       add_hpx_config_test(
@@ -306,6 +306,9 @@ function(hpx_check_for_cxx11_std_atomic)
         LIBRARIES ${HPX_CXX11_STD_ATOMIC_LIBRARIES}
         FILE ${ARGN}
       )
+      if(NOT HPX_WITH_CXX11_ATOMIC_128BIT)
+        unset(HPX_WITH_CXX11_ATOMIC_128BIT CACHE)
+      endif()
     endif()
   endif()
 endfunction()
@@ -324,7 +327,7 @@ function(hpx_check_for_cxx11_std_atomic_128bit)
     if(NOT HPX_WITH_CXX11_ATOMIC_128BIT)
       set(HPX_CXX11_STD_ATOMIC_LIBRARIES
           atomic
-          CACHE BOOL "std::atomics need separate library" FORCE
+          CACHE STRING "std::atomics need separate library" FORCE
       )
       unset(HPX_WITH_CXX11_ATOMIC_128BIT CACHE)
       add_hpx_config_test(
@@ -333,6 +336,9 @@ function(hpx_check_for_cxx11_std_atomic_128bit)
         LIBRARIES ${HPX_CXX11_STD_ATOMIC_LIBRARIES}
         FILE ${ARGN}
       )
+      if(NOT HPX_WITH_CXX11_ATOMIC_128BIT)
+        unset(HPX_WITH_CXX11_ATOMIC_128BIT CACHE)
+      endif()
     endif()
   endif()
 endfunction()


### PR DESCRIPTION
Fixes #5112 
We test a link to atomics and set the `HPX_WITH_CXX11_ATOMIC` if ok, but if it fails, we add lib atomic and try again. Then repeat the process with 128 bit atomics. If either needs lib atomic, then `HPX_CXX11_STD_ATOMIC_LIBRARIES` is set to `atomic` and we add that as a dependency to the main hpx_core library.

This fixes my problems (for now at least)

Edit : The problem seems to have been that the check_function_exists call was not delivering as expected.