### PR TITLE
Always define HPX_COMPUTE_HOST_CODE for host code

### DIFF
--- a/libs/core/config/include/hpx/config/compiler_specific.hpp
+++ b/libs/core/config/include/hpx/config/compiler_specific.hpp
@@ -103,9 +103,6 @@
 #  if defined(__CUDA_ARCH__)
      // nvcc compiling CUDA code, device mode.
 #    define HPX_COMPUTE_DEVICE_CODE
-#  else
-     // nvcc compiling CUDA code, host mode.
-#    define HPX_COMPUTE_HOST_CODE
 #  endif
 // Detecting Clang CUDA
 #elif defined(__clang__) && defined(__CUDA__)
@@ -113,9 +110,6 @@
 #  if defined(__CUDA_ARCH__)
      // clang compiling CUDA code, device mode.
 #    define HPX_COMPUTE_DEVICE_CODE
-#  else
-     // clang compiling CUDA code, host mode.
-#    define HPX_COMPUTE_HOST_CODE
 #  endif
 // Detecting HIPCC
 #elif defined(__HIPCC__)
@@ -134,13 +128,14 @@
 #  if defined(__HIP_DEVICE_COMPILE__)
      // hipclang compiling CUDA/HIP code, device mode.
 #    define HPX_COMPUTE_DEVICE_CODE
-#  else
-     // clang compiling CUDA/HIP code, host mode.
-#    define HPX_COMPUTE_HOST_CODE
 #  endif
 #endif
 
-#if defined(HPX_COMPUTE_DEVICE_CODE) || defined(HPX_COMPUTE_HOST_CODE)
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#  define HPX_COMPUTE_HOST_CODE
+#endif
+
+#if defined(HPX_COMPUTE_CODE)
 #define HPX_DEVICE __device__
 #define HPX_HOST __host__
 #define HPX_CONSTANT __constant__

--- a/libs/core/logging/include/hpx/logging/format/named_write.hpp
+++ b/libs/core/logging/include/hpx/logging/format/named_write.hpp
@@ -398,7 +398,7 @@ This will just configure "file" twice, ending up with writing only to "two.txt" 
             std::stringstream out;
             m_format(out, msg);
 
-#if !defined(HPX_COMPUTE_HOST_CODE)
+#if defined(HPX_COMPUTE_HOST_CODE)
             message formatted(std::move(out));
             m_destination(formatted);
 #endif

