### PR TITLE
Adapt replace(_if) to C++20

### DIFF
--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -74,10 +74,10 @@ Functions
 - :cpp:func:`hpx::remove_copy`
 - :cpp:func:`hpx::remove_copy_if`
 - :cpp:func:`hpx::remove_if`
-- :cpp:func:`hpx::parallel::v1::replace`
+- :cpp:func:`hpx::replace`
 - :cpp:func:`hpx::parallel::v1::replace_copy`
 - :cpp:func:`hpx::parallel::v1::replace_copy_if`
-- :cpp:func:`hpx::parallel::v1::replace_if`
+- :cpp:func:`hpx::replace_if`
 - :cpp:func:`hpx::parallel::v1::reverse`
 - :cpp:func:`hpx::parallel::v1::reverse_copy`
 - :cpp:func:`hpx::parallel::v1::rotate`

--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -75,8 +75,8 @@ Functions
 - :cpp:func:`hpx::remove_copy_if`
 - :cpp:func:`hpx::remove_if`
 - :cpp:func:`hpx::replace`
-- :cpp:func:`hpx::parallel::v1::replace_copy`
-- :cpp:func:`hpx::parallel::v1::replace_copy_if`
+- :cpp:func:`hpx::replace_copy`
+- :cpp:func:`hpx::replace_copy_if`
 - :cpp:func:`hpx::replace_if`
 - :cpp:func:`hpx::parallel::v1::reverse`
 - :cpp:func:`hpx::parallel::v1::reverse_copy`

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -482,11 +482,11 @@ Parallel algorithms
      * Copies the elements from a range to a new location for which the given predicate is ``false``
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`remove_copy`
-   * * :cpp:func:`hpx::parallel::v1::replace`
+   * * :cpp:func:`hpx::replace`
      * Replaces all values satisfying specific criteria with another value.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`replace`
-   * * :cpp:func:`hpx::parallel::v1::replace_if`
+   * * :cpp:func:`hpx::replace_if`
      * Replaces all values satisfying specific criteria with another value.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`replace`

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -490,11 +490,11 @@ Parallel algorithms
      * Replaces all values satisfying specific criteria with another value.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`replace`
-   * * :cpp:func:`hpx::parallel::v1::replace_copy`
+   * * :cpp:func:`hpx::replace_copy`
      * Copies a range, replacing elements satisfying specific criteria with another value.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`replace_copy`
-   * * :cpp:func:`hpx::parallel::v1::replace_copy_if`
+   * * :cpp:func:`hpx::replace_copy_if`
      * Copies a range, replacing elements satisfying specific criteria with another value.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`replace_copy`

