### PR TITLE
Adapt remove and remove_if to C++20

### DIFF
--- a/libs/full/include/include/hpx/algorithm.hpp
+++ b/libs/full/include/include/hpx/algorithm.hpp
@@ -20,10 +20,8 @@ namespace hpx {
     using hpx::parallel::minmax_element;
     using hpx::parallel::partition;
     using hpx::parallel::partition_copy;
-    using hpx::parallel::remove;
     using hpx::parallel::remove_copy;
     using hpx::parallel::remove_copy_if;
-    using hpx::parallel::remove_if;
     using hpx::parallel::replace;
     using hpx::parallel::replace_copy;
     using hpx::parallel::replace_copy_if;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/find.hpp
@@ -26,7 +26,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                 return first;
             }
         }
-        return last;
+        return first;
     }
 
     // provide implementation of std::find_if supporting iterators/sentinels
@@ -42,7 +42,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                 return first;
             }
         }
-        return last;
+        return first;
     }
 
     // provide implementation of std::find_if supporting iterators/sentinels
@@ -58,6 +58,6 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
                 return first;
             }
         }
-        return last;
+        return first;
     }
 }}}}    // namespace hpx::parallel::v1::detail

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
@@ -354,3 +354,54 @@ namespace hpx { namespace parallel { inline namespace v1 {
             std::forward<Proj>(proj));
     }
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx {
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::remove
+    HPX_INLINE_CONSTEXPR_VARIABLE struct remove_t final
+      : hpx::functional::tag<remove_t>
+    {
+        // clang-format off
+        template <typename FwdIter,
+            typename T, HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<FwdIter1>::value
+            )>
+        // clang-format on
+        friend FwdIter tag_invoke(
+            hpx::remove_t, FwdIter first, FwdIter last, const T& val)
+        {
+            static_assert(std::is_move_assignable<*FwdIter>::value,
+                "the type of *first must meet the Cpp17MoveAssignable "
+                "requirements");
+
+            typedef typename std::iterator_traits<FwdIter>::value_type Type;
+
+            return parallel::detail::remove_if(
+                hpx::execution::seq, first, last,
+                [value](Type const& a) -> bool { return value == a; },
+                hpx::parallel::util::projection_identity());
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter,
+            typename T, HPX_CONCEPT_REQUIRES_(
+                parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value
+            )>
+        // clang-format on
+        friend FwdIter tag_invoke(hpx::remove_t, typename ExPolicy,
+            FwdIter first, FwdIter last, const T& val)
+        {
+            static_assert(std::is_move_assignable<*FwdIter>::value,
+                "the type of *first must meet the Cpp17MoveAssignable "
+                "requirements");
+
+            typedef typename std::iterator_traits<FwdIter>::value_type Type;
+
+            return parallel::detail::remove_if(
+                std::forward<ExPolicy>(policy), first, last,
+                [value](Type const& a) -> bool { return value == a; },
+                hpx::parallel::util::projection_identity());
+        }
+    }
+}    // namespace hpx

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2017 Taeguk Kwon
+//  Copyright (c) 2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,6 +8,128 @@
 /// \file parallel/algorithms/remove.hpp
 
 #pragma once
+
+#if defined(DOXYGEN)
+namespace hpx {
+
+    /// Removes all elements satisfying specific criteria from the range
+    /// [first, last) and returns a past-the-end iterator for the new
+    /// end of the range. This version removes all elements for which predicate
+    /// \a pred returns true.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first applications of
+    ///         the predicate \a pred and the projection \a proj.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a remove_if requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///
+    /// The assignments in the parallel \a remove_if algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a remove_if algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a remove_if algorithm returns a \a hpx::future<FwdIter>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or \a parallel_task_policy and
+    ///           returns \a FwdIter otherwise.
+    ///           The \a remove_if algorithm returns the iterator to the new end
+    ///           of the range.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename Pred,
+        typename Proj = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy, FwdIter>::type remove_if(
+        ExPolicy&& policy, FwdIter first, FwdIter last, Pred&& pred);
+
+    /////////////////////////////////////////////////////////////////////////////
+    /// Removes all elements satisfying specific criteria from the range
+    /// [first, last) and returns a past-the-end iterator for the new
+    /// end of the range. This version removes all elements that are
+    /// equal to \a value.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first applications of
+    ///         the operator==().
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam T           The type of the value to remove (deduced).
+    ///                     This value type must meet the requirements of
+    ///                     \a CopyConstructible.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param value        Specifies the value of elements to remove.
+    ///
+    /// The assignments in the parallel \a remove algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a remove algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a remove algorithm returns a \a hpx::future<FwdIter>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or \a parallel_task_policy and
+    ///           returns \a FwdIter otherwise.
+    ///           The \a remove algorithm returns the iterator to the new end
+    ///           of the range.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename T,
+        typename Proj = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy, FwdIter>::type remove(
+        ExPolicy&& policy, FwdIter first, FwdIter last, T const& value);
+
+}    // namespace hpx
+
+#else    // DOXYGEN
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
@@ -21,6 +144,7 @@
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/transfer.hpp>
+#include <hpx/parallel/algorithms/remove.hpp>    //might be useless - need CI to confirm
 #include <hpx/parallel/tagspec.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>
@@ -50,14 +174,18 @@ namespace hpx { namespace parallel { inline namespace v1 {
     namespace detail {
         /// \cond NOINTERNAL
 
-        // sequential remove_if with projection function
-        template <typename FwdIter, typename Pred, typename Proj>
-        FwdIter sequential_remove_if(
-            FwdIter first, FwdIter last, Pred&& pred, Proj&& proj)
+        template <typename Iter, typename Sent, typename UnaryPredicate,
+            typename Proj>
+        Iter sequential_remove_if(
+            Iter first, Sent last, UnaryPredicate p, Proj proj)
         {
-            return std::remove_if(first, last,
-                util::invoke_projected<Pred, Proj>(
-                    std::forward<Pred>(pred), std::forward<Proj>(proj)));
+            first = hpx::parallel::v1::detail::sequential_find_if(
+                first, last, p, proj);
+            if (first != last)
+                for (Iter i = first; ++i != last;)
+                    if (!p(*i))
+                        *first++ = std::move(*i);
+            return first;
         }
 
         template <typename FwdIter>
@@ -68,30 +196,31 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
             }
 
-            template <typename ExPolicy, typename Pred, typename Proj>
-            static FwdIter sequential(
-                ExPolicy, FwdIter first, FwdIter last, Pred&& pred, Proj&& proj)
+            template <typename ExPolicy, typename Iter, typename Sent,
+                typename Pred, typename Proj>
+            static Iter sequential(
+                ExPolicy, Iter first, Sent last, Pred&& pred, Proj&& proj)
             {
                 return sequential_remove_if(first, last,
                     std::forward<Pred>(pred), std::forward<Proj>(proj));
             }
 
-            template <typename ExPolicy, typename Pred, typename Proj>
-            static
-                typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
-                parallel(ExPolicy&& policy, FwdIter first, FwdIter last,
-                    Pred&& pred, Proj&& proj)
+            template <typename ExPolicy, typename Iter, typename Sent,
+                typename Pred, typename Proj>
+            static typename util::detail::algorithm_result<ExPolicy, Iter>::type
+            parallel(ExPolicy&& policy, Iter first, Sent last, Pred&& pred,
+                Proj&& proj)
             {
-                typedef hpx::util::zip_iterator<FwdIter, bool*> zip_iterator;
-                typedef util::detail::algorithm_result<ExPolicy, FwdIter>
+                typedef hpx::util::zip_iterator<Iter, bool*> zip_iterator;
+                typedef util::detail::algorithm_result<ExPolicy, Iter>
                     algorithm_result;
-                typedef typename std::iterator_traits<FwdIter>::difference_type
+                typedef typename std::iterator_traits<Iter>::difference_type
                     difference_type;
 
-                difference_type count = std::distance(first, last);
+                difference_type count = detail::distance(first, last);
 
                 if (count == 0)
-                    return algorithm_result::get(std::move(last));
+                    return algorithm_result::get(std::move(first));
 
 #if defined(HPX_HAVE_CXX17_SHARED_PTR_ARRAY)
                 std::shared_ptr<bool[]> flags(new bool[count]);
@@ -102,7 +231,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 using hpx::get;
                 using hpx::util::make_zip_iterator;
-                typedef util::scan_partitioner<ExPolicy, FwdIter, std::size_t,
+                typedef util::scan_partitioner<ExPolicy, Iter, std::size_t,
                     void, util::scan_partitioner_sequential_f3_tag>
                     scan_partitioner_type;
 
@@ -134,8 +263,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         return 0u;
                     });
 
-                std::shared_ptr<FwdIter> dest_ptr =
-                    std::make_shared<FwdIter>(first);
+                std::shared_ptr<Iter> dest_ptr = std::make_shared<Iter>(first);
                 auto f3 =
                     [dest_ptr, flags](zip_iterator part_begin,
                         std::size_t part_size,
@@ -146,7 +274,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     curr.get();    // rethrow exceptions
                     next.get();    // rethrow exceptions
 
-                    FwdIter& dest = *dest_ptr;
+                    Iter& dest = *dest_ptr;
 
                     if (dest == get<0>(part_begin.get_iterator_tuple()))
                     {
@@ -176,7 +304,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 auto f4 =
                     [dest_ptr, flags](
                         std::vector<hpx::shared_future<std::size_t>>&&,
-                        std::vector<hpx::future<void>>&&) mutable -> FwdIter {
+                        std::vector<hpx::future<void>>&&) mutable -> Iter {
                     HPX_UNUSED(flags);
                     return *dest_ptr;
                 };
@@ -198,80 +326,22 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Removes all elements satisfying specific criteria from the range
-    /// [first, last) and returns a past-the-end iterator for the new
-    /// end of the range. This version removes all elements for which predicate
-    /// \a pred returns true.
-    ///
-    /// \note   Complexity: Performs not more than \a last - \a first
-    ///         assignments, exactly \a last - \a first applications of
-    ///         the predicate \a pred and the projection \a proj.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam Pred        The type of the function/function object to use
-    ///                     (deduced). Unlike its sequential form, the parallel
-    ///                     overload of \a remove_if requires \a Pred to meet the
-    ///                     requirements of \a CopyConstructible.
-    /// \tparam Proj        The type of an optional projection function. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param pred         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last).This is an
-    ///                     unary predicate which returns \a true for the
-    ///                     required elements. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     bool pred(const Type &a);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it. The type \a Type must be such that an object of
-    ///                     type \a FwdIter can be dereferenced and then
-    ///                     implicitly converted to Type.
-    /// \param proj         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements as a
-    ///                     projection operation before the actual predicate
-    ///                     \a is invoked.
-    ///
-    /// The assignments in the parallel \a remove_if algorithm invoked with
-    /// an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The assignments in the parallel \a remove_if algorithm invoked with
-    /// an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a remove_if algorithm returns a \a hpx::future<FwdIter>
-    ///           if the execution policy is of type
-    ///           \a sequenced_task_policy or \a parallel_task_policy and
-    ///           returns \a FwdIter otherwise.
-    ///           The \a remove_if algorithm returns the iterator to the new end
-    ///           of the range.
-    ///
+    // clang-format off
     template <typename ExPolicy, typename FwdIter, typename Pred,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&& hpx::
-                traits::is_iterator<FwdIter>::value&& traits::is_projected<Proj,
-                    FwdIter>::value&& traits::is_indirect_callable<ExPolicy,
-                    Pred, traits::projected<Proj, FwdIter>>::value)>
-    typename util::detail::algorithm_result<ExPolicy, FwdIter>::type remove_if(
-        ExPolicy&& policy, FwdIter first, FwdIter last, Pred&& pred,
-        Proj&& proj = Proj())
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<FwdIter>::value &&
+            traits::is_projected<Proj,FwdIter>::value &&
+            traits::is_indirect_callable<ExPolicy,
+                Pred, traits::projected<Proj, FwdIter>>::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::remove_if is deprecated, use hpx::remove_if instead")
+        typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
+        remove_if(ExPolicy&& policy, FwdIter first, FwdIter last, Pred&& pred,
+            Proj&& proj = Proj())
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
@@ -283,67 +353,20 @@ namespace hpx { namespace parallel { inline namespace v1 {
             std::forward<Proj>(proj));
     }
 
-    /////////////////////////////////////////////////////////////////////////////
-    // remove
-    /// Removes all elements satisfying specific criteria from the range
-    /// [first, last) and returns a past-the-end iterator for the new
-    /// end of the range. This version removes all elements that are
-    /// equal to \a value.
-    ///
-    /// \note   Complexity: Performs not more than \a last - \a first
-    ///         assignments, exactly \a last - \a first applications of
-    ///         the operator==() and the projection \a proj.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam T           The type of the value to remove (deduced).
-    ///                     This value type must meet the requirements of
-    ///                     \a CopyConstructible.
-    /// \tparam Proj        The type of an optional projection function. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param value        Specifies the value of elements to remove.
-    /// \param proj         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements as a
-    ///                     projection operation before the actual predicate
-    ///                     \a is invoked.
-    ///
-    /// The assignments in the parallel \a remove algorithm invoked with
-    /// an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The assignments in the parallel \a remove algorithm invoked with
-    /// an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a remove algorithm returns a \a hpx::future<FwdIter>
-    ///           if the execution policy is of type
-    ///           \a sequenced_task_policy or \a parallel_task_policy and
-    ///           returns \a FwdIter otherwise.
-    ///           The \a remove algorithm returns the iterator to the new end
-    ///           of the range.
-    ///
+    // clang-format off
     template <typename ExPolicy, typename FwdIter, typename T,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<FwdIter>::value&&
-                    traits::is_projected<Proj, FwdIter>::value)>
-    typename util::detail::algorithm_result<ExPolicy, FwdIter>::type remove(
-        ExPolicy&& policy, FwdIter first, FwdIter last, T const& value,
-        Proj&& proj = Proj())
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<FwdIter>::value &&
+            traits::is_projected<Proj, FwdIter>::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(
+        1, 6, "hpx::parallel::remove is deprecated, use hpx::remove instead")
+        typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
+        remove(ExPolicy&& policy, FwdIter first, FwdIter last, T const& value,
+            Proj&& proj = Proj())
     {
         typedef typename std::iterator_traits<FwdIter>::value_type Type;
 
@@ -409,6 +432,7 @@ namespace hpx {
     HPX_INLINE_CONSTEXPR_VARIABLE struct remove_t final
       : hpx::functional::tag<remove_t>
     {
+    private:
         // clang-format off
         template <typename FwdIter,
             typename T, HPX_CONCEPT_REQUIRES_(
@@ -420,7 +444,7 @@ namespace hpx {
         {
             typedef typename std::iterator_traits<FwdIter>::value_type Type;
 
-            return remove_if(hpx::execution::seq, first, last,
+            return hpx::remove_if(hpx::execution::seq, first, last,
                 [value](Type const& a) -> bool { return value == a; });
         }
 
@@ -438,8 +462,10 @@ namespace hpx {
         {
             typedef typename std::iterator_traits<FwdIter>::value_type Type;
 
-            return remove_if(std::forward<ExPolicy>(policy), first, last,
+            return hpx::remove_if(std::forward<ExPolicy>(policy), first, last,
                 [value](Type const& a) -> bool { return value == a; });
         }
     } remove{};
 }    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
@@ -143,8 +143,9 @@ namespace hpx {
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/algorithms/detail/find.hpp>
 #include <hpx/parallel/algorithms/detail/transfer.hpp>
-#include <hpx/parallel/algorithms/remove.hpp>    //might be useless - need CI to confirm
+#include <hpx/parallel/algorithms/remove.hpp>
 #include <hpx/parallel/tagspec.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
@@ -466,7 +466,10 @@ namespace hpx {
         // clang-format off
         template <typename FwdIter,
             typename Pred, HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_iterator<FwdIter>::value
+                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::is_invocable_v<Pred,
+                    typename std::iterator_traits<FwdIter>::value_type
+                >
             )>
         // clang-format on
         friend FwdIter tag_invoke(
@@ -485,7 +488,10 @@ namespace hpx {
         template <typename ExPolicy, typename FwdIter,
             typename Pred, HPX_CONCEPT_REQUIRES_(
                 parallel::execution::is_execution_policy<ExPolicy>::value &&
-                hpx::traits::is_iterator<FwdIter>::value
+                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::is_invocable_v<Pred,
+                    typename std::iterator_traits<FwdIter>::value_type
+                >
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
@@ -12,6 +12,89 @@
 #if defined(DOXYGEN)
 namespace hpx {
 
+    /////////////////////////////////////////////////////////////////////////////
+    /// Removes all elements satisfying specific criteria from the range
+    /// [first, last) and returns a past-the-end iterator for the new
+    /// end of the range. This version removes all elements that are
+    /// equal to \a value.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first applications of
+    ///         the operator==().
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam T           The type of the value to remove (deduced).
+    ///                     This value type must meet the requirements of
+    ///                     \a CopyConstructible.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param value        Specifies the value of elements to remove.
+    ///
+    /// The assignments in the parallel \a remove algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    /// \returns  The \a remove algorithm returns a \a FwdIter.
+    ///           The \a remove algorithm returns the iterator to the new end
+    ///           of the range.
+    ///
+    template <typename FwdIter, typename T>
+    FwdIter remove(FwdIter first, FwdIter last, T const& value);
+
+    /////////////////////////////////////////////////////////////////////////////
+    /// Removes all elements satisfying specific criteria from the range
+    /// [first, last) and returns a past-the-end iterator for the new
+    /// end of the range. This version removes all elements that are
+    /// equal to \a value.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first applications of
+    ///         the operator==().
+    ///
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam T           The type of the value to remove (deduced).
+    ///                     This value type must meet the requirements of
+    ///                     \a CopyConstructible.
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param value        Specifies the value of elements to remove.
+    ///
+    /// The assignments in the parallel \a remove algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a remove algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a remove algorithm returns a \a hpx::future<FwdIter>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or \a parallel_task_policy and
+    ///           returns \a FwdIter otherwise.
+    ///           The \a remove algorithm returns the iterator to the new end
+    ///           of the range.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename T>
+    typename util::detail::algorithm_result<ExPolicy, FwdIter>::type remove(
+        ExPolicy&& policy, FwdIter first, FwdIter last, T const& value);
+
     /// Removes all elements satisfying specific criteria from the range
     /// [first, last) and returns a past-the-end iterator for the new
     /// end of the range. This version removes all elements for which predicate
@@ -19,7 +102,53 @@ namespace hpx {
     ///
     /// \note   Complexity: Performs not more than \a last - \a first
     ///         assignments, exactly \a last - \a first applications of
-    ///         the predicate \a pred and the projection \a proj.
+    ///         the predicate \a pred.
+    ///
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a remove_if requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///
+    /// The assignments in the parallel \a remove_if algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    /// \returns  The \a remove_if algorithm returns a \a FwdIter.
+    ///           The \a remove_if algorithm returns the iterator to the new end
+    ///           of the range.
+    ///
+    template <typename FwdIter, typename Pred>
+    FwdIter remove_if(FwdIter first, FwdIter last, Pred&& pred);
+
+    /// Removes all elements satisfying specific criteria from the range
+    /// [first, last) and returns a past-the-end iterator for the new
+    /// end of the range. This version removes all elements for which predicate
+    /// \a pred returns true.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first applications of
+    ///         the predicate \a pred.
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
     ///                     It describes the manner in which the execution
@@ -71,61 +200,9 @@ namespace hpx {
     ///           The \a remove_if algorithm returns the iterator to the new end
     ///           of the range.
     ///
-    template <typename ExPolicy, typename FwdIter, typename Pred,
-        typename Proj = util::projection_identity>
+    template <typename ExPolicy, typename FwdIter, typename Pred>
     typename util::detail::algorithm_result<ExPolicy, FwdIter>::type remove_if(
         ExPolicy&& policy, FwdIter first, FwdIter last, Pred&& pred);
-
-    /////////////////////////////////////////////////////////////////////////////
-    /// Removes all elements satisfying specific criteria from the range
-    /// [first, last) and returns a past-the-end iterator for the new
-    /// end of the range. This version removes all elements that are
-    /// equal to \a value.
-    ///
-    /// \note   Complexity: Performs not more than \a last - \a first
-    ///         assignments, exactly \a last - \a first applications of
-    ///         the operator==().
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam T           The type of the value to remove (deduced).
-    ///                     This value type must meet the requirements of
-    ///                     \a CopyConstructible.
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param value        Specifies the value of elements to remove.
-    ///
-    /// The assignments in the parallel \a remove algorithm invoked with
-    /// an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The assignments in the parallel \a remove algorithm invoked with
-    /// an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a remove algorithm returns a \a hpx::future<FwdIter>
-    ///           if the execution policy is of type
-    ///           \a sequenced_task_policy or \a parallel_task_policy and
-    ///           returns \a FwdIter otherwise.
-    ///           The \a remove algorithm returns the iterator to the new end
-    ///           of the range.
-    ///
-    template <typename ExPolicy, typename FwdIter, typename T,
-        typename Proj = util::projection_identity>
-    typename util::detail::algorithm_result<ExPolicy, FwdIter>::type remove(
-        ExPolicy&& policy, FwdIter first, FwdIter last, T const& value);
 
 }    // namespace hpx
 
@@ -175,17 +252,18 @@ namespace hpx { namespace parallel { inline namespace v1 {
     namespace detail {
         /// \cond NOINTERNAL
 
-        template <typename Iter, typename Sent, typename UnaryPredicate,
-            typename Proj>
-        Iter sequential_remove_if(
-            Iter first, Sent last, UnaryPredicate p, Proj proj)
+        template <typename Iter, typename Sent, typename Pred, typename Proj>
+        Iter sequential_remove_if(Iter first, Sent last, Pred pred, Proj proj)
         {
             first = hpx::parallel::v1::detail::sequential_find_if(
-                first, last, p, proj);
+                first, last, pred, proj);
+
             if (first != last)
                 for (Iter i = first; ++i != last;)
-                    if (!p(*i))
+                    if (!hpx::util::invoke(pred, hpx::util::invoke(proj, *i)))
+                    {
                         *first++ = std::move(*i);
+                    }
             return first;
         }
 
@@ -441,7 +519,7 @@ namespace hpx {
             )>
         // clang-format on
         friend FwdIter tag_invoke(
-            hpx::remove_t, FwdIter first, FwdIter last, const T& value)
+            hpx::remove_t, FwdIter first, FwdIter last, T const& value)
         {
             typedef typename std::iterator_traits<FwdIter>::value_type Type;
 
@@ -459,7 +537,7 @@ namespace hpx {
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             FwdIter>::type
         tag_invoke(hpx::remove_t, ExPolicy&& policy, FwdIter first,
-            FwdIter last, const T& value)
+            FwdIter last, T const& value)
         {
             typedef typename std::iterator_traits<FwdIter>::value_type Type;
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove.hpp
@@ -12,13 +12,154 @@
 #if defined(DOXYGEN)
 namespace hpx {
 
-    /// Removes all elements satisfying specific criteria from the range
-    /// [first, last) and returns a past-the-end iterator for the new
-    /// end of the range. This version removes all elements that are
-    /// equal to \a value.
+    /// Removes all elements that are equal to \a value from the range
+    /// [first, last) and and returns a subrange [ret, last), where ret
+    /// is a past-the-end iterator for the new end of the range.
     ///
     /// \note   Complexity: Performs not more than \a last - \a first
     ///         assignments, exactly \a last - \a first applications of
+    ///         the operator==() and the projection \a proj.
+    ///
+    /// \tparam FwdIter     The type of the source iterators used for the
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the end iterators used (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter.
+    /// \tparam T           The type of the value to remove (deduced).
+    ///                     This value type must meet the requirements of
+    ///                     \a CopyConstructible.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param value        Specifies the value of elements to remove.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a remove algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    /// \returns  The \a remove algorithm returns a \a
+    ///           subrange_t<FwdIter, Sent>.
+    ///           The \a remove algorithm returns an object {ret, last},
+    ///           where ret is a past-the-end iterator for a new
+    ///           subrange of the values all in valid but unspecified state.
+    ///
+    template <typename FwdIter, typename Sent, typename T,
+        typename Proj = util::projection_identity>
+    subrange_t<FwdIter, Sent> remove(
+        FwdIter first, Sent last, T const& value, Proj&& proj = Proj());
+
+    /// Removes all elements that are equal to \a value from the range
+    /// [first, last) and and returns a subrange [ret, last), where ret
+    /// is a past-the-end iterator for the new end of the range.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first applications of
+    ///         the operator==() and the projection \a proj.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used for the
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the end iterators used (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter.
+    /// \tparam T           The type of the value to remove (deduced).
+    ///                     This value type must meet the requirements of
+    ///                     \a CopyConstructible.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param value        Specifies the value of elements to remove.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a remove algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a remove algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a remove algorithm returns a \a
+    ///           hpx::future<subrange_t<FwdIter, Sent>>.
+    ///           The \a remove algorithm returns an object {ret, last},
+    ///           where ret is a past-the-end iterator for a new
+    ///           subrange of the values all in valid but unspecified state.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename Sent, typename T,
+        typename Proj = util::projection_identity>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        subrange_t<FwdIter, Sent>>::type
+    remove(ExPolicy&& policy, FwdIter first, Sent last, T const& value,
+        Proj&& proj = Proj());
+
+    /// Removes all elements that are equal to \a value from the range
+    /// \a rng and and returns a subrange [ret, util::end(rng)), where ret
+    /// is a past-the-end iterator for the new end of the range.
+    ///
+    /// \note   Complexity: Performs not more than \a util::end(rng)
+    ///         - \a util::begin(rng) assignments, exactly
+    ///         \a util::end(rng) - \a util::begin(rng) applications of
+    ///         the operator==() and the projection \a proj.
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an forward iterator.
+    /// \tparam T           The type of the value to remove (deduced).
+    ///                     This value type must meet the requirements of
+    ///                     \a CopyConstructible.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param value        Specifies the value of elements to remove.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a remove algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    /// \returns  The \a remove algorithm returns a \a
+    ///           subrange_t<typename hpx::traits::range_iterator<Rng>::type>.
+    ///           The \a remove algorithm returns an object {ret, last},
+    ///           where ret is a past-the-end iterator for a new
+    ///           subrange of the values all in valid but unspecified state.
+    ///
+    template <typename Rng, typename T,
+        typename Proj = util::projection_identity>
+    subrange_t<typename hpx::traits::range_iterator<Rng>::type> remove(
+        Rng&& rng, T const& value, Proj&& proj = Proj());
+
+    /// Removes all elements that are equal to \a value from the range
+    /// \a rng and and returns a subrange [ret, util::end(rng)), where ret
+    /// is a past-the-end iterator for the new end of the range.
+    ///
+    /// \note   Complexity: Performs not more than \a util::end(rng)
+    ///         - \a util::begin(rng) assignments, exactly
+    ///         \a util::end(rng) - \a util::begin(rng) applications of
     ///         the operator==() and the projection \a proj.
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
@@ -54,7 +195,8 @@ namespace hpx {
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a remove algorithm returns a \a hpx::future<FwdIter>
+    /// \returns  The \a remove algorithm returns a \a hpx::future<
+    ///           subrange_t<typename hpx::traits::range_iterator<Rng>::type>>
     ///           if the execution policy is of type
     ///           \a sequenced_task_policy or \a parallel_task_policy and
     ///           returns \a FwdIter otherwise.
@@ -63,18 +205,201 @@ namespace hpx {
     ///
     template <typename ExPolicy, typename Rng, typename T,
         typename Proj = util::projection_identity>
-    typename util::detail::algorithm_result<ExPolicy,
-        typename hpx::traits::range_iterator<Rng>::type>::type
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        subrange_t<typename hpx::traits::range_iterator<Rng>::type>>::type
     remove(ExPolicy&& policy, Rng&& rng, T const& value, Proj&& proj = Proj());
 
-    /// Removes all elements satisfying specific criteria from the range
-    /// [first, last) and returns a past-the-end iterator for the new
-    /// end of the range. This version removes all elements for which predicate
-    /// \a pred returns true.
+    /// Removes all elements for which predicate \a pred returns true
+    /// from the range [first, last) and returns a subrange [ret, last),
+    /// where ret is a past-the-end iterator for the new end of the range.
     ///
     /// \note   Complexity: Performs not more than \a last - \a first
     ///         assignments, exactly \a last - \a first applications of
     ///         the predicate \a pred and the projection \a proj.
+    ///
+    /// \tparam FwdIter     The type of the source iterators used for the
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the end iterators used (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a remove_if requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible..
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a remove_if algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    /// \returns  The \a remove_if algorithm returns a \a
+    ///           subrange_t<FwdIter, Sent>.
+    ///           The \a remove_if algorithm returns an object {ret, last},
+    ///           where ret is a past-the-end iterator for a new
+    ///           subrange of the values all in valid but unspecified state.
+    ///
+    template <typename FwdIter, typename Sent, typename Pred,
+        typename Proj = hpx::parallel::util::projection_identity>
+    subrange_t<FwdIter, Sent> remove_if(
+        FwdIter first, Sent sent, Pred&& pred, Proj&& proj = Proj());
+
+    /// Removes all elements for which predicate \a pred returns true
+    /// from the range [first, last) and returns a subrange [ret, last),
+    /// where ret is a past-the-end iterator for the new end of the range.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first applications of
+    ///         the predicate \a pred and the projection \a proj.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used for the
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam Sent        The type of the end iterators used (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a remove_if requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a remove_if algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a remove_if algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a remove_if algorithm returns a \a
+    ///           hpx::future<subrange_t<FwdIter, Sent>>.
+    ///           The \a remove_if algorithm returns an object {ret, last},
+    ///           where ret is a past-the-end iterator for a new
+    ///           subrange of the values all in valid but unspecified state.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename Sent, typename Pred,
+        typename Proj = hpx::parallel::util::projection_identity>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        subrange_t<FwdIter, Sent>>::type
+    remove_if(ExPolicy&& policy, FwdIter first, Sent sent, Pred&& pred,
+        Proj&& proj = Proj());
+
+    /// Removes all elements that are equal to \a value from the range
+    /// \a rng and and returns a subrange [ret, util::end(rng)), where ret
+    /// is a past-the-end iterator for the new end of the range.
+    ///
+    /// \note   Complexity: Performs not more than \a util::end(rng)
+    ///         - \a util::begin(rng) assignments, exactly
+    ///         \a util::end(rng) - \a util::begin(rng) applications of
+    ///         the operator==() and the projection \a proj.
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a remove_if requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     required elements. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a remove_if algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    /// \returns  The \a remove_if algorithm returns a \a
+    ///           subrange_t<typename hpx::traits::range_iterator<Rng>::type>.
+    ///           The \a remove_if algorithm returns an object {ret, last},
+    ///           where ret is a past-the-end iterator for a new
+    ///           subrange of the values all in valid but unspecified state.
+    ///
+    template <typename Rng, typename T,
+        typename Proj = util::projection_identity>
+    subrange_t<typename hpx::traits::range_iterator<Rng>::type> remove_if(
+        Rng&& rng, Pred&& pred, Proj&& proj = Proj());
+
+    /// Removes all elements that are equal to \a value from the range
+    /// \a rng and and returns a subrange [ret, util::end(rng)), where ret
+    /// is a past-the-end iterator for the new end of the range.
+    ///
+    /// \note   Complexity: Performs not more than \a util::end(rng)
+    ///         - \a util::begin(rng) assignments, exactly
+    ///         \a util::end(rng) - \a util::begin(rng) applications of
+    ///         the operator==() and the projection \a proj.
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
     ///                     It describes the manner in which the execution
@@ -123,17 +448,20 @@ namespace hpx {
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a remove_if algorithm returns a \a hpx::future<FwdIter>
+    /// \returns  The \a remove_if algorithm returns a \a
+    ///           hpx::future<subrange_t<
+    ///           typename hpx::traits::range_iterator<Rng>::type>>
     ///           if the execution policy is of type
     ///           \a sequenced_task_policy or \a parallel_task_policy and
     ///           returns \a FwdIter otherwise.
-    ///           The \a remove_if algorithm returns the iterator to the new end
-    ///           of the range.
+    ///           The \a remove_if algorithm returns an object {ret, last},
+    ///           where ret is a past-the-end iterator for a new
+    ///           subrange of the values all in valid but unspecified state.
     ///
     template <typename ExPolicy, typename Rng, typename Pred,
         typename Proj = util::projection_identity>
-    typename util::detail::algorithm_result<ExPolicy,
-        typename hpx::traits::range_iterator<Rng>::type>::type
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        subrange_t<typename hpx::traits::range_iterator<Rng>::type>>::type
     remove_if(ExPolicy&& policy, Rng&& rng, Pred&& pred, Proj&& proj = Proj());
 
 }    // namespace hpx
@@ -320,7 +648,7 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend subrange_t<FwdIter, Sent> tag_invoke(hpx::ranges::remove_t,
-            FwdIter first, Sent last, const T& value, Proj&& proj = Proj())
+            FwdIter first, Sent last, T const& value, Proj&& proj = Proj())
         {
             typedef typename std::iterator_traits<FwdIter>::value_type Type;
 
@@ -339,7 +667,7 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend subrange_t<typename hpx::traits::range_iterator<Rng>::type>
-        tag_invoke(hpx::ranges::remove_t, Rng&& rng, const T& value,
+        tag_invoke(hpx::ranges::remove_t, Rng&& rng, T const& value,
             Proj&& proj = Proj())
         {
             typedef typename std::iterator_traits<
@@ -365,7 +693,7 @@ namespace hpx { namespace ranges {
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             subrange_t<FwdIter, Sent>>::type
         tag_invoke(hpx::ranges::remove_t, ExPolicy&& policy, FwdIter first,
-            Sent last, const T& value, Proj&& proj = Proj())
+            Sent last, T const& value, Proj&& proj = Proj())
         {
             typedef typename std::iterator_traits<FwdIter>::value_type Type;
 
@@ -387,7 +715,7 @@ namespace hpx { namespace ranges {
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             subrange_t<typename hpx::traits::range_iterator<Rng>::type>>::type
         tag_invoke(hpx::ranges::remove_t, ExPolicy&& policy, Rng&& rng,
-            const T& value, Proj&& proj = Proj())
+            T const& value, Proj&& proj = Proj())
         {
             typedef typename std::iterator_traits<
                 typename hpx::traits::range_iterator<Rng>::type>::value_type

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2017 Taeguk Kwon
+//  Copyright (c) 2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,20 +9,9 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/concepts/concepts.hpp>
-#include <hpx/iterator_support/range.hpp>
-#include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/iterator_support/traits/is_range.hpp>
+#if defined(DOXYGEN)
+namespace hpx {
 
-#include <hpx/algorithms/traits/projected.hpp>
-#include <hpx/algorithms/traits/projected_range.hpp>
-#include <hpx/parallel/algorithms/remove.hpp>
-
-#include <type_traits>
-#include <utility>
-
-namespace hpx { namespace parallel { inline namespace v1 {
     /// Removes all elements satisfying specific criteria from the range
     /// [first, last) and returns a past-the-end iterator for the new
     /// end of the range. This version removes all elements that are
@@ -72,17 +62,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           of the range.
     ///
     template <typename ExPolicy, typename Rng, typename T,
-        typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<ExPolicy>::value&& hpx::traits::is_range<
-                Rng>::value&& traits::is_projected_range<Proj, Rng>::value)>
+        typename Proj = util::projection_identity>
     typename util::detail::algorithm_result<ExPolicy,
         typename hpx::traits::range_iterator<Rng>::type>::type
-    remove(ExPolicy&& policy, Rng&& rng, T const& value, Proj&& proj = Proj())
-    {
-        return remove(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
-            hpx::util::end(rng), value, std::forward<Proj>(proj));
-    }
+    remove(ExPolicy&& policy, Rng&& rng, T const& value, Proj&& proj = Proj());
 
     /// Removes all elements satisfying specific criteria from the range
     /// [first, last) and returns a past-the-end iterator for the new
@@ -148,6 +131,50 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           of the range.
     ///
     template <typename ExPolicy, typename Rng, typename Pred,
+        typename Proj = util::projection_identity>
+    typename util::detail::algorithm_result<ExPolicy,
+        typename hpx::traits::range_iterator<Rng>::type>::type
+    remove_if(ExPolicy&& policy, Rng&& rng, Pred&& pred, Proj&& proj = Proj());
+
+}    // namespace hpx
+
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/iterator_support/iterator_range.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/iterator_support/traits/is_range.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+
+#include <hpx/algorithms/traits/projected.hpp>
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/parallel/algorithms/remove.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1 {
+
+    template <typename ExPolicy, typename Rng, typename T,
+        typename Proj = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value&& hpx::traits::is_range<
+                Rng>::value&& traits::is_projected_range<Proj, Rng>::value)>
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::remove is deprecated, use hpx::ranges::remove "
+        "instead")
+    typename util::detail::algorithm_result<ExPolicy,
+        typename hpx::traits::range_iterator<Rng>::type>::type
+        remove(
+            ExPolicy&& policy, Rng&& rng, T const& value, Proj&& proj = Proj())
+    {
+        return remove(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+            hpx::util::end(rng), value, std::forward<Proj>(proj));
+    }
+
+    template <typename ExPolicy, typename Rng, typename Pred,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
                 hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
@@ -162,3 +189,217 @@ namespace hpx { namespace parallel { inline namespace v1 {
             std::forward<Proj>(proj));
     }
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx { namespace ranges {
+    template <typename I, typename S = I>
+    using subrange_t = hpx::util::iterator_range<I, S>;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::remove_if
+    HPX_INLINE_CONSTEXPR_VARIABLE struct remove_if_t final
+      : hpx::functional::tag<remove_if_t>
+    {
+    private:
+        // clang-format off
+        template <typename FwdIter, typename Sent, typename Pred,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::parallel::traits::is_projected<Proj, FwdIter>::value &&
+                hpx::traits::is_sentinel_for<Sent, FwdIter>::value
+            )>
+        // clang-format on
+        friend subrange_t<FwdIter, Sent> tag_invoke(hpx::ranges::remove_if_t,
+            FwdIter first, Sent sent, Pred&& pred, Proj&& proj = Proj())
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
+                "Required at least forward iterator.");
+
+            return hpx::parallel::util::make_subrange<FwdIter, Sent>(
+                hpx::parallel::v1::detail::remove_if<FwdIter>().call(
+                    hpx::execution::seq, std::true_type{}, first, sent,
+                    std::forward<Pred>(pred), std::forward<Proj>(proj)),
+                sent);
+        }
+
+        // clang-format off
+        template <typename Rng, typename Pred,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value
+            )>
+        // clang-format on
+        friend subrange_t<typename hpx::traits::range_iterator<Rng>::type>
+        tag_invoke(hpx::ranges::remove_if_t, Rng&& rng, Pred&& pred,
+            Proj&& proj = Proj())
+        {
+            return hpx::parallel::util::make_subrange<
+                typename hpx::traits::range_iterator<Rng>::type,
+                typename hpx::traits::range_sentinel<Rng>::type>(
+                hpx::parallel::v1::detail::remove_if<
+                    typename hpx::traits::range_iterator<Rng>::type>()
+                    .call(hpx::execution::seq, std::true_type{},
+                        hpx::util::begin(rng), hpx::util::end(rng),
+                        std::forward<Pred>(pred), std::forward<Proj>(proj)),
+                hpx::util::end(rng));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter, typename Sent, typename Pred,
+        typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::traits::is_sentinel_for<Sent, FwdIter>::value &&
+                hpx::parallel::traits::is_projected<Proj, FwdIter>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy,
+                    Pred, hpx::parallel::traits::projected<Proj, FwdIter>>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            subrange_t<FwdIter, Sent>>::type
+        tag_invoke(hpx::ranges::remove_if_t, ExPolicy&& policy, FwdIter first,
+            Sent sent, Pred&& pred, Proj&& proj = Proj())
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
+                "Required at least forward iterator.");
+
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
+
+            return hpx::parallel::util::make_subrange<FwdIter, Sent>(
+                hpx::parallel::v1::detail::remove_if<FwdIter>().call(
+                    std::forward<ExPolicy>(policy), is_seq(), first, sent,
+                    std::forward<Pred>(pred), std::forward<Proj>(proj)),
+                sent);
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng, typename Pred,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy,
+                    Pred, hpx::parallel::traits::projected_range<Proj, Rng>>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            subrange_t<typename hpx::traits::range_iterator<Rng>::type>>::type
+        tag_invoke(hpx::ranges::remove_if_t, ExPolicy&& policy, Rng&& rng,
+            Pred&& pred, Proj&& proj = Proj())
+        {
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
+
+            return hpx::parallel::util::make_subrange<
+                typename hpx::traits::range_iterator<Rng>::type,
+                typename hpx::traits::range_sentinel<Rng>::type>(
+                hpx::parallel::v1::detail::remove_if<
+                    typename hpx::traits::range_iterator<Rng>::type>()
+                    .call(std::forward<ExPolicy>(policy), is_seq(),
+                        hpx::util::begin(rng), hpx::util::end(rng),
+                        std::forward<Pred>(pred), std::forward<Proj>(proj)),
+                hpx::util::end(rng));
+        }
+    } remove_if{};
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::remove
+    HPX_INLINE_CONSTEXPR_VARIABLE struct remove_t final
+      : hpx::functional::tag<remove_t>
+    {
+    private:
+        // clang-format off
+        template <typename FwdIter, typename Sent,
+            typename T, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::parallel::traits::is_projected<Proj, FwdIter>::value &&
+                hpx::traits::is_sentinel_for<Sent, FwdIter>::value
+            )>
+        // clang-format on
+        friend subrange_t<FwdIter, Sent> tag_invoke(hpx::ranges::remove_t,
+            FwdIter first, Sent last, const T& value, Proj&& proj = Proj())
+        {
+            typedef typename std::iterator_traits<FwdIter>::value_type Type;
+
+            return hpx::ranges::remove_if(
+                first, last,
+                [value](Type const& a) -> bool { return value == a; },
+                std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename Rng, typename T,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value
+            )>
+        // clang-format on
+        friend subrange_t<typename hpx::traits::range_iterator<Rng>::type>
+        tag_invoke(hpx::ranges::remove_t, Rng&& rng, const T& value,
+            Proj&& proj = Proj())
+        {
+            typedef typename std::iterator_traits<
+                typename hpx::traits::range_iterator<Rng>::type>::value_type
+                Type;
+
+            return hpx::ranges::remove_if(
+                std::forward<Rng>(rng),
+                [value](Type const& a) -> bool { return value == a; },
+                std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter, typename Sent,
+            typename T, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::traits::is_sentinel_for<Sent, FwdIter>::value &&
+                hpx::parallel::traits::is_projected<Proj, FwdIter>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            subrange_t<FwdIter, Sent>>::type
+        tag_invoke(hpx::ranges::remove_t, ExPolicy&& policy, FwdIter first,
+            Sent last, const T& value, Proj&& proj = Proj())
+        {
+            typedef typename std::iterator_traits<FwdIter>::value_type Type;
+
+            return hpx::ranges::remove_if(
+                std::forward<ExPolicy>(policy), first, last,
+                [value](Type const& a) -> bool { return value == a; },
+                std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng, typename T,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            subrange_t<typename hpx::traits::range_iterator<Rng>::type>>::type
+        tag_invoke(hpx::ranges::remove_t, ExPolicy&& policy, Rng&& rng,
+            const T& value, Proj&& proj = Proj())
+        {
+            typedef typename std::iterator_traits<
+                typename hpx::traits::range_iterator<Rng>::type>::value_type
+                Type;
+
+            return hpx::ranges::remove_if(
+                std::forward<ExPolicy>(policy), std::forward<Rng>(rng),
+                [value](Type const& a) -> bool { return value == a; },
+                std::forward<Proj>(proj));
+        }
+
+    } remove{};
+}}    // namespace hpx::ranges
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove.hpp
@@ -485,15 +485,18 @@ namespace hpx {
 
 namespace hpx { namespace parallel { inline namespace v1 {
 
+    // clang-format off
     template <typename ExPolicy, typename Rng, typename T,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<ExPolicy>::value&& hpx::traits::is_range<
-                Rng>::value&& traits::is_projected_range<Proj, Rng>::value)>
+            hpx::is_execution_policy<ExPolicy>::value&&
+            hpx::traits::is_range<Rng>::value&&
+            traits::is_projected_range<Proj, Rng>::value
+        )>
+    // clang-format on
     HPX_DEPRECATED_V(1, 6,
         "hpx::parallel::remove is deprecated, use hpx::ranges::remove "
-        "instead")
-    typename util::detail::algorithm_result<ExPolicy,
+        "instead") typename util::detail::algorithm_result<ExPolicy,
         typename hpx::traits::range_iterator<Rng>::type>::type
         remove(
             ExPolicy&& policy, Rng&& rng, T const& value, Proj&& proj = Proj())
@@ -502,12 +505,17 @@ namespace hpx { namespace parallel { inline namespace v1 {
             hpx::util::end(rng), value, std::forward<Proj>(proj));
     }
 
+    // clang-format off
     template <typename ExPolicy, typename Rng, typename Pred,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
-                    Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
-                    Pred, traits::projected_range<Proj, Rng>>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value&&
+            hpx::traits::is_range<Rng>::value&&
+            traits::is_projected_range<Proj, Rng>::value&&
+            traits::is_indirect_callable<ExPolicy,
+                Pred, traits::projected_range<Proj, Rng>>::value
+        )>
+    // clang-format on
     typename util::detail::algorithm_result<ExPolicy,
         typename hpx::traits::range_iterator<Rng>::type>::type
     remove_if(ExPolicy&& policy, Rng&& rng, Pred&& pred, Proj&& proj = Proj())
@@ -534,7 +542,10 @@ namespace hpx { namespace ranges {
             HPX_CONCEPT_REQUIRES_(
                 hpx::traits::is_iterator<FwdIter>::value &&
                 hpx::parallel::traits::is_projected<Proj, FwdIter>::value &&
-                hpx::traits::is_sentinel_for<Sent, FwdIter>::value
+                hpx::traits::is_sentinel_for<Sent, FwdIter>::value &&
+                hpx::is_invocable_v<Pred,
+                    typename std::iterator_traits<FwdIter>::value_type
+                >
             )>
         // clang-format on
         friend subrange_t<FwdIter, Sent> tag_invoke(hpx::ranges::remove_if_t,
@@ -555,7 +566,12 @@ namespace hpx { namespace ranges {
             typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::traits::is_range<Rng>::value &&
-                hpx::parallel::traits::is_projected_range<Proj, Rng>::value
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
+                hpx::is_invocable_v<Pred,
+                    typename std::iterator_traits<
+                        typename hpx::traits::range_iterator<Rng>::type
+                    >::value_type
+                >
             )>
         // clang-format on
         friend subrange_t<typename hpx::traits::range_iterator<Rng>::type>

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/result_types.hpp
@@ -187,6 +187,25 @@ namespace hpx { namespace parallel { namespace util {
         }
     };
 
+    template <typename Iterator, typename Sentinel = Iterator>
+    hpx::util::iterator_range<Iterator, Sentinel> make_subrange(
+        Iterator iterator, Sentinel sentinel)
+    {
+        return hpx::util::make_iterator_range<Iterator, Sentinel>(
+            iterator, sentinel);
+    }
+
+    template <typename Iterator, typename Sentinel = Iterator>
+    hpx::future<hpx::util::iterator_range<Iterator, Sentinel>> make_subrange(
+        hpx::future<Iterator>&& iterator, Sentinel sentinel)
+    {
+        return lcos::make_future<hpx::util::iterator_range<Iterator, Sentinel>>(
+            std::move(iterator), [sentinel](Iterator&& it) {
+                return hpx::util::iterator_range<Iterator, Sentinel>(
+                    it, sentinel);
+            });
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
         template <typename ZipIter>

--- a/libs/parallelism/algorithms/tests/performance/benchmark_remove.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_remove.cpp
@@ -121,7 +121,7 @@ double run_remove_benchmark_hpx(int test_count, ExPolicy policy,
         hpx::copy(hpx::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now();
-        hpx::parallel::remove(policy, first, last, value);
+        hpx::remove(policy, first, last, value);
         time += hpx::chrono::high_resolution_clock::now() - elapsed;
     }
 

--- a/libs/parallelism/algorithms/tests/performance/benchmark_remove_if.cpp
+++ b/libs/parallelism/algorithms/tests/performance/benchmark_remove_if.cpp
@@ -119,7 +119,7 @@ double run_remove_if_benchmark_hpx(int test_count, ExPolicy policy,
         hpx::copy(hpx::execution::par, org_first, org_last, first);
 
         std::uint64_t elapsed = hpx::chrono::high_resolution_clock::now();
-        hpx::parallel::remove_if(policy, first, last, pred);
+        hpx::remove_if(policy, first, last, pred);
         time += hpx::chrono::high_resolution_clock::now() - elapsed;
     }
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove_tests.hpp
@@ -127,7 +127,7 @@ void test_remove(
     std::generate(std::begin(c), std::end(c), random_fill(rand_base, 6));
     d = c;
 
-    auto result = hpx::parallel::remove(
+    auto result = hpx::remove(
         policy, iterator(std::begin(c)), iterator(std::end(c)), value);
     auto solution = std::remove(std::begin(d), std::end(d), value);
 
@@ -153,7 +153,7 @@ void test_remove_async(
     std::generate(std::begin(c), std::end(c), random_fill(rand_base, 6));
     d = c;
 
-    auto f = hpx::parallel::remove(
+    auto f = hpx::remove(
         policy, iterator(std::begin(c)), iterator(std::end(c)), value);
     auto result = f.get();
     auto solution = std::remove(std::begin(d), std::end(d), value);

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove_tests.hpp
@@ -534,60 +534,6 @@ void test_remove_bad_alloc_async(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-template <typename ExPolicy, typename IteratorTag, typename DataType>
-void test_remove_etc(ExPolicy policy, IteratorTag, DataType, int rand_base,
-    bool test_for_remove_if = false)
-{
-    static_assert(hpx::is_execution_policy<ExPolicy>::value,
-        "hpx::is_execution_policy<ExPolicy>::value");
-
-    typedef typename std::vector<DataType>::iterator base_iterator;
-
-    std::size_t const size = 10007;
-    std::vector<DataType> c(size), org;
-    std::generate(
-        std::begin(c), std::end(c), random_fill(rand_base, size / 10));
-    org = c;
-
-    // Test projection.
-    {
-        typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-        c = org;
-
-        DataType value(rand_base);
-        iterator result;
-
-        if (test_for_remove_if)
-        {
-            // The new overloads do not accept projections.
-            // We use the deprecated version instead.
-            result = hpx::parallel::remove_if(
-                policy, iterator(std::begin(c)), iterator(std::end(c)),
-                [&value](DataType const& a) -> bool { return a == value; },
-                [&value](DataType const&) -> DataType& {
-                    // This is projection.
-                    return value;
-                });
-        }
-        else
-        {
-            // The new overloads do not accept projections.
-            // We use the deprecated version instead.
-            result = hpx::parallel::remove(policy, iterator(std::begin(c)),
-                iterator(std::end(c)), value,
-                [&value](DataType const&) -> DataType& {
-                    // This is projection.
-                    return value;
-                });
-        }
-
-        auto dist = std::distance(std::begin(c), result.base());
-        HPX_TEST_EQ(dist, 0);
-    }
-}
-
-///////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_remove(IteratorTag, int rand_base)
 {
@@ -707,10 +653,6 @@ void test_remove(bool test_for_remove_if = false)
     {
         test_remove(IteratorTag(), rand_base);
     }
-
-    ////////// Another test cases for justifying the implementation.
-    test_remove_etc(hpx::execution::seq, IteratorTag(), user_defined_type(),
-        rand_base, test_for_remove_if);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove_tests.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove_tests.hpp
@@ -181,7 +181,7 @@ void test_remove_if(
     std::generate(std::begin(c), std::end(c), random_fill(rand_base, 6));
     d = c;
 
-    auto result = hpx::parallel::remove_if(
+    auto result = hpx::remove_if(
         policy, iterator(std::begin(c)), iterator(std::end(c)), pred);
     auto solution = std::remove_if(std::begin(d), std::end(d), pred);
 
@@ -207,7 +207,7 @@ void test_remove_if_async(
     std::generate(std::begin(c), std::end(c), random_fill(rand_base, 6));
     d = c;
 
-    auto f = hpx::parallel::remove_if(
+    auto f = hpx::remove_if(
         policy, iterator(std::begin(c)), iterator(std::end(c)), pred);
     auto result = f.get();
     auto solution = std::remove_if(std::begin(d), std::end(d), pred);
@@ -239,12 +239,12 @@ void test_remove_exception(
     {
         if (test_for_remove_if)
         {
-            hpx::parallel::remove_if(policy, decorated_iterator(std::begin(c)),
+            hpx::remove_if(policy, decorated_iterator(std::begin(c)),
                 decorated_iterator(std::end(c)), throw_always());
         }
         else
         {
-            hpx::parallel::remove(policy,
+            hpx::remove(policy,
                 decorated_iterator(
                     std::begin(c), []() { throw std::runtime_error("test"); }),
                 decorated_iterator(std::end(c)), int(10));
@@ -285,13 +285,12 @@ void test_remove_exception_async(
 
         if (test_for_remove_if)
         {
-            f = hpx::parallel::remove_if(policy,
-                decorated_iterator(std::begin(c)),
+            f = hpx::remove_if(policy, decorated_iterator(std::begin(c)),
                 decorated_iterator(std::end(c)), throw_always());
         }
         else
         {
-            f = hpx::parallel::remove(policy,
+            f = hpx::remove(policy,
                 decorated_iterator(
                     std::begin(c), []() { throw std::runtime_error("test"); }),
                 decorated_iterator(std::end(c)), int(10));
@@ -337,12 +336,12 @@ void test_remove_bad_alloc(
     {
         if (test_for_remove_if)
         {
-            hpx::parallel::remove_if(policy, decorated_iterator(std::begin(c)),
+            hpx::remove_if(policy, decorated_iterator(std::begin(c)),
                 decorated_iterator(std::end(c)), throw_bad_alloc());
         }
         else
         {
-            hpx::parallel::remove(policy,
+            hpx::remove(policy,
                 decorated_iterator(
                     std::begin(c), []() { throw std::bad_alloc(); }),
                 decorated_iterator(std::end(c)), int(10));
@@ -382,13 +381,12 @@ void test_remove_bad_alloc_async(
 
         if (test_for_remove_if)
         {
-            f = hpx::parallel::remove_if(policy,
-                decorated_iterator(std::begin(c)),
+            f = hpx::remove_if(policy, decorated_iterator(std::begin(c)),
                 decorated_iterator(std::end(c)), throw_bad_alloc());
         }
         else
         {
-            f = hpx::parallel::remove(policy,
+            f = hpx::remove(policy,
                 decorated_iterator(
                     std::begin(c), []() { throw std::bad_alloc(); }),
                 decorated_iterator(std::end(c)), int(10));

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/iter_sent.hpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/iter_sent.hpp
@@ -28,6 +28,38 @@ private:
     ValueType stop;
 };
 
+template <typename Iter, typename ValueType,
+    typename Enable =
+        std::enable_if_t<hpx::traits::is_forward_iterator<Iter>::value>>
+bool operator==(Iter it, Sentinel<ValueType> s)
+{
+    return *it == s.get_stop();
+}
+
+template <typename Iter, typename ValueType,
+    typename Enable =
+        std::enable_if_t<hpx::traits::is_forward_iterator<Iter>::value>>
+bool operator==(Sentinel<ValueType> s, Iter it)
+{
+    return *it == s.get_stop();
+}
+
+template <typename Iter, typename ValueType,
+    typename Enable =
+        std::enable_if_t<hpx::traits::is_forward_iterator<Iter>::value>>
+bool operator!=(Iter it, Sentinel<ValueType> s)
+{
+    return *it != s.get_stop();
+}
+
+template <typename Iter, typename ValueType,
+    typename Enable =
+        std::enable_if_t<hpx::traits::is_forward_iterator<Iter>::value>>
+bool operator!=(Sentinel<ValueType> s, Iter it)
+{
+    return *it != s.get_stop();
+}
+
 template <typename Value>
 struct iterator
 {

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/iter_sent.hpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/iter_sent.hpp
@@ -31,7 +31,7 @@ private:
 template <typename Iter, typename ValueType,
     typename Enable =
         std::enable_if_t<hpx::traits::is_forward_iterator<Iter>::value>>
-bool operator==(Iter it, Sentinel<ValueType> s)
+bool operator==(Iter it, sentinel<ValueType> s)
 {
     return *it == s.get_stop();
 }
@@ -39,7 +39,7 @@ bool operator==(Iter it, Sentinel<ValueType> s)
 template <typename Iter, typename ValueType,
     typename Enable =
         std::enable_if_t<hpx::traits::is_forward_iterator<Iter>::value>>
-bool operator==(Sentinel<ValueType> s, Iter it)
+bool operator==(sentinel<ValueType> s, Iter it)
 {
     return *it == s.get_stop();
 }
@@ -47,7 +47,7 @@ bool operator==(Sentinel<ValueType> s, Iter it)
 template <typename Iter, typename ValueType,
     typename Enable =
         std::enable_if_t<hpx::traits::is_forward_iterator<Iter>::value>>
-bool operator!=(Iter it, Sentinel<ValueType> s)
+bool operator!=(Iter it, sentinel<ValueType> s)
 {
     return *it != s.get_stop();
 }
@@ -55,7 +55,7 @@ bool operator!=(Iter it, Sentinel<ValueType> s)
 template <typename Iter, typename ValueType,
     typename Enable =
         std::enable_if_t<hpx::traits::is_forward_iterator<Iter>::value>>
-bool operator!=(Sentinel<ValueType> s, Iter it)
+bool operator!=(sentinel<ValueType> s, Iter it)
 {
     return *it != s.get_stop();
 }

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_if_range.cpp
@@ -80,7 +80,7 @@ void test_remove_if_sent()
     auto pred = [](std::int16_t const& a) -> bool { return a % 42 == 0; };
 
     auto pre_result = std::count_if(std::begin(c), std::end(c), pred);
-    hpx::ranges::remove_if(std::begin(c), Sentinel<std::int16_t>{50}, pred);
+    hpx::ranges::remove_if(std::begin(c), sentinel<std::int16_t>{50}, pred);
     auto post_result = std::count_if(std::begin(c), std::end(c), pred);
 
     HPX_TEST(pre_result == 2 && post_result == 1);
@@ -102,7 +102,7 @@ void test_remove_if_sent(ExPolicy policy)
 
     auto pre_result = std::count_if(std::begin(c), std::end(c), pred);
     hpx::ranges::remove_if(
-        policy, std::begin(c), Sentinel<std::int16_t>{50}, pred);
+        policy, std::begin(c), sentinel<std::int16_t>{50}, pred);
     auto post_result = std::count_if(std::begin(c), std::end(c), pred);
 
     HPX_TEST(pre_result == 2 && post_result == 1);

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_if_range.cpp
@@ -68,32 +68,44 @@ struct random_fill
 };
 
 ////////////////////////////////////////////////////////////////////////////
-// test case for Iter - Sent (not complete)
-template <typename ExPolicy, typename DataType>
-void test_remove_if_2(ExPolicy policy, DataType)
+// test case for iterator - sentinel_value
+void test_remove_if_sent()
+{
+    using hpx::get;
+
+    std::size_t const size = 100;
+    std::vector<std::int16_t> c(size);
+    std::iota(std::begin(c), std::end(c), 1);
+
+    auto pred = [](std::int16_t const& a) -> bool { return a % 42 == 0; };
+
+    auto pre_result = std::count_if(std::begin(c), std::end(c), pred);
+    hpx::ranges::remove_if(std::begin(c), Sentinel<std::int16_t>{50}, pred);
+    auto post_result = std::count_if(std::begin(c), std::end(c), pred);
+
+    HPX_TEST(pre_result == 2 && post_result == 1);
+}
+
+template <typename ExPolicy>
+void test_remove_if_sent(ExPolicy policy)
 {
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
     using hpx::get;
 
-    std::size_t const size = 10007;
-    std::vector<DataType> c(size), d;
-    std::generate(std::begin(c), std::end(c), random_fill(0, 6));
-    d = c;
+    std::size_t const size = 100;
+    std::vector<std::int16_t> c(size);
+    std::iota(std::begin(c), std::end(c), 1);
 
-    auto pred = [](DataType const& a) -> bool { return a == 0; };
+    auto pred = [](std::int16_t const& a) -> bool { return a % 42 == 0; };
 
-    auto iter = Iterator<std::int16_t>{-5};
-    auto sent = Sentinel<std::int16_t>{4};
+    auto pre_result = std::count_if(std::begin(c), std::end(c), pred);
+    hpx::ranges::remove_if(
+        policy, std::begin(c), Sentinel<std::int16_t>{50}, pred);
+    auto post_result = std::count_if(std::begin(c), std::end(c), pred);
 
-    auto result = hpx::ranges::remove_if(policy, iter, sent, pred);
-    auto solution = std::remove_if(std::begin(d), std::end(d), pred);
-
-    bool equality =
-        test::equal(std::begin(c), result.begin(), std::begin(d), solution);
-
-    HPX_TEST(equality);
+    HPX_TEST(pre_result == 2 && post_result == 1);
 }
 
 template <typename DataType>
@@ -179,7 +191,9 @@ void test_remove_if()
     test_remove_if_async(seq(task), DataType());
     test_remove_if_async(par(task), DataType());
 
-    // test_remove_if_2(par, DataType());
+    test_remove_if_sent();
+    test_remove_if_sent(par);
+    test_remove_if_sent(par_unseq);
 }
 
 void test_remove_if()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_range.cpp
@@ -81,7 +81,7 @@ void test_remove_sent()
     int value = 42;
 
     auto pre_result = std::count(std::begin(c), std::end(c), value);
-    hpx::ranges::remove(std::begin(c), Sentinel<std::int16_t>{50}, value);
+    hpx::ranges::remove(std::begin(c), sentinel<std::int16_t>{50}, value);
     auto post_result = std::count(std::begin(c), std::end(c), value);
 
     HPX_TEST(pre_result == 2 && post_result == 1);
@@ -104,7 +104,7 @@ void test_remove_sent(ExPolicy policy)
 
     auto pre_result = std::count(std::begin(c), std::end(c), value);
     hpx::ranges::remove(
-        policy, std::begin(c), Sentinel<std::int16_t>{50}, value);
+        policy, std::begin(c), sentinel<std::int16_t>{50}, value);
     auto post_result = std::count(std::begin(c), std::end(c), value);
 
     HPX_TEST(pre_result == 2 && post_result == 1);

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_range.cpp
@@ -82,10 +82,10 @@ void test_remove(ExPolicy policy, DataType)
 
     auto value = DataType(0);
 
-    auto result = hpx::parallel::remove(policy, c, value);
+    auto result = hpx::ranges::remove(policy, c, value);
     auto solution = std::remove(std::begin(d), std::end(d), value);
 
-    bool equality = test::equal(std::begin(c), result, std::begin(d), solution);
+    bool equality = test::equal(std::begin(c), std::begin(result), std::begin(d), solution);
 
     HPX_TEST(equality);
 }
@@ -105,11 +105,11 @@ void test_remove_async(ExPolicy policy, DataType)
 
     auto value = DataType(0);
 
-    auto f = hpx::parallel::remove(policy, c, value);
+    auto f = hpx::ranges::remove(policy, c, value);
     auto result = f.get();
     auto solution = std::remove(std::begin(d), std::end(d), value);
 
-    bool equality = test::equal(std::begin(c), result, std::begin(d), solution);
+    bool equality = test::equal(std::begin(c), std::begin(result), std::begin(d), solution);
 
     HPX_TEST(equality);
 }


### PR DESCRIPTION
This adapts `hpx::remove` and `hpx::ranges:remove_if` to C++20 with the latest API, supporting `iterator` - `sentinel` pairs and `ranges`.

flyby: adds `make_subrange` utility function.

#### todo
- [x] We need to provide consistent tests for the `iterator` - `sentinel` cases. I think `remove` is a good starting point for that, but I have not managed to make it work yet. We could accept this without the test and work all the `iterator`-`sentinel` test cases in a separate 
- [x] Extra tests will be added soon for any other overloads (e.g. without exec-policy). ~**Please don't merge yet**~.
- [x] Provide docs for iterator-sentinel `ranges::remove` and `ranges::remove_if` overloads.
