### PR TITLE
Fix htts_v2 tests linking

### DIFF
--- a/tests/performance/local/htts_v2/CMakeLists.txt
+++ b/tests/performance/local/htts_v2/CMakeLists.txt
@@ -4,64 +4,21 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(boost_library_dependencies ${Boost_LIBRARIES})
-
-set(benchmarks
-    htts2_payload_precision
-    # htts2_payload_baseline
-    htts2_hpx
-)
-
-set(htts2_payload_precision_FLAGS
-    NOLIBS
-    DEPENDENCIES
-    ${boost_library_dependencies}
-    hpx_assertion
-    hpx_config
-    hpx_format
-    hpx_program_options
-)
+set(benchmarks htts2_payload_precision htts2_hpx)
 
 if(HPX_WITH_EXAMPLES_OPENMP)
   set(benchmarks ${benchmarks} htts2_omp)
-  set(htts2_omp_FLAGS
-      NOLIBS
-      DEPENDENCIES
-      ${boost_library_dependencies}
-      hpx_assertion
-      hpx_config
-      hpx_format
-      hpx_program_options
-  )
 endif()
 
 if(HPX_WITH_EXAMPLES_QTHREADS)
   set(benchmarks ${benchmarks} htts2_qthreads)
-  set(htts2_qthreads_FLAGS
-      NOLIBS
-      DEPENDENCIES
-      ${boost_library_dependencies}
-      ${QTHREADS_LIBRARY}
-      hpx_assertion
-      hpx_config
-      hpx_format
-      hpx_program_options
-  )
+  set(htts2_qthreads_LIBRARIES ${QTHREADS_LIBRARY})
   set(htts2_qthreads_INCLUDE_DIRECTORIES ${QTHREADS_INCLUDE_DIR})
 endif()
 
 if(HPX_WITH_EXAMPLES_TBB)
   set(benchmarks ${benchmarks} htts2_tbb)
-  set(htts2_tbb_FLAGS
-      NOLIBS
-      DEPENDENCIES
-      ${boost_library_dependencies}
-      ${TBB_LIBRARY}
-      hpx_assertion
-      hpx_config
-      hpx_format
-      hpx_program_options
-  )
+  set(htts2_tbb_LIBRARIES ${TBB_LIBRARY})
   set(htts2_tbb_INCLUDE_DIRECTORIES ${TBB_INCLUDE_DIR})
 endif()
 
@@ -74,12 +31,12 @@ foreach(benchmark ${benchmarks})
   add_hpx_executable(
     ${benchmark} INTERNAL_FLAGS
     SOURCES ${sources} ${${benchmark}_FLAGS}
+    DEPENDENCIES ${${benchmark}_LIBRARIES}
     EXCLUDE_FROM_ALL
     HPX_PREFIX ${HPX_BUILD_PREFIX}
     FOLDER "Benchmarks/HTTS v2/${benchmark}"
   )
 
-  target_compile_definitions(${benchmark} PRIVATE HPX_MODULE_STATIC_LINKING)
   target_include_directories(
     ${benchmark} SYSTEM PRIVATE ${${benchmark}_INCLUDE_DIRECTORIES}
   )


### PR DESCRIPTION
Looks like there is an ABI problem with boost regex, this is an attempt to fix it