### PR TITLE
Replaced tag_invoke with tag_fallback_invoke for adjacent_find algorithm

### DIFF
--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_find.hpp
@@ -122,6 +122,7 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/executors/execution_policy.hpp>
+#include <hpx/functional/tag_fallback_invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/parallel/algorithms/adjacent_find.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
@@ -268,7 +269,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
 namespace hpx {
     HPX_INLINE_CONSTEXPR_VARIABLE struct adjacent_find_t final
-      : hpx::functional::tag<adjacent_find_t>
+      : hpx::functional::tag_fallback<adjacent_find_t>
     {
     private:
         // clang-format off
@@ -278,7 +279,7 @@ namespace hpx {
                 hpx::traits::is_input_iterator<FwdIter>::value
             )>
         // clang-format on
-        friend FwdIter tag_invoke(hpx::adjacent_find_t, FwdIter first,
+        friend FwdIter tag_fallback_invoke(hpx::adjacent_find_t, FwdIter first,
             FwdIter last, Pred&& pred = Pred())
         {
             using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
@@ -297,8 +298,8 @@ namespace hpx {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             FwdIter>::type
-        tag_invoke(hpx::adjacent_find_t, ExPolicy&& policy, FwdIter first,
-            FwdIter last, Pred&& pred = Pred())
+        tag_fallback_invoke(hpx::adjacent_find_t, ExPolicy&& policy,
+            FwdIter first, FwdIter last, Pred&& pred = Pred())
         {
             using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
             return hpx::parallel::v1::detail::adjacent_find_(

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/adjacent_find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/adjacent_find.hpp
@@ -271,7 +271,7 @@ namespace hpx { namespace ranges {
 
 namespace hpx { namespace ranges {
     HPX_INLINE_CONSTEXPR_VARIABLE struct adjacent_find_t final
-      : hpx::functional::tag<adjacent_find_t>
+      : hpx::functional::tag_fallback<adjacent_find_t>
     {
     private:
         // clang-format off
@@ -289,8 +289,9 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend FwdIter tag_invoke(hpx::ranges::adjacent_find_t, FwdIter first,
-            Sent last, Pred&& pred = Pred(), Proj&& proj = Proj())
+        friend FwdIter tag_fallback_invoke(hpx::ranges::adjacent_find_t,
+            FwdIter first, Sent last, Pred&& pred = Pred(),
+            Proj&& proj = Proj())
         {
             using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
             return hpx::parallel::v1::detail::adjacent_find_(
@@ -316,7 +317,7 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             FwdIter>::type
-        tag_invoke(hpx::ranges::adjacent_find_t, ExPolicy&& policy,
+        tag_fallback_invoke(hpx::ranges::adjacent_find_t, ExPolicy&& policy,
             FwdIter first, Sent last, Pred&& pred = Pred(),
             Proj&& proj = Proj())
         {
@@ -342,7 +343,7 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend typename hpx::traits::range_traits<Rng>::iterator_type
-        tag_invoke(hpx::ranges::adjacent_find_t, Rng&& rng,
+        tag_fallback_invoke(hpx::ranges::adjacent_find_t, Rng&& rng,
             Pred&& pred = Pred(), Proj&& proj = Proj())
         {
             using iterator_type =
@@ -372,8 +373,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             typename hpx::traits::range_traits<Rng>::iterator_type>::type
-        tag_invoke(hpx::ranges::adjacent_find_t, ExPolicy&& policy, Rng&& rng,
-            Pred&& pred = Pred(), Proj&& proj = Proj())
+        tag_fallback_invoke(hpx::ranges::adjacent_find_t, ExPolicy&& policy,
+            Rng&& rng, Pred&& pred = Pred(), Proj&& proj = Proj())
         {
             using iterator_type =
                 typename hpx::traits::range_traits<Rng>::iterator_type;


### PR DESCRIPTION
Replaced tag_invoke with tag_fallback_invoke for adjacent_find algorithm as mentioned here https://github.com/STEllAR-GROUP/hpx/pull/5176#issuecomment-781142703 .