### PR TITLE
Fixing environment handling for FreeBSD

### DIFF
--- a/components/performance_counters/memory/CMakeLists.txt
+++ b/components/performance_counters/memory/CMakeLists.txt
@@ -8,6 +8,11 @@ if(NOT HPX_WITH_DISTRIBUTED_RUNTIME)
   return()
 endif()
 
+# The memory counters are not supported on FreeBSD
+if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+  return()
+endif()
+
 set(HPX_COMPONENTS
     ${HPX_COMPONENTS} memory
     CACHE INTERNAL "list of HPX components"

--- a/components/process/include/hpx/components/process/util/posix/initializers/inherit_env.hpp
+++ b/components/process/include/hpx/components/process/util/posix/initializers/inherit_env.hpp
@@ -11,17 +11,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/debugging/environ.hpp>
 
 #if !defined(HPX_WINDOWS)
 #include <hpx/components/process/util/posix/initializers/initializer_base.hpp>
-
-// From <https://svn.boost.org/trac/boost/changeset/67768>
-#if defined(__APPLE__) && defined(__DYNAMIC__)
-extern "C" { extern char ***_NSGetEnviron(void); }
-#   define environ (*_NSGetEnviron())
-#else
-#   include <unistd.h>
-#endif
 
 namespace hpx { namespace components { namespace process { namespace posix {
 
@@ -33,7 +26,11 @@ public:
     template <class PosixExecutor>
     void on_fork_setup(PosixExecutor &e) const
     {
+#if defined(__FreeBSD__)
+        e.env = freebsd_environ;
+#else
         e.env = environ;
+#endif
     }
 };
 

--- a/examples/quickstart/CMakeLists.txt
+++ b/examples/quickstart/CMakeLists.txt
@@ -14,7 +14,6 @@ set(example_programs
     fibonacci_futures
     fibonacci_local
     file_serialization
-    init_globally
     latch_local
     pipeline1
     safe_object
@@ -22,6 +21,10 @@ set(example_programs
     use_main_thread
     wait_composition
 )
+
+if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+  set(example_programs ${example_programs} init_globally)
+endif()
 
 if(HPX_WITH_DISTRIBUTED_RUNTIME)
   set(example_programs

--- a/libs/core/debugging/CMakeLists.txt
+++ b/libs/core/debugging/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2019-2021 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 set(debugging_headers
     hpx/debugging/attach_debugger.hpp hpx/debugging/backtrace.hpp
     hpx/debugging/backtrace/backtrace.hpp hpx/debugging/demangle_helper.hpp
-    hpx/debugging/print.hpp
+    hpx/debugging/environ.hpp hpx/debugging/print.hpp
 )
 
 # cmake-format: off

--- a/libs/core/debugging/include/hpx/debugging/environ.hpp
+++ b/libs/core/debugging/include/hpx/debugging/environ.hpp
@@ -1,0 +1,43 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+// The 'environ' should be declared in some cases. E.g. Linux man page says:
+// (This variable must be declared in the user program, but is declared in
+// the header file unistd.h in case the header files came from libc4 or libc5,
+// and in case they came from glibc and _GNU_SOURCE was defined.)
+// To be safe, declare it here.
+
+#if defined(__linux) || defined(linux) || defined(__linux__)
+#include <sys/mman.h>
+#include <unistd.h>
+#elif defined(__APPLE__)
+// It appears that on Mac OS X the 'environ' variable is not
+// available to dynamically linked libraries.
+// See: http://article.gmane.org/gmane.comp.lib.boost.devel/103843
+// See: http://lists.gnu.org/archive/html/bug-guile/2004-01/msg00013.html
+#include <unistd.h>
+// The proper include for this is crt_externs.h, however it's not
+// available on iOS. The right replacement is not known. See
+// https://svn.boost.org/trac/boost/ticket/5053
+extern "C" {
+extern char*** _NSGetEnviron(void);
+}
+#define environ (*_NSGetEnviron())
+#elif defined(HPX_WINDOWS)
+#include <winsock2.h>
+#define environ _environ
+#elif defined(__FreeBSD__)
+// On FreeBSD the environment is available for executables only, so needs to be
+// handled explicitly (e.g. see hpx_init_impl.hpp)
+// The variable is defined in .../runtime_local/src/custom_exception_info.cpp
+extern HPX_CORE_EXPORT char** freebsd_environ;
+#else
+extern char** environ;
+#endif

--- a/libs/full/performance_counters/tests/regressions/CMakeLists.txt
+++ b/libs/full/performance_counters/tests/regressions/CMakeLists.txt
@@ -5,11 +5,12 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests discover_counters_1787 dynamic_counters_loaded_1508 statistics_2666
-          uptime_1737
-)
+set(tests discover_counters_1787 statistics_2666 uptime_1737)
 
-set(dynamic_counters_loaded_1508_FLAGS DEPENDENCIES memory_component)
+if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+  set(tests ${tests} dynamic_counters_loaded_1508)
+  set(dynamic_counters_loaded_1508_FLAGS DEPENDENCIES memory_component)
+endif()
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/full/runtime_local/src/custom_exception_info.cpp
+++ b/libs/full/runtime_local/src/custom_exception_info.cpp
@@ -11,9 +11,9 @@
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/command_line_handling/command_line_handling.hpp>
-#include <hpx/debugging/backtrace.hpp>
 #include <hpx/execution_base/register_locks.hpp>
 #include <hpx/futures/futures_factory.hpp>
+#include <hpx/modules/debugging.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/logging.hpp>
@@ -50,15 +50,6 @@
 #include <system_error>
 #include <utility>
 #include <vector>
-
-#ifdef __APPLE__
-#include <crt_externs.h>
-#define environ (*_NSGetEnviron())
-#elif defined(__FreeBSD__)
-HPX_EXPORT char** freebsd_environ = nullptr;
-#elif !defined(HPX_WINDOWS)
-extern char** environ;
-#endif
 
 namespace hpx {
     char const* get_runtime_state_name(state st);


### PR DESCRIPTION
- flyby: disable memory perf counters for FreeBSD

Fixes #5115