### PR TITLE
Add program options variable map to resource partitioner init

### DIFF
--- a/libs/core/schedulers/tests/unit/schedule_last.cpp
+++ b/libs/core/schedulers/tests/unit/schedule_last.cpp
@@ -44,7 +44,7 @@ void test_scheduler(int argc, char* argv[])
 
     init_args.cfg = {"hpx.os_threads=1"};
     init_args.rp_callback = [](auto& rp,
-                                const hpx::program_options::variables_map&) {
+                                hpx::program_options::variables_map const&) {
         rp.create_thread_pool("default",
             [](hpx::threads::thread_pool_init_parameters thread_pool_init,
                 hpx::threads::policies::thread_queue_init_parameters

--- a/libs/core/schedulers/tests/unit/schedule_last.cpp
+++ b/libs/core/schedulers/tests/unit/schedule_last.cpp
@@ -43,7 +43,8 @@ void test_scheduler(int argc, char* argv[])
     hpx::init_params init_args;
 
     init_args.cfg = {"hpx.os_threads=1"};
-    init_args.rp_callback = [](auto& rp) {
+    init_args.rp_callback = [](auto& rp,
+                                const hpx::program_options::variables_map&) {
         rp.create_thread_pool("default",
             [](hpx::threads::thread_pool_init_parameters thread_pool_init,
                 hpx::threads::policies::thread_queue_init_parameters

--- a/libs/full/compute/tests/unit/numa_allocator.cpp
+++ b/libs/full/compute/tests/unit/numa_allocator.cpp
@@ -85,9 +85,9 @@ void test_binding(std::shared_ptr<Binder<T>> numa_binder, Allocator& allocator)
     std::string domain_string = allocator.get_page_numa_domains(M, num_bytes);
 
     // now generate the 'correct' string of numa domains per page
-    const std::size_t pagesize = hpx::threads::get_memory_page_size();
-    const std::size_t pageN = pagesize / sizeof(T);
-    const std::size_t num_pages = (num_bytes + pagesize - 1) / pagesize;
+    std::size_t const pagesize = hpx::threads::get_memory_page_size();
+    std::size_t const pageN = pagesize / sizeof(T);
+    std::size_t const num_pages = (num_bytes + pagesize - 1) / pagesize;
     T* page_ptr = M;
 
     std::stringstream temp;
@@ -217,7 +217,7 @@ using high_priority_sched =
 using hpx::threads::policies::scheduler_mode;
 
 void init_resource_partitioner_handler(
-    hpx::resource::partitioner& rp, const hpx::program_options::variables_map&)
+    hpx::resource::partitioner& rp, hpx::program_options::variables_map const&)
 {
     using numa_scheduler =
         hpx::threads::policies::shared_priority_queue_scheduler<>;

--- a/libs/full/compute/tests/unit/numa_allocator.cpp
+++ b/libs/full/compute/tests/unit/numa_allocator.cpp
@@ -216,7 +216,8 @@ using high_priority_sched =
     hpx::threads::policies::shared_priority_queue_scheduler<>;
 using hpx::threads::policies::scheduler_mode;
 
-void init_resource_partitioner_handler(hpx::resource::partitioner& rp)
+void init_resource_partitioner_handler(
+    hpx::resource::partitioner& rp, const hpx::program_options::variables_map&)
 {
     using numa_scheduler =
         hpx::threads::policies::shared_priority_queue_scheduler<>;

--- a/libs/full/init_runtime/include/hpx/hpx_init_params.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_init_params.hpp
@@ -47,7 +47,8 @@ namespace hpx {
     namespace resource {
         // Utilities to init the thread_pools of the resource partitioner
         using rp_callback_type =
-            hpx::util::function_nonser<void(hpx::resource::partitioner&)>;
+            hpx::util::function_nonser<void(hpx::resource::partitioner&,
+                const hpx::program_options::variables_map&)>;
     }    // namespace resource
     /// \endcond
 

--- a/libs/full/init_runtime/include/hpx/hpx_init_params.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_init_params.hpp
@@ -48,7 +48,7 @@ namespace hpx {
         // Utilities to init the thread_pools of the resource partitioner
         using rp_callback_type =
             hpx::util::function_nonser<void(hpx::resource::partitioner&,
-                const hpx::program_options::variables_map&)>;
+                hpx::program_options::variables_map const&)>;
     }    // namespace resource
     /// \endcond
 

--- a/libs/full/init_runtime/src/hpx_init.cpp
+++ b/libs/full/init_runtime/src/hpx_init.cpp
@@ -869,7 +869,7 @@ namespace hpx {
                     // If thread_pools initialization in user main
                     if (params.rp_callback)
                     {
-                        params.rp_callback(rp);
+                        params.rp_callback(rp, cmdline.vm_);
                     }
 
                     // Setup all internal parameters of the resource_partitioner

--- a/libs/full/resource_partitioner/examples/CMakeLists.txt
+++ b/libs/full/resource_partitioner/examples/CMakeLists.txt
@@ -46,10 +46,10 @@ set(oversubscribing_resource_partitioner_FLAGS DEPENDENCIES iostreams_component)
 set(simple_resource_partitioner_FLAGS DEPENDENCIES iostreams_component)
 
 set(oversubscribing_resource_partitioner_PARAMETERS
-    THREADS_PER_LOCALITY 4 "--use-pools" "--use-scheduler"
+    THREADS_PER_LOCALITY 4 "--use-pools" "--pool-threads" 1
 )
 set(simple_resource_partitioner_PARAMETERS THREADS_PER_LOCALITY 4 "--use-pools"
-                                           "--use-scheduler"
+                                           "--pool-threads" 1
 )
 set(simplest_resource_partitioner_1_PARAMETERS THREADS_PER_LOCALITY 4)
 set(simplest_resource_partitioner_2_PARAMETERS THREADS_PER_LOCALITY 4)

--- a/libs/full/resource_partitioner/examples/guided_pool_test.cpp
+++ b/libs/full/resource_partitioner/examples/guided_pool_test.cpp
@@ -223,7 +223,7 @@ int hpx_main()
 }
 
 void init_resource_partitioner_handler(hpx::resource::partitioner& rp,
-    hpx::program_options::variables_map const& vm)
+    hpx::program_options::variables_map const&)
 {
     // create a thread pool and supply a lambda that returns a new pool with
     // a user supplied scheduler attached

--- a/libs/full/resource_partitioner/examples/guided_pool_test.cpp
+++ b/libs/full/resource_partitioner/examples/guided_pool_test.cpp
@@ -222,8 +222,8 @@ int hpx_main()
     return hpx::finalize();
 }
 
-void init_resource_partitioner_handler(hpx::resource::partitioner& rp,
-    hpx::program_options::variables_map const&)
+void init_resource_partitioner_handler(
+    hpx::resource::partitioner& rp, hpx::program_options::variables_map const&)
 {
     // create a thread pool and supply a lambda that returns a new pool with
     // a user supplied scheduler attached

--- a/libs/full/resource_partitioner/examples/guided_pool_test.cpp
+++ b/libs/full/resource_partitioner/examples/guided_pool_test.cpp
@@ -222,7 +222,8 @@ int hpx_main()
     return hpx::finalize();
 }
 
-void init_resource_partitioner_handler(hpx::resource::partitioner& rp)
+void init_resource_partitioner_handler(hpx::resource::partitioner& rp,
+    const hpx::program_options::variables_map& vm)
 {
     // create a thread pool and supply a lambda that returns a new pool with
     // a user supplied scheduler attached

--- a/libs/full/resource_partitioner/examples/guided_pool_test.cpp
+++ b/libs/full/resource_partitioner/examples/guided_pool_test.cpp
@@ -39,7 +39,7 @@ using hpx::threads::policies::scheduler_mode;
 // template class hpx::threads::detail::scheduled_thread_pool<high_priority_sched>;
 
 // dummy function we will call using async
-void async_guided(std::size_t n, bool printout, const std::string& message)
+void async_guided(std::size_t n, bool printout, std::string const& message)
 {
     if (printout)
     {
@@ -84,7 +84,7 @@ namespace hpx { namespace parallel { namespace execution {
     {
         // ------------------------------------------------------------------------
         // specialize the hint operator for params
-        int operator()(std::size_t i, bool b, const std::string& msg) const
+        int operator()(std::size_t i, bool b, std::string const& msg) const
         {
             std::cout << "<std::size_t, bool, const std::string> hint "
                       << "invoked with : " << i << " " << b << " " << msg
@@ -94,7 +94,7 @@ namespace hpx { namespace parallel { namespace execution {
 
         // ------------------------------------------------------------------------
         // specialize the hint operator for params
-        int operator()(int i, double d, const std::string& msg) const
+        int operator()(int i, double d, std::string const& msg) const
         {
             std::cout << "<int, double, const std::string> hint "
                       << "invoked with : " << i << " " << d << " " << msg
@@ -162,7 +162,7 @@ int hpx_main()
     // invoke a lambda asynchronously and use the numa executor
     hpx::future<double> gf2 = hpx::async(
         guided_lambda_exec,
-        [](int, double, const std::string& msg) mutable -> double {
+        [](int, double, std::string const& msg) mutable -> double {
             std::cout << "inside <int, double, string> async lambda " << msg
                       << std::endl;
             // return a double as an example
@@ -223,7 +223,7 @@ int hpx_main()
 }
 
 void init_resource_partitioner_handler(hpx::resource::partitioner& rp,
-    const hpx::program_options::variables_map& vm)
+    hpx::program_options::variables_map const& vm)
 {
     // create a thread pool and supply a lambda that returns a new pool with
     // a user supplied scheduler attached
@@ -251,11 +251,11 @@ void init_resource_partitioner_handler(hpx::resource::partitioner& rp,
     // rp.add_resource(rp.numa_domains()[0].cores()[0].pus(), CUSTOM_POOL_NAME);
     // add N cores to Custom pool
     int count = 0;
-    for (const hpx::resource::numa_domain& d : rp.numa_domains())
+    for (hpx::resource::numa_domain const& d : rp.numa_domains())
     {
-        for (const hpx::resource::core& c : d.cores())
+        for (hpx::resource::core const& c : d.cores())
         {
-            for (const hpx::resource::pu& p : c.pus())
+            for (hpx::resource::pu const& p : c.pus())
             {
                 if (count < pool_threads)
                 {

--- a/libs/full/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
+++ b/libs/full/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
@@ -26,6 +26,9 @@
 //
 #include "system_characteristics.hpp"
 
+// NB
+// this test needs to be updated as it no longer does what it is supposed to do
+
 namespace resource { namespace pools {
     enum ids
     {
@@ -37,8 +40,8 @@ namespace resource { namespace pools {
 }}    // namespace resource::pools
 
 static bool use_pools = false;
-static bool use_scheduler = false;
 static int pool_threads = 1;
+static const std::string pool_name = "mpi";
 
 // this is our custom scheduler type
 using high_priority_sched =
@@ -62,17 +65,8 @@ void do_stuff(std::size_t n, bool printout)
 }
 
 // this is called on an hpx thread after the runtime starts up
-int hpx_main(hpx::program_options::variables_map& vm)
+int hpx_main(/*hpx::program_options::variables_map& vm*/)
 {
-    if (vm.count("use-pools"))
-        use_pools = true;
-    if (vm.count("use-scheduler"))
-        use_scheduler = true;
-    //
-    std::cout << "[hpx_main] starting ..."
-              << "use_pools " << use_pools << " "
-              << "use_scheduler " << use_scheduler << "\n";
-
     std::size_t num_threads = hpx::get_num_worker_threads();
     hpx::cout << "HPX using threads = " << num_threads << std::endl;
 
@@ -97,7 +91,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     {
         // get executors
         mpi_executor = hpx::execution::parallel_executor(
-            &hpx::resource::get_thread_pool("mpi"));
+            &hpx::resource::get_thread_pool(pool_name));
         hpx::cout << "\n[hpx_main] got mpi executor " << std::endl;
     }
     else
@@ -225,127 +219,69 @@ int hpx_main(hpx::program_options::variables_map& vm)
     return hpx::finalize();
 }
 
+// -------------------------------------------------------------------------
+void init_resource_partitioner_handler(hpx::resource::partitioner& rp,
+    const hpx::program_options::variables_map& vm)
+{
+    use_pools = vm.count("use-pools") != 0;
+    pool_threads = vm["pool-threads"].as<int>();
+
+    std::cout << "[hpx_main] starting ..."
+              << "use_pools " << use_pools << " "
+              << "pool-threads " << pool_threads << "\n";
+
+    if (pool_threads > 0)
+    {
+        // we use unspecified as the scheduler type and it will be set according to
+        // the --hpx:queuing=xxx option or default.
+        std::uint32_t deft =
+            hpx::threads::policies::scheduler_mode::default_mode;
+        rp.create_thread_pool(pool_name,
+            hpx::resource::scheduling_policy::shared_priority,
+            hpx::threads::policies::scheduler_mode(deft));
+        // add N pus to network pool
+        int count = 0;
+        for (const hpx::resource::numa_domain& d : rp.numa_domains())
+        {
+            for (const hpx::resource::core& c : d.cores())
+            {
+                for (const hpx::resource::pu& p : c.pus())
+                {
+                    if (count < pool_threads)
+                    {
+                        std::cout << "Added pu " << count++ << " to pool \""
+                                  << pool_name << "\"\n";
+                        rp.add_resource(p, pool_name);
+                    }
+                }
+            }
+        }
+
+        rp.create_thread_pool("default",
+            hpx::resource::scheduling_policy::unspecified,
+            hpx::threads::policies::scheduler_mode(deft));
+    }
+}
+
 // the normal int main function that is called at startup and runs on an OS thread
 // the user must call hpx::init to start the hpx runtime which will execute hpx_main
 // on an hpx thread
 int main(int argc, char* argv[])
 {
+    // clang-format off
     hpx::program_options::options_description desc_cmdline("Test options");
-    desc_cmdline.add_options()(
-        "use-pools,u", "Enable advanced HPX thread pools and executors")(
-        "use-scheduler,s", "Enable custom priority scheduler")("pool-threads,m",
-        hpx::program_options::value<int>()->default_value(1),
-        "Number of threads to assign to custom pool");
-
-    // HPX uses a boost program options variable map, but we need it before
-    // hpx-main, so we will create another one here and throw it away after use
-    hpx::program_options::variables_map vm;
-    hpx::program_options::store(
-        hpx::program_options::command_line_parser(argc, argv)
-            .allow_unregistered()
-            .options(desc_cmdline)
-            .run(),
-        vm);
-
-    if (vm.count("use-pools"))
-    {
-        use_pools = true;
-    }
-    if (vm.count("use-scheduler"))
-    {
-        use_scheduler = true;
-    }
-
-    pool_threads = vm["pool-threads"].as<int>();
+    desc_cmdline.add_options()
+        ("use-pools,u", "Enable advanced HPX thread pools and executors")
+        ("use-scheduler,s", "Enable custom priority scheduler")
+        ("pool-threads,m", hpx::program_options::value<int>()->default_value(1),
+            "Number of threads to assign to custom pool");
+    // clang-format on
 
     hpx::init_params iparams;
 
     iparams.desc_cmdline = desc_cmdline;
     iparams.rp_mode = hpx::resource::mode_allow_oversubscription;
-    iparams.rp_callback = [](auto& rp) {
-        //    auto &topo = rp.get_topology();
-        std::cout << "[main] obtained reference to the resource_partitioner\n";
-
-        // create a thread pool and supply a lambda that returns a new pool with
-        // the a user supplied scheduler attached
-        rp.create_thread_pool("default",
-            [](hpx::threads::thread_pool_init_parameters init,
-                hpx::threads::policies::thread_queue_init_parameters
-                    thread_queue_init)
-                -> std::unique_ptr<hpx::threads::thread_pool_base> {
-                std::cout << "User defined scheduler creation callback "
-                          << std::endl;
-
-                high_priority_sched::init_parameter_type scheduler_init(
-                    init.num_threads_, {1, 1, 64}, init.affinity_data_,
-                    thread_queue_init, "shared-priority-scheduler");
-                std::unique_ptr<high_priority_sched> scheduler(
-                    new high_priority_sched(scheduler_init));
-
-                init.mode_ = scheduler_mode(scheduler_mode::do_background_work |
-                    scheduler_mode::delay_exit);
-
-                std::unique_ptr<hpx::threads::thread_pool_base> pool(
-                    new hpx::threads::detail::scheduled_thread_pool<
-                        high_priority_sched>(std::move(scheduler), init));
-                return pool;
-            });
-
-        rp.add_resource(rp.numa_domains(), "default");
-
-        if (use_pools)
-        {
-            // Create a thread pool using the default scheduler provided by HPX
-            //        rp.create_thread_pool("mpi",
-            //            hpx::resource::scheduling_policy::local_priority_fifo);
-            //std::cout << "[main] " << "thread_pools created \n";
-
-            // create a thread pool and supply a lambda that returns a new pool with
-            // the a user supplied scheduler attached
-            rp.create_thread_pool("mpi",
-                [](hpx::threads::thread_pool_init_parameters init,
-                    hpx::threads::policies::thread_queue_init_parameters
-                        thread_queue_init)
-                    -> std::unique_ptr<hpx::threads::thread_pool_base> {
-                    std::cout << "User defined scheduler creation callback "
-                              << std::endl;
-
-                    high_priority_sched::init_parameter_type scheduler_init(
-                        init.num_threads_, {1, 1, 64}, init.affinity_data_,
-                        thread_queue_init, "shared-priority-scheduler");
-                    std::unique_ptr<high_priority_sched> scheduler(
-                        new high_priority_sched(scheduler_init));
-
-                    init.mode_ = scheduler_mode(scheduler_mode::delay_exit);
-
-                    std::unique_ptr<hpx::threads::thread_pool_base> pool(
-                        new hpx::threads::detail::scheduled_thread_pool<
-                            high_priority_sched>(std::move(scheduler), init));
-                    return pool;
-                });
-
-            // rp.add_resource(rp.numa_domains()[0].cores()[0].pus(), "mpi");
-            // add N cores to mpi pool
-            int count = 0;
-            for (const hpx::resource::numa_domain& d : rp.numa_domains())
-            {
-                for (const hpx::resource::core& c : d.cores())
-                {
-                    for (const hpx::resource::pu& p : c.pus())
-                    {
-                        if (count < pool_threads)
-                        {
-                            std::cout << "Added pu " << count++
-                                      << " to mpi pool\n";
-                            rp.add_resource(p, "mpi");
-                        }
-                    }
-                }
-            }
-
-            std::cout << "[main] resources added to thread_pools \n";
-        }
-    };
+    iparams.rp_callback = init_resource_partitioner_handler;
 
     return hpx::init(argc, argv, iparams);
 }

--- a/libs/full/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
+++ b/libs/full/resource_partitioner/examples/oversubscribing_resource_partitioner.cpp
@@ -41,7 +41,7 @@ namespace resource { namespace pools {
 
 static bool use_pools = false;
 static int pool_threads = 1;
-static const std::string pool_name = "mpi";
+static std::string const pool_name = "mpi";
 
 // this is our custom scheduler type
 using high_priority_sched =
@@ -221,7 +221,7 @@ int hpx_main(/*hpx::program_options::variables_map& vm*/)
 
 // -------------------------------------------------------------------------
 void init_resource_partitioner_handler(hpx::resource::partitioner& rp,
-    const hpx::program_options::variables_map& vm)
+    hpx::program_options::variables_map const& vm)
 {
     use_pools = vm.count("use-pools") != 0;
     pool_threads = vm["pool-threads"].as<int>();
@@ -241,11 +241,11 @@ void init_resource_partitioner_handler(hpx::resource::partitioner& rp,
             hpx::threads::policies::scheduler_mode(deft));
         // add N pus to network pool
         int count = 0;
-        for (const hpx::resource::numa_domain& d : rp.numa_domains())
+        for (hpx::resource::numa_domain const& d : rp.numa_domains())
         {
-            for (const hpx::resource::core& c : d.cores())
+            for (hpx::resource::core const& c : d.cores())
             {
-                for (const hpx::resource::pu& p : c.pus())
+                for (hpx::resource::pu const& p : c.pus())
                 {
                     if (count < pool_threads)
                     {

--- a/libs/full/resource_partitioner/examples/simple_resource_partitioner.cpp
+++ b/libs/full/resource_partitioner/examples/simple_resource_partitioner.cpp
@@ -32,8 +32,8 @@
 
 // ------------------------------------------------------------------------
 static bool use_pools = false;
-static bool use_scheduler = false;
 static int pool_threads = 1;
+static const std::string pool_name = "mpi";
 
 // ------------------------------------------------------------------------
 // this is our custom scheduler type
@@ -60,17 +60,8 @@ void do_stuff(std::size_t n, bool printout)
 
 // ------------------------------------------------------------------------
 // this is called on an hpx thread after the runtime starts up
-int hpx_main(hpx::program_options::variables_map& vm)
+int hpx_main(hpx::program_options::variables_map&)
 {
-    if (vm.count("use-pools"))
-        use_pools = true;
-    if (vm.count("use-scheduler"))
-        use_scheduler = true;
-    //
-    std::cout << "[hpx_main] starting ..."
-              << "use_pools " << use_pools << " "
-              << "use_scheduler " << use_scheduler << "\n";
-
     std::size_t num_threads = hpx::get_num_worker_threads();
     hpx::cout << "HPX using threads = " << num_threads << std::endl;
 
@@ -88,7 +79,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     {
         // get executors
         hpx::execution::parallel_executor mpi_exec(
-            &hpx::resource::get_thread_pool("mpi"));
+            &hpx::resource::get_thread_pool(pool_name));
         mpi_executor = mpi_exec;
         hpx::cout << "\n[hpx_main] got mpi executor " << std::endl;
     }
@@ -219,67 +210,27 @@ int hpx_main(hpx::program_options::variables_map& vm)
     return hpx::finalize();
 }
 
-void init_resource_partitioner_handler(hpx::resource::partitioner& rp)
+// -------------------------------------------------------------------------
+void init_resource_partitioner_handler(hpx::resource::partitioner& rp,
+    const hpx::program_options::variables_map& vm)
 {
-    // create a thread pool and supply a lambda that returns a new pool with
-    // the a user supplied scheduler attached
-    rp.create_thread_pool("default",
-        [](hpx::threads::thread_pool_init_parameters init,
-            hpx::threads::policies::thread_queue_init_parameters
-                thread_queue_init)
-            -> std::unique_ptr<hpx::threads::thread_pool_base> {
-            std::cout << "User defined scheduler creation callback "
-                      << std::endl;
+    use_pools = vm.count("use-pools") != 0;
+    pool_threads = vm["pool-threads"].as<int>();
 
-            numa_scheduler::init_parameter_type scheduler_init(
-                init.num_threads_, {1, 1, 64}, init.affinity_data_,
-                thread_queue_init, "shared-priority-scheduler");
-            std::unique_ptr<numa_scheduler> scheduler(
-                new numa_scheduler(scheduler_init));
+    std::cout << "[hpx_main] starting ..."
+              << "use_pools " << use_pools << " "
+              << "pool-threads " << pool_threads << "\n";
 
-            init.mode_ = scheduler_mode(scheduler_mode::do_background_work |
-                scheduler_mode::delay_exit);
-
-            std::unique_ptr<hpx::threads::thread_pool_base> pool(
-                new hpx::threads::detail::scheduled_thread_pool<numa_scheduler>(
-                    std::move(scheduler), init));
-            return pool;
-        });
-
-    if (use_pools)
+    if (pool_threads > 0)
     {
-        // Create a thread pool using the default scheduler provided by HPX
-        //        rp.create_thread_pool("mpi",
-        //            hpx::resource::scheduling_policy::local_priority_fifo);
-        //std::cout << "[main] " << "thread_pools created \n";
-
-        // create a thread pool and supply a lambda that returns a new pool with
-        // the a user supplied scheduler attached
-        rp.create_thread_pool("mpi",
-            [](hpx::threads::thread_pool_init_parameters init,
-                hpx::threads::policies::thread_queue_init_parameters
-                    thread_queue_init)
-                -> std::unique_ptr<hpx::threads::thread_pool_base> {
-                std::cout << "User defined scheduler creation callback "
-                          << std::endl;
-
-                numa_scheduler::init_parameter_type scheduler_init(
-                    init.num_threads_, {1, 1, 64}, init.affinity_data_,
-                    thread_queue_init, "shared-priority-scheduler");
-
-                std::unique_ptr<numa_scheduler> scheduler(
-                    new numa_scheduler(scheduler_init));
-
-                init.mode_ = scheduler_mode(scheduler_mode::delay_exit);
-
-                std::unique_ptr<hpx::threads::thread_pool_base> pool(
-                    new hpx::threads::detail::scheduled_thread_pool<
-                        numa_scheduler>(std::move(scheduler), init));
-                return pool;
-            });
-
-        // rp.add_resource(rp.numa_domains()[0].cores()[0].pus(), "mpi");
-        // add N cores to mpi pool
+        // we use unspecified as the scheduler type and it will be set according to
+        // the --hpx:queuing=xxx option or default.
+        std::uint32_t deft =
+            hpx::threads::policies::scheduler_mode::default_mode;
+        rp.create_thread_pool(pool_name,
+            hpx::resource::scheduling_policy::shared_priority,
+            hpx::threads::policies::scheduler_mode(deft));
+        // add N pus to network pool
         int count = 0;
         for (const hpx::resource::numa_domain& d : rp.numa_domains())
         {
@@ -289,14 +240,17 @@ void init_resource_partitioner_handler(hpx::resource::partitioner& rp)
                 {
                     if (count < pool_threads)
                     {
-                        std::cout << "Added pu " << count++ << " to mpi pool\n";
-                        rp.add_resource(p, "mpi");
+                        std::cout << "Added pu " << count++ << " to pool \""
+                                  << pool_name << "\"\n";
+                        rp.add_resource(p, pool_name);
                     }
                 }
             }
         }
 
-        std::cout << "[rp_callback] resources added to thread_pools \n";
+        rp.create_thread_pool("default",
+            hpx::resource::scheduling_policy::unspecified,
+            hpx::threads::policies::scheduler_mode(deft));
     }
 }
 
@@ -306,33 +260,13 @@ void init_resource_partitioner_handler(hpx::resource::partitioner& rp)
 // on an hpx thread
 int main(int argc, char* argv[])
 {
+    // clang-format off
     hpx::program_options::options_description desc_cmdline("Test options");
-    desc_cmdline.add_options()(
-        "use-pools,u", "Enable advanced HPX thread pools and executors")(
-        "use-scheduler,s", "Enable custom priority scheduler")("pool-threads,m",
-        hpx::program_options::value<int>()->default_value(1),
-        "Number of threads to assign to custom pool");
-
-    // HPX uses a boost program options variable map, but we need it before
-    // hpx-main, so we will create another one here and throw it away after use
-    hpx::program_options::variables_map vm;
-    hpx::program_options::store(
-        hpx::program_options::command_line_parser(argc, argv)
-            .allow_unregistered()
-            .options(desc_cmdline)
-            .run(),
-        vm);
-
-    if (vm.count("use-pools"))
-    {
-        use_pools = true;
-    }
-    if (vm.count("use-scheduler"))
-    {
-        use_scheduler = true;
-    }
-
-    pool_threads = vm["pool-threads"].as<int>();
+    desc_cmdline.add_options()
+        ("use-pools,u", "Enable advanced HPX thread pools and executors")
+        ("pool-threads,m", hpx::program_options::value<int>()->default_value(1),
+            "Number of threads to assign to custom pool");
+    // clang-format on
 
     // Setup the init parameters
     hpx::init_params init_args;

--- a/libs/full/resource_partitioner/examples/simple_resource_partitioner.cpp
+++ b/libs/full/resource_partitioner/examples/simple_resource_partitioner.cpp
@@ -33,7 +33,7 @@
 // ------------------------------------------------------------------------
 static bool use_pools = false;
 static int pool_threads = 1;
-static const std::string pool_name = "mpi";
+static std::string const pool_name = "mpi";
 
 // ------------------------------------------------------------------------
 // this is our custom scheduler type
@@ -212,7 +212,7 @@ int hpx_main(hpx::program_options::variables_map&)
 
 // -------------------------------------------------------------------------
 void init_resource_partitioner_handler(hpx::resource::partitioner& rp,
-    const hpx::program_options::variables_map& vm)
+    hpx::program_options::variables_map const& vm)
 {
     use_pools = vm.count("use-pools") != 0;
     pool_threads = vm["pool-threads"].as<int>();
@@ -232,11 +232,11 @@ void init_resource_partitioner_handler(hpx::resource::partitioner& rp,
             hpx::threads::policies::scheduler_mode(deft));
         // add N pus to network pool
         int count = 0;
-        for (const hpx::resource::numa_domain& d : rp.numa_domains())
+        for (hpx::resource::numa_domain const& d : rp.numa_domains())
         {
-            for (const hpx::resource::core& c : d.cores())
+            for (hpx::resource::core const& c : d.cores())
             {
-                for (const hpx::resource::pu& p : c.pus())
+                for (hpx::resource::pu const& p : c.pus())
                 {
                     if (count < pool_threads)
                     {

--- a/libs/full/resource_partitioner/examples/simplest_resource_partitioner_2.cpp
+++ b/libs/full/resource_partitioner/examples/simplest_resource_partitioner_2.cpp
@@ -20,7 +20,7 @@ int hpx_main()
 }
 
 void init_resource_partitioner_handler(hpx::resource::partitioner& rp,
-    const hpx::program_options::variables_map& /*vm*/)
+    hpx::program_options::variables_map const& /*vm*/)
 {
     rp.create_thread_pool("my-thread-pool");
 
@@ -29,9 +29,9 @@ void init_resource_partitioner_handler(hpx::resource::partitioner& rp,
 
     hpx::resource::numa_domain const& d = rp.numa_domains()[0];
 
-    for (const hpx::resource::core& c : d.cores())
+    for (hpx::resource::core const& c : d.cores())
     {
-        for (const hpx::resource::pu& p : c.pus())
+        for (hpx::resource::pu const& p : c.pus())
         {
             if (one_numa_domain && !skipped_first_pu)
             {

--- a/libs/full/resource_partitioner/examples/simplest_resource_partitioner_2.cpp
+++ b/libs/full/resource_partitioner/examples/simplest_resource_partitioner_2.cpp
@@ -19,7 +19,8 @@ int hpx_main()
     return hpx::finalize();
 }
 
-void init_resource_partitioner_handler(hpx::resource::partitioner& rp)
+void init_resource_partitioner_handler(hpx::resource::partitioner& rp,
+    const hpx::program_options::variables_map& /*vm*/)
 {
     rp.create_thread_pool("my-thread-pool");
 

--- a/libs/full/resource_partitioner/tests/unit/named_pool_executor.cpp
+++ b/libs/full/resource_partitioner/tests/unit/named_pool_executor.cpp
@@ -23,7 +23,7 @@
 #include <utility>
 #include <vector>
 
-const int max_threads = 4;
+int const max_threads = 4;
 
 // dummy function we will call using async
 void dummy_task(std::size_t n, std::string const& text)
@@ -117,7 +117,7 @@ int hpx_main()
 }
 
 void init_resource_partitioner_handler(
-    hpx::resource::partitioner& rp, const hpx::program_options::variables_map&)
+    hpx::resource::partitioner& rp, hpx::program_options::variables_map const&)
 {
     // before adding pools - set the default pool name to "pool-0"
     rp.set_default_pool_name("pool-0");
@@ -132,11 +132,11 @@ void init_resource_partitioner_handler(
 
     // add one PU to each pool
     int thread_count = 0;
-    for (const hpx::resource::numa_domain& d : rp.numa_domains())
+    for (hpx::resource::numa_domain const& d : rp.numa_domains())
     {
-        for (const hpx::resource::core& c : d.cores())
+        for (hpx::resource::core const& c : d.cores())
         {
-            for (const hpx::resource::pu& p : c.pus())
+            for (hpx::resource::pu const& p : c.pus())
             {
                 if (thread_count < max_threads)
                 {

--- a/libs/full/resource_partitioner/tests/unit/named_pool_executor.cpp
+++ b/libs/full/resource_partitioner/tests/unit/named_pool_executor.cpp
@@ -116,7 +116,8 @@ int hpx_main()
     return hpx::finalize();
 }
 
-void init_resource_partitioner_handler(hpx::resource::partitioner& rp)
+void init_resource_partitioner_handler(
+    hpx::resource::partitioner& rp, const hpx::program_options::variables_map&)
 {
     // before adding pools - set the default pool name to "pool-0"
     rp.set_default_pool_name("pool-0");

--- a/tests/unit/resource/cross_pool_injection.cpp
+++ b/tests/unit/resource/cross_pool_injection.cpp
@@ -98,7 +98,7 @@ int hpx_main()
     // randomly create tasks that run on a random pool
     // attach continuations to them that run on different
     // random pools
-    const int loops = 1000;
+    int const loops = 1000;
     //
     std::cout << "1: Starting HP " << loops << std::endl;
     std::atomic<int> counter(loops);
@@ -208,7 +208,7 @@ int hpx_main()
 }
 
 void init_resource_partitioner_handler(hpx::resource::partitioner& rp,
-    const hpx::program_options::variables_map& vm,
+    hpx::program_options::variables_map const&,
     hpx::resource::scheduling_policy policy)
 {
     num_pools = 0;
@@ -226,11 +226,11 @@ void init_resource_partitioner_handler(hpx::resource::partitioner& rp,
     std::size_t threads_remaining = max_threads;
     std::size_t threads_in_pool = 0;
     // create pools randomly and add a random number of PUs to each pool
-    for (const hpx::resource::numa_domain& d : rp.numa_domains())
+    for (hpx::resource::numa_domain const& d : rp.numa_domains())
     {
-        for (const hpx::resource::core& c : d.cores())
+        for (hpx::resource::core const& c : d.cores())
         {
-            for (const hpx::resource::pu& p : c.pus())
+            for (hpx::resource::pu const& p : c.pus())
             {
                 if (threads_in_pool == 0)
                 {

--- a/tests/unit/resource/cross_pool_injection.cpp
+++ b/tests/unit/resource/cross_pool_injection.cpp
@@ -207,8 +207,9 @@ int hpx_main()
     return hpx::finalize();
 }
 
-void init_resource_partitioner_handler(
-    hpx::resource::partitioner& rp, hpx::resource::scheduling_policy policy)
+void init_resource_partitioner_handler(hpx::resource::partitioner& rp,
+    const hpx::program_options::variables_map& vm,
+    hpx::resource::scheduling_policy policy)
 {
     num_pools = 0;
 

--- a/tests/unit/resource/scheduler_binding_check.cpp
+++ b/tests/unit/resource/scheduler_binding_check.cpp
@@ -47,7 +47,7 @@ struct dec_counter
 
 void threadLoop()
 {
-    const unsigned iterations = 2048;
+    unsigned const iterations = 2048;
     std::atomic<int> count_down(iterations);
 
     auto f = [&count_down](std::size_t iteration, std::size_t thread_expected) {
@@ -106,7 +106,7 @@ int main(int argc, char* argv[])
     hpx::init_params init_args;
 
     init_args.rp_callback = [](auto& rp,
-                                const hpx::program_options::variables_map&) {
+                                hpx::program_options::variables_map const&) {
         // setup the default pool with a numa/binding aware scheduler
         rp.create_thread_pool("default",
             hpx::resource::scheduling_policy::shared_priority,

--- a/tests/unit/resource/shutdown_suspended_pus.cpp
+++ b/tests/unit/resource/shutdown_suspended_pus.cpp
@@ -53,7 +53,8 @@ void test_scheduler(
     hpx::init_params init_args;
 
     init_args.cfg = {"hpx.os_threads=4"};
-    init_args.rp_callback = [scheduler](auto& rp) {
+    init_args.rp_callback = [scheduler](auto& rp,
+                                const hpx::program_options::variables_map&) {
         rp.create_thread_pool("default", scheduler,
             hpx::threads::policies::scheduler_mode(
                 hpx::threads::policies::default_mode |

--- a/tests/unit/resource/shutdown_suspended_pus.cpp
+++ b/tests/unit/resource/shutdown_suspended_pus.cpp
@@ -54,7 +54,7 @@ void test_scheduler(
 
     init_args.cfg = {"hpx.os_threads=4"};
     init_args.rp_callback = [scheduler](auto& rp,
-                                const hpx::program_options::variables_map&) {
+                                hpx::program_options::variables_map const&) {
         rp.create_thread_pool("default", scheduler,
             hpx::threads::policies::scheduler_mode(
                 hpx::threads::policies::default_mode |

--- a/tests/unit/resource/suspend_disabled.cpp
+++ b/tests/unit/resource/suspend_disabled.cpp
@@ -49,7 +49,7 @@ int main(int argc, char* argv[])
 
     init_args.cfg = {"hpx.os_threads=4"};
     init_args.rp_callback = [](auto& rp,
-                                const hpx::program_options::variables_map&) {
+                                hpx::program_options::variables_map const&) {
         // Explicitly disable elasticity if it is in defaults
         rp.create_thread_pool("default",
             hpx::resource::scheduling_policy::local_priority_fifo,

--- a/tests/unit/resource/suspend_disabled.cpp
+++ b/tests/unit/resource/suspend_disabled.cpp
@@ -48,7 +48,8 @@ int main(int argc, char* argv[])
     hpx::init_params init_args;
 
     init_args.cfg = {"hpx.os_threads=4"};
-    init_args.rp_callback = [](auto& rp) {
+    init_args.rp_callback = [](auto& rp,
+                                const hpx::program_options::variables_map&) {
         // Explicitly disable elasticity if it is in defaults
         rp.create_thread_pool("default",
             hpx::resource::scheduling_policy::local_priority_fifo,

--- a/tests/unit/resource/suspend_pool.cpp
+++ b/tests/unit/resource/suspend_pool.cpp
@@ -139,7 +139,8 @@ void test_scheduler(
     hpx::init_params init_args;
 
     init_args.cfg = {"hpx.os_threads=4"};
-    init_args.rp_callback = [scheduler](auto& rp) {
+    init_args.rp_callback = [scheduler](auto& rp,
+                                const hpx::program_options::variables_map&) {
         rp.create_thread_pool("worker", scheduler);
 
         int const worker_pool_threads = 3;

--- a/tests/unit/resource/suspend_pool.cpp
+++ b/tests/unit/resource/suspend_pool.cpp
@@ -140,17 +140,17 @@ void test_scheduler(
 
     init_args.cfg = {"hpx.os_threads=4"};
     init_args.rp_callback = [scheduler](auto& rp,
-                                const hpx::program_options::variables_map&) {
+                                hpx::program_options::variables_map const&) {
         rp.create_thread_pool("worker", scheduler);
 
         int const worker_pool_threads = 3;
         int worker_pool_threads_added = 0;
 
-        for (const hpx::resource::numa_domain& d : rp.numa_domains())
+        for (hpx::resource::numa_domain const& d : rp.numa_domains())
         {
-            for (const hpx::resource::core& c : d.cores())
+            for (hpx::resource::core const& c : d.cores())
             {
-                for (const hpx::resource::pu& p : c.pus())
+                for (hpx::resource::pu const& p : c.pus())
                 {
                     if (worker_pool_threads_added < worker_pool_threads)
                     {

--- a/tests/unit/resource/suspend_pool_external.cpp
+++ b/tests/unit/resource/suspend_pool_external.cpp
@@ -32,7 +32,7 @@ void test_scheduler(
 
     init_args.cfg = {"hpx.os_threads=4"};
     init_args.rp_callback = [scheduler](auto& rp,
-                                const hpx::program_options::variables_map&) {
+                                hpx::program_options::variables_map const&) {
         rp.create_thread_pool("default", scheduler);
     };
 

--- a/tests/unit/resource/suspend_pool_external.cpp
+++ b/tests/unit/resource/suspend_pool_external.cpp
@@ -31,7 +31,8 @@ void test_scheduler(
     hpx::init_params init_args;
 
     init_args.cfg = {"hpx.os_threads=4"};
-    init_args.rp_callback = [scheduler](auto& rp) {
+    init_args.rp_callback = [scheduler](auto& rp,
+                                const hpx::program_options::variables_map&) {
         rp.create_thread_pool("default", scheduler);
     };
 

--- a/tests/unit/resource/suspend_runtime.cpp
+++ b/tests/unit/resource/suspend_runtime.cpp
@@ -28,7 +28,7 @@ void test_scheduler(
 
     init_args.cfg = {"hpx.os_threads=4"};
     init_args.rp_callback = [scheduler](auto& rp,
-                                const hpx::program_options::variables_map&) {
+                                hpx::program_options::variables_map const&) {
         rp.create_thread_pool("default", scheduler);
     };
 

--- a/tests/unit/resource/suspend_runtime.cpp
+++ b/tests/unit/resource/suspend_runtime.cpp
@@ -27,7 +27,8 @@ void test_scheduler(
     hpx::init_params init_args;
 
     init_args.cfg = {"hpx.os_threads=4"};
-    init_args.rp_callback = [scheduler](auto& rp) {
+    init_args.rp_callback = [scheduler](auto& rp,
+                                const hpx::program_options::variables_map&) {
         rp.create_thread_pool("default", scheduler);
     };
 

--- a/tests/unit/resource/suspend_thread.cpp
+++ b/tests/unit/resource/suspend_thread.cpp
@@ -199,7 +199,7 @@ void test_scheduler(
     hpx::init_params init_args;
     init_args.cfg = {"hpx.os_threads=4"};
     init_args.rp_callback = [scheduler](auto& rp,
-                                const hpx::program_options::variables_map&) {
+                                hpx::program_options::variables_map const&) {
         rp.create_thread_pool("default", scheduler,
             hpx::threads::policies::scheduler_mode(
                 hpx::threads::policies::default_mode |

--- a/tests/unit/resource/suspend_thread.cpp
+++ b/tests/unit/resource/suspend_thread.cpp
@@ -13,8 +13,8 @@
 #include <hpx/include/threads.hpp>
 #include <hpx/modules/schedulers.hpp>
 #include <hpx/modules/testing.hpp>
-#include <hpx/threading_base/scheduler_mode.hpp>
 #include <hpx/modules/timing.hpp>
+#include <hpx/threading_base/scheduler_mode.hpp>
 
 #include <cstddef>
 #include <memory>
@@ -198,7 +198,8 @@ void test_scheduler(
 {
     hpx::init_params init_args;
     init_args.cfg = {"hpx.os_threads=4"};
-    init_args.rp_callback = [scheduler](auto& rp) {
+    init_args.rp_callback = [scheduler](auto& rp,
+                                const hpx::program_options::variables_map&) {
         rp.create_thread_pool("default", scheduler,
             hpx::threads::policies::scheduler_mode(
                 hpx::threads::policies::default_mode |

--- a/tests/unit/resource/suspend_thread_external.cpp
+++ b/tests/unit/resource/suspend_thread_external.cpp
@@ -153,7 +153,7 @@ void test_scheduler(
 
     init_args.cfg = {"hpx.os_threads=4"};
     init_args.rp_callback = [scheduler](auto& rp,
-                                const hpx::program_options::variables_map&) {
+                                hpx::program_options::variables_map const&) {
         rp.create_thread_pool("worker", scheduler,
             hpx::threads::policies::scheduler_mode(
                 hpx::threads::policies::default_mode |
@@ -162,11 +162,11 @@ void test_scheduler(
         int const worker_pool_threads = 3;
         int worker_pool_threads_added = 0;
 
-        for (const hpx::resource::numa_domain& d : rp.numa_domains())
+        for (hpx::resource::numa_domain const& d : rp.numa_domains())
         {
-            for (const hpx::resource::core& c : d.cores())
+            for (hpx::resource::core const& c : d.cores())
             {
-                for (const hpx::resource::pu& p : c.pus())
+                for (hpx::resource::pu const& p : c.pus())
                 {
                     if (worker_pool_threads_added < worker_pool_threads)
                     {

--- a/tests/unit/resource/suspend_thread_external.cpp
+++ b/tests/unit/resource/suspend_thread_external.cpp
@@ -13,8 +13,8 @@
 #include <hpx/include/threads.hpp>
 #include <hpx/modules/schedulers.hpp>
 #include <hpx/modules/testing.hpp>
-#include <hpx/threading_base/scheduler_mode.hpp>
 #include <hpx/modules/timing.hpp>
+#include <hpx/threading_base/scheduler_mode.hpp>
 
 #include <cstddef>
 #include <memory>
@@ -152,7 +152,8 @@ void test_scheduler(
     hpx::init_params init_args;
 
     init_args.cfg = {"hpx.os_threads=4"};
-    init_args.rp_callback = [scheduler](auto& rp) {
+    init_args.rp_callback = [scheduler](auto& rp,
+                                const hpx::program_options::variables_map&) {
         rp.create_thread_pool("worker", scheduler,
             hpx::threads::policies::scheduler_mode(
                 hpx::threads::policies::default_mode |


### PR DESCRIPTION
Passing the variables map to the init callback for the resource
partitioner makes passing of options like "--pool-threads" more
straightforward than some of the alternatives such as parsing
the command-line twice.

Some of the examples/tests that use the resource partitioner
had copy/pasted a bunch of init from some very early tests and
some cleanup/simplication has been made, but not to all tests
so far.
