### PR TITLE
Fix a link error when async_cuda is enabled, but not cuda_compute

### DIFF
--- a/cmake/HPX_AddExecutable.cmake
+++ b/cmake/HPX_AddExecutable.cmake
@@ -194,10 +194,7 @@ function(add_hpx_executable name)
     endforeach()
   endif()
 
-  if(HPX_WITH_CUDA
-     AND (HPX_WITH_CUDA_COMPUTE OR HPX_WITH_ASYNC_CUDA)
-     AND NOT HPX_WITH_CUDA_CLANG
-  )
+  if((HPX_WITH_CUDA_COMPUTE OR HPX_WITH_ASYNC_CUDA) AND NOT HPX_WITH_CUDA_CLANG)
     cuda_add_executable(
       ${name} ${${name}_SOURCES} ${${name}_HEADERS} ${${name}_AUXILIARY}
     )

--- a/libs/full/async_cuda/CMakeLists.txt
+++ b/libs/full/async_cuda/CMakeLists.txt
@@ -51,7 +51,7 @@ endif()
 
 if(HPX_WITH_HIP AND TARGET roc::hipblas)
   set(async_cuda_extra_deps ${async_cuda_extra_deps} roc::hipblas)
-elseif(HPX_WITH_CUDA AND TARGET Cuda::cuda)
+elseif(HPX_WITH_ASYNC_CUDA AND TARGET Cuda::cuda)
   set(async_cuda_extra_deps ${async_cuda_extra_deps} Cuda::cuda
                             ${CUDA_CUBLAS_LIBRARIES}
   )
@@ -71,3 +71,6 @@ add_hpx_module(
   DEPENDENCIES hpx_core hpx_parallelism ${async_cuda_extra_deps}
   CMAKE_SUBDIRS examples tests
 )
+
+# if(HPX_WITH_ASYNC_CUDA AND TARGET Cuda::cuda)
+# CUDA_ADD_CUBLAS_TO_TARGET(hpx_async_cuda) endif()


### PR DESCRIPTION
Just replaces a couple of CUDA statements with ASYNC_CUDA in cmake - not 100% tested, but dashboard should reveal if it causes trouble