### PR TITLE
Make sure HPX_DEBUG is set based on HPX's build type, not consuming project's build type

### DIFF
--- a/.github/workflows/windows_debug.yml
+++ b/.github/workflows/windows_debug.yml
@@ -38,12 +38,8 @@ jobs:
       run: |
           cmake --build build --config Debug \
           --target ALL_BUILD \
-            cmake_debug_build_dir_targets_test.make_build_dir \
-            cmake_debug_build_dir_targets_test.make_configure \
-            cmake_debug_build_dir_targets_test.make_compile   \
-            cmake_debug_build_dir_macros_test.make_build_dir \
-            cmake_debug_build_dir_macros_test.make_configure \
-            cmake_debug_build_dir_macros_test.make_compile   \
+            cmake_debug_build_dir_targets_test \
+            cmake_debug_build_dir_macros_test \
           -- -maxcpucount -verbosity:minimal -nologo
     - name: Install
       shell: bash
@@ -54,12 +50,8 @@ jobs:
       run: |
           cmake --build build --config Debug \
             --target \
-              cmake_debug_install_dir_targets_test.make_build_dir \
-              cmake_debug_install_dir_targets_test.make_configure \
-              cmake_debug_install_dir_targets_test.make_compile   \
-              cmake_debug_install_dir_macros_test.make_build_dir \
-              cmake_debug_install_dir_macros_test.make_configure \
-              cmake_debug_install_dir_macros_test.make_compile   \
+              cmake_debug_install_dir_targets_test \
+              cmake_debug_install_dir_macros_test \
             -- -maxcpucount -verbosity:minimal -nologo
     - name: Test
       shell: bash

--- a/.github/workflows/windows_debug.yml
+++ b/.github/workflows/windows_debug.yml
@@ -38,21 +38,11 @@ jobs:
       run: |
           cmake --build build --config Debug \
           --target ALL_BUILD \
-            cmake_debug_build_dir_targets_test \
-            cmake_debug_build_dir_macros_test \
           -- -maxcpucount -verbosity:minimal -nologo
     - name: Install
       shell: bash
       run: |
           cmake --install build --config Debug
-    - name: Build External
-      shell: bash
-      run: |
-          cmake --build build --config Debug \
-            --target \
-              cmake_debug_install_dir_targets_test \
-              cmake_debug_install_dir_macros_test \
-            -- -maxcpucount -verbosity:minimal -nologo
     - name: Test
       shell: bash
       run: |

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -37,21 +37,11 @@ jobs:
       run: |
           cmake --build build --config Release \
           --target ALL_BUILD \
-            cmake_release_build_dir_targets_test \
-            cmake_release_build_dir_macros_test \
           -- -maxcpucount -verbosity:minimal -nologo
     - name: Install
       shell: bash
       run: |
           cmake --install build --config Release
-    - name: Build External
-      shell: bash
-      run: |
-          cmake --build build --config Release \
-            --target \
-              cmake_release_install_dir_targets_test \
-              cmake_release_install_dir_macros_test \
-            -- -maxcpucount -verbosity:minimal -nologo
     - name: Test
       shell: bash
       run: |

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -37,12 +37,8 @@ jobs:
       run: |
           cmake --build build --config Release \
           --target ALL_BUILD \
-            cmake_release_build_dir_targets_test.make_build_dir \
-            cmake_release_build_dir_targets_test.make_configure \
-            cmake_release_build_dir_targets_test.make_compile   \
-            cmake_release_build_dir_macros_test.make_build_dir \
-            cmake_release_build_dir_macros_test.make_configure \
-            cmake_release_build_dir_macros_test.make_compile   \
+            cmake_release_build_dir_targets_test \
+            cmake_release_build_dir_macros_test \
           -- -maxcpucount -verbosity:minimal -nologo
     - name: Install
       shell: bash
@@ -53,12 +49,8 @@ jobs:
       run: |
           cmake --build build --config Release \
             --target \
