### PR TITLE
Minor adapted algos fixes

### DIFF
--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
@@ -448,9 +448,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
     {
         typedef typename std::iterator_traits<FwdIter>::value_type Type;
 
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
+
         // Just utilize existing parallel remove_if.
-        return remove_if(
-            std::forward<ExPolicy>(policy), first, last,
+        return detail::remove_if<FwdIter>().call(
+            std::forward<ExPolicy>(policy), is_seq(), first, last,
             [value](Type const& a) -> bool { return value == a; },
             std::forward<Proj>(proj));
     }

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove_copy.hpp
@@ -615,9 +615,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 OutIter>>::type remove_copy(ExPolicy&& policy, Rng&& rng,
             OutIter dest, T const& val, Proj&& proj = Proj())
     {
-        return remove_copy(std::forward<ExPolicy>(policy),
-            hpx::util::begin(rng), hpx::util::end(rng), dest, val,
-            std::forward<Proj>(proj));
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
+
+        return hpx::parallel::v1::detail::remove_copy<util::in_out_result<
+            typename hpx::traits::range_traits<Rng>::iterator_type, OutIter>>()
+            .call(std::forward<ExPolicy>(policy), is_seq(),
+                hpx::util::begin(rng), hpx::util::end(rng), dest, val,
+                std::forward<Proj>(proj));
     }
 
     // clang-format off
@@ -642,9 +646,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 OutIter>>::type remove_copy_if(ExPolicy&& policy, Rng&& rng,
             OutIter dest, F&& f, Proj&& proj = Proj())
     {
-        return remove_copy_if(std::forward<ExPolicy>(policy),
-            hpx::util::begin(rng), hpx::util::end(rng), dest,
-            std::forward<F>(f), std::forward<Proj>(proj));
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
+
+        return hpx::parallel::v1::detail::remove_copy_if<util::in_out_result<
+            typename hpx::traits::range_traits<Rng>::iterator_type, OutIter>>()
+            .call(std::forward<ExPolicy>(policy), is_seq(),
+                hpx::util::begin(rng), hpx::util::end(rng), dest,
+                std::forward<F>(f), std::forward<Proj>(proj));
     }
 }}}    // namespace hpx::parallel::v1
 
