### PR TITLE
Scheduler mode

### DIFF
--- a/libs/core/threading_base/src/scheduler_base.cpp
+++ b/libs/core/threading_base/src/scheduler_base.cpp
@@ -103,7 +103,11 @@ namespace hpx { namespace threads { namespace policies {
     void scheduler_base::do_some_work(std::size_t)
     {
 #if defined(HPX_HAVE_THREAD_MANAGER_IDLE_BACKOFF)
-        cond_.notify_all();
+        if (mode_.data_.load(std::memory_order_relaxed) &
+            policies::enable_idle_backoff)
+        {
+            cond_.notify_all();
+        }
 #endif
     }
 

--- a/libs/full/threadmanager/src/threadmanager.cpp
+++ b/libs/full/threadmanager/src/threadmanager.cpp
@@ -224,7 +224,7 @@ namespace hpx { namespace threads {
                     new local_sched_type(init));
 
                 // set the default scheduler flags
-                sched->add_scheduler_mode(thread_pool_init.mode_);
+                sched->set_scheduler_mode(thread_pool_init.mode_);
                 // conditionally set/unset this flag
                 sched->update_scheduler_mode(
                     policies::enable_stealing_numa, !numa_sensitive);
@@ -268,7 +268,7 @@ namespace hpx { namespace threads {
                     new local_sched_type(init));
 
                 // set the default scheduler flags
-                sched->add_scheduler_mode(thread_pool_init.mode_);
+                sched->set_scheduler_mode(thread_pool_init.mode_);
                 // conditionally set/unset this flag
                 sched->update_scheduler_mode(
                     policies::enable_stealing_numa, !numa_sensitive);
@@ -308,7 +308,7 @@ namespace hpx { namespace threads {
                     new local_sched_type(init));
 
                 // set the default scheduler flags
-                sched->add_scheduler_mode(thread_pool_init.mode_);
+                sched->set_scheduler_mode(thread_pool_init.mode_);
                 // conditionally set/unset this flag
                 sched->update_scheduler_mode(
                     policies::enable_stealing_numa, !numa_sensitive);
@@ -345,7 +345,7 @@ namespace hpx { namespace threads {
                     new local_sched_type(init));
 
                 // set the default scheduler flags
-                sched->add_scheduler_mode(thread_pool_init.mode_);
+                sched->set_scheduler_mode(thread_pool_init.mode_);
                 // conditionally set/unset this flag
                 sched->update_scheduler_mode(
                     policies::enable_stealing_numa, !numa_sensitive);
@@ -389,7 +389,7 @@ namespace hpx { namespace threads {
                     new local_sched_type(init));
 
                 // set the default scheduler flags
-                sched->add_scheduler_mode(thread_pool_init.mode_);
+                sched->set_scheduler_mode(thread_pool_init.mode_);
                 // conditionally set/unset this flag
                 sched->update_scheduler_mode(
                     policies::enable_stealing_numa, !numa_sensitive);
@@ -436,7 +436,7 @@ namespace hpx { namespace threads {
                     new local_sched_type(init));
 
                 // set the default scheduler flags
-                sched->add_scheduler_mode(thread_pool_init.mode_);
+                sched->set_scheduler_mode(thread_pool_init.mode_);
                 // conditionally set/unset this flag
                 sched->update_scheduler_mode(
                     policies::enable_stealing_numa, !numa_sensitive);
@@ -484,7 +484,7 @@ namespace hpx { namespace threads {
                     new local_sched_type(init));
 
                 // set the default scheduler flags
-                sched->add_scheduler_mode(thread_pool_init.mode_);
+                sched->set_scheduler_mode(thread_pool_init.mode_);
                 // conditionally set/unset this flag
                 sched->update_scheduler_mode(
                     policies::enable_stealing_numa, !numa_sensitive);
@@ -519,7 +519,7 @@ namespace hpx { namespace threads {
                     new local_sched_type(init));
 
                 // set the default scheduler flags
-                sched->add_scheduler_mode(thread_pool_init.mode_);
+                sched->set_scheduler_mode(thread_pool_init.mode_);
                 // conditionally set/unset this flag
                 sched->update_scheduler_mode(
                     policies::enable_stealing_numa, !numa_sensitive);


### PR DESCRIPTION
I had problems with background idle flags being set even when I had set them to off - this PR fixes a wrong use of add_scheduler_mode - it should be set_scheduler_mode on initialization.

I also protected a couple of places that don't need to be run when the idle flag is unset.