### PR TITLE
Remove HPX_WITH_THREAD_SCHEDULERS CMake option

### DIFF
--- a/.jenkins/cscs/env-clang-oldest.sh
+++ b/.jenkins/cscs/env-clang-oldest.sh
@@ -27,7 +27,6 @@ spack load ninja
 
 configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"
 configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT="
-configure_extra_options+=" -DHPX_WITH_THREAD_SCHEDULERS=\"abp-priority;local;static-priority;static\""
 configure_extra_options+=" -DHPX_WITH_MALLOC=system"
 configure_extra_options+=" -DHPX_WITH_CXX${CXX_STD}=ON"
 configure_extra_options+=" -DHPX_WITH_NETWORKING=OFF"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1057,65 +1057,6 @@ hpx_option(
   CATEGORY "Profiling"
 )
 
-# ##############################################################################
-# Scheduler configuration
-# ##############################################################################
-hpx_option(
-  HPX_WITH_THREAD_SCHEDULERS
-  STRING
-  "Which thread schedulers are built. Options are: all, abp-priority, local, static-priority, static, shared-priority. For multiple enabled schedulers, separate with a semicolon (default: all)"
-  "all"
-  CATEGORY "Thread Manager"
-  ADVANCED
-)
-
-string(TOUPPER "${HPX_WITH_THREAD_SCHEDULERS}" HPX_WITH_THREAD_SCHEDULERS_UC)
-foreach(_scheduler ${HPX_WITH_THREAD_SCHEDULERS_UC})
-  if(_scheduler STREQUAL "ALL")
-    set(_all On)
-    set(HPX_WITH_ALL_SCHEDULERS
-        ON
-        CACHE INTERNAL ""
-    )
-  endif()
-  if(_scheduler STREQUAL "ABP-PRIORITY" OR _all)
-    hpx_add_config_define(HPX_HAVE_ABP_SCHEDULER)
-    set(HPX_WITH_ABP_SCHEDULER
-        ON
-        CACHE INTERNAL ""
-    )
-  endif()
-  if(_scheduler STREQUAL "LOCAL" OR _all)
-    hpx_add_config_define(HPX_HAVE_LOCAL_SCHEDULER)
-    set(HPX_WITH_LOCAL_SCHEDULER
-        ON
-        CACHE INTERNAL ""
-    )
-  endif()
-  if(_scheduler STREQUAL "STATIC-PRIORITY" OR _all)
-    hpx_add_config_define(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
-    set(HPX_WITH_STATIC_PRIORITY_SCHEDULER
-        ON
-        CACHE INTERNAL ""
-    )
-  endif()
-  if(_scheduler STREQUAL "STATIC" OR _all)
-    hpx_add_config_define(HPX_HAVE_STATIC_SCHEDULER)
-    set(HPX_WITH_STATIC_SCHEDULER
-        ON
-        CACHE INTERNAL ""
-    )
-  endif()
-  if(_scheduler STREQUAL "SHARED-PRIORITY" OR _all)
-    hpx_add_config_define(HPX_HAVE_SHARED_PRIORITY_SCHEDULER)
-    set(HPX_WITH_SHARED_PRIORITY_SCHEDULER
-        ON
-        CACHE INTERNAL ""
-    )
-  endif()
-  unset(_all)
-endforeach()
-
 # Experimental settings
 hpx_option(
   HPX_WITH_IO_POOL

--- a/libs/core/schedulers/include/hpx/modules/schedulers.hpp
+++ b/libs/core/schedulers/include/hpx/modules/schedulers.hpp
@@ -8,16 +8,8 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
-#include <hpx/schedulers/local_queue_scheduler.hpp>
-#endif
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
-#include <hpx/schedulers/static_queue_scheduler.hpp>
-#endif
 #include <hpx/schedulers/local_priority_queue_scheduler.hpp>
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
-#include <hpx/schedulers/static_priority_queue_scheduler.hpp>
-#endif
-#if defined(HPX_HAVE_SHARED_PRIORITY_SCHEDULER)
+#include <hpx/schedulers/local_queue_scheduler.hpp>
 #include <hpx/schedulers/shared_priority_queue_scheduler.hpp>
-#endif
+#include <hpx/schedulers/static_priority_queue_scheduler.hpp>
+#include <hpx/schedulers/static_queue_scheduler.hpp>

--- a/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_queue_scheduler.hpp
@@ -9,7 +9,6 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
 #include <hpx/affinity/affinity_data.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/functional/function.hpp>
@@ -925,5 +924,3 @@ namespace hpx { namespace threads { namespace policies {
 }}}    // namespace hpx::threads::policies
 
 #include <hpx/config/warnings_suffix.hpp>
-
-#endif

--- a/libs/core/schedulers/include/hpx/schedulers/lockfree_queue_backends.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/lockfree_queue_backends.hpp
@@ -195,7 +195,6 @@ namespace hpx { namespace threads { namespace policies {
         };
     };
 
-#if defined(HPX_HAVE_ABP_SCHEDULER)
     ////////////////////////////////////////////////////////////////////////////
     // FIFO + stealing at opposite end.
     struct lockfree_abp_fifo;
@@ -303,7 +302,6 @@ namespace hpx { namespace threads { namespace policies {
         };
     };
 
-#endif    // HPX_HAVE_ABP_SCHEDULER
 #endif    // HPX_HAVE_CXX11_STD_ATOMIC_128BIT
 
 }}}    // namespace hpx::threads::policies

--- a/libs/core/schedulers/include/hpx/schedulers/static_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/static_priority_queue_scheduler.hpp
@@ -10,7 +10,6 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
 #include <hpx/assert.hpp>
 #include <hpx/schedulers/local_priority_queue_scheduler.hpp>
 #include <hpx/schedulers/lockfree_queue_backends.hpp>
@@ -82,5 +81,3 @@ namespace hpx { namespace threads { namespace policies {
 }}}    // namespace hpx::threads::policies
 
 #include <hpx/config/warnings_suffix.hpp>
-
-#endif

--- a/libs/core/schedulers/include/hpx/schedulers/static_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/static_queue_scheduler.hpp
@@ -9,7 +9,6 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
 #include <hpx/assert.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/schedulers/deadlock_detection.hpp>
@@ -156,5 +155,3 @@ namespace hpx { namespace threads { namespace policies {
 }}}    // namespace hpx::threads::policies
 
 #include <hpx/config/warnings_suffix.hpp>
-
-#endif

--- a/libs/core/schedulers/tests/unit/schedule_last.cpp
+++ b/libs/core/schedulers/tests/unit/schedule_last.cpp
@@ -90,7 +90,7 @@ int main(int argc, char* argv[])
         test_scheduler<scheduler_type>(argc, argv);
     }
 
