### PR TITLE
Sort printed config options

### DIFF
--- a/cmake/HPX_PrintSummary.cmake
+++ b/cmake/HPX_PrintSummary.cmake
@@ -28,6 +28,7 @@ function(create_configuration_summary message module_name)
   get_property(
     _variableNames GLOBAL PROPERTY HPX_MODULE_CONFIG_${module_name_uc}
   )
+  list(SORT _variableNames)
 
   # Only print the module configuration if options specified
   list(LENGTH _variableNames _length)


### PR DESCRIPTION
Makes the config options more readable as alphabetically ordered, if nobody is against it..