### PR TITLE
Adapt remove_copy(_if) to C++20

### DIFF
--- a/libs/full/include/include/hpx/algorithm.hpp
+++ b/libs/full/include/include/hpx/algorithm.hpp
@@ -20,8 +20,6 @@ namespace hpx {
     using hpx::parallel::minmax_element;
     using hpx::parallel::partition;
     using hpx::parallel::partition_copy;
-    using hpx::parallel::remove_copy;
-    using hpx::parallel::remove_copy_if;
     using hpx::parallel::replace;
     using hpx::parallel::replace_copy;
     using hpx::parallel::replace_copy_if;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
@@ -35,10 +35,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \cond NOINTERNAL
 
         // sequential remove_copy
-        template <typename InIter, typename OutIter, typename T, typename Proj>
-        inline util::in_out_result<InIter, OutIter> sequential_remove_copy(
-            InIter first, InIter last, OutIter dest, T const& value,
-            Proj&& proj)
+        template <typename InIter, typename Sent, typename OutIter, typename T,
+            typename Proj>
+        constexpr inline util::in_out_result<InIter, OutIter>
+        sequential_remove_copy(
+            InIter first, Sent last, OutIter dest, T const& value, Proj&& proj)
         {
             for (/* */; first != last; ++first)
             {
@@ -59,21 +60,21 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
             }
 
-            template <typename ExPolicy, typename InIter, typename OutIter,
-                typename T, typename Proj>
+            template <typename ExPolicy, typename InIter, typename Sent,
+                typename OutIter, typename T, typename Proj>
             static util::in_out_result<InIter, OutIter> sequential(ExPolicy,
-                InIter first, InIter last, OutIter dest, T const& val,
+                InIter first, Sent last, OutIter dest, T const& val,
                 Proj&& proj)
             {
                 return sequential_remove_copy(
                     first, last, dest, val, std::forward<Proj>(proj));
             }
 
-            template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-                typename T, typename Proj>
+            template <typename ExPolicy, typename FwdIter1, typename Sent,
+                typename FwdIter2, typename T, typename Proj>
             static typename util::detail::algorithm_result<ExPolicy,
                 util::in_out_result<FwdIter1, FwdIter2>>::type
-            parallel(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+            parallel(ExPolicy&& policy, FwdIter1 first, Sent last,
                 FwdIter2 dest, T const& val, Proj&& proj)
             {
                 return copy_if<IterPair>().call(
@@ -151,18 +152,25 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           element in the destination range, one past the last element
     ///           copied.
     ///
+    // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename T, typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&& hpx::
-                traits::is_iterator<FwdIter1>::value&& hpx::traits::is_iterator<
-                    FwdIter2>::value&& traits::is_projected<Proj,
-                    FwdIter1>::value&& traits::is_indirect_callable<ExPolicy,
-                    std::equal_to<T>, traits::projected<Proj, FwdIter1>,
-                    traits::projected<Proj, T const*>>::value)>
-    typename util::detail::algorithm_result<ExPolicy,
-        util::in_out_result<FwdIter1, FwdIter2>>::type
-    remove_copy(ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest,
-        T const& val, Proj&& proj = Proj())
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value&&
+            hpx::traits::is_iterator<FwdIter1>::value&&
+            hpx::traits::is_iterator<FwdIter2>::value&&
+            traits::is_projected<Proj,FwdIter1>::value&&
+            traits::is_indirect_callable<ExPolicy,
+                std::equal_to<T>, traits::projected<Proj, FwdIter1>,
+                traits::projected<Proj, T const*>>::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::remove_if is deprecated, use hpx::remove_if instead")
+        typename util::detail::algorithm_result<ExPolicy,
+            util::in_out_result<FwdIter1, FwdIter2>>::type
+        remove_copy(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+            FwdIter2 dest, T const& val, Proj&& proj = Proj())
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
             "Requires at least forward iterator.");
@@ -182,9 +190,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \cond NOINTERNAL
 
         // sequential remove_copy_if
-        template <typename InIter, typename OutIter, typename F, typename Proj>
+        template <typename InIter, typename Sent, typename OutIter, typename F,
+            typename Proj>
         inline util::in_out_result<InIter, OutIter> sequential_remove_copy_if(
-            InIter first, InIter last, OutIter dest, F p, Proj&& proj)
+            InIter first, Sent last, OutIter dest, F p, Proj&& proj)
         {
             for (/* */; first != last; ++first)
             {
@@ -206,20 +215,20 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
             }
 
-            template <typename ExPolicy, typename InIter, typename OutIter,
-                typename F, typename Proj>
+            template <typename ExPolicy, typename InIter, typename Sent,
+                typename OutIter, typename F, typename Proj>
             static util::in_out_result<InIter, OutIter> sequential(ExPolicy,
-                InIter first, InIter last, OutIter dest, F&& f, Proj&& proj)
+                InIter first, Sent last, OutIter dest, F&& f, Proj&& proj)
             {
                 return sequential_remove_copy_if(first, last, dest,
                     std::forward<F>(f), std::forward<Proj>(proj));
             }
 
-            template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-                typename F, typename Proj>
+            template <typename ExPolicy, typename FwdIter1, typename Sent,
+                typename FwdIter2, typename F, typename Proj>
             static typename util::detail::algorithm_result<ExPolicy,
                 util::in_out_result<FwdIter1, FwdIter2>>::type
-            parallel(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+            parallel(ExPolicy&& policy, FwdIter1 first, Sent last,
                 FwdIter2 dest, F&& f, Proj&& proj)
             {
                 typedef typename std::iterator_traits<FwdIter1>::value_type
@@ -318,18 +327,24 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           element in the destination range, one past the last element
     ///           copied.
     ///
+    // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename F, typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<FwdIter1>::value&&
-                    traits::is_projected<Proj, FwdIter1>::value&&
-                        traits::is_indirect_callable<ExPolicy, F,
-                            traits::projected<Proj, FwdIter1>>::value&&
-                            hpx::traits::is_iterator<FwdIter2>::value)>
-    typename util::detail::algorithm_result<ExPolicy,
-        util::in_out_result<FwdIter1, FwdIter2>>::type
-    remove_copy_if(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
-        FwdIter2 dest, F&& f, Proj&& proj = Proj())
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value&&
+            hpx::traits::is_iterator<FwdIter1>::value&&
+            traits::is_projected<Proj, FwdIter1>::value&&
+                traits::is_indirect_callable<ExPolicy, F,
+                    traits::projected<Proj, FwdIter1>>::value&&
+            hpx::traits::is_iterator<FwdIter2>::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::remove_if is deprecated, use hpx::remove_if instead")
+        typename util::detail::algorithm_result<ExPolicy,
+            util::in_out_result<FwdIter1, FwdIter2>>::type
+        remove_copy_if(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+            FwdIter2 dest, F&& f, Proj&& proj = Proj())
     {
         static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
             "Requires at least forward iterator.");
@@ -343,3 +358,129 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 std::forward<F>(f), std::forward<Proj>(proj));
     }
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx {
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::remove_copy_if
+    HPX_INLINE_CONSTEXPR_VARIABLE struct remove_copy_if_t final
+      : hpx::functional::tag<remove_copy_if_t>
+    {
+        // clang-format off
+        template <typename InIter, typename OutIter,
+            typename Pred, HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_iterator<OutIter>::value &&
+                hpx::is_invocable_v<Pred,
+                    typename std::iterator_traits<InIter>::value_type
+                >
+            )>
+        // clang-format on
+        friend OutIter tag_invoke(hpx::remove_copy_if_t, InIter first,
+            InIter last, OutIter dest, Pred&& pred)
+        {
+            static_assert((hpx::traits::is_input_iterator<InIter>::value),
+                "Required input iterator.");
+
+            static_assert((hpx::traits::is_output_iterator<InIter>::value),
+                "Required output iterator.");
+
+            auto&& res =
+                hpx::parallel::v1::detail::remove_copy_if<
+                    hpx::parallel::util::in_out_result<InIter, OutIter>>()
+                    .call(hpx::execution::sequenced_policy{}, std::true_type{},
+                        first, last, dest, std::forward<Pred>(pred),
+                        hpx::parallel::util::projection_identity());
+
+            return hpx::parallel::util::get_second_element(std::move(res));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+            typename Pred, HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value&&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::is_invocable_v<Pred,
+                    typename std::iterator_traits<FwdIter1>::value_type
+                >
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter2>::type
+        tag_invoke(hpx::remove_copy_if_t, ExPolicy&& policy, FwdIter1 first,
+            FwdIter1 last, FwdIter2 dest, Pred&& pred)
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Required at least forward iterator.");
+
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+                "Required at least forward iterator.");
+
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
+
+            auto&& res = hpx::parallel::v1::detail::remove_copy_if<
+                hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
+                             .call(std::forward<ExPolicy>(policy), is_seq(),
+                                 first, last, dest, std::forward<Pred>(pred),
+                                 hpx::parallel::util::projection_identity());
+
+            return hpx::parallel::util::get_second_element(std::move(res));
+        }
+    } remove_copy_if{};
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::remove_copy
+    HPX_INLINE_CONSTEXPR_VARIABLE struct remove_copy_t final
+      : hpx::functional::tag<remove_copy_t>
+    {
+    private:
+        // clang-format off
+        template <typename InIter, typename OutIter,
+            typename T, HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_iterator<OutIter>::value
+            )>
+        // clang-format on
+        friend OutIter tag_invoke(hpx::remove_copy_t, InIter first, InIter last,
+            OutIter dest, T const& value)
+        {
+            static_assert((hpx::traits::is_input_iterator<InIter>::value),
+                "Requires at least input iterator.");
+
+            static_assert((hpx::traits::is_output_iterator<InIter>::value),
+                "Requires at least output iterator.");
+
+            typedef typename std::iterator_traits<InIter>::value_type Type;
+
+            return hpx::remove_copy_if(first, last, dest,
+                [value](Type const& a) -> bool { return value == a; });
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+            typename T, HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value&&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            FwdIter2>::type
+        tag_invoke(hpx::remove_copy_t, ExPolicy&& policy, FwdIter1 first,
+            FwdIter1 last, FwdIter2 dest, T const& value)
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Required at least forward iterator.");
+
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+                "Required at least forward iterator.");
+
+            typedef typename std::iterator_traits<FwdIter1>::value_type Type;
+
+            return hpx::remove_copy_if(std::forward<ExPolicy>(policy), first,
+                last, dest,
+                [value](Type const& a) -> bool { return value == a; });
+        }
+
+    } remove_copy{};
+}    // namespace hpx

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2015 Daniel Bourgeois
+//  Copyright (c) 2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,6 +8,248 @@
 /// \file parallel/algorithms/remove_copy.hpp
 
 #pragma once
