### PR TITLE
Force CMake to set the -std=c++XX flag

### DIFF
--- a/cmake/HPX_CheckCXXStandard.cmake
+++ b/cmake/HPX_CheckCXXStandard.cmake
@@ -54,5 +54,11 @@ endif()
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+# We explicitly set the default to 98 to force CMake to emit a -std=c++XX flag.
+# Some compilers (clang) have a different default standard for cpp and cu
+# files, but CMake does not know about this difference. If the standard is set
+# to the .cpp default in CMake, CMake will omit the flag, resulting in the
+# wrong standard for .cu files.
+set(CMAKE_CXX_STANDARD_DEFAULT 98)
 
 hpx_info("Using C++${HPX_CXX_STANDARD}")

--- a/cmake/templates/HPXConfig.cmake.in
+++ b/cmake/templates/HPXConfig.cmake.in
@@ -34,6 +34,12 @@ set(HPX_PREFIX "${_hpx_root_dir}")
 set(HPX_DEBUG_POSTFIX "@HPX_DEBUG_POSTFIX@")
 set(HPX_BUILD_TYPE "@CMAKE_BUILD_TYPE@")
 set(HPX_CXX_STANDARD "@HPX_CXX_STANDARD@")
+# We explicitly set the default to 98 to force CMake to emit a -std=c++XX flag.
+# Some compilers (clang) have a different default standard for cpp and cu
+# files, but CMake does not know about this difference. If the standard is set
+# to the .cpp default in CMake, CMake will omit the flag, resulting in the
+# wrong standard for .cu files.
+set(CMAKE_CXX_STANDARD_DEFAULT 98)
 
 set(HPX_GIT_COMMIT
     "@HPX_WITH_GIT_COMMIT@"


### PR DESCRIPTION
Fixes CUDA compilation with clang.

@NK-Nikunj would you mind trying this out?

Based on https://github.com/kokkos/kokkos/issues/2520 and https://github.com/masterleinad/kokkos/commit/2a562399fa273952b1910f4c690e4f1a50e9d0ff.
