### PR TITLE
Remove dependency on boost/iterators/iterator_categories.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2194,6 +2194,19 @@ if(HPX_WITH_POOL_EXECUTOR_COMPATIBILITY)
   hpx_add_config_define(HPX_HAVE_POOL_EXECUTOR_COMPATIBILITY)
 endif()
 
+# Compatibility with using Boost.Iterator traversal tags, introduced in V1.7.0
+hpx_option(
+  HPX_ITERATOR_SUPPORT_WITH_BOOST_ITERATOR_TRAVERSAL_TAG_COMPATIBILITY BOOL
+  "Enable Boost.Iterator traversal tag compatibility. (default: OFF)" OFF
+  ADVANCED CATEGORY "Modules"
+)
+if(HPX_ITERATOR_SUPPORT_WITH_BOOST_ITERATOR_TRAVERSAL_TAG_COMPATIBILITY)
+  hpx_add_config_define_namespace(
+    DEFINE HPX_ITERATOR_SUPPORT_HAVE_BOOST_ITERATOR_TRAVERSAL_TAG_COMPATIBILITY
+    NAMESPACE ITERATOR_SUPPORT
+  )
+endif()
+
 # ##############################################################################
 # Find Our dependencies: These are all dependencies needed to build the core
 # library. Dependencies that are only needed by plugins, examples or tests

