### PR TITLE
Seperate segmented algorithms for for_each_n

### DIFF
--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/for_each.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/for_each.hpp
@@ -179,39 +179,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 },
                 std::move(segments)));
         }
-
-        /// Segmented implementation using for_each.
-        template <typename ExPolicy, typename FwdIter, typename Size,
-            typename F, typename Proj>
-        typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
-        for_each_n_(ExPolicy&& policy, FwdIter first, Size count, F&& f,
-            Proj&& proj, std::false_type);
-
-        template <typename ExPolicy, typename FwdIter, typename Size,
-            typename F, typename Proj>
-        typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
-        for_each_n_(ExPolicy&& policy, FwdIter first, Size count, F&& f,
-            Proj&& proj, std::true_type)
-        {
-            using iterator_traits =
-                hpx::traits::segmented_iterator_traits<FwdIter>;
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
-            if (detail::is_negative(count) || count == 0)
-            {
-                using result =
-                    util::detail::algorithm_result<ExPolicy, FwdIter>;
-                return result::get(std::move(first));
-            }
-
-            auto last = first;
-            detail::advance(last, std::size_t(count));
-            return segmented_for_each(
-                hpx::parallel::v1::detail::for_each<
-                    typename iterator_traits::local_iterator>(),
-                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
-                std::forward<Proj>(proj), is_seq());
-        }
         /// \endcond
     }    // namespace detail
 }}}      // namespace hpx::parallel::v1
