### PR TITLE
Make sure codespell checks run on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,7 +304,7 @@ jobs:
       - run:
           name: Running codespell
           command: |
-              if [ "$CIRCLE_PR_NUMBER" ]; then
+              if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
                   cd /hpx/source
                   codespell --version
                   codespell --ignore-words tools/.codespell_whitelist --skip='*.h5,*.png' $(git diff --name-only origin/master...) > /tmp/spelling_suggestions.txt


### PR DESCRIPTION
I *think* this fixes it. The CircleCI build will show if it's correct. I'll check if it does the right thing on master once merged.