### PR TITLE
Remove leftover Boost include from sync_wait.hpp

### DIFF
--- a/libs/parallelism/execution/include/hpx/execution/algorithms/sync_wait.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/sync_wait.hpp
@@ -14,8 +14,6 @@
 #include <hpx/synchronization/mutex.hpp>
 #include <hpx/type_support/pack.hpp>
 
-#include <boost/variant.hpp>
-
 #include <exception>
 #include <tuple>
 #include <type_traits>


### PR DESCRIPTION
This was a leftover from debugging sender traits.