-              cmake_release_install_dir_targets_test.make_build_dir \
-              cmake_release_install_dir_targets_test.make_configure \
-              cmake_release_install_dir_targets_test.make_compile   \
-              cmake_release_install_dir_macros_test.make_build_dir \
-              cmake_release_install_dir_macros_test.make_configure \
-              cmake_release_install_dir_macros_test.make_compile   \
+              cmake_release_install_dir_targets_test \
+              cmake_release_install_dir_macros_test \
             -- -maxcpucount -verbosity:minimal -nologo
     - name: Test
       shell: bash

--- a/cmake/HPX_CompilerFlagsTargets.cmake
+++ b/cmake/HPX_CompilerFlagsTargets.cmake
@@ -14,12 +14,15 @@ target_compile_features(hpx_private_flags INTERFACE cxx_std_${HPX_CXX_STANDARD})
 target_compile_features(hpx_public_flags INTERFACE cxx_std_${HPX_CXX_STANDARD})
 
 # Set other flags that should always be set
-target_compile_definitions(
-  hpx_private_flags INTERFACE $<$<CONFIG:Debug>:HPX_DEBUG>
-)
-target_compile_definitions(
-  hpx_public_flags INTERFACE $<$<CONFIG:Debug>:HPX_DEBUG>
-)
+
+# HPX_DEBUG must be set without a generator expression as it determines ABI
+# compatibility. Projects in Release mode using HPX in Debug mode must have
+# HPX_DEBUG set, and projects in Debug mode using HPX in Release mode must not
+# have HPX_DEBUG set. HPX_DEBUG must also not be set by projects using HPX.
+if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+  target_compile_definitions(hpx_private_flags INTERFACE HPX_DEBUG)
+  target_compile_definitions(hpx_public_flags INTERFACE HPX_DEBUG)
+endif()
 
 target_compile_definitions(
   hpx_private_flags

--- a/examples/gtest_emulation/CMakeLists.txt
+++ b/examples/gtest_emulation/CMakeLists.txt
@@ -25,6 +25,9 @@ if(EXISTS "${HPX_DIR}")
   add_executable(hpx_main_ext_main hpx_main_ext_main.cpp)
   target_link_libraries(hpx_main_ext_main PRIVATE hpx_helper_interface)
 
+  enable_testing()
+  add_test(hello_world_test hpx_main_ext_main)
+
 else()
   message(
     WARNING

--- a/examples/hello_world_component/CMakeLists.txt
+++ b/examples/hello_world_component/CMakeLists.txt
@@ -11,20 +11,22 @@ project(hello_world_client CXX)
 if(EXISTS "${HPX_DIR}")
   find_package(HPX REQUIRED)
 
-  add_library(hello_world_component SHARED hello_world_component.cpp)
+  if(HPX_WITH_DISTRIBUTED_RUNTIME)
+    add_library(hello_world_component SHARED hello_world_component.cpp)
+  endif()
 
   add_executable(hello_world_client hello_world_client.cpp)
   target_include_directories(hello_world_client PRIVATE ${test_SOURCE_DIR})
 
   if("${SETUP_TYPE}" STREQUAL "TARGETS")
-    target_link_libraries(
-      hello_world_component PUBLIC HPX::hpx HPX::iostreams_component
-    )
-    target_link_libraries(hello_world_component PRIVATE HPX::component)
-
-    target_link_libraries(
-      hello_world_client PRIVATE hello_world_component HPX::wrap_main
-    )
+    if(HPX_WITH_DISTRIBUTED_RUNTIME)
+      target_link_libraries(
+        hello_world_component PUBLIC HPX::hpx HPX::iostreams_component
+      )
+      target_link_libraries(hello_world_component PRIVATE HPX::component)
+      target_link_libraries(hello_world_client PRIVATE hello_world_component)
+    endif()
+    target_link_libraries(hello_world_client PRIVATE HPX::hpx HPX::wrap_main)
 
     # We still support not linking to HPX::wrap_main when
     # HPX_WITH_DYNAMIC_HPX_MAIN=OFF for legacy use. This can only be done using
@@ -41,17 +43,23 @@ if(EXISTS "${HPX_DIR}")
       )
     endif()
   elseif("${SETUP_TYPE}" STREQUAL "MACROS")
-    hpx_setup_target(
-      hello_world_component
-      COMPONENT_DEPENDENCIES iostreams
-      DEPENDENCIES HPX::wrap_main
-      TYPE COMPONENT
-    )
-
-    hpx_setup_target(hello_world_client DEPENDENCIES hello_world_component)
+    if(HPX_WITH_DISTRIBUTED_RUNTIME)
+      hpx_setup_target(
+        hello_world_component
+        COMPONENT_DEPENDENCIES iostreams
+        DEPENDENCIES HPX::wrap_main
+        TYPE COMPONENT
+      )
+      hpx_setup_target(hello_world_client DEPENDENCIES hello_world_component)
+    else()
+      hpx_setup_target(hello_world_client)
+    endif()
   else()
     message(FATAL_ERROR "Unknown SETUP_TYPE=\"${SETUP_TYPE}\"")
   endif()
+
+  enable_testing()
+  add_test(hello_world_test hello_world_client)
 else()
   message(
     WARNING

--- a/examples/hello_world_component/CMakeLists.txt
+++ b/examples/hello_world_component/CMakeLists.txt
@@ -58,6 +58,21 @@ if(EXISTS "${HPX_DIR}")
     message(FATAL_ERROR "Unknown SETUP_TYPE=\"${SETUP_TYPE}\"")
   endif()
 
+  if(MSVC)
+    # Only for the purposes of testing we output the executable and libraries to
+    # the output directory of HPX
+    set_target_properties(
+      hello_world_client PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+                                    ${HPX_OUTPUT_DIRECTORY}
+    )
+    if(HPX_WITH_DISTRIBUTED_RUNTIME)
+      set_target_properties(
+        hello_world_component PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+                                         ${HPX_OUTPUT_DIRECTORY}
+      )
+    endif()
+  endif()
+
   enable_testing()
   add_test(hello_world_test hello_world_client)
 else()

--- a/examples/hello_world_component/hello_world_client.cpp
+++ b/examples/hello_world_component/hello_world_client.cpp
@@ -4,13 +4,20 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// Please keep the duplicate hpx/config.hpp include further down. It makes the
+// code within the [hello_world_client... block self-contained for the
+// documentation.
+#include <hpx/config.hpp>
+#if defined(HPX_WITH_DISTRIBUTED_RUNTIME)
+
 //[hello_world_client_getting_started
 #include <hpx/config.hpp>
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
-#include "hello_world_component.hpp"
-#include <hpx/hpx_main.hpp>
+#if defined(HPX_COMPUTE_HOST_CODE)
+#include <hpx/wrap_main.hpp>
 
-int main(int argc, char* argv[])
+#include "hello_world_component.hpp"
+
+int main()
 {
     {
         // Create a single instance of the component on this locality.
@@ -25,3 +32,17 @@ int main(int argc, char* argv[])
 }
 #endif
 //]
+#else
+#include <hpx/thread.hpp>
+#include <hpx/wrap_main.hpp>
+
+#include <iostream>
+
+int main()
+{
+    std::cout << "Hello World from HPX-thread with id "
+              << hpx::this_thread::get_id() << std::endl;
+
+    return 0;
+}
+#endif

--- a/tests/unit/build/CMakeLists.txt
+++ b/tests/unit/build/CMakeLists.txt
@@ -42,6 +42,11 @@ function(
     set(ADDITIONAL_CMAKE_OPTIONS ${ADDITIONAL_CMAKE_OPTIONS}
                                  -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
     )
+  else()
+    set(ADDITIONAL_CMAKE_OPTIONS
+        ${ADDITIONAL_CMAKE_OPTIONS}
+        -DHPX_OUTPUT_DIRECTORY=${PROJECT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/bin
+    )
   endif()
   set(test_dir "${PROJECT_SOURCE_DIR}/${test_dir}")
   add_custom_target(

--- a/tests/unit/build/CMakeLists.txt
+++ b/tests/unit/build/CMakeLists.txt
@@ -109,48 +109,50 @@ else()
   endif()
 endif()
 
-foreach(build_type ${build_types})
-  string(TOLOWER "${build_type}" build_type_lc)
+if(NOT MSVC)
+  foreach(build_type ${build_types})
+    string(TOLOWER "${build_type}" build_type_lc)
 
-  create_cmake_test(
-    cmake_${build_type_lc}_build_dir_targets_test FALSE
-    "${PROJECT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}" TARGETS ${build_type}
-    "examples/hello_world_component"
-  )
-
-  create_cmake_test(
-    cmake_${build_type_lc}_build_dir_macros_test FALSE
-    "${PROJECT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}" MACROS ${build_type}
-    "examples/hello_world_component"
-  )
-
-  create_cmake_test(
-    cmake_${build_type_lc}_install_dir_targets_test TRUE
-    "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}" TARGETS
-    ${build_type} "examples/hello_world_component"
-  )
-
-  create_cmake_test(
-    cmake_${build_type_lc}_install_dir_macros_test TRUE
-    "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}" MACROS
-    ${build_type} "examples/hello_world_component"
-  )
-
-  if(HPX_WITH_DYNAMIC_HPX_MAIN)
-    # Google test emulation
     create_cmake_test(
-      cmake_${build_type_lc}_build_dir_gtest_emulation_test FALSE
+      cmake_${build_type_lc}_build_dir_targets_test FALSE
       "${PROJECT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}" TARGETS
-      ${build_type} "examples/gtest_emulation"
+      ${build_type} "examples/hello_world_component"
     )
 
     create_cmake_test(
-      cmake_${build_type_lc}_install_dir_gtest_emulation_test TRUE
-      "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}" TARGETS
-      ${build_type} "examples/gtest_emulation"
+      cmake_${build_type_lc}_build_dir_macros_test FALSE
+      "${PROJECT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}" MACROS
+      ${build_type} "examples/hello_world_component"
     )
-  endif()
-endforeach()
+
+    create_cmake_test(
+      cmake_${build_type_lc}_install_dir_targets_test TRUE
+      "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}" TARGETS
+      ${build_type} "examples/hello_world_component"
+    )
+
+    create_cmake_test(
+      cmake_${build_type_lc}_install_dir_macros_test TRUE
+      "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}" MACROS
+      ${build_type} "examples/hello_world_component"
+    )
+
+    if(HPX_WITH_DYNAMIC_HPX_MAIN)
+      # Google test emulation
+      create_cmake_test(
+        cmake_${build_type_lc}_build_dir_gtest_emulation_test FALSE
+        "${PROJECT_BINARY_DIR}/lib/cmake/${HPX_PACKAGE_NAME}" TARGETS
+        ${build_type} "examples/gtest_emulation"
+      )
+
+      create_cmake_test(
+        cmake_${build_type_lc}_install_dir_gtest_emulation_test TRUE
+        "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}" TARGETS
+        ${build_type} "examples/gtest_emulation"
+      )
+    endif()
+  endforeach()
+endif()
 
 # PkgConfig
 if(NOT MSVC

--- a/tests/unit/build/CMakeLists.txt
+++ b/tests/unit/build/CMakeLists.txt
@@ -10,10 +10,6 @@ if(NOT HPX_WITH_TESTS_EXTERNAL_BUILD)
   return()
 endif()
 
-if(NOT HPX_WITH_DISTRIBUTED_RUNTIME)
-  return()
-endif()
-
 # Try building an external cmake based project ...
 function(
   create_cmake_test
@@ -25,11 +21,6 @@ function(
   test_dir
 )
   set(build_dir "${CMAKE_CURRENT_BINARY_DIR}/${name}")
-  add_custom_target(
-    ${name}.make_build_dir
-    COMMAND "${CMAKE_COMMAND}" -E make_directory "${build_dir}"
-    VERBATIM
-  )
   set(ADDITIONAL_CMAKE_OPTIONS -DUSING_INSTALL_DIR=${using_install_dir})
   set(ADDITIONAL_CMAKE_OPTIONS -DSETUP_TYPE=${setup_type})
   if(CMAKE_TOOLCHAIN_FILE)
@@ -47,11 +38,6 @@ function(
                                  -DCMAKE_SYSROOT=${CMAKE_SYSROOT}
     )
   endif()
-  if(WIN32)
-    set(ADDITIONAL_CMAKE_OPTIONS ${ADDITIONAL_CMAKE_OPTIONS} -G
-                                 "${CMAKE_GENERATOR}"
-    )
-  endif()
   if(NOT MSVC)
     set(ADDITIONAL_CMAKE_OPTIONS ${ADDITIONAL_CMAKE_OPTIONS}
                                  -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
@@ -59,39 +45,24 @@ function(
   endif()
   set(test_dir "${PROJECT_SOURCE_DIR}/${test_dir}")
   add_custom_target(
-    ${name}.make_configure
+    ${name}
     COMMAND
-      "${CMAKE_COMMAND}" -E chdir "${build_dir}" "${CMAKE_COMMAND}" ${test_dir}
+      "${CMAKE_CTEST_COMMAND}" --build-and-test "${test_dir}" "${build_dir}"
+      --build-generator "${CMAKE_GENERATOR}" --build-noclean --build-options
       -DHPX_DIR=${hpx_dir} -DBOOST_ROOT=${BOOST_ROOT}
       ${ADDITIONAL_CMAKE_OPTIONS} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS_SAFE}
-      -DCMAKE_BUILD_TYPE=${build_type}
+      -DCMAKE_BUILD_TYPE=${build_type} --test-command "${CMAKE_CTEST_COMMAND}"
+      --output-on-failure
     VERBATIM
   )
-  add_dependencies(
-    ${name}.make_configure ${name}.make_build_dir hpx hpx_init hpx_wrap
-    iostreams_component
-  )
-  add_custom_target(
-    ${name}.make_compile
-    COMMAND "${CMAKE_COMMAND}" --build "${build_dir}" --config ${build_type}
-    VERBATIM
-  )
-  add_dependencies(${name}.make_compile ${name}.make_configure)
-  add_hpx_pseudo_target(${name})
-  add_hpx_pseudo_dependencies_no_shortening(${name} ${name}.make_compile)
+  add_dependencies(${name} hpx hpx_init hpx_wrap)
+  if(HPX_WITH_DISTRIBUTED_RUNTIME)
+    add_dependencies(${name} iostreams_component)
+  endif()
 
   if(MSVC)
-    set_target_properties(
-      ${name}.make_build_dir PROPERTIES FOLDER "Tests/Unit/Build"
-    )
-    set_target_properties(
-      ${name}.make_configure PROPERTIES FOLDER "Tests/Unit/Build"
-    )
-    set_target_properties(
-      ${name}.make_compile PROPERTIES FOLDER "Tests/Unit/Build"
-    )
+    set_target_properties(${name} PROPERTIES FOLDER "Tests/Unit/Build")
   endif()
-  # add_hpx_unit_test( "build" ${name} EXECUTABLE "${build_dir}/test" )
 endfunction()
 
 function(create_pkgconfig_test name hpx_dir)
@@ -112,13 +83,13 @@ function(create_pkgconfig_test name hpx_dir)
       BUILD_TYPE=$<CONFIGURATION>
     VERBATIM
   )
-  add_dependencies(
-    ${name}.make_compile ${name}.make_build_dir hpx hpx_init
-    iostreams_component
-  )
+  add_dependencies(${name}.make_compile ${name}.make_build_dir hpx hpx_init)
+  if(HPX_WITH_DISTRIBUTED_RUNTIME)
+    add_dependencies(${name}.make_compile iostreams_component)
+  endif()
+
   add_hpx_pseudo_target(${name})
   add_hpx_pseudo_dependencies(${name} ${name}.make_compile)
-
 endfunction()
 
 if(MSVC)
@@ -176,27 +147,33 @@ foreach(build_type ${build_types})
   endif()
 endforeach()
 
-# TODO: Support pkgconfig? PkgConfig if(NOT MSVC AND NOT APPLE AND NOT
-# HPX_WITH_HIP ) # Disabling test for hipcc since the workaround for one of its
-# bug resulted in # breaking clang-7 CI (with -DHPX_WITH_DYNAMIC_MAIN=OFF) #
-# https://github.com/ROCm-Developer-Tools/HIP/issues/2167#issuecomment-712286173
-# find_package(PkgConfig) if(PKGCONFIG_FOUND) create_pkgconfig_test(
-# pkgconfig_build_dir_test "${PROJECT_BINARY_DIR}/lib/pkgconfig" )
-#
-# create_pkgconfig_test( pkgconfig_install_dir_test
-# "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig" ) endif() endif()
+# PkgConfig
+if(NOT MSVC
+   AND NOT APPLE
+   AND NOT HPX_WITH_HIP
+   AND HPX_WITH_DISTRIBUTED_RUNTIME
+)
+  # Disabling test for hipcc since the workaround for one of its bug resulted in
+  # breaking clang-7 CI (with -DHPX_WITH_DYNAMIC_MAIN=OFF)
+  # https://github.com/ROCm-Developer-Tools/HIP/issues/2167#issuecomment-712286173
+  find_package(PkgConfig)
+  if(PKGCONFIG_FOUND)
+    create_pkgconfig_test(
+      pkgconfig_build_dir_test "${PROJECT_BINARY_DIR}/lib/pkgconfig"
+    )
 
-set(build_systems cmake)
+    create_pkgconfig_test(
+      pkgconfig_install_dir_test "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig"
+    )
+  endif()
+endif()
+
 set(cmake_tests build_dir_targets install_dir_targets build_dir_macros
                 install_dir_macros
 )
 if(HPX_WITH_DYNAMIC_HPX_MAIN)
   list(APPEND cmake_tests build_dir_gtest_emulation install_dir_gtest_emulation)
 endif()
-# if(NOT CMAKE_TOOLCHAIN_FILE AND PKGCONFIG_FOUND AND NOT MSVC AND NOT APPLE AND
-# NOT HPX_WITH_HIP ) set(build_systems ${build_systems} pkgconfig)
-# set(pkgconfig_tests build_dir install_dir) endif()
-
 set(system cmake)
 add_hpx_pseudo_target(tests.unit.build.${system})
 foreach(build_type ${build_types})
@@ -219,15 +196,24 @@ foreach(build_type ${build_types})
 endforeach()
 add_hpx_pseudo_dependencies(tests.unit.build tests.unit.build.${system})
 
-set(system pkgconfig)
-add_hpx_pseudo_target(tests.unit.build.${system})
-foreach(test ${${system}_tests})
-  add_hpx_pseudo_target(tests.unit.build.${system}.${test})
-  add_hpx_pseudo_dependencies(
-    tests.unit.build.${system}.${test} ${system}_${test}_test
-  )
-  add_hpx_pseudo_dependencies(
-    tests.unit.build.${system} tests.unit.build.${system}.${test}
-  )
-endforeach()
-add_hpx_pseudo_dependencies(tests.unit.build tests.unit.build.${system})
+if(NOT CMAKE_TOOLCHAIN_FILE
+   AND PKGCONFIG_FOUND
+   AND NOT MSVC
+   AND NOT APPLE
+   AND NOT HPX_WITH_HIP
+   AND HPX_WITH_DISTRIBUTED_RUNTIME
+)
+  set(pkgconfig_tests build_dir install_dir)
+  set(system pkgconfig)
+  add_hpx_pseudo_target(tests.unit.build.${system})
+  foreach(test ${${system}_tests})
+    add_hpx_pseudo_target(tests.unit.build.${system}.${test})
+    add_hpx_pseudo_dependencies(
+      tests.unit.build.${system}.${test} ${system}_${test}_test
+    )
+    add_hpx_pseudo_dependencies(
+      tests.unit.build.${system} tests.unit.build.${system}.${test}
+    )
+  endforeach()
+  add_hpx_pseudo_dependencies(tests.unit.build tests.unit.build.${system})
+endif()


### PR DESCRIPTION
Attempts to fix #5099 properly. The `HPX_DEBUG` definition was being set with a generator expression based on the build type of the project being built, meaning it was not consistent between HPX and consumers as it was meant to be.

@rbyshko would you mind trying this out? Locally I can now mix release/debug builds freely in the example you provided.

I still have to figure out the testing situation for this on CI, hence a draft.