### PR TITLE
Set compatibility headers by default to on

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -349,7 +349,6 @@ with section("parse"):
                                         'pargs': { 'flags': ['APPEND'],
                                                    'nargs': '1+'}},
     'add_hpx_module': { 'kwargs': { 'CMAKE_SUBDIRS': '+',
-                                    'COMPATIBILITY_HEADERS': 1,
                                     'COMPAT_HEADERS': '+',
                                     'DEPENDENCIES': '+',
                                     'EXCLUDE_FROM_GLOBAL_HEADER': '+',

--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -417,7 +417,7 @@ function(add_hpx_module libname modulename)
 
   include(HPX_PrintSummary)
   create_configuration_summary(
-    "  Module configuration summary (${modulename}):" "${modulename}"
+    "    Module configuration (${modulename}):" "${modulename}"
   )
 
 endfunction(add_hpx_module)

--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -9,7 +9,6 @@ include(HPX_ExportTargets)
 function(add_hpx_module libname modulename)
   # Retrieve arguments
   set(options CUDA CONFIG_FILES)
-  # Compatibility needs to be on/off to allow 3 states : ON/OFF and disabled
   set(one_value_args GLOBAL_HEADER_GEN)
   set(multi_value_args
       SOURCES

--- a/cmake/HPX_AddModule.cmake
+++ b/cmake/HPX_AddModule.cmake
@@ -10,7 +10,7 @@ function(add_hpx_module libname modulename)
   # Retrieve arguments
   set(options CUDA CONFIG_FILES)
   # Compatibility needs to be on/off to allow 3 states : ON/OFF and disabled
-  set(one_value_args COMPATIBILITY_HEADERS GLOBAL_HEADER_GEN)
+  set(one_value_args GLOBAL_HEADER_GEN)
   set(multi_value_args
       SOURCES
       HEADERS
@@ -35,12 +35,6 @@ function(add_hpx_module libname modulename)
   include(HPX_Message)
   include(HPX_Option)
 
-  if(NOT "${${modulename}_COMPATIBILITY_HEADERS}" STREQUAL "")
-    set(_have_compatibility_headers_option TRUE)
-  else()
-    set(_have_compatibility_headers_option FALSE)
-  endif()
-
   # Global headers should be always generated except if explicitly disabled
   if("${${modulename}_GLOBAL_HEADER_GEN}" STREQUAL "")
     set(${modulename}_GLOBAL_HEADER_GEN ON)
@@ -61,23 +55,6 @@ function(add_hpx_module libname modulename)
             FORCE
   )
 
-  # HPX options
-  if(${_have_compatibility_headers_option})
-    set(_compatibility_headers_default OFF)
-    if(${modulename}_COMPATIBILITY_HEADERS)
-      set(_compatibility_headers_default ON)
-    endif()
-    hpx_option(
-      HPX_${modulename_upper}_WITH_COMPATIBILITY_HEADERS
-      BOOL
-      "Enable compatibility headers for old headers. (default: ${_compatibility_headers_default})"
-      ${_compatibility_headers_default}
-      ADVANCED
-      CATEGORY "Modules"
-      MODULE ${modulename_upper}
-    )
-  endif()
-
   # Main directories of the module
   set(SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/src")
   set(HEADER_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/include")
@@ -85,9 +62,7 @@ function(add_hpx_module libname modulename)
   hpx_debug("Add module ${modulename}: SOURCE_ROOT: ${SOURCE_ROOT}")
   hpx_debug("Add module ${modulename}: HEADER_ROOT: ${HEADER_ROOT}")
 
-  if(${_have_compatibility_headers_option}
-     AND HPX_${modulename_upper}_WITH_COMPATIBILITY_HEADERS
-  )
+  if(${modulename}_COMPAT_HEADERS)
     set(COMPAT_HEADER_ROOT "${CMAKE_CURRENT_BINARY_DIR}/include_compatibility")
     file(MAKE_DIRECTORY ${COMPAT_HEADER_ROOT})
     hpx_debug(
@@ -104,9 +79,7 @@ function(add_hpx_module libname modulename)
   list(TRANSFORM ${modulename}_HEADERS PREPEND ${HEADER_ROOT}/ OUTPUT_VARIABLE
                                                                headers
   )
-  if(${_have_compatibility_headers_option}
-     AND HPX_${modulename_upper}_WITH_COMPATIBILITY_HEADERS
-  )
+  if(${modulename}_COMPAT_HEADERS)
     string(REPLACE ";=>;" "=>" ${modulename}_COMPAT_HEADERS
                    "${${modulename}_COMPAT_HEADERS}"
     )
@@ -288,9 +261,7 @@ function(add_hpx_module libname modulename)
     target_link_libraries(hpx_${modulename} PUBLIC hpx_config_registry)
   endif()
 
-  if(${_have_compatibility_headers_option}
-     AND HPX_${modulename_upper}_WITH_COMPATIBILITY_HEADERS
-  )
+  if(${modulename}_COMPAT_HEADERS)
     target_include_directories(
       hpx_${modulename} PUBLIC $<BUILD_INTERFACE:${COMPAT_HEADER_ROOT}>
     )
@@ -316,9 +287,7 @@ function(add_hpx_module libname modulename)
     CLASS "Source Files"
     TARGETS ${sources}
   )
-  if(${_have_compatibility_headers_option}
-     AND HPX_${modulename_upper}_WITH_COMPATIBILITY_HEADERS
-  )
+  if(${modulename}_COMPAT_HEADERS)
     add_hpx_source_group(
       NAME hpx_${modulename}
       ROOT ${COMPAT_HEADER_ROOT}/hpx
@@ -385,9 +354,7 @@ function(add_hpx_module libname modulename)
   )
 
   # Install the compatibility headers from the source
-  if(${_have_compatibility_headers_option}
-     AND HPX_${modulename_upper}_WITH_COMPATIBILITY_HEADERS
-  )
+  if(${modulename}_COMPAT_HEADERS)
     install(
       DIRECTORY ${COMPAT_HEADER_ROOT}/hpx
       DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/cmake/HPX_PrintSummary.cmake
+++ b/cmake/HPX_PrintSummary.cmake
@@ -6,9 +6,6 @@
 
 function(create_configuration_summary message module_name)
 
-  hpx_info("")
-  hpx_info(${message})
-
   set(hpx_config_information)
   set(upper_cfg_name "HPX")
   set(upper_option_suffix "")
@@ -31,22 +28,27 @@ function(create_configuration_summary message module_name)
   get_property(
     _variableNames GLOBAL PROPERTY HPX_MODULE_CONFIG_${module_name_uc}
   )
-  foreach(_variableName ${_variableNames})
-    if(${_variableName}Category)
 
-      # handle only options which start with HPX_WITH_
-      string(FIND ${_variableName} "${upper_cfg_name}_WITH_" __pos)
+  # Only print the module configuration if options specified
+  list(LENGTH _variableNames _length)
+  if(${_length} GREATER_EQUAL 1)
+    hpx_info("")
+    hpx_info(${message})
 
-      # hpx_info("  ${_variableName} ${module_name} ${module_name_uc},
-      # ${upper_cfg_name} ${__pos}")
+    foreach(_variableName ${_variableNames})
+      if(${_variableName}Category)
 
-      if(${__pos} EQUAL 0)
-        get_property(
-          _value
-          CACHE "${_variableName}"
-          PROPERTY VALUE
-        )
-        hpx_info("    ${_variableName}=${_value}")
+        # handle only options which start with HPX_WITH_
+        string(FIND ${_variableName} "${upper_cfg_name}_WITH_" __pos)
+
+        if(${__pos} EQUAL 0)
+          get_property(
+            _value
+            CACHE "${_variableName}"
+            PROPERTY VALUE
+          )
+          hpx_info("    ${_variableName}=${_value}")
+        endif()
 
         string(REPLACE "_WITH_" "_HAVE_" __variableName ${_variableName})
         list(FIND DEFINITIONS_VARS ${__variableName} __pos)
@@ -69,10 +71,9 @@ function(create_configuration_summary message module_name)
             )
           endif()
         endif()
-
       endif()
-    endif()
-  endforeach()
+    endforeach()
+  endif()
 
   if(hpx_config_information)
     string(REPLACE ";" "" hpx_config_information ${hpx_config_information})

--- a/docs/sphinx/contributing/modules.rst
+++ b/docs/sphinx/contributing/modules.rst
@@ -76,10 +76,6 @@ header files in most cases.
 
 Optional single-value arguments are:
 
-* ``COMPATIBILITY_HEADERS``: Can be ``ON``, ``OFF``, or left out. Enables
-  compatibility headers. Creates a variable which can be turned on or off by the
-  user when set to ``ON`` or ``OFF``. If left out the option is completely
-  disabled.
 * ``INSTALL_BINARIES``: Install the resulting library.
 
 Optional multi-value arguments-are:

--- a/docs/sphinx/contributing/modules.rst
+++ b/docs/sphinx/contributing/modules.rst
@@ -72,8 +72,6 @@ header files in most cases.
 
 ``add_hpx_module`` requires a module name. Optional flags are:
 
-* ``DEPRECATION_WARNINGS``: Enables deprecation warnings for the module.
-
 Optional single-value arguments are:
 
 * ``INSTALL_BINARIES``: Install the resulting library.

--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -58,7 +58,7 @@ set(_hpx_core_modules
 # cmake-format: on
 
 hpx_info("")
-hpx_info("Configuring libhpx_core modules:")
+hpx_info("  Configuring libhpx_core modules")
 
 foreach(module ${_hpx_core_modules})
   add_subdirectory(${module})

--- a/libs/core/affinity/CMakeLists.txt
+++ b/libs/core/affinity/CMakeLists.txt
@@ -26,7 +26,6 @@ set(affinity_sources affinity_data.cpp parse_affinity_options.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   core affinity
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${affinity_sources}
   HEADERS ${affinity_headers}

--- a/libs/core/allocator_support/CMakeLists.txt
+++ b/libs/core/allocator_support/CMakeLists.txt
@@ -25,7 +25,6 @@ set(allocator_support_sources)
 include(HPX_AddModule)
 add_hpx_module(
   core allocator_support
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${allocator_support_sources}
   HEADERS ${allocator_support_headers}

--- a/libs/core/asio/CMakeLists.txt
+++ b/libs/core/asio/CMakeLists.txt
@@ -22,7 +22,6 @@ set(asio_sources asio_util.cpp map_hostnames.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   core asio
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   SOURCES ${asio_sources}
   HEADERS ${asio_headers}

--- a/libs/core/assertion/CMakeLists.txt
+++ b/libs/core/assertion/CMakeLists.txt
@@ -28,7 +28,6 @@ set(assertion_sources assertion.cpp source_location.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   core assertion
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN OFF
   SOURCES ${assertion_sources}
   HEADERS ${assertion_headers}

--- a/libs/core/cache/CMakeLists.txt
+++ b/libs/core/cache/CMakeLists.txt
@@ -46,7 +46,6 @@ set(cache_sources)
 include(HPX_AddModule)
 add_hpx_module(
   core cache
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   SOURCES ${cache_sources}
   HEADERS ${cache_headers}
   COMPAT_HEADERS ${cache_compat_headers}

--- a/libs/core/concepts/CMakeLists.txt
+++ b/libs/core/concepts/CMakeLists.txt
@@ -24,7 +24,6 @@ set(concepts_sources)
 include(HPX_AddModule)
 add_hpx_module(
   core concepts
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${concepts_sources}
   HEADERS ${concepts_headers}

--- a/libs/core/concurrency/CMakeLists.txt
+++ b/libs/core/concurrency/CMakeLists.txt
@@ -40,7 +40,6 @@ set(concurrency_sources barrier.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   core concurrency
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${concurrency_sources}
   HEADERS ${concurrency_headers}

--- a/libs/core/config/CMakeLists.txt
+++ b/libs/core/config/CMakeLists.txt
@@ -40,7 +40,6 @@ set(config_sources version.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   core config CONFIG_FILES
-  COMPATIBILITY_HEADERS OFF # Added in 1.4.0
   GLOBAL_HEADER_GEN OFF
   SOURCES ${config_sources}
   HEADERS ${config_headers}

--- a/libs/core/coroutines/CMakeLists.txt
+++ b/libs/core/coroutines/CMakeLists.txt
@@ -111,7 +111,6 @@ set_source_files_properties(
 include(HPX_AddModule)
 add_hpx_module(
   core coroutines
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${coroutines_sources}
   HEADERS ${coroutines_headers} OBJECTS "${switch_to_fiber_object}"

--- a/libs/core/datastructures/CMakeLists.txt
+++ b/libs/core/datastructures/CMakeLists.txt
@@ -51,7 +51,6 @@ set(datastructures_sources)
 include(HPX_AddModule)
 add_hpx_module(
   core datastructures
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${datastructures_sources}
   HEADERS ${datastructures_headers}

--- a/libs/core/debugging/CMakeLists.txt
+++ b/libs/core/debugging/CMakeLists.txt
@@ -26,7 +26,6 @@ set(debugging_sources attach_debugger.cpp backtrace.cpp print.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   core debugging
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${debugging_sources}
   HEADERS ${debugging_headers}

--- a/libs/core/errors/CMakeLists.txt
+++ b/libs/core/errors/CMakeLists.txt
@@ -42,7 +42,6 @@ set(errors_sources error_code.cpp exception.cpp exception_list.cpp
 include(HPX_AddModule)
 add_hpx_module(
   core errors
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${errors_sources}
   HEADERS ${errors_headers}

--- a/libs/core/execution_base/CMakeLists.txt
+++ b/libs/core/execution_base/CMakeLists.txt
@@ -43,7 +43,6 @@ set(execution_base_sources agent_ref.cpp register_locks.cpp
 include(HPX_AddModule)
 add_hpx_module(
   core execution_base
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   SOURCES ${execution_base_sources}
   HEADERS ${execution_base_headers}

--- a/libs/core/filesystem/CMakeLists.txt
+++ b/libs/core/filesystem/CMakeLists.txt
@@ -23,7 +23,6 @@ include(HPX_AddModule)
 add_hpx_module(
   core filesystem
   GLOBAL_HEADER_GEN OFF
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   HEADERS ${filesystem_headers}
   COMPAT_HEADERS ${filesystem_compat_headers}
   MODULE_DEPENDENCIES hpx_config

--- a/libs/core/format/CMakeLists.txt
+++ b/libs/core/format/CMakeLists.txt
@@ -27,7 +27,6 @@ set(format_sources format.cpp util/bad_lexical_cast.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   core format
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN OFF
   SOURCES ${format_sources}
   HEADERS ${format_headers}

--- a/libs/core/functional/CMakeLists.txt
+++ b/libs/core/functional/CMakeLists.txt
@@ -79,7 +79,6 @@ set(functional_sources basic_function.cpp empty_function.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   core functional
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   EXCLUDE_FROM_GLOBAL_HEADER
     "hpx/functional/traits/get_function_address.hpp"

--- a/libs/core/hardware/CMakeLists.txt
+++ b/libs/core/hardware/CMakeLists.txt
@@ -45,7 +45,6 @@ include(HPX_AddModule)
 
 add_hpx_module(
   core hardware
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   EXCLUDE_FROM_GLOBAL_HEADER
     "hpx/hardware/cpuid/linux_x86.hpp"
     "hpx/hardware/cpuid/msvc.hpp"

--- a/libs/core/hashing/CMakeLists.txt
+++ b/libs/core/hashing/CMakeLists.txt
@@ -21,7 +21,6 @@ set(hashing_sources)
 include(HPX_AddModule)
 add_hpx_module(
   core hashing
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${hashing_sources}
   HEADERS ${hashing_headers}

--- a/libs/core/io_service/CMakeLists.txt
+++ b/libs/core/io_service/CMakeLists.txt
@@ -23,7 +23,6 @@ set(io_service_sources io_service_pool.cpp io_service_thread_pool.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   core io_service
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   SOURCES ${io_service_sources}
   HEADERS ${io_service_headers}

--- a/libs/core/iterator_support/CMakeLists.txt
+++ b/libs/core/iterator_support/CMakeLists.txt
@@ -38,7 +38,6 @@ set(iterator_support_sources)
 include(HPX_AddModule)
 add_hpx_module(
   core iterator_support
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   EXCLUDE_FROM_GLOBAL_HEADER "hpx/iterator_support/traits/is_iterator.hpp"
                              "hpx/iterator_support/traits/is_range.hpp"

--- a/libs/core/itt_notify/CMakeLists.txt
+++ b/libs/core/itt_notify/CMakeLists.txt
@@ -25,7 +25,6 @@ set(itt_notify_sources itt_notify.cpp thread_name.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   core itt_notify
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN OFF
   SOURCES ${itt_notify_sources}
   HEADERS ${itt_notify_headers}

--- a/libs/core/logging/CMakeLists.txt
+++ b/libs/core/logging/CMakeLists.txt
@@ -56,7 +56,6 @@ set(logging_sources
 include(HPX_AddModule)
 add_hpx_module(
   core logging
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN OFF
   SOURCES ${logging_sources}
   HEADERS ${logging_headers}

--- a/libs/core/plugin/CMakeLists.txt
+++ b/libs/core/plugin/CMakeLists.txt
@@ -44,7 +44,6 @@ set(plugin_compat_headers
 include(HPX_AddModule)
 add_hpx_module(
   core plugin
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN OFF
   HEADERS ${plugin_headers}
   COMPAT_HEADERS ${plugin_compat_headers}

--- a/libs/core/prefix/CMakeLists.txt
+++ b/libs/core/prefix/CMakeLists.txt
@@ -21,7 +21,6 @@ set(prefix_sources find_prefix.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   core prefix
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   SOURCES ${prefix_sources}
   HEADERS ${prefix_headers}

--- a/libs/core/preprocessor/CMakeLists.txt
+++ b/libs/core/preprocessor/CMakeLists.txt
@@ -28,7 +28,6 @@ set(preprocessor_sources)
 include(HPX_AddModule)
 add_hpx_module(
   core preprocessor
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   SOURCES ${preprocessor_sources}
   HEADERS ${preprocessor_headers}
   COMPAT_HEADERS ${preprocessor_compat_headers}

--- a/libs/core/schedulers/CMakeLists.txt
+++ b/libs/core/schedulers/CMakeLists.txt
@@ -47,7 +47,6 @@ set(schedulers_sources deadlock_detection.cpp maintain_queue_wait_times.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   core schedulers
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN OFF
   SOURCES ${schedulers_sources}
   HEADERS ${schedulers_headers}

--- a/libs/core/serialization/CMakeLists.txt
+++ b/libs/core/serialization/CMakeLists.txt
@@ -151,7 +151,6 @@ endif()
 include(HPX_AddModule)
 add_hpx_module(
   core serialization
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${serialization_sources}
   HEADERS ${serialization_headers}

--- a/libs/core/static_reinit/CMakeLists.txt
+++ b/libs/core/static_reinit/CMakeLists.txt
@@ -26,7 +26,6 @@ set(static_reinit_sources static_reinit.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   core static_reinit
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${static_reinit_sources}
   HEADERS ${static_reinit_headers}

--- a/libs/core/statistics/CMakeLists.txt
+++ b/libs/core/statistics/CMakeLists.txt
@@ -32,7 +32,6 @@ set(statistics_sources)
 include(HPX_AddModule)
 add_hpx_module(
   core statistics
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${statistics_sources}
   HEADERS ${statistics_headers}

--- a/libs/core/synchronization/CMakeLists.txt
+++ b/libs/core/synchronization/CMakeLists.txt
@@ -70,7 +70,6 @@ set(synchronization_sources
 include(HPX_AddModule)
 add_hpx_module(
   core synchronization
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${synchronization_sources}
   HEADERS ${synchronization_headers}

--- a/libs/core/testing/CMakeLists.txt
+++ b/libs/core/testing/CMakeLists.txt
@@ -25,7 +25,6 @@ set(testing_sources testing.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   core testing
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN OFF
   SOURCES ${testing_sources}
   HEADERS ${testing_headers}

--- a/libs/core/thread_pools/CMakeLists.txt
+++ b/libs/core/thread_pools/CMakeLists.txt
@@ -27,7 +27,6 @@ set(thread_pools_sources scheduled_thread_pool.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   core thread_pools
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   SOURCES ${thread_pools_sources}
   HEADERS ${thread_pools_headers}

--- a/libs/core/thread_support/CMakeLists.txt
+++ b/libs/core/thread_support/CMakeLists.txt
@@ -31,7 +31,6 @@ set(thread_support_sources set_thread_name.cpp spinlock.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   core thread_support
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${thread_support_sources}
   HEADERS ${thread_support_headers}

--- a/libs/core/threading_base/CMakeLists.txt
+++ b/libs/core/threading_base/CMakeLists.txt
@@ -81,7 +81,6 @@ endif()
 include(HPX_AddModule)
 add_hpx_module(
   core threading_base
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   EXCLUDE_FROM_GLOBAL_HEADER "hpx/threading_base/thread_data_stackful.hpp"
                              "hpx/threading_base/thread_data_stackless.hpp"

--- a/libs/core/timing/CMakeLists.txt
+++ b/libs/core/timing/CMakeLists.txt
@@ -35,7 +35,6 @@ set(timing_sources)
 include(HPX_AddModule)
 add_hpx_module(
   core timing
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${timing_sources}
   HEADERS ${timing_headers}

--- a/libs/core/topology/CMakeLists.txt
+++ b/libs/core/topology/CMakeLists.txt
@@ -49,7 +49,6 @@ set(topology_sources cpu_mask.cpp topology.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   core topology
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${topology_sources}
   HEADERS ${topology_headers}

--- a/libs/core/type_support/CMakeLists.txt
+++ b/libs/core/type_support/CMakeLists.txt
@@ -43,7 +43,6 @@ set(type_support_sources)
 include(HPX_AddModule)
 add_hpx_module(
   core type_support
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${type_support_sources}
   HEADERS ${type_support_headers}

--- a/libs/core/util/CMakeLists.txt
+++ b/libs/core/util/CMakeLists.txt
@@ -31,7 +31,6 @@ set(util_sources manage_config.cpp regex_from_pattern.cpp sed_transform.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   core util
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${util_sources}
   HEADERS ${util_headers}

--- a/libs/core/version/CMakeLists.txt
+++ b/libs/core/version/CMakeLists.txt
@@ -20,7 +20,6 @@ endif()
 include(HPX_AddModule)
 add_hpx_module(
   core version
-  COMPATIBILITY_HEADERS OFF # Added in 1.4.0
   GLOBAL_HEADER_GEN OFF
   SOURCES ${version_sources}
   HEADERS ${version_headers}

--- a/libs/create_module_skeleton.py
+++ b/libs/create_module_skeleton.py
@@ -249,7 +249,7 @@ modules_cmakelists += ')\n# cmake-format: on\n'
 
 modules_cmakelists += f'''
 hpx_info("")
-hpx_info("Configuring libhpx_{lib_name} modules:")
+hpx_info("Configuring libhpx_{lib_name} modules")
 
 foreach(module ${{_hpx_{lib_name}_modules}})
   add_subdirectory(${{module}})

--- a/libs/create_module_skeleton.py
+++ b/libs/create_module_skeleton.py
@@ -94,7 +94,6 @@ set({module_name}_sources)
 include(HPX_AddModule)
 add_hpx_module(
   {lib_name} {module_name}
-  COMPATIBILITY_HEADERS OFF
   GLOBAL_HEADER_GEN ON
   SOURCES ${{{module_name}_sources}}
   HEADERS ${{{module_name}_headers}}

--- a/libs/full/CMakeLists.txt
+++ b/libs/full/CMakeLists.txt
@@ -51,7 +51,7 @@ set(_hpx_full_modules
 # cmake-format: on
 
 hpx_info("")
-hpx_info("Configuring libhpx modules:")
+hpx_info("  Configuring libhpx modules")
 
 foreach(module ${_hpx_full_modules})
   add_subdirectory(${module})

--- a/libs/full/actions/CMakeLists.txt
+++ b/libs/full/actions/CMakeLists.txt
@@ -58,7 +58,6 @@ set(actions_sources base_action.cpp continuation.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   full actions
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   SOURCES ${actions_sources}
   HEADERS ${actions_headers}

--- a/libs/full/actions_base/CMakeLists.txt
+++ b/libs/full/actions_base/CMakeLists.txt
@@ -80,7 +80,6 @@ set(actions_base_sources
 include(HPX_AddModule)
 add_hpx_module(
   full actions_base
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   SOURCES ${actions_base_sources}
   HEADERS ${actions_base_headers}

--- a/libs/full/agas/CMakeLists.txt
+++ b/libs/full/agas/CMakeLists.txt
@@ -28,7 +28,6 @@ set(agas_sources addressing_service.cpp detail/interface.cpp state.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   full agas
-  COMPATIBILITY_HEADERS ON # Added in 1.7.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${agas_sources}
   HEADERS ${agas_headers}

--- a/libs/full/agas_base/CMakeLists.txt
+++ b/libs/full/agas_base/CMakeLists.txt
@@ -65,7 +65,6 @@ set(agas_base_sources
 include(HPX_AddModule)
 add_hpx_module(
   full agas_base
-  COMPATIBILITY_HEADERS ON # Added in 1.7.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${agas_base_sources}
   HEADERS ${agas_base_headers}

--- a/libs/full/async_colocated/CMakeLists.txt
+++ b/libs/full/async_colocated/CMakeLists.txt
@@ -49,7 +49,6 @@ set(async_colocated_sources server/destroy_component.cpp get_colocation_id.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   full async_colocated
-  COMPATIBILITY_HEADERS ON # added in hpx V1.6.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${async_colocated_sources}
   HEADERS ${async_colocated_headers}

--- a/libs/full/async_cuda/CMakeLists.txt
+++ b/libs/full/async_cuda/CMakeLists.txt
@@ -53,7 +53,6 @@ endif()
 include(HPX_AddModule)
 add_hpx_module(
   full async_cuda
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   SOURCES ${async_cuda_sources}
   HEADERS ${async_cuda_headers}

--- a/libs/full/async_distributed/CMakeLists.txt
+++ b/libs/full/async_distributed/CMakeLists.txt
@@ -81,7 +81,6 @@ set(async_compat_headers
 include(HPX_AddModule)
 add_hpx_module(
   full async_distributed
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN OFF
   HEADERS ${async_headers}
   COMPAT_HEADERS ${async_compat_headers}

--- a/libs/full/batch_environments/CMakeLists.txt
+++ b/libs/full/batch_environments/CMakeLists.txt
@@ -32,7 +32,6 @@ set(batch_environments_sources alps_environment.cpp batch_environment.cpp
 include(HPX_AddModule)
 add_hpx_module(
   full batch_environments
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${batch_environments_sources}
   HEADERS ${batch_environments_headers}

--- a/libs/full/checkpoint/CMakeLists.txt
+++ b/libs/full/checkpoint/CMakeLists.txt
@@ -28,7 +28,6 @@ set(checkpoint_sources)
 include(HPX_AddModule)
 add_hpx_module(
   full checkpoint
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${checkpoint_sources}
   HEADERS ${checkpoint_headers}

--- a/libs/full/checkpoint_base/CMakeLists.txt
+++ b/libs/full/checkpoint_base/CMakeLists.txt
@@ -15,7 +15,6 @@ set(checkpoint_base_sources checkpoint_data.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   full checkpoint_base
-  COMPATIBILITY_HEADERS OFF
   GLOBAL_HEADER_GEN ON
   SOURCES ${checkpoint_base_sources}
   HEADERS ${checkpoint_base_headers}

--- a/libs/full/collectives/CMakeLists.txt
+++ b/libs/full/collectives/CMakeLists.txt
@@ -58,7 +58,6 @@ set(collectives_sources
 include(HPX_AddModule)
 add_hpx_module(
   full collectives
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   SOURCES ${collectives_sources}
   HEADERS ${collectives_headers}
   COMPAT_HEADERS ${collectives_compat_headers}

--- a/libs/full/command_line_handling/CMakeLists.txt
+++ b/libs/full/command_line_handling/CMakeLists.txt
@@ -31,7 +31,6 @@ endif()
 include(HPX_AddModule)
 add_hpx_module(
   full command_line_handling
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   SOURCES ${command_line_handling_sources}
   HEADERS ${command_line_handling_headers}

--- a/libs/full/components/CMakeLists.txt
+++ b/libs/full/components/CMakeLists.txt
@@ -43,7 +43,6 @@ set(components_sources basename_registration.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   full components
-  COMPATIBILITY_HEADERS ON # Added in 1.7.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${components_sources}
   HEADERS ${components_headers}

--- a/libs/full/components_base/CMakeLists.txt
+++ b/libs/full/components_base/CMakeLists.txt
@@ -103,7 +103,6 @@ set(components_base_sources
 include(HPX_AddModule)
 add_hpx_module(
   full components_base
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   SOURCES ${components_base_sources}
   HEADERS ${components_base_headers}

--- a/libs/full/compute/CMakeLists.txt
+++ b/libs/full/compute/CMakeLists.txt
@@ -51,7 +51,6 @@ endif()
 include(HPX_AddModule)
 add_hpx_module(
   full compute
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   SOURCES ${compute_sources}
   HEADERS ${compute_headers}

--- a/libs/full/executors_distributed/CMakeLists.txt
+++ b/libs/full/executors_distributed/CMakeLists.txt
@@ -25,7 +25,6 @@ set(executors_distributed_compat_headers
 include(HPX_AddModule)
 add_hpx_module(
   full executors_distributed
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   HEADERS ${executors_distributed_headers}
   COMPAT_HEADERS ${executors_distributed_compat_headers}

--- a/libs/full/lcos_distributed/CMakeLists.txt
+++ b/libs/full/lcos_distributed/CMakeLists.txt
@@ -29,7 +29,6 @@ set(lcos_distributed_sources)
 include(HPX_AddModule)
 add_hpx_module(
   full lcos_distributed
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   SOURCES ${lcos_distributed_sources}
   HEADERS ${lcos_distributed_headers}

--- a/libs/full/mpi_base/CMakeLists.txt
+++ b/libs/full/mpi_base/CMakeLists.txt
@@ -33,7 +33,6 @@ set(mpi_base_sources mpi_environment.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   full mpi_base
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   SOURCES ${mpi_base_sources}
   HEADERS ${mpi_base_headers}

--- a/libs/full/naming/CMakeLists.txt
+++ b/libs/full/naming/CMakeLists.txt
@@ -29,7 +29,6 @@ set(naming_sources credit_handling.cpp detail/preprocess_gid_types.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   full naming
-  COMPATIBILITY_HEADERS ON # added in hpx V1.6.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${naming_sources}
   HEADERS ${naming_headers}

--- a/libs/full/naming_base/CMakeLists.txt
+++ b/libs/full/naming_base/CMakeLists.txt
@@ -30,7 +30,6 @@ set(naming_base_sources address.cpp gid_type.cpp id_type.cpp unmanaged.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   full naming_base
-  COMPATIBILITY_HEADERS ON # introduced in V1.6.0
   GLOBAL_HEADER_GEN ON
   HEADERS ${naming_base_headers}
   COMPAT_HEADERS ${naming_base_compat_headers}

--- a/libs/full/resource_partitioner/CMakeLists.txt
+++ b/libs/full/resource_partitioner/CMakeLists.txt
@@ -32,7 +32,6 @@ endif()
 include(HPX_AddModule)
 add_hpx_module(
   full resource_partitioner
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN ON
   SOURCES ${resource_partitioner_sources}
   HEADERS ${resource_partitioner_headers}

--- a/libs/full/runtime_components_base/CMakeLists.txt
+++ b/libs/full/runtime_components_base/CMakeLists.txt
@@ -31,7 +31,6 @@ set(runtime_components_base_sources component_registry.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   full runtime_components_base
-  COMPATIBILITY_HEADERS OFF
   GLOBAL_HEADER_GEN ON
   SOURCES ${runtime_components_base_sources}
   HEADERS ${runtime_components_base_headers}

--- a/libs/full/runtime_configuration/CMakeLists.txt
+++ b/libs/full/runtime_configuration/CMakeLists.txt
@@ -43,7 +43,6 @@ set(runtime_configuration_sources ini.cpp init_ini_data.cpp
 include(HPX_AddModule)
 add_hpx_module(
   full runtime_configuration
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   SOURCES ${runtime_configuration_sources}
   HEADERS ${runtime_configuration_headers}

--- a/libs/full/runtime_distributed/CMakeLists.txt
+++ b/libs/full/runtime_distributed/CMakeLists.txt
@@ -49,7 +49,6 @@ endif()
 include(HPX_AddModule)
 add_hpx_module(
   full runtime_distributed
-  COMPATIBILITY_HEADERS ON # added in hpx V1.6.0
   GLOBAL_HEADER_GEN OFF
   SOURCES ${runtime_distributed_sources}
   HEADERS ${runtime_distributed_headers}

--- a/libs/full/runtime_local/CMakeLists.txt
+++ b/libs/full/runtime_local/CMakeLists.txt
@@ -86,7 +86,6 @@ set(runtime_local_sources
 include(HPX_AddModule)
 add_hpx_module(
   full runtime_local
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   SOURCES ${runtime_local_sources}
   HEADERS ${runtime_local_headers}

--- a/libs/full/segmented_algorithms/CMakeLists.txt
+++ b/libs/full/segmented_algorithms/CMakeLists.txt
@@ -45,7 +45,6 @@ set(segmented_algorithms_compat_headers
 include(HPX_AddModule)
 add_hpx_module(
   full segmented_algorithms
-  COMPATIBILITY_HEADERS ON
   HEADERS ${segmented_algorithms_headers}
   COMPAT_HEADERS ${segmented_algorithms_compat_headers}
   DEPENDENCIES hpx_core hpx_parallelism

--- a/libs/full/thread_executors/CMakeLists.txt
+++ b/libs/full/thread_executors/CMakeLists.txt
@@ -62,7 +62,6 @@ set(thread_executors_sources
 include(HPX_AddModule)
 add_hpx_module(
   full thread_executors
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   SOURCES ${thread_executors_sources}
   HEADERS ${thread_executors_headers}

--- a/libs/full/threadmanager/CMakeLists.txt
+++ b/libs/full/threadmanager/CMakeLists.txt
@@ -24,7 +24,6 @@ set(threadmanager_sources threadmanager.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   full threadmanager
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   GLOBAL_HEADER_GEN OFF
   SOURCES ${threadmanager_sources}
   HEADERS ${threadmanager_headers}

--- a/libs/parallelism/CMakeLists.txt
+++ b/libs/parallelism/CMakeLists.txt
@@ -28,7 +28,7 @@ set(_hpx_parallelism_modules
 # cmake-format: on
 
 hpx_info("")
-hpx_info("Configuring libhpx_parallelism modules:")
+hpx_info("  Configuring libhpx_parallelism modules")
 
 foreach(module ${_hpx_parallelism_modules})
   add_subdirectory(${module})

--- a/libs/parallelism/algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/CMakeLists.txt
@@ -185,7 +185,6 @@ set(algorithms_sources handle_exception_termination_handler.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   parallelism algorithms
-  COMPATIBILITY_HEADERS ON
   HEADERS ${algorithms_headers}
   COMPAT_HEADERS ${algorithms_compat_headers}
   SOURCES ${algorithms_sources}

--- a/libs/parallelism/async_base/CMakeLists.txt
+++ b/libs/parallelism/async_base/CMakeLists.txt
@@ -26,7 +26,6 @@ set(async_base_compat_headers
 include(HPX_AddModule)
 add_hpx_module(
   parallelism async_base
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   HEADERS ${async_base_headers}
   COMPAT_HEADERS ${async_base_compat_headers}

--- a/libs/parallelism/async_combinators/CMakeLists.txt
+++ b/libs/parallelism/async_combinators/CMakeLists.txt
@@ -37,7 +37,6 @@ set(async_combinators_compat_headers
 include(HPX_AddModule)
 add_hpx_module(
   parallelism async_combinators
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   HEADERS ${async_combinators_headers}
   COMPAT_HEADERS ${async_combinators_compat_headers}

--- a/libs/parallelism/execution/CMakeLists.txt
+++ b/libs/parallelism/execution/CMakeLists.txt
@@ -85,7 +85,6 @@ add_hpx_module(
   parallelism execution
   SOURCES ${execution_sources}
   HEADERS ${execution_headers}
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   COMPAT_HEADERS ${execution_compat_headers}
   DEPENDENCIES hpx_core
   MODULE_DEPENDENCIES hpx_async_base hpx_async_combinators hpx_threading

--- a/libs/parallelism/executors/CMakeLists.txt
+++ b/libs/parallelism/executors/CMakeLists.txt
@@ -68,7 +68,6 @@ set(executors_sources current_executor.cpp exception_list_callbacks.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   parallelism executors
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   SOURCES ${executors_sources}
   HEADERS ${executors_headers}

--- a/libs/parallelism/futures/CMakeLists.txt
+++ b/libs/parallelism/futures/CMakeLists.txt
@@ -57,7 +57,6 @@ set(futures_sources future_data.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   parallelism futures
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   SOURCES ${futures_sources}
   HEADERS ${futures_headers}

--- a/libs/parallelism/lcos_local/CMakeLists.txt
+++ b/libs/parallelism/lcos_local/CMakeLists.txt
@@ -49,7 +49,6 @@ set(lcos_local_sources composable_guard.cpp preprocess_future.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   parallelism lcos_local
-  COMPATIBILITY_HEADERS ON # Added in 1.5.0
   SOURCES ${lcos_local_sources}
   HEADERS ${lcos_local_headers}
   COMPAT_HEADERS ${lcos_local_compat_headers}

--- a/libs/parallelism/pack_traversal/CMakeLists.txt
+++ b/libs/parallelism/pack_traversal/CMakeLists.txt
@@ -31,7 +31,6 @@ set(pack_traversal_compat_headers
 include(HPX_AddModule)
 add_hpx_module(
   parallelism pack_traversal
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   HEADERS ${pack_traversal_headers}
   COMPAT_HEADERS ${pack_traversal_compat_headers}

--- a/libs/parallelism/threading/CMakeLists.txt
+++ b/libs/parallelism/threading/CMakeLists.txt
@@ -23,7 +23,6 @@ set(threading_sources thread.cpp)
 include(HPX_AddModule)
 add_hpx_module(
   parallelism threading
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   SOURCES ${threading_sources}
   HEADERS ${threading_headers}

--- a/libs/parallelism/timed_execution/CMakeLists.txt
+++ b/libs/parallelism/timed_execution/CMakeLists.txt
@@ -27,7 +27,6 @@ set(timed_execution_compat_headers
 include(HPX_AddModule)
 add_hpx_module(
   parallelism timed_execution
-  COMPATIBILITY_HEADERS ON
   GLOBAL_HEADER_GEN ON
   HEADERS ${timed_execution_headers}
   COMPAT_HEADERS ${timed_execution_compat_headers}


### PR DESCRIPTION
Fixes #5163

- Remove the `COMPATIBILITY_HEADERS` option in the `add_hpx_module` cmake function as it is now set to `ON` by default
- Modify the print summary to print only the extraordinary options (if compatibility headers is off or other options)
