### PR TITLE
Reduce vector sizes in partial sort benchmarks when running in debug mode

### DIFF
--- a/libs/parallelism/algorithms/tests/performance/benchmark_partial_sort.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_partial_sort.cpp
@@ -24,7 +24,11 @@ std::mt19937 gen(seed);
 void function01(void)
 {
     typedef std::less<std::uint64_t> compare_t;
+#if defined(HPX_DEBUG)
+    constexpr std::uint32_t NELEM = 100;
+#else
     constexpr std::uint32_t NELEM = 10000;
+#endif
 
     std::vector<uint64_t> A, B;
     A.reserve(NELEM);
@@ -62,7 +66,11 @@ void function01(void)
 
 void function02(void)
 {
+#if defined(HPX_DEBUG)
+    constexpr std::uint32_t NELEM = 100000;
+#else
     constexpr std::uint32_t NELEM = 10000000;
+#endif
 
     std::less<std::uint64_t> comp;
     std::vector<std::uint64_t> A, B;

--- a/libs/parallelism/algorithms/tests/performance/benchmark_partial_sort_parallel.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_partial_sort_parallel.cpp
@@ -24,7 +24,12 @@ std::mt19937 gen(seed);
 void function01()
 {
     typedef std::less<std::uint64_t> compare_t;
+#if defined(HPX_DEBUG)
+    constexpr std::uint32_t NELEM = 100;
+#else
     constexpr std::uint32_t NELEM = 10000;
+#endif
+
 
     std::vector<std::uint64_t> A, B;
     A.reserve(NELEM);
@@ -63,7 +68,11 @@ void function01()
 void function02()
 {
     std::less<std::uint64_t> comp;
+#if defined(HPX_DEBUG)
+    constexpr std::uint32_t NELEM = 100000;
+#else
     constexpr std::uint32_t NELEM = 10000000;
+#endif
 
     std::vector<std::uint64_t> A, B;
     A.reserve(NELEM);
@@ -119,7 +128,11 @@ void function02()
 void function03()
 {
     typedef std::less<std::uint64_t> compare_t;
+#if defined(HPX_DEBUG)
+    constexpr std::uint32_t NELEM = 10000;
+#else
     constexpr std::uint32_t NELEM = 1000000;
+#endif
 
     std::vector<std::uint64_t> A, B;
     A.reserve(NELEM);


### PR DESCRIPTION
The benchmarks otherwise take too long to run.