### PR TITLE
Use C++20 on clang-newest Jenkins CI configuration

### DIFF
--- a/.jenkins/cscs/env-clang-newest.sh
+++ b/.jenkins/cscs/env-clang-newest.sh
@@ -9,11 +9,11 @@ source $SPACK_ROOT/share/spack/setup-env.sh
 export CRAYPE_LINK_TYPE=dynamic
 export APPS_ROOT="/apps/daint/SSL/HPX/packages"
 export CLANG_VER="11.0.0"
-export CXX_STD="17"
+export CXX_STD="20"
 export BOOST_VER="1.75.0"
 export HWLOC_VER="2.2.0"
 export CLANG_ROOT="${APPS_ROOT}/llvm-${CLANG_VER}"
-export BOOST_ROOT="${APPS_ROOT}/boost-${BOOST_VER}-clang-${CLANG_VER}-c++${CXX_STD}-release"
+export BOOST_ROOT="${APPS_ROOT}/boost-${BOOST_VER}-clang-${CLANG_VER}-c++17-release"
 export HWLOC_ROOT="${APPS_ROOT}/hwloc-${HWLOC_VER}-gcc-10.2.0"
 export CXXFLAGS="-Wno-unused-command-line-argument -stdlib=libc++ -nostdinc++ -I${CLANG_ROOT}/include/c++/v1 -L${CLANG_ROOT}/lib -Wl,-rpath,${CLANG_ROOT}/lib,-lsupc++"
 export LDCXXFLAGS="-stdlib=libc++ -L${CLANG_ROOT}/lib -Wl,-rpath,${CLANG_ROOT}/lib,-lsupc++"

