### PR TITLE
Use sequential_find and friends from separate detail header

### DIFF
--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
@@ -507,8 +507,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 ExPolicy, Iter first, Sent last, F&& f, Proj&& proj)
             {
                 return detail::sequential_find_if_not(first, last,
-                           util::invoke_projected<F, Proj>(std::forward<F>(f),
-                               std::forward<Proj>(proj))) == last;
+                           std::forward<F>(f),
+                           std::forward<Proj>(proj)) == last;
             }
 
             template <typename ExPolicy, typename FwdIter, typename Sent,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/find.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,17 +9,19 @@
 
 #include <hpx/config.hpp>
 #include <hpx/functional/invoke.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
 
 namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
     // provide implementation of std::find supporting iterators/sentinels
-    template <typename Iterator, typename Sentinel, typename T>
+    template <typename Iterator, typename Sentinel, typename T,
+        typename Proj = util::projection_identity>
     inline constexpr Iterator sequential_find(
-        Iterator first, Sentinel last, T const& value)
+        Iterator first, Sentinel last, T const& value, Proj proj = Proj())
     {
         for (; first != last; ++first)
         {
-            if (*first == value)
+            if (hpx::util::invoke(proj, *first) == value)
             {
                 return first;
             }
@@ -27,13 +30,14 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     }
 
     // provide implementation of std::find_if supporting iterators/sentinels
-    template <typename Iterator, typename Sentinel, typename Pred>
+    template <typename Iterator, typename Sentinel, typename Pred,
+        typename Proj = util::projection_identity>
     inline constexpr Iterator sequential_find_if(
-        Iterator first, Sentinel last, Pred pred)
+        Iterator first, Sentinel last, Pred pred, Proj proj = Proj())
     {
         for (; first != last; ++first)
         {
-            if (hpx::util::invoke(pred, *first))
+            if (hpx::util::invoke(pred, hpx::util::invoke(proj, *first)))
             {
                 return first;
             }
@@ -42,13 +46,14 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     }
 
     // provide implementation of std::find_if supporting iterators/sentinels
-    template <typename Iterator, typename Sentinel, typename Pred>
+    template <typename Iterator, typename Sentinel, typename Pred,
+        typename Proj = util::projection_identity>
     inline constexpr Iterator sequential_find_if_not(
-        Iterator first, Sentinel last, Pred pred)
+        Iterator first, Sentinel last, Pred pred, Proj proj = Proj())
     {
         for (; first != last; ++first)
         {
-            if (!hpx::util::invoke(pred, *first))
+            if (!hpx::util::invoke(pred, hpx::util::invoke(proj, *first)))
             {
                 return first;
             }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/find.hpp
@@ -383,6 +383,7 @@ namespace hpx {
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/advance_to_sentinel.hpp>
+#include <hpx/parallel/algorithms/detail/find.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/compare_projected.hpp>
@@ -404,20 +405,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///////////////////////////////////////////////////////////////////////////
     // find
     namespace detail {
-
-        template <typename Iter, typename Sent, typename T, typename Proj>
-        constexpr Iter sequential_find(
-            Iter first, Sent last, T const& value, Proj&& proj)
-        {
-            for (/**/; first != last; ++first)
-            {
-                if (hpx::util::invoke(proj, *first) == value)
-                {
-                    break;
-                }
-            }
-            return first;
-        }
 
         template <typename FwdIter>
         struct find : public detail::algorithm<find<FwdIter>, FwdIter>
@@ -538,20 +525,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///////////////////////////////////////////////////////////////////////////
     // find_if
     namespace detail {
-
-        template <typename Iter, typename Sent, typename Pred, typename Proj>
-        constexpr Iter sequential_find_if(
-            Iter first, Sent last, Pred&& pred, Proj&& proj)
-        {
-            for (/**/; first != last; ++first)
-            {
-                if (hpx::util::invoke(pred, hpx::util::invoke(proj, *first)))
-                {
-                    break;
-                }
-            }
-            return first;
-        }
 
         template <typename FwdIter>
         struct find_if : public detail::algorithm<find_if<FwdIter>, FwdIter>
@@ -678,20 +651,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///////////////////////////////////////////////////////////////////////////
     // find_if_not
     namespace detail {
-
-        template <typename Iter, typename Sent, typename Pred, typename Proj>
-        constexpr Iter sequential_find_if_not(
-            Iter first, Sent last, Pred&& pred, Proj&& proj)
-        {
-            for (/**/; first != last; ++first)
-            {
-                if (!hpx::util::invoke(pred, hpx::util::invoke(proj, *first)))
-                {
-                    break;
-                }
-            }
-            return first;
-        }
 
         template <typename FwdIter>
         struct find_if_not


### PR DESCRIPTION
This makes `hpx::find` and friends to use the `sequential_find` functions that are located under the detail directory and thus removes the ones placed in the same header.

flyby: It adds the projection utility in the overloads under the separate header.