+
+#if defined(DOXYGEN)
+namespace hpx {
+
+    /// Copies the elements in the range, defined by [first, last), to another
+    /// range beginning at \a dest. Copies only the elements for which the
+    /// comparison operator returns false when compare to value.
+    /// The order of the elements that are not removed is preserved.
+    ///
+    /// Effects: Copies all the elements referred to by the iterator it in the
+    ///          range [first,last) for which the following corresponding
+    ///          conditions do not hold: *it == value
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first applications of the
+    ///         predicate \a f.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam T           The type that the result of dereferencing FwdIter1 is
+    ///                     compared to.
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param val          Value to be removed.
+    ///
+    /// The assignments in the parallel \a remove_copy algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    /// \returns  The \a remove_copy algorithm returns an
+    ///           \a OutIter.
+    ///           The \a remove_copy algorithm returns the
+    ///           iterator to the element past the last element copied.
+    ///
+    template <typename InIter, typename OutIter, typename T>
+    FwdIter remove_copy(
+        InIter first, InIter last, OutIter dest, T const& value);
+
+    /// Copies the elements in the range, defined by [first, last), to another
+    /// range beginning at \a dest. Copies only the elements for which the
+    /// comparison operator returns false when compare to value.
+    /// The order of the elements that are not removed is preserved.
+    ///
+    /// Effects: Copies all the elements referred to by the iterator it in the
+    ///          range [first,last) for which the following corresponding
+    ///          conditions do not hold: *it == value
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first applications of the
+    ///         predicate \a f.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam T           The type that the result of dereferencing FwdIter1 is
+    ///                     compared to.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param val          Value to be removed.
+    ///
+    /// The assignments in the parallel \a remove_copy algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a remove_copy algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a remove_copy algorithm returns a
+    ///           \a hpx::future<FwdIter2>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2
+    ///           otherwise.
+    ///           The \a remove_copy algorithm returns the
+    ///           iterator to the element past the last element copied.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename T>
+    FwdIter remove_copy(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+        FwdIter2 dest, T const& val);
+
+    /// Copies the elements in the range, defined by [first, last), to another
+    /// range beginning at \a dest. Copies only the elements for which the
+    /// predicate \a f returns false. The order of the elements that are not
+    /// removed is preserved.
+    ///
+    /// Effects: Copies all the elements referred to by the iterator it in the
+    ///          range [first,last) for which the following corresponding
+    ///          conditions do not hold:
+    ///          INVOKE(pred, *it) != false.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first applications of the
+    ///         predicate \a f.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced).
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     elements to be removed. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a InIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///
+    /// The assignments in the parallel \a remove_copy_if algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    ///
+    /// \returns  The \a remove_copy_if algorithm returns an
+    ///           \a OutIter
+    ///           The \a remove_copy_if algorithm returns the
+    ///           iterator to the element past the last element copied.
+    ///
+    template <typename InIter, typename OutIter, typename Pred>
+    FwdIter remove_copy_if(
+        InIter first, InIter last, OutIter dest, Pred&& pred);
+
+    /// Copies the elements in the range, defined by [first, last), to another
+    /// range beginning at \a dest. Copies only the elements for which the
+    /// predicate \a f returns false. The order of the elements that are not
+    /// removed is preserved.
+    ///
+    /// Effects: Copies all the elements referred to by the iterator it in the
+    ///          range [first,last) for which the following corresponding
+    ///          conditions do not hold:
+    ///          INVOKE(pred, *it) != false.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first applications of the
+    ///         predicate \a f.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a remove_copy_if requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     elements to be removed. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to Type.
+    ///
+    /// The assignments in the parallel \a remove_copy_if algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a remove_copy_if algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a remove_copy_if algorithm returns a
+    ///           \a hpx::future<FwdIter2>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2
+    ///           otherwise.
+    ///           The \a remove_copy_if algorithm returns the
+    ///           iterator to the element past the last element copied.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename Pred>
+    FwdIter remove_copy_if(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+        FwdIter2 dest, Pred&& pred);
+
+}    // namespace hpx
+
+#else    // DOXYGEN
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
@@ -87,71 +330,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Copies the elements in the range, defined by [first, last), to another
-    /// range beginning at \a dest. Copies only the elements for which the
-    /// comparison operator returns false when compare to val.
-    /// The order of the elements that are not removed is preserved.
-    ///
-    /// Effects: Copies all the elements referred to by the iterator it in the
-    ///          range [first,last) for which the following corresponding
-    ///          conditions do not hold: INVOKE(proj, *it) == value
-    ///
-    /// \note   Complexity: Performs not more than \a last - \a first
-    ///         assignments, exactly \a last - \a first applications of the
-    ///         predicate \a f.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter1    The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam T           The type that the result of dereferencing FwdIter1 is
-    ///                     compared to.
-    /// \tparam Proj        The type of an optional projection function. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param val          Value to be removed.
-    /// \param proj         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements as a
-    ///                     projection operation before the actual predicate
-    ///                     \a is invoked.
-    ///
-    /// The assignments in the parallel \a remove_copy algorithm invoked with
-    /// an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The assignments in the parallel \a remove_copy algorithm invoked with
-    /// an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a remove_copy algorithm returns a
-    ///           \a hpx::future<tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)> >
-    ///           if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)>
-    ///           otherwise.
-    ///           The \a copy algorithm returns the pair of the input iterator
-    ///           forwarded to the first element after the last in the input
-    ///           sequence and the output iterator to the
-    ///           element in the destination range, one past the last element
-    ///           copied.
-    ///
     // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename T, typename Proj = util::projection_identity,
@@ -246,87 +424,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Copies the elements in the range, defined by [first, last), to another
-    /// range beginning at \a dest. Copies only the elements for which the
-    /// predicate \a f returns false. The order of the elements that are not
-    /// removed is preserved.
-    ///
-    /// Effects: Copies all the elements referred to by the iterator it in the
-    ///          range [first,last) for which the following corresponding
-    ///          conditions do not hold:
-    ///          INVOKE(pred, INVOKE(proj, *it)) != false.
-    ///
-    /// \note   Complexity: Performs not more than \a last - \a first
-    ///         assignments, exactly \a last - \a first applications of the
-    ///         predicate \a f.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter1     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2     The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam F           The type of the function/function object to use
-    ///                     (deduced). Unlike its sequential form, the parallel
-    ///                     overload of \a copy_if requires \a F to meet the
-    ///                     requirements of \a CopyConstructible.
-    /// \tparam Proj        The type of an optional projection function. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param f            Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last).This is an
-    ///                     unary predicate which returns \a true for the
-    ///                     elements to be removed. The signature of this predicate
-    ///                     should be equivalent to:
-    ///                     \code
-    ///                     bool pred(const Type &a);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it. The type \a Type must be such that an object of
-    ///                     type \a FwdIter1 can be dereferenced and then
-    ///                     implicitly converted to Type.
-    /// \param proj         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements as a
-    ///                     projection operation before the actual predicate
-    ///                     \a is invoked.
-    ///
-    /// The assignments in the parallel \a remove_copy_if algorithm invoked with
-    /// an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The assignments in the parallel \a remove_copy_if algorithm invoked with
-    /// an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a remove_copy_if algorithm returns a
-    ///           \a hpx::future<tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)> >
-    ///           if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)>
-    ///           otherwise.
-    ///           The \a copy algorithm returns the pair of the input iterator
-    ///           forwarded to the first element after the last in the input
-    ///           sequence and the output iterator to the
-    ///           element in the destination range, one past the last element
-    ///           copied.
-    ///
     // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename F, typename Proj = util::projection_identity,
@@ -484,3 +581,5 @@ namespace hpx {
 
     } remove_copy{};
 }    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove_copy.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2015 Hartmut Kaiser
