### PR TITLE
Fixing spelling errors 

### DIFF
--- a/docs/joss_paper/paper.bib
+++ b/docs/joss_paper/paper.bib
@@ -175,7 +175,7 @@
                   John Biddiscombe and
                   Lars Viklund and
                   Omer Katz},
-  title        = {{STEllAR-GROUP/hpxcl: Inital release}},
+  title        = {{STEllAR-GROUP/hpxcl: Initial release}},
   month        = sep,
   year         = 2018,
   publisher    = {Zenodo},

--- a/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
+++ b/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
@@ -489,12 +489,12 @@ The ``hpx.parcel`` configuration section
        ``HPX_PARCEL_MAX_CONNECTIONS_PER_LOCALITY`` (``4``).
    * * ``hpx.parcel.max_message_size``
      * This property defines the maximum allowed message size which will be
-       transferrable through the :term:`parcel` layer. The default depends on the
+       transferable through the :term:`parcel` layer. The default depends on the
        compile time preprocessor constant ``HPX_PARCEL_MAX_MESSAGE_SIZE``
        (``1000000000`` bytes).
    * * ``hpx.parcel.max_outbound_message_size``
      * This property defines the maximum allowed outbound coalesced message size
-       which will be transferrable through the parcel layer. The default depends
+       which will be transferable through the parcel layer. The default depends
        on the compile time preprocessor constant
        ``HPX_PARCEL_MAX_OUTBOUND_MESSAGE_SIZE`` (``1000000`` bytes).
    * * ``hpx.parcel.array_optimization``
@@ -568,11 +568,11 @@ The following settings relate to the TCP/IP parcelport.
        taken from ``hpx.parcel.max_connections_per_locality``.
    * * ``hpx.parcel.tcp.max_message_size``
      * This property defines the maximum allowed message size which will be
-       transferrable through the :term:`parcel` layer. The default is taken from
+       transferable through the :term:`parcel` layer. The default is taken from
        ``hpx.parcel.max_message_size``.
    * * ``hpx.parcel.tcp.max_outbound_message_size``
      * This property defines the maximum allowed outbound coalesced message size
-       which will be transferrable through the :term:`parcel` layer. The default is
+       which will be transferable through the :term:`parcel` layer. The default is
        taken from ``hpx.parcel.max_outbound_connections``.
 
 The following settings relate to the MPI parcelport. These settings take effect
@@ -657,11 +657,11 @@ equivalent cmake variable is ``HPX_WITH_PARCELPORT_MPI`` and has to be set to
        taken from ``hpx.parcel.max_connections_per_locality``.
    * * ``hpx.parcel.mpi.max_message_size``
      * This property defines the maximum allowed message size which will be
-       transferrable through the :term:`parcel` layer. The default is taken from
+       transferable through the :term:`parcel` layer. The default is taken from
        ``hpx.parcel.max_message_size``.
    * * ``hpx.parcel.mpi.max_outbound_message_size``
      * This property defines the maximum allowed outbound coalesced message size
-       which will be transferrable through the :term:`parcel` layer. The default is
+       which will be transferable through the :term:`parcel` layer. The default is
        taken from ``hpx.parcel.max_outbound_connections``.
 
 The ``hpx.agas`` configuration section

--- a/docs/sphinx/releases/whats_new_0_9_6.rst
+++ b/docs/sphinx/releases/whats_new_0_9_6.rst
@@ -127,7 +127,7 @@ again a very long list of newly implemented features and fixed issues.
 * :hpx-issue:`741` - assertion 'px != 0' failed: HPX(assertion_failure) for low
   numbers of OS threads
 * :hpx-issue:`739` - Performance counters do not count to the end of the program
-  or evalution
+  or evaluation
 * :hpx-issue:`738` - Dedicated AGAS server runs don't work; console ignores -a
   option.
 * :hpx-issue:`737` - Missing bind overloads

--- a/docs/sphinx/releases/whats_new_0_9_8.rst
+++ b/docs/sphinx/releases/whats_new_0_9_8.rst
@@ -170,7 +170,7 @@ Here is a list of the important tickets we closed for this release.
   to non-thread safe writes
 * :hpx-issue:`1011` - After installation, running applications from the
   build/staging directory no longer works
-* :hpx-issue:`1010` - Mergable decrement requests are not being merged
+* :hpx-issue:`1010` - Mergeable decrement requests are not being merged
 * :hpx-issue:`1009` - ``--hpx:list-symbolic-names`` crashes
 * :hpx-issue:`1007` - Components are not properly destroyed
 * :hpx-issue:`1006` - Segfault/hang in set_data

