### PR TITLE
Remove some minor unnecessary CMake options

### DIFF
--- a/.github/workflows/windows_debug.yml
+++ b/.github/workflows/windows_debug.yml
@@ -26,7 +26,6 @@ jobs:
           cmake . -Bbuild -G'Visual Studio 16 2019' \
               -DCMAKE_BUILD_TYPE=Debug \
               -DCMAKE_TOOLCHAIN_FILE='C:/projects/vcpkg/scripts/buildsystems/vcpkg.cmake' \
-              -DHPX_WITH_PSEUDO_DEPENDENCIES=OFF \
               -DHPX_WITH_EXAMPLES=ON \
               -DHPX_WITH_TESTS=ON \
               -DHPX_WITH_TESTS_UNIT=ON \

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -26,7 +26,6 @@ jobs:
           cmake . -Bbuild -G'Visual Studio 16 2019' \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_TOOLCHAIN_FILE='C:/projects/vcpkg/scripts/buildsystems/vcpkg.cmake' \
-              -DHPX_WITH_PSEUDO_DEPENDENCIES=OFF \
               -DHPX_WITH_EXAMPLES=ON \
               -DHPX_WITH_TESTS=ON \
               -DHPX_WITH_TESTS_UNIT=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -666,25 +666,6 @@ else()
 endif()
 
 # ##############################################################################