+//  Copyright (c) 2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,25 +9,182 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/concepts/concepts.hpp>
-#include <hpx/iterator_support/range.hpp>
-#include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/iterator_support/traits/is_range.hpp>
-#include <hpx/parallel/util/tagged_pair.hpp>
+#if defined(DOXYGEN)
+namespace hpx {
 
-#include <hpx/algorithms/traits/projected.hpp>
-#include <hpx/algorithms/traits/projected_range.hpp>
-#include <hpx/parallel/algorithms/remove_copy.hpp>
-#include <hpx/parallel/tagspec.hpp>
-#include <hpx/parallel/util/projection_identity.hpp>
-#include <hpx/parallel/util/result_types.hpp>
-
-#include <type_traits>
-#include <utility>
-
-namespace hpx { namespace parallel { inline namespace v1 {
     /// Copies the elements in the range, defined by [first, last), to another
+    /// range beginning at \a dest. Copies only the elements for which the
+    /// comparison operator returns false when compare to val.
+    /// The order of the elements that are not removed is preserved.
+    ///
+    /// Effects: Copies all the elements referred to by the iterator it in the
+    ///          range [first,last) for which the following corresponding
+    ///          conditions do not hold: INVOKE(proj, *it) == value
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first applications of the
+    ///         predicate \a f.
+    ///
+    /// \tparam I           The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam S           The type of the end iterators used (deduced). This
+    ///                     sentinel type must be a sentinel for I.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam T           The type that the result of dereferencing InIter is
+    ///                     compared to.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param result       Refers to the beginning of the destination range.
+    /// \param val          Value to be removed.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a remove_copy algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    /// \returns  The \a ranges::remove_copy algorithm returns a
+    ///           \a ranges::remove_copy_result<I, O>
+    ///           The \a ranges::remove_copy algorithm returns an object
+    ///           {last, result + N}, where N is the number of
+    ///           elements copied.
+    ///
+    template <typename I, typename S, typename O, typename T,
+        typename Proj = hpx::parallel::util::projection_identity>
+    ranges::remove_copy_result<I, O> ranges::remove_copy(
+        I first, S last, O result, const T& val, Proj proj = {});
+
+    /// Copies the elements in the range, defined by [first, last), to another
+    /// range beginning at \a dest. Copies only the elements for which the
+    /// comparison operator returns false when compare to val.
+    /// The order of the elements that are not removed is preserved.
+    ///
+    /// Effects: Copies all the elements referred to by the iterator it in the
+    ///          range [first,last) for which the following corresponding
+    ///          conditions do not hold: INVOKE(proj, *it) == value
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first applications of the
+    ///         predicate \a f.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam I           The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     Forward iterator.
+    /// \tparam S           The type of the end iterators used (deduced). This
+    ///                     sentinel type must be a sentinel for I.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam T           The type that the result of dereferencing InIter is
+    ///                     compared to.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param result       Refers to the beginning of the destination range.
+    /// \param val          Value to be removed.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a remove_copy algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a remove_copy algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a ranges::remove_copy algorithm returns a
+    ///           \a hpx::future<ranges::remove_copy_result<I, O>>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a ranges::remove_copy_result<I, O>
+    ///           otherwise.
+    ///           The \a ranges::remove_copy algorithm returns an object
+    ///           {last, result + N}, where N is the number of
+    ///           elements copied.
+    ///
+    template <typename ExPolicy, typename I, typename S, typename O, typename T,
+        typename Proj = hpx::parallel::util::projection_identity>
+    ranges::remove_copy_result<I, O> ranges::remove_copy(ExPolicy&& policy,
+        I first, S last, O result, const T& val, Proj proj = {});
+
+    /// Copies the elements in the range, defined by rng, to another
+    /// range beginning at \a dest. Copies only the elements for which the
+    /// comparison operator returns false when compare to val.
+    /// The order of the elements that are not removed is preserved.
+    ///
+    /// Effects: Copies all the elements referred to by the iterator it in the
+    ///          range [first,last) for which the following corresponding
+    ///          conditions do not hold: INVOKE(proj, *it) == value
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first applications of the
+    ///         predicate \a f.
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam T           The type that the result of dereferencing InIter is
+    ///                     compared to.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param val          Value to be removed.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a remove_copy algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    /// \returns  The \a ranges::remove_copy algorithm returns a
+    ///           \a remove_copy_result<
+    ///            typename hpx::traits::range_iterator<Rng>::type, O>.
+    ///           The \a ranges::remove_copy algorithm returns an object
+    ///           {last, result + N}, where N is the number of
+    ///           elements copied.
+    ///
+    ///
+    template <typename Rng, typename O, typename T,
+        typename Proj = hpx::parallel::util::projection_identity>
+    remove_copy_result<typename hpx::traits::range_iterator<Rng>::type, O>
+    ranges::remove_copy(Rng&& rng, O dest, T const& val, Proj&& proj = Proj());
+
+    /// Copies the elements in the range, defined by rng, to another
     /// range beginning at \a dest. Copies only the elements for which the
     /// comparison operator returns false when compare to val.
     /// The order of the elements that are not removed is preserved.
@@ -46,7 +204,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// \tparam Rng         The type of the source range used (deduced).
     ///                     The iterators extracted from this range type must
     ///                     meet the requirements of an input iterator.
-    /// \tparam OutIter     The type of the iterator representing the
+    /// \tparam O           The type of the iterator representing the
     ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     output iterator.
@@ -76,43 +234,100 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a remove_copy algorithm returns a
-    ///           \a hpx::future<tagged_pair<tag::in(InIter), tag::out(OutIter)> >
+    /// \returns  The \a ranges::remove_copy algorithm returns a
+    ///           \a hpx::future<remove_copy_result<
+    ///            typename hpx::traits::range_iterator<Rng>::type, O>>
     ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a tagged_pair<tag::in(InIter), tag::out(OutIter)>
+    ///           returns \a remove_copy_result<
+    ///            typename hpx::traits::range_iterator<Rng>::type, O>
     ///           otherwise.
-    ///           The \a copy algorithm returns the pair of the input iterator
-    ///           forwarded to the first element after the last in the input
-    ///           sequence and the output iterator to the
-    ///           element in the destination range, one past the last element
-    ///           copied.
+    ///           The \a ranges::remove_copy algorithm returns an object
+    ///           {last, result + N}, where N is the number of
+    ///           elements copied.
     ///
-    template <typename ExPolicy, typename Rng, typename OutIter, typename T,
-        typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
-                    OutIter>::value&& traits::is_projected_range<Proj,
-                    Rng>::value&& traits::is_indirect_callable<ExPolicy,
-                    std::equal_to<T>, traits::projected_range<Proj, Rng>,
-                    traits::projected<Proj, T const*>>::value)>
-    typename util::detail::algorithm_result<ExPolicy,
-        util::in_out_result<
-            typename hpx::traits::range_traits<Rng>::iterator_type,
-            OutIter>>::type
-    remove_copy(ExPolicy&& policy, Rng&& rng, OutIter dest, T const& val,
-        Proj&& proj = Proj())
-    {
-        return remove_copy(std::forward<ExPolicy>(policy),
-            hpx::util::begin(rng), hpx::util::end(rng), dest, val,
-            std::forward<Proj>(proj));
-    }
+    template <typename ExPolicy, typename Rng, typename O, typename T,
+        typename Proj = hpx::parallel::util::projection_identity>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        remove_copy_result<typename hpx::traits::range_iterator<Rng>::type,
+            O>>::type
+    ranges::remove_copy(ExPolicy&& policy, Rng&& rng, O dest, T const& val,
+        Proj&& proj = Proj());
 
     /////////////////////////////////////////////////////////////////////////////
     /// Copies the elements in the range, defined by [first, last), to another
     /// range beginning at \a dest. Copies only the elements for which the
-    /// predicate \a f returns false. The order of the elements that are not
+    /// predicate \a pred returns false. The order of the elements that are not
+    /// removed is preserved.
+    ///
+    /// Effects: Copies all the elements referred to by the iterator it in the
+    ///          range [first,last) for which the following corresponding
+    ///          conditions do not hold:
+    ///          INVOKE(pred, INVOKE(proj, *it)) != false.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first applications of the
+    ///         predicate \a f.
+    ///
+    /// \tparam I           The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     Input iterator.
+    /// \tparam S           The type of the end iterators used (deduced). This
+    ///                     sentinel type must be a sentinel for I.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a remove_copy_if requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param result       Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     elements to be removed. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a InIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a remove_copy_if algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    /// \returns  The \a ranges::remove_copy_if algorithm
+    ///           returns \a ranges::remove_copy_if_result<I, O>.
+    ///           The \a ranges::remove_copy algorithm returns an object
+    ///           {last, result + N}, where N is the number of
+    ///           elements copied.
+    ///
+    template <typename I, typename Sent, typename O, typename Pred,
+        typename Proj = hpx::parallel::util::projection_identity>
+    ranges::remove_copy_if_result<I, O> ranges::remove_copy_if(
+        I first, Sent last, O dest, Pred&& pred, Proj&& proj = Proj());
+
+    /////////////////////////////////////////////////////////////////////////////
+    /// Copies the elements in the range, defined by [first, last), to another
+    /// range beginning at \a dest. Copies only the elements for which the
+    /// predicate \a pred returns false. The order of the elements that are not
     /// removed is preserved.
     ///
     /// Effects: Copies all the elements referred to by the iterator it in the
@@ -128,26 +343,30 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///                     It describes the manner in which the execution
     ///                     of the algorithm may be parallelized and the manner
     ///                     in which it executes the assignments.
-    /// \tparam Rng         The type of the source range used (deduced).
-    ///                     The iterators extracted from this range type must
-    ///                     meet the requirements of an input iterator.
-    /// \tparam OutIter     The type of the iterator representing the
+    /// \tparam I           The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     Forward iterator.
+    /// \tparam S           The type of the end iterators used (deduced). This
+    ///                     sentinel type must be a sentinel for I.
+    /// \tparam O           The type of the iterator representing the
     ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     output iterator.
-    /// \tparam F           The type of the function/function object to use
+    /// \tparam Pred        The type of the function/function object to use
     ///                     (deduced). Unlike its sequential form, the parallel
-    ///                     overload of \a copy_if requires \a F to meet the
+    ///                     overload of \a remove_copy_if requires \a Pred to meet the
     ///                     requirements of \a CopyConstructible.
     /// \tparam Proj        The type of an optional projection function. This
     ///                     defaults to \a util::projection_identity
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
-    /// \param rng          Refers to the sequence of elements the algorithm
-    ///                     will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param f            Specifies the function (or function object) which
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param result       Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
     ///                     will be invoked for each of the elements in the
     ///                     sequence specified by [first, last).This is an
     ///                     unary predicate which returns \a true for the
@@ -176,19 +395,222 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a remove_copy_if algorithm returns a
-    ///           \a hpx::future<tagged_pair<tag::in(InIter), tag::out(OutIter)> >
+    /// \returns  The \a ranges::remove_copy_if algorithm returns a
+    ///           \a hpx::future<ranges::remove_copy_if_result<I, O>>
     ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a tagged_pair<tag::in(InIter), tag::out(OutIter)>
+    ///           returns \a ranges::remove_copy_if_result<I, O>
     ///           otherwise.
-    ///           The \a copy algorithm returns the pair of the input iterator
-    ///           forwarded to the first element after the last in the input
-    ///           sequence and the output iterator to the
-    ///           element in the destination range, one past the last element
-    ///           copied.
+    ///           The \a ranges::remove_copy algorithm returns an object
+    ///           {last, result + N}, where N is the number of
+    ///           elements copied.
     ///
+    template <typename ExPolicy, typename I, typename Sent, typename O,
+        typename Pred, typename Proj = hpx::parallel::util::projection_identity>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        remove_copy_if_result<I, O>>::type
+    ranges::remove_copy_if(ExPolicy&& policy, I first, Sent last, O dest,
+        Pred&& pred, Proj&& proj = Proj());
+
+    /////////////////////////////////////////////////////////////////////////////
+    /// Copies the elements in the range, defined by rng, to another
+    /// range beginning at \a dest. Copies only the elements for which the
+    /// predicate \a pred returns false. The order of the elements that are not
+    /// removed is preserved.
+    ///
+    /// Effects: Copies all the elements referred to by the iterator it in the
+    ///          range rng for which the following corresponding
+    ///          conditions do not hold:
+    ///          INVOKE(pred, INVOKE(proj, *it)) != false.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first applications of the
+    ///         predicate \a pred.
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a copy_if requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     elements to be removed. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a InIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a remove_copy_if algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    /// \returns  The \a ranges::remove_copy_if algorithm returns a
+    ///           \a remove_copy_if_result<
+    ///             typename hpx::traits::range_iterator<Rng>::type, O>>.
+    ///           The \a ranges::remove_copy algorithm returns an object
+    ///           {last, result + N}, where N is the number of
+    ///           elements copied.
+    ///
+    template <typename Rng, typename O, typename Pred,
+        typename Proj = hpx::parallel::util::projection_identity>
+    remove_copy_if_result<typename hpx::traits::range_iterator<Rng>::type, O>
+    ranges::remove_copy_if(
+        Rng&& rng, O dest, Pred&& pred, Proj&& proj = Proj());
+
+    /////////////////////////////////////////////////////////////////////////////
+    /// Copies the elements in the range, defined by rng, to another
+    /// range beginning at \a dest. Copies only the elements for which the
+    /// predicate \a pred returns false. The order of the elements that are not
+    /// removed is preserved.
+    ///
+    /// Effects: Copies all the elements referred to by the iterator it in the
+    ///          range rng for which the following corresponding
+    ///          conditions do not hold:
+    ///          INVOKE(pred, INVOKE(proj, *it)) != false.
+    ///
+    /// \note   Complexity: Performs not more than \a last - \a first
+    ///         assignments, exactly \a last - \a first applications of the
+    ///         predicate \a pred.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam O           The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a copy_if requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     elements to be removed. The signature of this predicate
+    ///                     should be equivalent to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a InIter can be dereferenced and then
+    ///                     implicitly converted to Type.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a remove_copy_if algorithm invoked with
+    /// an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a remove_copy_if algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a ranges::remove_copy_if algorithm returns a
+    ///           \a hpx::future<remove_copy_if_result<
+    ///             typename hpx::traits::range_iterator<Rng>::type, O>>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a remove_copy_if_result<
+    ///             typename hpx::traits::range_iterator<Rng>::type, O>>
+    ///           otherwise.
+    ///           The \a ranges::remove_copy algorithm returns an object
+    ///           {last, result + N}, where N is the number of
+    ///           elements copied.
+    ///
+    template <typename ExPolicy, typename Rng, typename O, typename Pred,
+        typename Proj = hpx::parallel::util::projection_identity>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        remove_copy_if_result<typename hpx::traits::range_iterator<Rng>::type,
+            O>>::type
+    ranges::remove_copy_if(ExPolicy&& policy, Rng&& rng, O dest, Pred&& pred,
+        Proj&& proj = Proj());
+
+}    // namespace hpx
+
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/iterator_support/traits/is_range.hpp>
+#include <hpx/parallel/util/tagged_pair.hpp>
+
+#include <hpx/algorithms/traits/projected.hpp>
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/parallel/algorithms/remove_copy.hpp>
+#include <hpx/parallel/tagspec.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+#include <hpx/parallel/util/result_types.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1 {
+
+    template <typename ExPolicy, typename Rng, typename OutIter, typename T,
+        typename Proj = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
+                hpx::traits::is_range<Rng>::value&& hpx::traits::is_iterator<
+                    OutIter>::value&& traits::is_projected_range<Proj,
+                    Rng>::value&& traits::is_indirect_callable<ExPolicy,
+                    std::equal_to<T>, traits::projected_range<Proj, Rng>,
+                    traits::projected<Proj, T const*>>::value)>
+    typename util::detail::algorithm_result<ExPolicy,
+        util::in_out_result<
+            typename hpx::traits::range_traits<Rng>::iterator_type,
+            OutIter>>::type
+    remove_copy(ExPolicy&& policy, Rng&& rng, OutIter dest, T const& val,
+        Proj&& proj = Proj())
+    {
+        return remove_copy(std::forward<ExPolicy>(policy),
+            hpx::util::begin(rng), hpx::util::end(rng), dest, val,
+            std::forward<Proj>(proj));
+    }
+
     template <typename ExPolicy, typename Rng, typename OutIter, typename F,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
@@ -451,3 +873,5 @@ namespace hpx { namespace ranges {
 
     } remove_copy{};
 }}    // namespace hpx::ranges
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove_copy.hpp
@@ -257,7 +257,10 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_range<Rng>::value&&
                 hpx::parallel::traits::is_projected_range<Proj,Rng>::value &&
                 hpx::is_invocable_v<Pred,