--- a/examples/cancelable_action/cancelable_action/server/cancelable_action.hpp
+++ b/examples/cancelable_action/cancelable_action/server/cancelable_action.hpp
@@ -22,10 +22,17 @@ namespace examples { namespace server
     ///////////////////////////////////////////////////////////////////////////
     inline void delay(int c)
     {
+#if defined(HPX_CLANG_VERSION) && (HPX_CLANG_VERSION >= 100000)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-volatile"
+#endif
         double volatile d = 0.;
         for (int i = 0; i < c; ++i)
             d += 1 / (2. * i + 1);
         (void) d;
+#if defined(HPX_CLANG_VERSION) && (HPX_CLANG_VERSION >= 100000)
+#pragma clang diagnostic pop
+#endif
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/core/config/include/hpx/config/endian.hpp
+++ b/libs/core/config/include/hpx/config/endian.hpp
@@ -8,7 +8,7 @@
 
 #include <hpx/config.hpp>
 
-#if HPX_HAVE_CXX20_STD_ENDIAN
+#if defined(HPX_HAVE_CXX20_STD_ENDIAN)
 #include <bit>
 #endif
 
@@ -16,7 +16,7 @@
 /// \cond NODETAIL
 namespace hpx {
 
-#if HPX_HAVE_CXX20_STD_ENDIAN
+#if defined(HPX_HAVE_CXX20_STD_ENDIAN)
     using std::endian;
 #else
     enum class endian

--- a/libs/core/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
@@ -28,6 +28,7 @@
 #include <hpx/topology/topology.hpp>
 
 #include <array>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <exception>
@@ -1398,10 +1399,10 @@ namespace hpx { namespace threads { namespace policies {
 
         // used to make sure the scheduler is only initialized once on a thread
         std::mutex init_mutex;
-        volatile bool initialized_;
+        bool initialized_;
         // a flag to ensure startup debug info is only printed on one thread
-        volatile bool debug_init_;
-        volatile std::size_t thread_init_counter_;
+        bool debug_init_;
+        std::atomic<std::size_t> thread_init_counter_;
         // used in thread pool checks
         std::size_t pool_index_;
     };

--- a/libs/core/serialization/tests/performance/serialization_performance.cpp
+++ b/libs/core/serialization/tests/performance/serialization_performance.cpp
@@ -128,12 +128,12 @@ namespace hpx_test {
         Integers ids;
         Strings strings;
 
-        bool operator==(const Record& other)
+        bool operator==(const Record& other) const
         {
             return (ids == other.ids && strings == other.strings);
         }
 
-        bool operator!=(const Record& other)
+        bool operator!=(const Record& other) const
         {
             return !(*this == other);
         }

--- a/libs/full/compute/include/hpx/compute/traits/allocator_traits.hpp
+++ b/libs/full/compute/include/hpx/compute/traits/allocator_traits.hpp
@@ -28,16 +28,15 @@ namespace hpx { namespace compute { namespace traits {
         template <typename Allocator, typename Enable = void>
         struct get_target_traits
         {
-            typedef compute::traits::access_target<compute::host::target> type;
+            using type = compute::traits::access_target<compute::host::target>;
         };
 
         template <typename Allocator>
         struct get_target_traits<Allocator,
             typename util::always_void<typename Allocator::target_type>::type>
         {
-            typedef compute::traits::access_target<
-                typename Allocator::target_type>
-                type;
+            using type =
+                compute::traits::access_target<typename Allocator::target_type>;
         };
 
         template <typename Allocator, typename Enable = void>
@@ -46,7 +45,7 @@ namespace hpx { namespace compute { namespace traits {
             ;
 #else
         {
-            typedef typename std::allocator_traits<Allocator>::value_type& type;
+            using type = typename std::allocator_traits<Allocator>::value_type&;
         };
 #endif
 
@@ -63,8 +62,8 @@ namespace hpx { namespace compute { namespace traits {
             ;
 #else
         {
-            typedef typename std::allocator_traits<Allocator>::value_type const&
-                type;
+            using type =
+                typename std::allocator_traits<Allocator>::value_type const&;
         };
 #endif
 
@@ -79,7 +78,7 @@ namespace hpx { namespace compute { namespace traits {
         template <typename Allocator, typename Enable = void>
         struct target_helper_result
         {
-            typedef compute::host::target type;
+            using type = compute::host::target;
         };
 
         template <typename Allocator>
@@ -87,7 +86,7 @@ namespace hpx { namespace compute { namespace traits {
             typename hpx::util::always_void<
                 typename Allocator::target_type>::type>
         {
-            typedef decltype(std::declval<Allocator const&>().target()) type;
+            using type = decltype(std::declval<Allocator const&>().target());
         };
 
         ///////////////////////////////////////////////////////////////////////
@@ -120,14 +119,20 @@ namespace hpx { namespace compute { namespace traits {
         {
             template <typename Allocator, typename... Ts>
             HPX_HOST_DEVICE static void call(hpx::traits::detail::wrap_int,
-                Allocator& alloc, typename Allocator::pointer p,
-                typename Allocator::size_type count, Ts&&... vs)
+                Allocator& alloc,
+                typename std::allocator_traits<Allocator>::pointer p,
+                typename std::allocator_traits<Allocator>::size_type count,
+                Ts&&... vs)
             {
-                typedef typename Allocator::pointer pointer;
-                typedef typename Allocator::value_type value_type;
+                using pointer =
+                    typename std::allocator_traits<Allocator>::pointer;
+                using value_type =
+                    typename std::allocator_traits<Allocator>::value_type;
+                using size_type =
+                    typename std::allocator_traits<Allocator>::size_type;
                 value_type init_value(std::forward<Ts>(vs)...);
                 pointer end = p + count;
-                typename Allocator::size_type allocated = 0;
+                size_type allocated = 0;
                 for (pointer it = p; it != end; ++it)
                 {
 #if defined(__CUDA_ARCH__)
@@ -152,10 +157,10 @@ namespace hpx { namespace compute { namespace traits {
 
             template <typename Allocator, typename... Ts>
             HPX_HOST_DEVICE static auto call(int, Allocator& alloc,
-                typename Allocator::pointer p,
-                typename Allocator::size_type count, Ts&&... vs)
-                -> decltype(
-                    alloc.bulk_construct(p, count, std::forward<Ts>(vs)...))
+                typename std::allocator_traits<Allocator>::pointer p,
+                typename std::allocator_traits<Allocator>::size_type count,
+                Ts&&... vs) -> decltype(alloc.bulk_construct(p, count,
+                std::forward<Ts>(vs)...))
             {
                 alloc.bulk_construct(p, count, std::forward<Ts>(vs)...);
             }
@@ -163,7 +168,8 @@ namespace hpx { namespace compute { namespace traits {
 
         template <typename Allocator, typename... Ts>
         HPX_HOST_DEVICE void call_bulk_construct(Allocator& alloc,
-            typename Allocator::pointer p, typename Allocator::size_type count,
+            typename std::allocator_traits<Allocator>::pointer p,
+            typename std::allocator_traits<Allocator>::size_type count,
             Ts&&... vs)
         {
             bulk_construct::call(0, alloc, p, count, std::forward<Ts>(vs)...);
@@ -174,10 +180,13 @@ namespace hpx { namespace compute { namespace traits {
         {
             template <typename Allocator>
             HPX_HOST_DEVICE static void call(hpx::traits::detail::wrap_int,
-                Allocator& alloc, typename Allocator::pointer p,
-                typename Allocator::size_type count) noexcept
+                Allocator& alloc,
+                typename std::allocator_traits<Allocator>::pointer p,
+                typename std::allocator_traits<Allocator>::size_type
+                    count) noexcept
             {
-                typedef typename Allocator::pointer pointer;
+                using pointer =
+                    typename std::allocator_traits<Allocator>::pointer;
                 pointer end = p + count;
                 for (pointer it = p; it != end; ++it)
                 {
@@ -187,9 +196,9 @@ namespace hpx { namespace compute { namespace traits {
 
             template <typename Allocator>
             HPX_HOST_DEVICE static auto call(int, Allocator& alloc,
-                typename Allocator::pointer p,
-                typename Allocator::size_type count) noexcept
-                -> decltype(alloc.bulk_destroy(p, count))
+                typename std::allocator_traits<Allocator>::pointer p,
+                typename std::allocator_traits<Allocator>::size_type
+                    count) noexcept -> decltype(alloc.bulk_destroy(p, count))
             {
                 alloc.bulk_destroy(p, count);
             }
@@ -197,8 +206,8 @@ namespace hpx { namespace compute { namespace traits {
 
         template <typename Allocator>
         HPX_HOST_DEVICE void call_bulk_destroy(Allocator& alloc,
-            typename Allocator::pointer p,
-            typename Allocator::size_type count) noexcept
+            typename std::allocator_traits<Allocator>::pointer p,
+            typename std::allocator_traits<Allocator>::size_type count) noexcept
         {
             bulk_destroy::call(0, alloc, p, count);
         }
@@ -212,11 +221,11 @@ namespace hpx { namespace compute { namespace traits {
     {
 #if defined(HPX_NATIVE_MIC)
     public:
-        typedef typename Allocator::value_type value_type;
-        typedef typename Allocator::pointer pointer;
-        typedef typename Allocator::const_pointer const_pointer;
-        typedef typename Allocator::size_type size_type;
-        typedef typename Allocator::difference_type difference_type;
+        using value_type = typename Allocator::value_type;
+        using pointer = typename Allocator::pointer;
+        using const_pointer = typename Allocator::const_pointer;
+        using size_type = typename Allocator::size_type;
+        using difference_type = typename Allocator::difference_type;
 
         static pointer allocate(
             Allocator& alloc, size_type n, const_pointer hint = nullptr)
@@ -247,7 +256,7 @@ namespace hpx { namespace compute { namespace traits {
         }
 #else
     private:
-        typedef std::allocator_traits<Allocator> base_type;
+        using base_type = std::allocator_traits<Allocator>;
 
     public:
         using typename base_type::pointer;
@@ -255,13 +264,13 @@ namespace hpx { namespace compute { namespace traits {
         using typename base_type::value_type;
 #endif
 
-        typedef typename detail::get_reference_type<Allocator>::type reference;
-        typedef typename detail::get_const_reference_type<Allocator>::type
-            const_reference;
+        using reference = typename detail::get_reference_type<Allocator>::type;
+        using const_reference =
+            typename detail::get_const_reference_type<Allocator>::type;
 
-        typedef
-            typename detail::get_target_traits<Allocator>::type access_target;
-        typedef typename access_target::target_type target_type;
+        using access_target =
+            typename detail::get_target_traits<Allocator>::type;
+        using target_type = typename access_target::target_type;
 
         HPX_HOST_DEVICE
         static auto target(Allocator const& alloc)

--- a/libs/parallelism/pack_traversal/tests/regressions/unwrapping_noncopyable.cpp
+++ b/libs/parallelism/pack_traversal/tests/regressions/unwrapping_noncopyable.cpp
@@ -11,7 +11,11 @@
 
 struct noncopyable
 {
+    noncopyable() = default;
+    noncopyable(noncopyable&&) = default;
+    noncopyable& operator=(noncopyable&&) = default;
     noncopyable(noncopyable const&) = delete;
+    noncopyable& operator=(noncopyable const&) = delete;
 };
 
 int main()

--- a/tests/regressions/threads/block_os_threads_1036.cpp
+++ b/tests/regressions/threads/block_os_threads_1036.cpp
@@ -52,7 +52,6 @@ void blocker(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-volatile int i = 0;
 std::uint64_t delay = 100;
 
 int hpx_main()
@@ -100,8 +99,6 @@ int hpx_main()
             {
                 if (td.elapsed() > delay_sec)
                     break;
-                else
-                    ++i;
             }
         }
 


### PR DESCRIPTION
Tentatively just changed the C++ standard on the `clang-newest` builder. Boost might need a separate build, although I think this configuration is free of compiled Boost.