@@ -809,6 +817,9 @@ namespace hpx { namespace ranges {
         friend remove_copy_result<I, O> tag_invoke(hpx::ranges::remove_copy_t,
             I first, Sent last, O dest, T const& value, Proj&& proj = Proj())
         {
+            static_assert((hpx::traits::is_input_iterator<I>::value),
+                "Required at least input iterator.");
+
             typedef typename std::iterator_traits<I>::value_type Type;
 
             return hpx::ranges::remove_copy_if(
@@ -830,6 +841,11 @@ namespace hpx { namespace ranges {
         tag_invoke(hpx::ranges::remove_copy_t, Rng&& rng, O dest,
             T const& value, Proj&& proj = Proj())
         {
+            static_assert(
+                (hpx::traits::is_input_iterator<
+                    typename hpx::traits::range_iterator<Rng>::type>::value),
+                "Required at input forward iterator.");
+
             typedef typename std::iterator_traits<
                 typename hpx::traits::range_iterator<Rng>::type>::value_type
                 Type;
@@ -856,6 +872,9 @@ namespace hpx { namespace ranges {
         tag_invoke(hpx::ranges::remove_copy_t, ExPolicy&& policy, I first,
             Sent last, O dest, T const& value, Proj&& proj = Proj())
         {
+            static_assert((hpx::traits::is_forward_iterator<I>::value),
+                "Required at least forward iterator.");
+
             typedef typename std::iterator_traits<I>::value_type Type;
 
             return hpx::ranges::remove_copy_if(
@@ -879,6 +898,11 @@ namespace hpx { namespace ranges {
         tag_invoke(hpx::ranges::remove_copy_t, ExPolicy&& policy, Rng&& rng,
             O dest, T const& value, Proj&& proj = Proj())
         {
+            static_assert(
+                (hpx::traits::is_forward_iterator<
+                    typename hpx::traits::range_iterator<Rng>::type>::value),
+                "Required at least forward iterator.");
+
             typedef typename std::iterator_traits<
                 typename hpx::traits::range_iterator<Rng>::type>::value_type
                 Type;

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/replace.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/replace.hpp
@@ -1103,9 +1103,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
         replace(ExPolicy&& policy, Rng&& rng, T1 const& old_value,
             T2 const& new_value, Proj&& proj = Proj())
     {
-        return hpx::replace(std::forward<ExPolicy>(policy),
-            hpx::util::begin(rng), hpx::util::end(rng), old_value, new_value,
-            std::forward<Proj>(proj));
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
+
+        return hpx::parallel::v1::detail::replace<
+            typename hpx::traits::range_traits<Rng>::iterator_type>()
+            .call(std::forward<ExPolicy>(policy), is_seq(),
+                hpx::util::begin(rng), hpx::util::end(rng), old_value,
+                new_value, std::forward<Proj>(proj));
     }
 
     // clang-format off
@@ -1126,9 +1130,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
         replace_if(ExPolicy&& policy, Rng&& rng, F&& f, T const& new_value,
             Proj&& proj = Proj())
     {
-        return hpx::replace_if(std::forward<ExPolicy>(policy),
-            hpx::util::begin(rng), hpx::util::end(rng), std::forward<F>(f),
-            new_value, std::forward<Proj>(proj));
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
+
+        return hpx::parallel::v1::detail::replace_if<
+            typename hpx::traits::range_traits<Rng>::iterator_type>()
+            .call(std::forward<ExPolicy>(policy), is_seq(),
+                hpx::util::begin(rng), hpx::util::end(rng), std::forward<F>(f),
+                new_value, std::forward<Proj>(proj));
     }
 
     // clang-format off
@@ -1152,9 +1160,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
         type replace_copy(ExPolicy&& policy, Rng&& rng, OutIter dest,
             T1 const& old_value, T2 const& new_value, Proj&& proj = Proj())
     {
-        return replace_copy(std::forward<ExPolicy>(policy),
-            hpx::util::begin(rng), hpx::util::end(rng), dest, old_value,
-            new_value, std::forward<Proj>(proj));
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
+
+        return hpx::parallel::v1::detail::replace_copy<util::in_out_result<
+            typename hpx::traits::range_traits<Rng>::iterator_type, OutIter>>()
+            .call(std::forward<ExPolicy>(policy), is_seq(),
+                hpx::util::begin(rng), hpx::util::end(rng), dest, old_value,
+                new_value, std::forward<Proj>(proj));
     }
 
     // clang-format off
@@ -1177,9 +1189,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
             OutIter>>::type replace_copy_if(ExPolicy&& policy, Rng&& rng,
         OutIter dest, F&& f, T const& new_value, Proj&& proj = Proj())
     {
-        return replace_copy_if(std::forward<ExPolicy>(policy),
-            hpx::util::begin(rng), hpx::util::end(rng), dest,
-            std::forward<F>(f), new_value, std::forward<Proj>(proj));
+        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
+
+        return hpx::parallel::v1::detail::replace_copy_if<util::in_out_result<
+            typename hpx::traits::range_traits<Rng>::iterator_type, OutIter>>()
+            .call(std::forward<ExPolicy>(policy), is_seq(),
+                hpx::util::begin(rng), hpx::util::end(rng), dest,
+                std::forward<F>(f), new_value, std::forward<Proj>(proj));
     }
 }}}    // namespace hpx::parallel::v1
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy.cpp
@@ -82,34 +82,6 @@ void test_remove_copy(ExPolicy policy, IteratorTag)
     HPX_TEST_EQ(count, middle_idx);
 }
 
-template <typename IteratorTag>
-void test_remove_copy_async(IteratorTag)
-{
-    typedef std::vector<std::size_t>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    std::vector<std::size_t> c(10007);
-    std::vector<std::size_t> d(c.size() / 2);
-    std::uniform_int_distribution<> dis(0, (c.size() >> 1) - 1);
-
-    std::size_t middle_idx = dis(gen);
-    auto middle = std::begin(c) + middle_idx;
-    std::fill(std::begin(c), middle, 1);
-    std::fill(middle, std::end(c), 2);
-
-    hpx::remove_copy(iterator(std::begin(c)), iterator(std::end(c)),
-        std::begin(d), std::size_t(2));
-
-    std::size_t count = 0;
-    HPX_TEST(std::equal(std::begin(c), middle, std::begin(d),
-        [&count](std::size_t v1, std::size_t v2) -> bool {
-            HPX_TEST_EQ(v1, v2);
-            ++count;
-            return v1 == v2;
-        }));
-    HPX_TEST_EQ(count, middle_idx);
-}
-
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_async(ExPolicy p, IteratorTag)
 {
@@ -211,7 +183,6 @@ void test_remove_copy()
     test_remove_copy(par, IteratorTag());
     test_remove_copy(par_unseq, IteratorTag());
 
-    test_remove_copy_async(IteratorTag());
     test_remove_copy_async(seq(task), IteratorTag());
     test_remove_copy_async(par(task), IteratorTag());
 }

--- a/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy_if.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/remove_copy_if.cpp
@@ -100,43 +100,6 @@ void test_remove_copy_if(ExPolicy policy, IteratorTag)
     HPX_TEST_EQ(count, d.size());
 }
 
-template <typename IteratorTag>
-void test_remove_copy_if_async(IteratorTag)
-{
-    typedef std::vector<int>::iterator base_iterator;
-    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
-
-    std::vector<int> c(10007);
-    std::vector<int> d(c.size());
-    std::uniform_int_distribution<> dis(0, (c.size() >> 1) - 1);
-    std::uniform_int_distribution<> dist(0, c.size() - 1);
-
-    std::size_t middle_idx = dis(gen);
-    auto middle = std::begin(c) + middle_idx;
-    std::iota(std::begin(c), middle, static_cast<int>(dist(gen)));
-    std::fill(middle, std::end(c), -1);
-
-    hpx::remove_copy_if(iterator(std::begin(c)), iterator(std::end(c)),
-        std::begin(d), [](int i) { return i < 0; });
-
-    std::size_t count = 0;
-    HPX_TEST(std::equal(
-        std::begin(c), middle, std::begin(d), [&count](int v1, int v2) -> bool {
-            HPX_TEST_EQ(v1, v2);
-            ++count;
-            return v1 == v2;
-        }));
-
-    HPX_TEST(std::equal(middle, std::end(c), std::begin(d) + middle_idx,
-        [&count](int v1, int v2) -> bool {
-            HPX_TEST_NEQ(v1, v2);
-            ++count;
-            return v1 != v2;
-        }));
-
-    HPX_TEST_EQ(count, d.size());
-}
-
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_if_async(ExPolicy p, IteratorTag)
 {
@@ -246,7 +209,6 @@ void test_remove_copy_if()
     test_remove_copy_if(par, IteratorTag());
     test_remove_copy_if(par_unseq, IteratorTag());
 
-    test_remove_copy_if_async(IteratorTag());
     test_remove_copy_if_async(seq(task), IteratorTag());
     test_remove_copy_if_async(par(task), IteratorTag());
 }

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_if_range.cpp
@@ -140,40 +140,6 @@ void test_remove_copy_if(ExPolicy policy, IteratorTag)
     HPX_TEST_EQ(count, d.size());
 }
 
-template <typename IteratorTag>
-void test_remove_copy_if_async(IteratorTag)
-{
-    typedef test::test_container<std::vector<int>, IteratorTag> test_vector;
-
-    test_vector c(10007);
-    std::vector<int> d(c.size());
-    std::size_t middle_idx = std::rand() % (c.size() / 2);
-    auto middle =
-        hpx::parallel::v1::detail::next(std::begin(c.base()), middle_idx);
-    std::iota(
-        std::begin(c.base()), middle, static_cast<int>(std::rand() % c.size()));
-    std::fill(middle, std::end(c.base()), -1);
-
-    hpx::ranges::remove_copy_if(c, std::begin(d), [](int i) { return i < 0; });
-
-    std::size_t count = 0;
-    HPX_TEST(std::equal(std::begin(c.base()), middle, std::begin(d),
-        [&count](int v1, int v2) -> bool {
-            HPX_TEST_EQ(v1, v2);
-            ++count;
-            return v1 == v2;
-        }));
-
-    HPX_TEST(std::equal(middle, std::end(c.base()), std::begin(d) + middle_idx,
-        [&count](int v1, int v2) -> bool {
-            HPX_TEST_NEQ(v1, v2);
-            ++count;
-            return v1 != v2;
-        }));
-
-    HPX_TEST_EQ(count, d.size());
-}
-
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_if_async(ExPolicy p, IteratorTag)
 {
@@ -276,7 +242,6 @@ void test_remove_copy_if()
     test_remove_copy_if(par, IteratorTag());
     test_remove_copy_if(par_unseq, IteratorTag());
 
-    test_remove_copy_if_async(IteratorTag());
     test_remove_copy_if_async(seq(task), IteratorTag());
     test_remove_copy_if_async(par(task), IteratorTag());
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/remove_copy_range.cpp
@@ -123,32 +123,6 @@ void test_remove_copy(ExPolicy policy, IteratorTag)
     HPX_TEST_EQ(count, middle_idx);
 }
 
-template <typename IteratorTag>
-void test_remove_copy_async(IteratorTag)
-{
-    typedef test::test_container<std::vector<std::size_t>, IteratorTag>
-        test_vector;
-
-    test_vector c(10007);
-    std::vector<std::size_t> d(c.size() / 2);
-    std::size_t middle_idx = std::rand() % (c.size() / 2);
-    auto middle =
-        hpx::parallel::v1::detail::next(std::begin(c.base()), middle_idx);
-    std::fill(std::begin(c.base()), middle, 1);
-    std::fill(middle, std::end(c.base()), 2);
-
-    hpx::ranges::remove_copy(c, std::begin(d), std::size_t(2));
-
-    std::size_t count = 0;
-    HPX_TEST(std::equal(std::begin(c.base()), middle, std::begin(d),
-        [&count](std::size_t v1, std::size_t v2) -> bool {
-            HPX_TEST_EQ(v1, v2);
-            ++count;
-            return v1 == v2;
-        }));
-    HPX_TEST_EQ(count, middle_idx);
-}
-
 template <typename ExPolicy, typename IteratorTag>
 void test_remove_copy_async(ExPolicy p, IteratorTag)
 {
@@ -247,7 +221,6 @@ void test_remove_copy()
     test_remove_copy(par, IteratorTag());
     test_remove_copy(par_unseq, IteratorTag());
 
-    test_remove_copy_async(IteratorTag());
     test_remove_copy_async(seq(task), IteratorTag());
     test_remove_copy_async(par(task), IteratorTag());
 


### PR DESCRIPTION
This fixes minor flaws on previous adaptations of mine:

1. It removes unnecessary "async without execution policy" tests.
2. It imposes deprecated algos to use base implementations instead of unquialified  (or adapted qualified ones). In general, I tried to avoid using top level algos.
3. It adds `static_assert`ions for the iterator types of the adapted overloads.
4. _todo:_ Change `tag`s to `tag_fallback`s maybe.

I am curious to see if GCC will complain about deprecations on the lambda calls.