### PR TITLE
Update .codespell_whitelist

### DIFF
--- a/tools/.codespell_whitelist
+++ b/tools/.codespell_whitelist
@@ -18,5 +18,5 @@ rouge
 stoll
 tim
 uint
-Vill
+vill
 wit


### PR DESCRIPTION
Changes the "Vill" entry to be in lower case. Codespell has an interesting way of matching whitelisted words... Since the dictionary contains "will" in lower case the whitelisted word also has to be in lower case.