--- a/libs/core/logging/include/hpx/logging/message.hpp
+++ b/libs/core/logging/include/hpx/logging/message.hpp
@@ -55,25 +55,25 @@ namespace hpx { namespace util { namespace logging {
          */
         explicit message(std::stringstream msg)
           :
-#if !defined(HPX_COMPUTE_HOST_CODE)
+#if defined(HPX_COMPUTE_HOST_CODE)
           m_str(std::move(msg))
           ,
 #endif
           m_full_msg_computed(false)
         {
-#if defined(HPX_COMPUTE_HOST_CODE)
+#if !defined(HPX_COMPUTE_HOST_CODE)
             HPX_UNUSED(msg);
 #endif
         }
 
         message(message&& other) noexcept
           :
-#if !defined(HPX_COMPUTE_HOST_CODE)
+#if defined(HPX_COMPUTE_HOST_CODE)
           m_str(std::move(other.m_str))
           ,
 #endif
           m_full_msg_computed(other.m_full_msg_computed)
-#if !defined(HPX_COMPUTE_HOST_CODE)
+#if defined(HPX_COMPUTE_HOST_CODE)
           , m_full_msg(std::move(other.m_full_msg))
 #endif
         {

--- a/libs/full/compute_cuda/include/hpx/compute/cuda/allocator.hpp
+++ b/libs/full/compute_cuda/include/hpx/compute/cuda/allocator.hpp
@@ -210,12 +210,12 @@ namespace hpx { namespace cuda { namespace experimental {
         template <typename... Args>
         HPX_HOST_DEVICE void construct(pointer p,
             Args&&...
-#if defined(HPX_COMPUTE_HOST_CODE) || defined(HPX_COMPUTE_DEVICE_CODE)
+#if defined(HPX_COMPUTE_CODE)
             args
 #endif
         )
         {
-#if defined(HPX_COMPUTE_HOST_CODE) || defined(HPX_COMPUTE_DEVICE_CODE)
+#if defined(HPX_COMPUTE_CODE)
             detail::launch(
                 target_, 1, 1,
                 [] HPX_DEVICE(T * p, Args const&... args) {
@@ -231,7 +231,7 @@ namespace hpx { namespace cuda { namespace experimental {
         // Calls the destructor of count objects pointed to by p
         HPX_HOST_DEVICE void bulk_destroy(pointer p, std::size_t count)
         {
-#if defined(HPX_COMPUTE_HOST_CODE) || defined(HPX_COMPUTE_DEVICE_CODE)
+#if defined(HPX_COMPUTE_CODE)
             int threads_per_block = (hpx::util::min)(1024, int(count));
             int num_blocks =
                 int((count + threads_per_block) / threads_per_block) - 1;

--- a/libs/full/compute_cuda/include/hpx/compute/cuda/default_executor.hpp
+++ b/libs/full/compute_cuda/include/hpx/compute/cuda/default_executor.hpp
@@ -43,12 +43,12 @@ namespace hpx { namespace cuda { namespace experimental {
             static void call(hpx::cuda::experimental::target const& target,
                 F&& f, Shape const& shape,
                 Ts&&...
-#if defined(HPX_COMPUTE_DEVICE_CODE) || defined(HPX_COMPUTE_HOST_CODE)
+#if defined(HPX_COMPUTE_CODE)
                 ts
 #endif
             )
             {
-#if defined(HPX_COMPUTE_DEVICE_CODE) || defined(HPX_COMPUTE_HOST_CODE)
+#if defined(HPX_COMPUTE_CODE)
                 std::size_t count = util::size(shape);
 
                 int threads_per_block =
@@ -99,12 +99,12 @@ namespace hpx { namespace cuda { namespace experimental {
             static void call(hpx::cuda::experimental::target const& target,
                 F&& f, Shape const& shape,
                 Ts&&...
-#if defined(HPX_COMPUTE_DEVICE_CODE) || defined(HPX_COMPUTE_HOST_CODE)
+#if defined(HPX_COMPUTE_CODE)
                 ts
 #endif
             )
             {
-#if defined(HPX_COMPUTE_DEVICE_CODE) || defined(HPX_COMPUTE_HOST_CODE)
+#if defined(HPX_COMPUTE_CODE)
                 typedef typename hpx::traits::range_traits<Shape>::value_type
                     value_type;
 

--- a/libs/full/compute_cuda/include/hpx/compute/cuda/detail/launch.hpp
+++ b/libs/full/compute_cuda/include/hpx/compute/cuda/detail/launch.hpp
@@ -96,7 +96,7 @@ namespace hpx { namespace cuda { namespace experimental { namespace detail {
             static_assert(sizeof(Closure) < 256,
                 "We currently require the closure to be less than 256 bytes");
 
-#if defined(HPX_COMPUTE_HOST_CODE)
+#if defined(HPX_COMPUTE_CODE) && defined(HPX_COMPUTE_HOST_CODE)
             detail::scoped_active_target active(tgt);
 
             launch_function<<<grid_dim, block_dim, 0, active.stream()>>>(


### PR DESCRIPTION
Always define `HPX_COMPUTE_HOST_CODE` for host code, instead of only when compiling with nvcc or hipcc. This is a subtle change, which may in the worst case break someone's code, but I think it's mostly safe. This means that one doesn't have to do `#if !defined(HPX_COMPUTE_DEVICE_CODE)` when one wants something to be compiled only for the host, and `#if defined(HPX_COMPUTE_HOST_CODE)` will be enough (and the two are equivalent after with this PR). I've also cleaned up some other #ifdefs that I think didn't do right in the first place.