@@ -275,6 +242,70 @@ namespace hpx { namespace segmented {
 
         using iterator_traits = hpx::traits::segmented_iterator_traits<SegIter>;
 
+        return segmented_for_each(
+            hpx::parallel::v1::detail::for_each<
+                typename iterator_traits::local_iterator>(),
+            std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+            hpx::parallel::util::projection_identity(), is_seq());
+    }
+
+    // clang-format off
+    template <typename InIter, typename Size,
+        typename F,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::traits::is_iterator<InIter>::value &&
+            hpx::traits::is_segmented_iterator<InIter>::value
+        )>
+    // clang-format on
+    InIter tag_invoke(hpx::for_each_n_t, InIter first, Size count, F&& f)
+    {
+        static_assert((hpx::traits::is_forward_iterator<InIter>::value),
+            "Requires at least input iterator.");
+
+        using iterator_traits = hpx::traits::segmented_iterator_traits<InIter>;
+
+        if (hpx::parallel::v1::detail::is_negative(count) || count == 0)
+        {
+            return first;
+        }
+
+        auto last = first;
+        hpx::parallel::v1::detail::advance(last, std::size_t(count));
+        return hpx::parallel::v1::detail::segmented_for_each(
+            hpx::parallel::v1::detail::for_each<
+                typename iterator_traits::local_iterator>(),
+            hpx::execution::seq, first, last, std::forward<F>(f),
+            hpx::parallel::util::projection_identity(), std::true_type());
+    }
+
+    //clang-format off
+    template <typename ExPolicy, typename SegIter, typename Size, typename F,
+        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
+                hpx::traits::is_iterator<SegIter>::value&&
+                    hpx::traits::is_segmented_iterator<SegIter>::value)>
+    //clang-format on
+    typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
+        SegIter>::type
+    tag_invoke(
+        hpx::for_each_n_t, ExPolicy&& policy, SegIter first, Size count, F&& f)
+    {
+        static_assert((hpx::traits::is_forward_iterator<SegIter>::value),
+            "Requires at least input iterator.");
+
+        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
+
+        if (hpx::parallel::v1::detail::is_negative(count) || count == 0)
+        {
+            using result =
+                hpx::parallel::util::detail::algorithm_result<ExPolicy,
+                    SegIter>;
+            return result::get(std::move(first));
+        }
+
+        using iterator_traits = hpx::traits::segmented_iterator_traits<SegIter>;
+
+        auto last = first;
+        hpx::parallel::v1::detail::advance(last, std::size_t(count));
         return segmented_for_each(
             hpx::parallel::v1::detail::for_each<
                 typename iterator_traits::local_iterator>(),

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/for_each.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/for_each.hpp
@@ -278,7 +278,7 @@ namespace hpx { namespace segmented {
             hpx::parallel::util::projection_identity(), std::true_type());
     }
 
-    //clang-format off
+    // clang-format off
     template <typename ExPolicy, typename SegIter, typename Size,
         typename F,
         HPX_CONCEPT_REQUIRES_(
@@ -286,7 +286,7 @@ namespace hpx { namespace segmented {
             hpx::traits::is_iterator<SegIter>::value &&
             hpx::traits::is_segmented_iterator<SegIter>::value
         )>
-    //clang-format on
+    // clang-format on
     typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
         SegIter>::type
     tag_invoke(

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/for_each.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/for_each.hpp
@@ -259,7 +259,7 @@ namespace hpx { namespace segmented {
     // clang-format on
     InIter tag_invoke(hpx::for_each_n_t, InIter first, Size count, F&& f)
     {
-        static_assert((hpx::traits::is_forward_iterator<InIter>::value),
+        static_assert((hpx::traits::is_input_iterator<InIter>::value),
             "Requires at least input iterator.");
 
         using iterator_traits = hpx::traits::segmented_iterator_traits<InIter>;
@@ -279,10 +279,13 @@ namespace hpx { namespace segmented {
     }
 
     //clang-format off
-    template <typename ExPolicy, typename SegIter, typename Size, typename F,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value&&
-                hpx::traits::is_iterator<SegIter>::value&&
-                    hpx::traits::is_segmented_iterator<SegIter>::value)>
+    template <typename ExPolicy, typename SegIter, typename Size,
+        typename F,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<SegIter>::value &&
+            hpx::traits::is_segmented_iterator<SegIter>::value
+        )>
     //clang-format on
     typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
         SegIter>::type

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -490,47 +490,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
     }    // namespace detail
 
     // clang-format off
-    template <typename ExPolicy, typename FwdIter, typename Size, typename F,
-        typename Proj = util::projection_identity,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::is_execution_policy<ExPolicy>::value&&
-            hpx::traits::is_iterator<FwdIter>::value&&
-            hpx::parallel::traits::is_projected<Proj, FwdIter>::value&&
-            hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
-            hpx::parallel::traits::projected<Proj, FwdIter>>::value
-        )>
-    // clang-format on
-    HPX_DEPRECATED_V(1, 6,
-        "hpx::parallel::for_each_n is deprecated, use hpx::for_each_n "
-        "instead")
-        typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
-        for_each_n(ExPolicy&& policy, FwdIter first, Size count, F&& f,
-            Proj&& proj = Proj())
-    {
-        static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
-            "Requires at least forward iterator.");
-
-        // if count is representing a negative value or zero, we do nothing
-        if (detail::is_negative(count) || count == 0)
-        {
-            return util::detail::algorithm_result<ExPolicy, FwdIter>::get(
-                std::move(first));
-        }
-
-        using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
-
-#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-        return detail::for_each_n_(std::forward<ExPolicy>(policy), first, count,
-            std::forward<F>(f), std::forward<Proj>(proj), is_segmented());
-#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
-#pragma GCC diagnostic pop
-#endif
-    }
-
-    // clang-format off
     template <typename ExPolicy, typename FwdIterB, typename FwdIterE,
         typename F, typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -490,6 +490,49 @@ namespace hpx { namespace parallel { inline namespace v1 {
     }    // namespace detail
 
     // clang-format off
+    template <typename ExPolicy, typename FwdIter, typename Size, typename F,
+        typename Proj = util::projection_identity,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value&&
+            hpx::traits::is_iterator<FwdIter>::value&&
+            hpx::parallel::traits::is_projected<Proj, FwdIter>::value&&
+            hpx::parallel::traits::is_indirect_callable<ExPolicy, F,
+            hpx::parallel::traits::projected<Proj,
+            FwdIter>>::value
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 6,
+        "hpx::parallel::for_each_n is deprecated, use hpx::for_each_n "
+        "instead")
+        typename util::detail::algorithm_result<ExPolicy, FwdIter>::type
+        for_each_n(ExPolicy&& policy, FwdIter first, Size count, F&& f,
+            Proj&& proj = Proj())
+    {
+        static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
+            "Requires at least forward iterator.");
+
+        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
+
+        // if count is representing a negative value or zero, we do nothing
+        if (detail::is_negative(count) || count == 0)
+        {
+            using result = util::detail::algorithm_result<ExPolicy, FwdIter>;
+            return result::get(std::move(first));
+        }
+
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+        return parallel::v1::detail::for_each_n<FwdIter>().call(
+            std::forward<ExPolicy>(policy), is_seq(), first, std::size_t(count),
+            std::forward<F>(f), std::forward<Proj>(proj));
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic pop
+#endif
+    }
+
+    // clang-format off
     template <typename ExPolicy, typename FwdIterB, typename FwdIterE,
         typename F, typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/for_each.hpp
@@ -551,8 +551,8 @@ namespace hpx { namespace ranges {
             hpx::ranges::for_each_n_t, InIter first, Size count, F&& f,
             Proj&& proj = Proj())
         {
-            static_assert((hpx::traits::is_forward_iterator<InIter>::value),
-                "Requires at least forward iterator.");
+            static_assert((hpx::traits::is_input_iterator<InIter>::value),
+                "Requires at least input iterator.");
 
             // if count is representing a negative value, we do nothing
             if (parallel::v1::detail::is_negative(count))

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/for_each.hpp
@@ -581,7 +581,7 @@ namespace hpx { namespace ranges {
         tag_fallback_invoke(hpx::ranges::for_each_n_t, ExPolicy&& policy,
             FwdIter first, Size count, F&& f, Proj&& proj = Proj())
         {
-            static_assert((hpx::traits::is_forward_iterator<InIter>::value),
+            static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Requires at least forward iterator.");
 
             // if count is representing a negative value, we do nothing

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/for_each.hpp
@@ -421,7 +421,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::for_each
     HPX_INLINE_CONSTEXPR_VARIABLE struct for_each_t final
-      : hpx::functional::tag<for_each_t>
+      : hpx::functional::tag_fallback<for_each_t>
     {
         // clang-format off
         template <typename InIter, typename Sent, typename F,
@@ -434,8 +434,9 @@ namespace hpx { namespace ranges {
                     hpx::execution::sequenced_policy, F,
                     hpx::parallel::traits::projected<Proj, InIter>>::value)>
         // clang-format on
-        friend for_each_result<InIter, F> tag_invoke(hpx::ranges::for_each_t,
-            InIter first, Sent last, F&& f, Proj&& proj = Proj())
+        friend for_each_result<InIter, F> tag_fallback_invoke(
+            hpx::ranges::for_each_t, InIter first, Sent last, F&& f,
+            Proj&& proj = Proj())
         {
             static_assert((hpx::traits::is_forward_iterator<InIter>::value),
                 "Requires at least forward iterator.");
@@ -458,7 +459,7 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend for_each_result<typename hpx::traits::range_iterator<Rng>::type,
             F>
-        tag_invoke(
+        tag_fallback_invoke(
             hpx::ranges::for_each_t, Rng&& rng, F&& f, Proj&& proj = Proj())
         {
             using iterator_type =
@@ -487,8 +488,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             FwdIter>::type
-        tag_invoke(hpx::ranges::for_each_t, ExPolicy&& policy, FwdIter first,
-            Sent last, F&& f, Proj&& proj = Proj())
+        tag_fallback_invoke(hpx::ranges::for_each_t, ExPolicy&& policy,
+            FwdIter first, Sent last, F&& f, Proj&& proj = Proj())
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Requires at least forward iterator.");
@@ -512,8 +513,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             typename hpx::traits::range_iterator<Rng>::type>::type
-        tag_invoke(hpx::ranges::for_each_t, ExPolicy&& policy, Rng&& rng, F&& f,
-            Proj&& proj = Proj())
+        tag_fallback_invoke(hpx::ranges::for_each_t, ExPolicy&& policy,
+            Rng&& rng, F&& f, Proj&& proj = Proj())
         {
             using iterator_type =
                 typename hpx::traits::range_traits<Rng>::iterator_type;
@@ -534,7 +535,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::for_each_n
     HPX_INLINE_CONSTEXPR_VARIABLE struct for_each_n_t final
-      : hpx::functional::tag<for_each_n_t>
+      : hpx::functional::tag_fallback<for_each_n_t>
     {
         // clang-format off
         template <typename InIter, typename Size, typename F,
@@ -546,18 +547,22 @@ namespace hpx { namespace ranges {
                     hpx::execution::sequenced_policy, F,
                     hpx::parallel::traits::projected<Proj, InIter>>::value)>
         // clang-format on
-        friend for_each_n_result<InIter, F> tag_invoke(
+        friend for_each_n_result<InIter, F> tag_fallback_invoke(
             hpx::ranges::for_each_n_t, InIter first, Size count, F&& f,
             Proj&& proj = Proj())
         {
+            static_assert((hpx::traits::is_forward_iterator<InIter>::value),
+                "Requires at least forward iterator.");
+
             // if count is representing a negative value, we do nothing
             if (parallel::v1::detail::is_negative(count))
             {
                 return {std::move(first), std::forward<F>(f)};
             }
 
-            auto it = for_each_n(
-                hpx::execution::seq, first, count, f, std::forward<Proj>(proj));
+            auto it = parallel::v1::detail::for_each_n<InIter>().call(
+                hpx::execution::seq, std::true_type(), first, count, f,
+                std::forward<Proj>(proj));
             return {std::move(it), std::forward<F>(f)};
         }
 
@@ -573,9 +578,12 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             FwdIter>::type
-        tag_invoke(hpx::ranges::for_each_n_t, ExPolicy&& policy, FwdIter first,
-            Size count, F&& f, Proj&& proj = Proj())
+        tag_fallback_invoke(hpx::ranges::for_each_n_t, ExPolicy&& policy,
+            FwdIter first, Size count, F&& f, Proj&& proj = Proj())
         {
+            static_assert((hpx::traits::is_forward_iterator<InIter>::value),
+                "Requires at least forward iterator.");
+
             // if count is representing a negative value, we do nothing
             if (parallel::v1::detail::is_negative(count))
             {
@@ -583,11 +591,11 @@ namespace hpx { namespace ranges {
                     FwdIter>::get(std::move(first));
             }
 
-            using is_segmented = hpx::traits::is_segmented_iterator<FwdIter>;
+            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 
-            return parallel::v1::detail::for_each_n_(
-                std::forward<ExPolicy>(policy), first, count,
-                std::forward<F>(f), std::forward<Proj>(proj), is_segmented());
+            return parallel::v1::detail::for_each_n<FwdIter>().call(
+                std::forward<ExPolicy>(policy), is_seq(), first, count,
+                std::forward<F>(f), std::forward<Proj>(proj));
         }
     } for_each_n{};
 }}    // namespace hpx::ranges


### PR DESCRIPTION
Seperate segmented algorithms for for_each_n and move tag_invoke to tag_fallback_invoke for for_each_n

## Proposed Changes

Removed for_each_n_ function that used to dispatch to segmented/non-segmented algorithms
Added tag_invoke overload to segmented_algorithms/for_each.hpp instead that does the dispatching
Replaced tag_invoke with tag_fallback_invoke so that it properly falls back to the non-segmented overload

## Any background context you want to provide?
Issue #5156 
Issue #5204 