### PR TITLE
Removing ESSENTIAL option to the doc example

### DIFF
--- a/docs/sphinx/manual/creating_hpx_projects.rst
+++ b/docs/sphinx/manual/creating_hpx_projects.rst
@@ -350,7 +350,6 @@ After adding the component, the way you add the executable is as follows:
 
    # build your application using HPX
    add_hpx_executable(hello_world
-       ESSENTIAL
        SOURCES hello_world_client.cpp
        COMPONENT_DEPENDENCIES hello_world)
 


### PR DESCRIPTION
Looks like this option is not parsed in `add_hpx_executable` so simply removing it.