--- a/libs/core/iterator_support/CMakeLists.txt
+++ b/libs/core/iterator_support/CMakeLists.txt
@@ -8,6 +8,7 @@ set(iterator_support_headers
     hpx/iterator_support/traits/is_iterator.hpp
     hpx/iterator_support/traits/is_range.hpp
     hpx/iterator_support/traits/is_sentinel_for.hpp
+    hpx/iterator_support/boost_iterator_categories.hpp
     hpx/iterator_support/counting_iterator.hpp
     hpx/iterator_support/generator_iterator.hpp
     hpx/iterator_support/iterator_adaptor.hpp

--- a/libs/core/iterator_support/include/hpx/iterator_support/boost_iterator_categories.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/boost_iterator_categories.hpp
@@ -1,0 +1,209 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// (C) Copyright Jeremy Siek 2002.
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if !defined(                                                                  \
+    HPX_ITERATOR_SUPPORT_HAVE_BOOST_ITERATOR_TRAVERSAL_TAG_COMPATIBILITY)
+
+#include <hpx/type_support/identity.hpp>
+#include <hpx/type_support/lazy_conditional.hpp>
+
+#include <iterator>
+#include <type_traits>
+
+namespace hpx { namespace iterators {
+
+    // Traversal Categories
+    struct no_traversal_tag
+    {
+    };
+
+    struct incrementable_traversal_tag : no_traversal_tag
+    {
+    };
+
+    struct single_pass_traversal_tag : incrementable_traversal_tag
+    {
+    };
+
+    struct forward_traversal_tag : single_pass_traversal_tag
+    {
+    };
+
+    struct bidirectional_traversal_tag : forward_traversal_tag
+    {
+    };
+
+    struct random_access_traversal_tag : bidirectional_traversal_tag
+    {
+    };
+
+    namespace detail {
+
+        // Convert a standard iterator category to a traversal tag.
+        // This is broken out into a separate meta-function to reduce
+        // the cost of instantiating iterator_category_to_traversal, below,
+        // for new-style types.
+        template <typename Cat>
+        struct std_category_to_traversal
+          : hpx::util::lazy_conditional<
+                std::is_convertible<Cat,
+                    std::random_access_iterator_tag>::value,
+                hpx::util::identity<random_access_traversal_tag>,
+                hpx::util::lazy_conditional<
+                    std::is_convertible<Cat,
+                        std::bidirectional_iterator_tag>::value,
+                    hpx::util::identity<bidirectional_traversal_tag>,
+                    hpx::util::lazy_conditional<
+                        std::is_convertible<Cat,
+                            std::forward_iterator_tag>::value,
+                        hpx::util::identity<forward_traversal_tag>,
+                        hpx::util::lazy_conditional<
+                            std::is_convertible<Cat,
+                                std::input_iterator_tag>::value,
+                            hpx::util::identity<single_pass_traversal_tag>,
+                            hpx::util::lazy_conditional<
+                                std::is_convertible<Cat,
+                                    std::output_iterator_tag>::value,
+                                hpx::util::identity<
+                                    incrementable_traversal_tag>,
+                                hpx::util::identity<no_traversal_tag>>>>>>
+        {
+        };
+    }    // namespace detail
+
+    // Convert an iterator category into a traversal tag
+    template <typename Cat>
+    struct iterator_category_to_traversal
+      : hpx::util::lazy_conditional<
+            std::is_convertible<Cat, incrementable_traversal_tag>::value,
+            hpx::util::identity<Cat>, detail::std_category_to_traversal<Cat>>
+    {
+    };
+
+    // Trait to get an iterator's traversal category
+    template <typename Iterator>
+    struct iterator_traversal
+      : iterator_category_to_traversal<
+            typename std::iterator_traits<Iterator>::iterator_category>
+    {
+    };
+
+    // Convert an iterator traversal to one of the traversal tags.
+    template <typename Traversal>
+    struct pure_traversal_tag
+      : hpx::util::lazy_conditional<
+            std::is_convertible<Traversal, random_access_traversal_tag>::value,
+            hpx::util::identity<random_access_traversal_tag>,
+            hpx::util::lazy_conditional<std::is_convertible<Traversal,
+                                            bidirectional_traversal_tag>::value,
+                hpx::util::identity<bidirectional_traversal_tag>,
+                hpx::util::lazy_conditional<std::is_convertible<Traversal,
+                                                forward_traversal_tag>::value,
+                    hpx::util::identity<forward_traversal_tag>,
+                    hpx::util::lazy_conditional<
+                        std::is_convertible<Traversal,
+                            single_pass_traversal_tag>::value,
+                        hpx::util::identity<single_pass_traversal_tag>,
+                        hpx::util::lazy_conditional<
+                            std::is_convertible<Traversal,
+                                incrementable_traversal_tag>::value,
+                            hpx::util::identity<incrementable_traversal_tag>,
+                            hpx::util::identity<no_traversal_tag>>>>>>
+    {
+    };
+
+    // Trait to retrieve one of the iterator traversal tags from the
+    // iterator category or traversal.
+    template <typename Iterator>
+    struct pure_iterator_traversal
+      : pure_traversal_tag<typename iterator_traversal<Iterator>::type>
+    {
+    };
+}}    // namespace hpx::iterators
+
+#define HPX_ITERATOR_TRAVERSAL_TAG_NS hpx
+
+#else
+
+#include <boost/iterator/iterator_categories.hpp>
+
+#define HPX_ITERATOR_TRAVERSAL_TAG_NS boost
+
+#endif    // HPX_ITERATOR_SUPPORT_HAVE_BOOST_ITERATOR_TRAVERSAL_TAG_COMPATIBILITY
+
+namespace hpx {
+
+    using HPX_ITERATOR_TRAVERSAL_TAG_NS::iterators::bidirectional_traversal_tag;
+    using HPX_ITERATOR_TRAVERSAL_TAG_NS::iterators::forward_traversal_tag;
+    using HPX_ITERATOR_TRAVERSAL_TAG_NS::iterators::incrementable_traversal_tag;
+    using HPX_ITERATOR_TRAVERSAL_TAG_NS::iterators::no_traversal_tag;
+    using HPX_ITERATOR_TRAVERSAL_TAG_NS::iterators::random_access_traversal_tag;
+    using HPX_ITERATOR_TRAVERSAL_TAG_NS::iterators::single_pass_traversal_tag;
+
+    namespace traits {
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Traversal>
+        using pure_traversal_tag =
+            HPX_ITERATOR_TRAVERSAL_TAG_NS::iterators::pure_traversal_tag<
+                Traversal>;
+
+        template <typename Traversal>
+        using pure_traversal_tag_t =
+            typename pure_traversal_tag<Traversal>::type;
+
+        template <typename Traversal>
+        HPX_INLINE_CONSTEXPR_VARIABLE bool pure_traversal_tag_v =
+            pure_traversal_tag<Traversal>::value;
+
+        template <typename Iterator>
+        using pure_iterator_traversal =
+            HPX_ITERATOR_TRAVERSAL_TAG_NS::iterators::pure_iterator_traversal<
+                Iterator>;
+
+        template <typename Iterator>
+        using pure_iterator_traversal_t =
+            typename pure_iterator_traversal<Iterator>::type;
+
+        template <typename Iterator>
+        HPX_INLINE_CONSTEXPR_VARIABLE bool pure_iterator_traversal_v =
+            pure_iterator_traversal<Iterator>::value;
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Cat>
+        using iterator_category_to_traversal = HPX_ITERATOR_TRAVERSAL_TAG_NS::
+            iterators::iterator_category_to_traversal<Cat>;
+
+        template <typename Cat>
+        using iterator_category_to_traversal_t =
+            typename iterator_category_to_traversal<Cat>::type;
+
+        template <typename Cat>
+        HPX_INLINE_CONSTEXPR_VARIABLE bool iterator_category_to_traversal_v =
+            iterator_category_to_traversal<Cat>::value;
+
+        template <typename Iterator>
+        using iterator_traversal =
+            HPX_ITERATOR_TRAVERSAL_TAG_NS::iterators::iterator_traversal<
+                Iterator>;
+
+        template <typename Iterator>
+        using iterator_traversal_t =
+            typename iterator_traversal<Iterator>::type;
+
+        template <typename Iterator>
+        HPX_INLINE_CONSTEXPR_VARIABLE bool iterator_traversal_v =
+            iterator_traversal<Iterator>::value;
+    }    // namespace traits
+}    // namespace hpx
+
+#undef HPX_ITERATOR_TRAVERSAL_TAG_NS

--- a/libs/core/iterator_support/include/hpx/iterator_support/traits/is_iterator.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/traits/is_iterator.hpp
@@ -8,10 +8,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/iterator_support/boost_iterator_categories.hpp>
 #include <hpx/type_support/always_void.hpp>
 #include <hpx/type_support/equality.hpp>
-
-#include <boost/iterator/iterator_categories.hpp>
 
 #include <iterator>
 #include <type_traits>
@@ -274,20 +273,20 @@ namespace hpx { namespace traits {
          * ForwardIterator concept.
          */
         template <typename Iter>
-        struct satisfy_traversal_concept<Iter, boost::forward_traversal_tag>
+        struct satisfy_traversal_concept<Iter, hpx::forward_traversal_tag>
           : bidirectional_concept<Iter>
         {
         };
 
         template <typename Iter>
-        struct satisfy_traversal_concept<Iter,
-            boost::bidirectional_traversal_tag> : bidirectional_concept<Iter>
+        struct satisfy_traversal_concept<Iter, hpx::bidirectional_traversal_tag>
+          : bidirectional_concept<Iter>
         {
         };
 
         template <typename Iter>
-        struct satisfy_traversal_concept<Iter,
-            boost::random_access_traversal_tag> : random_access_concept<Iter>
+        struct satisfy_traversal_concept<Iter, hpx::random_access_traversal_tag>
+          : random_access_concept<Iter>
         {
         };
     }    // namespace detail
@@ -297,8 +296,15 @@ namespace hpx { namespace traits {
     {
     };
 
+    template <typename Iter>
+    using is_iterator_t = typename is_iterator<Iter>::type;
+
+    template <typename Iter>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_iterator_v = is_iterator<Iter>::value;
+
+    ///////////////////////////////////////////////////////////////////////////
     namespace detail {
-        ///////////////////////////////////////////////////////////////////////
+
         template <typename Iter, typename Cat, typename Enable = void>
         struct belongs_to_iterator_category : std::false_type
         {
@@ -323,7 +329,7 @@ namespace hpx { namespace traits {
             typename std::enable_if<is_iterator<Iter>::value>::type>
           : std::integral_constant<bool,
                 std::is_base_of<Traversal,
-                    typename boost::iterator_traversal<Iter>::type>::value ||
+                    hpx::traits::iterator_traversal_t<Iter>>::value ||
                     satisfy_traversal_concept<Iter, Traversal>::value>
         {
         };
@@ -351,32 +357,31 @@ namespace hpx { namespace traits {
         template <typename Iter, typename Traversal>
         struct has_traversal<Iter, Traversal,
             typename std::enable_if<is_iterator<Iter>::value>::type>
-          : std::is_same<Traversal,
-                typename boost::iterator_traversal<Iter>::type>
+          : std::is_same<Traversal, hpx::traits::iterator_traversal_t<Iter>>
         {
         };
 
         template <typename Iter>
-        struct has_traversal<Iter, boost::bidirectional_traversal_tag,
+        struct has_traversal<Iter, hpx::bidirectional_traversal_tag,
             typename std::enable_if<is_iterator<Iter>::value>::type>
           : std::integral_constant<bool,
-                std::is_same<boost::bidirectional_traversal_tag,
-                    typename boost::iterator_traversal<Iter>::type>::value ||
+                std::is_same<hpx::bidirectional_traversal_tag,
+                    hpx::traits::iterator_traversal_t<Iter>>::value ||
                     (satisfy_traversal_concept<Iter,
-                         boost::bidirectional_traversal_tag>::value &&
+                         hpx::bidirectional_traversal_tag>::value &&
                         !satisfy_traversal_concept<Iter,
-                            boost::random_access_traversal_tag>::value)>
+                            hpx::random_access_traversal_tag>::value)>
         {
         };
 
         template <typename Iter>
-        struct has_traversal<Iter, boost::random_access_traversal_tag,
+        struct has_traversal<Iter, hpx::random_access_traversal_tag,
             typename std::enable_if<is_iterator<Iter>::value>::type>
           : std::integral_constant<bool,
-                std::is_same<boost::random_access_traversal_tag,
-                    typename boost::iterator_traversal<Iter>::type>::value ||
+                std::is_same<hpx::random_access_traversal_tag,
+                    hpx::traits::iterator_traversal_t<Iter>>::value ||
                     satisfy_traversal_concept<Iter,
-                        boost::random_access_traversal_tag>::value>
+                        hpx::random_access_traversal_tag>::value>
         {
         };
     }    // namespace detail
@@ -397,9 +402,16 @@ namespace hpx { namespace traits {
                 std::output_iterator_tag>::value ||
                 detail::belongs_to_iterator_traversal<
                     typename std::decay<Iter>::type,
-                    boost::incrementable_traversal_tag>::value>
+                    hpx::incrementable_traversal_tag>::value>
     {
     };
+
+    template <typename Iter>
+    using is_output_iterator_t = typename is_output_iterator<Iter>::type;
+
+    template <typename Iter>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_output_iterator_v =
+        is_output_iterator<Iter>::value;
 
     template <typename Iter, typename Enable = void>
     struct is_input_iterator
@@ -409,9 +421,16 @@ namespace hpx { namespace traits {
                 std::input_iterator_tag>::value ||
                 detail::belongs_to_iterator_traversal<
                     typename std::decay<Iter>::type,
-                    boost::single_pass_traversal_tag>::value>
+                    hpx::single_pass_traversal_tag>::value>
     {
     };
+
+    template <typename Iter>
+    using is_input_iterator_t = typename is_input_iterator<Iter>::type;
+
+    template <typename Iter>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_input_iterator_v =
+        is_input_iterator<Iter>::value;
 
     template <typename Iter, typename Enable = void>
     struct is_forward_iterator
@@ -421,9 +440,16 @@ namespace hpx { namespace traits {
                 std::forward_iterator_tag>::value ||
                 detail::belongs_to_iterator_traversal<
                     typename std::decay<Iter>::type,
-                    boost::forward_traversal_tag>::value>
+                    hpx::forward_traversal_tag>::value>
     {
     };
+
+    template <typename Iter>
+    using is_forward_iterator_t = typename is_forward_iterator<Iter>::type;
+
+    template <typename Iter>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_forward_iterator_v =
+        is_forward_iterator<Iter>::value;
 
     template <typename Iter, typename Enable = void>
     struct is_bidirectional_iterator
@@ -433,9 +459,17 @@ namespace hpx { namespace traits {
                 std::bidirectional_iterator_tag>::value ||
                 detail::belongs_to_iterator_traversal<
                     typename std::decay<Iter>::type,
-                    boost::bidirectional_traversal_tag>::value>
+                    hpx::bidirectional_traversal_tag>::value>
     {
     };
+
+    template <typename Iter>
+    using is_bidirectional_iterator_t =
+        typename is_bidirectional_iterator<Iter>::type;
+
+    template <typename Iter>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_bidirectional_iterator_v =
+        is_bidirectional_iterator<Iter>::value;
 
     template <typename Iter, typename Enable = void>
     struct is_random_access_iterator
@@ -443,20 +477,50 @@ namespace hpx { namespace traits {
             detail::has_category<typename std::decay<Iter>::type,
                 std::random_access_iterator_tag>::value ||
                 detail::has_traversal<typename std::decay<Iter>::type,
-                    boost::random_access_traversal_tag>::value>
+                    hpx::random_access_traversal_tag>::value>
     {
     };
+
+    template <typename Iter>
+    using is_random_access_iterator_t =
+        typename is_random_access_iterator<Iter>::type;
+
+    template <typename Iter>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_random_access_iterator_v =
+        is_random_access_iterator<Iter>::value;
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Iterator, typename Enable = void>
     struct is_segmented_iterator;
 
+    template <typename Iter>
+    using is_segmented_iterator_t = typename is_segmented_iterator<Iter>::type;
+
+    template <typename Iter>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_segmented_iterator_v =
+        is_segmented_iterator<Iter>::value;
+
     template <typename Iterator, typename Enable = void>
     struct is_segmented_local_iterator;
+
+    template <typename Iter>
+    using is_segmented_local_iterator_t =
+        typename is_segmented_local_iterator<Iter>::type;
+
+    template <typename Iter>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_segmented_local_iterator_v =
+        is_segmented_local_iterator<Iter>::value;
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Iter, typename Enable = void>
     struct is_zip_iterator : std::false_type
     {
     };
+
+    template <typename Iter>
+    using is_zip_iterator_t = typename is_zip_iterator<Iter>::type;
+
+    template <typename Iter>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_zip_iterator_v =
+        is_zip_iterator<Iter>::value;
 }}    // namespace hpx::traits

--- a/libs/core/iterator_support/tests/unit/CMakeLists.txt
+++ b/libs/core/iterator_support/tests/unit/CMakeLists.txt
@@ -1,10 +1,11 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2019-2021 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    boost_iterator_categories
     counting_iterator
     is_iterator
     is_range

--- a/libs/core/iterator_support/tests/unit/boost_iterator_categories.cpp
+++ b/libs/core/iterator_support/tests/unit/boost_iterator_categories.cpp
@@ -1,0 +1,38 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/iterator_support.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <iterator>
+#include <type_traits>
+
+int main()
+{
+    // convert std tags to traversal tags
+    static_assert(std::is_same<hpx::traits::iterator_category_to_traversal_t<
+                                   std::random_access_iterator_tag>,
+                      hpx::random_access_traversal_tag>::value,
+        "std::random_access_iterator_tag == hpx::random_access_traversal_tag");
+    static_assert(std::is_same<hpx::traits::iterator_category_to_traversal_t<
+                                   std::bidirectional_iterator_tag>,
+                      hpx::bidirectional_traversal_tag>::value,
+        "std::bidirectional_iterator_tag == hpx::bidirectional_traversal_tag");
+    static_assert(std::is_same<hpx::traits::iterator_category_to_traversal_t<
+                                   std::forward_iterator_tag>,
+                      hpx::forward_traversal_tag>::value,
+        "std::forward_iterator_tag == hpx::forward_traversal_tag");
+    static_assert(std::is_same<hpx::traits::iterator_category_to_traversal_t<
+                                   std::output_iterator_tag>,
+                      hpx::incrementable_traversal_tag>::value,
+        "std::output_iterator_tag == hpx::incrementable_traversal_tag");
+    static_assert(std::is_same<hpx::traits::iterator_category_to_traversal_t<
+                                   std::input_iterator_tag>,
+                      hpx::single_pass_traversal_tag>::value,
+        "std::input_iterator_tag == hpx::single_pass_traversal_tag");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/iterator_support/tests/unit/is_iterator.cpp
+++ b/libs/core/iterator_support/tests/unit/is_iterator.cpp
@@ -669,44 +669,44 @@ void satisfy_traversal_concept_forward()
     {
         using iterator = std::ostream_iterator<int>;
         HPX_TEST_MSG((!satisfy_traversal_concept<iterator,
-                         boost::forward_traversal_tag>::value),
+                         hpx::forward_traversal_tag>::value),
             "output iterator");
     }
     {
         using iterator = std::istream_iterator<int>;
         HPX_TEST_MSG((!satisfy_traversal_concept<iterator,
-                         boost::forward_traversal_tag>::value),
+                         hpx::forward_traversal_tag>::value),
             "input iterator");
     }
     {
         // see comment on definition for explanation
         using iterator = typename std::forward_list<int>::iterator;
         HPX_TEST_MSG((!satisfy_traversal_concept<iterator,
-                         boost::forward_traversal_tag>::value),
+                         hpx::forward_traversal_tag>::value),
             "forward iterator");
     }
     {
         using iterator = typename std::list<int>::iterator;
         HPX_TEST_MSG((satisfy_traversal_concept<iterator,
-                         boost::forward_traversal_tag>::value),
+                         hpx::forward_traversal_tag>::value),
             "bidirectional iterator");
     }
     {
         using iterator = typename std::vector<int>::iterator;
         HPX_TEST_MSG((satisfy_traversal_concept<iterator,
-                         boost::forward_traversal_tag>::value),
+                         hpx::forward_traversal_tag>::value),
             "random access iterator");
     }
     {
         using iterator = bidirectional_traversal_iterator;
         HPX_TEST_MSG((satisfy_traversal_concept<iterator,
-                         boost::forward_traversal_tag>::value),
+                         hpx::forward_traversal_tag>::value),
             "bidirectional traversal input iterator");
     }
     {
         using iterator = random_access_traversal_iterator;
         HPX_TEST_MSG((satisfy_traversal_concept<iterator,
-                         boost::forward_traversal_tag>::value),
+                         hpx::forward_traversal_tag>::value),
             "random access traversal input iterator");
     }
 }
@@ -718,43 +718,43 @@ void satisfy_traversal_concept_bidirectional()
     {
         using iterator = std::ostream_iterator<int>;
         HPX_TEST_MSG((!satisfy_traversal_concept<iterator,
-                         boost::bidirectional_traversal_tag>::value),
+                         hpx::bidirectional_traversal_tag>::value),
             "output iterator");
     }
     {
         using iterator = std::istream_iterator<int>;
         HPX_TEST_MSG((!satisfy_traversal_concept<iterator,
-                         boost::bidirectional_traversal_tag>::value),
+                         hpx::bidirectional_traversal_tag>::value),
             "input iterator");
     }
     {
         using iterator = typename std::forward_list<int>::iterator;
         HPX_TEST_MSG((!satisfy_traversal_concept<iterator,
-                         boost::bidirectional_traversal_tag>::value),
+                         hpx::bidirectional_traversal_tag>::value),
             "forward iterator");
     }
     {
         using iterator = typename std::list<int>::iterator;
         HPX_TEST_MSG((satisfy_traversal_concept<iterator,
-                         boost::bidirectional_traversal_tag>::value),
+                         hpx::bidirectional_traversal_tag>::value),
             "bidirectional iterator");
     }
     {
         using iterator = typename std::vector<int>::iterator;
         HPX_TEST_MSG((satisfy_traversal_concept<iterator,
-                         boost::bidirectional_traversal_tag>::value),
+                         hpx::bidirectional_traversal_tag>::value),
             "random access iterator");
     }
     {
         using iterator = bidirectional_traversal_iterator;
         HPX_TEST_MSG((satisfy_traversal_concept<iterator,
-                         boost::bidirectional_traversal_tag>::value),
+                         hpx::bidirectional_traversal_tag>::value),
             "bidirectional traversal input iterator");
     }
     {
         using iterator = random_access_traversal_iterator;
         HPX_TEST_MSG((satisfy_traversal_concept<iterator,
-                         boost::bidirectional_traversal_tag>::value),
+                         hpx::bidirectional_traversal_tag>::value),
             "random access traversal input iterator");
     }
 }
@@ -766,43 +766,43 @@ void satisfy_traversal_concept_random_access()
     {
         using iterator = std::ostream_iterator<int>;
         HPX_TEST_MSG((!satisfy_traversal_concept<iterator,
-                         boost::random_access_traversal_tag>::value),
+                         hpx::random_access_traversal_tag>::value),
             "output iterator");
     }
     {
         using iterator = std::istream_iterator<int>;
         HPX_TEST_MSG((!satisfy_traversal_concept<iterator,
-                         boost::random_access_traversal_tag>::value),
+                         hpx::random_access_traversal_tag>::value),
             "input iterator");
     }
     {
         using iterator = typename std::forward_list<int>::iterator;
         HPX_TEST_MSG((!satisfy_traversal_concept<iterator,
-                         boost::random_access_traversal_tag>::value),
+                         hpx::random_access_traversal_tag>::value),
             "forward iterator");
     }
     {
         using iterator = typename std::list<int>::iterator;
         HPX_TEST_MSG((!satisfy_traversal_concept<iterator,
-                         boost::random_access_traversal_tag>::value),
+                         hpx::random_access_traversal_tag>::value),
             "bidirectional iterator");
     }
     {
         using iterator = typename std::vector<int>::iterator;
         HPX_TEST_MSG((satisfy_traversal_concept<iterator,
-                         boost::random_access_traversal_tag>::value),
+                         hpx::random_access_traversal_tag>::value),
             "random access iterator");
     }
     {
         using iterator = bidirectional_traversal_iterator;
         HPX_TEST_MSG((!satisfy_traversal_concept<iterator,
-                         boost::random_access_traversal_tag>::value),
+                         hpx::random_access_traversal_tag>::value),
             "bidirectional traversal input iterator");
     }
     {
         using iterator = random_access_traversal_iterator;
         HPX_TEST_MSG((satisfy_traversal_concept<iterator,
-                         boost::random_access_traversal_tag>::value),
+                         hpx::random_access_traversal_tag>::value),
             "random access traversal input iterator");
     }
 }

--- a/libs/core/type_support/include/hpx/type_support/identity.hpp
+++ b/libs/core/type_support/include/hpx/type_support/identity.hpp
@@ -10,6 +10,6 @@ namespace hpx { namespace util {
     template <typename T>
     struct identity
     {
-        typedef T type;
+        using type = T;
     };
 }}    // namespace hpx::util

--- a/libs/core/type_support/include/hpx/type_support/lazy_enable_if.hpp
+++ b/libs/core/type_support/include/hpx/type_support/lazy_enable_if.hpp
@@ -15,6 +15,6 @@ namespace hpx { namespace util {
     template <typename T>
     struct lazy_enable_if<true, T>
     {
-        typedef typename T::type type;
+        using type = typename T::type;
     };
 }}    // namespace hpx::util


### PR DESCRIPTION
- flyby: add `_t `/`_v` variations for `is_iterator` traits
