### PR TITLE
P1897 operator| overloads

### DIFF
--- a/libs/parallelism/execution/CMakeLists.txt
+++ b/libs/parallelism/execution/CMakeLists.txt
@@ -9,6 +9,10 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(execution_headers
     hpx/execution/algorithms/detail/is_negative.hpp
     hpx/execution/algorithms/detail/predicates.hpp
+    hpx/execution/algorithms/detail/single_result.hpp
+    hpx/execution/algorithms/just.hpp
+    hpx/execution/algorithms/just_on.hpp
+    hpx/execution/algorithms/on.hpp
     hpx/execution/algorithms/sync_wait.hpp
     hpx/execution/algorithms/transform.hpp
     hpx/execution/detail/async_launch_policy_dispatch.hpp

--- a/libs/parallelism/execution/CMakeLists.txt
+++ b/libs/parallelism/execution/CMakeLists.txt
@@ -8,6 +8,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(execution_headers
     hpx/execution/algorithms/detail/is_negative.hpp
+    hpx/execution/algorithms/detail/partial_algorithm.hpp
     hpx/execution/algorithms/detail/predicates.hpp
     hpx/execution/algorithms/detail/single_result.hpp
     hpx/execution/algorithms/just.hpp

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/detail/partial_algorithm.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/detail/partial_algorithm.hpp
@@ -1,0 +1,42 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx {
+    namespace execution {
+        namespace experimental {
+            namespace detail {
+    template <typename Tag, typename... Ts>
+    struct partial_algorithm;
+
+    template <typename Tag, typename T>
+    struct partial_algorithm<Tag, T>
+    {
+        std::decay_t<T> t;
+
+        template <typename U>
+        friend constexpr HPX_FORCEINLINE auto operator|(
+            U&& u, partial_algorithm p)
+        {
+            return Tag{}(std::forward<U>(u), std::move(p.t));
+        }
+    };
+
+    template <typename Tag>
+    struct partial_algorithm<Tag>
+    {
+        template <typename U>
+        friend constexpr HPX_FORCEINLINE auto operator|(
+            U&& u, partial_algorithm)
+        {
+            return Tag{}(std::forward<U>(u));
+        }
+    };
+}}}}    // namespace hpx::execution::experimental::detail

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/detail/single_result.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/detail/single_result.hpp
@@ -1,0 +1,53 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/type_support/pack.hpp>
+
+namespace hpx {
+    namespace execution {
+        namespace experimental {
+            namespace detail {
+    template <typename Variants>
+    struct sync_wait_single_result
+    {
+        static_assert(sizeof(Variants) == 0,
+            "sync_wait expects the predecessor sender to have a single variant "
+            "with a single type in sender_traits<>::value_types");
+    };
+
+    template <>
+    struct sync_wait_single_result<hpx::util::pack<hpx::util::pack<>>>
+    {
+        using type = void;
+    };
+
+    template <typename T>
+    struct sync_wait_single_result<hpx::util::pack<hpx::util::pack<T>>>
+    {
+        using type = T;
+    };
+
+    template <typename T, typename U, typename... Ts>
+    struct sync_wait_single_result<
+        hpx::util::pack<hpx::util::pack<T, U, Ts...>>>
+    {
+        static_assert(sizeof(T) == 0,
+            "sync_wait expects the predecessor sender to have a single variant "
+            "with a single type in sender_traits<>::value_types (single "
+            "variant with two or more types given)");
+    };
+
+    template <typename T, typename U, typename... Ts>
+    struct sync_wait_single_result<hpx::util::pack<T, U, Ts...>>
+    {
+        static_assert(sizeof(T) == 0,
+            "sync_wait expects the predecessor sender to have a single variant "
+            "with a single type in sender_traits<>::value_types (two or more "
+            "variants given)");
+    };
+}}}}    // namespace hpx::execution::experimental::detail

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/just.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/just.hpp
@@ -1,0 +1,79 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/datastructures/member_pack.hpp>
+#include <hpx/execution_base/receiver.hpp>
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/functional/tag_fallback_invoke.hpp>
+#include <hpx/type_support/pack.hpp>
+
+#include <cstddef>
+#include <utility>
+
+namespace hpx { namespace execution { namespace experimental {
+    namespace detail {
+        template <typename Is, typename... Ts>
+        struct just_sender;
+
+        template <typename std::size_t... Is, typename... Ts>
+        struct just_sender<hpx::util::index_pack<Is...>, Ts...>
+        {
+            // TODO: Are references allowed?
+            hpx::util::member_pack_for<std::decay_t<Ts>...> ts;
+
+            template <typename... Ts_>
+            explicit constexpr just_sender(Ts_&&... ts)
+              : ts(std::piecewise_construct, std::forward<Ts_>(ts)...)
+            {
+            }
+
+            template <template <typename...> class Tuple,
+                template <typename...> class Variant>
+            using value_types = Variant<Tuple<Ts...>>;
+
+            template <template <typename...> class Variant>
+            using error_types = Variant<>;
+
+            static constexpr bool sends_done = false;
+
+            template <typename R>
+            struct operation_state
+            {
+                std::decay_t<R> r;
+                hpx::util::member_pack_for<std::decay_t<Ts>...> ts;
+
+                void start() noexcept
+                {
+                    hpx::execution::experimental::set_value(
+                        std::move(r), std::move(ts).template get<Is>()...);
+                }
+            };
+
+            template <typename R>
+            auto connect(R&& r)
+            {
+                return operation_state<R>{std::forward<R>(r), std::move(ts)};
+            }
+        };
+    }    // namespace detail
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct just_t final
+      : hpx::functional::tag_fallback<just_t>
+    {
+    private:
+        template <typename... Ts>
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            just_t, Ts&&... ts)
+        {
+            return detail::just_sender<
+                typename hpx::util::make_index_pack<sizeof...(Ts)>::type,
+                Ts...>{std::forward<Ts>(ts)...};
+        }
+    } just{};
+}}}    // namespace hpx::execution::experimental

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/just_on.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/just_on.hpp
@@ -1,0 +1,37 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/execution/algorithms/just.hpp>
+#include <hpx/execution/algorithms/on.hpp>
+#include <hpx/execution_base/receiver.hpp>
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/functional/invoke_result.hpp>
+#include <hpx/functional/tag_fallback_invoke.hpp>
+#include <hpx/type_support/pack.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <exception>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace execution { namespace experimental {
+    HPX_INLINE_CONSTEXPR_VARIABLE struct just_on_t final
+      : hpx::functional::tag_fallback<just_on_t>
+    {
+    private:
+        template <typename Scheduler, typename... Ts>
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            just_on_t, Scheduler&& scheduler, Ts&&... ts)
+        {
+            return on(just(std::forward<Ts>(ts)...),
+                std::forward<Scheduler>(scheduler));
+        }
+    } just_on{};
+}}}    // namespace hpx::execution::experimental

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/on.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/on.hpp
@@ -1,0 +1,100 @@
+//  Copyright (c) 2020 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/execution_base/receiver.hpp>
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/functional/tag_fallback_invoke.hpp>
+#include <hpx/type_support/pack.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <exception>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace execution { namespace experimental {
+    namespace detail {
+        template <typename R, typename Scheduler>
+        struct on_receiver
+        {
+            typename std::decay<R>::type r;
+            typename std::decay<Scheduler>::type scheduler;
+
+            template <typename R_, typename Scheduler_>
+            on_receiver(R_&& r, Scheduler_&& scheduler)
+              : r(std::forward<R>(r))
+              , scheduler(std::forward<Scheduler>(scheduler))
+            {
+            }
+
+            template <typename E>
+            void set_error(E&& e) noexcept
+            {
+                hpx::execution::experimental::set_error(
+                    std::move(r), std::forward<E>(e));
+            }
+
+            void set_done() noexcept
+            {
+                hpx::execution::experimental::set_done(std::move(r));
+            };
+
+            template <typename... Ts>
+            void set_value(Ts&&... ts) noexcept
+            {
+                hpx::execution::experimental::execute(
+                    scheduler, [=, r = std::move(r)]() mutable {
+                        hpx::execution::experimental::set_value(
+                            std::move(r), std::forward<Ts>(ts)...);
+                    });
+            }
+        };
+
+        template <typename S, typename Scheduler>
+        struct on_sender
+        {
+            typename std::decay<S>::type s;
+            typename std::decay<Scheduler>::type scheduler;
+
+            template <template <typename...> class Tuple,
+                template <typename...> class Variant>
+            using value_types =
+                typename hpx::execution::experimental::sender_traits<
+                    S>::template value_types<Tuple, Variant>;
+
+            template <template <typename...> class Variant>
+            using error_types =
+                typename hpx::execution::experimental::sender_traits<
+                    S>::template error_types<Variant>;
+
+            static constexpr bool sends_done = false;
+
+            template <typename R>
+            auto connect(R&& r)
+            {
+                return hpx::execution::experimental::connect(std::move(s),
+                    on_receiver<R, Scheduler>(
+                        std::forward<R>(r), std::move(scheduler)));
+            }
+        };
+    }    // namespace detail
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct on_t final
+      : hpx::functional::tag_fallback<on_t>
+    {
+    private:
+        template <typename S, typename Scheduler>
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            on_t, S&& s, Scheduler&& scheduler)
+        {
+            return detail::on_sender<S, Scheduler>{
+                std::forward<S>(s), std::forward<Scheduler>(scheduler)};
+        }
+    } on{};
+}}}    // namespace hpx::execution::experimental

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/on.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/on.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
 #include <hpx/execution_base/receiver.hpp>
 #include <hpx/execution_base/sender.hpp>
 #include <hpx/functional/tag_fallback_invoke.hpp>
