### PR TITLE
Fix parallel remove/remove_copy/transform namespace references in docs

### DIFF
--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -70,10 +70,10 @@ Functions
 - :cpp:func:`hpx::partial_sort`
 - :cpp:func:`hpx::parallel::v1::partition`
 - :cpp:func:`hpx::parallel::v1::partition_copy`
-- :cpp:func:`hpx::parallel::v1::remove`
-- :cpp:func:`hpx::parallel::v1::remove_copy`
-- :cpp:func:`hpx::parallel::v1::remove_copy_if`
-- :cpp:func:`hpx::parallel::v1::remove_if`
+- :cpp:func:`hpx::remove`
+- :cpp:func:`hpx::remove_copy`
+- :cpp:func:`hpx::remove_copy_if`
+- :cpp:func:`hpx::remove_if`
 - :cpp:func:`hpx::parallel::v1::replace`
 - :cpp:func:`hpx::parallel::v1::replace_copy`
 - :cpp:func:`hpx::parallel::v1::replace_copy_if`

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -466,19 +466,19 @@ Parallel algorithms
      * Saves the result of N applications of a function.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`generate_n`
-   * * :cpp:func:`hpx::parallel::v1::remove`
+   * * :cpp:func:`hpx::remove`
      * Removes the elements from a range that are equal to the given value.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`remove`
-   * * :cpp:func:`hpx::parallel::v1::remove_if`
+   * * :cpp:func:`hpx::remove_if`
      * Removes the elements from a range that are equal to the given predicate is ``false``
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`remove`
-   * * :cpp:func:`hpx::parallel::v1::remove_copy`
+   * * :cpp:func:`hpx::remove_copy`
      * Copies the elements from a range to a new location that are not equal to the given value.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`remove_copy`
-   * * :cpp:func:`hpx::parallel::v1::remove_copy_if`
+   * * :cpp:func:`hpx::remove_copy_if`
      * Copies the elements from a range to a new location for which the given predicate is ``false``
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`remove_copy`
@@ -518,7 +518,7 @@ Parallel algorithms
      * Swaps two ranges of elements.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`swap_ranges`
-   * * :cpp:func:`hpx::parallel::v1::transform`
+   * * :cpp:func:`hpx::transform`
      * Applies a function to a range of elements.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`transform`


### PR DESCRIPTION
Fixing a minor documentation oversight on the parallel algos I adapted.
