### PR TITLE
Another attempt at fixing the Fedora 35 problem

### DIFF
--- a/libs/core/coroutines/CMakeLists.txt
+++ b/libs/core/coroutines/CMakeLists.txt
@@ -52,6 +52,7 @@ set(coroutines_compat_headers
 
 set(coroutines_sources
     detail/context_base.cpp
+    detail/context_posix.cpp
     detail/coroutine_impl.cpp
     detail/coroutine_self.cpp
     detail/posix_utility.cpp

--- a/libs/core/coroutines/src/detail/context_posix.cpp
+++ b/libs/core/coroutines/src/detail/context_posix.cpp
@@ -1,0 +1,22 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if defined(_POSIX_VERSION) || defined(__bgq__) || defined(__powerpc__) ||     \
+    defined(__s390x__)
+#include <hpx/coroutines/detail/context_posix.hpp>
+
+#include <cstddef>
+
+namespace hpx { namespace threads { namespace coroutines { namespace detail {
+    namespace posix {
+
+        std::ptrdiff_t ucontext_context_impl_base::default_stack_size =
+            SIGSTKSZ;
+}}}}}    // namespace hpx::threads::coroutines::detail::posix
+
+#endif


### PR DESCRIPTION
On Fedora rawhide we get the following error on power and s390

```
In file included from /usr/include/signal.h:315,
                 from /usr/include/sys/param.h:28,
                 from /builddir/build/BUILD/hpx-1.6.0/libs/core/coroutines/include/hpx/coroutines/detail/posix_utility.hpp:55,
                 from /builddir/build/BUILD/hpx-1.6.0/libs/core/coroutines/include/hpx/coroutines/detail/context_posix.hpp:164,
                 from /builddir/build/BUILD/hpx-1.6.0/libs/core/coroutines/include/hpx/coroutines/detail/context_impl.hpp:129,
                 from /builddir/build/BUILD/hpx-1.6.0/libs/core/coroutines/include/hpx/coroutines/detail/context_base.hpp:44,
                 from /builddir/build/BUILD/hpx-1.6.0/libs/core/coroutines/src/detail/context_base.cpp:12:
/builddir/build/BUILD/hpx-1.6.0/libs/core/coroutines/include/hpx/coroutines/detail/context_posix.hpp:224:62: error: call to non-'constexpr' function 'long int sysconf(int)'
  224 |             static std::ptrdiff_t const default_stack_size = SIGSTKSZ;
```

More details

https://koji.fedoraproject.org/koji/watchlogs?taskID=62453133