### PR TITLE
Working around hwloc limitation on certain platforms

### DIFF
--- a/.jenkins/lsu/env-clang-9.sh
+++ b/.jenkins/lsu/env-clang-9.sh
@@ -18,3 +18,7 @@ configure_extra_options+=" -DHPX_WITH_MALLOC=system"
 configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS=ON"
 configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
 configure_extra_options+=" -DHPX_WITH_PARCELPORT_MPI=ON"
+
+# Make sure HWLOC does not report 'cores'. This is purely an option to enable
+# testing the topology code under conditions close to those on FreeBSD.
+configure_extra_options+=" -DHPX_TOPOLOGY_WITH_ADDITIONAL_HWLOC_TESTING=ON"

--- a/libs/core/topology/CMakeLists.txt
+++ b/libs/core/topology/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020 The STE||AR-Group
+# Copyright (c) 2019-2021 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,6 +7,25 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+# Special option to enable testing of FreeBSD specific limitations This is
+# purely an option allowing to test whether things work properly on systems that
+# may not report cores in the topology at all (e.g. FreeBSD). There is no need
+# for a user to every enable this.
+hpx_option(
+  HPX_TOPOLOGY_WITH_ADDITIONAL_HWLOC_TESTING BOOL
+  "Enable HWLOC filtering that makes it report no cores, this is purely an "
+  "option supporting better testing - do not enable under normal circumstances. "
+  "(default: OFF)" OFF ADVANCED
+  CATEGORY "Modules"
+  MODULE TOPOLOGY
+)
+
+if(HPX_TOPOLOGY_WITH_ADDITIONAL_HWLOC_TESTING)
+  hpx_add_config_define_namespace(
+    DEFINE HPX_TOPOLOGY_HAVE_ADDITIONAL_HWLOC_TESTING NAMESPACE TOPOLOGY
+  )
+endif()
 
 # Default location is $HPX_ROOT/libs/topology/include
 set(topology_headers hpx/topology/cpu_mask.hpp hpx/topology/topology.hpp)

