### PR TITLE
Move copy algorithms to tag_fallback_invoke

### DIFF
--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -691,8 +691,8 @@ namespace hpx {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             FwdIter2>::type
-        tag_fallback_invoke(hpx::copy_n_t, ExPolicy&& policy, FwdIter1 first, Size count,
-            FwdIter2 dest)
+        tag_fallback_invoke(hpx::copy_n_t, ExPolicy&& policy, FwdIter1 first,
+            Size count, FwdIter2 dest)
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
                 "Required at least forward iterator.");

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -204,7 +204,7 @@ namespace hpx {
 #include <hpx/assert.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/functional/tag_fallback_invoke.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>
@@ -635,7 +635,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::copy
     HPX_INLINE_CONSTEXPR_VARIABLE struct copy_t final
-      : hpx::functional::tag<copy_t>
+      : hpx::functional::tag_fallback<copy_t>
     {
     private:
         // clang-format off
@@ -648,7 +648,7 @@ namespace hpx {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             FwdIter2>::type
-        tag_invoke(hpx::copy_t, ExPolicy&& policy, FwdIter1 first,
+        tag_fallback_invoke(hpx::copy_t, ExPolicy&& policy, FwdIter1 first,
             FwdIter1 last, FwdIter2 dest)
         {
             return parallel::util::get_second_element(
@@ -664,7 +664,7 @@ namespace hpx {
                 hpx::traits::is_iterator<FwdIter2>::value
             )>
         // clang-format on
-        friend FwdIter2 tag_invoke(
+        friend FwdIter2 tag_fallback_invoke(
             hpx::copy_t, FwdIter1 first, FwdIter1 last, FwdIter2 dest)
         {
             return parallel::util::get_second_element(
@@ -677,7 +677,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::copy_n
     HPX_INLINE_CONSTEXPR_VARIABLE struct copy_n_t final
-      : hpx::functional::tag<copy_n_t>
+      : hpx::functional::tag_fallback<copy_n_t>
     {
     private:
         // clang-format off
@@ -691,7 +691,7 @@ namespace hpx {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             FwdIter2>::type
-        tag_invoke(hpx::copy_n_t, ExPolicy&& policy, FwdIter1 first, Size count,
+        tag_fallback_invoke(hpx::copy_n_t, ExPolicy&& policy, FwdIter1 first, Size count,
             FwdIter2 dest)
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
@@ -724,7 +724,7 @@ namespace hpx {
                 hpx::traits::is_iterator<FwdIter2>::value
             )>
         // clang-format on
-        friend FwdIter2 tag_invoke(
+        friend FwdIter2 tag_fallback_invoke(
             hpx::copy_n_t, FwdIter1 first, Size count, FwdIter2 dest)
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
@@ -751,7 +751,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::copy_if
     HPX_INLINE_CONSTEXPR_VARIABLE struct copy_if_t final
-      : hpx::functional::tag<copy_if_t>
+      : hpx::functional::tag_fallback<copy_if_t>
     {
     private:
         // clang-format off
@@ -768,7 +768,7 @@ namespace hpx {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             FwdIter2>::type
-        tag_invoke(hpx::copy_if_t, ExPolicy&& policy, FwdIter1 first,
+        tag_fallback_invoke(hpx::copy_if_t, ExPolicy&& policy, FwdIter1 first,
             FwdIter1 last, FwdIter2 dest, Pred&& pred)
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
@@ -798,7 +798,7 @@ namespace hpx {
                 >
             )>
         // clang-format on
-        friend FwdIter2 tag_invoke(hpx::copy_if_t, FwdIter1 first,
+        friend FwdIter2 tag_fallback_invoke(hpx::copy_if_t, FwdIter1 first,
             FwdIter1 last, FwdIter2 dest, Pred&& pred)
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/copy.hpp
@@ -349,7 +349,7 @@ namespace hpx { namespace ranges {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_invoke.hpp>
+#include <hpx/functional/tag_fallback_invoke.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
@@ -378,7 +378,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::copy
     HPX_INLINE_CONSTEXPR_VARIABLE struct copy_t final
-      : hpx::functional::tag<copy_t>
+      : hpx::functional::tag_fallback<copy_t>
     {
     private:
         // clang-format off
@@ -393,8 +393,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             ranges::copy_result<FwdIter1, FwdIter>>::type
-        tag_invoke(hpx::ranges::copy_t, ExPolicy&& policy, FwdIter1 iter,
-            Sent1 sent, FwdIter dest)
+        tag_fallback_invoke(hpx::ranges::copy_t, ExPolicy&& policy,
+            FwdIter1 iter, Sent1 sent, FwdIter dest)
         {
             using copy_iter_t =
                 hpx::parallel::v1::detail::copy_iter<FwdIter1, FwdIter>;
@@ -415,7 +415,7 @@ namespace hpx { namespace ranges {
             ranges::copy_result<
                 typename hpx::traits::range_traits<Rng>::iterator_type,
                 FwdIter>>::type
-        tag_invoke(
+        tag_fallback_invoke(
             hpx::ranges::copy_t, ExPolicy&& policy, Rng&& rng, FwdIter dest)
         {
             using copy_iter_t = hpx::parallel::v1::detail::copy_iter<
@@ -435,7 +435,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
-        friend ranges::copy_result<FwdIter1, FwdIter> tag_invoke(
+        friend ranges::copy_result<FwdIter1, FwdIter> tag_fallback_invoke(
             hpx::ranges::copy_t, FwdIter1 iter, Sent1 sent, FwdIter dest)
         {
             using copy_iter_t =
@@ -454,7 +454,7 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend ranges::copy_result<
             typename hpx::traits::range_traits<Rng>::iterator_type, FwdIter>
-        tag_invoke(hpx::ranges::copy_t, Rng&& rng, FwdIter dest)
+        tag_fallback_invoke(hpx::ranges::copy_t, Rng&& rng, FwdIter dest)
         {
             using copy_iter_t = hpx::parallel::v1::detail::copy_iter<
                 typename hpx::traits::range_traits<Rng>::iterator_type,
@@ -469,7 +469,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::copy_n
     HPX_INLINE_CONSTEXPR_VARIABLE struct copy_n_t final
-      : hpx::functional::tag<copy_n_t>
+      : hpx::functional::tag_fallback<copy_n_t>
     {
     private:
         // clang-format off
@@ -482,8 +482,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             ranges::copy_n_result<FwdIter1, FwdIter2>>::type
-        tag_invoke(hpx::ranges::copy_n_t, ExPolicy&& policy, FwdIter1 first,
-            Size count, FwdIter2 dest)
+        tag_fallback_invoke(hpx::ranges::copy_n_t, ExPolicy&& policy,
+            FwdIter1 first, Size count, FwdIter2 dest)
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
                 "Required at least forward iterator.");
@@ -514,7 +514,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_iterator<FwdIter1>::value &&
                 hpx::traits::is_iterator<FwdIter2>::value)>
         // clang-format on
-        friend ranges::copy_n_result<FwdIter1, FwdIter2> tag_invoke(
+        friend ranges::copy_n_result<FwdIter1, FwdIter2> tag_fallback_invoke(
             hpx::ranges::copy_n_t, FwdIter1 first, Size count, FwdIter2 dest)
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
@@ -539,7 +539,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::copy_if
     HPX_INLINE_CONSTEXPR_VARIABLE struct copy_if_t final
-      : hpx::functional::tag<copy_if_t>
+      : hpx::functional::tag_fallback<copy_if_t>
     {
     private:
         // clang-format off
@@ -559,8 +559,9 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             ranges::copy_if_result<FwdIter1, FwdIter>>::type
-        tag_invoke(hpx::ranges::copy_if_t, ExPolicy&& policy, FwdIter1 iter,
-            Sent1 sent, FwdIter dest, Pred&& pred, Proj&& proj = Proj())
+        tag_fallback_invoke(hpx::ranges::copy_if_t, ExPolicy&& policy,
+            FwdIter1 iter, Sent1 sent, FwdIter dest, Pred&& pred,
+            Proj&& proj = Proj())
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
                 "Required at least forward iterator.");
@@ -596,8 +597,8 @@ namespace hpx { namespace ranges {
             ranges::copy_if_result<
                 typename hpx::traits::range_traits<Rng>::iterator_type,
                 FwdIter>>::type
-        tag_invoke(hpx::ranges::copy_if_t, ExPolicy&& policy, Rng&& rng,
-            FwdIter dest, Pred&& pred, Proj&& proj = Proj())
+        tag_fallback_invoke(hpx::ranges::copy_if_t, ExPolicy&& policy,
+            Rng&& rng, FwdIter dest, Pred&& pred, Proj&& proj = Proj())
         {
             static_assert(hpx::traits::is_forward_iterator<FwdIter>::value ||
                     (hpx::is_sequenced_execution_policy<ExPolicy>::value &&
@@ -630,7 +631,7 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend ranges::copy_if_result<FwdIter1, FwdIter> tag_invoke(
+        friend ranges::copy_if_result<FwdIter1, FwdIter> tag_fallback_invoke(
             hpx::ranges::copy_if_t, FwdIter1 iter, Sent1 sent, FwdIter dest,
             Pred&& pred, Proj&& proj = Proj())
         {
@@ -661,8 +662,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend ranges::copy_if_result<
             typename hpx::traits::range_traits<Rng>::iterator_type, FwdIter>
-        tag_invoke(hpx::ranges::copy_if_t, Rng&& rng, FwdIter dest, Pred&& pred,
-            Proj&& proj = Proj())
+        tag_fallback_invoke(hpx::ranges::copy_if_t, Rng&& rng, FwdIter dest,
+            Pred&& pred, Proj&& proj = Proj())
         {
             static_assert((hpx::traits::is_output_iterator<FwdIter>::value),
                 "Required at least output iterator.");


### PR DESCRIPTION
## Proposed Changes

  - replaced tag_fallback_invoke header
  - replaced tag   with   tag_fallback
  - replaced tag_invoke    with   tag_fallback_invoke

## Any background context you want to provide?
From PR #5156 