--- a/docs/sphinx/releases/whats_new_0_9_9.rst
+++ b/docs/sphinx/releases/whats_new_0_9_9.rst
@@ -249,7 +249,7 @@ Here is a list of the important tickets we closed for this release.
 * :hpx-issue:`1109` - More tests adjustments
 * :hpx-issue:`1108` - Clarify build rules for "libboost_atomic-mt.so"?
 * :hpx-issue:`1107` - Remove unnecessary null pointer checks
-* :hpx-issue:`1106` - network_storage benchmark imporvements, adding legends to
+* :hpx-issue:`1106` - network_storage benchmark improvements, adding legends to
   plots and tidying layout
 * :hpx-issue:`1105` - Add more plot outputs and improve instructions doc
 * :hpx-issue:`1104` - Complete quoting for parameters of some CMake commands

--- a/docs/sphinx/releases/whats_new_0_9_99.rst
+++ b/docs/sphinx/releases/whats_new_0_9_99.rst
@@ -179,7 +179,7 @@ Here is a list of the important tickets we closed for this release.
 * :hpx-pr:`2205` - The indirect_packaged_task::operator() needs to be run on a
   HPX thread
 * :hpx-pr:`2204` - Variadic executor parameters
-* :hpx-pr:`2203` - Delay-initialize members of partitoned iterator
+* :hpx-pr:`2203` - Delay-initialize members of partitioned iterator
 * :hpx-pr:`2202` - Added segmented fill for hpx::vector
 * :hpx-issue:`2201` - Null Thread id encountered on partitioned_vector
 * :hpx-pr:`2200` - Fix hangs

--- a/docs/sphinx/releases/whats_new_1_0_0.rst
+++ b/docs/sphinx/releases/whats_new_1_0_0.rst
@@ -335,7 +335,7 @@ Here is a list of the important tickets we closed for this release.
 * :hpx-issue:`2376` - Boost trunk's spinlock initializer fails to compile
 * :hpx-pr:`2375` - Add support for minimal thread local data
 * :hpx-pr:`2374` - Adding API functions set_config_entry_callback
-* :hpx-pr:`2373` - Add a simple utility for debugging that gives supended task
+* :hpx-pr:`2373` - Add a simple utility for debugging that gives suspended task
   backtraces
 * :hpx-pr:`2372` - Barrier Fixes
 * :hpx-issue:`2370` - Can't wait on a wrapped future

--- a/examples/quickstart/composable_guard.cpp
+++ b/examples/quickstart/composable_guard.cpp
@@ -23,7 +23,7 @@
 //
 // Because guards don't add locking structures to the current environment
 // during a calculation, they can never deadlock. Guards use only a
-// few atomic operations to perform their operaions, and never cause a
+// few atomic operations to perform their operations, and never cause a
 // task to block, so they should be quite fast.
 //
 // To use guards, call the run_guarded() method, supplying it with

--- a/examples/spell_check/5desk.txt
+++ b/examples/spell_check/5desk.txt
@@ -55436,7 +55436,7 @@ transfer
 transferable
 transferal
 transference
-transferrable
+transferable
 transferrer
 Transfiguration
 transfiguration

