### PR TITLE
Fixing compatibility warnings in hpx::transform implementation

### DIFF
--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
@@ -417,7 +417,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             hpx::traits::is_iterator<OutIter>::value &&
             traits::is_projected_range<Proj, Rng>::value &&
             traits::is_indirect_callable<ExPolicy, F,
-                traits::projected_range<Proj, Rng>>::value
+                traits::projected_range<Proj, Rng>
+            >::value
         )>
     // clang-format on
     HPX_DEPRECATED_V(1, 6,

--- a/plugins/parcelport/libfabric/sender.cpp
+++ b/plugins/parcelport/libfabric/sender.cpp
@@ -52,7 +52,7 @@ namespace libfabric
                     << " index " << decnumber(c.data_.index_));
             if (c.type_ == serialization::chunk_type_pointer)
             {
-                LOG_EXCLUSIVE(util::high_resolution_timer regtimer);
+                LOG_EXCLUSIVE(chrono::high_resolution_timer regtimer);
 
                 // create a new memory region from the user supplied pointer
                 region_type *zero_copy_region =


### PR DESCRIPTION
- flyby: fixing compatibility warning in libfabric parcelport
