### PR TITLE
Attempt to fix compilation of context implementations with unity build enabled

### DIFF
--- a/libs/core/coroutines/src/detail/context_posix.cpp
+++ b/libs/core/coroutines/src/detail/context_posix.cpp
@@ -6,8 +6,10 @@
 
 #include <hpx/config.hpp>
 
-#if defined(_POSIX_VERSION) || defined(__bgq__) || defined(__powerpc__) ||     \
-    defined(__s390x__)
+#if !defined(HPX_HAVE_GENERIC_CONTEXT_COROUTINES) &&                           \
+    !(defined(__linux) || defined(linux) || defined(__linux__)) &&             \
+    (defined(_POSIX_VERSION) || defined(__bgq__) || defined(__powerpc__) ||    \
+        defined(__s390x__))
 #include <hpx/coroutines/detail/context_posix.hpp>
 
 #include <cstddef>


### PR DESCRIPTION
I merged #5194 prematurely. The unity build configuration did not work with the given changes, and this attempts to fix it (cscs/clang-newest tests this and is the one which should pass if this is correct).