### PR TITLE
Store annotated_function annotations as std::strings

### DIFF
--- a/libs/core/threading_base/CMakeLists.txt
+++ b/libs/core/threading_base/CMakeLists.txt
@@ -59,6 +59,7 @@ set(threading_base_compat_headers
 # cmake-format: on
 
 set(threading_base_sources
+    annotated_function.cpp
     execution_agent.cpp
     external_timer.cpp
     print.cpp

--- a/libs/core/threading_base/include/hpx/threading_base/annotated_function.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/annotated_function.hpp
@@ -37,7 +37,7 @@ namespace hpx { namespace util {
     {
         HPX_NON_COPYABLE(annotate_function);
 
-        explicit annotate_function(std::string const&) {}
+        explicit annotate_function(std::string) {}
         template <typename F>
         explicit HPX_HOST_DEVICE annotate_function(F&&)
         {
@@ -51,9 +51,9 @@ namespace hpx { namespace util {
     {
         HPX_NON_COPYABLE(annotate_function);
 
-        explicit annotate_function(std::string const& name)
-          : name_(name)
-          , task_(thread_domain_, hpx::util::itt::string_handle(name))
+        explicit annotate_function(std::string name)
+          : name_(std::move(name))
+          , task_(thread_domain_, hpx::util::itt::string_handle(name.c_str()))
         {
         }
         template <typename F>
@@ -74,8 +74,8 @@ namespace hpx { namespace util {
     {
         HPX_NON_COPYABLE(annotate_function);
 
-        explicit annotate_function(std::string const& name)
-          : name_(name)
+        explicit annotate_function(std::string name)
+          : name_(std::move(name))
           , desc_(hpx::threads::get_self_ptr() ?
                     hpx::threads::set_thread_description(
                         hpx::threads::get_self_id(), name_.c_str()) :
@@ -125,15 +125,15 @@ namespace hpx { namespace util {
             {
             }
 
-            annotated_function(F const& f, std::string const& name)
+            annotated_function(F const& f, std::string name)
               : f_(f)
-              , name_(name)
+              , name_(std::move(name))
             {
             }
 
-            annotated_function(F&& f, std::string const& name)
+            annotated_function(F&& f, std::string name)
               : f_(std::move(f))
-              , name_(name)
+              , name_(std::move(name))
             {
             }
 
@@ -187,12 +187,12 @@ namespace hpx { namespace util {
 
     template <typename F>
     detail::annotated_function<typename std::decay<F>::type> annotated_function(
-        F&& f, std::string const& name = "")
+        F&& f, std::string name = "")
     {
         typedef detail::annotated_function<typename std::decay<F>::type>
             result_type;
 
-        return result_type(std::forward<F>(f), name);
+        return result_type(std::forward<F>(f), std::move(name));
     }
 
 #else
@@ -201,7 +201,7 @@ namespace hpx { namespace util {
     {
         HPX_NON_COPYABLE(annotate_function);
 
-        explicit annotate_function(std::string const& /*name*/) {}
+        explicit annotate_function(std::string /*name*/) {}
         template <typename F>
         explicit HPX_HOST_DEVICE annotate_function(F&& /*f*/)
         {
@@ -218,7 +218,7 @@ namespace hpx { namespace util {
     ///
     /// \param function
     template <typename F>
-    F&& annotated_function(F&& f, std::string const& = "")
+    F&& annotated_function(F&& f, std::string = "")
     {
         return std::forward<F>(f);
     }

--- a/libs/core/threading_base/src/annotated_function.cpp
+++ b/libs/core/threading_base/src/annotated_function.cpp
@@ -1,0 +1,23 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#if defined(HPX_HAVE_THREAD_DESCRIPTION) && defined(HPX_HAVE_APEX)
+#include <hpx/threading_base/annotated_function.hpp>
+
+#include <string>
+#include <unordered_set>
+#include <utility>
+
+namespace hpx { namespace util { namespace detail {
+    char const* store_function_annotation(std::string&& name)
+    {
+        static thread_local std::unordered_set<std::string> names;
+        auto r = names.insert(std::move(name));
+        return (*std::get<0>(r)).c_str();
+    }
+}}}    // namespace hpx::util::detail
+#endif


### PR DESCRIPTION
Storing the annotations in the `annotated_function` wrapper ensures that the annotations live at least until its `operator()` is called, by which point the annotation should already have been set to APEX.

The `annotation_check` test is updated to use dynamically allocated annotations which go out of scope before the tasks have completed (and it fails before the second commit in this PR).

Fixes #5126.