-#if defined(HPX_HAVE_ABP_SCHEDULER) && defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
     {
         using scheduler_type =
             hpx::threads::policies::local_priority_queue_scheduler<std::mutex,

--- a/libs/core/thread_pools/src/scheduled_thread_pool.cpp
+++ b/libs/core/thread_pools/src/scheduled_thread_pool.cpp
@@ -9,27 +9,21 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 /// explicit template instantiation for the thread pools of our choice
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
 #include <hpx/schedulers/local_queue_scheduler.hpp>
 template class HPX_CORE_EXPORT hpx::threads::policies::local_queue_scheduler<>;
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::local_queue_scheduler<>>;
-#endif
 
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
 #include <hpx/schedulers/static_queue_scheduler.hpp>
 template class HPX_CORE_EXPORT hpx::threads::policies::static_queue_scheduler<>;
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::static_queue_scheduler<>>;
-#endif
 
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
 #include <hpx/schedulers/static_priority_queue_scheduler.hpp>
 template class HPX_CORE_EXPORT
     hpx::threads::policies::static_priority_queue_scheduler<>;
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::static_priority_queue_scheduler<>>;
-#endif
 
 #include <hpx/schedulers/local_priority_queue_scheduler.hpp>
 template class HPX_CORE_EXPORT
@@ -47,7 +41,7 @@ template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
         hpx::threads::policies::lockfree_lifo>>;
 #endif
 
-#if defined(HPX_HAVE_ABP_SCHEDULER) && defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
 template class HPX_CORE_EXPORT
     hpx::threads::policies::local_priority_queue_scheduler<std::mutex,
         hpx::threads::policies::lockfree_abp_fifo>;
@@ -62,10 +56,8 @@ template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
         hpx::threads::policies::lockfree_abp_lifo>>;
 #endif
 
-#if defined(HPX_HAVE_SHARED_PRIORITY_SCHEDULER)
 #include <hpx/schedulers/shared_priority_queue_scheduler.hpp>
 template class HPX_CORE_EXPORT
     hpx::threads::policies::shared_priority_queue_scheduler<>;
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::shared_priority_queue_scheduler<>>;
-#endif

--- a/libs/core/threading_base/include/hpx/threading_base/annotated_function.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/annotated_function.hpp
@@ -180,7 +180,8 @@ namespace hpx { namespace util {
             char const* name_;
         };
 
-        HPX_CORE_EXPORT char const* store_function_annotation(std::string&& name);
+        HPX_CORE_EXPORT char const* store_function_annotation(
+            std::string&& name);
     }    // namespace detail
 
     template <typename F>

--- a/libs/core/threading_base/tests/regressions/thread_stacksize_current.cpp
+++ b/libs/core/threading_base/tests/regressions/thread_stacksize_current.cpp
@@ -63,28 +63,9 @@ int hpx_main()
 
 int main(int argc, char** argv)
 {
-    std::vector<std::string> schedulers = {
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
-        "local",
-#endif
-        "local-priority-fifo",
-#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
-        "local-priority-lifo",
-#endif
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
-        "static",
-#endif
-#if defined(HPX_HAVE_STATIC_PRIOIRITY_SCHEDULER)
-        "static-priority",
-#endif
-#if defined(HPX_HAVE_ABP_SCHEDULER) && defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
-        "abp-priority-fifo",
-        "abp-priority-lifo",
-#endif
-#if defined(HPX_HAVE_SHARED_PRIOIRITY_SCHEDULER)
-        "shared-priority"
-#endif
-    };
+    std::vector<std::string> schedulers = {"local", "local-priority-fifo",
+        "local-priority-lifo", "static", "static-priority", "abp-priority-fifo",
+        "abp-priority-lifo", "shared-priority"};
     for (auto const& scheduler : schedulers)
     {
         hpx::init_params iparams;

--- a/libs/full/thread_executors/include/hpx/execution/executors/this_thread_executors.hpp
+++ b/libs/full/thread_executors/include/hpx/execution/executors/this_thread_executors.hpp
@@ -14,15 +14,11 @@
 
 namespace hpx { namespace parallel { namespace execution {
     ///////////////////////////////////////////////////////////////////////////
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
     using this_thread_static_queue_executor =
         threads::executors::this_thread_static_queue_executor;
-#endif
 
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     using this_thread_static_priority_queue_executor =
         threads::executors::this_thread_static_priority_queue_executor;
-#endif
 }}}    // namespace hpx::parallel::execution
 
 #endif

--- a/libs/full/thread_executors/include/hpx/execution/executors/thread_pool_executors.hpp
+++ b/libs/full/thread_executors/include/hpx/execution/executors/thread_pool_executors.hpp
@@ -16,7 +16,6 @@
 
 namespace hpx { namespace parallel { namespace execution {
     ///////////////////////////////////////////////////////////////////////////
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
     /// Creates a new local_queue_executor
     ///
     /// \param max_punits   [in] The maximum number of processing units to
@@ -26,9 +25,7 @@ namespace hpx { namespace parallel { namespace execution {
     ///                     (default: 1).
     ///
     using local_queue_executor = threads::executors::local_queue_executor;
-#endif
 
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
     /// Creates a new static_queue_executor
     ///
     /// \param max_punits   [in] The maximum number of processing units to
@@ -38,7 +35,6 @@ namespace hpx { namespace parallel { namespace execution {
     ///                     (default: 1).
     ///
     using static_queue_executor = threads::executors::static_queue_executor;
-#endif
 
     /// Creates a new local_priority_queue_executor
     ///
@@ -51,7 +47,6 @@ namespace hpx { namespace parallel { namespace execution {
     using local_priority_queue_executor =
         threads::executors::local_priority_queue_executor;
 
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     /// Creates a new static_priority_queue_executor
     ///
     /// \param max_punits   [in] The maximum number of processing units to
@@ -62,6 +57,5 @@ namespace hpx { namespace parallel { namespace execution {
     ///
     using static_priority_queue_executor =
         threads::executors::static_priority_queue_executor;
-#endif
 }}}    // namespace hpx::parallel::execution
 #endif

--- a/libs/full/thread_executors/include/hpx/execution/executors/thread_pool_os_executors.hpp
+++ b/libs/full/thread_executors/include/hpx/execution/executors/thread_pool_os_executors.hpp
@@ -15,7 +15,6 @@
 
 namespace hpx { namespace parallel { namespace execution {
     ///////////////////////////////////////////////////////////////////////////
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
     /// Creates a new local_queue_os_executor
     ///
     /// \param max_punits   [in] The maximum number of processing units to
@@ -25,9 +24,7 @@ namespace hpx { namespace parallel { namespace execution {
     ///                     (default: 1).
     ///
     using local_queue_os_executor = threads::executors::local_queue_os_executor;
-#endif
 
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
     /// Creates a new static_queue_os_executor
     ///
     /// \param max_punits   [in] The maximum number of processing units to
@@ -38,7 +35,6 @@ namespace hpx { namespace parallel { namespace execution {
     ///
     using static_queue_os_executor =
         threads::executors::static_queue_os_executor;
-#endif
 
     /// Creates a new local_priority_queue_executor
     ///
@@ -51,7 +47,6 @@ namespace hpx { namespace parallel { namespace execution {
     using local_priority_queue_os_executor =
         threads::executors::local_priority_queue_os_executor;
 
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     /// Creates a new static_priority_queue_executor
     ///
     /// \param max_punits   [in] The maximum number of processing units to
@@ -62,6 +57,5 @@ namespace hpx { namespace parallel { namespace execution {
     ///
     using static_priority_queue_os_executor =
         threads::executors::static_priority_queue_os_executor;
-#endif
 }}}    // namespace hpx::parallel::execution
 #endif

--- a/libs/full/thread_executors/include/hpx/thread_executors/embedded_thread_pool_executors.hpp
+++ b/libs/full/thread_executors/include/hpx/thread_executors/embedded_thread_pool_executors.hpp
@@ -155,7 +155,6 @@ namespace hpx { namespace threads { namespace executors {
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
     struct HPX_EXPORT local_queue_executor : public scheduled_executor
     {
         local_queue_executor();
@@ -163,9 +162,7 @@ namespace hpx { namespace threads { namespace executors {
         explicit local_queue_executor(
             std::size_t max_punits, std::size_t min_punits = 1);
     };
-#endif
 
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
     struct HPX_EXPORT static_queue_executor : public scheduled_executor
     {
         static_queue_executor();
@@ -173,7 +170,6 @@ namespace hpx { namespace threads { namespace executors {
         explicit static_queue_executor(
             std::size_t max_punits, std::size_t min_punits = 1);
     };
-#endif
 
     struct HPX_EXPORT local_priority_queue_executor : public scheduled_executor
     {
@@ -183,7 +179,6 @@ namespace hpx { namespace threads { namespace executors {
             std::size_t max_punits, std::size_t min_punits = 1);
     };
 
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     struct HPX_EXPORT static_priority_queue_executor : public scheduled_executor
     {
         static_priority_queue_executor();
@@ -191,7 +186,6 @@ namespace hpx { namespace threads { namespace executors {
         explicit static_priority_queue_executor(
             std::size_t max_punits, std::size_t min_punits = 1);
     };
-#endif
 
 }}}    // namespace hpx::threads::executors
 

--- a/libs/full/thread_executors/include/hpx/thread_executors/this_thread_executors.hpp
+++ b/libs/full/thread_executors/include/hpx/thread_executors/this_thread_executors.hpp
@@ -8,9 +8,7 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_THREAD_EXECUTORS_COMPATIBILITY) &&                        \
-    (defined(HPX_HAVE_STATIC_SCHEDULER) ||                                     \
-        defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER))
+#if defined(HPX_HAVE_THREAD_EXECUTORS_COMPATIBILITY)
 
 #include <hpx/affinity/affinity_data.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
@@ -141,21 +139,17 @@ namespace hpx { namespace threads { namespace executors {
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
     struct HPX_EXPORT this_thread_static_queue_executor
       : public scheduled_executor
     {
         this_thread_static_queue_executor();
     };
-#endif
 
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     struct HPX_EXPORT this_thread_static_priority_queue_executor
       : public scheduled_executor
     {
         this_thread_static_priority_queue_executor();
     };
-#endif
 }}}    // namespace hpx::threads::executors
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/thread_executors/include/hpx/thread_executors/thread_pool_attached_executors.hpp
+++ b/libs/full/thread_executors/include/hpx/thread_executors/thread_pool_attached_executors.hpp
@@ -13,23 +13,17 @@
 
 namespace hpx { namespace threads { namespace executors {
     ///////////////////////////////////////////////////////////////////////////
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
     using local_queue_attached_executor =
         parallel::execution::local_queue_attached_executor;
-#endif
 
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
     using static_queue_attached_executor =
         parallel::execution::static_queue_attached_executor;
-#endif
 
     using local_priority_queue_attached_executor =
         parallel::execution::local_priority_queue_attached_executor;
 
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     using static_priority_queue_attached_executor =
         parallel::execution::static_priority_queue_attached_executor;
-#endif
 }}}    // namespace hpx::threads::executors
 
 #endif

--- a/libs/full/thread_executors/include/hpx/thread_executors/thread_pool_os_executors.hpp
+++ b/libs/full/thread_executors/include/hpx/thread_executors/thread_pool_os_executors.hpp
@@ -121,7 +121,6 @@ namespace hpx { namespace threads { namespace executors {
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
     struct HPX_EXPORT local_queue_os_executor : public scheduled_executor
     {
         local_queue_os_executor(std::size_t num_threads,
@@ -129,9 +128,7 @@ namespace hpx { namespace threads { namespace executors {
             util::optional<policies::callback_notifier> notifier =
                 util::nullopt);
     };
-#endif
 
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
     struct HPX_EXPORT static_queue_os_executor : public scheduled_executor
     {
         static_queue_os_executor(std::size_t num_threads,
@@ -139,7 +136,6 @@ namespace hpx { namespace threads { namespace executors {
             util::optional<policies::callback_notifier> notifier =
                 util::nullopt);
     };
-#endif
 
     struct HPX_EXPORT local_priority_queue_os_executor
       : public scheduled_executor
@@ -150,7 +146,6 @@ namespace hpx { namespace threads { namespace executors {
                 util::nullopt);
     };
 
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     struct HPX_EXPORT static_priority_queue_os_executor
       : public scheduled_executor
     {
@@ -159,7 +154,6 @@ namespace hpx { namespace threads { namespace executors {
             util::optional<policies::callback_notifier> notifier =
                 util::nullopt);
     };
-#endif
 }}}    // namespace hpx::threads::executors
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/thread_executors/src/embedded_thread_pool_executors.cpp
+++ b/libs/full/thread_executors/src/embedded_thread_pool_executors.cpp
@@ -9,22 +9,16 @@
 #if defined(HPX_HAVE_THREAD_EXECUTORS_COMPATIBILITY) &&                        \
     defined(HPX_HAVE_EMBEDDED_THREAD_POOLS_COMPATIBILITY)
 
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
-#include <hpx/schedulers/local_queue_scheduler.hpp>
-#endif
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
-#include <hpx/schedulers/static_queue_scheduler.hpp>
-#endif
-#include <hpx/schedulers/local_priority_queue_scheduler.hpp>
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
-#include <hpx/schedulers/static_priority_queue_scheduler.hpp>
-#endif
 #include <hpx/assert.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/execution/detail/execution_parameter_callbacks.hpp>
 #include <hpx/execution_base/this_thread.hpp>
 #include <hpx/functional/deferred_call.hpp>
 #include <hpx/functional/unique_function.hpp>
+#include <hpx/schedulers/local_priority_queue_scheduler.hpp>
+#include <hpx/schedulers/local_queue_scheduler.hpp>
+#include <hpx/schedulers/static_priority_queue_scheduler.hpp>
+#include <hpx/schedulers/static_queue_scheduler.hpp>
 #include <hpx/thread_executors/detail/on_self_reset.hpp>
 #include <hpx/thread_executors/manage_thread_executor.hpp>
 #include <hpx/thread_executors/resource_manager.hpp>
@@ -463,7 +457,6 @@ namespace hpx { namespace threads { namespace executors { namespace detail {
 }}}}    // namespace hpx::threads::executors::detail
 
 namespace hpx { namespace threads { namespace executors {
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
     ///////////////////////////////////////////////////////////////////////////
     local_queue_executor::local_queue_executor()
       : scheduled_executor(new detail::embedded_thread_pool_executor<
@@ -480,9 +473,7 @@ namespace hpx { namespace threads { namespace executors {
             max_punits, min_punits, "local_queue_executor"))
     {
     }
-#endif
 
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
     ///////////////////////////////////////////////////////////////////////////
     static_queue_executor::static_queue_executor()
       : scheduled_executor(new detail::embedded_thread_pool_executor<
@@ -499,7 +490,6 @@ namespace hpx { namespace threads { namespace executors {
             max_punits, min_punits, "static_queue_executor"))
     {
     }
-#endif
 
     ///////////////////////////////////////////////////////////////////////////
     local_priority_queue_executor::local_priority_queue_executor()
@@ -518,7 +508,6 @@ namespace hpx { namespace threads { namespace executors {
     {
     }
 
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     ///////////////////////////////////////////////////////////////////////////
     static_priority_queue_executor::static_priority_queue_executor()
       : scheduled_executor(new detail::embedded_thread_pool_executor<
@@ -535,7 +524,6 @@ namespace hpx { namespace threads { namespace executors {
             max_punits, min_punits, "static_priority_queue_executor"))
     {
     }
-#endif
 
 }}}    // namespace hpx::threads::executors
 #endif

--- a/libs/full/thread_executors/src/this_thread_executors.cpp
+++ b/libs/full/thread_executors/src/this_thread_executors.cpp
@@ -7,16 +7,10 @@
 #include <hpx/thread_executors/this_thread_executors.hpp>
 
 #if defined(HPX_HAVE_THREAD_EXECUTORS_COMPATIBILITY) &&                        \
-    defined(HPX_HAVE_EMBEDDED_THREAD_POOLS_COMPATIBILITY) &&                   \
-    (defined(HPX_HAVE_STATIC_SCHEDULER) ||                                     \
-        defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER))
+    defined(HPX_HAVE_EMBEDDED_THREAD_POOLS_COMPATIBILITY)
 
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
 #include <hpx/schedulers/static_priority_queue_scheduler.hpp>
-#endif
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
 #include <hpx/schedulers/static_queue_scheduler.hpp>
-#endif
 
 #include <hpx/affinity/affinity_data.hpp>
 #include <hpx/assert.hpp>
@@ -456,7 +450,6 @@ namespace hpx { namespace threads { namespace executors { namespace detail {
 }}}}    // namespace hpx::threads::executors::detail
 
 namespace hpx { namespace threads { namespace executors {
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
     ///////////////////////////////////////////////////////////////////////////
     this_thread_static_queue_executor::this_thread_static_queue_executor()
       : scheduled_executor(new detail::this_thread_executor<
@@ -464,9 +457,7 @@ namespace hpx { namespace threads { namespace executors {
             "this_thread_static_queue_executor"))
     {
     }
-#endif
 
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     ///////////////////////////////////////////////////////////////////////////
     this_thread_static_priority_queue_executor::
         this_thread_static_priority_queue_executor()
@@ -475,7 +466,6 @@ namespace hpx { namespace threads { namespace executors {
             "this_thread_static_priority_queue_executor"))
     {
     }
-#endif
 }}}    // namespace hpx::threads::executors
 
 #endif

--- a/libs/full/thread_executors/src/thread_pool_os_executors.cpp
+++ b/libs/full/thread_executors/src/thread_pool_os_executors.cpp
@@ -10,22 +10,16 @@
 #include <hpx/thread_executors/thread_pool_os_executors.hpp>
 #include <hpx/threading_base/thread_pool_base.hpp>
 
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
-#include <hpx/schedulers/local_queue_scheduler.hpp>
-#endif
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
-#include <hpx/schedulers/static_queue_scheduler.hpp>
-#endif
-#include <hpx/schedulers/local_priority_queue_scheduler.hpp>
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
-#include <hpx/schedulers/static_priority_queue_scheduler.hpp>
-#endif
 #include <hpx/assert.hpp>
 #include <hpx/coroutines/thread_enums.hpp>
 #include <hpx/datastructures/optional.hpp>
 #include <hpx/execution_base/this_thread.hpp>
 #include <hpx/functional/bind.hpp>
 #include <hpx/functional/unique_function.hpp>
+#include <hpx/schedulers/local_priority_queue_scheduler.hpp>
+#include <hpx/schedulers/local_queue_scheduler.hpp>
+#include <hpx/schedulers/static_priority_queue_scheduler.hpp>
+#include <hpx/schedulers/static_queue_scheduler.hpp>
 #include <hpx/threading_base/thread_description.hpp>
 
 #include <atomic>
@@ -261,7 +255,6 @@ namespace hpx { namespace threads { namespace executors { namespace detail {
 }}}}    // namespace hpx::threads::executors::detail
 
 namespace hpx { namespace threads { namespace executors {
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
     ///////////////////////////////////////////////////////////////////////////
     local_queue_os_executor::local_queue_os_executor(std::size_t num_threads,
         policies::detail::affinity_data const& affinity_data,
@@ -271,9 +264,7 @@ namespace hpx { namespace threads { namespace executors {
             num_threads, affinity_data, notifier))
     {
     }
-#endif
 
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
     ///////////////////////////////////////////////////////////////////////////
     static_queue_os_executor::static_queue_os_executor(std::size_t num_threads,
         policies::detail::affinity_data const& affinity_data,
@@ -283,7 +274,6 @@ namespace hpx { namespace threads { namespace executors {
             num_threads, affinity_data, notifier))
     {
     }
-#endif
 
     ///////////////////////////////////////////////////////////////////////////
     local_priority_queue_os_executor::local_priority_queue_os_executor(
@@ -296,7 +286,6 @@ namespace hpx { namespace threads { namespace executors {
     {
     }
 
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     ///////////////////////////////////////////////////////////////////////////
     static_priority_queue_os_executor::static_priority_queue_os_executor(
         std::size_t num_threads,
@@ -307,6 +296,5 @@ namespace hpx { namespace threads { namespace executors {
             num_threads, affinity_data, notifier))
     {
     }
-#endif
 }}}    // namespace hpx::threads::executors
 #endif

--- a/libs/full/thread_executors/tests/unit/resource_manager.cpp
+++ b/libs/full/thread_executors/tests/unit/resource_manager.cpp
@@ -108,16 +108,10 @@ void test_executors(std::size_t num_pus)
 
     processing_units = (processing_units / num_pus) * num_pus;
 
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
     test_executors<local_queue_executor>(processing_units, num_pus);
-#endif
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
     test_executors<static_queue_executor>(processing_units, num_pus);
-#endif
     test_executors<local_priority_queue_executor>(processing_units, num_pus);
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     test_executors<static_priority_queue_executor>(processing_units, num_pus);
-#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -197,18 +191,12 @@ void test_executors_shrink(std::size_t num_pus)
     processing_units =
         (std::max)((processing_units / num_pus) * num_pus, std::size_t(1));
 
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
     test_executors_shrink<local_queue_executor>(processing_units, num_pus);
-#endif
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
     test_executors_shrink<static_queue_executor>(processing_units, num_pus);
-#endif
     test_executors_shrink<local_priority_queue_executor>(
         processing_units, num_pus);
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     test_executors_shrink<static_priority_queue_executor>(
         processing_units, num_pus);
-#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/thread_executors/tests/unit/standalone_thread_pool_os_executors.cpp
+++ b/libs/full/thread_executors/tests/unit/standalone_thread_pool_os_executors.cpp
@@ -184,19 +184,10 @@ int main()
 {
     using namespace hpx::parallel;
 
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
     spawn_test<execution::local_queue_os_executor>();
-#endif
-
     spawn_test<execution::local_priority_queue_os_executor>();
-
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
     spawn_test<execution::static_queue_os_executor>();
-#endif
-
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     spawn_test<execution::static_priority_queue_os_executor>();
-#endif
 
     return hpx::util::report_errors();
 }

--- a/libs/full/thread_executors/tests/unit/this_thread_executors.cpp
+++ b/libs/full/thread_executors/tests/unit/this_thread_executors.cpp
@@ -150,19 +150,15 @@ int hpx_main()
 {
     using namespace hpx::parallel;
 
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
     {
         execution::this_thread_static_queue_executor exec;
         test_this_thread_executor(exec);
     }
-#endif
 
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     {
         execution::this_thread_static_priority_queue_executor exec;
         test_this_thread_executor(exec);
     }
-#endif
 
     return hpx::finalize();
 }

--- a/libs/full/thread_executors/tests/unit/thread_pool_executors.cpp
+++ b/libs/full/thread_executors/tests/unit/thread_pool_executors.cpp
@@ -153,24 +153,20 @@ int hpx_main()
 
     std::size_t num_threads = hpx::get_os_thread_count();
 
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
     {
         execution::static_queue_executor exec(num_threads);
         test_thread_pool_executor(exec);
     }
-#endif
 
     {
         execution::local_priority_queue_executor exec(num_threads);
         test_thread_pool_executor(exec);
     }
 
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     {
         execution::static_priority_queue_executor exec(num_threads);
         test_thread_pool_executor(exec);
     }
-#endif
 
     return hpx::finalize();
 }

--- a/libs/full/thread_executors/tests/unit/thread_pool_os_executors.cpp
+++ b/libs/full/thread_executors/tests/unit/thread_pool_os_executors.cpp
@@ -155,13 +155,11 @@ int hpx_main()
     std::size_t num_threads = hpx::get_os_thread_count();
     auto const& partitioner = hpx::resource::get_partitioner();
 
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
     {
         execution::static_queue_os_executor exec(
             num_threads, partitioner.get_affinity_data());
         test_thread_pool_os_executor(exec);
     }
-#endif
 
     {
         execution::local_priority_queue_os_executor exec(
@@ -169,13 +167,11 @@ int hpx_main()
         test_thread_pool_os_executor(exec);
     }
 
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     {
         execution::static_priority_queue_os_executor exec(
             num_threads, partitioner.get_affinity_data());
         test_thread_pool_os_executor(exec);
     }
-#endif
 
     return hpx::finalize();
 }

--- a/libs/full/thread_executors/tests/unit/timed_this_thread_executors.cpp
+++ b/libs/full/thread_executors/tests/unit/timed_this_thread_executors.cpp
@@ -69,20 +69,16 @@ int hpx_main()
     std::size_t num_threads = hpx::get_os_thread_count();
     HPX_UNUSED(num_threads);
 
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
     {
         hpx::parallel::execution::this_thread_static_queue_executor exec;
         test_timed_this_thread_executor(exec);
     }
-#endif
 
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     {
         hpx::parallel::execution::this_thread_static_priority_queue_executor
             exec;
         test_timed_this_thread_executor(exec);
     }
-#endif
 
     return hpx::finalize();
 }

--- a/libs/full/thread_executors/tests/unit/timed_thread_pool_executors.cpp
+++ b/libs/full/thread_executors/tests/unit/timed_thread_pool_executors.cpp
@@ -68,12 +68,10 @@ int hpx_main()
 {
     std::size_t num_threads = hpx::get_os_thread_count();
 
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
     {
         hpx::parallel::execution::static_queue_executor exec(num_threads);
         test_timed_thread_pool_executor(exec);
     }
-#endif
 
     {
         hpx::parallel::execution::local_priority_queue_executor exec(
@@ -81,13 +79,11 @@ int hpx_main()
         test_timed_thread_pool_executor(exec);
     }
 
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     {
         hpx::parallel::execution::static_priority_queue_executor exec(
             num_threads);
         test_timed_thread_pool_executor(exec);
     }
-#endif
 
     return hpx::finalize();
 }

--- a/libs/full/threadmanager/src/threadmanager.cpp
+++ b/libs/full/threadmanager/src/threadmanager.cpp
@@ -210,7 +210,6 @@ namespace hpx { namespace threads {
             }
             case resource::local:
             {
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
                 // instantiate the scheduler
                 using local_sched_type =
                     hpx::threads::policies::local_queue_scheduler<>;
@@ -234,12 +233,6 @@ namespace hpx { namespace threads {
                     new hpx::threads::detail::scheduled_thread_pool<
                         local_sched_type>(std::move(sched), thread_pool_init));
                 pools_.push_back(std::move(pool));
-#else
-                throw hpx::detail::command_line_error(
-                    "Command line option --hpx:queuing=local "
-                    "is not configured in this build. Please rebuild with "
-                    "'cmake -DHPX_WITH_THREAD_SCHEDULERS=local'.");
-#endif
                 break;
             }
 
@@ -321,17 +314,14 @@ namespace hpx { namespace threads {
 #else
                 throw hpx::detail::command_line_error(
                     "Command line option --hpx:queuing=local-priority-lifo "
-                    "is not configured in this build. Please rebuild with "
-                    "'cmake -DHPX_WITH_THREAD_SCHEDULERS=local-priority-lifo'. "
-                    "Additionally, please make sure 128bit atomics are "
-                    "available.");
+                    "is not configured in this build. Please make sure 128bit "
+                    "atomics are available.");
 #endif
                 break;
             }
 
             case resource::static_:
             {
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
                 // instantiate the scheduler
                 using local_sched_type =
                     hpx::threads::policies::static_queue_scheduler<>;
@@ -355,18 +345,11 @@ namespace hpx { namespace threads {
                     new hpx::threads::detail::scheduled_thread_pool<
                         local_sched_type>(std::move(sched), thread_pool_init));
                 pools_.push_back(std::move(pool));
-#else
-                throw hpx::detail::command_line_error(
-                    "Command line option --hpx:queuing=static "
-                    "is not configured in this build. Please rebuild with "
-                    "'cmake -DHPX_WITH_THREAD_SCHEDULERS=static'.");
-#endif
                 break;
             }
 
             case resource::static_priority:
             {
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
                 // set parameters for scheduler and pool instantiation and
                 // perform compatibility checks
                 std::size_t num_high_priority_queues =
@@ -399,19 +382,12 @@ namespace hpx { namespace threads {
                     new hpx::threads::detail::scheduled_thread_pool<
                         local_sched_type>(std::move(sched), thread_pool_init));
                 pools_.push_back(std::move(pool));
-#else
-                throw hpx::detail::command_line_error(
-                    "Command line option --hpx:queuing=static-priority "
-                    "is not configured in this build. Please rebuild with "
-                    "'cmake "
-                    "-DHPX_WITH_THREAD_SCHEDULERS=static-priority'.");
-#endif
                 break;
             }
 
             case resource::abp_priority_fifo:
             {
-#if defined(HPX_HAVE_ABP_SCHEDULER) && defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
                 // set parameters for scheduler and pool instantiation and
                 // perform compatibility checks
                 std::size_t num_high_priority_queues =
@@ -449,17 +425,15 @@ namespace hpx { namespace threads {
 #else
                 throw hpx::detail::command_line_error(
                     "Command line option --hpx:queuing=abp-priority-fifo "
-                    "is not configured in this build. Please rebuild with "
-                    "'cmake -DHPX_WITH_THREAD_SCHEDULERS=abp-priority'. "
-                    "Additionally, please make sure 128bit atomics are "
-                    "available.");
+                    "is not configured in this build. Please make sure 128bit "
+                    "atomics are available.");
 #endif
                 break;
             }
 
             case resource::abp_priority_lifo:
             {
-#if defined(HPX_HAVE_ABP_SCHEDULER) && defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
                 // set parameters for scheduler and pool instantiation and
                 // perform compatibility checks
                 std::size_t num_high_priority_queues =
@@ -497,15 +471,14 @@ namespace hpx { namespace threads {
 #else
                 throw hpx::detail::command_line_error(
                     "Command line option --hpx:queuing=abp-priority-lifo "
-                    "is not configured in this build. Please rebuild with "
-                    "'cmake -DHPX_WITH_THREAD_SCHEDULERS=abp-priority'.");
+                    "is not configured in this build. Please make sure 128bit "
+                    "atomics are available.");
 #endif
                 break;
             }
 
             case resource::shared_priority:
             {
-#if defined(HPX_HAVE_SHARED_PRIORITY_SCHEDULER)
                 // instantiate the scheduler
                 typedef hpx::threads::policies::
                     shared_priority_queue_scheduler<>
@@ -529,13 +502,6 @@ namespace hpx { namespace threads {
                     new hpx::threads::detail::scheduled_thread_pool<
                         local_sched_type>(std::move(sched), thread_pool_init));
                 pools_.push_back(std::move(pool));
-#else
-                throw hpx::detail::command_line_error(
-                    "Command line option --hpx:queuing=shared-priority "
-                    "is not configured in this build. Please rebuild with "
-                    "'cmake "
-                    "-DHPX_WITH_THREAD_SCHEDULERS=shared-priority'.");
-#endif
                 break;
             }
             }

--- a/libs/parallelism/executors/include/hpx/executors/thread_pool_attached_executors.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/thread_pool_attached_executors.hpp
@@ -10,20 +10,14 @@
 
 namespace hpx { namespace parallel { namespace execution {
 #if defined(HPX_HAVE_THREAD_EXECUTORS_COMPATIBILITY)
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
     using local_queue_attached_executor = restricted_thread_pool_executor;
-#endif
 
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
     using static_queue_attached_executor = restricted_thread_pool_executor;
-#endif
 
     using local_priority_queue_attached_executor =
         restricted_thread_pool_executor;
 
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     using static_priority_queue_attached_executor =
         restricted_thread_pool_executor;
-#endif
 #endif
 }}}    // namespace hpx::parallel::execution

--- a/libs/parallelism/executors/tests/unit/thread_pool_attached_executors.cpp
+++ b/libs/parallelism/executors/tests/unit/thread_pool_attached_executors.cpp
@@ -153,24 +153,20 @@ int hpx_main()
 
     std::size_t num_threads = hpx::get_os_thread_count();
 
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
     {
         execution::static_queue_attached_executor exec(0, num_threads);
         test_thread_pool_attached_executor(exec);
     }
-#endif
 
     {
         execution::local_priority_queue_attached_executor exec(0, num_threads);
         test_thread_pool_attached_executor(exec);
     }
 
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
     {
         execution::static_priority_queue_attached_executor exec(0, num_threads);
         test_thread_pool_attached_executor(exec);
     }
-#endif
 
     return hpx::finalize();
 }

--- a/tests/unit/resource/cross_pool_injection.cpp
+++ b/tests/unit/resource/cross_pool_injection.cpp
@@ -267,27 +267,19 @@ void test_scheduler(
 int main(int argc, char* argv[])
 {
     std::vector<hpx::resource::scheduling_policy> schedulers = {
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
         hpx::resource::scheduling_policy::local,
         hpx::resource::scheduling_policy::local_priority_fifo,
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::local_priority_lifo,
 #endif
-#endif
-#if defined(HPX_HAVE_ABP_SCHEDULER) && defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::abp_priority_fifo,
         hpx::resource::scheduling_policy::abp_priority_lifo,
 #endif
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
         hpx::resource::scheduling_policy::static_,
-#endif
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
         hpx::resource::scheduling_policy::static_priority,
-#endif
-#if defined(HPX_HAVE_SHARED_PRIORITY_SCHEDULER)
-    // The shared_priority scheduler sometimes hangs in this test.
-    //hpx::resource::scheduling_policy::shared_priority,
-#endif
+        // The shared_priority scheduler sometimes hangs in this test.
+        //hpx::resource::scheduling_policy::shared_priority,
     };
 
     for (auto const scheduler : schedulers)

--- a/tests/unit/resource/shutdown_suspended_pus.cpp
+++ b/tests/unit/resource/shutdown_suspended_pus.cpp
@@ -69,20 +69,16 @@ int main(int argc, char* argv[])
     {
         // These schedulers should succeed
         std::vector<hpx::resource::scheduling_policy> schedulers = {
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
             hpx::resource::scheduling_policy::local,
             hpx::resource::scheduling_policy::local_priority_fifo,
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
             hpx::resource::scheduling_policy::local_priority_lifo,
 #endif
-#endif
-#if defined(HPX_HAVE_ABP_SCHEDULER) && defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
             hpx::resource::scheduling_policy::abp_priority_fifo,
             hpx::resource::scheduling_policy::abp_priority_lifo,
 #endif
-#if defined(HPX_HAVE_SHARED_PRIORITY_SCHEDULER)
             hpx::resource::scheduling_policy::shared_priority,
-#endif
         };
 
         for (auto const scheduler : schedulers)
@@ -94,12 +90,8 @@ int main(int argc, char* argv[])
     {
         // These schedulers should fail
         std::vector<hpx::resource::scheduling_policy> schedulers = {
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
             hpx::resource::scheduling_policy::static_,
-#endif
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
             hpx::resource::scheduling_policy::static_priority,
-#endif
         };
 
         for (auto const scheduler : schedulers)

--- a/tests/unit/resource/suspend_pool.cpp
+++ b/tests/unit/resource/suspend_pool.cpp
@@ -168,26 +168,18 @@ void test_scheduler(
 int main(int argc, char* argv[])
 {
     std::vector<hpx::resource::scheduling_policy> schedulers = {
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
         hpx::resource::scheduling_policy::local,
         hpx::resource::scheduling_policy::local_priority_fifo,
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::local_priority_lifo,
 #endif
-#endif
-#if defined(HPX_HAVE_ABP_SCHEDULER) && defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::abp_priority_fifo,
         hpx::resource::scheduling_policy::abp_priority_lifo,
 #endif
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
         hpx::resource::scheduling_policy::static_,
-#endif
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
         hpx::resource::scheduling_policy::static_priority,
-#endif
-#if defined(HPX_HAVE_SHARED_PRIORITY_SCHEDULER)
         hpx::resource::scheduling_policy::shared_priority,
-#endif
     };
 
     for (auto const scheduler : schedulers)

--- a/tests/unit/resource/suspend_pool_external.cpp
+++ b/tests/unit/resource/suspend_pool_external.cpp
@@ -81,26 +81,18 @@ void test_scheduler(
 int main(int argc, char* argv[])
 {
     std::vector<hpx::resource::scheduling_policy> schedulers = {
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
         hpx::resource::scheduling_policy::local,
         hpx::resource::scheduling_policy::local_priority_fifo,
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::local_priority_lifo,
 #endif
-#endif
-#if defined(HPX_HAVE_ABP_SCHEDULER) && defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::abp_priority_fifo,
         hpx::resource::scheduling_policy::abp_priority_lifo,
 #endif
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
         hpx::resource::scheduling_policy::static_,
-#endif
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
         hpx::resource::scheduling_policy::static_priority,
-#endif
-#if defined(HPX_HAVE_SHARED_PRIORITY_SCHEDULER)
         hpx::resource::scheduling_policy::shared_priority,
-#endif
     };
 
     for (auto const scheduler : schedulers)

--- a/tests/unit/resource/suspend_runtime.cpp
+++ b/tests/unit/resource/suspend_runtime.cpp
@@ -59,26 +59,18 @@ void test_scheduler(
 int main(int argc, char* argv[])
 {
     std::vector<hpx::resource::scheduling_policy> schedulers = {
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
         hpx::resource::scheduling_policy::local,
         hpx::resource::scheduling_policy::local_priority_fifo,
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::local_priority_lifo,
 #endif
-#endif
-#if defined(HPX_HAVE_ABP_SCHEDULER) && defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::abp_priority_fifo,
         hpx::resource::scheduling_policy::abp_priority_lifo,
 #endif
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
         hpx::resource::scheduling_policy::static_,
-#endif
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
         hpx::resource::scheduling_policy::static_priority,
-#endif
-#if defined(HPX_HAVE_SHARED_PRIORITY_SCHEDULER)
         hpx::resource::scheduling_policy::shared_priority,
-#endif
     };
 
     for (auto const scheduler : schedulers)

--- a/tests/unit/resource/suspend_thread.cpp
+++ b/tests/unit/resource/suspend_thread.cpp
@@ -217,20 +217,16 @@ int main(int argc, char* argv[])
     {
         // These schedulers should succeed
         std::vector<hpx::resource::scheduling_policy> schedulers = {
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
             hpx::resource::scheduling_policy::local,
             hpx::resource::scheduling_policy::local_priority_fifo,
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
             hpx::resource::scheduling_policy::local_priority_lifo,
 #endif
-#endif
-#if defined(HPX_HAVE_ABP_SCHEDULER) && defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
             hpx::resource::scheduling_policy::abp_priority_fifo,
             hpx::resource::scheduling_policy::abp_priority_lifo,
 #endif
-#if defined(HPX_HAVE_SHARED_PRIORITY_SCHEDULER)
             hpx::resource::scheduling_policy::shared_priority,
-#endif
         };
 
         for (auto const scheduler : schedulers)
@@ -242,12 +238,8 @@ int main(int argc, char* argv[])
     {
         // These schedulers should fail
         std::vector<hpx::resource::scheduling_policy> schedulers = {
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
             hpx::resource::scheduling_policy::static_,
-#endif
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
             hpx::resource::scheduling_policy::static_priority,
-#endif
         };
 
         for (auto const scheduler : schedulers)

--- a/tests/unit/resource/suspend_thread_external.cpp
+++ b/tests/unit/resource/suspend_thread_external.cpp
@@ -184,26 +184,18 @@ void test_scheduler(
 int main(int argc, char* argv[])
 {
     std::vector<hpx::resource::scheduling_policy> schedulers = {
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
         hpx::resource::scheduling_policy::local,
         hpx::resource::scheduling_policy::local_priority_fifo,
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::local_priority_lifo,
 #endif
-#endif
-#if defined(HPX_HAVE_ABP_SCHEDULER) && defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::abp_priority_fifo,
         hpx::resource::scheduling_policy::abp_priority_lifo,
 #endif
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
         hpx::resource::scheduling_policy::static_,
-#endif
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
         hpx::resource::scheduling_policy::static_priority,
-#endif
-#if defined(HPX_HAVE_SHARED_PRIORITY_SCHEDULER)
         hpx::resource::scheduling_policy::shared_priority,
-#endif
     };
 
     for (auto const scheduler : schedulers)

--- a/tests/unit/resource/suspend_thread_timed.cpp
+++ b/tests/unit/resource/suspend_thread_timed.cpp
@@ -132,14 +132,12 @@ int main(int argc, char* argv[])
     {
         // These schedulers should succeed
         std::vector<hpx::resource::scheduling_policy> schedulers = {
-#if defined(HPX_HAVE_LOCAL_SCHEDULER)
             hpx::resource::scheduling_policy::local,
             hpx::resource::scheduling_policy::local_priority_fifo,
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
             hpx::resource::scheduling_policy::local_priority_lifo,
 #endif
-#endif
-#if defined(HPX_HAVE_ABP_SCHEDULER) && defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
             hpx::resource::scheduling_policy::abp_priority_fifo,
             hpx::resource::scheduling_policy::abp_priority_lifo,
 #endif
@@ -154,16 +152,10 @@ int main(int argc, char* argv[])
     {
         // These schedulers should fail
         std::vector<hpx::resource::scheduling_policy> schedulers = {
-#if defined(HPX_HAVE_STATIC_SCHEDULER)
             hpx::resource::scheduling_policy::static_,
-#endif
-#if defined(HPX_HAVE_STATIC_PRIORITY_SCHEDULER)
             hpx::resource::scheduling_policy::static_priority,
-#endif
-#if defined(HPX_HAVE_SHARED_PRIORITY_SCHEDULER)
-        // until timed thread problems are fix, disable this
-        //hpx::resource::scheduling_policy::shared_priority,
-#endif
+            // until timed thread problems are fix, disable this
+            //hpx::resource::scheduling_policy::shared_priority,
         };
 
         for (auto const scheduler : schedulers)


### PR DESCRIPTION
Instead enables everything that is enable-able.

@biddisco I've added a fallback for the shared priority scheduler for when `HPX_WITH_MAX_CPU_COUNT` is undefined (HPX doesn't use fixed-size bitsets in this case). It seems to work ok, but I'd appreciate you having a look.
