### PR TITLE
Fix C++20 replace algo adaptation misses

### DIFF
--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/replace.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/replace.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2014-2017 Hartmut Kaiser
-//  Copyright (c) 2021      Giannis Gonidelis
+//  Copyright (c)      2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -27,8 +27,6 @@ namespace hpx {
     ///                     input iterator.
     /// \tparam T           The type of the old and new values to replace (deduced).
     ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
     /// \param first        Refers to the beginning of the sequence of elements
     ///                     the algorithm will be applied to.
     /// \param last         Refers to the end of the sequence of elements the
@@ -114,8 +112,6 @@ namespace hpx {
     ///                     (deduced).
     /// \tparam T           The type of the new values to replace (deduced).
     ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
     /// \param first        Refers to the beginning of the sequence of elements
     ///                     the algorithm will be applied to.
     /// \param last         Refers to the end of the sequence of elements the
@@ -239,8 +235,6 @@ namespace hpx {
     ///                     output iterator.
     /// \tparam T          The type of the old and new values (deduced).
     ///
-    /// \param policy       The execution policy to use for the scheduling of
-    ///                     the iterations.
     /// \param first        Refers to the beginning of the sequence of elements
     ///                     the algorithm will be applied to.
     /// \param last         Refers to the end of the sequence of elements the
@@ -751,7 +745,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     }    // namespace detail
 
     // clang-format off
-    template <typename ExPolicy, typename FwdIter1, typename Sent,
+    template <typename ExPolicy, typename FwdIter1,
         typename FwdIter2, typename T1, typename T2,
         typename Proj = util::projection_identity,
         HPX_CONCEPT_REQUIRES_(

--- a/libs/parallelism/algorithms/tests/unit/algorithms/replace_copy.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/replace_copy.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c)      2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -117,6 +118,7 @@ template <typename IteratorTag>
 void test_replace_copy()
 {
     using namespace hpx::execution;
+    test_replace_copy(IteratorTag());
     test_replace_copy(seq, IteratorTag());
     test_replace_copy(par, IteratorTag());
     test_replace_copy(par_unseq, IteratorTag());
@@ -132,6 +134,40 @@ void replace_copy_test()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_replace_copy_exception(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::replace_copy(decorated_iterator(std::begin(c),
+                              []() { throw std::runtime_error("test"); }),
+            decorated_iterator(std::end(c)), std::begin(d), std::size_t(42),
+            std::size_t(43));
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_exception(ExPolicy policy, IteratorTag)
 {
@@ -216,6 +252,7 @@ void test_replace_copy_exception()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_replace_copy_exception(IteratorTag());
     test_replace_copy_exception(seq, IteratorTag());
     test_replace_copy_exception(par, IteratorTag());
 
@@ -230,6 +267,38 @@ void replace_copy_exception_test()
 }
 
 //////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_replace_copy_bad_alloc(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    try
+    {
+        hpx::replace_copy(
+            decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
+            decorated_iterator(std::end(c)), std::begin(d), std::size_t(42),
+            std::size_t(43));
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_bad_alloc = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_bad_alloc(ExPolicy policy, IteratorTag)
 {
@@ -310,6 +379,7 @@ void test_replace_copy_bad_alloc()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_replace_copy_bad_alloc(IteratorTag());
     test_replace_copy_bad_alloc(seq, IteratorTag());
     test_replace_copy_bad_alloc(par, IteratorTag());
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/replace_copy_if.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/replace_copy_if.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c)      2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -148,6 +149,40 @@ void replace_copy_if_test()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_replace_copy_if_exception(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::replace_copy_if(decorated_iterator(std::begin(c),
+                                 []() { throw std::runtime_error("test"); }),
+            decorated_iterator(std::end(c)), std::begin(d), equal_f(42),
+            std::size_t(43));
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_if_exception(ExPolicy policy, IteratorTag)
 {
@@ -232,6 +267,7 @@ void test_replace_copy_if_exception()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_replace_copy_if_exception(IteratorTag());
     test_replace_copy_if_exception(seq, IteratorTag());
     test_replace_copy_if_exception(par, IteratorTag());
 
@@ -246,6 +282,38 @@ void replace_copy_if_exception_test()
 }
 
 //////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_replace_copy_if_bad_alloc(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    try
+    {
+        hpx::replace_copy_if(
+            decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
+            decorated_iterator(std::end(c)), std::begin(d), equal_f(42),
+            std::size_t(43));
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_bad_alloc = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_if_bad_alloc(ExPolicy policy, IteratorTag)
 {
@@ -326,6 +394,7 @@ void test_replace_copy_if_bad_alloc()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_replace_copy_if_bad_alloc(IteratorTag());
     test_replace_copy_if_bad_alloc(seq, IteratorTag());
     test_replace_copy_if_bad_alloc(par, IteratorTag());
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/replace_if.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/replace_if.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c)      2921 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -33,6 +34,34 @@ struct equal_f
 
     std::size_t val_;
 };
+
+template <typename IteratorTag>
+void test_replace_if(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::copy(std::begin(c), std::end(c), std::begin(d));
+
+    std::size_t idx = std::rand() % c.size();    //-V104
+
+    hpx::replace_if(iterator(std::begin(c)), iterator(std::end(c)),
+        equal_f(c[idx]), c[idx] + 1);
+
+    std::replace_if(std::begin(d), std::end(d), equal_f(d[idx]), d[idx] + 1);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d.size());
+}
 
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_if(ExPolicy policy, IteratorTag)
@@ -98,6 +127,7 @@ template <typename IteratorTag>
 void test_replace_if()
 {
     using namespace hpx::execution;
+    test_replace_if(IteratorTag());
     test_replace_if(seq, IteratorTag());
     test_replace_if(par, IteratorTag());
     test_replace_if(par_unseq, IteratorTag());
@@ -113,6 +143,38 @@ void replace_if_test()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_replace_if_exception(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::replace_if(decorated_iterator(std::begin(c),
+                            []() { throw std::runtime_error("test"); }),
+            decorated_iterator(std::end(c)), equal_f(42), std::size_t(43));
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_if_exception(ExPolicy policy, IteratorTag)
 {
@@ -193,6 +255,7 @@ void test_replace_if_exception()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_replace_if_exception(IteratorTag());
     test_replace_if_exception(seq, IteratorTag());
     test_replace_if_exception(par, IteratorTag());
 
@@ -207,6 +270,36 @@ void replace_if_exception_test()
 }
 
 //////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_replace_if_bad_alloc(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    try
+    {
+        hpx::replace_if(
+            decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
+            decorated_iterator(std::end(c)), equal_f(42), std::size_t(43));
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_bad_alloc = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_if_bad_alloc(ExPolicy policy, IteratorTag)
 {
@@ -283,6 +376,7 @@ void test_replace_if_bad_alloc()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_replace_if_bad_alloc(IteratorTag());
     test_replace_if_bad_alloc(seq, IteratorTag());
     test_replace_if_bad_alloc(par, IteratorTag());
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_if_range.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c)      2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -180,6 +181,7 @@ template <typename IteratorTag>
 void test_replace_copy_if()
 {
     using namespace hpx::execution;
+    test_replace_copy_if(IteratorTag());
     test_replace_copy_if(seq, IteratorTag());
     test_replace_copy_if(par, IteratorTag());
     test_replace_copy_if(par_unseq, IteratorTag());
@@ -200,6 +202,42 @@ void replace_copy_if_test()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_replace_copy_if_exception(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::ranges::replace_copy_if(
+            hpx::util::make_iterator_range(
+                decorated_iterator(
+                    std::begin(c), []() { throw std::runtime_error("test"); }),
+                decorated_iterator(std::end(c))),
+            std::begin(d), equal_f(42), std::size_t(43));
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_if_exception(ExPolicy policy, IteratorTag)
 {
@@ -286,6 +324,7 @@ void test_replace_copy_if_exception()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_replace_copy_if_exception(IteratorTag());
     test_replace_copy_if_exception(seq, IteratorTag());
     test_replace_copy_if_exception(par, IteratorTag());
 
@@ -300,6 +339,39 @@ void replace_copy_if_exception_test()
 }
 
 //////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_replace_copy_if_bad_alloc(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    try
+    {
+        hpx::ranges::replace_copy_if(hpx::util::make_iterator_range(
+                                         decorated_iterator(std::begin(c),
+                                             []() { throw std::bad_alloc(); }),
+                                         decorated_iterator(std::end(c))),
+            std::begin(d), equal_f(42), std::size_t(43));
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_bad_alloc = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_if_bad_alloc(ExPolicy policy, IteratorTag)
 {
@@ -384,6 +456,7 @@ void test_replace_copy_if_bad_alloc()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_replace_copy_if_bad_alloc(IteratorTag());
     test_replace_copy_if_bad_alloc(seq, IteratorTag());
     test_replace_copy_if_bad_alloc(par, IteratorTag());
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_copy_range.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2015 Hartmut Kaiser
+//  Copyright (c)      2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -183,6 +184,42 @@ void replace_copy_test()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_replace_copy_exception(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::ranges::replace_copy(
+            hpx::util::make_iterator_range(
+                decorated_iterator(
+                    std::begin(c), []() { throw std::runtime_error("test"); }),
+                decorated_iterator(std::end(c))),
+            std::begin(d), std::size_t(42), std::size_t(43));
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& e)
+    {
+        caught_exception = true;
+        test::test_num_exceptions<hpx::execution::sequenced_policy,
+            IteratorTag>::call(hpx::execution::seq, e);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_exception);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_exception(ExPolicy policy, IteratorTag)
 {
@@ -269,6 +306,7 @@ void test_replace_copy_exception()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_replace_copy_exception(IteratorTag());
     test_replace_copy_exception(seq, IteratorTag());
     test_replace_copy_exception(par, IteratorTag());
 
@@ -283,6 +321,39 @@ void replace_copy_exception_test()
 }
 
 //////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_replace_copy_bad_alloc(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d(c.size());
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    try
+    {
+        hpx::ranges::replace_copy(hpx::util::make_iterator_range(
+                                      decorated_iterator(std::begin(c),
+                                          []() { throw std::bad_alloc(); }),
+                                      decorated_iterator(std::end(c))),
+            std::begin(d), std::size_t(42), std::size_t(43));
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_bad_alloc = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_copy_bad_alloc(ExPolicy policy, IteratorTag)
 {
@@ -367,6 +438,7 @@ void test_replace_copy_bad_alloc()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_replace_copy_bad_alloc(IteratorTag());
     test_replace_copy_bad_alloc(seq, IteratorTag());
     test_replace_copy_bad_alloc(par, IteratorTag());
 

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_if_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/replace_if_range.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014-2015 Hartmut Kaiser
+//  Copyright (c)      2021 Giannis Gonidelis
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -301,6 +302,7 @@ void test_replace_if_exception()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_replace_if_exception(IteratorTag());
     test_replace_if_exception(seq, IteratorTag());
     test_replace_if_exception(par, IteratorTag());
 
@@ -320,6 +322,38 @@ void replace_if_exception_test()
 }
 
 //////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_replace_if_bad_alloc(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::decorated_iterator<base_iterator, IteratorTag>
+        decorated_iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    bool caught_bad_alloc = false;
+    try
+    {
+        hpx::ranges::replace_if(hpx::util::make_iterator_range(
+                                    decorated_iterator(std::begin(c),
+                                        []() { throw std::bad_alloc(); }),
+                                    decorated_iterator(std::end(c))),
+            equal_f(42), std::size_t(43));
+        HPX_TEST(false);
+    }
+    catch (std::bad_alloc const&)
+    {
+        caught_bad_alloc = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_bad_alloc);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_replace_if_bad_alloc(ExPolicy policy, IteratorTag)
 {
@@ -402,6 +436,7 @@ void test_replace_if_bad_alloc()
     // If the execution policy object is of type vector_execution_policy,
     // std::terminate shall be called. therefore we do not test exceptions
     // with a vector execution policy
+    test_replace_if_bad_alloc(IteratorTag());
     test_replace_if_bad_alloc(seq, IteratorTag());
     test_replace_if_bad_alloc(par, IteratorTag());
 


### PR DESCRIPTION
MInor `hpx::replace` and `hpx::ranges::replace` misses from previous adaptation.

1. Docs signature matching.
2. Add tests for the no-exec-policy overloads.
3. Minor typo in deprecated overload.