--- a/libs/full/include/include/hpx/algorithm.hpp
+++ b/libs/full/include/include/hpx/algorithm.hpp
@@ -20,8 +20,6 @@ namespace hpx {
     using hpx::parallel::minmax_element;
     using hpx::parallel::partition;
     using hpx::parallel::partition_copy;
-    using hpx::parallel::replace_copy;
-    using hpx::parallel::replace_copy_if;
     using hpx::parallel::reverse;
     using hpx::parallel::reverse_copy;
     using hpx::parallel::rotate;

--- a/libs/full/include/include/hpx/algorithm.hpp
+++ b/libs/full/include/include/hpx/algorithm.hpp
@@ -20,10 +20,8 @@ namespace hpx {
     using hpx::parallel::minmax_element;
     using hpx::parallel::partition;
     using hpx::parallel::partition_copy;
-    using hpx::parallel::replace;
     using hpx::parallel::replace_copy;
     using hpx::parallel::replace_copy_if;
-    using hpx::parallel::replace_if;
     using hpx::parallel::reverse;
     using hpx::parallel::reverse_copy;
     using hpx::parallel::rotate;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/replace.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/replace.hpp
@@ -740,7 +740,7 @@ namespace hpx {
 
             typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
 
-            return parallel::util::detail::algorithm_result<void>::get(
+            return parallel::util::detail::algorithm_result<ExPolicy>::get(
                 hpx::parallel::v1::detail::replace_if<FwdIter>().call(
                     std::forward<ExPolicy>(policy), is_seq(), first, last,
                     std::forward<Pred>(pred), new_value,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/replace.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/replace.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2021      Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,6 +8,472 @@
 /// \file parallel/algorithms/replace.hpp
 
 #pragma once
+
+#if defined(DOXYGEN)
+
+namespace hpx {
+
+    /// Replaces all elements satisfying specific criteria with \a new_value
+    /// in the range [first, last).
+    ///
+    /// Effects: Substitutes elements referred by the iterator it in the range
+    ///          [first, last) with new_value, when the following corresponding
+    ///          conditions hold: *it == old_value
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam T           The type of the old and new values to replace (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param old_value    Refers to the old value of the elements to replace.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    ///
+    /// The assignments in the parallel \a replace algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    ///
+    /// \returns  The \a replace algorithm returns a \a void.
+    ///
+    template <typename Initer, typename T>
+    void replace(
+        InIter first, InIter last, T const& old_value, T const& new_value);
+
+    /// Replaces all elements satisfying specific criteria with \a new_value
+    /// in the range [first, last).
+    ///
+    /// Effects: Substitutes elements referred by the iterator it in the range
+    ///          [first, last) with new_value, when the following corresponding
+    ///          conditions hold: *it == old_value
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam T          The type of the old and new values to replace (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param old_value    Refers to the old value of the elements to replace.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    ///
+    /// The assignments in the parallel \a replace algorithm invoked with an
+    /// execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a replace algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a replace algorithm returns a \a hpx::future<void> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a void otherwise.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename T>
+    typename parallel::util::detail::algorithm_result<ExPolicy, void>::type
+    replace(ExPolicy&& policy, FwdIter first, FwdIter last, T const& old_value,
+        T const& new_value);
+
+    /// Replaces all elements satisfying specific criteria (for which predicate
+    /// \a f returns true) with \a new_value in the range [first, last).
+    ///
+    /// Effects: Substitutes elements referred by the iterator it in the range
+    ///          [first, last) with new_value, when the following corresponding
+    ///          conditions hold: INVOKE(f, *it) != false
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first applications of
+    ///         the predicate.
+    ///
+    /// \tparam Iter        The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a equal requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///                     (deduced).
+    /// \tparam T           The type of the new values to replace (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     elements which need to replaced. The
+    ///                     signature of this predicate should be equivalent
+    ///                     to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a InIter can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    ///
+    /// The assignments in the parallel \a replace_if algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    ///
+    /// \returns  The \a replace_if algorithm returns \a void.
+    ///
+    template <typename Iter, typename Pred, typename T>
+    void replace_if(Iter first, Iter last, Pred&& pred, T const& new_value);
+
+    /// Replaces all elements satisfying specific criteria (for which predicate
+    /// \a f returns true) with \a new_value in the range [first, last).
+    ///
+    /// Effects: Substitutes elements referred by the iterator it in the range
+    ///          [first, last) with new_value, when the following corresponding
+    ///          conditions hold: INVOKE(f, *it) != false
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first applications of
+    ///         the predicate.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter     The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a equal requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///                     (deduced).
+    /// \tparam T           The type of the new values to replace (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     elements which need to replaced. The
+    ///                     signature of this predicate should be equivalent
+    ///                     to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    ///
+    /// The assignments in the parallel \a replace_if algorithm invoked with an
+    /// execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a replace_if algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a replace_if algorithm returns a \a hpx::future<void>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy
+    ///           and returns \a void otherwise.
+    ///
+    template <typename ExPolicy, typename FwdIter, typename Pred, typename T>
+    typename parallel::util::detail::algorithm_result<ExPolicy, void>::type
+    replace_if(ExPolicy&& policy, FwdIter first, FwdIter last, Pred&& pred,
+        T const& new_value);
+
+    /// Copies the all elements from the range [first, last) to another range
+    /// beginning at \a dest replacing all elements satisfying a specific
+    /// criteria with \a new_value.
+    ///
+    /// Effects: Assigns to every iterator it in the range
+    ///          [result, result + (last - first)) either new_value or
+    ///          *(first + (it - result)) depending on whether the following
+    ///          corresponding condition holds:
+    ///          *(first + (i - result)) == old_value
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first applications of
+    ///         the predicate.
+    ///
+
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam T          The type of the old and new values (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param old_value    Refers to the old value of the elements to replace.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    ///
+    /// The assignments in the parallel \a replace_copy algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    ///
+    /// \returns  The \a replace_copy algorithm returns an
+    ///           \a OutIter
+    ///           The \a replace_copy algorithm returns the
+    ///           Iterator to the element past the last element copied.
+    ///
+    template <typename InIter, typename OutIter, typename T>
+    OutIter replace_copy(InIter first, InIter last, OutIter dest,
+        T const& old_value, T const& new_value);
+
+    /// Copies the all elements from the range [first, last) to another range
+    /// beginning at \a dest replacing all elements satisfying a specific
+    /// criteria with \a new_value.
+    ///
+    /// Effects: Assigns to every iterator it in the range
+    ///          [result, result + (last - first)) either new_value or
+    ///          *(first + (it - result)) depending on whether the following
+    ///          corresponding condition holds:
+    ///          *(first + (i - result)) == old_value
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first applications of
+    ///         the predicate.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam T           The type of the old and new values (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param old_value    Refers to the old value of the elements to replace.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    ///
+    /// The assignments in the parallel \a replace_copy algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a replace_copy algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a replace_copy algorithm returns a
+    ///           \a hpx::future<FwdIter2>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a FwdIter2
+    ///           otherwise.
+    ///           The \a replace_copy algorithm returns the
+    ///           Iterator to the element past the last element copied.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename T>
+    typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    replace_copy(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+        FwdIter2 dest, T const& old_value, T const& new_value);
+
+    /// Copies the all elements from the range [first, last) to another range
+    /// beginning at \a dest replacing all elements satisfying a specific
+    /// criteria with \a new_value.
+    ///
+    /// Effects: Assigns to every iterator it in the range
+    ///          [result, result + (last - first)) either new_value or
+    ///          *(first + (it - result)) depending on whether the following
+    ///          corresponding condition holds:
+    ///          INVOKE(f, *(first + (i - result))) != false
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first applications of
+    ///         the predicate.
+    ///
+    /// \tparam InIter      The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a equal requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///                     (deduced).
+    /// \tparam T           The type of the new values to replace (deduced).
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     elements which need to replaced. The
+    ///                     signature of this predicate should be equivalent
+    ///                     to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a InIter can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    ///
+    /// The assignments in the parallel \a replace_copy_if algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    ///
+    /// \returns  The \a replace_copy_if algorithm returns an
+    ///           \a OutIter.
+    ///           The \a replace_copy_if algorithm returns
+    ///           the output iterator to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename InIter, typename OutIter, typename Pred, typename T>
+    OutIter replace_copy_if(InIter first, InIter last, OutIter dest,
+        Pred&& pred, T const& new_value);
+
+    /// Copies the all elements from the range [first, last) to another range
+    /// beginning at \a dest replacing all elements satisfying a specific
+    /// criteria with \a new_value.
+    ///
+    /// Effects: Assigns to every iterator it in the range
+    ///          [result, result + (last - first)) either new_value or
+    ///          *(first + (it - result)) depending on whether the following
+    ///          corresponding condition holds:
+    ///          INVOKE(f, *(first + (i - result))) != false
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first applications of
+    ///         the predicate.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a equal requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///                     (deduced).
+    /// \tparam T           The type of the new values to replace (deduced).
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     elements which need to replaced. The
+    ///                     signature of this predicate should be equivalent
+    ///                     to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter1 can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    ///
+    /// The assignments in the parallel \a replace_copy_if algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a replace_copy_if algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a replace_copy_if algorithm returns a
+    ///           \a hpx::future<FwdIter2>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy
+    ///           and returns \a FwdIter2
+    ///           otherwise.
+    ///           The \a replace_copy_if algorithm returns the
+    ///           iterator to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename Pred, typename T>
+    typename parallel::util::detail::algorithm_result<ExPolicy, FwdIter2>::type
+    replace_copy_if(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
+        FwdIter2 dest, Pred&& pred, T const& new_value);
+
+}    // namespace hpx
+
+#else    // DOXYGEN
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
@@ -92,57 +559,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Replaces all elements satisfying specific criteria with \a new_value
-    /// in the range [first, last).
-    ///
-    /// Effects: Substitutes elements referred by the iterator it in the range
-    ///          [first, last) with new_value, when the following corresponding
-    ///          conditions hold: INVOKE(proj, *it) == old_value
-    ///
-    /// \note   Complexity: Performs exactly \a last - \a first assignments.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of a
-    ///                     forward iterator.
-    /// \tparam T1          The type of the old value to replace (deduced).
-    /// \tparam T2          The type of the new values to replace (deduced).
-    /// \tparam Proj        The type of an optional projection function. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param old_value    Refers to the old value of the elements to replace.
-    /// \param new_value    Refers to the new value to use as the replacement.
-    /// \param proj         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements as a
-    ///                     projection operation before the actual predicate
-    ///                     \a is invoked.
-    ///
-    /// The assignments in the parallel \a replace algorithm invoked with an
-    /// execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The assignments in the parallel \a replace algorithm invoked with
-    /// an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a replace algorithm returns a \a hpx::future<FwdIter> if
-    ///           the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a void otherwise.
-    ///           It returns \a last.
-    ///
     // clang-format off
     template <typename ExPolicy, typename FwdIter, typename T1, typename T2,
         typename Proj = util::projection_identity,
@@ -235,76 +651,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Replaces all elements satisfying specific criteria (for which predicate
-    /// \a f returns true) with \a new_value in the range [first, last).
-    ///
-    /// Effects: Substitutes elements referred by the iterator it in the range
-    ///          [first, last) with new_value, when the following corresponding
-    ///          conditions hold: INVOKE(f, INVOKE(proj, *it)) != false
-    ///
-    /// \note   Complexity: Performs exactly \a last - \a first applications of
-    ///         the predicate.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter     The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of a
-    ///                     forward iterator.
-    /// \tparam F           The type of the function/function object to use
-    ///                     (deduced). Unlike its sequential form, the parallel
-    ///                     overload of \a equal requires \a F to meet the
-    ///                     requirements of \a CopyConstructible.
-    ///                     (deduced).
-    /// \tparam T           The type of the new values to replace (deduced).
-    /// \tparam Proj        The type of an optional projection function. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param f            Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last).This is an
-    ///                     unary predicate which returns \a true for the
-    ///                     elements which need to replaced. The
-    ///                     signature of this predicate should be equivalent
-    ///                     to:
-    ///                     \code
-    ///                     bool pred(const Type &a);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it. The type \a Type must be such that an object of
-    ///                     type \a FwdIter can be dereferenced and then
-    ///                     implicitly converted to \a Type.
-    /// \param new_value    Refers to the new value to use as the replacement.
-    /// \param proj         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements as a
-    ///                     projection operation before the actual predicate
-    ///                     \a is invoked.
-    ///
-    /// The assignments in the parallel \a replace_if algorithm invoked with an
-    /// execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The assignments in the parallel \a replace_if algorithm invoked with
-    /// an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a replace_if algorithm returns a \a hpx::future<FwdIter>
-    ///           if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy
-    ///           and returns \a FwdIter otherwise.
-    ///           It returns \a last.
-    ///
     // clang-format off
     template <typename ExPolicy, typename FwdIter, typename F, typename T,
         typename Proj = util::projection_identity,
@@ -404,71 +750,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Copies the all elements from the range [first, last) to another range
-    /// beginning at \a dest replacing all elements satisfying a specific
-    /// criteria with \a new_value.
-    ///
-    /// Effects: Assigns to every iterator it in the range
-    ///          [result, result + (last - first)) either new_value or
-    ///          *(first + (it - result)) depending on whether the following
-    ///          corresponding condition holds:
-    ///          INVOKE(proj, *(first + (i - result))) == old_value
-    ///
-    /// \note   Complexity: Performs exactly \a last - \a first applications of
-    ///         the predicate.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter1    The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam T1          The type of the old value to replace (deduced).
-    /// \tparam T2          The type of the new values to replace (deduced).
-    /// \tparam Proj        The type of an optional projection function. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param old_value    Refers to the old value of the elements to replace.
-    /// \param new_value    Refers to the new value to use as the replacement.
-    /// \param proj         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements as a
-    ///                     projection operation before the actual predicate
-    ///                     \a is invoked.
-    ///
-    /// The assignments in the parallel \a replace_copy algorithm invoked
-    /// with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The assignments in the parallel \a replace_copy algorithm invoked
-    /// with an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a replace_copy algorithm returns a
-    ///           \a hpx::future<tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)> >
-    ///           if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)>
-    ///           otherwise.
-    ///           The \a copy algorithm returns the pair of the input iterator
-    ///           \a last and the output iterator to the
-    ///           element in the destination range, one past the last element
-    ///           copied.
-    ///
     // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename Sent,
         typename FwdIter2, typename T1, typename T2,
@@ -577,89 +858,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         /// \endcond
     }    // namespace detail
 
-    /// Copies the all elements from the range [first, last) to another range
-    /// beginning at \a dest replacing all elements satisfying a specific
-    /// criteria with \a new_value.
-    ///
-    /// Effects: Assigns to every iterator it in the range
-    ///          [result, result + (last - first)) either new_value or
-    ///          *(first + (it - result)) depending on whether the following
-    ///          corresponding condition holds:
-    ///          INVOKE(f, INVOKE(proj, *(first + (i - result)))) != false
-    ///
-    /// \note   Complexity: Performs exactly \a last - \a first applications of
-    ///         the predicate.
-    ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
-    /// \tparam FwdIter1    The type of the source iterators used (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam FwdIter2    The type of the iterator representing the
-    ///                     destination range (deduced).
-    ///                     This iterator type must meet the requirements of an
-    ///                     forward iterator.
-    /// \tparam F           The type of the function/function object to use
-    ///                     (deduced). Unlike its sequential form, the parallel
-    ///                     overload of \a equal requires \a F to meet the
-    ///                     requirements of \a CopyConstructible.
-    ///                     (deduced).
-    /// \tparam T           The type of the new values to replace (deduced).
-    /// \tparam Proj        The type of an optional projection function. This
-    ///                     defaults to \a util::projection_identity
-    ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
-    /// \param first        Refers to the beginning of the sequence of elements
-    ///                     the algorithm will be applied to.
-    /// \param last         Refers to the end of the sequence of elements the
-    ///                     algorithm will be applied to.
-    /// \param dest         Refers to the beginning of the destination range.
-    /// \param f            Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements in the
-    ///                     sequence specified by [first, last).This is an
-    ///                     unary predicate which returns \a true for the
-    ///                     elements which need to replaced. The
-    ///                     signature of this predicate should be equivalent
-    ///                     to:
-    ///                     \code
-    ///                     bool pred(const Type &a);
-    ///                     \endcode \n
-    ///                     The signature does not need to have const&, but
-    ///                     the function must not modify the objects passed to
-    ///                     it. The type \a Type must be such that an object of
-    ///                     type \a FwdIter1 can be dereferenced and then
-    ///                     implicitly converted to \a Type.
-    /// \param new_value    Refers to the new value to use as the replacement.
-    /// \param proj         Specifies the function (or function object) which
-    ///                     will be invoked for each of the elements as a
-    ///                     projection operation before the actual predicate
-    ///                     \a is invoked.
-    ///
-    /// The assignments in the parallel \a replace_copy_if algorithm invoked
-    /// with an execution policy object of type \a sequenced_policy
-    /// execute in sequential order in the calling thread.
-    ///
-    /// The assignments in the parallel \a replace_copy_if algorithm invoked
-    /// with an execution policy object of type \a parallel_policy or
-    /// \a parallel_task_policy are permitted to execute in an unordered
-    /// fashion in unspecified threads, and indeterminately sequenced
-    /// within each thread.
-    ///
-    /// \returns  The \a replace_copy_if algorithm returns a
-    ///           \a hpx::future<tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)> >
-    ///           if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy
-    ///           and returns \a tagged_pair<tag::in(FwdIter1), tag::out(FwdIter2)>
-    ///           otherwise.
-    ///           The \a replace_copy_if algorithm returns the input iterator
-    ///           \a last and the output iterator to the
-    ///           element in the destination range, one past the last element
-    ///           copied.
-    ///
     // clang-format off
     template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
         typename F, typename T, typename Proj = util::projection_identity,
@@ -923,3 +1121,5 @@ namespace hpx {
         }
     } replace_copy{};
 }    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/replace.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/replace.hpp
@@ -71,20 +71,27 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           \a parallel_task_policy and
     ///           returns \a void otherwise.
     ///
+    // clang-format off
     template <typename ExPolicy, typename Rng, typename T1, typename T2,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
-                    Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
-                    std::equal_to<T1>, traits::projected_range<Proj, Rng>,
-                    traits::projected<Proj, T1 const*>>::value)>
-    typename util::detail::algorithm_result<ExPolicy,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value &&
+            traits::is_projected_range<Proj, Rng>::value &&
+            traits::is_indirect_callable<ExPolicy,
+                std::equal_to<T1>, traits::projected_range<Proj, Rng>,
+                traits::projected<Proj, T1 const*>>::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 7,
+        "hpx::parallel::replace is deprecated, use hpx::ranges::replace "
+        "instead") typename util::detail::algorithm_result<ExPolicy,
         typename hpx::traits::range_traits<Rng>::iterator_type>::type
-    replace(ExPolicy&& policy, Rng&& rng, T1 const& old_value,
-        T2 const& new_value, Proj&& proj = Proj())
+        replace(ExPolicy&& policy, Rng&& rng, T1 const& old_value,
+            T2 const& new_value, Proj&& proj = Proj())
     {
-        return replace(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
-            hpx::util::end(rng), old_value, new_value,
+        return hpx::replace(std::forward<ExPolicy>(policy),
+            hpx::util::begin(rng), hpx::util::end(rng), old_value, new_value,
             std::forward<Proj>(proj));
     }
 
@@ -156,20 +163,27 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           and returns \a void otherwise.
     ///           It returns \a last.
     ///
+    // clang-format off
     template <typename ExPolicy, typename Rng, typename F, typename T,
         typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
-                    Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
-                    F, traits::projected_range<Proj, Rng>>::value)>
-    typename util::detail::algorithm_result<ExPolicy,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value &&
+            traits::is_projected_range<Proj, Rng>::value &&
+            traits::is_indirect_callable<ExPolicy,
+                    F, traits::projected_range<Proj, Rng>>::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 7,
+        "hpx::parallel::replace_if is deprecated, use hpx::ranges::replace_if "
+        "instead") typename util::detail::algorithm_result<ExPolicy,
         typename hpx::traits::range_traits<Rng>::iterator_type>::type
-    replace_if(ExPolicy&& policy, Rng&& rng, F&& f, T const& new_value,
-        Proj&& proj = Proj())
+        replace_if(ExPolicy&& policy, Rng&& rng, F&& f, T const& new_value,
+            Proj&& proj = Proj())
     {
-        return replace_if(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
-            hpx::util::end(rng), std::forward<F>(f), new_value,
-            std::forward<Proj>(proj));
+        return hpx::replace_if(std::forward<ExPolicy>(policy),
+            hpx::util::begin(rng), hpx::util::end(rng), std::forward<F>(f),
+            new_value, std::forward<Proj>(proj));
     }
 
     /// Copies the all elements from the range [first, last) to another range
@@ -235,13 +249,18 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           element in the destination range, one past the last element
     ///           copied.
     ///
+    // clang-format off
     template <typename ExPolicy, typename Rng, typename OutIter, typename T1,
         typename T2, typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
-                    Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
-                    std::equal_to<T1>, traits::projected_range<Proj, Rng>,
-                    traits::projected<Proj, T1 const*>>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value &&
+            traits::is_projected_range<Proj, Rng>::value &&
+            traits::is_indirect_callable<
+                ExPolicy,std::equal_to<T1>, traits::projected_range<Proj, Rng>,
+                    traits::projected<Proj, T1 const*>>::value
+        )>
+    // clang-format on
     typename util::detail::algorithm_result<ExPolicy,
         hpx::util::tagged_pair<
             tag::in(typename hpx::traits::range_traits<Rng>::iterator_type),
@@ -335,12 +354,17 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           element in the destination range, one past the last element
     ///           copied.
     ///
+    // clang-format off
     template <typename ExPolicy, typename Rng, typename OutIter, typename F,
         typename T, typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_range<Rng>::value&& traits::is_projected_range<
-                    Proj, Rng>::value&& traits::is_indirect_callable<ExPolicy,
-                    F, traits::projected_range<Proj, Rng>>::value)>
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value &&
+            traits::is_projected_range<Proj, Rng>::value &&
+            traits::is_indirect_callable<ExPolicy,
+                F, traits::projected_range<Proj, Rng>>::value
+        )>
+    // clang-format on
     typename util::detail::algorithm_result<ExPolicy,
         hpx::util::tagged_pair<
             tag::in(typename hpx::traits::range_traits<Rng>::iterator_type),
@@ -353,3 +377,237 @@ namespace hpx { namespace parallel { inline namespace v1 {
             std::forward<F>(f), new_value, std::forward<Proj>(proj));
     }
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx { namespace ranges {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::replace_if
+    HPX_INLINE_CONSTEXPR_VARIABLE struct replace_if_t final
+      : hpx::functional::tag<replace_if_t>
+    {
+    private:
+        // clang-format off
+        template <typename Iter, typename Sent, typename Pred,
+        typename T, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<Iter>::value &&
+                hpx::parallel::traits::is_projected<Proj, Iter>::value &&
+                hpx::traits::is_sentinel_for<Sent, Iter>::value &&
+                hpx::is_invocable_v<Pred,
+                    typename std::iterator_traits<Iter>::value_type
+                >
+            )>
+        // clang-format on
+        friend Iter tag_invoke(hpx::ranges::replace_if_t, Iter first, Sent sent,
+            Pred&& pred, T const& new_value, Proj&& proj = Proj())
+        {
+            static_assert((hpx::traits::is_input_iterator<Iter>::value),
+                "Required at least input iterator.");
+
+            return hpx::parallel::v1::detail::replace_if<Iter>().call(
+                hpx::execution::seq, std::true_type{}, first, sent,
+                std::forward<Pred>(pred), new_value, std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename Rng, typename Pred,
+        typename T, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
+                hpx::is_invocable_v<Pred,
+                    typename std::iterator_traits<
+                        typename hpx::traits::range_iterator<Rng>::type
+                    >::value_type
+                >
+            )>
+        // clang-format on
+        friend typename hpx::traits::range_iterator<Rng>::type tag_invoke(
+            hpx::ranges::replace_if_t, Rng&& rng, Pred&& pred,
+            T const& new_value, Proj&& proj = Proj())
+        {
+            static_assert(
+                (hpx::traits::is_input_iterator<
+                    typename hpx::traits::range_iterator<Rng>::type>::value),
+                "Required at least input iterator.");
+
+            return hpx::parallel::v1::detail::replace_if<
+                typename hpx::traits::range_iterator<Rng>::type>()
+                .call(hpx::execution::seq, std::true_type{},
+                    hpx::util::begin(rng), hpx::util::end(rng),
+                    std::forward<Pred>(pred), new_value,
+                    std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Iter, typename Sent, typename Pred,
+        typename T, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<Iter>::value &&
+                hpx::parallel::traits::is_projected<Proj, Iter>::value &&
+                hpx::traits::is_sentinel_for<Sent, Iter>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy,
+                    Pred, hpx::parallel::traits::projected<Proj, Iter>>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            Iter>::type
+        tag_invoke(hpx::ranges::replace_if_t, ExPolicy&& policy, Iter first,
+            Sent sent, Pred&& pred, T const& new_value, Proj&& proj = Proj())
+        {
+            static_assert((hpx::traits::is_forward_iterator<Iter>::value),
+                "Required at least forward iterator.");
+
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
+
+            return hpx::parallel::v1::detail::replace_if<Iter>().call(
+                std::forward<ExPolicy>(policy), is_seq(), first, sent,
+                std::forward<Pred>(pred), new_value, std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng, typename Pred,
+        typename T, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy,
+                    Pred, hpx::parallel::traits::projected_range<Proj, Rng>>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            typename hpx::traits::range_iterator<Rng>::type>::type
+        tag_invoke(hpx::ranges::replace_if_t, ExPolicy&& policy, Rng&& rng,
+            Pred&& pred, T const& new_value, Proj&& proj = Proj())
+        {
+            static_assert(
+                (hpx::traits::is_forward_iterator<
+                    typename hpx::traits::range_iterator<Rng>::type>::value),
+                "Required at least forward iterator.");
+
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
+
+            return hpx::parallel::v1::detail::replace_if<
+                typename hpx::traits::range_iterator<Rng>::type>()
+                .call(std::forward<ExPolicy>(policy), is_seq(),
+                    hpx::util::begin(rng), hpx::util::end(rng),
+                    std::forward<Pred>(pred), new_value,
+                    std::forward<Proj>(proj));
+        }
+    } replace_if{};
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::replace
+    HPX_INLINE_CONSTEXPR_VARIABLE struct replace_t final
+      : hpx::functional::tag<replace_t>
+    {
+    private:
+        // clang-format off
+        template <typename Iter, typename Sent, typename T1,
+        typename T2, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<Iter>::value &&
+                hpx::parallel::traits::is_projected<Proj, Iter>::value &&
+                hpx::traits::is_sentinel_for<Sent, Iter>::value
+            )>
+        // clang-format on
+        friend Iter tag_invoke(hpx::ranges::replace_t, Iter first, Sent sent,
+            T1 const& old_value, T2 const& new_value, Proj&& proj = Proj())
+        {
+            static_assert((hpx::traits::is_input_iterator<Iter>::value),
+                "Required at least input iterator.");
+
+            typedef typename std::iterator_traits<Iter>::value_type Type;
+
+            return hpx::ranges::replace_if(
+                first, sent,
+                [old_value](Type const& a) -> bool { return old_value == a; },
+                new_value, std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename Rng, typename T1,
+        typename T2, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value
+            )>
+        // clang-format on
+        friend typename hpx::traits::range_iterator<Rng>::type tag_invoke(
+            hpx::ranges::replace_t, Rng&& rng, T1 const& old_value,
+            T2 const& new_value, Proj&& proj = Proj())
+        {
+            static_assert(
+                (hpx::traits::is_input_iterator<
+                    typename hpx::traits::range_iterator<Rng>::type>::value),
+                "Required at least input iterator.");
+
+            typedef typename std::iterator_traits<
+                typename hpx::traits::range_iterator<Rng>::type>::value_type
+                Type;
+
+            return hpx::ranges::replace_if(
+                std::forward<Rng>(rng),
+                [old_value](Type const& a) -> bool { return old_value == a; },
+                new_value, std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Iter, typename Sent, typename T1,
+        typename T2, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<Iter>::value &&
+                hpx::traits::is_sentinel_for<Sent, Iter>::value &&
+                hpx::parallel::traits::is_projected<Proj, Iter>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            Iter>::type
+        tag_invoke(hpx::ranges::replace_t, ExPolicy&& policy, Iter first,
+            Sent sent, T1 const& old_value, T2 const& new_value,
+            Proj&& proj = Proj())
+        {
+            static_assert((hpx::traits::is_forward_iterator<Iter>::value),
+                "Required at least forward iterator.");
+
+            typedef typename std::iterator_traits<Iter>::value_type Type;
+
+            return hpx::ranges::replace_if(
+                std::forward<ExPolicy>(policy), first, sent,
+                [old_value](Type const& a) -> bool { return old_value == a; },
+                new_value, std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng, typename T1,
+        typename T2, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            typename hpx::traits::range_iterator<Rng>::type>::type
+        tag_invoke(hpx::ranges::replace_t, ExPolicy&& policy, Rng&& rng,
+            T1 const& old_value, T2 const& new_value, Proj&& proj = Proj())
+        {
+            static_assert(
+                (hpx::traits::is_forward_iterator<
+                    typename hpx::traits::range_iterator<Rng>::type>::value),
+                "Required at least forward iterator.");
+
+            typedef typename std::iterator_traits<
+                typename hpx::traits::range_iterator<Rng>::type>::value_type
+                Type;
+
+            return hpx::ranges::replace_if(
+                std::forward<ExPolicy>(policy), std::forward<Rng>(rng),
+                [old_value](Type const& a) -> bool { return old_value == a; },
+                new_value, std::forward<Proj>(proj));
+        }
+    } replace{};
+}}    // namespace hpx::ranges

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/replace.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/replace.hpp
@@ -1185,9 +1185,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
 namespace hpx { namespace ranges {
 
+    /// `replace_copy_if_result` is equivalent to
+    /// `hpx::parallel::util::in_out_result`
     template <typename I, typename O>
     using replace_copy_if_result = hpx::parallel::util::in_out_result<I, O>;
 
+    /// `replace_copy_result` is equivalent to
+    /// `hpx::parallel::util::in_out_result`
     template <typename I, typename O>
     using replace_copy_result = hpx::parallel::util::in_out_result<I, O>;
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/replace.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/replace.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2015 Hartmut Kaiser
+//  Copyright (c) 2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,22 +9,11 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_fallback_invoke.hpp>
-#include <hpx/iterator_support/range.hpp>
-#include <hpx/iterator_support/traits/is_range.hpp>
-#include <hpx/parallel/util/tagged_pair.hpp>
+#if defined(DOXYGEN)
 
-#include <hpx/algorithms/traits/projected_range.hpp>
-#include <hpx/parallel/algorithms/replace.hpp>
-#include <hpx/parallel/tagspec.hpp>
-#include <hpx/parallel/util/projection_identity.hpp>
+namespace hpx {
 
-#include <type_traits>
-#include <utility>
-
-namespace hpx { namespace parallel { inline namespace v1 {
+    ///////////////////////////////////////////////////////////////////////////
     /// Replaces all elements satisfying specific criteria with \a new_value
     /// in the range [first, last).
     ///
@@ -31,6 +21,143 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     /// Effects: Substitutes elements referred by the iterator it in the range
     ///          [first,last) with new_value, when the following corresponding
+    ///          conditions hold: INVOKE(proj, *i) == old_value
+    ///
+    /// \tparam Iter        The type of the source iterator used (deduced).
+    ///                     The iterator type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Sent        The type of the end iterators used (deduced). This
+    ///                     sentinel type must be a sentinel for Iter.
+    /// \tparam T1          The type of the old value to replace (deduced).
+    /// \tparam T2          The type of the new values to replace (deduced).
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param old_value    Refers to the old value of the elements to replace.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a replace algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    /// \returns  The \a replace algorithm returns an \a Iter.
+    ///
+    template <typename Iter, typename Sent, typename T1, typename T2,
+        typename Proj = hpx::parallel::util::projection_identity>
+    Iter replace(Iter first, Sent sent, T1 const& old_value,
+        T2 const& new_value, Proj&& proj = Proj());
+
+    /// Replaces all elements satisfying specific criteria with \a new_value
+    /// in the range \a rng.
+    ///
+    /// \note   Complexity: Performs exactly \a util::end(rng) - \a util::begin(rng)
+    ///         assignments.
+    ///
+    /// Effects: Substitutes elements referred by the iterator it in the range
+    ///          rng with new_value, when the following corresponding
+    ///          conditions hold: INVOKE(proj, *i) == old_value
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of a forward iterator.
+    /// \tparam T1          The type of the old value to replace (deduced).
+    /// \tparam T2          The type of the new values to replace (deduced).
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param old_value    Refers to the old value of the elements to replace.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a replace algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    /// \returns  The \a replace algorithm returns an
+    ///           \a hpx::traits::range_iterator<Rng>::type.
+    ///
+    template <typename Rng, typename T1, typename T2,
+        typename Proj = hpx::parallel::util::projection_identity>
+    typename hpx::traits::range_iterator<Rng>::type replace(Rng&& rng,
+        T1 const& old_value, T2 const& new_value, Proj&& proj = Proj());
+
+    /// Replaces all elements satisfying specific criteria with \a new_value
+    /// in the range [first, last).
+    ///
+    /// \note   Complexity: Performs exactly \a last - \a first assignments.
+    ///
+    /// Effects: Substitutes elements referred by the iterator it in the range
+    ///          [first,last) with new_value, when the following corresponding
+    ///          conditions hold: INVOKE(proj, *i) == old_value
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Iter        The type of the source iterator used (deduced).
+    ///                     The iterator type must
+    ///                     meet the requirements of a forward iterator.
+    /// \tparam Sent        The type of the end iterators used (deduced). This
+    ///                     sentinel type must be a sentinel for Iter.
+    /// \tparam T1          The type of the old value to replace (deduced).
+    /// \tparam T2          The type of the new values to replace (deduced).
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param old_value    Refers to the old value of the elements to replace.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a replace algorithm invoked with an
+    /// execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a replace algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a replace algorithm returns a \a hpx::future<Iter> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a Iter otherwise.
+    ///
+    template <typename ExPolicy, typename Iter, typename Sent, typename T1,
+        typename T2, typename Proj = hpx::parallel::util::projection_identity>
+    typename parallel::util::detail::algorithm_result<ExPolicy, Iter>::type
+    replace(ExPolicy&& policy, Iter first, Sent sent, T1 const& old_value,
+        T2 const& new_value, Proj&& proj = Proj());
+
+    /// Replaces all elements satisfying specific criteria with \a new_value
+    /// in the range \a rng.
+    ///
+    /// \note   Complexity: Performs exactly \a util::end(rng) - \a util::begin(rng)
+    ///         assignments.
+    ///
+    /// Effects: Substitutes elements referred by the iterator it in the range
+    ///          rng with new_value, when the following corresponding
     ///          conditions hold: INVOKE(proj, *i) == old_value
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
@@ -55,6 +182,142 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///                     will be invoked for each of the elements as a
     ///                     projection operation before the actual predicate
     ///                     \a is invoked.
+    /// The assignments in the parallel \a replace algorithm invoked with an
+    /// execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a replace algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a replace algorithm returns an
+    ///           \a hpx::future<hpx::traits::range_iterator<Rng>::type> if
+    ///           the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a hpx::traits::range_iterator<Rng>::type otherwise.
+    ///
+    template <typename ExPolicy, typename Rng, typename T1, typename T2,
+        typename Proj = hpx::parallel::util::projection_identity>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        typename hpx::traits::range_iterator<Rng>::type>::type
+    replace(ExPolicy&& policy, Rng&& rng, T1 const& old_value,
+        T2 const& new_value, Proj&& proj = Proj());
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Replaces all elements satisfying specific criteria (for which predicate
+    /// \a f returns true) with \a new_value in the range [first, sent).
+    ///
+    /// \note   Complexity: Performs exactly \a sent - \a first applications of
+    ///         the predicate.
+    ///
+    /// Effects: Substitutes elements referred by the iterator it in the range
+    ///          [first, sent) with new_value, when the following corresponding
+    ///          conditions hold: INVOKE(f, INVOKE(proj, *it)) != false
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Iter        The type of the source iterator used (deduced).
+    ///                     The iterator type must
+    ///                     meet the requirements of a forward iterator.
+    /// \tparam Sent        The type of the end iterators used (deduced). This
+    ///                     sentinel type must be a sentinel for Iter.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a equal requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///                     (deduced).
+    /// \tparam T           The type of the new values to replace (deduced).
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     elements which need to replaced. The
+    ///                     signature of this predicate should be equivalent
+    ///                     to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a Iter can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a replace_if algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    ///
+    /// \returns  The \a replace_if algorithm returns an \a Iter
+    ///           It returns \a last.
+    ///
+    template <typename Iter, typename Sent, typename Pred, typename T,
+        typename Proj = hpx::parallel::util::projection_identity>
+    Iter replace_if(Iter first, Sent sent, Pred&& pred, T const& new_value,
+        Proj&& proj = Proj());
+
+    /// Replaces all elements satisfying specific criteria (for which predicate
+    /// \a pred returns true) with \a new_value in the range rng.
+    ///
+    /// \note   Complexity: Performs exactly \a util::end(rng) - \a util::begin(rng)
+    ///         applications of the predicate.
+    ///
+    /// Effects: Substitutes elements referred by the iterator it in the range
+    ///          rng with new_value, when the following corresponding
+    ///          conditions hold: INVOKE(f, INVOKE(proj, *it)) != false
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of a forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a equal requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///                     (deduced).
+    /// \tparam T           The type of the new values to replace (deduced).
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by rng.This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     elements which need to replaced. The
+    ///                     signature of this predicate should be equivalent
+    ///                     to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
     ///
     /// The assignments in the parallel \a replace algorithm invoked with an
     /// execution policy object of type \a sequenced_policy
@@ -66,56 +329,36 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a replace algorithm returns a \a hpx::future<void> if
-    ///           the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy and
-    ///           returns \a void otherwise.
+    /// \returns  The \a replace_if algorithm returns an \a hpx::traits::range_iterator<Rng>::type
+    ///           It returns \a last.
     ///
-    // clang-format off
-    template <typename ExPolicy, typename Rng, typename T1, typename T2,
-        typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_range<Rng>::value &&
-            traits::is_projected_range<Proj, Rng>::value &&
-            traits::is_indirect_callable<ExPolicy,
-                std::equal_to<T1>, traits::projected_range<Proj, Rng>,
-                traits::projected<Proj, T1 const*>>::value
-        )>
-    // clang-format on
-    HPX_DEPRECATED_V(1, 7,
-        "hpx::parallel::replace is deprecated, use hpx::ranges::replace "
-        "instead") typename util::detail::algorithm_result<ExPolicy,
-        typename hpx::traits::range_traits<Rng>::iterator_type>::type
-        replace(ExPolicy&& policy, Rng&& rng, T1 const& old_value,
-            T2 const& new_value, Proj&& proj = Proj())
-    {
-        return hpx::replace(std::forward<ExPolicy>(policy),
-            hpx::util::begin(rng), hpx::util::end(rng), old_value, new_value,
-            std::forward<Proj>(proj));
-    }
+    template <typename Rng, typename Pred, typename T,
+        typename Proj = hpx::parallel::util::projection_identity>
+    typename hpx::traits::range_iterator<Rng>::type replace_if(
+        Rng&& rng, Pred&& pred, T const& new_value, Proj&& proj = Proj());
 
     /// Replaces all elements satisfying specific criteria (for which predicate
-    /// \a f returns true) with \a new_value in the range [first, last).
+    /// \a pred returns true) with \a new_value in the range rng.
     ///
-    /// \note   Complexity: Performs exactly \a last - \a first applications of
-    ///         the predicate.
+    /// \note   Complexity: Performs exactly \a util::end(rng) - \a util::begin(rng)
+    ///         applications of the predicate.
     ///
     /// Effects: Substitutes elements referred by the iterator it in the range
-    ///          [first, last) with new_value, when the following corresponding
+    ///          rng with new_value, when the following corresponding
     ///          conditions hold: INVOKE(f, INVOKE(proj, *it)) != false
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
     ///                     It describes the manner in which the execution
     ///                     of the algorithm may be parallelized and the manner
     ///                     in which it executes the assignments.
-    /// \tparam Rng         The type of the source range used (deduced).
-    ///                     The iterators extracted from this range type must
+    /// \tparam Iter        The type of the source iterator used (deduced).
+    ///                     The iterator type must
     ///                     meet the requirements of a forward iterator.
-    /// \tparam F           The type of the function/function object to use
+    /// \tparam Sent        The type of the end iterators used (deduced). This
+    ///                     sentinel type must be a sentinel for Iter.
+    /// \tparam Pred        The type of the function/function object to use
     ///                     (deduced). Unlike its sequential form, the parallel
-    ///                     overload of \a equal requires \a F to meet the
+    ///                     overload of \a equal requires \a Pred to meet the
     ///                     requirements of \a CopyConstructible.
     ///                     (deduced).
     /// \tparam T           The type of the new values to replace (deduced).
@@ -124,9 +367,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
-    /// \param rng          Refers to the sequence of elements the algorithm
-    ///                     will be applied to.
-    /// \param f            Specifies the function (or function object) which
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param pred         Specifies the function (or function object) which
     ///                     will be invoked for each of the elements in the
     ///                     sequence specified by [first, last).This is an
     ///                     unary predicate which returns \a true for the
@@ -157,48 +402,289 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a replace_if algorithm returns a \a hpx::future<FwdIter>
+    /// \returns  The \a replace_if algorithm returns a \a hpx::future<Iter>
     ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy
-    ///           and returns \a void otherwise.
+    ///           \a parallel_task_policy.
     ///           It returns \a last.
     ///
-    // clang-format off
-    template <typename ExPolicy, typename Rng, typename F, typename T,
-        typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_range<Rng>::value &&
-            traits::is_projected_range<Proj, Rng>::value &&
-            traits::is_indirect_callable<ExPolicy,
-                    F, traits::projected_range<Proj, Rng>>::value
-        )>
-    // clang-format on
-    HPX_DEPRECATED_V(1, 7,
-        "hpx::parallel::replace_if is deprecated, use hpx::ranges::replace_if "
-        "instead") typename util::detail::algorithm_result<ExPolicy,
-        typename hpx::traits::range_traits<Rng>::iterator_type>::type
-        replace_if(ExPolicy&& policy, Rng&& rng, F&& f, T const& new_value,
-            Proj&& proj = Proj())
-    {
-        return hpx::replace_if(std::forward<ExPolicy>(policy),
-            hpx::util::begin(rng), hpx::util::end(rng), std::forward<F>(f),
-            new_value, std::forward<Proj>(proj));
-    }
+    template <typename ExPolicy, typename Iter, typename Sent, typename Pred,
+        typename T, typename Proj = hpx::parallel::util::projection_identity>
+    typename parallel::util::detail::algorithm_result<ExPolicy, Iter>::type t
+    replace_if(ExPolicy&& policy, Iter first, Sent sent, Pred&& pred,
+        T const& new_value, Proj&& proj = Proj());
 
-    /// Copies the all elements from the range [first, last) to another range
+    /// Replaces all elements satisfying specific criteria (for which predicate
+    /// \a pred returns true) with \a new_value in the range rng.
+    ///
+    /// \note   Complexity: Performs exactly \a util::end(rng) - \a util::begin(rng)
+    ///         applications of the predicate.
+    ///
+    /// Effects: Substitutes elements referred by the iterator it in the range
+    ///          rng with new_value, when the following corresponding
+    ///          conditions hold: INVOKE(f, INVOKE(proj, *it)) != false
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of a forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a equal requires \a F to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///                     (deduced).
+    /// \tparam T           The type of the new values to replace (deduced).
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by rng.This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     elements which need to replaced. The
+    ///                     signature of this predicate should be equivalent
+    ///                     to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a replace algorithm invoked with an
+    /// execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a replace algorithm invoked with
+    /// an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a replace_if algorithm returns a \a
+    ///           hpx::future<typename hpx::traits::range_iterator<Rng>::type>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy.
+    ///           It returns \a last.
+    ///
+    template <typename ExPolicy, typename Rng, typename Pred, typename T,
+        typename Proj = hpx::parallel::util::projection_identity>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        typename hpx::traits::range_iterator<Rng>::type>::type
+    replace_if(ExPolicy&& policy, Rng&& rng, Pred&& pred, T const& new_value,
+        Proj&& proj = Proj());
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// Copies the all elements from the range [first, sent) to another range
     /// beginning at \a dest replacing all elements satisfying a specific
     /// criteria with \a new_value.
     ///
     /// Effects: Assigns to every iterator it in the range
-    ///          [result, result + (last - first)) either new_value or
+    ///          [result, result + (sent - first)) either new_value or
     ///          *(first + (it - result)) depending on whether the following
     ///          corresponding condition holds:
     ///          INVOKE(proj, *(first + (i - result))) == old_value
     ///
-    /// \note   Complexity: Performs exactly \a last - \a first applications of
+    /// \note   Complexity: Performs exactly \a sent - \a first applications of
     ///         the predicate.
+    ///
+    /// \tparam Iter        The type of the source iterator used (deduced).
+    ///                     The iterator type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Sent        The type of the end iterators used (deduced). This
+    ///                     sentinel type must be a sentinel for Iter.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam T1          The type of the old value to replace (deduced).
+    /// \tparam T2          The type of the new values to replace (deduced).
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param sent         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param old_value    Refers to the old value of the elements to replace.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a replace_copy algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    /// \returns  The \a replace_copy algorithm returns an
+    ///           \a in_out_result<InIter, OutIter>.
+    ///           The \a copy algorithm returns the pair of the input iterator
+    ///           \a last and the output iterator to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename Initer, typename Sent, typename OutIter, typename T1,
+        typename T2, typename Proj = hpx::parallel::util::projection_identity>
+    replace_copy_result<InIter, OutIter> replace_copy(InIter first, Sent sent,
+        OutIter dest, T1 const& old_value, T2 const& new_value,
+        Proj&& proj = Proj());
+
+    /// Copies the all elements from the range rbg to another range
+    /// beginning at \a dest replacing all elements satisfying a specific
+    /// criteria with \a new_value.
+    ///
+    /// Effects: Assigns to every iterator it in the range
+    ///          [result, result + (util::end(rng) - util::begin(rng))) either new_value or
+    ///          *(first + (it - result)) depending on whether the following
+    ///          corresponding condition holds:
+    ///          INVOKE(proj, *(first + (i - result))) == old_value
+    ///
+    /// \note   Complexity: Performs exactly \a util::end(rng) - \a util::begin(rng)
+    ///         applications of the predicate.
+    ///
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam T1          The type of the old value to replace (deduced).
+    /// \tparam T2          The type of the new values to replace (deduced).
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param old_value    Refers to the old value of the elements to replace.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a replace_copy algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    /// \returns  The \a replace_copy algorithm returns an
+    ///           \a in_out_result<typename hpx::traits::range_iterator<
+    ///             Rng>::type, OutIter>.
+    ///           The \a copy algorithm returns the pair of the input iterator
+    ///           \a last and the output iterator to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename Rng, typename OutIter, typename T1, typename T2,
+        typename Proj = hpx::parallel::util::projection_identity>
+    replace_copy_result<typename hpx::traits::range_iterator<Rng>::type,
+        OutIter>
+    replace_copy(Rng&& rng, OutIter dest, T1 const& old_value,
+        T2 const& new_value, Proj&& proj = Proj());
+
+    /// Copies the all elements from the range [first, sent) to another range
+    /// beginning at \a dest replacing all elements satisfying a specific
+    /// criteria with \a new_value.
+    ///
+    /// Effects: Assigns to every iterator it in the range
+    ///          [result, result + (sent - first)) either new_value or
+    ///          *(first + (it - result)) depending on whether the following
+    ///          corresponding condition holds:
+    ///          INVOKE(proj, *(first + (i - result))) == old_value
+    ///
+    /// \note   Complexity: Performs exactly \a sent - \a first applications of
+    ///         the predicate.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterator used (deduced).
+    ///                     The iterator type must
+    ///                     meet the requirements of an forward iterator.
+    /// \tparam Sent        The type of the end iterators used (deduced). This
+    ///                     sentinel type must be a sentinel for Iter.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam T1          The type of the old value to replace (deduced).
+    /// \tparam T2          The type of the new values to replace (deduced).
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param sent         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param old_value    Refers to the old value of the elements to replace.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a replace_copy algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a replace_copy algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a replace_copy algorithm returns a
+    ///           \a hpx::future<in_out_result<FwdIter1, FwdIter2>>
+    ///           if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a in_out_result<FwdIter1, FwdIter2>
+    ///           otherwise.
+    ///           The \a copy algorithm returns the pair of the forward iterator
+    ///           \a last and the output iterator to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename ExPolicy, typename FwdIter1, typename Sent,
+        typename FwdIter2, typename T1, typename T2,
+        typename Proj = hpx::parallel::util::projection_identity>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        replace_copy_result<FwdIter1, FwdIter2>>::type
+    replace_copy(ExPolicy&& policy, FwdIter1 first, Sent sent, FwdIter2 dest,
+        T1 const& old_value, T2 const& new_value, Proj&& proj = Proj());
+
+    /// Copies the all elements from the range rbg to another range
+    /// beginning at \a dest replacing all elements satisfying a specific
+    /// criteria with \a new_value.
+    ///
+    /// Effects: Assigns to every iterator it in the range
+    ///          [result, result + (util::end(rng) - util::begin(rng))) either new_value or
+    ///          *(first + (it - result)) depending on whether the following
+    ///          corresponding condition holds:
+    ///          INVOKE(proj, *(first + (i - result))) == old_value
+    ///
+    /// \note   Complexity: Performs exactly \a util::end(rng) - \a util::begin(rng)
+    ///         applications of the predicate.
     ///
     /// \tparam ExPolicy    The type of the execution policy to use (deduced).
     ///                     It describes the manner in which the execution
@@ -207,10 +693,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// \tparam Rng         The type of the source range used (deduced).
     ///                     The iterators extracted from this range type must
     ///                     meet the requirements of an input iterator.
-    /// \tparam OutIter     The type of the iterator representing the
+    /// \tparam FwdIter     The type of the iterator representing the
     ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
-    ///                     output iterator.
+    ///                     forward iterator.
     /// \tparam T1          The type of the old value to replace (deduced).
     /// \tparam T2          The type of the new values to replace (deduced).
     /// \tparam Proj        The type of an optional projection function. This
@@ -239,60 +725,113 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// within each thread.
     ///
     /// \returns  The \a replace_copy algorithm returns a
-    ///           \a hpx::future<tagged_pair<tag::in(InIter), tag::out(OutIter)> >
+    ///           \a hpx::future<in_out_result<
+    ///            typename hpx::traits::range_iterator<Rng>::type, FwdIter>>
     ///           if the execution policy is of type
     ///           \a sequenced_task_policy or
     ///           \a parallel_task_policy and
-    ///           returns \a tagged_pair<tag::in(InIter), tag::out(OutIter)>
-    ///           otherwise.
+    ///           returns \a in_out_result<
+    ///            typename hpx::traits::range_iterator<Rng>::type, FwdIter>>
     ///           The \a copy algorithm returns the pair of the input iterator
-    ///           \a last and the output iterator to the
+    ///           \a last and the forward iterator to the
     ///           element in the destination range, one past the last element
     ///           copied.
     ///
-    // clang-format off
-    template <typename ExPolicy, typename Rng, typename OutIter, typename T1,
-        typename T2, typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<ExPolicy>::value &&
-            hpx::traits::is_range<Rng>::value &&
-            traits::is_projected_range<Proj, Rng>::value &&
-            traits::is_indirect_callable<
-                ExPolicy,std::equal_to<T1>, traits::projected_range<Proj, Rng>,
-                    traits::projected<Proj, T1 const*>>::value
-        )>
-    // clang-format on
-    HPX_DEPRECATED_V(1, 7,
-        "hpx::parallel::replace_copy is deprecated, use "
-        "hpx::ranges::replace_copy "
-        "instead") typename util::detail::algorithm_result<ExPolicy,
-        util::in_out_result<
-            typename hpx::traits::range_traits<Rng>::iterator_type, OutIter>>::
-        type replace_copy(ExPolicy&& policy, Rng&& rng, OutIter dest,
-            T1 const& old_value, T2 const& new_value, Proj&& proj = Proj())
-    {
-        return replace_copy(std::forward<ExPolicy>(policy),
-            hpx::util::begin(rng), hpx::util::end(rng), dest, old_value,
-            new_value, std::forward<Proj>(proj));
-    }
+    template <typename ExPolicy, typename Rng, typename FwdIter, typename T1,
+        typename T2, typename Proj = hpx::parallel::util::projection_identity>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        replace_copy_result<typename hpx::traits::range_iterator<Rng>::type,
+            FwdIter>>::type
+    replace_copy(ExPolicy&& policy, Rng&& rng, FwdIter dest,
+        T1 const& old_value, T2 const& new_value, Proj&& proj = Proj());
 
-    /// Copies the all elements from the range [first, last) to another range
+    ///////////////////////////////////////////////////////////////////////////
+    /// Copies the all elements from the range [first, sent) to another range
     /// beginning at \a dest replacing all elements satisfying a specific
     /// criteria with \a new_value.
     ///
     /// Effects: Assigns to every iterator it in the range
-    ///          [result, result + (last - first)) either new_value or
+    ///          [result, result + (sent - first)) either new_value or
     ///          *(first + (it - result)) depending on whether the following
     ///          corresponding condition holds:
     ///          INVOKE(f, INVOKE(proj, *(first + (i - result)))) != false
     ///
-    /// \note   Complexity: Performs exactly \a last - \a first applications of
+    /// \note   Complexity: Performs exactly \a sent - \a first applications of
     ///         the predicate.
     ///
-    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
-    ///                     It describes the manner in which the execution
-    ///                     of the algorithm may be parallelized and the manner
-    ///                     in which it executes the assignments.
+    /// \tparam InIter      The type of the source iterator used (deduced).
+    ///                     The iterator type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Sent        The type of the end iterators used (deduced). This
+    ///                     sentinel type must be a sentinel for InIter.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a equal requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///                     (deduced).
+    /// \tparam T           The type of the new values to replace (deduced).
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param sent         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     elements which need to replaced. The
+    ///                     signature of this predicate should be equivalent
+    ///                     to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a replace_copy_if algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    /// \returns  The \a replace_copy_if algorithm returns a
+    ///           \a in_out_result<InIter, OutIter>.
+    ///           The \a replace_copy_if algorithm returns the input iterator
+    ///           \a last and the output iterator to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename InIter, typename Sent, typename OutIter, typename Pred,
+        typename T, typename Proj = hpx::parallel::util::projection_identity>
+    replace_copy_if_result<InIter, OutIter> replace_copy_if(InIter first,
+        Sent sent, OutIter dest, Pred&& pred, T const& new_value,
+        Proj&& proj = Proj());
+
+    /// Copies the all elements from the range rng to another range
+    /// beginning at \a dest replacing all elements satisfying a specific
+    /// criteria with \a new_value.
+    ///
+    /// Effects: Assigns to every iterator it in the range
+    ///          [result, result + (util::end(rng) - util::begin(rng))) either new_value or
+    ///          *(first + (it - result)) depending on whether the following
+    ///          corresponding condition holds:
+    ///          INVOKE(f, INVOKE(proj, *(first + (i - result)))) != false
+    ///
+    /// \note   Complexity: Performs exactly \a util::end(rng) - \a util::begin(rng)
+    ///         applications of the predicate.
+    ///
     /// \tparam Rng         The type of the source range used (deduced).
     ///                     The iterators extracted from this range type must
     ///                     meet the requirements of an input iterator.
@@ -300,9 +839,86 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///                     destination range (deduced).
     ///                     This iterator type must meet the requirements of an
     ///                     output iterator.
-    /// \tparam F           The type of the function/function object to use
+    /// \tparam Pred        The type of the function/function object to use
     ///                     (deduced). Unlike its sequential form, the parallel
-    ///                     overload of \a equal requires \a F to meet the
+    ///                     overload of \a equal requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///                     (deduced).
+    /// \tparam T           The type of the new values to replace (deduced).
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     elements which need to replaced. The
+    ///                     signature of this predicate should be equivalent
+    ///                     to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a replace_copy_if algorithm
+    /// execute in sequential order in the calling thread.
+    ///
+    /// \returns  The \a replace_copy_if algorithm returns an
+    ///           \a in_out_result<typename hpx::traits::range_iterator<Rng>::type,
+    ///             OutIter>.
+    ///           The \a replace_copy_if algorithm returns the input iterator
+    ///           \a last and the output iterator to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename Rng, typename OutIter, typename Pred, typename T,
+        typename Proj = hpx::parallel::util::projection_identity>
+    replace_copy_if_result<typename hpx::traits::range_iterator<Rng>::type,
+        OutIter>
+    replace_copy_if(Rng&& rng, OutIter dest, Pred&& pred, T const& new_value,
+        Proj&& proj = Proj());
+
+    /// Copies the all elements from the range [first, sent) to another range
+    /// beginning at \a dest replacing all elements satisfying a specific
+    /// criteria with \a new_value.
+    ///
+    /// Effects: Assigns to every iterator it in the range
+    ///          [result, result + (sent - first)) either new_value or
+    ///          *(first + (it - result)) depending on whether the following
+    ///          corresponding condition holds:
+    ///          INVOKE(f, INVOKE(proj, *(first + (i - result)))) != false
+    ///
+    /// \note   Complexity: Performs exactly \a sent - \a first applications of
+    ///         the predicate.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterator used (deduced).
+    ///                     The iterator type must
+    ///                     meet the requirements of a forward iterator.
+    /// \tparam Sent        The type of the end iterators used (deduced). This
+    ///                     sentinel type must be a sentinel for InIter.
+    /// \tparam FwdIter2    The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a equal requires \a Pred to meet the
     ///                     requirements of \a CopyConstructible.
     ///                     (deduced).
     /// \tparam T           The type of the new values to replace (deduced).
@@ -311,10 +927,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///
     /// \param policy       The execution policy to use for the scheduling of
     ///                     the iterations.
-    /// \param rng          Refers to the sequence of elements the algorithm
-    ///                     will be applied to.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param sent         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
     /// \param dest         Refers to the beginning of the destination range.
-    /// \param f            Specifies the function (or function object) which
+    /// \param pred         Specifies the function (or function object) which
     ///                     will be invoked for each of the elements in the
     ///                     sequence specified by [first, last).This is an
     ///                     unary predicate which returns \a true for the
@@ -345,18 +963,200 @@ namespace hpx { namespace parallel { inline namespace v1 {
     /// fashion in unspecified threads, and indeterminately sequenced
     /// within each thread.
     ///
-    /// \returns  The \a replace_copy_if algorithm returns a
-    ///           \a hpx::future<tagged_pair<tag::in(InIter), tag::out(OutIter)> >
-    ///           if the execution policy is of type
-    ///           \a sequenced_task_policy or
-    ///           \a parallel_task_policy
-    ///           and returns \a tagged_pair<tag::in(InIter), tag::out(OutIter)>
-    ///           otherwise.
+    /// \returns  The \a replace_copy_if algorithm returns an
+    ///           \a hpx::future<FwdIter1, FwdIter2>.
     ///           The \a replace_copy_if algorithm returns the input iterator
     ///           \a last and the output iterator to the
     ///           element in the destination range, one past the last element
     ///           copied.
     ///
+    template <typename ExPolicy, typename FwdIter1, typename Sent,
+        typename FwdIter2, typename Pred, typename T,
+        typename Proj = hpx::parallel::util::projection_identity>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        replace_copy_if_result<FwdIter1, FwdIter2>>::type
+    replace_copy_if(ExPolicy&& policy, FwdIter1 first, Sent sent, FwdIter2 dest,
+        Pred&& pred, T const& new_value, Proj&& proj = Proj());
+
+    /// Copies the all elements from the range rng to another range
+    /// beginning at \a dest replacing all elements satisfying a specific
+    /// criteria with \a new_value.
+    ///
+    /// Effects: Assigns to every iterator it in the range
+    ///          [result, result + (util::end(rng) - util::begin(rng))) either new_value or
+    ///          *(first + (it - result)) depending on whether the following
+    ///          corresponding condition holds:
+    ///          INVOKE(f, INVOKE(proj, *(first + (i - result)))) != false
+    ///
+    /// \note   Complexity: Performs exactly \a util::end(rng) - \a util::begin(rng)
+    ///         applications of the predicate.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng         The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam OutIter     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     output iterator.
+    /// \tparam Pred        The type of the function/function object to use
+    ///                     (deduced). Unlike its sequential form, the parallel
+    ///                     overload of \a equal requires \a Pred to meet the
+    ///                     requirements of \a CopyConstructible.
+    ///                     (deduced).
+    /// \tparam T           The type of the new values to replace (deduced).
+    /// \tparam Proj        The type of an optional projection function. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng          Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param dest         Refers to the beginning of the destination range.
+    /// \param pred         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements in the
+    ///                     sequence specified by [first, last).This is an
+    ///                     unary predicate which returns \a true for the
+    ///                     elements which need to replaced. The
+    ///                     signature of this predicate should be equivalent
+    ///                     to:
+    ///                     \code
+    ///                     bool pred(const Type &a);
+    ///                     \endcode \n
+    ///                     The signature does not need to have const&, but
+    ///                     the function must not modify the objects passed to
+    ///                     it. The type \a Type must be such that an object of
+    ///                     type \a FwdIter can be dereferenced and then
+    ///                     implicitly converted to \a Type.
+    /// \param new_value    Refers to the new value to use as the replacement.
+    /// \param proj         Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements as a
+    ///                     projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The assignments in the parallel \a replace_copy_if algorithm invoked
+    /// with an execution policy object of type \a sequenced_policy
+    /// execute in sequential order in the calling thread.
+    ///
+    /// The assignments in the parallel \a replace_copy_if algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a replace_copy_if algorithm returns an
+    ///           \a hpx::future<in_out_result<typename hpx::traits::range_iterator<Rng>::type,
+    ///             OutIter>>.
+    ///           The \a replace_copy_if algorithm returns the input iterator
+    ///           \a last and the output iterator to the
+    ///           element in the destination range, one past the last element
+    ///           copied.
+    ///
+    template <typename ExPolicy, typename Rng, typename FwdIter, typename Pred,
+        typename T, typename Proj = hpx::parallel::util::projection_identity>
+    typename parallel::util::detail::algorithm_result<ExPolicy,
+        replace_copy_if_result<typename hpx::traits::range_iterator<Rng>::type,
+            FwdIter>>::type
+    replace_copy_if(ExPolicy&& policy, Rng&& rng, FwdIter dest, Pred&& pred,
+        T const& new_value, Proj&& proj = Proj());
+
+}    // namespace hpx
+
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/tag_fallback_invoke.hpp>
+#include <hpx/iterator_support/range.hpp>
+#include <hpx/iterator_support/traits/is_range.hpp>
+#include <hpx/parallel/util/tagged_pair.hpp>
+
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/parallel/algorithms/replace.hpp>
+#include <hpx/parallel/tagspec.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace parallel { inline namespace v1 {
+
+    // clang-format off
+    template <typename ExPolicy, typename Rng, typename T1, typename T2,
+        typename Proj = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value &&
+            traits::is_projected_range<Proj, Rng>::value &&
+            traits::is_indirect_callable<ExPolicy,
+                std::equal_to<T1>, traits::projected_range<Proj, Rng>,
+                traits::projected<Proj, T1 const*>>::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 7,
+        "hpx::parallel::replace is deprecated, use hpx::ranges::replace "
+        "instead") typename util::detail::algorithm_result<ExPolicy,
+        typename hpx::traits::range_traits<Rng>::iterator_type>::type
+        replace(ExPolicy&& policy, Rng&& rng, T1 const& old_value,
+            T2 const& new_value, Proj&& proj = Proj())
+    {
+        return hpx::replace(std::forward<ExPolicy>(policy),
+            hpx::util::begin(rng), hpx::util::end(rng), old_value, new_value,
+            std::forward<Proj>(proj));
+    }
+
+    // clang-format off
+    template <typename ExPolicy, typename Rng, typename F, typename T,
+        typename Proj = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value &&
+            traits::is_projected_range<Proj, Rng>::value &&
+            traits::is_indirect_callable<ExPolicy,
+                    F, traits::projected_range<Proj, Rng>>::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 7,
+        "hpx::parallel::replace_if is deprecated, use hpx::ranges::replace_if "
+        "instead") typename util::detail::algorithm_result<ExPolicy,
+        typename hpx::traits::range_traits<Rng>::iterator_type>::type
+        replace_if(ExPolicy&& policy, Rng&& rng, F&& f, T const& new_value,
+            Proj&& proj = Proj())
+    {
+        return hpx::replace_if(std::forward<ExPolicy>(policy),
+            hpx::util::begin(rng), hpx::util::end(rng), std::forward<F>(f),
+            new_value, std::forward<Proj>(proj));
+    }
+
+    // clang-format off
+    template <typename ExPolicy, typename Rng, typename OutIter, typename T1,
+        typename T2, typename Proj = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_range<Rng>::value &&
+            traits::is_projected_range<Proj, Rng>::value &&
+            traits::is_indirect_callable<
+                ExPolicy,std::equal_to<T1>, traits::projected_range<Proj, Rng>,
+                    traits::projected<Proj, T1 const*>>::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 7,
+        "hpx::parallel::replace_copy is deprecated, use "
+        "hpx::ranges::replace_copy "
+        "instead") typename util::detail::algorithm_result<ExPolicy,
+        util::in_out_result<
+            typename hpx::traits::range_traits<Rng>::iterator_type, OutIter>>::
+        type replace_copy(ExPolicy&& policy, Rng&& rng, OutIter dest,
+            T1 const& old_value, T2 const& new_value, Proj&& proj = Proj())
+    {
+        return replace_copy(std::forward<ExPolicy>(policy),
+            hpx::util::begin(rng), hpx::util::end(rng), dest, old_value,
+            new_value, std::forward<Proj>(proj));
+    }
+
     // clang-format off
     template <typename ExPolicy, typename Rng, typename OutIter, typename F,
         typename T, typename Proj = util::projection_identity,
@@ -908,3 +1708,5 @@ namespace hpx { namespace ranges {
         }
     } replace_copy{};
 }}    // namespace hpx::ranges
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/replace.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/replace.hpp
@@ -262,12 +262,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     traits::projected<Proj, T1 const*>>::value
         )>
     // clang-format on
-    typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_pair<
-            tag::in(typename hpx::traits::range_traits<Rng>::iterator_type),
-            tag::out(OutIter)>>::type
-    replace_copy(ExPolicy&& policy, Rng&& rng, OutIter dest,
-        T1 const& old_value, T2 const& new_value, Proj&& proj = Proj())
+    HPX_DEPRECATED_V(1, 7,
+        "hpx::parallel::replace_copy is deprecated, use "
+        "hpx::ranges::replace_copy "
+        "instead") typename util::detail::algorithm_result<ExPolicy,
+        util::in_out_result<
+            typename hpx::traits::range_traits<Rng>::iterator_type, OutIter>>::
+        type replace_copy(ExPolicy&& policy, Rng&& rng, OutIter dest,
+            T1 const& old_value, T2 const& new_value, Proj&& proj = Proj())
     {
         return replace_copy(std::forward<ExPolicy>(policy),
             hpx::util::begin(rng), hpx::util::end(rng), dest, old_value,
@@ -366,12 +368,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 F, traits::projected_range<Proj, Rng>>::value
         )>
     // clang-format on
-    typename util::detail::algorithm_result<ExPolicy,
-        hpx::util::tagged_pair<
-            tag::in(typename hpx::traits::range_traits<Rng>::iterator_type),
-            tag::out(OutIter)>>::type
-    replace_copy_if(ExPolicy&& policy, Rng&& rng, OutIter dest, F&& f,
-        T const& new_value, Proj&& proj = Proj())
+    HPX_DEPRECATED_V(1, 7,
+        "hpx::parallel::replace_copy_if is deprecated, use "
+        "hpx::ranges::replace_copy_if "
+        "instead") typename util::detail::algorithm_result<ExPolicy,
+        util::in_out_result<
+            typename hpx::traits::range_traits<Rng>::iterator_type,
+            OutIter>>::type replace_copy_if(ExPolicy&& policy, Rng&& rng,
+        OutIter dest, F&& f, T const& new_value, Proj&& proj = Proj())
     {
         return replace_copy_if(std::forward<ExPolicy>(policy),
             hpx::util::begin(rng), hpx::util::end(rng), dest,
@@ -694,8 +698,9 @@ namespace hpx { namespace ranges {
         }
 
         // clang-format off
-        template <typename ExPolicy, typename FwdIter1, typename Sent, typename FwdIter2, typename Pred,
-        typename T, typename Proj = hpx::parallel::util::projection_identity,
+        template <typename ExPolicy, typename FwdIter1, typename Sent,
+        typename FwdIter2, typename Pred, typename T,
+        typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
@@ -773,8 +778,9 @@ namespace hpx { namespace ranges {
     {
     private:
         // clang-format off
-        template <typename InIter, typename Sent, typename OutIter,
-        typename T1, typename T2, typename Proj = hpx::parallel::util::projection_identity,
+        template <typename InIter, typename Sent,
+        typename OutIter, typename T1, typename T2,
+        typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::traits::is_iterator<InIter>::value &&
                 hpx::parallel::traits::is_projected<Proj, InIter>::value &&
@@ -801,7 +807,8 @@ namespace hpx { namespace ranges {
 
         // clang-format off
         template <typename Rng, typename OutIter,
-        typename T1, typename T2, typename Proj = hpx::parallel::util::projection_identity,
+        typename T1, typename T2,
+        typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::traits::is_range<Rng>::value &&
                 hpx::parallel::traits::is_projected_range<Proj, Rng>::value
@@ -833,8 +840,9 @@ namespace hpx { namespace ranges {
         }
 
         // clang-format off
-        template <typename ExPolicy, typename FwdIter1, typename Sent, typename FwdIter2,
-        typename T1, typename T2, typename Proj = hpx::parallel::util::projection_identity,
+        template <typename ExPolicy, typename FwdIter1,
+        typename Sent, typename FwdIter2, typename T1,
+        typename T2, typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_iterator<FwdIter1>::value &&
@@ -865,7 +873,8 @@ namespace hpx { namespace ranges {
 
         // clang-format off
         template <typename ExPolicy, typename Rng, typename FwdIter,
-        typename T1, typename T2, typename Proj = hpx::parallel::util::projection_identity,
+        typename T1, typename T2,
+        typename Proj = hpx::parallel::util::projection_identity,
             HPX_CONCEPT_REQUIRES_(
                 hpx::is_execution_policy<ExPolicy>::value &&
                 hpx::traits::is_range<Rng>::value &&

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/replace.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/replace.hpp
@@ -10,6 +10,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/tag_fallback_invoke.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
 #include <hpx/parallel/util/tagged_pair.hpp>
@@ -380,10 +381,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
 namespace hpx { namespace ranges {
 
+    template <typename I, typename O>
+    using replace_copy_if_result = hpx::parallel::util::in_out_result<I, O>;
+
+    template <typename I, typename O>
+    using replace_copy_result = hpx::parallel::util::in_out_result<I, O>;
+
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::replace_if
     HPX_INLINE_CONSTEXPR_VARIABLE struct replace_if_t final
-      : hpx::functional::tag<replace_if_t>
+      : hpx::functional::tag_fallback<replace_if_t>
     {
     private:
         // clang-format off
@@ -398,8 +405,8 @@ namespace hpx { namespace ranges {
                 >
             )>
         // clang-format on
-        friend Iter tag_invoke(hpx::ranges::replace_if_t, Iter first, Sent sent,
-            Pred&& pred, T const& new_value, Proj&& proj = Proj())
+        friend Iter tag_fallback_invoke(hpx::ranges::replace_if_t, Iter first,
+            Sent sent, Pred&& pred, T const& new_value, Proj&& proj = Proj())
         {
             static_assert((hpx::traits::is_input_iterator<Iter>::value),
                 "Required at least input iterator.");
@@ -422,8 +429,8 @@ namespace hpx { namespace ranges {
                 >
             )>
         // clang-format on
-        friend typename hpx::traits::range_iterator<Rng>::type tag_invoke(
-            hpx::ranges::replace_if_t, Rng&& rng, Pred&& pred,
+        friend typename hpx::traits::range_iterator<Rng>::type
+        tag_fallback_invoke(hpx::ranges::replace_if_t, Rng&& rng, Pred&& pred,
             T const& new_value, Proj&& proj = Proj())
         {
             static_assert(
@@ -453,8 +460,9 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             Iter>::type
-        tag_invoke(hpx::ranges::replace_if_t, ExPolicy&& policy, Iter first,
-            Sent sent, Pred&& pred, T const& new_value, Proj&& proj = Proj())
+        tag_fallback_invoke(hpx::ranges::replace_if_t, ExPolicy&& policy,
+            Iter first, Sent sent, Pred&& pred, T const& new_value,
+            Proj&& proj = Proj())
         {
             static_assert((hpx::traits::is_forward_iterator<Iter>::value),
                 "Required at least forward iterator.");
@@ -479,8 +487,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             typename hpx::traits::range_iterator<Rng>::type>::type
-        tag_invoke(hpx::ranges::replace_if_t, ExPolicy&& policy, Rng&& rng,
-            Pred&& pred, T const& new_value, Proj&& proj = Proj())
+        tag_fallback_invoke(hpx::ranges::replace_if_t, ExPolicy&& policy,
+            Rng&& rng, Pred&& pred, T const& new_value, Proj&& proj = Proj())
         {
             static_assert(
                 (hpx::traits::is_forward_iterator<
@@ -501,7 +509,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::replace
     HPX_INLINE_CONSTEXPR_VARIABLE struct replace_t final
-      : hpx::functional::tag<replace_t>
+      : hpx::functional::tag_fallback<replace_t>
     {
     private:
         // clang-format off
@@ -513,8 +521,9 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_sentinel_for<Sent, Iter>::value
             )>
         // clang-format on
-        friend Iter tag_invoke(hpx::ranges::replace_t, Iter first, Sent sent,
-            T1 const& old_value, T2 const& new_value, Proj&& proj = Proj())
+        friend Iter tag_fallback_invoke(hpx::ranges::replace_t, Iter first,
+            Sent sent, T1 const& old_value, T2 const& new_value,
+            Proj&& proj = Proj())
         {
             static_assert((hpx::traits::is_input_iterator<Iter>::value),
                 "Required at least input iterator.");
@@ -535,9 +544,9 @@ namespace hpx { namespace ranges {
                 hpx::parallel::traits::is_projected_range<Proj, Rng>::value
             )>
         // clang-format on
-        friend typename hpx::traits::range_iterator<Rng>::type tag_invoke(
-            hpx::ranges::replace_t, Rng&& rng, T1 const& old_value,
-            T2 const& new_value, Proj&& proj = Proj())
+        friend typename hpx::traits::range_iterator<Rng>::type
+        tag_fallback_invoke(hpx::ranges::replace_t, Rng&& rng,
+            T1 const& old_value, T2 const& new_value, Proj&& proj = Proj())
         {
             static_assert(
                 (hpx::traits::is_input_iterator<
@@ -566,8 +575,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             Iter>::type
-        tag_invoke(hpx::ranges::replace_t, ExPolicy&& policy, Iter first,
-            Sent sent, T1 const& old_value, T2 const& new_value,
+        tag_fallback_invoke(hpx::ranges::replace_t, ExPolicy&& policy,
+            Iter first, Sent sent, T1 const& old_value, T2 const& new_value,
             Proj&& proj = Proj())
         {
             static_assert((hpx::traits::is_forward_iterator<Iter>::value),
@@ -592,8 +601,9 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             typename hpx::traits::range_iterator<Rng>::type>::type
-        tag_invoke(hpx::ranges::replace_t, ExPolicy&& policy, Rng&& rng,
-            T1 const& old_value, T2 const& new_value, Proj&& proj = Proj())
+        tag_fallback_invoke(hpx::ranges::replace_t, ExPolicy&& policy,
+            Rng&& rng, T1 const& old_value, T2 const& new_value,
+            Proj&& proj = Proj())
         {
             static_assert(
                 (hpx::traits::is_forward_iterator<
@@ -610,4 +620,282 @@ namespace hpx { namespace ranges {
                 new_value, std::forward<Proj>(proj));
         }
     } replace{};
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::replace_copy_if
+    HPX_INLINE_CONSTEXPR_VARIABLE struct replace_copy_if_t final
+      : hpx::functional::tag_fallback<replace_copy_if_t>
+    {
+    private:
+        // clang-format off
+        template <typename InIter, typename Sent, typename OutIter, typename Pred,
+        typename T, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<InIter>::value &&
+                hpx::traits::is_iterator<OutIter>::value &&
+                hpx::parallel::traits::is_projected<Proj, InIter>::value &&
+                hpx::traits::is_sentinel_for<Sent, InIter>::value &&
+                hpx::is_invocable_v<Pred,
+                    typename std::iterator_traits<InIter>::value_type
+                >
+            )>
+        // clang-format on
+        friend replace_copy_if_result<InIter, OutIter> tag_fallback_invoke(
+            hpx::ranges::replace_copy_if_t, InIter first, Sent sent,
+            OutIter dest, Pred&& pred, T const& new_value, Proj&& proj = Proj())
+        {
+            static_assert((hpx::traits::is_input_iterator<InIter>::value),
+                "Required at least input iterator.");
+
+            static_assert((hpx::traits::is_output_iterator<OutIter>::value),
+                "Required at least output iterator.");
+
+            return hpx::parallel::v1::detail::replace_copy_if<
+                hpx::parallel::util::in_out_result<InIter, OutIter>>()
+                .call(hpx::execution::seq, std::true_type{}, first, sent, dest,
+                    std::forward<Pred>(pred), new_value,
+                    std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename Rng, typename OutIter, typename Pred,
+        typename T, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value &&
+                hpx::traits::is_iterator<OutIter>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
+                hpx::is_invocable_v<Pred,
+                    typename std::iterator_traits<
+                        typename hpx::traits::range_iterator<Rng>::type
+                    >::value_type
+                >
+            )>
+        // clang-format on
+        friend replace_copy_if_result<
+            typename hpx::traits::range_iterator<Rng>::type, OutIter>
+        tag_fallback_invoke(hpx::ranges::replace_copy_if_t, Rng&& rng,
+            OutIter dest, Pred&& pred, T const& new_value, Proj&& proj = Proj())
+        {
+            static_assert(
+                (hpx::traits::is_input_iterator<
+                    typename hpx::traits::range_iterator<Rng>::type>::value),
+                "Required at least input iterator.");
+
+            static_assert((hpx::traits::is_output_iterator<OutIter>::value),
+                "Required at least output iterator.");
+
+            return hpx::parallel::v1::detail::replace_copy_if<
+                hpx::parallel::util::in_out_result<
+                    typename hpx::traits::range_iterator<Rng>::type, OutIter>>()
+                .call(hpx::execution::seq, std::true_type{},
+                    hpx::util::begin(rng), hpx::util::end(rng), dest,
+                    std::forward<Pred>(pred), new_value,
+                    std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename Sent, typename FwdIter2, typename Pred,
+        typename T, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::parallel::traits::is_projected<Proj, FwdIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent, FwdIter1>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy,
+                    Pred, hpx::parallel::traits::projected<Proj, FwdIter1>>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            replace_copy_if_result<FwdIter1, FwdIter2>>::type
+        tag_fallback_invoke(hpx::ranges::replace_copy_if_t, ExPolicy&& policy,
+            FwdIter1 first, Sent sent, FwdIter2 dest, Pred&& pred,
+            T const& new_value, Proj&& proj = Proj())
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Required at least forward iterator.");
+
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+                "Required at least forward iterator.");
+
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
+
+            return hpx::parallel::v1::detail::replace_copy_if<
+                hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
+                .call(std::forward<ExPolicy>(policy), is_seq(), first, sent,
+                    dest, std::forward<Pred>(pred), new_value,
+                    std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng, typename FwdIter, typename Pred,
+        typename T, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::traits::is_iterator<FwdIter>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value &&
+                hpx::parallel::traits::is_indirect_callable<ExPolicy,
+                    Pred, hpx::parallel::traits::projected_range<Proj, Rng>>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            replace_copy_if_result<
+                typename hpx::traits::range_iterator<Rng>::type, FwdIter>>::type
+        tag_fallback_invoke(hpx::ranges::replace_copy_if_t, ExPolicy&& policy,
+            Rng&& rng, FwdIter dest, Pred&& pred, T const& new_value,
+            Proj&& proj = Proj())
+        {
+            static_assert(
+                (hpx::traits::is_forward_iterator<
+                    typename hpx::traits::range_iterator<Rng>::type>::value),
+                "Required at least forward iterator.");
+
+            static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
+                "Required at least forward iterator.");
+
+            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
+
+            return hpx::parallel::v1::detail::replace_copy_if<
+                hpx::parallel::util::in_out_result<
+                    typename hpx::traits::range_iterator<Rng>::type, FwdIter>>()
+                .call(std::forward<ExPolicy>(policy), is_seq(),
+                    hpx::util::begin(rng), hpx::util::end(rng), dest,
+                    std::forward<Pred>(pred), new_value,
+                    std::forward<Proj>(proj));
+        }
+    } replace_copy_if{};
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::ranges::replace_copy
+    HPX_INLINE_CONSTEXPR_VARIABLE struct replace_copy_t final
+      : hpx::functional::tag_fallback<replace_copy_t>
+    {
+    private:
+        // clang-format off
+        template <typename InIter, typename Sent, typename OutIter,
+        typename T1, typename T2, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<InIter>::value &&
+                hpx::parallel::traits::is_projected<Proj, InIter>::value &&
+                hpx::traits::is_sentinel_for<Sent, InIter>::value
+            )>
+        // clang-format on
+        friend replace_copy_result<InIter, OutIter> tag_fallback_invoke(
+            hpx::ranges::replace_copy_t, InIter first, Sent sent, OutIter dest,
+            T1 const& old_value, T2 const& new_value, Proj&& proj = Proj())
+        {
+            static_assert((hpx::traits::is_input_iterator<InIter>::value),
+                "Required at least input iterator.");
+
+            static_assert((hpx::traits::is_output_iterator<OutIter>::value),
+                "Required at least output iterator.");
+
+            typedef typename std::iterator_traits<InIter>::value_type Type;
+
+            return hpx::ranges::replace_copy_if(
+                hpx::execution::seq, first, sent, dest,
+                [old_value](Type const& a) -> bool { return old_value == a; },
+                new_value, std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename Rng, typename OutIter,
+        typename T1, typename T2, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value
+            )>
+        // clang-format on
+        friend replace_copy_result<
+            typename hpx::traits::range_iterator<Rng>::type, OutIter>
+        tag_fallback_invoke(hpx::ranges::replace_copy_t, Rng&& rng,
+            OutIter dest, T1 const& old_value, T2 const& new_value,
+            Proj&& proj = Proj())
+        {
+            static_assert(
+                (hpx::traits::is_input_iterator<
+                    typename hpx::traits::range_iterator<Rng>::type>::value),
+                "Required at least input iterator.");
+
+            static_assert((hpx::traits::is_output_iterator<OutIter>::value),
+                "Required at least output iterator.");
+
+            typedef typename std::iterator_traits<
+                typename hpx::traits::range_iterator<Rng>::type>::value_type
+                Type;
+
+            return hpx::ranges::replace_copy_if(
+                hpx::execution::seq, hpx::util::begin(rng), hpx::util::end(rng),
+                dest,
+                [old_value](Type const& a) -> bool { return old_value == a; },
+                new_value, std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename Sent, typename FwdIter2,
+        typename T1, typename T2, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::traits::is_sentinel_for<Sent, FwdIter1>::value &&
+                hpx::parallel::traits::is_projected<Proj, FwdIter1>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            replace_copy_result<FwdIter1, FwdIter2>>::type
+        tag_fallback_invoke(hpx::ranges::replace_copy_t, ExPolicy&& policy,
+            FwdIter1 first, Sent sent, FwdIter2 dest, T1 const& old_value,
+            T2 const& new_value, Proj&& proj = Proj())
+        {
+            static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+                "Required at least forward iterator.");
+
+            static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+                "Required at least forward iterator.");
+
+            typedef typename std::iterator_traits<FwdIter1>::value_type Type;
+
+            return hpx::ranges::replace_copy_if(
+                std::forward<ExPolicy>(policy), first, sent, dest,
+                [old_value](Type const& a) -> bool { return old_value == a; },
+                new_value, std::forward<Proj>(proj));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng, typename FwdIter,
+        typename T1, typename T2, typename Proj = hpx::parallel::util::projection_identity,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng>::value &&
+                hpx::parallel::traits::is_projected_range<Proj, Rng>::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            replace_copy_result<typename hpx::traits::range_iterator<Rng>::type,
+                FwdIter>>::type
+        tag_fallback_invoke(hpx::ranges::replace_copy_t, ExPolicy&& policy,
+            Rng&& rng, FwdIter dest, T1 const& old_value, T2 const& new_value,
+            Proj&& proj = Proj())
+        {
+            static_assert(
+                (hpx::traits::is_forward_iterator<
+                    typename hpx::traits::range_iterator<Rng>::type>::value),
+                "Required at least forward iterator.");
+
+            static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
+                "Required at least forward iterator.");
+
+            typedef typename std::iterator_traits<
+                typename hpx::traits::range_iterator<Rng>::type>::value_type
+                Type;
+
+            return hpx::ranges::replace_copy_if(
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                hpx::util::end(rng), dest,
+                [old_value](Type const& a) -> bool { return old_value == a; },
+                new_value, std::forward<Proj>(proj));
+        }
+    } replace_copy{};
 }}    // namespace hpx::ranges

--- a/libs/parallelism/algorithms/tests/unit/algorithms/replace.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/replace.cpp
@@ -35,8 +35,8 @@ void test_replace(ExPolicy policy, IteratorTag)
 
     std::size_t idx = std::rand() % c.size();    //-V104
 
-    hpx::parallel::replace(policy, iterator(std::begin(c)),
-        iterator(std::end(c)), c[idx], c[idx] + 1);
+    hpx::replace(policy, iterator(std::begin(c)), iterator(std::end(c)), c[idx],
+        c[idx] + 1);
 
     std::replace(std::begin(d), std::end(d), d[idx], d[idx] + 1);
 
@@ -63,7 +63,7 @@ void test_replace_async(ExPolicy p, IteratorTag)
 
     std::size_t idx = std::rand() % c.size();    //-V104
 
-    hpx::future<void> f = hpx::parallel::replace(
+    hpx::future<void> f = hpx::replace(
         p, iterator(std::begin(c)), iterator(std::end(c)), c[idx], c[idx] + 1);
     f.wait();
 
@@ -114,7 +114,7 @@ void test_replace_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::replace(policy,
+        hpx::replace(policy,
             decorated_iterator(
                 std::begin(c), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c)), std::size_t(42), std::size_t(43));
@@ -147,7 +147,7 @@ void test_replace_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::parallel::replace(p,
+        hpx::future<void> f = hpx::replace(p,
             decorated_iterator(
                 std::begin(c), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c)), std::size_t(42), std::size_t(43));
@@ -208,7 +208,7 @@ void test_replace_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::replace(policy,
+        hpx::replace(policy,
             decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c)), std::size_t(42), std::size_t(43));
         HPX_TEST(false);
@@ -239,7 +239,7 @@ void test_replace_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::parallel::replace(p,
+        hpx::future<void> f = hpx::replace(p,
             decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c)), std::size_t(42), std::size_t(43));
         returned_from_algorithm = true;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/replace_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/replace_copy.cpp
@@ -19,6 +19,36 @@
 #include "test_utils.hpp"
 
 ////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_replace_copy(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d1(c.size());
+    std::vector<std::size_t> d2(c.size());    //-V656
+
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    std::size_t idx = std::rand() % c.size();    //-V104
+
+    hpx::replace_copy(iterator(std::begin(c)), iterator(std::end(c)),
+        std::begin(d1), c[idx], c[idx] + 1);
+
+    std::replace_copy(
+        std::begin(c), std::end(c), std::begin(d2), c[idx], c[idx] + 1);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(d1), std::end(d1), std::begin(d2),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d1.size());
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy(ExPolicy policy, IteratorTag)
 {
@@ -36,8 +66,8 @@ void test_replace_copy(ExPolicy policy, IteratorTag)
 
     std::size_t idx = std::rand() % c.size();    //-V104
 
-    hpx::parallel::replace_copy(policy, iterator(std::begin(c)),
-        iterator(std::end(c)), std::begin(d1), c[idx], c[idx] + 1);
+    hpx::replace_copy(policy, iterator(std::begin(c)), iterator(std::end(c)),
+        std::begin(d1), c[idx], c[idx] + 1);
 
     std::replace_copy(
         std::begin(c), std::end(c), std::begin(d2), c[idx], c[idx] + 1);
@@ -66,7 +96,7 @@ void test_replace_copy_async(ExPolicy p, IteratorTag)
 
     std::size_t idx = std::rand() % c.size();    //-V104
 
-    auto f = hpx::parallel::replace_copy(p, iterator(std::begin(c)),
+    auto f = hpx::replace_copy(p, iterator(std::begin(c)),
         iterator(std::end(c)), std::begin(d1), c[idx], c[idx] + 1);
     f.wait();
 
@@ -119,7 +149,7 @@ void test_replace_copy_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::replace_copy(policy,
+        hpx::replace_copy(policy,
             decorated_iterator(
                 std::begin(c), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c)), std::begin(d), std::size_t(42),
@@ -154,7 +184,7 @@ void test_replace_copy_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::replace_copy(p,
+        auto f = hpx::replace_copy(p,
             decorated_iterator(
                 std::begin(c), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c)), std::begin(d), std::size_t(42),
@@ -217,7 +247,7 @@ void test_replace_copy_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::replace_copy(policy,
+        hpx::replace_copy(policy,
             decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c)), std::begin(d), std::size_t(42),
             std::size_t(43));
@@ -250,7 +280,7 @@ void test_replace_copy_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::replace_copy(p,
+        auto f = hpx::replace_copy(p,
             decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c)), std::begin(d), std::size_t(42),
             std::size_t(43));

--- a/libs/parallelism/algorithms/tests/unit/algorithms/replace_if.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/replace_if.cpp
@@ -50,8 +50,8 @@ void test_replace_if(ExPolicy policy, IteratorTag)
 
     std::size_t idx = std::rand() % c.size();    //-V104
 
-    hpx::parallel::replace_if(policy, iterator(std::begin(c)),
-        iterator(std::end(c)), equal_f(c[idx]), c[idx] + 1);
+    hpx::replace_if(policy, iterator(std::begin(c)), iterator(std::end(c)),
+        equal_f(c[idx]), c[idx] + 1);
 
     std::replace_if(std::begin(d), std::end(d), equal_f(d[idx]), d[idx] + 1);
 
@@ -78,7 +78,7 @@ void test_replace_if_async(ExPolicy p, IteratorTag)
 
     std::size_t idx = std::rand() % c.size();    //-V104
 
-    hpx::future<void> f = hpx::parallel::replace_if(p, iterator(std::begin(c)),
+    hpx::future<void> f = hpx::replace_if(p, iterator(std::begin(c)),
         iterator(std::end(c)), equal_f(c[idx]), c[idx] + 1);
     f.wait();
 
@@ -129,7 +129,7 @@ void test_replace_if_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::replace_if(policy,
+        hpx::replace_if(policy,
             decorated_iterator(
                 std::begin(c), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c)), equal_f(42), std::size_t(43));
@@ -162,7 +162,7 @@ void test_replace_if_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::parallel::replace_if(p,
+        hpx::future<void> f = hpx::replace_if(p,
             decorated_iterator(
                 std::begin(c), []() { throw std::runtime_error("test"); }),
             decorated_iterator(std::end(c)), equal_f(42), std::size_t(43));
@@ -223,7 +223,7 @@ void test_replace_if_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::replace_if(policy,
+        hpx::replace_if(policy,
             decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c)), equal_f(42), std::size_t(43));
         HPX_TEST(false);
@@ -254,7 +254,7 @@ void test_replace_if_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<void> f = hpx::parallel::replace_if(p,
+        hpx::future<void> f = hpx::replace_if(p,
             decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c)), equal_f(42), std::size_t(43));
         returned_from_algorithm = true;

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_if_range.cpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <vector>
 
+#include "iter_sent.hpp"
 #include "test_utils.hpp"
 
 ////////////////////////////////////////////////////////////////////////////
@@ -35,6 +36,52 @@ struct equal_f
     std::size_t val_;
 };
 
+////////////////////////////////////////////////////////////////////////////
+void test_replace_copy_if_sent()
+{
+    using hpx::get;
+
+    std::size_t const size = 100;
+    std::vector<std::int16_t> c(size), d(size);
+    std::iota(std::begin(c), std::end(c), 0);
+    c[99] = 42;
+
+    int new_value = 1;
+
+    auto pred = [](std::int16_t const& a) -> bool { return a == 42; };
+
+    hpx::ranges::replace_copy_if(std::begin(c), sentinel<std::int16_t>{50},
+        std::begin(d), pred, new_value);
+    auto result1 = std::count_if(std::begin(d), std::end(d), pred);
+
+    HPX_TEST(result1 == 0);
+}
+
+template <typename ExPolicy>
+void test_replace_copy_if_sent(ExPolicy policy)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    using hpx::get;
+
+    std::size_t const size = 100;
+    std::vector<std::int16_t> c(size), d(size);
+    std::iota(std::begin(c), std::end(c), 0);
+    c[99] = 42;
+
+    int new_value = 1;
+
+    auto pred = [](std::int16_t const& a) -> bool { return a == 42; };
+
+    hpx::ranges::replace_copy_if(policy, std::begin(c),
+        sentinel<std::int16_t>{50}, std::begin(d), pred, new_value);
+    auto result1 = std::count_if(std::begin(d), std::end(d), pred);
+
+    HPX_TEST(result1 == 0);
+}
+
+////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
 void test_replace_copy_if(IteratorTag)
 {
@@ -139,6 +186,11 @@ void test_replace_copy_if()
 
     test_replace_copy_if_async(seq(task), IteratorTag());
     test_replace_copy_if_async(par(task), IteratorTag());
+
+    test_replace_copy_if_sent();
+    test_replace_copy_if_sent(seq);
+    test_replace_copy_if_sent(par);
+    test_replace_copy_if_sent(par_unseq);
 }
 
 void replace_copy_if_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_if_range.cpp
@@ -35,6 +35,36 @@ struct equal_f
     std::size_t val_;
 };
 
+template <typename IteratorTag>
+void test_replace_copy_if(IteratorTag)
+{
+    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
+        test_vector;
+
+    test_vector c(10007);
+    std::vector<std::size_t> d1(c.size());
+    std::vector<std::size_t> d2(c.size());    //-V656
+
+    std::iota(std::begin(c.base()), std::end(c.base()), std::rand());
+
+    std::size_t idx = std::rand() % c.size();    //-V104
+
+    hpx::ranges::replace_copy_if(
+        c, std::begin(d1), equal_f(c[idx]), c[idx] + 1);
+
+    std::replace_copy_if(std::begin(c.base()), std::end(c.base()),
+        std::begin(d2), equal_f(c[idx]), c[idx] + 1);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(d1), std::end(d1), std::begin(d2),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d1.size());
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_if(ExPolicy policy, IteratorTag)
 {
@@ -52,7 +82,7 @@ void test_replace_copy_if(ExPolicy policy, IteratorTag)
 
     std::size_t idx = std::rand() % c.size();    //-V104
 
-    hpx::parallel::replace_copy_if(
+    hpx::ranges::replace_copy_if(
         policy, c, std::begin(d1), equal_f(c[idx]), c[idx] + 1);
 
     std::replace_copy_if(std::begin(c.base()), std::end(c.base()),
@@ -82,7 +112,7 @@ void test_replace_copy_if_async(ExPolicy p, IteratorTag)
 
     std::size_t idx = std::rand() % c.size();    //-V104
 
-    auto f = hpx::parallel::replace_copy_if(
+    auto f = hpx::ranges::replace_copy_if(
         p, c, std::begin(d1), equal_f(c[idx]), c[idx] + 1);
     f.wait();
 
@@ -135,7 +165,7 @@ void test_replace_copy_if_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::replace_copy_if(policy,
+        hpx::ranges::replace_copy_if(policy,
             hpx::util::make_iterator_range(
                 decorated_iterator(
                     std::begin(c), []() { throw std::runtime_error("test"); }),
@@ -171,7 +201,7 @@ void test_replace_copy_if_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::replace_copy_if(p,
+        auto f = hpx::ranges::replace_copy_if(p,
             hpx::util::make_iterator_range(
                 decorated_iterator(
                     std::begin(c), []() { throw std::runtime_error("test"); }),
@@ -235,7 +265,7 @@ void test_replace_copy_if_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::replace_copy_if(policy,
+        hpx::ranges::replace_copy_if(policy,
             hpx::util::make_iterator_range(
                 decorated_iterator(
                     std::begin(c), []() { throw std::bad_alloc(); }),
@@ -270,7 +300,7 @@ void test_replace_copy_if_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::replace_copy_if(p,
+        auto f = hpx::ranges::replace_copy_if(p,
             hpx::util::make_iterator_range(
                 decorated_iterator(
                     std::begin(c), []() { throw std::bad_alloc(); }),

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_range.cpp
@@ -17,7 +17,53 @@
 #include <string>
 #include <vector>
 
+#include "iter_sent.hpp"
 #include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+void test_replace_copy_sent()
+{
+    using hpx::get;
+
+    std::size_t const size = 100;
+    std::vector<std::int16_t> c(size), d(size);
+    std::iota(std::begin(c), std::end(c), 0);
+    c[99] = 42;
+
+    int old_value = 42;
+    int new_value = 1;
+
+    hpx::ranges::replace_copy(std::begin(c), sentinel<std::int16_t>{50},
+        std::begin(d), old_value, new_value);
+    auto result1 = std::count(std::begin(d), std::end(d), old_value);
+    auto result2 = std::count(std::begin(d), std::end(d), new_value);
+
+    HPX_TEST(result1 == 0 && result2 == 2);
+}
+
+template <typename ExPolicy>
+void test_replace_copy_sent(ExPolicy policy)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    using hpx::get;
+
+    std::size_t const size = 100;
+    std::vector<std::int16_t> c(size), d(size);
+    std::iota(std::begin(c), std::end(c), 0);
+    c[99] = 42;
+
+    int old_value = 42;
+    int new_value = 1;
+
+    hpx::ranges::replace_copy(policy, std::begin(c), sentinel<std::int16_t>{50},
+        std::begin(d), old_value, new_value);
+    auto result1 = std::count(std::begin(d), std::end(d), old_value);
+    auto result2 = std::count(std::begin(d), std::end(d), new_value);
+
+    HPX_TEST(result1 == 0 && result2 == 2);
+}
 
 ////////////////////////////////////////////////////////////////////////////
 template <typename IteratorTag>
@@ -116,12 +162,18 @@ template <typename IteratorTag>
 void test_replace_copy()
 {
     using namespace hpx::execution;
+    test_replace_copy(IteratorTag());
     test_replace_copy(seq, IteratorTag());
     test_replace_copy(par, IteratorTag());
     test_replace_copy(par_unseq, IteratorTag());
 
     test_replace_copy_async(seq(task), IteratorTag());
     test_replace_copy_async(par(task), IteratorTag());
+
+    test_replace_copy_sent();
+    test_replace_copy_sent(seq);
+    test_replace_copy_sent(par);
+    test_replace_copy_sent(par_unseq);
 }
 
 void replace_copy_test()

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_range.cpp
@@ -20,6 +20,35 @@
 #include "test_utils.hpp"
 
 ////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_replace_copy(IteratorTag)
+{
+    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
+        test_vector;
+
+    test_vector c(10007);
+    std::vector<std::size_t> d1(c.size());
+    std::vector<std::size_t> d2(c.size());    //-V656
+
+    std::iota(std::begin(c.base()), std::end(c.base()), std::rand());
+
+    std::size_t idx = std::rand() % c.size();    //-V104
+
+    hpx::ranges::replace_copy(c, std::begin(d1), c[idx], c[idx] + 1);
+
+    std::replace_copy(std::begin(c.base()), std::end(c.base()), std::begin(d2),
+        c[idx], c[idx] + 1);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(d1), std::end(d1), std::begin(d2),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d1.size());
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy(ExPolicy policy, IteratorTag)
 {
@@ -37,7 +66,7 @@ void test_replace_copy(ExPolicy policy, IteratorTag)
 
     std::size_t idx = std::rand() % c.size();    //-V104
 
-    hpx::parallel::replace_copy(policy, c, std::begin(d1), c[idx], c[idx] + 1);
+    hpx::ranges::replace_copy(policy, c, std::begin(d1), c[idx], c[idx] + 1);
 
     std::replace_copy(std::begin(c.base()), std::end(c.base()), std::begin(d2),
         c[idx], c[idx] + 1);
@@ -67,7 +96,7 @@ void test_replace_copy_async(ExPolicy p, IteratorTag)
     std::size_t idx = std::rand() % c.size();    //-V104
 
     auto f =
-        hpx::parallel::replace_copy(p, c, std::begin(d1), c[idx], c[idx] + 1);
+        hpx::ranges::replace_copy(p, c, std::begin(d1), c[idx], c[idx] + 1);
     f.wait();
 
     std::replace_copy(std::begin(c.base()), std::end(c.base()), std::begin(d2),
@@ -119,7 +148,7 @@ void test_replace_copy_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::replace_copy(policy,
+        hpx::ranges::replace_copy(policy,
             hpx::util::make_iterator_range(
                 decorated_iterator(
                     std::begin(c), []() { throw std::runtime_error("test"); }),
@@ -155,7 +184,7 @@ void test_replace_copy_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::replace_copy(p,
+        auto f = hpx::ranges::replace_copy(p,
             hpx::util::make_iterator_range(
                 decorated_iterator(
                     std::begin(c), []() { throw std::runtime_error("test"); }),
@@ -219,7 +248,7 @@ void test_replace_copy_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::replace_copy(policy,
+        hpx::ranges::replace_copy(policy,
             hpx::util::make_iterator_range(
                 decorated_iterator(
                     std::begin(c), []() { throw std::bad_alloc(); }),
@@ -254,7 +283,7 @@ void test_replace_copy_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::replace_copy(p,
+        auto f = hpx::ranges::replace_copy(p,
             hpx::util::make_iterator_range(
                 decorated_iterator(
                     std::begin(c), []() { throw std::bad_alloc(); }),

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_range.cpp
@@ -17,9 +17,82 @@
 #include <string>
 #include <vector>
 
+#include "iter_sent.hpp"
 #include "test_utils.hpp"
 
+////////////////////////////////////////////////////////////////////////////
+void test_replace_sent()
+{
+    using hpx::get;
+
+    std::size_t const size = 100;
+    std::vector<std::int16_t> c(size);
+    std::iota(std::begin(c), std::end(c), 0);
+    c[99] = 42;    //both c[99] and c[42] equal 42
+
+    int old_value = 42;
+    int new_value = 99;
+
+    auto pre_result = std::count(std::begin(c), std::end(c), old_value);
+    hpx::ranges::replace(
+        std::begin(c), sentinel<std::int16_t>{50}, old_value, new_value);
+    auto post_result = std::count(std::begin(c), std::end(c), old_value);
+
+    HPX_TEST(pre_result == 2 && post_result == 1);
+}
+
+template <typename ExPolicy>
+void test_replace_sent(ExPolicy policy)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    using hpx::get;
+
+    std::size_t const size = 100;
+    std::vector<std::int16_t> c(size);
+    std::iota(std::begin(c), std::end(c), 0);
+    c[99] = 42;    //both c[99] and c[42] equal 42
+
+    int old_value = 42;
+    int new_value = 99;
+
+    auto pre_result = std::count(std::begin(c), std::end(c), old_value);
+    hpx::ranges::replace(policy, std::begin(c), sentinel<std::int16_t>{50},
+        old_value, new_value);
+    auto post_result = std::count(std::begin(c), std::end(c), old_value);
+
+    HPX_TEST(pre_result == 2 && post_result == 1);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_replace(IteratorTag)
+{
+    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
+        test_vector;
+
+    test_vector c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c.base()), std::end(c.base()), std::rand());
+    std::copy(std::begin(c.base()), std::end(c.base()), std::begin(d));
+
+    std::size_t idx = std::rand() % c.size();    //-V104
+
+    hpx::ranges::replace(c, c[idx], c[idx] + 1);
+
+    std::replace(std::begin(d), std::end(d), d[idx], d[idx] + 1);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c.base()), std::end(c.base()), std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d.size());
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_replace(ExPolicy policy, IteratorTag)
 {
@@ -36,7 +109,7 @@ void test_replace(ExPolicy policy, IteratorTag)
 
     std::size_t idx = std::rand() % c.size();    //-V104
 
-    hpx::parallel::replace(policy, c, c[idx], c[idx] + 1);
+    hpx::ranges::replace(policy, c, c[idx], c[idx] + 1);
 
     std::replace(std::begin(d), std::end(d), d[idx], d[idx] + 1);
 
@@ -63,7 +136,7 @@ void test_replace_async(ExPolicy p, IteratorTag)
 
     std::size_t idx = std::rand() % c.size();    //-V104
 
-    auto f = hpx::parallel::replace(p, c, c[idx], c[idx] + 1);
+    auto f = hpx::ranges::replace(p, c, c[idx], c[idx] + 1);
     f.wait();
 
     std::replace(std::begin(d), std::end(d), d[idx], d[idx] + 1);
@@ -82,12 +155,18 @@ template <typename IteratorTag>
 void test_replace()
 {
     using namespace hpx::execution;
+    test_replace(IteratorTag());
     test_replace(seq, IteratorTag());
     test_replace(par, IteratorTag());
     test_replace(par_unseq, IteratorTag());
 
     test_replace_async(seq(task), IteratorTag());
     test_replace_async(par(task), IteratorTag());
+
+    test_replace_sent();
+    test_replace_sent(seq);
+    test_replace_sent(par);
+    test_replace_sent(par_unseq);
 }
 
 void replace_test()
@@ -113,7 +192,7 @@ void test_replace_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::replace(policy,
+        hpx::ranges::replace(policy,
             hpx::util::make_iterator_range(
                 decorated_iterator(
                     std::begin(c), []() { throw std::runtime_error("test"); }),
@@ -148,7 +227,7 @@ void test_replace_exception_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::replace(p,
+        auto f = hpx::ranges::replace(p,
             hpx::util::make_iterator_range(
                 decorated_iterator(
                     std::begin(c), []() { throw std::runtime_error("test"); }),
@@ -211,7 +290,7 @@ void test_replace_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::replace(policy,
+        hpx::ranges::replace(policy,
             hpx::util::make_iterator_range(
                 decorated_iterator(
                     std::begin(c), []() { throw std::bad_alloc(); }),
@@ -245,7 +324,7 @@ void test_replace_bad_alloc_async(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        auto f = hpx::parallel::replace(p,
+        auto f = hpx::ranges::replace(p,
             hpx::util::make_iterator_range(
                 decorated_iterator(
                     std::begin(c), []() { throw std::bad_alloc(); }),


### PR DESCRIPTION
This adapts `replace`/`replace_if`/`replace_copy`/`replace_copy_if` to C++20.

Please don't merge yet, docs will be added soon.