-# Native TLS configuration
-# ##############################################################################
-hpx_option(
-  HPX_WITH_NATIVE_TLS
-  BOOL
-  "Use native TLS support if available (default: ${HPX_WITH_NATIVE_TLS_DEFAULT})"
-  ON
-  ADVANCED
-)
-if(HPX_WITH_NATIVE_TLS)
-  hpx_info("Native TLS is enabled.")
-  hpx_add_config_define(HPX_HAVE_NATIVE_TLS)
-else()
-  hpx_error(
-    "Native TLS is disabled. HPX requires native TLS. This option will be removed in a future release."
-  )
-endif()
-
-# ##############################################################################
 # Threadlevel Nice option
 # ##############################################################################
 hpx_option(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,18 +292,10 @@ if(HPX_WITH_DOCUMENTATION)
   endforeach()
 endif()
 
-if(MSVC)
-  hpx_option(
-    HPX_WITH_PSEUDO_DEPENDENCIES BOOL
-    "Force creating pseudo targets and pseudo dependencies (default OFF)." OFF
-    CATEGORY "Build Targets"
-  )
+if(WIN32)
+  set(HPX_WITH_PSEUDO_DEPENDENCIES OFF)
 else()
-  hpx_option(
-    HPX_WITH_PSEUDO_DEPENDENCIES BOOL
-    "Force creating pseudo targets and pseudo dependencies (default ON)." ON
-    CATEGORY "Build Targets"
-  )
+  set(HPX_WITH_PSEUDO_DEPENDENCIES ON)
 endif()
 
 hpx_option(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -790,20 +790,6 @@ hpx_add_config_define(
   HPX_HAVE_MAX_NUMA_DOMAIN_COUNT ${HPX_WITH_MAX_NUMA_DOMAIN_COUNT}
 )
 
-# Deprecated in 1.4.0
-hpx_option(
-  HPX_WITH_MORE_THAN_64_THREADS
-  BOOL
-  "HPX applications will be able to run on more than 64 cores (This variable is deprecated. The value is derived from HPX_WITH_MAX_CPU_COUNT instead.)"
-  ""
-  CATEGORY "Thread Manager"
-  ADVANCED
-)
-if(HPX_WITH_MORE_THAN_64_THREADS)
-  hpx_warn(
-    "HPX_WITH_MORE_THAN_64_THREADS is deprecated. Instead use HPX_WITH_MAX_CPU_COUNT directly. If HPX_WITH_MAX_CPU_COUNT is greater than 64, or empty, HPX_HAVE_MORE_THAN_64_THREADS will be automatically set."
-  )
-endif()
 hpx_option(
   HPX_WITH_THREAD_STACK_MMAP BOOL
   "Use mmap for stack allocation on appropriate platforms" ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,12 +253,6 @@ hpx_option(
 )
 
 hpx_option(
-  HPX_WITH_DEFAULT_TARGETS BOOL
-  "Associate the core HPX library with the default build target (default: ON)."
-  ON ADVANCED CATEGORY "Build Targets"
-)
-
-hpx_option(
   HPX_WITH_COMPILER_WARNINGS BOOL "Enable compiler warnings (default: ON)" ON
   ADVANCED
 )

--- a/cmake/HPX_SetupBoost.cmake
+++ b/cmake/HPX_SetupBoost.cmake
@@ -59,10 +59,6 @@ if(NOT TARGET hpx_dependencies_boost)
     set(__boost_libraries ${__boost_libraries} system)
   endif()
 
-  if(NOT HPX_WITH_NATIVE_TLS)
-    set(__boost_libraries ${__boost_libraries} thread)
-  endif()
-
   if(HPX_WITH_GENERIC_CONTEXT_COROUTINES)
     # if context is needed, we should still link with boost thread and chrono
     set(__boost_libraries ${__boost_libraries} context thread chrono)

--- a/components/component_storage/CMakeLists.txt
+++ b/components/component_storage/CMakeLists.txt
@@ -13,10 +13,6 @@ set(HPX_COMPONENTS
     CACHE INTERNAL "list of HPX components"
 )
 
-if(NOT HPX_WITH_DEFAULT_TARGETS)
-  set(_exclude_from_all_flag EXCLUDE_FROM_ALL)
-endif()
-
 set(component_storage_headers
     hpx/components/component_storage/server/component_storage.hpp
     hpx/components/component_storage/server/migrate_from_storage.hpp
@@ -41,8 +37,7 @@ add_hpx_component(
   PREPEND_SOURCE_ROOT
   SOURCE_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/src
   SOURCES ${component_storage_sources}
-  DEPENDENCIES unordered_component ${_exclude_from_all_flag}
-               ${HPX_WITH_UNITY_BUILD_OPTION}
+  DEPENDENCIES unordered_component ${HPX_WITH_UNITY_BUILD_OPTION}
 )
 
 target_compile_definitions(

--- a/components/containers/partitioned_vector/CMakeLists.txt
+++ b/components/containers/partitioned_vector/CMakeLists.txt
@@ -13,10 +13,6 @@ set(HPX_COMPONENTS
     CACHE INTERNAL "list of HPX components"
 )
 
-if(NOT HPX_WITH_DEFAULT_TARGETS)
-  set(_exclude_from_all_flag EXCLUDE_FROM_ALL)
-endif()
-
 set(partitioned_vector_headers
     hpx/components/containers/coarray/coarray.hpp
     hpx/components/containers/partitioned_vector/detail/view_element.hpp
@@ -54,8 +50,7 @@ add_hpx_component(
   HEADERS ${partitioned_vector_headers}
   PREPEND_SOURCE_ROOT
   SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/src"
-  SOURCES ${partitioned_vector_sources} ${_exclude_from_all_flag}
-          ${HPX_WITH_UNITY_BUILD_OPTION}
+  SOURCES ${partitioned_vector_sources} ${HPX_WITH_UNITY_BUILD_OPTION}
 )
 
 target_compile_definitions(

--- a/components/containers/unordered/CMakeLists.txt
+++ b/components/containers/unordered/CMakeLists.txt
@@ -13,10 +13,6 @@ set(HPX_COMPONENTS
     CACHE INTERNAL "list of HPX components"
 )
 
-if(NOT HPX_WITH_DEFAULT_TARGETS)
-  set(_exclude_from_all_flag EXCLUDE_FROM_ALL)
-endif()
-
 set(unordered_headers
     hpx/components/containers/unordered/partition_unordered_map_component.hpp
     hpx/components/containers/unordered/unordered_map.hpp
@@ -34,8 +30,7 @@ add_hpx_component(
   HEADERS ${unordered_headers}
   PREPEND_SOURCE_ROOT
   SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/src"
-  SOURCES ${unordered_sources} ${_exclude_from_all_flag}
-          ${HPX_WITH_UNITY_BUILD_OPTION}
+  SOURCES ${unordered_sources} ${HPX_WITH_UNITY_BUILD_OPTION}
 )
 
 add_hpx_pseudo_dependencies(components.containers.unordered unordered_component)

--- a/components/create_component_skeleton.py
+++ b/components/create_component_skeleton.py
@@ -31,10 +31,6 @@ cmake_header = f'''# Copyright (c) 2019 The STE||AR-Group
 '''
 
 root_cmakelists_template = cmake_header + f'''
-if(NOT HPX_WITH_DEFAULT_TARGETS)
-  set(_exclude_from_all_flag EXCLUDE_FROM_ALL)
-endif()
-
 set({component_name}_headers)
 
 set({component_name}_sources)
@@ -47,7 +43,6 @@ add_hpx_component({component_name}
   HEADERS ${{{component_name}_headers}}
   SOURCE_ROOT "${{CMAKE_CURRENT_SOURCE_DIR}}/src"
   SOURCES ${{{component_name}_sources}}
-  ${{_exclude_from_all_flag}}
 )
 '''
 

--- a/components/iostreams/CMakeLists.txt
+++ b/components/iostreams/CMakeLists.txt
@@ -14,10 +14,6 @@ set(HPX_COMPONENTS
     CACHE INTERNAL "list of HPX components"
 )
 
-if(NOT HPX_WITH_DEFAULT_TARGETS)
-  set(_exclude_from_all_flag EXCLUDE_FROM_ALL)
-endif()
-
 set(iostreams_headers
     hpx/components/iostreams/server/buffer.hpp
     hpx/components/iostreams/server/order_output.hpp
@@ -43,8 +39,7 @@ add_hpx_component(
   HEADERS ${iostreams_headers}
   PREPEND_SOURCE_ROOT
   SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/src"
-  SOURCES ${iostreams_sources} ${_exclude_from_all_flag}
-          ${HPX_WITH_UNITY_BUILD_OPTION}
+  SOURCES ${iostreams_sources} ${HPX_WITH_UNITY_BUILD_OPTION}
 )
 
 target_compile_definitions(

--- a/components/performance_counters/io/CMakeLists.txt
+++ b/components/performance_counters/io/CMakeLists.txt
@@ -10,10 +10,6 @@ if(HPX_WITH_IO_COUNTERS)
       CACHE INTERNAL "list of HPX components"
   )
 
-  if(NOT HPX_WITH_DEFAULT_TARGETS)
-    set(_exclude_from_all_flag EXCLUDE_FROM_ALL)
-  endif()
-
   set(io_counters_headers
       hpx/components/performance_counters/io/io_counters.hpp
   )
@@ -28,8 +24,7 @@ if(HPX_WITH_IO_COUNTERS)
     HEADERS ${io_counters_headers}
     PREPEND_SOURCE_ROOT
     SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/src"
-    SOURCES ${io_counters_sources} ${_exclude_from_all_flag}
-            ${HPX_WITH_UNITY_BUILD_OPTION}
+    SOURCES ${io_counters_sources} ${HPX_WITH_UNITY_BUILD_OPTION}
   )
 
   add_hpx_pseudo_dependencies(

--- a/components/performance_counters/memory/CMakeLists.txt
+++ b/components/performance_counters/memory/CMakeLists.txt
@@ -18,10 +18,6 @@ set(HPX_COMPONENTS
     CACHE INTERNAL "list of HPX components"
 )
 
-if(NOT HPX_WITH_DEFAULT_TARGETS)
-  set(_exclude_from_all_flag EXCLUDE_FROM_ALL)
-endif()
-
 set(memory_headers hpx/components/performance_counters/memory/mem_counter.hpp)
 
 set(memory_sources mem_counter_linux.cpp mem_counter_macosx.cpp
@@ -36,8 +32,7 @@ add_hpx_component(
   HEADERS ${memory_headers}
   PREPEND_SOURCE_ROOT
   SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/src"
-  SOURCES ${memory_sources} ${_exclude_from_all_flag}
-          ${HPX_WITH_UNITY_BUILD_OPTION}
+  SOURCES ${memory_sources} ${HPX_WITH_UNITY_BUILD_OPTION}
 )
 
 add_hpx_pseudo_dependencies(

--- a/components/performance_counters/papi/CMakeLists.txt
+++ b/components/performance_counters/papi/CMakeLists.txt
@@ -10,10 +10,6 @@ if(HPX_WITH_PAPI)
       CACHE INTERNAL "list of HPX components"
   )
 
-  if(NOT HPX_WITH_DEFAULT_TARGETS)
-    set(_exclude_from_all_flag EXCLUDE_FROM_ALL)
-  endif()
-
   set(papi_counters_headers
       hpx/components/performance_counters/papi/server/papi.hpp
       hpx/components/performance_counters/papi/util/papi.hpp
@@ -30,8 +26,7 @@ if(HPX_WITH_PAPI)
     PREPEND_SOURCE_ROOT
     SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/src"
     SOURCES ${papi_counters_sources}
-    DEPENDENCIES Papi::papi ${_exclude_from_all_flag}
-                 ${HPX_WITH_UNITY_BUILD_OPTION}
+    DEPENDENCIES Papi::papi ${HPX_WITH_UNITY_BUILD_OPTION}
   )
 
   add_hpx_pseudo_dependencies(

--- a/components/process/CMakeLists.txt
+++ b/components/process/CMakeLists.txt
@@ -13,10 +13,6 @@ set(HPX_COMPONENTS
     CACHE INTERNAL "list of HPX components"
 )
 
-if(NOT HPX_WITH_DEFAULT_TARGETS)
-  set(_exclude_from_all_flag EXCLUDE_FROM_ALL)
-endif()
-
 set(process_headers
     hpx/components/process/util/windows/wait_for_exit.hpp
     hpx/components/process/util/windows/terminate.hpp
@@ -121,8 +117,7 @@ add_hpx_component(
   HEADERS ${process_headers}
   PREPEND_SOURCE_ROOT
   SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/src"
-  SOURCES ${process_sources} ${_exclude_from_all_flag}
-          ${HPX_WITH_UNITY_BUILD_OPTION}
+  SOURCES ${process_sources} ${HPX_WITH_UNITY_BUILD_OPTION}
 )
 
 target_compile_definitions(process_component PRIVATE HPX_PROCESS_EXPORTS)

--- a/libs/core/thread_support/include/hpx/thread_support/thread_specific_ptr.hpp
+++ b/libs/core/thread_support/include/hpx/thread_support/thread_specific_ptr.hpp
@@ -22,14 +22,6 @@
 #endif
 // clang-format on
 
-// native implementation
-#if !defined(HPX_HAVE_NATIVE_TLS)
-
-#error                                                                         \
-    "platforms without support for native thread local storage are not supported"
-
-#else
-
 #if (!defined(__ANDROID__) && !defined(ANDROID)) && !defined(__bgq__)
 
 namespace hpx { namespace util {
@@ -138,5 +130,4 @@ namespace hpx { namespace util {
     };
 }}    // namespace hpx::util
 
-#endif
 #endif


### PR DESCRIPTION
Removes `HPX_WITH_DEFAULT_TARGETS`, `HPX_WITH_PSEUDO_DEPENDENCIES`, `HPX_WITH_MORE_THAN_64_THREADS`, and `HPX_WITH_NATIVE_TLS`. The last two are definitely unnecessary. `HPX_WITH_PSEUDO_DEPENDENCIES` is always off on Windows, on otherwise, so I've just made it an internal variable. `HPX_WITH_DEFAULT_TARGETS` I could see someone finding useful so please speak up if you think it should be kept around.