--- a/libs/core/topology/include/hpx/topology/topology.hpp
+++ b/libs/core/topology/include/hpx/topology/topology.hpp
@@ -333,7 +333,8 @@ namespace hpx { namespace threads {
 
         std::size_t init_core_number(std::size_t num_thread)
         {
-            return init_node_number(num_thread, HWLOC_OBJ_CORE);
+            return init_node_number(
+                num_thread, use_pus_as_cores_ ? HWLOC_OBJ_PU : HWLOC_OBJ_CORE);
         }
 
         void extract_node_mask(hwloc_obj_t parent, mask_type& mask) const;
@@ -369,14 +370,15 @@ namespace hpx { namespace threads {
         // This is mainly to skip the first Core on the Xeon Phi
         // which is reserved for OS related tasks
 #if !defined(HPX_NATIVE_MIC)
-        static const std::size_t pu_offset = 0;
-        static const std::size_t core_offset = 0;
+        static constexpr std::size_t pu_offset = 0;
+        static constexpr std::size_t core_offset = 0;
 #else
-        static const std::size_t pu_offset = 4;
-        static const std::size_t core_offset = 1;
+        static constexpr std::size_t pu_offset = 4;
+        static constexpr std::size_t core_offset = 1;
 #endif
 
         std::size_t num_of_pus_;
+        bool use_pus_as_cores_;
 
         using mutex_type = hpx::util::spinlock;
         mutable mutex_type topo_mtx;

--- a/libs/core/topology/src/topology.cpp
+++ b/libs/core/topology/src/topology.cpp
@@ -1320,6 +1320,7 @@ namespace hpx { namespace threads {
 #if !defined(__APPLE__)
         hwloc_membind_policy_t policy = ::HWLOC_MEMBIND_BIND;
         hwloc_nodeset_t ns = reinterpret_cast<hwloc_nodeset_t>(nodeset);
+
         int ret =
 #if HWLOC_API_VERSION >= 0x00010b06
             hwloc_set_area_membind(
@@ -1362,6 +1363,7 @@ namespace hpx { namespace threads {
         {
             nodeset.reset(hwloc_bitmap_alloc());
         }
+
         //
         hwloc_membind_policy_t policy;
         hwloc_nodeset_t ns =
@@ -1381,6 +1383,7 @@ namespace hpx { namespace threads {
                 "hwloc_get_area_membind_nodeset failed");
             return bitmap_to_mask(ns, HWLOC_OBJ_MACHINE);
         }
+
         return bitmap_to_mask(ns, HWLOC_OBJ_NUMANODE);
     }
 
@@ -1392,6 +1395,7 @@ namespace hpx { namespace threads {
         {
             nodeset.reset(hwloc_bitmap_alloc());
         }
+
         //
         hwloc_nodeset_t ns =
             reinterpret_cast<hwloc_nodeset_t>(nodeset.get_bmp());
@@ -1400,12 +1404,18 @@ namespace hpx { namespace threads {
             topo, addr, 1, ns, HWLOC_MEMBIND_BYNODESET);
         if (ret < 0)
         {
+#if defined(__FreeBSD__)
+            // on some platforms this API is not supported (e.g. FreeBSD)
+            return 0;
+#else
             std::string msg(strerror(errno));
             HPX_THROW_EXCEPTION(kernel_error,
                 "hpx::threads::topology::get_numa_domain",
                 "hwloc_get_area_memlocation failed " + msg);
             return -1;
+#endif
         }
+
         threads::mask_type mask = bitmap_to_mask(ns, HWLOC_OBJ_NUMANODE);
         return static_cast<int>(threads::find_first(mask));
 #else

--- a/libs/core/topology/src/topology.cpp
+++ b/libs/core/topology/src/topology.cpp
@@ -205,6 +205,7 @@ namespace hpx { namespace threads {
 
     topology::topology()
       : topo(nullptr)
+      , use_pus_as_cores_(false)
       , machine_affinity_mask_(0)
     {    // {{{
         int err = hwloc_topology_init(&topo);
@@ -339,26 +340,41 @@ namespace hpx { namespace threads {
         std::unique_lock<mutex_type> lk(topo_mtx);
 
         int num_cores = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_CORE);
+        bool use_pus = false;
 
         // If num_cores is smaller 0, we have an error, it should never be zero
         // either to avoid division by zero, we should always have at least one
         // core
         if (num_cores <= 0)
         {
-            HPX_THROWS_IF(ec, no_success, "topology::hwloc_get_nobjs_by_type",
-                "Failed to get number of cores");
-            return std::size_t(-1);
+            // on some platforms, hwloc can't report the number of cores (BSD),
+            // fall back to report the number of PUs instead
+            num_cores = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_PU);
+            if (num_cores <= 0)
+            {
+                HPX_THROWS_IF(ec, no_success,
+                    "topology::hwloc_get_nobjs_by_type",
+                    "Failed to get number of cores");
+                return std::size_t(-1);
+            }
+            use_pus = true;
         }
         num_core %= num_cores;    //-V101 //-V104 //-V107
 
         hwloc_obj_t core_obj;
+        if (!use_pus)
+        {
+            core_obj = hwloc_get_obj_by_type(
+                topo, HWLOC_OBJ_CORE, static_cast<unsigned>(num_core));
+
+            num_pu %= core_obj->arity;    //-V101 //-V104
+            return std::size_t(core_obj->children[num_pu]->logical_index);
+        }
 
         core_obj = hwloc_get_obj_by_type(
-            topo, HWLOC_OBJ_CORE, static_cast<unsigned>(num_core));
+            topo, HWLOC_OBJ_PU, static_cast<unsigned>(num_core));
 
-        num_pu %= core_obj->arity;    //-V101 //-V104
-
-        return std::size_t(core_obj->children[num_pu]->logical_index);
+        return std::size_t(core_obj->logical_index);
     }    // }}}
 
     ///////////////////////////////////////////////////////////////////////////
@@ -729,6 +745,7 @@ namespace hpx { namespace threads {
     std::size_t topology::get_number_of_cores() const
     {
         int nobjs = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_CORE);
+
         // If num_cores is smaller 0, we have an error
         if (0 > nobjs)
         {
@@ -812,8 +829,9 @@ namespace hpx { namespace threads {
 
         {
             std::unique_lock<mutex_type> lk(topo_mtx);
-            core_obj = hwloc_get_obj_by_type(
-                topo, HWLOC_OBJ_CORE, static_cast<unsigned>(core));
+            core_obj = hwloc_get_obj_by_type(topo,
+                use_pus_as_cores_ ? HWLOC_OBJ_PU : HWLOC_OBJ_CORE,
+                static_cast<unsigned>(core));
         }
 
         if (core_obj)
@@ -841,7 +859,8 @@ namespace hpx { namespace threads {
         {
             HPX_ASSERT(num_socket == detail::get_index(socket_obj));
             std::size_t pu_count = 0;
-            return extract_node_count(socket_obj, HWLOC_OBJ_CORE, pu_count);
+            return extract_node_count(socket_obj,
+                use_pus_as_cores_ ? HWLOC_OBJ_PU : HWLOC_OBJ_CORE, pu_count);
         }
 
         return get_number_of_cores();
@@ -862,7 +881,8 @@ namespace hpx { namespace threads {
             HPX_ASSERT(numa_node == detail::get_index(node_obj));
             std::size_t pu_count = 0;
             node_obj = detail::adjust_node_obj(node_obj);
-            return extract_node_count(node_obj, HWLOC_OBJ_CORE, pu_count);
+            return extract_node_count(node_obj,
+                use_pus_as_cores_ ? HWLOC_OBJ_PU : HWLOC_OBJ_CORE, pu_count);
         }
 
         return get_number_of_cores();
@@ -1063,8 +1083,9 @@ namespace hpx { namespace threads {
 
         {
             std::unique_lock<mutex_type> lk(topo_mtx);
-            core_obj = hwloc_get_obj_by_type(
-                topo, HWLOC_OBJ_CORE, static_cast<unsigned>(num_core));
+            core_obj = hwloc_get_obj_by_type(topo,
+                use_pus_as_cores_ ? HWLOC_OBJ_PU : HWLOC_OBJ_CORE,
+                static_cast<unsigned>(num_core));
         }
 
         if (core_obj)
@@ -1119,7 +1140,9 @@ namespace hpx { namespace threads {
 
         {
             std::unique_lock<mutex_type> lk(topo_mtx);
-            int num_cores = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_CORE);
+            int num_cores = hwloc_get_nbobjs_by_type(
+                topo, use_pus_as_cores_ ? HWLOC_OBJ_PU : HWLOC_OBJ_CORE);
+
             // If num_cores is smaller 0, we have an error, it should never be zero
             // either to avoid division by zero, we should always have at least one
             // core
@@ -1132,8 +1155,9 @@ namespace hpx { namespace threads {
             }
 
             num_core = (num_core + core_offset) % std::size_t(num_cores);
-            obj = hwloc_get_obj_by_type(
-                topo, HWLOC_OBJ_CORE, static_cast<unsigned>(num_core));
+            obj = hwloc_get_obj_by_type(topo,
+                use_pus_as_cores_ ? HWLOC_OBJ_PU : HWLOC_OBJ_CORE,
+                static_cast<unsigned>(num_core));
         }
 
         if (!obj)
@@ -1155,10 +1179,19 @@ namespace hpx { namespace threads {
     void topology::init_num_of_pus()
     {
         num_of_pus_ = 1;
+        use_pus_as_cores_ = false;
+
         {
             std::unique_lock<mutex_type> lk(topo_mtx);
-            int num_of_pus = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_PU);
 
+            // on some platforms, hwloc can't report the number of cores (BSD),
+            // in this case we use PUs as cores
+            if (hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_CORE) <= 0)
+            {
+                use_pus_as_cores_ = true;
+            }
+
+            int num_of_pus = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_PU);
             if (num_of_pus > 0)
             {
                 num_of_pus_ = static_cast<std::size_t>(num_of_pus);


### PR DESCRIPTION
- on certain platforms (like BSD), hwloc doesn't correctly report the number of cores, use number of PUs instead

Fixes #5115

@bgoglin I have no way of actually testing this. Would you be able to verify if this fixes the issue by any chance?