### PR TITLE
Add HPX_WITH_PRECOMPILED_HEADERS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,6 +326,83 @@ if(HPX_WITH_UNITY_BUILD)
   set(HPX_WITH_UNITY_BUILD_OPTION UNITY_BUILD)
 endif()
 
+hpx_option(
+  HPX_WITH_PRECOMPILED_HEADERS
+  BOOL
+  "Enable precompiled headers for certain build targets (experimental, requires CMake 3.16 or newer) (default OFF)"
+  OFF
+  ADVANCED
+)
+if(HPX_WITH_PRECOMPILED_HEADERS)
+  if(CMAKE_VERSION VERSION_LESS "3.16")
+    hpx_error("HPX_WITH_UNITY_BUILD=ON but this requires CMake 3.16 or newer.")
+  endif()
+
+  set(HPX_WITH_PRECOMPILED_HEADERS_INTERNAL ON)
+
+  add_library(hpx_precompiled_headers OBJECT libs/src/dummy.cpp)
+  target_link_libraries(hpx_precompiled_headers PRIVATE hpx_private_flags)
+  target_precompile_headers(
+    hpx_precompiled_headers
+    PRIVATE
+    <algorithm>
+    <array>
+    <atomic>
+    <bitset>
+    <cassert>
+    <cctype>
+    <cerrno>
+    <chrono>
+    <climits>
+    <cmath>
+    <complex>
+    <condition_variable>
+    <cstddef>
+    <cstdint>
+    <cstdio>
+    <cstdlib>
+    <cstring>
+    <ctime>
+    <deque>
+    <exception>
+    <forward_list>
+    <fstream>
+    <functional>
+    <iomanip>
+    <ios>
+    <iosfwd>
+    <iostream>
+    <iterator>
+    <limits>
+    <list>
+    <locale>
+    <map>
+    <memory>
+    <mutex>
+    <new>
+    <numeric>
+    <ostream>
+    <random>
+    <regex>
+    <set>
+    <shared_mutex>
+    <sstream>
+    <stack>
+    <stdexcept>
+    <string>
+    <system_error>
+    <thread>
+    <tuple>
+    <type_traits>
+    <typeinfo>
+    <unordered_map>
+    <unordered_set>
+    <utility>
+    <variant>
+    <vector>
+  )
+endif()
+
 # ##############################################################################
 # Dynamic hpx_main
 # ##############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,6 +401,8 @@ if(HPX_WITH_PRECOMPILED_HEADERS)
     <variant>
     <vector>
   )
+
+  set_target_properties(hpx_precompiled_headers PROPERTIES FOLDER "Core")
 endif()
 
 # ##############################################################################

--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -303,6 +303,12 @@ function(add_hpx_module libname modulename)
     PUBLIC hpx_base_libraries
   )
 
+  if(HPX_WITH_PRECOMPILED_HEADERS)
+    target_precompile_headers(
+      hpx_${modulename} REUSE_FROM hpx_precompiled_headers
+    )
+  endif()
+
   # All core modules depend on the config registry
   if("${libname}" STREQUAL "core" AND NOT "${modulename}" STREQUAL
                                       "config_registry"

--- a/cmake/HPX_AddParcelport.cmake
+++ b/cmake/HPX_AddParcelport.cmake
@@ -60,6 +60,12 @@ function(add_parcelport name)
     set_target_properties(${parcelport_name} PROPERTIES UNITY_BUILD ON)
   endif()
 
+  if(HPX_WITH_PRECOMPILED_HEADERS)
+    target_precompile_headers(
+      ${parcelport_name} REUSE_FROM hpx_precompiled_headers
+    )
+  endif()
+
   if(${name}_EXPORT)
     get_target_property(
       _link_libraries ${parcelport_name} INTERFACE_LINK_LIBRARIES

--- a/cmake/HPX_SetupTarget.cmake
+++ b/cmake/HPX_SetupTarget.cmake
@@ -188,6 +188,10 @@ function(hpx_setup_target target)
     set_target_properties(${target} PROPERTIES UNITY_BUILD ON)
   endif()
 
+  if(HPX_WITH_PRECOMPILED_HEADERS_INTERNAL)
+    target_precompile_headers(${target} REUSE_FROM hpx_precompiled_headers)
+  endif()
+
   get_target_property(target_EXCLUDE_FROM_ALL ${target} EXCLUDE_FROM_ALL)
 
   if(target_EXPORT AND NOT target_EXCLUDE_FROM_ALL)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -300,6 +300,10 @@ if(HPX_WITH_UNITY_BUILD)
   set_target_properties(hpx_full PROPERTIES UNITY_BUILD ON)
 endif()
 
+if(HPX_WITH_PRECOMPILED_HEADERS)
+  target_precompile_headers(hpx_full REUSE_FROM hpx_precompiled_headers)
+endif()
+
 target_link_libraries(
   hpx_full
   PUBLIC hpx_public_flags


### PR DESCRIPTION
Seems to give a modest improvement (5-10% on top of a unity build, for `hpx_core`). The list of headers may need some tweaking, since there's a tradeoff between how many headers are included and how many are actually used by HPX.

Boost headers are not included since they need to come after `hpx/config.hpp` (what's the reason for this?).

I've no clue if this will work correctly on Windows, so please give it a try and see what happens!