-                    typename hpx::traits::range_iterator<Rng>::type>
+                    typename std::iterator_traits<
+                        typename hpx::traits::range_iterator<Rng>::type
+                    >::value_type
+                >
             )>
         // clang-format on
         friend remove_copy_if_result<
@@ -265,6 +268,11 @@ namespace hpx { namespace ranges {
         tag_invoke(hpx::ranges::remove_copy_if_t, Rng&& rng, O dest,
             Pred&& pred, Proj&& proj = Proj())
         {
+            static_assert(
+                (hpx::traits::is_input_iterator<
+                    typename hpx::traits::range_iterator<Rng>::type>::value),
+                "Required at least input iterator.");
+
             return hpx::parallel::v1::detail::remove_copy_if<
                 hpx::parallel::util::in_out_result<
                     typename hpx::traits::range_iterator<Rng>::type, O>>()
@@ -326,6 +334,11 @@ namespace hpx { namespace ranges {
         tag_invoke(hpx::ranges::remove_copy_if_t, ExPolicy&& policy, Rng&& rng,
             O dest, Pred&& pred, Proj&& proj = Proj())
         {
+            static_assert(
+                (hpx::traits::is_forward_iterator<
+                    typename hpx::traits::range_iterator<Rng>::type>::value),
+                "Required at least forward iterator.");
+
             typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
             return hpx::parallel::v1::detail::remove_copy_if<
@@ -395,7 +408,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_iterator<I>::value &&
                 hpx::traits::is_sentinel_for<Sent, I>::value &&
                 hpx::traits::is_iterator<O>::value &&
-                hpx::parallel::traits::is_projected<Proj, I>::value                
+                hpx::parallel::traits::is_projected<Proj, I>::value
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove_copy.hpp
@@ -208,3 +208,233 @@ namespace hpx { namespace parallel { inline namespace v1 {
             std::forward<F>(f), std::forward<Proj>(proj));
     }
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx { namespace ranges {
+    template <typename I, typename O>
+    using remove_copy_result = hpx::parallel::util::in_out_result<I, O>;
+
+    template <typename I, typename O>
+    using remove_copy_if_result = hpx::parallel::util::in_out_result<I, O>;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::remove_copy_if
+    HPX_INLINE_CONSTEXPR_VARIABLE struct remove_copy_if_t final
+      : hpx::functional::tag<remove_copy_if_t>
+    {
+        // clang-format off
+        template <typename I, typename Sent, typename O, typename Pred,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<I>::value &&
+                hpx::parallel::traits::is_projected<Proj, I>::value &&
+                hpx::traits::is_sentinel_for<Sent, I>::value &&
+                hpx::traits::is_iterator<O>::value &&
+                hpx::is_invocable_v<Pred,
+                    typename std::iterator_traits<I>::value_type
+                >
+            )>
+        // clang-format on
+        friend remove_copy_if_result<I, O> tag_invoke(
+            hpx::ranges::remove_copy_if_t, I first, Sent last, O dest,
+            Pred&& pred, Proj&& proj = Proj())
+        {
+            static_assert((hpx::traits::is_input_iterator<I>::value),
+                "Required input iterator.");
+
+            static_assert((hpx::traits::is_output_iterator<O>::value),
+                "Required output iterator.");
+
+            return hpx::parallel::v1::detail::remove_copy_if<
+                hpx::parallel::util::in_out_result<I, O>>()
+                .call(hpx::execution::seq, std::true_type{}, first, last, dest,
+                    std::forward<Pred>(pred), std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename Rng, typename O, typename Pred,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value&&
+                hpx::parallel::traits::is_projected_range<Proj,Rng>::value &&
+                hpx::is_invocable_v<Pred,
+                    typename hpx::traits::range_iterator<Rng>::type>
+            )>
+        // clang-format on
+        friend remove_copy_if_result<
+            typename hpx::traits::range_iterator<Rng>::type, O>
+        tag_invoke(hpx::ranges::remove_copy_if_t, Rng&& rng, O dest,
+            Pred&& pred, Proj&& proj = Proj())
+        {
+            return hpx::parallel::v1::detail::remove_copy_if<
+                hpx::parallel::util::in_out_result<
+                    typename hpx::traits::range_iterator<Rng>::type, O>>()
+                .call(hpx::execution::seq, std::true_type{},
+                    hpx::util::begin(rng), hpx::util::end(rng), dest,
+                    std::forward<Pred>(pred), std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename I, typename Sent, typename O,
+         typename Pred, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value&&
+                hpx::traits::is_iterator<I>::value &&
+                hpx::traits::is_sentinel_for<Sent, I>::value &&
+                hpx::traits::is_iterator<O>::value &&
+                hpx::parallel::traits::is_projected<Proj, I>::value &&
+                hpx::is_invocable_v<Pred,
+                    typename std::iterator_traits<I>::value_type
+                >
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            remove_copy_if_result<I, O>>::type
+        tag_invoke(hpx::ranges::remove_copy_if_t, ExPolicy&& policy, I first,
+            Sent last, O dest, Pred&& pred, Proj&& proj = Proj())
+        {
+            static_assert((hpx::traits::is_forward_iterator<I>::value),
+                "Required at least forward iterator.");
+
+            static_assert((hpx::traits::is_forward_iterator<O>::value),
+                "Required at least forward iterator.");
+
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
+
+            return hpx::parallel::v1::detail::remove_copy_if<
+                hpx::parallel::util::in_out_result<I, O>>()
+                .call(std::forward<ExPolicy>(policy), is_seq(), first, last,
+                    dest, std::forward<Pred>(pred), std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng, typename O, typename Pred,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
+                hpx::is_invocable_v<Pred,
+                    typename std::iterator_traits<
+                        typename hpx::traits::range_iterator<Rng>::type
+                    >::value_type
+                >
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            remove_copy_if_result<
+                typename hpx::traits::range_iterator<Rng>::type, O>>::type
+        tag_invoke(hpx::ranges::remove_copy_if_t, ExPolicy&& policy, Rng&& rng,
+            O dest, Pred&& pred, Proj&& proj = Proj())
+        {
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
+
+            return hpx::parallel::v1::detail::remove_copy_if<
+                hpx::parallel::util::in_out_result<
+                    typename hpx::traits::range_iterator<Rng>::type, O>>()
+                .call(std::forward<ExPolicy>(policy), is_seq(),
+                    hpx::util::begin(rng), hpx::util::end(rng), dest,
+                    std::forward<Pred>(pred), std::forward<Proj>(proj));
+        }
+    } remove_copy_if{};
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::remove_copy
+    HPX_INLINE_CONSTEXPR_VARIABLE struct remove_copy_t final
+      : hpx::functional::tag<remove_copy_t>
+    {
+    private:
+        // clang-format off
+        template <typename I, typename Sent, typename O,
+        typename T, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<I>::value &&
+                hpx::traits::is_sentinel_for<Sent, I>::value &&
+                hpx::traits::is_iterator<O>::value &&
+                hpx::parallel::traits::is_projected<Proj, I>::value
+            )>
+        // clang-format on
+        friend remove_copy_result<I, O> tag_invoke(hpx::ranges::remove_copy_t,
+            I first, Sent last, O dest, T const& value, Proj&& proj = Proj())
+        {
+            typedef typename std::iterator_traits<I>::value_type Type;
+
+            return hpx::ranges::remove_copy_if(
+                first, last, dest,
+                [value](Type const& a) -> bool { return value == a; },
+                std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename Rng, typename O, typename T,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value
+            )>
+        // clang-format on
+        friend remove_copy_result<
+            typename hpx::traits::range_iterator<Rng>::type, O>
+        tag_invoke(hpx::ranges::remove_copy_t, Rng&& rng, O dest,
+            T const& value, Proj&& proj = Proj())
+        {
+            typedef typename std::iterator_traits<
+                typename hpx::traits::range_iterator<Rng>::type>::value_type
+                Type;
+
+            return hpx::ranges::remove_copy_if(
+                std::forward<Rng>(rng), dest,
+                [value](Type const& a) -> bool { return value == a; },
+                std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename I, typename Sent, typename O,
+         typename T, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value&&
+                hpx::traits::is_iterator<I>::value &&
+                hpx::traits::is_sentinel_for<Sent, I>::value &&
+                hpx::traits::is_iterator<O>::value &&
+                hpx::parallel::traits::is_projected<Proj, I>::value                
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            remove_copy_result<I, O>>::type
+        tag_invoke(hpx::ranges::remove_copy_t, ExPolicy&& policy, I first,
+            Sent last, O dest, T const& value, Proj&& proj = Proj())
+        {
+            typedef typename std::iterator_traits<I>::value_type Type;
+
+            return hpx::ranges::remove_copy_if(
+                std::forward<ExPolicy>(policy), first, last, dest,
+                [value](Type const& a) -> bool { return value == a; },
+                std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng, typename O, typename T,
+            typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                parallel::execution::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            remove_copy_result<typename hpx::traits::range_iterator<Rng>::type,
+                O>>::type
+        tag_invoke(hpx::ranges::remove_copy_t, ExPolicy&& policy, Rng&& rng,
+            O dest, T const& value, Proj&& proj = Proj())
+        {
+            typedef typename std::iterator_traits<
+                typename hpx::traits::range_iterator<Rng>::type>::value_type
+                Type;
+
+            return hpx::ranges::remove_copy_if(
+                std::forward<ExPolicy>(policy), std::forward<Rng>(rng), dest,
+                [value](Type const& a) -> bool { return value == a; },
+                std::forward<Proj>(proj));
+        }
+
+    } remove_copy{};
+}}    // namespace hpx::ranges

--- a/libs/parallelism/algorithms/tests/regressions/scan_shortlength.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/scan_shortlength.cpp
@@ -28,10 +28,10 @@ void test_zero()
 
     auto p_copy_if = hpx::ranges::copy_if(par, a.begin(), a.end(), b.begin(),
         [](int bar) { return bar % 2 == 1; });
-    auto p_remove_copy_if = hpx::parallel::remove_copy_if(par, a.begin(),
-        a.end(), c.begin(), [](int bar) { return bar % 2 != 1; });
+    auto p_remove_copy_if = hpx::remove_copy_if(par, a.begin(), a.end(),
+        c.begin(), [](int bar) { return bar % 2 != 1; });
     auto p_remove_copy =
-        hpx::parallel::remove_copy(par, a.begin(), a.end(), d.begin(), 0);
+        hpx::remove_copy(par, a.begin(), a.end(), d.begin(), 0);
 
     Iter ans_copy_if = std::copy_if(
         a.begin(), a.end(), b.begin(), [](int bar) { return bar % 2 == 1; });
@@ -40,8 +40,8 @@ void test_zero()
     Iter ans_remove_copy = std::remove_copy(a.begin(), a.end(), d.begin(), 0);
 
     HPX_TEST(p_copy_if.out == ans_copy_if);
-    HPX_TEST(p_remove_copy_if.out == ans_remove_copy_if);
-    HPX_TEST(p_remove_copy.out == ans_remove_copy);
+    HPX_TEST(p_remove_copy_if == ans_remove_copy_if);
+    HPX_TEST(p_remove_copy == ans_remove_copy);
 }
 
 void test_async_zero()
@@ -53,10 +53,10 @@ void test_async_zero()
 
     auto f_copy_if = hpx::ranges::copy_if(par(task), a.begin(), a.end(),
         b.begin(), [](int bar) { return bar % 2 == 1; });
-    auto f_remove_copy_if = hpx::parallel::remove_copy_if(par(task), a.begin(),
-        a.end(), c.begin(), [](int bar) { return bar % 2 != 1; });
+    auto f_remove_copy_if = hpx::remove_copy_if(par(task), a.begin(), a.end(),
+        c.begin(), [](int bar) { return bar % 2 != 1; });
     auto f_remove_copy =
-        hpx::parallel::remove_copy(par(task), a.begin(), a.end(), d.begin(), 0);
+        hpx::remove_copy(par(task), a.begin(), a.end(), d.begin(), 0);
 
     Iter ans_copy_if = std::copy_if(
         a.begin(), a.end(), b.begin(), [](int bar) { return bar % 2 == 1; });
@@ -65,8 +65,8 @@ void test_async_zero()
     Iter ans_remove_copy = std::remove_copy(a.begin(), a.end(), d.begin(), 0);
 
     HPX_TEST(f_copy_if.get().out == ans_copy_if);
-    HPX_TEST(f_remove_copy_if.get().out == ans_remove_copy_if);
-    HPX_TEST(f_remove_copy.get().out == ans_remove_copy);
+    HPX_TEST(f_remove_copy_if.get() == ans_remove_copy_if);
+    HPX_TEST(f_remove_copy.get() == ans_remove_copy);
 }
 
 void test_one(std::vector<int> a)
@@ -78,10 +78,10 @@ void test_one(std::vector<int> a)
 
     auto p_copy_if = hpx::ranges::copy_if(par, a.begin(), a.end(), b.begin(),
         [](int bar) { return bar % 2 == 1; });
-    auto p_remove_copy_if = hpx::parallel::remove_copy_if(par, a.begin(),
-        a.end(), c.begin(), [](int bar) { return bar % 2 != 1; });
+    auto p_remove_copy_if = hpx::remove_copy_if(par, a.begin(), a.end(),
+        c.begin(), [](int bar) { return bar % 2 != 1; });
     auto p_remove_copy =
-        hpx::parallel::remove_copy(par, a.begin(), a.end(), d.begin(), 0);
+        hpx::remove_copy(par, a.begin(), a.end(), d.begin(), 0);
 
     HPX_UNUSED(p_copy_if);
     HPX_UNUSED(p_remove_copy_if);
@@ -115,10 +115,10 @@ void test_async_one(std::vector<int> a)
 
     auto f_copy_if = hpx::ranges::copy_if(par(task), a.begin(), a.end(),
         b.begin(), [](int bar) { return bar % 2 == 1; });
-    auto f_remove_copy_if = hpx::parallel::remove_copy_if(par(task), a.begin(),
-        a.end(), c.begin(), [](int bar) { return bar % 2 != 1; });
+    auto f_remove_copy_if = hpx::remove_copy_if(par(task), a.begin(), a.end(),
+        c.begin(), [](int bar) { return bar % 2 != 1; });
     auto f_remove_copy =
-        hpx::parallel::remove_copy(par(task), a.begin(), a.end(), d.begin(), 0);
+        hpx::remove_copy(par(task), a.begin(), a.end(), d.begin(), 0);
 
     std::copy_if(a.begin(), a.end(), b_ans.begin(),
         [](int bar) { return bar % 2 == 1; });

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy.cpp
@@ -41,8 +41,8 @@ void test_remove_copy(ExPolicy policy, IteratorTag)
     std::fill(std::begin(c), middle, 1);
     std::fill(middle, std::end(c), 2);
 
-    hpx::parallel::remove_copy(policy, iterator(std::begin(c)),
-        iterator(std::end(c)), std::begin(d), std::size_t(2));
+    hpx::remove_copy(policy, iterator(std::begin(c)), iterator(std::end(c)),
+        std::begin(d), std::size_t(2));
 
     std::size_t count = 0;
     HPX_TEST(std::equal(std::begin(c), middle, std::begin(d),
@@ -69,8 +69,8 @@ void test_remove_copy_async(ExPolicy p, IteratorTag)
     std::fill(std::begin(c), middle, 1);
     std::fill(middle, std::end(c), 2);
 
-    auto f = hpx::parallel::remove_copy(p, iterator(std::begin(c)),
-        iterator(std::end(c)), std::begin(d), std::size_t(2));
+    auto f = hpx::remove_copy(p, iterator(std::begin(c)), iterator(std::end(c)),
+        std::begin(d), std::size_t(2));
 
     f.wait();
 
@@ -97,8 +97,8 @@ void test_remove_copy_outiter(ExPolicy policy, IteratorTag)
     std::vector<std::size_t> d(0);
     std::iota(std::begin(c), std::end(c), 0);
 
-    hpx::parallel::remove_copy(policy, iterator(std::begin(c)),
-        iterator(std::end(c)), std::back_inserter(d), std::size_t(3000));
+    hpx::remove_copy(policy, iterator(std::begin(c)), iterator(std::end(c)),
+        std::back_inserter(d), std::size_t(3000));
 
     std::size_t count = 0;
     HPX_TEST(std::equal(std::begin(c), std::begin(c) + 3000, std::begin(d),
@@ -126,8 +126,8 @@ void test_remove_copy_outiter_async(ExPolicy p, IteratorTag)
     std::vector<std::size_t> d(0);
     std::iota(std::begin(c), std::end(c), 0);
 
-    auto f = hpx::parallel::remove_copy(p, iterator(std::begin(c)),
-        iterator(std::end(c)), std::back_inserter(d), std::size_t(3000));
+    auto f = hpx::remove_copy(p, iterator(std::begin(c)), iterator(std::end(c)),
+        std::back_inserter(d), std::size_t(3000));
     f.wait();
 
     std::size_t count = 0;
@@ -182,7 +182,7 @@ void test_remove_copy_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::remove_copy(policy,
+        hpx::remove_copy(policy,
             decorated_iterator(
                 std::begin(c), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c)), std::begin(d), std::size_t(3000));
@@ -216,7 +216,7 @@ void test_remove_copy_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::remove_copy(p,
+        auto f = hpx::remove_copy(p,
             decorated_iterator(
                 std::begin(c), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c)), std::begin(d), std::size_t(3000));
@@ -278,7 +278,7 @@ void test_remove_copy_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::remove_copy(policy,
+        hpx::remove_copy(policy,
             decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c)), std::begin(d), std::size_t(3000));
         HPX_TEST(false);
@@ -310,7 +310,7 @@ void test_remove_copy_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::remove_copy(p,
+        auto f = hpx::remove_copy(p,
             decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c)), std::begin(d), std::size_t(3000));
         returned_from_algorithm = true;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy.cpp
@@ -23,6 +23,34 @@
 int seed = std::random_device{}();
 std::mt19937 gen(seed);
 
+template <typename IteratorTag>
+void test_remove_copy(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size() / 2);
+    std::uniform_int_distribution<> dis(0, (c.size() >> 1) - 1);
+
+    std::size_t middle_idx = dis(gen);
+    auto middle = std::begin(c) + middle_idx;
+    std::fill(std::begin(c), middle, 1);
+    std::fill(middle, std::end(c), 2);
+
+    hpx::remove_copy(iterator(std::begin(c)), iterator(std::end(c)),
+        std::begin(d), std::size_t(2));
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), middle, std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, middle_idx);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy(ExPolicy policy, IteratorTag)
 {
@@ -42,6 +70,34 @@ void test_remove_copy(ExPolicy policy, IteratorTag)
     std::fill(middle, std::end(c), 2);
 
     hpx::remove_copy(policy, iterator(std::begin(c)), iterator(std::end(c)),
+        std::begin(d), std::size_t(2));
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), middle, std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, middle_idx);
+}
+
+template <typename IteratorTag>
+void test_remove_copy_async(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size() / 2);
+    std::uniform_int_distribution<> dis(0, (c.size() >> 1) - 1);
+
+    std::size_t middle_idx = dis(gen);
+    auto middle = std::begin(c) + middle_idx;
+    std::fill(std::begin(c), middle, 1);
+    std::fill(middle, std::end(c), 2);
+
+    hpx::remove_copy(iterator(std::begin(c)), iterator(std::end(c)),
         std::begin(d), std::size_t(2));
 
     std::size_t count = 0;
@@ -150,10 +206,12 @@ template <typename IteratorTag>
 void test_remove_copy()
 {
     using namespace hpx::execution;
+    test_remove_copy(IteratorTag());
     test_remove_copy(seq, IteratorTag());
     test_remove_copy(par, IteratorTag());
     test_remove_copy(par_unseq, IteratorTag());
 
+    test_remove_copy_async(IteratorTag());
     test_remove_copy_async(seq(task), IteratorTag());
     test_remove_copy_async(par(task), IteratorTag());
 }

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy_if.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy_if.cpp
@@ -42,8 +42,8 @@ void test_remove_copy_if(ExPolicy policy, IteratorTag)
     std::iota(std::begin(c), middle, static_cast<int>(dist(gen)));
     std::fill(middle, std::end(c), -1);
 
-    hpx::parallel::remove_copy_if(policy, iterator(std::begin(c)),
-        iterator(std::end(c)), std::begin(d), [](int i) { return i < 0; });
+    hpx::remove_copy_if(policy, iterator(std::begin(c)), iterator(std::end(c)),
+        std::begin(d), [](int i) { return i < 0; });
 
     std::size_t count = 0;
     HPX_TEST(std::equal(
@@ -79,7 +79,7 @@ void test_remove_copy_if_async(ExPolicy p, IteratorTag)
     std::iota(std::begin(c), middle, static_cast<int>(dist(gen)));
     std::fill(middle, std::end(c), -1);
 
-    auto f = hpx::parallel::remove_copy_if(p, iterator(std::begin(c)),
+    auto f = hpx::remove_copy_if(p, iterator(std::begin(c)),
         iterator(std::end(c)), std::begin(d), [](int i) { return i < 0; });
     f.wait();
 
@@ -120,9 +120,8 @@ void test_remove_copy_if_outiter(ExPolicy policy, IteratorTag)
     std::iota(std::begin(c), middle, static_cast<int>(dist(gen)));
     std::fill(middle, std::end(c), -1);
 
-    hpx::parallel::remove_copy_if(policy, iterator(std::begin(c)),
-        iterator(std::end(c)), std::back_inserter(d),
-        [](int i) { return i < 0; });
+    hpx::remove_copy_if(policy, iterator(std::begin(c)), iterator(std::end(c)),
+        std::back_inserter(d), [](int i) { return i < 0; });
 
     HPX_TEST(std::equal(
         std::begin(c), middle, std::begin(d), [](int v1, int v2) -> bool {
@@ -149,9 +148,9 @@ void test_remove_copy_if_outiter_async(ExPolicy p, IteratorTag)
     std::iota(std::begin(c), middle, static_cast<int>(dist(gen)));
     std::fill(middle, std::end(c), -1);
 
-    auto f = hpx::parallel::remove_copy_if(p, iterator(std::begin(c)),
-        iterator(std::end(c)), std::back_inserter(d),
-        [](int i) { return i < 0; });
+    auto f =
+        hpx::remove_copy_if(p, iterator(std::begin(c)), iterator(std::end(c)),
+            std::back_inserter(d), [](int i) { return i < 0; });
     f.wait();
 
     HPX_TEST(std::equal(
@@ -199,7 +198,7 @@ void test_remove_copy_if_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::remove_copy_if(policy, iterator(std::begin(c)),
+        hpx::remove_copy_if(policy, iterator(std::begin(c)),
             iterator(std::end(c)), std::begin(d), [](std::size_t v) {
                 return throw std::runtime_error("test"), v == 0;
             });
@@ -232,7 +231,7 @@ void test_remove_copy_if_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::remove_copy_if(p, iterator(std::begin(c)),
+        auto f = hpx::remove_copy_if(p, iterator(std::begin(c)),
             iterator(std::end(c)), std::begin(d), [](std::size_t v) {
                 return throw std::runtime_error("test"), v == 0;
             });
@@ -294,7 +293,7 @@ void test_remove_copy_if_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::remove_copy_if(policy, iterator(std::begin(c)),
+        hpx::remove_copy_if(policy, iterator(std::begin(c)),
             iterator(std::end(c)), std::begin(d),
             [](std::size_t v) { return throw std::bad_alloc(), v; });
 
@@ -326,7 +325,7 @@ void test_remove_copy_if_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::remove_copy_if(p, iterator(std::begin(c)),
+        auto f = hpx::remove_copy_if(p, iterator(std::begin(c)),
             iterator(std::end(c)), std::begin(d),
             [](std::size_t v) { return throw std::bad_alloc(), v; });
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_if_range.cpp
@@ -16,9 +16,70 @@
 #include <string>
 #include <vector>
 
+#include "iter_sent.hpp"
 #include "test_utils.hpp"
 
 ////////////////////////////////////////////////////////////////////////////
+// This test should be valid once remove_adapt is accepted and
+// iter_sent implements a valid sentinel
+
+// template <typename ExPolicy>
+// void test_remove_copy_if_sent(ExPolicy policy)
+// {
+//     static_assert(hpx::is_execution_policy<ExPolicy>::value,
+//         "hpx::is_execution_policy<ExPolicy>::value");
+
+//     using hpx::get;
+
+//     std::size_t const size = 100;
+//     std::vector<std::int16_t> c(size), d(size);
+//     std::iota(std::begin(c), std::end(c), 1);
+
+//     auto pred = [](std::int16_t const& a) -> bool { return a % 42 == 0; };
+
+//     auto pre_result = std::count_if(std::begin(c), std::end(c), pred);
+//     hpx::ranges::remove_copy_if(
+//         std::begin(c), sentinel<std::int16_t>{50}, std::begin(d), pred);
+//     auto post_result = std::count_if(std::begin(c), std::end(c), pred);
+
+//     HPX_TEST(pre_result == 2 && post_result == 1);
+// }
+
+////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_remove_copy_if(IteratorTag)
+{
+    typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
+
+    test_vector c(10007);
+    std::vector<int> d(c.size());
+    std::size_t middle_idx = std::rand() % (c.size() / 2);
+    auto middle =
+        hpx::parallel::v1::detail::next(std::begin(c.base()), middle_idx);
+    std::iota(
+        std::begin(c.base()), middle, static_cast<int>(std::rand() % c.size()));
+    std::fill(middle, std::end(c.base()), -1);
+
+    hpx::ranges::remove_copy_if(c, std::begin(d), [](int i) { return i < 0; });
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c.base()), middle, std::begin(d),
+        [&count](int v1, int v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+
+    HPX_TEST(std::equal(middle, std::end(c.base()), std::begin(d) + middle_idx,
+        [&count](int v1, int v2) -> bool {
+            HPX_TEST_NEQ(v1, v2);
+            ++count;
+            return v1 != v2;
+        }));
+
+    HPX_TEST_EQ(count, d.size());
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_if(ExPolicy policy, IteratorTag)
 {
@@ -36,8 +97,42 @@ void test_remove_copy_if(ExPolicy policy, IteratorTag)
         std::begin(c.base()), middle, static_cast<int>(std::rand() % c.size()));
     std::fill(middle, std::end(c.base()), -1);
 
-    hpx::parallel::remove_copy_if(
+    hpx::ranges::remove_copy_if(
         policy, c, std::begin(d), [](int i) { return i < 0; });
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c.base()), middle, std::begin(d),
+        [&count](int v1, int v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+
+    HPX_TEST(std::equal(middle, std::end(c.base()), std::begin(d) + middle_idx,
+        [&count](int v1, int v2) -> bool {
+            HPX_TEST_NEQ(v1, v2);
+            ++count;
+            return v1 != v2;
+        }));
+
+    HPX_TEST_EQ(count, d.size());
+}
+
+template <typename IteratorTag>
+void test_remove_copy_if_async(IteratorTag)
+{
+    typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
+
+    test_vector c(10007);
+    std::vector<int> d(c.size());
+    std::size_t middle_idx = std::rand() % (c.size() / 2);
+    auto middle =
+        hpx::parallel::v1::detail::next(std::begin(c.base()), middle_idx);
+    std::iota(
+        std::begin(c.base()), middle, static_cast<int>(std::rand() % c.size()));
+    std::fill(middle, std::end(c.base()), -1);
+
+    hpx::ranges::remove_copy_if(c, std::begin(d), [](int i) { return i < 0; });
 
     std::size_t count = 0;
     HPX_TEST(std::equal(std::begin(c.base()), middle, std::begin(d),
@@ -71,7 +166,7 @@ void test_remove_copy_if_async(ExPolicy p, IteratorTag)
         std::begin(c.base()), middle, static_cast<int>(std::rand() % c.size()));
     std::fill(middle, std::end(c.base()), -1);
 
-    auto f = hpx::parallel::remove_copy_if(
+    auto f = hpx::ranges::remove_copy_if(
         p, c, std::begin(d), [](int i) { return i < 0; });
     f.wait();
 
@@ -110,7 +205,7 @@ void test_remove_copy_if_outiter(ExPolicy policy, IteratorTag)
         std::begin(c.base()), middle, static_cast<int>(std::rand() % c.size()));
     std::fill(middle, std::end(c.base()), -1);
 
-    hpx::parallel::remove_copy_if(
+    hpx::ranges::remove_copy_if(
         policy, c, std::back_inserter(d), [](int i) { return i < 0; });
 
     HPX_TEST(std::equal(std::begin(c.base()), middle, std::begin(d),
@@ -136,7 +231,7 @@ void test_remove_copy_if_outiter_async(ExPolicy p, IteratorTag)
         std::begin(c.base()), middle, static_cast<int>(std::rand() % c.size()));
     std::fill(middle, std::end(c.base()), -1);
 
-    auto f = hpx::parallel::remove_copy_if(
+    auto f = hpx::ranges::remove_copy_if(
         p, c, std::back_inserter(d), [](int i) { return i < 0; });
     f.wait();
 
@@ -154,12 +249,16 @@ void test_remove_copy_if()
 {
     using namespace hpx::execution;
 
+    test_remove_copy_if(IteratorTag());
     test_remove_copy_if(seq, IteratorTag());
     test_remove_copy_if(par, IteratorTag());
     test_remove_copy_if(par_unseq, IteratorTag());
 
+    test_remove_copy_if_async(IteratorTag());
     test_remove_copy_if_async(seq(task), IteratorTag());
     test_remove_copy_if_async(par(task), IteratorTag());
+
+    // test_remove_copy_if_sent(seq);
 }
 
 void remove_copy_if_test()
@@ -184,7 +283,7 @@ void test_remove_copy_if_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::remove_copy_if(
+        hpx::ranges::remove_copy_if(
             policy, c, std::begin(d), [](std::size_t v) {
                 return throw std::runtime_error("test"), v == 0;
             });
@@ -216,8 +315,8 @@ void test_remove_copy_if_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::remove_copy_if(
-            p, c, std::begin(d), [](std::size_t v) {
+        auto f =
+            hpx::ranges::remove_copy_if(p, c, std::begin(d), [](std::size_t v) {
                 return throw std::runtime_error("test"), v == 0;
             });
 
@@ -277,7 +376,7 @@ void test_remove_copy_if_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::remove_copy_if(policy, c, std::begin(d),
+        hpx::ranges::remove_copy_if(policy, c, std::begin(d),
             [](std::size_t v) { return throw std::bad_alloc(), v; });
 
         HPX_TEST(false);
@@ -307,7 +406,7 @@ void test_remove_copy_if_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::remove_copy_if(p, c, std::begin(d),
+        auto f = hpx::ranges::remove_copy_if(p, c, std::begin(d),
             [](std::size_t v) { return throw std::bad_alloc(), v; });
 
         returned_from_algorithm = true;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_if_range.cpp
@@ -20,30 +20,51 @@
 #include "test_utils.hpp"
 
 ////////////////////////////////////////////////////////////////////////////
-// This test should be valid once remove_adapt is accepted and
-// iter_sent implements a valid sentinel
+void test_remove_copy_if_sent()
+{
+    using hpx::get;
 
-// template <typename ExPolicy>
-// void test_remove_copy_if_sent(ExPolicy policy)
-// {
-//     static_assert(hpx::is_execution_policy<ExPolicy>::value,
-//         "hpx::is_execution_policy<ExPolicy>::value");
+    std::size_t const size = 100;
+    std::vector<std::int16_t> c(size), d(size, 1), e(size, 1);
+    std::iota(std::begin(c), std::end(c), 1);
 
-//     using hpx::get;
+    auto pred1 = [](std::int16_t const& a) -> bool { return a % 42 != 0; };
+    auto pred2 = [](std::int16_t const& a) -> bool { return a % 42 == 0; };
 
-//     std::size_t const size = 100;
-//     std::vector<std::int16_t> c(size), d(size);
-//     std::iota(std::begin(c), std::end(c), 1);
+    hpx::ranges::remove_copy_if(c, std::begin(e), pred1);
+    auto result_e = std::count_if(std::begin(e), std::end(e), pred2);
 
-//     auto pred = [](std::int16_t const& a) -> bool { return a % 42 == 0; };
+    hpx::ranges::remove_copy_if(
+        std::begin(c), sentinel<std::int16_t>{50}, std::begin(d), pred1);
+    auto result_d = std::count_if(std::begin(d), std::end(d), pred2);
 
-//     auto pre_result = std::count_if(std::begin(c), std::end(c), pred);
-//     hpx::ranges::remove_copy_if(
-//         std::begin(c), sentinel<std::int16_t>{50}, std::begin(d), pred);
-//     auto post_result = std::count_if(std::begin(c), std::end(c), pred);
+    HPX_TEST(result_e == 2 && result_d == 1);
+}
 
-//     HPX_TEST(pre_result == 2 && post_result == 1);
-// }
+template <typename ExPolicy>
+void test_remove_copy_if_sent(ExPolicy policy)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    using hpx::get;
+
+    std::size_t const size = 100;
+    std::vector<std::int16_t> c(size), d(size, 1), e(size, 1);
+    std::iota(std::begin(c), std::end(c), 1);
+
+    auto pred1 = [](std::int16_t const& a) -> bool { return a % 42 != 0; };
+    auto pred2 = [](std::int16_t const& a) -> bool { return a % 42 == 0; };
+
+    hpx::ranges::remove_copy_if(c, std::begin(e), pred1);
+    auto result_e = std::count_if(std::begin(e), std::end(e), pred2);
+
+    hpx::ranges::remove_copy_if(policy, std::begin(c),
+        sentinel<std::int16_t>{50}, std::begin(d), pred1);
+    auto result_d = std::count_if(std::begin(d), std::end(d), pred2);
+
+    HPX_TEST(result_e == 2 && result_d == 1);
+}
 
 ////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
@@ -258,7 +279,10 @@ void test_remove_copy_if()
     test_remove_copy_if_async(seq(task), IteratorTag());
     test_remove_copy_if_async(par(task), IteratorTag());
 
-    // test_remove_copy_if_sent(seq);
+    test_remove_copy_if_sent();
+    test_remove_copy_if_sent(seq);
+    test_remove_copy_if_sent(par);
+    test_remove_copy_if_sent(par_unseq);
 }
 
 void remove_copy_if_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_if_range.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2015 Daniel Bourgeois
+//  Copyright (c) 2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_range.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2015 Daniel Bourgeois
+//  Copyright (c) 2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_range.cpp
@@ -20,6 +20,32 @@
 #include "test_utils.hpp"
 
 ////////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_remove_copy(IteratorTag)
+{
+    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
+        test_vector;
+
+    test_vector c(10007);
+    std::vector<std::size_t> d(c.size() / 2);
+    std::size_t middle_idx = std::rand() % (c.size() / 2);
+    auto middle =
+        hpx::parallel::v1::detail::next(std::begin(c.base()), middle_idx);
+    std::fill(std::begin(c.base()), middle, 1);
+    std::fill(middle, std::end(c.base()), 2);
+
+    hpx::ranges::remove_copy(c, std::begin(d), std::size_t(2));
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c.base()), middle, std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, middle_idx);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy(ExPolicy policy, IteratorTag)
 {
@@ -37,7 +63,33 @@ void test_remove_copy(ExPolicy policy, IteratorTag)
     std::fill(std::begin(c.base()), middle, 1);
     std::fill(middle, std::end(c.base()), 2);
 
-    hpx::parallel::remove_copy(policy, c, std::begin(d), std::size_t(2));
+    hpx::ranges::remove_copy(policy, c, std::begin(d), std::size_t(2));
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c.base()), middle, std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, middle_idx);
+}
+
+template <typename IteratorTag>
+void test_remove_copy_async(IteratorTag)
+{
+    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
+        test_vector;
+
+    test_vector c(10007);
+    std::vector<std::size_t> d(c.size() / 2);
+    std::size_t middle_idx = std::rand() % (c.size() / 2);
+    auto middle =
+        hpx::parallel::v1::detail::next(std::begin(c.base()), middle_idx);
+    std::fill(std::begin(c.base()), middle, 1);
+    std::fill(middle, std::end(c.base()), 2);
+
+    hpx::ranges::remove_copy(c, std::begin(d), std::size_t(2));
 
     std::size_t count = 0;
     HPX_TEST(std::equal(std::begin(c.base()), middle, std::begin(d),
@@ -63,7 +115,7 @@ void test_remove_copy_async(ExPolicy p, IteratorTag)
     std::fill(std::begin(c.base()), middle, 1);
     std::fill(middle, std::end(c.base()), 2);
 
-    auto f = hpx::parallel::remove_copy(p, c, std::begin(d), std::size_t(2));
+    auto f = hpx::ranges::remove_copy(p, c, std::begin(d), std::size_t(2));
     f.wait();
 
     std::size_t count = 0;
@@ -89,7 +141,7 @@ void test_remove_copy_outiter(ExPolicy policy, IteratorTag)
     std::vector<std::size_t> d(0);
     std::iota(std::begin(c), std::end(c), 0);
 
-    hpx::parallel::remove_copy(
+    hpx::ranges::remove_copy(
         policy, c, std::back_inserter(d), std::size_t(3000));
 
     std::size_t count = 0;
@@ -118,7 +170,7 @@ void test_remove_copy_outiter_async(ExPolicy p, IteratorTag)
     std::vector<std::size_t> d(0);
     std::iota(std::begin(c), std::end(c), 0);
 
-    auto f = hpx::parallel::remove_copy(
+    auto f = hpx::ranges::remove_copy(
         p, c, std::back_inserter(d), std::size_t(3000));
     f.wait();
 
@@ -142,10 +194,12 @@ template <typename IteratorTag>
 void test_remove_copy()
 {
     using namespace hpx::execution;
+    test_remove_copy(IteratorTag());
     test_remove_copy(seq, IteratorTag());
     test_remove_copy(par, IteratorTag());
     test_remove_copy(par_unseq, IteratorTag());
 
+    test_remove_copy_async(IteratorTag());
     test_remove_copy_async(seq(task), IteratorTag());
     test_remove_copy_async(par(task), IteratorTag());
 }
@@ -174,7 +228,7 @@ void test_remove_copy_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::remove_copy(policy,
+        hpx::ranges::remove_copy(policy,
             hpx::util::make_iterator_range(
                 decorated_iterator(
                     std::begin(c), []() { throw std::runtime_error("test"); }),
@@ -210,7 +264,7 @@ void test_remove_copy_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::remove_copy(p,
+        auto f = hpx::ranges::remove_copy(p,
             hpx::util::make_iterator_range(
                 decorated_iterator(
                     std::begin(c), []() { throw std::runtime_error("test"); }),
@@ -274,7 +328,7 @@ void test_remove_copy_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::remove_copy(policy,
+        hpx::ranges::remove_copy(policy,
             hpx::util::make_iterator_range(
                 decorated_iterator(
                     std::begin(c), []() { throw std::bad_alloc(); }),
@@ -309,7 +363,7 @@ void test_remove_copy_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::remove_copy(p,
+        auto f = hpx::ranges::remove_copy(p,
             hpx::util::make_iterator_range(
                 decorated_iterator(
                     std::begin(c), []() { throw std::bad_alloc(); }),

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_range.cpp
@@ -17,7 +17,54 @@
 #include <string>
 #include <vector>
 
+#include "iter_sent.hpp"
 #include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////////
+void test_remove_copy_sent()
+{
+    using hpx::get;
+
+    std::size_t const size = 100;
+    std::vector<std::int16_t> c(size), d(size, -1);
+    std::iota(std::begin(c), std::end(c), 1);
+    c[99] = 42;    //both c[99] and c[42] are equal to 42
+
+    int value = 42;
+
+    auto pred = [](const int& n) -> bool { return n > 0; };
+
+    hpx::ranges::remove_copy(
+        std::begin(c), sentinel<std::int16_t>{50}, std::begin(d), value);
+    auto result = std::count_if(std::begin(d), std::end(d), pred);
+
+    HPX_TEST(result == 48);
+}
+
+template <typename ExPolicy>
+void test_remove_copy_sent(ExPolicy policy)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    using hpx::get;
+
+    std::size_t const size = 100;
+    std::vector<std::int16_t> c(size), d(size, -1);
+    std::iota(std::begin(c), std::end(c), 1);
+
+    c[99] = 42;    //both c[99] and c[42] are equal to 42
+
+    int value = 42;
+
+    auto pred = [](const int& n) -> bool { return n > 0; };
+
+    hpx::ranges::remove_copy(policy, std::begin(c), sentinel<std::int16_t>{50},
+        std::begin(d), value);
+    auto result = std::count_if(std::begin(d), std::end(d), pred);
+
+    HPX_TEST(result == 48);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
@@ -202,6 +249,11 @@ void test_remove_copy()
     test_remove_copy_async(IteratorTag());
     test_remove_copy_async(seq(task), IteratorTag());
     test_remove_copy_async(par(task), IteratorTag());
+
+    test_remove_copy_sent();
+    test_remove_copy_sent(seq);
+    test_remove_copy_sent(par);
+    test_remove_copy_sent(par_unseq);
 }
 
 void remove_copy_test()


### PR DESCRIPTION
This adapts `remove_copy` and `remove_copy_if` to C++20 by providing the ranges overloads according to the Standard. 

Note: _It is based on #5125 in order for the iterator-sentinel_value test cases to run (due to iter_sent.hpp changes) and thus this particular test is commented out for the time being. When #5125 will be merged, proper rebasing will take place._

Proper documentation will be added soon.
