### PR TITLE
Don't run segmented algorithms twice on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -394,20 +394,30 @@ jobs:
           paths:
             - ./build
 
-  tests.unit1:
+  tests.unit:
     <<: *defaults
     steps:
       - attach_workspace:
           at: /hpx
       - run:
-          name: Building Unit Tests (1)
+          name: Building Unit Tests
           command: |
+              ninja -j2 -k 0 tests.unit
               ninja -j1 -k 0 tests.unit.modules.segmented_algorithms
       - run:
-          name: Running Unit Tests (1)
+          name: Running Unit Tests
           when: always
           command: |
               ulimit -c unlimited
+              ctest \
+                --timeout 60 \
+                -T test \
+                --no-compress-output \
+                --output-on-failure \
+                --tests-regex tests.unit \
+                --exclude-regex \
+              "tests.unit.modules.segmented_algorithms|\
+              tests.unit.modules.compute.numa_allocator"
               ctest \
                 --timeout 120 \
                 -T test \
@@ -421,33 +431,10 @@ jobs:
       - run:
           <<: *move_debug_log
       - store_test_results:
-          path: tests.unit1
+          path: tests.unit
       - store_artifacts:
-          path: tests.unit1
+          path: tests.unit
 
-  tests.unit2:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: /hpx
-      - run:
-          name: Building Unit Tests (2)
-          command: |
-              ninja -j2 -k 0 tests.unit
-      - run:
-          name: Running Unit Tests (2)
-          when: always
-          command: |
-              ulimit -c unlimited
-              ctest \
-                --timeout 60 \
-                -T test \
-                --no-compress-output \
-                --output-on-failure \
-                --tests-regex tests.unit \
-                --exclude-regex \
-              "tests.unit.modules.segmented_algorithms|\
-              tests.unit.modules.compute.numa_allocator"
       - run:
           <<: *convert_xml
       - run:
@@ -651,9 +638,7 @@ workflows:
           <<: *gh_pages_filter
       - tests.examples:
           <<: *core_dependency
-      - tests.unit1:
-          <<: *core_dependency
-      - tests.unit2:
+      - tests.unit:
           <<: *core_dependency
       - tests.regressions:
           <<: *core_dependency
@@ -676,8 +661,7 @@ workflows:
           requires:
             - core
             - tests.examples
-            - tests.unit1
-            - tests.unit2
+            - tests.unit
             - tests.regressions
             - tests.performance
             - tests.headers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,7 +408,12 @@ jobs:
           when: always
           command: |
               ulimit -c unlimited
-              ctest --timeout 60 -T test --no-compress-output --output-on-failure -R tests.unit.modules.segmented_algorithms -E tests.unit.modules.compute.numa_allocator
+              ctest \
+                --timeout 120 \
+                -T test \
+                --no-compress-output \
+                --output-on-failure \
+                --tests-regex tests.unit.modules.segmented_algorithms
       - run:
           <<: *convert_xml
       - run:
@@ -434,7 +439,15 @@ jobs:
           when: always
           command: |
               ulimit -c unlimited
-              ctest --timeout 60 -T test --no-compress-output --output-on-failure -R tests.unit -E tests.unit.modules.segmented_algorithms -E tests.unit.modules.compute.numa_allocator
+              ctest \
+                --timeout 60 \
+                -T test \
+                --no-compress-output \
+                --output-on-failure \
+                --tests-regex tests.unit \
+                --exclude-regex \
+              "tests.unit.modules.segmented_algorithms|\
+              tests.unit.modules.compute.numa_allocator"
       - run:
           <<: *convert_xml
       - run:

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_exclusive_scan.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_exclusive_scan.cpp
@@ -325,7 +325,11 @@ void exclusive_scan_tests_inplace_with_policy(
 template <typename T>
 void exclusive_scan_tests(std::vector<hpx::id_type>& localities)
 {
+#if defined(HPX_DEBUG)
+    std::size_t const length = 10000;
+#else
     std::size_t const length = 1000000;
+#endif
 
     exclusive_scan_tests_with_policy<T>(length, hpx::container_layout);
     exclusive_scan_tests_with_policy<T>(length, hpx::container_layout(3));

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_exclusive_scan2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_exclusive_scan2.cpp
@@ -325,7 +325,11 @@ void exclusive_scan_tests_inplace_with_policy(
 template <typename T>
 void exclusive_scan_tests(std::vector<hpx::id_type>& localities)
 {
+#if defined(HPX_DEBUG)
+    std::size_t const length = 10000;
+#else
     std::size_t const length = 1000000;
+#endif
 
     exclusive_scan_tests_with_policy<T>(length, hpx::container_layout);
     exclusive_scan_tests_with_policy<T>(length, hpx::container_layout(3));

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_inclusive_scan.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_inclusive_scan.cpp
@@ -320,7 +320,11 @@ void inclusive_scan_tests_inplace_with_policy(
 template <typename T>
 void inclusive_scan_tests(std::vector<hpx::id_type>& localities)
 {
+#if defined(HPX_DEBUG)
+    std::size_t const length = 10000;
+#else
     std::size_t const length = 1000000;
+#endif
 
     inclusive_scan_tests_with_policy<T>(length, hpx::container_layout);
     inclusive_scan_tests_with_policy<T>(length, hpx::container_layout(3));

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_inclusive_scan2.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_inclusive_scan2.cpp
@@ -320,7 +320,11 @@ void inclusive_scan_tests_inplace_with_policy(
 template <typename T>
 void inclusive_scan_tests(std::vector<hpx::id_type>& localities)
 {
+#if defined(HPX_DEBUG)
+    std::size_t const length = 10000;
+#else
     std::size_t const length = 1000000;
+#endif
 
     inclusive_scan_tests_with_policy<T>(length, hpx::container_layout);
     inclusive_scan_tests_with_policy<T>(length, hpx::container_layout(3));


### PR DESCRIPTION
Flyby: increase test timeout for segmented algorithms (This is just me being hopeful. It may be that the segmented algorithm tests have started timing out more frequently simply because they run slower. Whether this is due to CircleCI or HPX becoming slower is another question).