--- a/libs/core/concurrency/include/hpx/concurrency/detail/contiguous_index_queue.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/detail/contiguous_index_queue.hpp
@@ -79,7 +79,7 @@ namespace hpx { namespace concurrency { namespace detail {
 
         /// \brief Construct a new contiguous_index_queue.
         ///
-        /// Constrct a new queue with an empty range.
+        /// Construct a new queue with an empty range.
         constexpr contiguous_index_queue() noexcept
           : initial_range{}
           , current_range{}
@@ -88,7 +88,7 @@ namespace hpx { namespace concurrency { namespace detail {
 
         /// \brief Construct a new contiguous_index_queue with the given range.
         ///
-        /// Constrct a new queue with the given range as the initial range.
+        /// Construct a new queue with the given range as the initial range.
         constexpr contiguous_index_queue(T first, T last) noexcept
           : initial_range{}
           , current_range{}

--- a/libs/core/config/include/hpx/config.hpp
+++ b/libs/core/config/include/hpx/config.hpp
@@ -259,10 +259,10 @@
 /// thread got stuck.
 #if defined(HPX_HAVE_THREAD_BACKTRACE_ON_SUSPENSION) && \
   !defined(HPX_HAVE_STACKTRACES)
-#  error HPX_HAVE_THREAD_BACKTRACE_ON_SUSPENSION reqires HPX_HAVE_STACKTRACES to be defined!
+#  error HPX_HAVE_THREAD_BACKTRACE_ON_SUSPENSION requires HPX_HAVE_STACKTRACES to be defined!
 #endif
 
-/// By default we capture only 5 levels of stack back trace on suspension
+/// By default we capture only 20 levels of stack back trace on suspension
 #if !defined(HPX_HAVE_THREAD_BACKTRACE_DEPTH)
 #  define HPX_HAVE_THREAD_BACKTRACE_DEPTH 20
 #endif

--- a/libs/full/collectives/src/create_communication_set.cpp
+++ b/libs/full/collectives/src/create_communication_set.cpp
@@ -47,7 +47,7 @@ namespace hpx { namespace lcos {
     // calculated by counting the nodes that have a given node as its parent.
     //
     // The node some other node connects to is calculated by clearing the lowest
-    // significant bit set (for arities == 2, simular for other arities).
+    // significant bit set (for arities == 2, similar for other arities).
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<hpx::id_type> create_communication_set(char const* name,

--- a/libs/full/program_options/include/hpx/program_options/parsers.hpp
+++ b/libs/full/program_options/include/hpx/program_options/parsers.hpp
@@ -240,7 +240,7 @@ namespace hpx { namespace program_options {
     /** Collects the original tokens for all named options with
         'unregistered' flag set. If 'mode' is 'include_positional'
         also collects all positional options.
-        Returns the vector of origianl tokens for all collected
+        Returns the vector of original tokens for all collected
         options.
     */
     template <class Char>

--- a/libs/full/resiliency_distributed/examples/async_replay_distributed.cpp
+++ b/libs/full/resiliency_distributed/examples/async_replay_distributed.cpp
@@ -40,7 +40,7 @@ int universal_ans(std::vector<hpx::id_type> f_locales, std::size_t size)
     {
         // Throw a runtime error in case the node is faulty
         if (locale == hpx::find_here())
-            throw std::runtime_error("runtime error occured.");
+            throw std::runtime_error("runtime error occurred.");
     }
 
     return 42;

--- a/libs/full/resiliency_distributed/examples/async_replicate_distributed.cpp
+++ b/libs/full/resiliency_distributed/examples/async_replicate_distributed.cpp
@@ -37,7 +37,7 @@ int universal_ans(std::vector<hpx::id_type> f_locales, std::size_t size)
     {
         // Throw a runtime error in case the node is faulty
         if (locale == hpx::find_here())
-            throw std::runtime_error("runtime error occured.");
+            throw std::runtime_error("runtime error occurred.");
     }
 
     return 42;

--- a/libs/full/resiliency_distributed/tests/performance/replay/1d_stencil_replay_distributed.cpp
+++ b/libs/full/resiliency_distributed/tests/performance/replay/1d_stencil_replay_distributed.cpp
@@ -173,7 +173,7 @@ private:
         ar & size_;
         ar & checksum_;
         ar & test_value_;
-        // clang-format ons
+        // clang-format on
     }
 };
 
@@ -235,12 +235,12 @@ partition_data stencil_update(std::size_t sti, partition_data const& center,
     if (is_faulty_node)
     {
         if (dis(gen) < (error * 10))
-            throw std::runtime_error("Error occured");
+            throw std::runtime_error("Error occurred");
     }
     else
     {
         if (dis(gen) < error)
-            throw std::runtime_error("Error occured");
+            throw std::runtime_error("Error occurred");
     }
 
     return workspace;
@@ -390,8 +390,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
                     current[i - 1], current[i + 1], errors, is_faulty_node)
                     .then(hpx::launch::async,
                         [sti, &current, errors, i, &locales, &counter,
-                            num_localities, faults](
-                            hpx::future<partition_data>&& gg) {
+                            num_localities,
+                            faults](hpx::future<partition_data>&& gg) {
                             if (gg.has_exception())
                             {
                                 if (faults != 0)

--- a/libs/full/resiliency_distributed/tests/performance/replay/async_replay_distributed_validate.cpp
+++ b/libs/full/resiliency_distributed/tests/performance/replay/async_replay_distributed_validate.cpp
@@ -64,12 +64,12 @@ int universal_ans(std::vector<hpx::id_type> const& f_locales, std::size_t err,
         {
             is_faulty = true;
             if (dist(gen) < err * 10)
-                throw std::runtime_error("runtime error occured.");
+                throw std::runtime_error("runtime error occurred.");
         }
     }
 
     if (!is_faulty && dist(gen) < err)
-        throw std::runtime_error("runtime error occured.");
+        throw std::runtime_error("runtime error occurred.");
 
     return 42;
 }

--- a/libs/full/resiliency_distributed/tests/performance/replicate/async_replicate_distributed.cpp
+++ b/libs/full/resiliency_distributed/tests/performance/replicate/async_replicate_distributed.cpp
@@ -61,12 +61,12 @@ int universal_ans(
         {
             is_faulty = true;
             if (dist(gen) < err * 10)
-                throw std::runtime_error("runtime error occured.");
+                throw std::runtime_error("runtime error occurred.");
         }
     }
 
     if (!is_faulty && dist(gen) < err)
-        throw std::runtime_error("runtime error occured.");
+        throw std::runtime_error("runtime error occurred.");
 
     return 42;
 }

--- a/libs/full/resiliency_distributed/tests/performance/replicate/async_replicate_distributed_validate.cpp
+++ b/libs/full/resiliency_distributed/tests/performance/replicate/async_replicate_distributed_validate.cpp
@@ -61,12 +61,12 @@ int universal_ans(
         {
             is_faulty = true;
             if (dist(gen) < err * 10)
-                throw std::runtime_error("runtime error occured.");
+                throw std::runtime_error("runtime error occurred.");
         }
     }
 
     if (!is_faulty && dist(gen) < err)
-        throw std::runtime_error("runtime error occured.");
+        throw std::runtime_error("runtime error occurred.");
 
     return 42;
 }

--- a/libs/full/resiliency_distributed/tests/performance/replicate/async_replicate_distributed_vote.cpp
+++ b/libs/full/resiliency_distributed/tests/performance/replicate/async_replicate_distributed_vote.cpp
@@ -60,12 +60,12 @@ int universal_ans(
         {
             is_faulty = true;
             if (dist(gen) < err * 10)
-                throw std::runtime_error("runtime error occured.");
+                throw std::runtime_error("runtime error occurred.");
         }
     }
 
     if (!is_faulty && dist(gen) < err)
-        throw std::runtime_error("runtime error occured.");
+        throw std::runtime_error("runtime error occurred.");
 
     return 42;
 }

--- a/libs/full/resiliency_distributed/tests/performance/replicate/async_replicate_distributed_vote_validate.cpp
+++ b/libs/full/resiliency_distributed/tests/performance/replicate/async_replicate_distributed_vote_validate.cpp
@@ -61,12 +61,12 @@ int universal_ans(
         {
             is_faulty = true;
             if (dist(gen) < (err * 10))
-                throw std::runtime_error("runtime error occured.");
+                throw std::runtime_error("runtime error occurred.");
         }
     }
 
     if (!is_faulty && dist(gen) < err)
-        throw std::runtime_error("runtime error occured.");
+        throw std::runtime_error("runtime error occurred.");
 
     return 42;
 }

--- a/libs/parallelism/resiliency/examples/dataflow_replicate.cpp
+++ b/libs/parallelism/resiliency/examples/dataflow_replicate.cpp
@@ -70,7 +70,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         }
         catch (bad_calc_exception const&)
         {
-            std::cout << "Bad Calcuation!" << std::endl;
+            std::cout << "Bad Calculation!" << std::endl;
         }
 
         // Unsuccessful replicate
@@ -86,7 +86,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         }
         catch (bad_calc_exception const&)
         {
-            std::cout << "Bad Calcuation!" << std::endl;
+            std::cout << "Bad Calculation!" << std::endl;
         }
 
         // Aborted replicate
@@ -101,7 +101,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         }
         catch (bad_calc_exception const&)
         {
-            std::cout << "Bad Calcuation!" << std::endl;
+            std::cout << "Bad Calculation!" << std::endl;
         }
     }
 

--- a/plugins/parcelport/libfabric/receiver.hpp
+++ b/plugins/parcelport/libfabric/receiver.hpp
@@ -68,7 +68,7 @@ namespace libfabric
 
         // --------------------------------------------------------------------
         // The cleanup call deletes resources and sums counters from internals
-        // once cleanup is done, the recevier should not be used, other than
+        // once cleanup is done, the receiver should not be used, other than
         // dumping counters
         void cleanup();
 


### PR DESCRIPTION
...as reported by https://fossies.org/linux/test/hpx/codespell.html

Fixes #4940

Thanks @jschleus! One of the spelling problems can't be fixed, could you add the word to the whitelist, please (`'unitialized'`, here: https://github.com/STEllAR-GROUP/hpx/blob/master/docs/sphinx/releases/whats_new_1_1_0.rst)?