@@ -102,6 +103,14 @@ namespace hpx { namespace execution { namespace experimental {
         {
             return detail::on_sender<S, Scheduler>{
                 std::forward<S>(s), std::forward<Scheduler>(scheduler)};
+        }
+
+        template <typename Scheduler>
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            on_t, Scheduler&& scheduler)
+        {
+            return detail::partial_algorithm<on_t, Scheduler>{
+                std::forward<Scheduler>(scheduler)};
         }
     } on{};
 }}}    // namespace hpx::execution::experimental

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/on.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/on.hpp
@@ -34,19 +34,26 @@ namespace hpx { namespace execution { namespace experimental {
             }
 
             template <typename E>
-            void set_error(E&& e) noexcept
+            auto set_error(E&& e) noexcept
+                -> decltype(hpx::execution::experimental::set_error(
+                                std::move(r), std::forward<E>(e)),
+                    void())
             {
                 hpx::execution::experimental::set_error(
                     std::move(r), std::forward<E>(e));
             }
 
-            void set_done() noexcept
+            auto set_done() noexcept -> decltype(
+                hpx::execution::experimental::set_done(std::move(r)), void())
             {
                 hpx::execution::experimental::set_done(std::move(r));
             };
 
             template <typename... Ts>
-            void set_value(Ts&&... ts) noexcept
+            auto set_value(Ts&&... ts) noexcept
+                -> decltype(hpx::execution::experimental::set_value(
+                                std::move(r), std::forward<Ts>(ts)...),
+                    void())
             {
                 hpx::execution::experimental::execute(
                     scheduler, [=, r = std::move(r)]() mutable {

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/sync_wait.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/sync_wait.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/datastructures/optional.hpp>
+#include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
 #include <hpx/execution/algorithms/detail/single_result.hpp>
 #include <hpx/execution_base/operation_state.hpp>
 #include <hpx/execution_base/sender.hpp>
@@ -179,6 +180,11 @@ namespace hpx { namespace execution { namespace experimental {
 
             return detail::sync_wait_impl(
                 std::is_void<result_type>{}, std::forward<S>(s));
+        }
+
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(sync_wait_t)
+        {
+            return detail::partial_algorithm<sync_wait_t>{};
         }
     } sync_wait{};
 }}}    // namespace hpx::execution::experimental

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/transform.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/transform.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
 #include <hpx/execution_base/receiver.hpp>
 #include <hpx/execution_base/sender.hpp>
 #include <hpx/functional/tag_fallback_invoke.hpp>
@@ -152,6 +153,14 @@ namespace hpx { namespace execution { namespace experimental {
         {
             return detail::transform_sender<S, F>{
                 std::forward<S>(s), std::forward<F>(f)};
+        }
+
+        template <typename F>
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            transform_t, F&& f)
+        {
+            return detail::partial_algorithm<transform_t, F>{
+                std::forward<F>(f)};
         }
     } transform{};
 }}}    // namespace hpx::execution::experimental

--- a/libs/parallelism/execution/tests/unit/CMakeLists.txt
+++ b/libs/parallelism/execution/tests/unit/CMakeLists.txt
@@ -5,6 +5,11 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    algorithm_just
+    algorithm_just_on
+    algorithm_on
+    algorithm_sync_wait
+    algorithm_transform
     bulk_async
     created_executor
     executor_parameters

--- a/libs/parallelism/execution/tests/unit/algorithm_just.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_just.cpp
@@ -1,0 +1,101 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <atomic>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace ex = hpx::execution::experimental;
+
+template <typename F>
+struct callback_receiver
+{
+    std::decay_t<F> f;
+    std::atomic<bool>& set_value_called;
+
+    template <typename E>
+    void set_error(E&&) noexcept
+    {
+        HPX_TEST(false);
+    }
+
+    void set_done() noexcept
+    {
+        HPX_TEST(false);
+    };
+
+    template <typename... Ts>
+    void set_value(Ts&&... ts) noexcept
+    {
+        HPX_INVOKE(f, std::forward<Ts>(ts)...);
+        set_value_called = true;
+    }
+};
+
+template <typename T>
+struct custom_type
+{
+    std::atomic<bool>& called;
+    std::decay_t<T> x;
+};
+
+template <typename T>
+auto tag_invoke(ex::just_t, custom_type<T> c)
+{
+    c.called = true;
+    return ex::just(c.x);
+}
+
+int main()
+{
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::just();
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        ex::start(ex::connect(s, r));
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::just(3);
+        auto f = [](int x) { HPX_TEST_EQ(x, 3); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        ex::start(ex::connect(s, r));
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::just(std::string("hello"), 3);
+        auto f = [](std::string s, int x) {
+            HPX_TEST_EQ(s, std::string("hello"));
+            HPX_TEST_EQ(x, 3);
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        ex::start(ex::connect(s, r));
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        custom_type<int> c{tag_invoke_overload_called, 3};
+        auto s = ex::just(c);
+        auto f = [](int x) { HPX_TEST_EQ(x, 3); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        ex::start(ex::connect(s, r));
+        HPX_TEST(set_value_called);
+        HPX_TEST(tag_invoke_overload_called);
+    }
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/execution/tests/unit/algorithm_just.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_just.cpp
@@ -32,7 +32,8 @@ struct callback_receiver
     };
 
     template <typename... Ts>
-    void set_value(Ts&&... ts) noexcept
+    auto set_value(Ts&&... ts) noexcept
+        -> decltype(HPX_INVOKE(f, std::forward<Ts>(ts)...), void())
     {
         HPX_INVOKE(f, std::forward<Ts>(ts)...);
         set_value_called = true;

--- a/libs/parallelism/execution/tests/unit/algorithm_just_on.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_just_on.cpp
@@ -82,7 +82,8 @@ struct callback_receiver
     };
 
     template <typename... Ts>
-    void set_value(Ts&&... ts) noexcept
+    auto set_value(Ts&&... ts) noexcept
+        -> decltype(HPX_INVOKE(f, std::forward<Ts>(ts)...), void())
     {
         HPX_INVOKE(f, std::forward<Ts>(ts)...);
         set_value_called = true;

--- a/libs/parallelism/execution/tests/unit/algorithm_just_on.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_just_on.cpp
@@ -1,0 +1,160 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <atomic>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace ex = hpx::execution::experimental;
+
+struct scheduler
+{
+    std::atomic<bool>& execute_called;
+
+    template <typename F>
+    void execute(F&& f) const
+    {
+        execute_called = true;
+        HPX_INVOKE(std::forward<F>(f));
+    }
+
+    // The following are only here to make this a valid scheduler. The current
+    // implementation makes use of execute, but the implementation can be
+    // changed. If that happens the test for which function should be called
+    // should also be changed.
+    template <template <class...> class Tuple,
+        template <class...> class Variant>
+    using value_types = Variant<Tuple<>>;
+
+    static constexpr bool sends_done = false;
+
+    template <typename R>
+    struct operation_state
+    {
+        std::decay_t<R> r;
+        void start() noexcept
+        {
+            ex::set_value(std::move(r));
+        };
+    };
+
+    template <typename R>
+    auto connect(R&& r) &&
+    {
+        return operation_state<R>{std::forward<R>(r)};
+    }
+
+    constexpr void schedule() const {}
+
+    bool operator==(scheduler const&) const noexcept
+    {
+        return true;
+    }
+
+    bool operator!=(scheduler const&) const noexcept
+    {
+        return false;
+    }
+};
+
+template <typename F>
+struct callback_receiver
+{
+    std::decay_t<F> f;
+    std::atomic<bool>& set_value_called;
+
+    template <typename E>
+    void set_error(E&&) noexcept
+    {
+        HPX_TEST(false);
+    }
+
+    void set_done() noexcept
+    {
+        HPX_TEST(false);
+    };
+
+    template <typename... Ts>
+    void set_value(Ts&&... ts) noexcept
+    {
+        HPX_INVOKE(f, std::forward<Ts>(ts)...);
+        set_value_called = true;
+    }
+};
+
+template <typename T>
+struct custom_type
+{
+    std::atomic<bool>& tag_invoke_overload_called;
+    std::decay_t<T> x;
+};
+
+template <typename S, typename T>
+auto tag_invoke(ex::just_on_t, S&& s, custom_type<T> c)
+{
+    c.tag_invoke_overload_called = true;
+    return ex::just_on(std::forward<S>(s), c.x);
+}
+
+int main()
+{
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> scheduler_execute_called{false};
+        auto s = ex::just_on(scheduler{scheduler_execute_called});
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        ex::start(ex::connect(s, r));
+        HPX_TEST(set_value_called);
+        HPX_TEST(scheduler_execute_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> scheduler_execute_called{false};
+        auto s = ex::just_on(scheduler{scheduler_execute_called}, 3);
+        auto f = [](int x) { HPX_TEST_EQ(x, 3); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        ex::start(ex::connect(s, r));
+        HPX_TEST(set_value_called);
+        HPX_TEST(scheduler_execute_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> scheduler_execute_called{false};
+        auto s = ex::just_on(
+            scheduler{scheduler_execute_called}, std::string("hello"), 3);
+        auto f = [](std::string s, int x) {
+            HPX_TEST_EQ(s, std::string("hello"));
+            HPX_TEST_EQ(x, 3);
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        ex::start(ex::connect(s, r));
+        HPX_TEST(set_value_called);
+        HPX_TEST(scheduler_execute_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> scheduler_execute_called{false};
+        custom_type<int> c{tag_invoke_overload_called, 3};
+        auto s = ex::just_on(scheduler{scheduler_execute_called}, c);
+        auto f = [](int x) { HPX_TEST_EQ(x, 3); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        ex::start(ex::connect(s, r));
+        HPX_TEST(set_value_called);
+        HPX_TEST(tag_invoke_overload_called);
+        HPX_TEST(scheduler_execute_called);
+    }
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/execution/tests/unit/algorithm_on.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_on.cpp
@@ -247,6 +247,26 @@ int main()
         HPX_TEST(scheduler_execute_called);
     }
 
+    // operator| overload
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> scheduler_execute_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        auto s = ex::just(std::string("hello"), 3) |
+            ex::on(scheduler{
+                scheduler_execute_called, tag_invoke_overload_called});
+        auto f = [](std::string s, int x) {
+            HPX_TEST_EQ(s, std::string("hello"));
+            HPX_TEST_EQ(x, 3);
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        ex::start(ex::connect(s, r));
+        HPX_TEST(set_value_called);
+        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(scheduler_execute_called);
+    }
+
+    // tag_invoke overload
     {
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};

--- a/libs/parallelism/execution/tests/unit/algorithm_on.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_on.cpp
@@ -113,7 +113,8 @@ struct callback_receiver
     };
 
     template <typename... Ts>
-    void set_value(Ts&&... ts) noexcept
+    auto set_value(Ts&&... ts) noexcept
+        -> decltype(HPX_INVOKE(f, std::forward<Ts>(ts)...), void())
     {
         HPX_INVOKE(f, std::forward<Ts>(ts)...);
         set_value_called = true;

--- a/libs/parallelism/execution/tests/unit/algorithm_on.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_on.cpp
@@ -1,0 +1,280 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <atomic>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace ex = hpx::execution::experimental;
+
+struct scheduler
+{
+    std::atomic<bool>& execute_called;
+    std::atomic<bool>& tag_invoke_on_called;
+
+    template <typename F>
+    void execute(F&& f) const
+    {
+        execute_called = true;
+        HPX_INVOKE(std::forward<F>(f));
+    }
+
+    template <template <class...> class Tuple,
+        template <class...> class Variant>
+    using value_types = Variant<Tuple<>>;
+
+    template <template <class...> class Variant>
+    using error_types = Variant<std::exception_ptr>;
+
+    static constexpr bool sends_done = false;
+
+    template <typename R>
+    struct operation_state
+    {
+        std::decay_t<R> r;
+        void start() noexcept
+        {
+            ex::set_value(std::move(r));
+        };
+    };
+
+    template <typename R>
+    auto connect(R&& r) &&
+    {
+        return operation_state<R>{std::forward<R>(r)};
+    }
+
+    struct sender
+    {
+        template <template <class...> class Tuple,
+            template <class...> class Variant>
+        using value_types = Variant<Tuple<>>;
+
+        template <template <class...> class Variant>
+        using error_types = Variant<std::exception_ptr>;
+
+        static constexpr bool sends_done = false;
+
+        template <typename R>
+        auto connect(R&& r) &&
+        {
+            return operation_state<R>{std::forward<R>(r)};
+        }
+    };
+
+    constexpr sender schedule() const
+    {
+        return {};
+    }
+
+    bool operator==(scheduler const&) const noexcept
+    {
+        return true;
+    }
+
+    bool operator!=(scheduler const&) const noexcept
+    {
+        return false;
+    }
+};
+
+struct scheduler2 : scheduler
+{
+    explicit scheduler2(scheduler s)
+      : scheduler(std::move(s))
+    {
+    }
+};
+
+template <typename F>
+struct callback_receiver
+{
+    std::decay_t<F> f;
+    std::atomic<bool>& set_value_called;
+
+    template <typename E>
+    void set_error(E&&) noexcept
+    {
+        HPX_TEST(false);
+    }
+
+    void set_done() noexcept
+    {
+        HPX_TEST(false);
+    };
+
+    template <typename... Ts>
+    void set_value(Ts&&... ts) noexcept
+    {
+        HPX_INVOKE(f, std::forward<Ts>(ts)...);
+        set_value_called = true;
+    }
+};
+
+struct error_sender
+{
+    template <template <class...> class Tuple,
+        template <class...> class Variant>
+    using value_types = Variant<Tuple<>>;
+
+    template <template <class...> class Variant>
+    using error_types = Variant<std::exception_ptr>;
+
+    static constexpr bool sends_done = false;
+
+    template <typename R>
+    struct operation_state
+    {
+        std::decay_t<R> r;
+        void start() noexcept
+        {
+            try
+            {
+                throw std::runtime_error("error");
+            }
+            catch (...)
+            {
+                ex::set_error(std::move(r), std::current_exception());
+            }
+        };
+    };
+
+    template <typename R>
+    auto connect(R&& r) &&
+    {
+        return operation_state<R>{std::forward<R>(r)};
+    }
+};
+
+template <typename F>
+struct error_callback_receiver
+{
+    std::decay_t<F> f;
+    std::atomic<bool>& set_error_called;
+
+    template <typename E>
+    void set_error(E&&) noexcept
+    {
+        set_error_called = true;
+    }
+
+    void set_done() noexcept
+    {
+        HPX_TEST(false);
+    };
+
+    template <typename... Ts>
+    void set_value(Ts&&...) noexcept
+    {
+        HPX_TEST(false);
+    }
+};
+
+void check_exception_ptr(std::exception_ptr eptr)
+{
+    try
+    {
+        std::rethrow_exception(eptr);
+    }
+    catch (const std::runtime_error& e)
+    {
+        HPX_TEST_EQ(std::string(e.what()), std::string("error"));
+    }
+};
+
+template <typename S>
+auto tag_invoke(ex::on_t, S&&, scheduler2&& s)
+{
+    s.tag_invoke_on_called = true;
+    return scheduler::sender{};
+}
+
+int main()
+{
+    // Success path
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> scheduler_execute_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        auto s = ex::on(ex::just(),
+            scheduler{scheduler_execute_called, tag_invoke_overload_called});
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        ex::start(ex::connect(s, r));
+        HPX_TEST(set_value_called);
+        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(scheduler_execute_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> scheduler_execute_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        auto s = ex::on(ex::just(3),
+            scheduler{scheduler_execute_called, tag_invoke_overload_called});
+        auto f = [](int x) { HPX_TEST_EQ(x, 3); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        ex::start(ex::connect(s, r));
+        HPX_TEST(set_value_called);
+        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(scheduler_execute_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> scheduler_execute_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        auto s = ex::on(ex::just(std::string("hello"), 3),
+            scheduler{scheduler_execute_called, tag_invoke_overload_called});
+        auto f = [](std::string s, int x) {
+            HPX_TEST_EQ(s, std::string("hello"));
+            HPX_TEST_EQ(x, 3);
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        ex::start(ex::connect(s, r));
+        HPX_TEST(set_value_called);
+        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(scheduler_execute_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> scheduler_execute_called{false};
+        auto s = ex::on(ex::just(),
+            scheduler2{scheduler{
+                scheduler_execute_called, tag_invoke_overload_called}});
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        ex::start(ex::connect(std::move(s), r));
+        HPX_TEST(set_value_called);
+        HPX_TEST(tag_invoke_overload_called);
+        HPX_TEST(!scheduler_execute_called);
+    }
+
+    // Failure path
+    {
+        std::atomic<bool> set_error_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> scheduler_execute_called{false};
+        auto s = ex::on(error_sender{},
+            scheduler{scheduler_execute_called, tag_invoke_overload_called});
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, set_error_called};
+        ex::start(ex::connect(std::move(s), r));
+        HPX_TEST(set_error_called);
+        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!scheduler_execute_called);
+    }
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/execution/tests/unit/algorithm_sync_wait.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_sync_wait.cpp
@@ -120,6 +120,24 @@ int main()
         HPX_TEST_EQ(ex::sync_wait(ex::just(3)), 3);
     }
 
+    // operator| overload
+    {
+        std::atomic<bool> start_called{false};
+        std::atomic<bool> connect_called{false};
+        std::atomic<bool> tag_invoke_sync_wait_overload_called{false};
+        sender{start_called, connect_called,
+            tag_invoke_sync_wait_overload_called} |
+            ex::sync_wait();
+        HPX_TEST(start_called);
+        HPX_TEST(connect_called);
+        HPX_TEST(!tag_invoke_sync_wait_overload_called);
+    }
+
+    {
+        HPX_TEST_EQ(ex::just(3) | ex::sync_wait(), 3);
+    }
+
+    // tag_invoke overload
     {
         std::atomic<bool> start_called{false};
         std::atomic<bool> connect_called{false};

--- a/libs/parallelism/execution/tests/unit/algorithm_sync_wait.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_sync_wait.cpp
@@ -1,0 +1,151 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <atomic>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace ex = hpx::execution::experimental;
+
+struct sender
+{
+    std::atomic<bool>& start_called;
+    std::atomic<bool>& connect_called;
+    std::atomic<bool>& tag_invoke_sync_wait_overload_called;
+
+    template <template <class...> class Tuple,
+        template <class...> class Variant>
+    using value_types = Variant<Tuple<>>;
+
+    template <template <class...> class Variant>
+    using error_types = Variant<std::exception_ptr>;
+
+    static constexpr bool sends_done = false;
+
+    template <typename R>
+    struct operation_state
+    {
+        std::atomic<bool>& start_called;
+        std::decay_t<R> r;
+        void start() noexcept
+        {
+            start_called = true;
+            ex::set_value(std::move(r));
+        };
+    };
+
+    template <typename R>
+    auto connect(R&& r) &&
+    {
+        connect_called = true;
+        return operation_state<R>{start_called, std::forward<R>(r)};
+    }
+};
+
+struct sender2 : sender
+{
+    explicit sender2(sender s)
+      : sender(std::move(s))
+    {
+    }
+};
+
+// NOTE: This is not a conforming sync_wait implementation. It only exists to
+// check that the tag_invoke overload is called.
+void tag_invoke(ex::sync_wait_t, sender2 s)
+{
+    s.tag_invoke_sync_wait_overload_called = true;
+}
+
+struct error_sender
+{
+    template <template <class...> class Tuple,
+        template <class...> class Variant>
+    using value_types = Variant<Tuple<>>;
+
+    template <template <class...> class Variant>
+    using error_types = Variant<std::exception_ptr>;
+
+    static constexpr bool sends_done = false;
+
+    template <typename R>
+    struct operation_state
+    {
+        std::decay_t<R> r;
+        void start() noexcept
+        {
+            try
+            {
+                throw std::runtime_error("error");
+            }
+            catch (...)
+            {
+                ex::set_error(std::move(r), std::current_exception());
+            }
+        };
+    };
+
+    template <typename R>
+    auto connect(R&& r) &&
+    {
+        return operation_state<R>{std::forward<R>(r)};
+    }
+};
+
+int main()
+{
+    // Success path
+    {
+        std::atomic<bool> start_called{false};
+        std::atomic<bool> connect_called{false};
+        std::atomic<bool> tag_invoke_sync_wait_overload_called{false};
+        ex::sync_wait(sender{start_called, connect_called,
+            tag_invoke_sync_wait_overload_called});
+        HPX_TEST(start_called);
+        HPX_TEST(connect_called);
+        HPX_TEST(!tag_invoke_sync_wait_overload_called);
+    }
+
+    {
+        HPX_TEST_EQ(ex::sync_wait(ex::just(3)), 3);
+    }
+
+    {
+        std::atomic<bool> start_called{false};
+        std::atomic<bool> connect_called{false};
+        std::atomic<bool> tag_invoke_sync_wait_overload_called{false};
+        ex::sync_wait(sender2{sender{start_called, connect_called,
+            tag_invoke_sync_wait_overload_called}});
+        HPX_TEST(!start_called);
+        HPX_TEST(!connect_called);
+        HPX_TEST(tag_invoke_sync_wait_overload_called);
+    }
+
+    // Failure path
+    {
+        bool exception_thrown = false;
+        try
+        {
+            ex::sync_wait(error_sender{});
+            HPX_TEST(false);
+        }
+        catch (std::runtime_error const& e)
+        {
+            HPX_TEST_EQ(std::string(e.what()), std::string("error"));
+            exception_thrown = true;
+        }
+        HPX_TEST(exception_thrown);
+    }
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/execution/tests/unit/algorithm_transform.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_transform.cpp
@@ -1,0 +1,213 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <atomic>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace ex = hpx::execution::experimental;
+
+template <typename F>
+struct callback_receiver
+{
+    std::decay_t<F> f;
+    std::atomic<bool>& set_value_called;
+
+    template <typename E>
+    void set_error(E&&) noexcept
+    {
+        HPX_TEST(false);
+    }
+
+    void set_done() noexcept
+    {
+        HPX_TEST(false);
+    };
+
+    template <typename... Ts>
+    void set_value(Ts&&... ts) noexcept
+    {
+        HPX_INVOKE(f, std::forward<Ts>(ts)...);
+        set_value_called = true;
+    }
+};
+
+template <typename F>
+struct error_callback_receiver
+{
+    std::decay_t<F> f;
+    std::atomic<bool>& set_error_called;
+
+    template <typename E>
+    void set_error(E&& e) noexcept
+    {
+        HPX_INVOKE(f, std::forward<E>(e));
+        set_error_called = true;
+    }
+
+    void set_done() noexcept
+    {
+        HPX_TEST(false);
+    };
+
+    template <typename... Ts>
+    void set_value(Ts&&...) noexcept
+    {
+        HPX_TEST(false);
+    }
+};
+
+struct custom_transformer
+{
+    std::atomic<bool>& tag_invoke_overload_called;
+    std::atomic<bool>& call_operator_called;
+    bool throws;
+
+    void operator()() const
+    {
+        call_operator_called = true;
+        if (throws)
+        {
+            throw std::runtime_error("error");
+        }
+    }
+};
+
+template <typename S>
+auto tag_invoke(ex::transform_t, S&& s, custom_transformer t)
+{
+    t.tag_invoke_overload_called = true;
+    return ex::transform(std::forward<S>(s), [t = std::move(t)]() { t(); });
+}
+
+void check_exception_ptr(std::exception_ptr eptr)
+{
+    try
+    {
+        std::rethrow_exception(eptr);
+    }
+    catch (const std::runtime_error& e)
+    {
+        HPX_TEST_EQ(std::string(e.what()), std::string("error"));
+    }
+};
+
+int main()
+{
+    // Success path
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::transform(ex::just(), [] {});
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        ex::start(ex::connect(s, r));
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::transform(ex::just(0), [](int x) { return ++x; });
+        auto f = [](int x) { HPX_TEST_EQ(x, 1); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        ex::start(ex::connect(s, r));
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s1 = ex::transform(ex::just(0), [](int x) { return ++x; });
+        auto s2 = ex::transform(std::move(s1), [](int x) { return ++x; });
+        auto s3 = ex::transform(std::move(s2), [](int x) { return ++x; });
+        auto s4 = ex::transform(std::move(s3), [](int x) { return ++x; });
+        auto f = [](int x) { HPX_TEST_EQ(x, 4); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        ex::start(ex::connect(std::move(s4), r));
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s1 = ex::transform(ex::just(), []() { return 3; });
+        auto s2 = ex::transform(std::move(s1), [](int x) { return x / 1.5; });
+        auto s3 = ex::transform(std::move(s2), [](double x) { return x / 2; });
+        auto s4 = ex::transform(
+            std::move(s3), [](int x) { return std::to_string(x); });
+        auto f = [](std::string x) { HPX_TEST_EQ(x, std::string("1")); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        ex::start(ex::connect(std::move(s4), r));
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> receiver_set_value_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> custom_transformer_call_operator_called{false};
+        auto s = ex::transform(ex::just(),
+            custom_transformer{tag_invoke_overload_called,
+                custom_transformer_call_operator_called, false});
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, receiver_set_value_called};
+        ex::start(ex::connect(s, r));
+        HPX_TEST(receiver_set_value_called);
+        HPX_TEST(tag_invoke_overload_called);
+        HPX_TEST(custom_transformer_call_operator_called);
+    }
+
+    // Failure path
+    {
+        std::atomic<bool> set_error_called{false};
+        auto s = ex::transform(
+            ex::just(), [] { throw std::runtime_error("error"); });
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, set_error_called};
+        ex::start(ex::connect(s, r));
+        HPX_TEST(set_error_called);
+    }
+
+    {
+        std::atomic<bool> set_error_called{false};
+        auto s1 = ex::transform(ex::just(0), [](int x) { return ++x; });
+        auto s2 = ex::transform(std::move(s1), [](int x) {
+            throw std::runtime_error("error");
+            return ++x;
+        });
+        auto s3 = ex::transform(std::move(s2), [](int x) {
+            HPX_TEST(false);
+            return ++x;
+        });
+        auto s4 = ex::transform(std::move(s3), [](int x) {
+            HPX_TEST(false);
+            return ++x;
+        });
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, set_error_called};
+        ex::start(ex::connect(std::move(s4), r));
+        HPX_TEST(set_error_called);
+    }
+
+    {
+        std::atomic<bool> receiver_set_error_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> custom_transformer_call_operator_called{false};
+        auto s = ex::transform(ex::just(),
+            custom_transformer{tag_invoke_overload_called,
+                custom_transformer_call_operator_called, true});
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, receiver_set_error_called};
+        ex::start(ex::connect(s, r));
+        HPX_TEST(receiver_set_error_called);
+        HPX_TEST(tag_invoke_overload_called);
+        HPX_TEST(custom_transformer_call_operator_called);
+    }
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/execution/tests/unit/algorithm_transform.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_transform.cpp
@@ -148,6 +148,20 @@ int main()
         HPX_TEST(set_value_called);
     }
 
+    // operator| overload
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::just() | ex::transform([]() { return 3; }) |
+            ex::transform([](int x) { return x / 1.5; }) |
+            ex::transform([](double x) { return x / 2; }) |
+            ex::transform([](int x) { return std::to_string(x); });
+        auto f = [](std::string x) { HPX_TEST_EQ(x, std::string("1")); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        ex::start(ex::connect(std::move(s), r));
+        HPX_TEST(set_value_called);
+    }
+
+    // tag_invoke overload
     {
         std::atomic<bool> receiver_set_value_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};

--- a/libs/parallelism/execution/tests/unit/algorithm_transform.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_transform.cpp
@@ -34,7 +34,8 @@ struct callback_receiver
     };
 
     template <typename... Ts>
-    void set_value(Ts&&... ts) noexcept
+    auto set_value(Ts&&... ts) noexcept
+        -> decltype(HPX_INVOKE(f, std::forward<Ts>(ts)...), void())
     {
         HPX_INVOKE(f, std::forward<Ts>(ts)...);
         set_value_called = true;

--- a/libs/parallelism/execution/tests/unit/future_then_executor.cpp
+++ b/libs/parallelism/execution/tests/unit/future_then_executor.cpp
@@ -23,7 +23,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 int p1()
 {
-    hpx::this_thread::sleep_for(std::chrono::milliseconds(500));
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
     return 1;
 }
 
@@ -31,7 +31,7 @@ int p2(hpx::future<int> f)
 {
     HPX_TEST(f.valid());
     int i = f.get();
-    hpx::this_thread::sleep_for(std::chrono::milliseconds(500));
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
     return 2 * i;
 }
 
@@ -40,7 +40,7 @@ void p3(hpx::future<int> f)
     HPX_TEST(f.valid());
     int i = f.get();
     (void) i;
-    hpx::this_thread::sleep_for(std::chrono::milliseconds(500));
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
     return;
 }
 


### PR DESCRIPTION
Adds `operator|` overloads for `on`, `sync_wait`, and `transform`. The other algorithms don't really benefit from an `operator|` overload.

Also builds on #5237.