### PR TITLE
Significantly speedup simple for_each, for_loop, and transform

### DIFF
--- a/libs/core/functional/include/hpx/functional/tag_fallback_invoke.hpp
+++ b/libs/core/functional/include/hpx/functional/tag_fallback_invoke.hpp
@@ -122,7 +122,8 @@ namespace hpx { namespace functional {
         struct tag_fallback_invoke_t
         {
             template <typename Tag, typename... Ts>
-            constexpr HPX_FORCEINLINE auto operator()(Tag tag, Ts&&... ts) const
+            HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
+                Tag tag, Ts&&... ts) const
                 noexcept(noexcept(tag_fallback_invoke(
                     std::declval<Tag>(), std::forward<Ts>(ts)...)))
                     -> decltype(tag_fallback_invoke(
@@ -146,9 +147,14 @@ namespace hpx { namespace functional {
     }    // namespace tag_fallback_invoke_t_ns
 
     inline namespace tag_fallback_invoke_ns {
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
         HPX_INLINE_CONSTEXPR_VARIABLE
         tag_fallback_invoke_t_ns::tag_fallback_invoke_t tag_fallback_invoke =
             {};
+#else
+        HPX_DEVICE static tag_fallback_invoke_t_ns::tag_fallback_invoke_t const
+            tag_fallback_invoke = {};
+#endif
     }    // namespace tag_fallback_invoke_ns
 
     ///////////////////////////////////////////////////////////////////////////
@@ -227,7 +233,8 @@ namespace hpx { namespace functional {
     /// template <typename T> auto tag_fallback_invoke(tag_t, T&& t) {...}
     ///
     /// With the same user-defined tag_invoke overload, the user-defined
-    /// overload will now be used if is a match even if isn't an exact match.
+    /// overload will now be used if it is a match even if it isn't an exact
+    /// match.
     /// This is because tag_fallback will dispatch to tag_fallback_invoke only
     /// if there are no matching tag_invoke overloads.
     template <typename Tag>
@@ -237,7 +244,8 @@ namespace hpx { namespace functional {
         template <typename... Args,
             typename Enable = typename std::enable_if<
                 is_tag_invocable_v<Tag, Args&&...>>::type>
-        constexpr HPX_FORCEINLINE auto operator()(Args&&... args) const
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
+            Args&&... args) const
             noexcept(is_nothrow_tag_invocable_v<Tag, Args...>)
                 -> tag_invoke_result_t<Tag, Args&&...>
         {
@@ -249,7 +257,8 @@ namespace hpx { namespace functional {
         template <typename... Args,
             typename Enable = typename std::enable_if<
                 !is_tag_invocable_v<Tag, Args&&...>>::type>
-        constexpr HPX_FORCEINLINE auto operator()(Args&&... args) const
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
+            Args&&... args) const
             noexcept(is_nothrow_tag_fallback_invocable_v<Tag, Args...>)
                 -> tag_fallback_invoke_result_t<Tag, Args&&...>
         {
@@ -267,7 +276,7 @@ namespace hpx { namespace functional {
     private:
         // is nothrow tag-fallback invocable
         template <typename... Args>
-        constexpr HPX_FORCEINLINE auto tag_fallback_invoke_impl(
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto tag_fallback_invoke_impl(
             std::true_type, Args&&... args) const noexcept
             -> tag_fallback_invoke_result_t<Tag, Args&&...>
         {
@@ -280,7 +289,8 @@ namespace hpx { namespace functional {
         template <typename... Args,
             typename Enable = typename std::enable_if<
                 is_nothrow_tag_invocable_v<Tag, Args&&...>>::type>
-        constexpr HPX_FORCEINLINE auto operator()(Args&&... args) const noexcept
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
+            Args&&... args) const noexcept
             -> tag_invoke_result_t<Tag, Args&&...>
         {
             return hpx::functional::tag_invoke(
@@ -293,7 +303,8 @@ namespace hpx { namespace functional {
                 is_nothrow_tag_fallback_invocable<Tag, Args&&...>,
             typename Enable = typename std::enable_if<
                 !is_nothrow_tag_invocable_v<Tag, Args&&...>>::type>
-        constexpr HPX_FORCEINLINE auto operator()(Args&&... args) const noexcept
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
+            Args&&... args) const noexcept
             -> decltype(tag_fallback_invoke_impl(
                 IsFallbackInvocable{}, std::forward<Args>(args)...))
         {

--- a/libs/core/functional/include/hpx/functional/tag_invoke.hpp
+++ b/libs/core/functional/include/hpx/functional/tag_invoke.hpp
@@ -120,7 +120,8 @@ namespace hpx { namespace functional {
         struct tag_invoke_t
         {
             template <typename Tag, typename... Ts>
-            constexpr HPX_FORCEINLINE auto operator()(Tag tag, Ts&&... ts) const
+            HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
+                Tag tag, Ts&&... ts) const
                 noexcept(noexcept(
                     tag_invoke(std::declval<Tag>(), std::forward<Ts>(ts)...)))
                     -> decltype(tag_invoke(
@@ -142,8 +143,12 @@ namespace hpx { namespace functional {
     }    // namespace tag_invoke_t_ns
 
     inline namespace tag_invoke_ns {
-        HPX_INLINE_CONSTEXPR_VARIABLE tag_invoke_t_ns::tag_invoke_t tag_invoke =
-            {};
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+        HPX_INLINE_CONSTEXPR_VARIABLE
+        tag_invoke_t_ns::tag_invoke_t tag_invoke = {};
+#else
+        HPX_DEVICE static tag_invoke_t_ns::tag_invoke_t const tag_invoke = {};
+#endif
     }    // namespace tag_invoke_ns
 
     ///////////////////////////////////////////////////////////////////////////
@@ -199,7 +204,8 @@ namespace hpx { namespace functional {
     struct tag
     {
         template <typename... Args>
-        constexpr HPX_FORCEINLINE auto operator()(Args&&... args) const
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
+            Args&&... args) const
             noexcept(is_nothrow_tag_invocable_v<Tag, Args...>)
                 -> tag_invoke_result_t<Tag, Args...>
         {
@@ -214,7 +220,8 @@ namespace hpx { namespace functional {
         template <typename... Args,
             typename Enable = typename std::enable_if<
                 is_nothrow_tag_invocable_v<Tag, Args...>>::type>
-        constexpr HPX_FORCEINLINE auto operator()(Args&&... args) const noexcept
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
+            Args&&... args) const noexcept
             -> tag_invoke_result_t<Tag, decltype(args)...>
         {
             return hpx::functional::tag_invoke(

--- a/libs/core/functional/include/hpx/functional/tag_priority_invoke.hpp
+++ b/libs/core/functional/include/hpx/functional/tag_priority_invoke.hpp
@@ -124,7 +124,8 @@ namespace hpx { namespace functional {
         struct tag_override_invoke_t
         {
             template <typename Tag, typename... Ts>
-            constexpr HPX_FORCEINLINE auto operator()(Tag tag, Ts&&... ts) const
+            HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
+                Tag tag, Ts&&... ts) const
                 noexcept(noexcept(tag_override_invoke(
                     std::declval<Tag>(), std::forward<Ts>(ts)...)))
                     -> decltype(tag_override_invoke(
@@ -148,9 +149,14 @@ namespace hpx { namespace functional {
     }    // namespace tag_override_invoke_t_ns
 
     inline namespace tag_override_invoke_ns {
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
         HPX_INLINE_CONSTEXPR_VARIABLE
         tag_override_invoke_t_ns::tag_override_invoke_t tag_override_invoke =
             {};
+#else
+        HPX_DEVICE static tag_override_invoke_t_ns::tag_override_invoke_t const
+            tag_override_invoke = {};
+#endif
     }    // namespace tag_override_invoke_ns
 
     ///////////////////////////////////////////////////////////////////////////
@@ -223,7 +229,8 @@ namespace hpx { namespace functional {
         template <typename... Args,
             typename Enable = typename std::enable_if<
                 is_tag_override_invocable_v<Tag, Args&&...>>::type>
-        constexpr HPX_FORCEINLINE auto operator()(Args&&... args) const
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
+            Args&&... args) const
             noexcept(is_nothrow_tag_override_invocable_v<Tag, Args...>)
                 -> tag_override_invoke_result_t<Tag, Args&&...>
         {
@@ -236,7 +243,8 @@ namespace hpx { namespace functional {
             typename Enable = typename std::enable_if<
                 !is_tag_override_invocable_v<Tag, Args&&...> &&
                 is_tag_invocable_v<Tag, Args&&...>>::type>
-        constexpr HPX_FORCEINLINE auto operator()(Args&&... args) const
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
+            Args&&... args) const
             noexcept(is_nothrow_tag_invocable_v<Tag, Args...>)
                 -> tag_invoke_result_t<Tag, Args&&...>
         {
@@ -251,7 +259,8 @@ namespace hpx { namespace functional {
                 !is_tag_override_invocable_v<Tag, Args&&...> &&
                 !is_tag_invocable_v<Tag, Args&&...> &&
                 is_tag_fallback_invocable_v<Tag, Args&&...>>::type>
-        constexpr HPX_FORCEINLINE auto operator()(Args&&... args) const
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
+            Args&&... args) const
             noexcept(is_nothrow_tag_fallback_invocable_v<Tag, Args...>)
                 -> tag_fallback_invoke_result_t<Tag, Args&&...>
         {
@@ -272,7 +281,8 @@ namespace hpx { namespace functional {
         template <typename... Args,
             typename Enable = typename std::enable_if<
                 is_nothrow_tag_override_invocable_v<Tag, Args&&...>>::type>
-        constexpr HPX_FORCEINLINE auto operator()(Args&&... args) const noexcept
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
+            Args&&... args) const noexcept
             -> tag_override_invoke_result_t<Tag, Args&&...>
         {
             return hpx::functional::tag_override_invoke(
@@ -284,7 +294,8 @@ namespace hpx { namespace functional {
             typename Enable = typename std::enable_if<
                 !is_nothrow_tag_override_invocable_v<Tag, Args&&...> &&
                 is_nothrow_tag_invocable_v<Tag, Args&&...>>::type>
-        constexpr HPX_FORCEINLINE auto operator()(Args&&... args) const noexcept
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
+            Args&&... args) const noexcept
             -> tag_invoke_result_t<Tag, Args&&...>
         {
             return hpx::functional::tag_invoke(
@@ -298,7 +309,8 @@ namespace hpx { namespace functional {
                 !is_nothrow_tag_override_invocable_v<Tag, Args&&...> &&
                 !is_nothrow_tag_invocable_v<Tag, Args&&...> &&
                 is_nothrow_tag_fallback_invocable_v<Tag, Args&&...>>::type>
-        constexpr HPX_FORCEINLINE auto operator()(Args&&... args) const noexcept
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
+            Args&&... args) const noexcept
             -> tag_fallback_invoke_result_t<Tag, Args&&...>
         {
             return hpx::functional::tag_fallback_invoke(

--- a/libs/core/threading_base/include/hpx/threading_base/annotated_function.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/annotated_function.hpp
@@ -37,9 +37,10 @@ namespace hpx { namespace util {
     {
         HPX_NON_COPYABLE(annotate_function);
 
-        explicit annotate_function(char const*) {}
+        explicit constexpr annotate_function(char const*) noexcept {}
+
         template <typename F>
-        explicit HPX_HOST_DEVICE annotate_function(F&&)
+        explicit HPX_HOST_DEVICE constexpr annotate_function(F&&) noexcept
         {
         }
 
@@ -214,9 +215,10 @@ namespace hpx { namespace util {
     {
         HPX_NON_COPYABLE(annotate_function);
 
-        explicit annotate_function(char const* /*name*/) {}
+        explicit constexpr annotate_function(char const* /*name*/) noexcept {}
+
         template <typename F>
-        explicit HPX_HOST_DEVICE annotate_function(F&& /*f*/)
+        explicit HPX_HOST_DEVICE constexpr annotate_function(F&& /*f*/) noexcept
         {
         }
 
@@ -231,13 +233,13 @@ namespace hpx { namespace util {
     ///
     /// \param function
     template <typename F>
-    F&& annotated_function(F&& f, char const* = nullptr)
+    constexpr F&& annotated_function(F&& f, char const* = nullptr) noexcept
     {
         return std::forward<F>(f);
     }
 
     template <typename F>
-    F&& annotated_function(F&& f, std::string const&)
+    constexpr F&& annotated_function(F&& f, std::string const&) noexcept
     {
         return std::forward<F>(f);
     }

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/scan.hpp
@@ -94,8 +94,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         if (part_size > 1)
                         {
                             // MSVC complains if 'op' is captured by reference
-                            util::loop_n<execution_policy_type>(part_begin + 1,
-                                part_size - 1,
+                            util::detail::loop_n<execution_policy_type>(
+                                part_begin + 1, part_size - 1,
                                 [&ret, op, conv](FwdIter const& curr) {
                                     ret = hpx::util::invoke(op, ret,
                                         hpx::util::invoke(conv, *curr));
@@ -108,7 +108,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         if (results.size() > 1)
                         {
                             // MSVC complains if 'op' is captured by reference
-                            util::loop_n<execution_policy_type>(
+                            util::detail::loop_n<execution_policy_type>(
                                 results.begin() + 1, results.size() - 1,
                                 [&ret, op](
                                     typename std::vector<T>::iterator const&

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/scan.hpp
@@ -85,18 +85,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
             parallel(ExPolicy&& policy, FwdIter first, FwdIter last, Op&& op,
                 Conv&& conv)
             {
+                using execution_policy_type = std::decay_t<ExPolicy>;
                 return util::partitioner<ExPolicy, T>::call(
                     std::forward<ExPolicy>(policy), first,
                     std::distance(first, last),
-                    [op, policy, conv](
-                        FwdIter part_begin, std::size_t part_size) -> T {
-                        HPX_UNUSED(policy);
-
+                    [op, conv](FwdIter part_begin, std::size_t part_size) -> T {
                         T ret = hpx::util::invoke(conv, *part_begin);
                         if (part_size > 1)
                         {
                             // MSVC complains if 'op' is captured by reference
-                            util::loop_n<ExPolicy>(part_begin + 1,
+                            util::loop_n<execution_policy_type>(part_begin + 1,
                                 part_size - 1,
                                 [&ret, op, conv](FwdIter const& curr) {
                                     ret = hpx::util::invoke(op, ret,
@@ -105,24 +103,21 @@ namespace hpx { namespace parallel { inline namespace v1 {
                         }
                         return ret;
                     },
-                    hpx::util::unwrapping(
-                        [op, policy](std::vector<T>&& results) -> T {
-                            HPX_UNUSED(policy);
-
-                            T ret = *results.begin();
-                            if (results.size() > 1)
-                            {
-                                // MSVC complains if 'op' is captured by reference
-                                util::loop_n<ExPolicy>(results.begin() + 1,
-                                    results.size() - 1,
-                                    [&ret, op](
-                                        typename std::vector<T>::iterator const&
-                                            curr) {
-                                        ret = hpx::util::invoke(op, ret, *curr);
-                                    });
-                            }
-                            return ret;
-                        }));
+                    hpx::util::unwrapping([op](std::vector<T>&& results) -> T {
+                        T ret = *results.begin();
+                        if (results.size() > 1)
+                        {
+                            // MSVC complains if 'op' is captured by reference
+                            util::loop_n<execution_policy_type>(
+                                results.begin() + 1, results.size() - 1,
+                                [&ret, op](
+                                    typename std::vector<T>::iterator const&
+                                        curr) {
+                                    ret = hpx::util::invoke(op, ret, *curr);
+                                });
+                        }
+                        return ret;
+                    }));
             }
         };
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
@@ -82,7 +82,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               std::size_t part_size) mutable {
                     // VS2015RC bails out when op is captured by ref
                     using hpx::get;
-                    util::loop_n<ExPolicy>(
+                    util::loop_n<std::decay_t<ExPolicy>>(
                         part_begin, part_size, [op](zip_iterator it) {
                             get<2>(*it) =
                                 hpx::util::invoke(op, get<0>(*it), get<1>(*it));

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
@@ -82,7 +82,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               std::size_t part_size) mutable {
                     // VS2015RC bails out when op is captured by ref
                     using hpx::get;
-                    util::loop_n<std::decay_t<ExPolicy>>(
+                    util::detail::loop_n<std::decay_t<ExPolicy>>(
                         part_begin, part_size, [op](zip_iterator it) {
                             get<2>(*it) =
                                 hpx::util::invoke(op, get<0>(*it), get<1>(*it));

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
@@ -292,8 +292,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               proj = std::forward<Proj>(proj)](
                               FwdIter part_begin,
                               std::size_t part_count) mutable -> bool {
-                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_count,
-                        tok, [&op, &tok, &proj](FwdIter const& curr) {
+                    util::detail::loop_n<std::decay_t<ExPolicy>>(part_begin,
+                        part_count, tok,
+                        [&op, &tok, &proj](FwdIter const& curr) {
                             if (hpx::util::invoke(
                                     op, hpx::util::invoke(proj, *curr)))
                             {
@@ -391,8 +392,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               proj = std::forward<Proj>(proj)](
                               FwdIter part_begin,
                               std::size_t part_count) mutable -> bool {
-                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_count,
-                        tok, [&op, &tok, &proj](FwdIter const& curr) {
+                    util::detail::loop_n<std::decay_t<ExPolicy>>(part_begin,
+                        part_count, tok,
+                        [&op, &tok, &proj](FwdIter const& curr) {
                             if (hpx::util::invoke(
                                     op, hpx::util::invoke(proj, *curr)))
                             {
@@ -490,8 +492,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               proj = std::forward<Proj>(proj)](
                               FwdIter part_begin,
                               std::size_t part_count) mutable -> bool {
-                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_count,
-                        tok, [&op, &tok, &proj](FwdIter const& curr) {
+                    util::detail::loop_n<std::decay_t<ExPolicy>>(part_begin,
+                        part_count, tok,
+                        [&op, &tok, &proj](FwdIter const& curr) {
                             if (!hpx::util::invoke(
                                     op, hpx::util::invoke(proj, *curr)))
                             {

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
@@ -292,8 +292,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               proj = std::forward<Proj>(proj)](
                               FwdIter part_begin,
                               std::size_t part_count) mutable -> bool {
-                    util::loop_n<ExPolicy>(part_begin, part_count, tok,
-                        [&op, &tok, &proj](FwdIter const& curr) {
+                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_count,
+                        tok, [&op, &tok, &proj](FwdIter const& curr) {
                             if (hpx::util::invoke(
                                     op, hpx::util::invoke(proj, *curr)))
                             {
@@ -391,8 +391,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               proj = std::forward<Proj>(proj)](
                               FwdIter part_begin,
                               std::size_t part_count) mutable -> bool {
-                    util::loop_n<ExPolicy>(part_begin, part_count, tok,
-                        [&op, &tok, &proj](FwdIter const& curr) {
+                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_count,
+                        tok, [&op, &tok, &proj](FwdIter const& curr) {
                             if (hpx::util::invoke(
                                     op, hpx::util::invoke(proj, *curr)))
                             {
@@ -490,8 +490,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               proj = std::forward<Proj>(proj)](
                               FwdIter part_begin,
                               std::size_t part_count) mutable -> bool {
-                    util::loop_n<ExPolicy>(part_begin, part_count, tok,
-                        [&op, &tok, &proj](FwdIter const& curr) {
+                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_count,
+                        tok, [&op, &tok, &proj](FwdIter const& curr) {
                             if (!hpx::util::invoke(
                                     op, hpx::util::invoke(proj, *curr)))
                             {

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -532,7 +532,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::size_t curr = 0;
 
                     // MSVC complains if proj is captured by ref below
-                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_size,
+                    util::detail::loop_n<std::decay_t<ExPolicy>>(part_begin,
+                        part_size,
                         [&pred, proj, &curr](zip_iterator it) mutable {
                             bool f = hpx::util::invoke(
                                 pred, hpx::util::invoke(proj, get<0>(*it)));
@@ -552,8 +553,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     next.get();    // rethrow exceptions
 
                     std::advance(dest, curr.get());
-                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_size,
-                        [&dest](zip_iterator it) mutable {
+                    util::detail::loop_n<std::decay_t<ExPolicy>>(part_begin,
+                        part_size, [&dest](zip_iterator it) mutable {
                             if (get<1>(*it))
                                 *dest++ = get<0>(*it);
                         });

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -532,7 +532,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::size_t curr = 0;
 
                     // MSVC complains if proj is captured by ref below
-                    util::loop_n<ExPolicy>(part_begin, part_size,
+                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_size,
                         [&pred, proj, &curr](zip_iterator it) mutable {
                             bool f = hpx::util::invoke(
                                 pred, hpx::util::invoke(proj, get<0>(*it)));
@@ -552,7 +552,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     next.get();    // rethrow exceptions
 
                     std::advance(dest, curr.get());
-                    util::loop_n<ExPolicy>(part_begin, part_size,
+                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_size,
                         [&dest](zip_iterator it) mutable {
                             if (get<1>(*it))
                                 *dest++ = get<0>(*it);

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/count.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/count.hpp
@@ -232,8 +232,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 operator()(Iter part_begin, std::size_t part_size)
             {
                 typename std::iterator_traits<Iter>::difference_type ret = 0;
-                util::loop_n<execution_policy_type>(part_begin, part_size,
-                    hpx::util::bind_back(*this, std::ref(ret)));
+                util::detail::loop_n<execution_policy_type>(part_begin,
+                    part_size, hpx::util::bind_back(*this, std::ref(ret)));
                 return ret;
             }
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/count.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/count.hpp
@@ -184,13 +184,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///////////////////////////////////////////////////////////////////////////
     // count
     namespace detail {
+
         /// \cond NOINTERNAL
         template <typename ExPolicy, typename Op, typename Proj>
         struct count_iteration
         {
-            typedef typename std::decay<ExPolicy>::type execution_policy_type;
-            typedef typename std::decay<Proj>::type proj_type;
-            typedef typename std::decay<Op>::type op_type;
+            using execution_policy_type = typename std::decay<ExPolicy>::type;
+            using proj_type = typename std::decay<Proj>::type;
+            using op_type = typename std::decay<Op>::type;
 
             op_type op_;
             proj_type proj_;
@@ -226,7 +227,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             count_iteration& operator=(count_iteration&&) = default;
 
             template <typename Iter>
-            HPX_HOST_DEVICE HPX_FORCEINLINE
+            HPX_HOST_DEVICE HPX_FORCEINLINE constexpr
                 typename std::iterator_traits<Iter>::difference_type
                 operator()(Iter part_begin, std::size_t part_size)
             {
@@ -237,7 +238,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             }
 
             template <typename Iter>
-            HPX_HOST_DEVICE HPX_FORCEINLINE void operator()(Iter curr,
+            HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void operator()(Iter curr,
                 typename std::iterator_traits<Iter>::difference_type& ret)
             {
                 ret += traits::count_bits(
@@ -267,7 +268,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 typename std::iterator_traits<InIterB>::difference_type ret = 0;
 
-                util::loop(policy, first, last,
+                util::loop(std::forward<ExPolicy>(policy), first, last,
                     hpx::util::bind_back(std::move(f1), std::ref(ret)));
 
                 return ret;
@@ -362,7 +363,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 typename std::iterator_traits<InIterB>::difference_type ret = 0;
 
-                util::loop(policy, first, last,
+                util::loop(std::forward<ExPolicy>(policy), first, last,
                     hpx::util::bind_back(std::move(f1), std::ref(ret)));
 
                 return ret;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/destroy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/destroy.hpp
@@ -162,7 +162,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             return util::foreach_partitioner<ExPolicy>::call(
                 std::forward<ExPolicy>(policy), first, count,
                 [](Iter first, std::size_t count, std::size_t) {
-                    return util::loop_n<std::decay_t<ExPolicy>>(
+                    return util::detail::loop_n<std::decay_t<ExPolicy>>(
                         first, count, [](Iter it) -> void {
                             using value_type =
                                 typename std::iterator_traits<Iter>::value_type;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/destroy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/destroy.hpp
@@ -162,7 +162,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             return util::foreach_partitioner<ExPolicy>::call(
                 std::forward<ExPolicy>(policy), first, count,
                 [](Iter first, std::size_t count, std::size_t) {
-                    return util::loop_n<ExPolicy>(
+                    return util::loop_n<std::decay_t<ExPolicy>>(
                         first, count, [](Iter it) -> void {
                             using value_type =
                                 typename std::iterator_traits<Iter>::value_type;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/equal.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/equal.hpp
@@ -285,7 +285,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               proj2 = std::forward<Proj2>(proj2)](
                               zip_iterator it,
                               std::size_t part_count) mutable -> bool {
-                    util::loop_n<ExPolicy>(it, part_count, tok,
+                    util::loop_n<std::decay_t<ExPolicy>>(it, part_count, tok,
                         [&f, &proj1, &proj2, &tok](zip_iterator const& curr) {
                             reference t = *curr;
                             if (!hpx::util::invoke(f,
@@ -390,7 +390,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 util::cancellation_token<> tok;
                 auto f1 = [f, tok](zip_iterator it,
                               std::size_t part_count) mutable -> bool {
-                    util::loop_n<ExPolicy>(it, part_count, tok,
+                    util::loop_n<std::decay_t<ExPolicy>>(it, part_count, tok,
                         [&f, &tok](zip_iterator const& curr) {
                             reference t = *curr;
                             if (!hpx::util::invoke(

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/equal.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/equal.hpp
@@ -285,7 +285,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               proj2 = std::forward<Proj2>(proj2)](
                               zip_iterator it,
                               std::size_t part_count) mutable -> bool {
-                    util::loop_n<std::decay_t<ExPolicy>>(it, part_count, tok,
+                    util::detail::loop_n<std::decay_t<ExPolicy>>(it, part_count,
+                        tok,
                         [&f, &proj1, &proj2, &tok](zip_iterator const& curr) {
                             reference t = *curr;
                             if (!hpx::util::invoke(f,
@@ -390,8 +391,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 util::cancellation_token<> tok;
                 auto f1 = [f, tok](zip_iterator it,
                               std::size_t part_count) mutable -> bool {
-                    util::loop_n<std::decay_t<ExPolicy>>(it, part_count, tok,
-                        [&f, &tok](zip_iterator const& curr) {
+                    util::detail::loop_n<std::decay_t<ExPolicy>>(it, part_count,
+                        tok, [&f, &tok](zip_iterator const& curr) {
                             reference t = *curr;
                             if (!hpx::util::invoke(
                                     f, hpx::get<0>(t), hpx::get<1>(t)))

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -130,7 +130,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     *dst++ = val;
 
                     // MSVC 2015 fails if op is captured by reference
-                    util::loop_n<std::decay_t<ExPolicy>>(
+                    util::detail::loop_n<std::decay_t<ExPolicy>>(
                         dst, part_size - 1, [=, &val](FwdIter2 it) {
                             *it = hpx::util::invoke(op, val, *it);
                         });

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -130,7 +130,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     *dst++ = val;
 
                     // MSVC 2015 fails if op is captured by reference
-                    util::loop_n<ExPolicy>(
+                    util::loop_n<std::decay_t<ExPolicy>>(
                         dst, part_size - 1, [=, &val](FwdIter2 it) {
                             *it = hpx::util::invoke(op, val, *it);
                         });

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -263,6 +263,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///////////////////////////////////////////////////////////////////////////
     // for_each_n
     namespace detail {
+
         /// \cond NOINTERNAL
         template <typename F, typename Proj = util::projection_identity>
         struct invoke_projected
@@ -338,9 +339,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename ExPolicy, typename F, typename Proj>
         struct for_each_iteration
         {
-            using execution_policy_type = typename std::decay<ExPolicy>::type;
-            using fun_type = typename std::decay<F>::type;
-            using proj_type = typename std::decay<Proj>::type;
+            using execution_policy_type = std::decay_t<ExPolicy>;
+            using fun_type = std::decay_t<F>;
+            using proj_type = Proj;
 
             fun_type f_;
             proj_type proj_;
@@ -392,8 +393,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         template <typename ExPolicy, typename F>
         struct for_each_iteration<ExPolicy, F, util::projection_identity>
         {
-            using execution_policy_type = typename std::decay<ExPolicy>::type;
-            using fun_type = typename std::decay<F>::type;
+            using execution_policy_type = std::decay_t<ExPolicy>;
+            using fun_type = std::decay_t<F>;
 
             fun_type f_;
 
@@ -463,8 +464,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             HPX_HOST_DEVICE static constexpr Iter sequential(
                 ExPolicy&&, InIter first, std::size_t count, F&& f, Proj&& proj)
             {
-                return util::loop_n<ExPolicy>(
-                    first, count, invoke_projected<F, Proj>{f, proj});
+                return util::loop_n<std::decay_t<ExPolicy>>(first, count,
+                    invoke_projected<F, std::decay_t<Proj>>{f, proj});
             }
 
             template <typename ExPolicy, typename InIter, typename F>
@@ -472,7 +473,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 InIter first, std::size_t count, F&& f,
                 util::projection_identity)
             {
-                return util::loop_n_ind<ExPolicy>(
+                return util::loop_n_ind<std::decay_t<ExPolicy>>(
                     first, count, std::forward<F>(f));
             }
 
@@ -485,8 +486,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
                 if (count != 0)
                 {
-                    auto f1 = for_each_iteration<ExPolicy, F, Proj>(
-                        std::forward<F>(f), std::forward<Proj>(proj));
+                    auto f1 =
+                        for_each_iteration<ExPolicy, F, std::decay_t<Proj>>(
+                            std::forward<F>(f), std::forward<Proj>(proj));
 
                     return util::foreach_partitioner<ExPolicy>::call(
                         std::forward<ExPolicy>(policy), first, count,
@@ -520,9 +522,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
             sequential(
                 ExPolicy&&, InIterB first, InIterE last, F&& f, Proj&& proj)
             {
-                return util::loop_n<typename std::decay<ExPolicy>::type>(first,
+                return util::loop_n<std::decay_t<ExPolicy>>(first,
                     static_cast<std::size_t>(detail::distance(first, last)),
-                    invoke_projected<F, Proj>{f, proj});
+                    invoke_projected<F, std::decay_t<Proj>>{f, proj});
             }
 
             template <typename ExPolicy, typename InIterB, typename InIterE,
@@ -534,7 +536,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 Proj&& proj)
             {
                 return util::loop(std::forward<ExPolicy>(policy), first, last,
-                    invoke_projected<F, Proj>{f, proj});
+                    invoke_projected<F, std::decay_t<Proj>>{f, proj});
             }
 
             template <typename ExPolicy, typename InIterB, typename InIterE,
@@ -545,8 +547,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             sequential(ExPolicy&&, InIterB first, InIterE last, F&& f,
                 util::projection_identity)
             {
-                return util::loop_n_ind<typename std::decay<ExPolicy>::type>(
-                    first,
+                return util::loop_n_ind<std::decay_t<ExPolicy>>(first,
                     static_cast<std::size_t>(detail::distance(first, last)),
                     std::forward<F>(f));
             }
@@ -572,8 +573,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
             {
                 if (first != last)
                 {
-                    auto f1 = for_each_iteration<ExPolicy, F, Proj>(
-                        std::forward<F>(f), std::forward<Proj>(proj));
+                    auto f1 =
+                        for_each_iteration<ExPolicy, F, std::decay_t<Proj>>(
+                            std::forward<F>(f), std::forward<Proj>(proj));
 
                     return util::foreach_partitioner<ExPolicy>::call(
                         std::forward<ExPolicy>(policy), first,
@@ -801,8 +803,7 @@ namespace hpx { namespace traits {
             parallel::v1::detail::for_each_iteration<ExPolicy, F, Proj> const&
                 f) noexcept
         {
-            return get_function_address<typename std::decay<F>::type>::call(
-                f.f_);
+            return get_function_address<std::decay_t<F>>::call(f.f_);
         }
     };
 
@@ -814,8 +815,7 @@ namespace hpx { namespace traits {
             parallel::v1::detail::for_each_iteration<ExPolicy, F, Proj> const&
                 f) noexcept
         {
-            return get_function_annotation<typename std::decay<F>::type>::call(
-                f.f_);
+            return get_function_annotation<std::decay_t<F>>::call(f.f_);
         }
     };
 
@@ -828,8 +828,7 @@ namespace hpx { namespace traits {
             parallel::v1::detail::for_each_iteration<ExPolicy, F, Proj> const&
                 f) noexcept
         {
-            return get_function_annotation_itt<
-                typename std::decay<F>::type>::call(f.f_);
+            return get_function_annotation_itt<std::decay_t<F>>::call(f.f_);
         }
     };
 #endif

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -350,7 +350,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void execute(
                 Iter part_begin, std::size_t part_size)
             {
-                util::loop_n<execution_policy_type>(part_begin, part_size,
+                util::detail::loop_n<execution_policy_type>(part_begin,
+                    part_size,
                     invoke_projected<fun_type, proj_type>{f_, proj_});
             }
 
@@ -402,7 +403,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void execute(
                 Iter part_begin, std::size_t part_size, std::true_type)
             {
-                util::loop_n<execution_policy_type>(
+                util::detail::loop_n<execution_policy_type>(
                     part_begin, part_size, invoke_projected<F>(f_));
             }
 
@@ -410,7 +411,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void execute(
                 Iter part_begin, std::size_t part_size, std::false_type)
             {
-                util::loop_n_ind<execution_policy_type>(
+                util::detail::loop_n_ind<execution_policy_type>(
                     part_begin, part_size, f_);
             }
 
@@ -464,8 +465,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             HPX_HOST_DEVICE static constexpr Iter sequential(
                 ExPolicy&&, InIter first, std::size_t count, F&& f, Proj&& proj)
             {
-                return util::loop_n<std::decay_t<ExPolicy>>(first, count,
-                    invoke_projected<F, std::decay_t<Proj>>{f, proj});
+                return util::detail::loop_n<std::decay_t<ExPolicy>>(first,
+                    count, invoke_projected<F, std::decay_t<Proj>>{f, proj});
             }
 
             template <typename ExPolicy, typename InIter, typename F>
@@ -473,7 +474,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 InIter first, std::size_t count, F&& f,
                 util::projection_identity)
             {
-                return util::loop_n_ind<std::decay_t<ExPolicy>>(
+                return util::detail::loop_n_ind<std::decay_t<ExPolicy>>(
                     first, count, std::forward<F>(f));
             }
 
@@ -522,7 +523,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             sequential(
                 ExPolicy&&, InIterB first, InIterE last, F&& f, Proj&& proj)
             {
-                return util::loop_n<std::decay_t<ExPolicy>>(first,
+                return util::detail::loop_n<std::decay_t<ExPolicy>>(first,
                     static_cast<std::size_t>(detail::distance(first, last)),
                     invoke_projected<F, std::decay_t<Proj>>{f, proj});
             }
@@ -547,7 +548,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             sequential(ExPolicy&&, InIterB first, InIterE last, F&& f,
                 util::projection_identity)
             {
-                return util::loop_n_ind<std::decay_t<ExPolicy>>(first,
+                return util::detail::loop_n_ind<std::decay_t<ExPolicy>>(first,
                     static_cast<std::size_t>(detail::distance(first, last)),
                     std::forward<F>(f));
             }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -918,7 +918,7 @@ namespace hpx {
                             hpx::traits::is_random_access_iterator<B>::value ||
                                 std::is_integral<B>::value>;
 
-                        parallel::util::detail::loop_n<B>::call(
+                        parallel::util::detail::loop_n_helper::call(
                             part_begin, part_steps, f_, pred());
                     }
                     else if (stride_ > 0)
@@ -985,7 +985,7 @@ namespace hpx {
                                 InIter>::value ||
                                 std::is_integral<InIter>::value>;
 
-                        parallel::util::detail::loop_n<InIter>::call(
+                        parallel::util::detail::loop_n_helper::call(
                             first, count, std::forward<F>(f), pred());
                     }
                     else if (stride > 0)

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop_induction.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop_induction.hpp
@@ -44,7 +44,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
             }
 
             HPX_HOST_DEVICE
-            constexpr void next_iteration(std::size_t /*index*/) noexcept
+            constexpr void next_iteration() noexcept
             {
                 ++curr_;
             }
@@ -80,7 +80,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
             }
 
             HPX_HOST_DEVICE
-            constexpr void next_iteration(std::size_t /*index*/) noexcept
+            constexpr void next_iteration() noexcept
             {
                 ++curr_;
             }
@@ -123,7 +123,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
             }
 
             HPX_HOST_DEVICE
-            constexpr void next_iteration(std::size_t /*index*/) noexcept
+            constexpr void next_iteration() noexcept
             {
                 curr_ = parallel::v1::detail::next(curr_, stride_);
             }
@@ -162,7 +162,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
             }
 
             HPX_HOST_DEVICE
-            constexpr void next_iteration(std::size_t /*index*/) noexcept
+            constexpr void next_iteration() noexcept
             {
                 curr_ = parallel::v1::detail::next(curr_, stride_);
             }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop_reduction.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop_reduction.hpp
@@ -58,7 +58,7 @@ namespace hpx { namespace parallel { inline namespace v2 {
                 return data_[hpx::get_worker_thread_num()].data_;
             }
 
-            constexpr void next_iteration(std::size_t /*index*/) noexcept {}
+            constexpr void next_iteration() noexcept {}
 
             void exit_iteration(std::size_t /*index*/)
             {

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -138,18 +138,16 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 using hpx::get;
                 using hpx::util::make_zip_iterator;
 
-                auto f3 = [op, policy](zip_iterator part_begin,
-                              std::size_t part_size, hpx::shared_future<T> curr,
+                auto f3 = [op](zip_iterator part_begin, std::size_t part_size,
+                              hpx::shared_future<T> curr,
                               hpx::shared_future<T> next) {
-                    HPX_UNUSED(policy);
-
                     next.get();    // rethrow exceptions
 
                     T val = curr.get();
                     FwdIter2 dst = get<1>(part_begin.get_iterator_tuple());
 
                     // MSVC 2015 fails if op is captured by reference
-                    util::loop_n<ExPolicy>(
+                    util::loop_n<std::decay_t<ExPolicy>>(
                         dst, part_size, [=, &val](FwdIter2 it) {
                             *it = hpx::util::invoke(op, val, *it);
                         });

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -147,7 +147,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     FwdIter2 dst = get<1>(part_begin.get_iterator_tuple());
 
                     // MSVC 2015 fails if op is captured by reference
-                    util::loop_n<std::decay_t<ExPolicy>>(
+                    util::detail::loop_n<std::decay_t<ExPolicy>>(
                         dst, part_size, [=, &val](FwdIter2 it) {
                             *it = hpx::util::invoke(op, val, *it);
                         });

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_partitioned.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_partitioned.hpp
@@ -198,7 +198,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     if (part_count == 1)
                         return fst_bool;
 
-                    util::loop_n<ExPolicy>(++part_begin, --part_count, tok,
+                    util::loop_n<std::decay_t<ExPolicy>>(++part_begin,
+                        --part_count, tok,
                         [&fst_bool, &pred_projected, &tok](
                             Iter const& a) -> void {
                             if (fst_bool !=

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_partitioned.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_partitioned.hpp
@@ -198,7 +198,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     if (part_count == 1)
                         return fst_bool;
 
-                    util::loop_n<std::decay_t<ExPolicy>>(++part_begin,
+                    util::detail::loop_n<std::decay_t<ExPolicy>>(++part_begin,
                         --part_count, tok,
                         [&fst_bool, &pred_projected, &tok](
                             Iter const& a) -> void {

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
@@ -289,7 +289,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               FwdIter part_begin,
                               std::size_t part_size) mutable -> bool {
                     FwdIter trail = part_begin++;
-                    util::loop_n<ExPolicy>(part_begin, part_size - 1,
+                    util::loop_n<std::decay_t<ExPolicy>>(part_begin,
+                        part_size - 1,
                         [&trail, &tok, &pred_projected](FwdIter it) -> void {
                             if (hpx::util::invoke(
                                     pred_projected, *it, *trail++))

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
@@ -289,7 +289,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               FwdIter part_begin,
                               std::size_t part_size) mutable -> bool {
                     FwdIter trail = part_begin++;
-                    util::loop_n<std::decay_t<ExPolicy>>(part_begin,
+                    util::detail::loop_n<std::decay_t<ExPolicy>>(part_begin,
                         part_size - 1,
                         [&trail, &tok, &pred_projected](FwdIter it) -> void {
                             if (hpx::util::invoke(

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/minmax.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/minmax.hpp
@@ -49,7 +49,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return it;
 
             FwdIter smallest = it;
-            util::loop_n<ExPolicy>(++it, count - 1,
+            util::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
                 [&f, &smallest, &proj](FwdIter const& curr) -> void {
                     if (hpx::util::invoke(f, hpx::util::invoke(proj, *curr),
                             hpx::util::invoke(proj, *smallest)))
@@ -80,7 +80,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 typename std::iterator_traits<FwdIter>::value_type smallest =
                     *it;
-                util::loop_n<ExPolicy>(++it, count - 1,
+                util::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
                     [&f, &smallest, &proj](FwdIter const& curr) -> void {
                         if (hpx::util::invoke(f,
                                 hpx::util::invoke(proj, **curr),
@@ -262,7 +262,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return it;
 
             FwdIter greatest = it;
-            util::loop_n<ExPolicy>(++it, count - 1,
+            util::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
                 [&f, &greatest, &proj](FwdIter const& curr) -> void {
                     if (hpx::util::invoke(f, hpx::util::invoke(proj, *greatest),
                             hpx::util::invoke(proj, *curr)))
@@ -293,7 +293,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 typename std::iterator_traits<FwdIter>::value_type greatest =
                     *it;
-                util::loop_n<ExPolicy>(++it, count - 1,
+                util::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
                     [&f, &greatest, &proj](FwdIter const& curr) -> void {
                         if (hpx::util::invoke(f,
                                 hpx::util::invoke(proj, *greatest),
@@ -477,7 +477,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             if (count == 0 || count == 1)
                 return result;
 
-            util::loop_n<ExPolicy>(++it, count - 1,
+            util::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
                 [&f, &result, &proj](FwdIter const& curr) -> void {
                     if (hpx::util::invoke(f, hpx::util::invoke(proj, *curr),
                             hpx::util::invoke(proj, *result.first)))
@@ -515,7 +515,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 typename std::iterator_traits<PairIter>::value_type result =
                     *it;
-                util::loop_n<ExPolicy>(++it, count - 1,
+                util::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
                     [&f, &result, &proj](PairIter const& curr) -> void {
                         if (hpx::util::invoke(f,
                                 hpx::util::invoke(proj, *curr->first),

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/minmax.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/minmax.hpp
@@ -49,7 +49,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return it;
 
             FwdIter smallest = it;
-            util::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
+            util::detail::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
                 [&f, &smallest, &proj](FwdIter const& curr) -> void {
                     if (hpx::util::invoke(f, hpx::util::invoke(proj, *curr),
                             hpx::util::invoke(proj, *smallest)))
@@ -80,7 +80,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 typename std::iterator_traits<FwdIter>::value_type smallest =
                     *it;
-                util::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
+                util::detail::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
                     [&f, &smallest, &proj](FwdIter const& curr) -> void {
                         if (hpx::util::invoke(f,
                                 hpx::util::invoke(proj, **curr),
@@ -262,7 +262,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 return it;
 
             FwdIter greatest = it;
-            util::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
+            util::detail::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
                 [&f, &greatest, &proj](FwdIter const& curr) -> void {
                     if (hpx::util::invoke(f, hpx::util::invoke(proj, *greatest),
                             hpx::util::invoke(proj, *curr)))
@@ -293,7 +293,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 typename std::iterator_traits<FwdIter>::value_type greatest =
                     *it;
-                util::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
+                util::detail::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
                     [&f, &greatest, &proj](FwdIter const& curr) -> void {
                         if (hpx::util::invoke(f,
                                 hpx::util::invoke(proj, *greatest),
@@ -477,7 +477,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             if (count == 0 || count == 1)
                 return result;
 
-            util::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
+            util::detail::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
                 [&f, &result, &proj](FwdIter const& curr) -> void {
                     if (hpx::util::invoke(f, hpx::util::invoke(proj, *curr),
                             hpx::util::invoke(proj, *result.first)))
@@ -515,7 +515,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 typename std::iterator_traits<PairIter>::value_type result =
                     *it;
-                util::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
+                util::detail::loop_n<std::decay_t<ExPolicy>>(++it, count - 1,
                     [&f, &result, &proj](PairIter const& curr) -> void {
                         if (hpx::util::invoke(f,
                                 hpx::util::invoke(proj, *curr->first),

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partition.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partition.hpp
@@ -1159,7 +1159,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::size_t true_count = 0;
 
                     // MSVC complains if pred or proj is captured by ref below
-                    util::loop_n<ExPolicy>(part_begin, part_size,
+                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_size,
                         [pred, proj, &true_count](zip_iterator it) mutable {
                             using hpx::util::invoke;
                             bool f = invoke(pred, invoke(proj, get<0>(*it)));
@@ -1196,7 +1196,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::advance(dest_true, count_true);
                     std::advance(dest_false, count_false);
 
-                    util::loop_n<ExPolicy>(part_begin, part_size,
+                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_size,
                         [&dest_true, &dest_false](zip_iterator it) mutable {
                             if (get<1>(*it))
                                 *dest_true++ = get<0>(*it);

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partition.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partition.hpp
@@ -1159,7 +1159,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::size_t true_count = 0;
 
                     // MSVC complains if pred or proj is captured by ref below
-                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_size,
+                    util::detail::loop_n<std::decay_t<ExPolicy>>(part_begin,
+                        part_size,
                         [pred, proj, &true_count](zip_iterator it) mutable {
                             using hpx::util::invoke;
                             bool f = invoke(pred, invoke(proj, get<0>(*it)));
@@ -1196,7 +1197,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::advance(dest_true, count_true);
                     std::advance(dest_false, count_false);
 
-                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_size,
+                    util::detail::loop_n<std::decay_t<ExPolicy>>(part_begin,
+                        part_size,
                         [&dest_true, &dest_false](zip_iterator it) mutable {
                             if (get<1>(*it))
                                 *dest_true++ = get<0>(*it);

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
@@ -318,8 +318,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               zip_iterator part_begin,
                               std::size_t part_size) -> std::size_t {
                     // MSVC complains if pred or proj is captured by ref below
-                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_size,
-                        [pred, proj](zip_iterator it) mutable {
+                    util::detail::loop_n<std::decay_t<ExPolicy>>(part_begin,
+                        part_size, [pred, proj](zip_iterator it) mutable {
                             bool f = hpx::util::invoke(
                                 pred, hpx::util::invoke(proj, get<0>(*it)));
 
@@ -358,7 +358,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     if (dest == get<0>(part_begin.get_iterator_tuple()))
                     {
                         // Self-assignment must be detected.
-                        util::loop_n<execution_policy_type>(
+                        util::detail::loop_n<execution_policy_type>(
                             part_begin, part_size, [&dest](zip_iterator it) {
                                 if (!get<1>(*it))
                                 {
@@ -372,7 +372,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     else
                     {
                         // Self-assignment can't be performed.
-                        util::loop_n<execution_policy_type>(
+                        util::detail::loop_n<execution_policy_type>(
                             part_begin, part_size, [&dest](zip_iterator it) {
                                 if (!get<1>(*it))
                                     *dest++ = std::move(get<0>(*it));

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
@@ -318,7 +318,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               zip_iterator part_begin,
                               std::size_t part_size) -> std::size_t {
                     // MSVC complains if pred or proj is captured by ref below
-                    util::loop_n<ExPolicy>(part_begin, part_size,
+                    util::loop_n<std::decay_t<ExPolicy>>(part_begin, part_size,
                         [pred, proj](zip_iterator it) mutable {
                             bool f = hpx::util::invoke(
                                 pred, hpx::util::invoke(proj, get<0>(*it)));
@@ -354,10 +354,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                     Iter& dest = *dest_ptr;
 
+                    using execution_policy_type = std::decay_t<ExPolicy>;
                     if (dest == get<0>(part_begin.get_iterator_tuple()))
                     {
                         // Self-assignment must be detected.
-                        util::loop_n<ExPolicy>(
+                        util::loop_n<execution_policy_type>(
                             part_begin, part_size, [&dest](zip_iterator it) {
                                 if (!get<1>(*it))
                                 {
@@ -371,7 +372,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     else
                     {
                         // Self-assignment can't be performed.
-                        util::loop_n<ExPolicy>(
+                        util::loop_n<execution_policy_type>(
                             part_begin, part_size, [&dest](zip_iterator it) {
                                 if (!get<1>(*it))
                                     *dest++ = std::move(get<0>(*it));

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -132,7 +132,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     FwdIter2 dst = get<1>(part_begin.get_iterator_tuple());
                     *dst++ = val;
 
-                    util::loop_n<ExPolicy>(
+                    util::loop_n<std::decay_t<ExPolicy>>(
                         dst, part_size - 1, [&op, &val](FwdIter2 it) -> void {
                             *it = hpx::util::invoke(op, val, *it);
                         });

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -132,7 +132,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     FwdIter2 dst = get<1>(part_begin.get_iterator_tuple());
                     *dst++ = val;
 
-                    util::loop_n<std::decay_t<ExPolicy>>(
+                    util::detail::loop_n<std::decay_t<ExPolicy>>(
                         dst, part_size - 1, [&op, &val](FwdIter2 it) -> void {
                             *it = hpx::util::invoke(op, val, *it);
                         });

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -153,7 +153,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     T val = curr.get();
                     FwdIter2 dst = get<1>(part_begin.get_iterator_tuple());
 
-                    util::loop_n<std::decay_t<ExPolicy>>(
+                    util::detail::loop_n<std::decay_t<ExPolicy>>(
                         dst, part_size, [&op, &val](FwdIter2 it) -> void {
                             *it = hpx::util::invoke(op, val, *it);
                         });

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -153,7 +153,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     T val = curr.get();
                     FwdIter2 dst = get<1>(part_begin.get_iterator_tuple());
 
-                    util::loop_n<ExPolicy>(
+                    util::loop_n<std::decay_t<ExPolicy>>(
                         dst, part_size, [&op, &val](FwdIter2 it) -> void {
                             *it = hpx::util::invoke(op, val, *it);
                         });

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -115,8 +115,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     FwdIter base = get<0>(part_begin.get_iterator_tuple());
 
                     // MSVC complains if pred or proj is captured by ref below
-                    util::loop_n<ExPolicy>(++part_begin, part_size,
-                        [base, pred, proj](zip_iterator it) mutable {
+                    util::loop_n<std::decay_t<ExPolicy>>(++part_begin,
+                        part_size, [base, pred, proj](zip_iterator it) mutable {
                             using hpx::util::invoke;
 
                             bool f = invoke(pred, invoke(proj, *base),
@@ -146,10 +146,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                     FwdIter& dest = *dest_ptr;
 
+                    using execution_policy_type = std::decay_t<ExPolicy>;
                     if (dest == get<0>(part_begin.get_iterator_tuple()))
                     {
                         // Self-assignment must be detected.
-                        util::loop_n<ExPolicy>(
+                        util::loop_n<execution_policy_type>(
                             part_begin, part_size, [&dest](zip_iterator it) {
                                 if (!get<1>(*it))
                                 {
@@ -163,7 +164,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     else
                     {
                         // Self-assignment can't be performed.
-                        util::loop_n<ExPolicy>(
+                        util::loop_n<execution_policy_type>(
                             part_begin, part_size, [&dest](zip_iterator it) {
                                 if (!get<1>(*it))
                                     *dest++ = std::move(get<0>(*it));
@@ -421,7 +422,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::size_t curr = 0;
 
                     // MSVC complains if pred or proj is captured by ref below
-                    util::loop_n<ExPolicy>(++part_begin, part_size,
+                    util::loop_n<std::decay_t<ExPolicy>>(++part_begin,
+                        part_size,
                         [base, pred, proj, &curr](zip_iterator it) mutable {
                             using hpx::util::invoke;
 
@@ -447,8 +449,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     next.get();    // rethrow exceptions
 
                     std::advance(dest, curr.get());
-                    util::loop_n<ExPolicy>(++part_begin, part_size,
-                        [&dest](zip_iterator it) mutable {
+                    util::loop_n<std::decay_t<ExPolicy>>(++part_begin,
+                        part_size, [&dest](zip_iterator it) mutable {
                             if (!get<1>(*it))
                                 *dest++ = get<0>(*it);
                         });

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -115,7 +115,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     FwdIter base = get<0>(part_begin.get_iterator_tuple());
 
                     // MSVC complains if pred or proj is captured by ref below
-                    util::loop_n<std::decay_t<ExPolicy>>(++part_begin,
+                    util::detail::loop_n<std::decay_t<ExPolicy>>(++part_begin,
                         part_size, [base, pred, proj](zip_iterator it) mutable {
                             using hpx::util::invoke;
 
@@ -150,7 +150,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     if (dest == get<0>(part_begin.get_iterator_tuple()))
                     {
                         // Self-assignment must be detected.
-                        util::loop_n<execution_policy_type>(
+                        util::detail::loop_n<execution_policy_type>(
                             part_begin, part_size, [&dest](zip_iterator it) {
                                 if (!get<1>(*it))
                                 {
@@ -164,7 +164,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     else
                     {
                         // Self-assignment can't be performed.
-                        util::loop_n<execution_policy_type>(
+                        util::detail::loop_n<execution_policy_type>(
                             part_begin, part_size, [&dest](zip_iterator it) {
                                 if (!get<1>(*it))
                                     *dest++ = std::move(get<0>(*it));
@@ -422,7 +422,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     std::size_t curr = 0;
 
                     // MSVC complains if pred or proj is captured by ref below
-                    util::loop_n<std::decay_t<ExPolicy>>(++part_begin,
+                    util::detail::loop_n<std::decay_t<ExPolicy>>(++part_begin,
                         part_size,
                         [base, pred, proj, &curr](zip_iterator it) mutable {
                             using hpx::util::invoke;
@@ -449,7 +449,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     next.get();    // rethrow exceptions
 
                     std::advance(dest, curr.get());
-                    util::loop_n<std::decay_t<ExPolicy>>(++part_begin,
+                    util::detail::loop_n<std::decay_t<ExPolicy>>(++part_begin,
                         part_size, [&dest](zip_iterator it) mutable {
                             if (!get<1>(*it))
                                 *dest++ = get<0>(*it);

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/for_each.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015 Hartmut Kaiser
+//  Copyright (c) 2015-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/parallelism/algorithms/include/hpx/parallel/datapar/loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/datapar/loop.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -15,6 +15,7 @@
 #include <hpx/execution/traits/vector_pack_load_store.hpp>
 #include <hpx/execution/traits/vector_pack_type.hpp>
 #include <hpx/executors/datapar/execution_policy_fwd.hpp>
+#include <hpx/functional/tag_invoke.hpp>
 #include <hpx/parallel/datapar/iterator_helpers.hpp>
 #include <hpx/parallel/util/loop.hpp>
 
@@ -345,9 +346,10 @@ namespace hpx { namespace parallel { namespace util {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename ExPolicy, typename Iter, typename F>
-    HPX_HOST_DEVICE HPX_FORCEINLINE typename std::enable_if<
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
         hpx::is_vectorpack_execution_policy<ExPolicy>::value, Iter>::type
-    loop_n(Iter it, std::size_t count, F&& f)
+    tag_invoke(hpx::parallel::util::loop_n_t<ExPolicy>, Iter it,
+        std::size_t count, F&& f)
     {
         return detail::datapar_loop_n<Iter>::call(
             it, count, std::forward<F>(f));

--- a/libs/parallelism/algorithms/include/hpx/parallel/datapar/loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/datapar/loop.hpp
@@ -345,14 +345,17 @@ namespace hpx { namespace parallel { namespace util {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename ExPolicy, typename Iter, typename F>
-    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
-        hpx::is_vectorpack_execution_policy<ExPolicy>::value, Iter>::type
-    tag_invoke(hpx::parallel::util::loop_n_t<ExPolicy>, Iter it,
-        std::size_t count, F&& f)
-    {
-        return detail::datapar_loop_n<Iter>::call(
-            it, count, std::forward<F>(f));
+    namespace detail {
+
+        template <typename ExPolicy, typename Iter, typename F>
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
+            hpx::is_vectorpack_execution_policy<ExPolicy>::value, Iter>::type
+        tag_invoke(hpx::parallel::util::detail::loop_n_t<ExPolicy>, Iter it,
+            std::size_t count, F&& f)
+        {
+            return hpx::parallel::util::detail::datapar_loop_n<Iter>::call(
+                it, count, std::forward<F>(f));
+        }
     }
 }}}    // namespace hpx::parallel::util
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/loop.hpp
@@ -361,7 +361,7 @@ namespace hpx { namespace parallel { namespace util {
             loop_n_t<ExPolicy>{};
 #else
         template <typename ExPolicy, typename Iter, typename F>
-        HPX_DEVICE HPX_FORCEINLINE constexpr Iter loop_n(
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iter loop_n(
             Iter it, std::size_t count, F&& f)
         {
             return hpx::parallel::util::detail::loop_n_t<ExPolicy>{}(
@@ -370,7 +370,7 @@ namespace hpx { namespace parallel { namespace util {
 
         template <typename ExPolicy, typename Iter, typename CancelToken,
             typename F>
-        HPX_DEVICE HPX_FORCEINLINE constexpr Iter loop_n(
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iter loop_n(
             Iter it, std::size_t count, CancelToken& tok, F&& f)
         {
             return hpx::parallel::util::detail::loop_n_t<ExPolicy>{}(
@@ -581,7 +581,7 @@ namespace hpx { namespace parallel { namespace util {
             loop_n_ind_t<ExPolicy>{};
 #else
         template <typename ExPolicy, typename Iter, typename F>
-        HPX_DEVICE HPX_FORCEINLINE constexpr Iter loop_n_ind(
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iter loop_n_ind(
             Iter it, std::size_t count, F&& f)
         {
             return hpx::parallel::util::detail::loop_n_ind_t<ExPolicy>{}(
@@ -590,7 +590,7 @@ namespace hpx { namespace parallel { namespace util {
 
         template <typename ExPolicy, typename Iter, typename CancelToken,
             typename F>
-        HPX_DEVICE HPX_FORCEINLINE constexpr Iter loop_n_ind(
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Iter loop_n_ind(
             Iter it, std::size_t count, CancelToken& tok, F&& f)
         {
             return hpx::parallel::util::detail::loop_n_ind_t<ExPolicy>{}(

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/loop.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -27,6 +27,7 @@
 #include <vector>
 
 namespace hpx { namespace parallel { namespace util {
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename ExPolicy, typename VecOnly, typename F,
         typename... Iters>
@@ -48,7 +49,7 @@ namespace hpx { namespace parallel { namespace util {
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
-        ///////////////////////////////////////////////////////////////////////
+
         // Helper class to repeatedly call a function starting from a given
         // iterator position.
         template <typename Iterator>
@@ -60,8 +61,9 @@ namespace hpx { namespace parallel { namespace util {
                 Begin it, End end, F&& f)
             {
                 for (/**/; it != end; ++it)
-                    f(it);
-
+                {
+                    HPX_INVOKE(f, it);
+                }
                 return it;
             }
 
@@ -74,7 +76,7 @@ namespace hpx { namespace parallel { namespace util {
                 {
                     if (tok.was_cancelled())
                         break;
-                    f(it);
+                    HPX_INVOKE(f, it);
                 }
                 return it;
             }
@@ -98,7 +100,59 @@ namespace hpx { namespace parallel { namespace util {
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
-        ///////////////////////////////////////////////////////////////////////
+
+        // Helper class to repeatedly call a function starting from a given
+        // iterator position.
+        template <typename Iterator>
+        struct loop_ind
+        {
+            ///////////////////////////////////////////////////////////////////
+            template <typename Begin, typename End, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr Begin call(
+                Begin it, End end, F&& f)
+            {
+                for (/**/; it != end; ++it)
+                {
+                    HPX_INVOKE(f, *it);
+                }
+                return it;
+            }
+
+            template <typename Begin, typename End, typename CancelToken,
+                typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr Begin call(
+                Begin it, End end, CancelToken& tok, F&& f)
+            {
+                for (/**/; it != end; ++it)
+                {
+                    if (tok.was_cancelled())
+                        break;
+                    HPX_INVOKE(f, *it);
+                }
+                return it;
+            }
+        };
+    }    // namespace detail
+
+    template <typename ExPolicy, typename Begin, typename End, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Begin loop_ind(
+        ExPolicy&&, Begin begin, End end, F&& f)
+    {
+        return detail::loop_ind<Begin>::call(begin, end, std::forward<F>(f));
+    }
+
+    template <typename ExPolicy, typename Begin, typename End,
+        typename CancelToken, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr Begin loop_ind(
+        ExPolicy&&, Begin begin, End end, CancelToken& tok, F&& f)
+    {
+        return detail::loop_ind<Begin>::call(
+            begin, end, tok, std::forward<F>(f));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail {
+
         // Helper class to repeatedly call a function starting from a given
         // iterator position.
         template <typename Iter1, typename Iter2>
@@ -113,7 +167,7 @@ namespace hpx { namespace parallel { namespace util {
             {
                 for (/**/; it1 != end1; (void) ++it1, ++it2)
                 {
-                    f(it1, it2);
+                    HPX_INVOKE(f, it1, it2);
                 }
 
                 return std::make_pair(std::move(it1), std::move(it2));
@@ -134,9 +188,9 @@ namespace hpx { namespace parallel { namespace util {
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
+
         // Helper class to repeatedly call a function a given number of times
         // starting from a given iterator position.
-
         template <typename Iterator>
         struct loop_n
         {
@@ -150,14 +204,14 @@ namespace hpx { namespace parallel { namespace util {
                 for (std::size_t i = 0; i < count;
                      (void) ++it, i += 4)    // -V112
                 {
-                    f(it);
-                    f(++it);
-                    f(++it);
-                    f(++it);
+                    HPX_INVOKE(f, it);
+                    HPX_INVOKE(f, ++it);
+                    HPX_INVOKE(f, ++it);
+                    HPX_INVOKE(f, ++it);
                 }
                 for (/**/; count < num; (void) ++count, ++it)
                 {
-                    f(it);
+                    HPX_INVOKE(f, it);
                 }
                 return it;
             }
@@ -168,10 +222,10 @@ namespace hpx { namespace parallel { namespace util {
             {
                 while (num >= 4)
                 {
-                    f(it);
-                    f(it + 1);
-                    f(it + 2);
-                    f(it + 3);
+                    HPX_INVOKE(f, it);
+                    HPX_INVOKE(f, it + 1);
+                    HPX_INVOKE(f, it + 2);
+                    HPX_INVOKE(f, it + 3);
 
                     it += 4;
                     num -= 4;
@@ -180,18 +234,18 @@ namespace hpx { namespace parallel { namespace util {
                 switch (num)
                 {
                 case 3:
-                    f(it);
-                    f(it + 1);
-                    f(it + 2);
+                    HPX_INVOKE(f, it);
+                    HPX_INVOKE(f, it + 1);
+                    HPX_INVOKE(f, it + 2);
                     break;
 
                 case 2:
-                    f(it);
-                    f(it + 1);
+                    HPX_INVOKE(f, it);
+                    HPX_INVOKE(f, it + 1);
                     break;
 
                 case 1:
-                    f(it);
+                    HPX_INVOKE(f, it);
                     break;
 
                 default:
@@ -211,16 +265,16 @@ namespace hpx { namespace parallel { namespace util {
                 {
                     if (tok.was_cancelled())
                         break;
-                    f(it);
-                    f(++it);
-                    f(++it);
-                    f(++it);
+                    HPX_INVOKE(f, it);
+                    HPX_INVOKE(f, ++it);
+                    HPX_INVOKE(f, ++it);
+                    HPX_INVOKE(f, ++it);
                 }
                 for (/**/; count < num; (void) ++count, ++it)
                 {
                     if (tok.was_cancelled())
                         break;
-                    f(it);
+                    HPX_INVOKE(f, it);
                 }
                 return it;
             }
@@ -234,10 +288,10 @@ namespace hpx { namespace parallel { namespace util {
                     if (tok.was_cancelled())
                         return it;
 
-                    f(it);
-                    f(it + 1);
-                    f(it + 2);
-                    f(it + 3);
+                    HPX_INVOKE(f, it);
+                    HPX_INVOKE(f, it + 1);
+                    HPX_INVOKE(f, it + 2);
+                    HPX_INVOKE(f, it + 3);
 
                     it += 4;
                     num -= 4;
@@ -246,18 +300,18 @@ namespace hpx { namespace parallel { namespace util {
                 switch (num)
                 {
                 case 3:
-                    f(it);
-                    f(it + 1);
-                    f(it + 2);
+                    HPX_INVOKE(f, it);
+                    HPX_INVOKE(f, it + 1);
+                    HPX_INVOKE(f, it + 2);
                     break;
 
                 case 2:
-                    f(it);
-                    f(it + 1);
+                    HPX_INVOKE(f, it);
+                    HPX_INVOKE(f, it + 1);
                     break;
 
                 case 1:
-                    f(it);
+                    HPX_INVOKE(f, it);
                     break;
 
                 default:
@@ -325,35 +379,169 @@ namespace hpx { namespace parallel { namespace util {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    //     namespace detail
-    //     {
-    //         ///////////////////////////////////////////////////////////////////////
-    //         // Helper class to repeatedly call a function starting from a given
-    //         // iterator position.
-    //         template <typename Iter1, typename Iter2>
-    //         struct loop2_n
-    //         {
-    //             ///////////////////////////////////////////////////////////////////
-    //             template <typename Begin1, typename Begin2, typename F>
-    //             HPX_HOST_DEVICE HPX_FORCEINLINE
-    //             static std::pair<Begin1, Begin2>
-    //             call(Begin1 it1, std::size_t count, Begin2 it2, F && f)
-    //             {
-    //                 for (/**/; count != 0; (void) ++it1, ++it2, --count)
-    //                     f(it1, it2);
-    //
-    //                 return std::make_pair(it1, it2);
-    //             }
-    //         };
-    //     }
-    //
-    //     template <typename ExPolicy, typename Begin1, typename Begin2, typename F>
-    //     HPX_HOST_DEVICE HPX_FORCEINLINE std::pair<Begin1, Begin2>
-    //     loop2_n(ExPolicy&&, Begin1 begin1, std::size_t count, Begin2 begin2, F && f)
-    //     {
-    //         return detail::loop2_n<Begin1, Begin2>::call(begin1, count, begin2,
-    //             std::forward<F>(f));
-    //     }
+    namespace detail {
+        // Helper class to repeatedly call a function a given number of times
+        // starting from a given iterator position.
+
+        template <typename Iterator>
+        struct loop_n_ind
+        {
+            ///////////////////////////////////////////////////////////////////
+            // handle sequences of non-futures
+            template <typename Iter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr Iter call(
+                Iter it, std::size_t num, F&& f, std::false_type)
+            {
+                std::size_t count(num & std::size_t(-4));    // -V112
+                for (std::size_t i = 0; i < count;
+                     (void) ++it, i += 4)    // -V112
+                {
+                    HPX_INVOKE(f, *it);
+                    HPX_INVOKE(f, *(++it));
+                    HPX_INVOKE(f, *(++it));
+                    HPX_INVOKE(f, *(++it));
+                }
+                for (/**/; count < num; (void) ++count, ++it)
+                {
+                    HPX_INVOKE(f, *it);
+                }
+
+                return it;
+            }
+
+            template <typename Iter, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr Iter call(
+                Iter it, std::size_t num, F&& f, std::true_type)
+            {
+                while (num >= 4)
+                {
+                    HPX_INVOKE(f, *it);
+                    HPX_INVOKE(f, *(it + 1));
+                    HPX_INVOKE(f, *(it + 2));
+                    HPX_INVOKE(f, *(it + 3));
+
+                    it += 4;
+                    num -= 4;
+                }
+
+                switch (num)
+                {
+                case 3:
+                    HPX_INVOKE(f, *it);
+                    HPX_INVOKE(f, *(it + 1));
+                    HPX_INVOKE(f, *(it + 2));
+                    break;
+
+                case 2:
+                    HPX_INVOKE(f, *it);
+                    HPX_INVOKE(f, *(it + 1));
+                    break;
+
+                case 1:
+                    HPX_INVOKE(f, *it);
+                    break;
+
+                default:
+                    break;
+                }
+
+                return it + num;
+            }
+
+            template <typename Iter, typename CancelToken, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr Iter call(Iter it,
+                std::size_t num, CancelToken& tok, F&& f, std::false_type)
+            {
+                std::size_t count(num & std::size_t(-4));    // -V112
+                for (std::size_t i = 0; i < count;
+                     (void) ++it, i += 4)    // -V112
+                {
+                    if (tok.was_cancelled())
+                        break;
+                    HPX_INVOKE(f, *it);
+                    HPX_INVOKE(f, *(++it));
+                    HPX_INVOKE(f, *(++it));
+                    HPX_INVOKE(f, *(++it));
+                }
+                for (/**/; count < num; (void) ++count, ++it)
+                {
+                    if (tok.was_cancelled())
+                        break;
+                    HPX_INVOKE(f, *it);
+                }
+                return it;
+            }
+
+            template <typename Iter, typename CancelToken, typename F>
+            HPX_HOST_DEVICE HPX_FORCEINLINE static constexpr Iter call(Iter it,
+                std::size_t num, CancelToken& tok, F&& f, std::true_type)
+            {
+                while (num >= 4)
+                {
+                    if (tok.was_cancelled())
+                        return it;
+
+                    HPX_INVOKE(f, *it);
+                    HPX_INVOKE(f, *(it + 1));
+                    HPX_INVOKE(f, *(it + 2));
+                    HPX_INVOKE(f, *(it + 3));
+
+                    it += 4;
+                    num -= 4;
+                }
+
+                switch (num)
+                {
+                case 3:
+                    HPX_INVOKE(f, *it);
+                    HPX_INVOKE(f, *(it + 1));
+                    HPX_INVOKE(f, *(it + 2));
+                    break;
+
+                case 2:
+                    HPX_INVOKE(f, *it);
+                    HPX_INVOKE(f, *(it + 1));
+                    break;
+
+                case 1:
+                    HPX_INVOKE(f, *it);
+                    break;
+
+                default:
+                    break;
+                }
+
+                return it + num;
+            }
+        };
+    }    // namespace detail
+
+    template <typename ExPolicy, typename Iter, typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
+        !hpx::is_vectorpack_execution_policy<ExPolicy>::value, Iter>::type
+    loop_n_ind(Iter it, std::size_t count, F&& f)
+    {
+        using pred = std::integral_constant<bool,
+            hpx::traits::is_random_access_iterator<Iter>::value ||
+                std::is_integral<Iter>::value>;
+
+        return detail::loop_n_ind<Iter>::call(
+            it, count, std::forward<F>(f), pred());
+    }
+
+    template <typename ExPolicy, typename Iter, typename CancelToken,
+        typename F>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr typename std::enable_if<
+        !hpx::is_vectorpack_execution_policy<ExPolicy>::value, Iter>::type
+    loop_n_ind(Iter it, std::size_t count, CancelToken& tok, F&& f)
+    {
+        using pred = std::integral_constant<bool,
+            hpx::traits::is_random_access_iterator<Iter>::value ||
+                std::is_integral<Iter>::value>;
+
+        return detail::loop_n_ind<Iter>::call(
+            it, count, tok, std::forward<F>(f), pred());
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
@@ -372,7 +560,9 @@ namespace hpx { namespace parallel { namespace util {
                 try
                 {
                     for (/**/; it != last; ++it)
-                        f(it);
+                    {
+                        HPX_INVOKE(f, it);
+                    }
                     return it;
                 }
                 catch (...)
@@ -398,7 +588,9 @@ namespace hpx { namespace parallel { namespace util {
                 catch (...)
                 {
                     for (/**/; base != dest; ++base)
-                        cleanup(base);
+                    {
+                        HPX_INVOKE(cleanup, base);
+                    }
                     throw;
                 }
             }
@@ -410,7 +602,7 @@ namespace hpx { namespace parallel { namespace util {
     HPX_FORCEINLINE constexpr Iter loop_with_cleanup(
         Iter it, Iter last, F&& f, Cleanup&& cleanup)
     {
-        typedef typename std::iterator_traits<Iter>::iterator_category cat;
+        using cat = typename std::iterator_traits<Iter>::iterator_category;
         return detail::loop_with_cleanup<cat>::call(
             it, last, std::forward<F>(f), std::forward<Cleanup>(cleanup));
     }
@@ -419,13 +611,14 @@ namespace hpx { namespace parallel { namespace util {
     HPX_FORCEINLINE constexpr FwdIter loop_with_cleanup(
         Iter it, Iter last, FwdIter dest, F&& f, Cleanup&& cleanup)
     {
-        typedef typename std::iterator_traits<Iter>::iterator_category cat;
+        using cat = typename std::iterator_traits<Iter>::iterator_category;
         return detail::loop_with_cleanup<cat>::call(
             it, last, dest, std::forward<F>(f), std::forward<Cleanup>(cleanup));
     }
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
+
         // Helper class to repeatedly call a function a given number of times
         // starting from a given iterator position.
         template <typename IterCat>
@@ -440,13 +633,17 @@ namespace hpx { namespace parallel { namespace util {
                 try
                 {
                     for (/**/; count != 0; (void) --count, ++it)
-                        f(it);
+                    {
+                        HPX_INVOKE(f, it);
+                    }
                     return it;
                 }
                 catch (...)
                 {
                     for (/**/; base != it; ++base)
-                        cleanup(base);
+                    {
+                        HPX_INVOKE(cleanup, base);
+                    }
                     throw;
                 }
             }
@@ -460,13 +657,17 @@ namespace hpx { namespace parallel { namespace util {
                 try
                 {
                     for (/**/; count != 0; (void) --count, ++it, ++dest)
-                        f(it, dest);
+                    {
+                        HPX_INVOKE(f, it, dest);
+                    }
                     return dest;
                 }
                 catch (...)
                 {
                     for (/**/; base != dest; ++base)
-                        cleanup(base);
+                    {
+                        HPX_INVOKE(cleanup, base);
+                    }
                     throw;
                 }
             }
@@ -484,7 +685,7 @@ namespace hpx { namespace parallel { namespace util {
                     {
                         if (tok.was_cancelled())
                             break;
-                        f(it);
+                        HPX_INVOKE(f, it);
                     }
                     return it;
                 }
@@ -492,7 +693,9 @@ namespace hpx { namespace parallel { namespace util {
                 {
                     tok.cancel();
                     for (/**/; base != it; ++base)
-                        cleanup(base);
+                    {
+                        HPX_INVOKE(cleanup, base);
+                    }
                     throw;
                 }
             }
@@ -509,7 +712,7 @@ namespace hpx { namespace parallel { namespace util {
                     {
                         if (tok.was_cancelled())
                             break;
-                        f(it, dest);
+                        HPX_INVOKE(f, it, dest);
                     }
                     return dest;
                 }
@@ -517,7 +720,9 @@ namespace hpx { namespace parallel { namespace util {
                 {
                     tok.cancel();
                     for (/**/; base != dest; ++base)
-                        cleanup(base);
+                    {
+                        HPX_INVOKE(cleanup, base);
+                    }
                     throw;
                 }
             }
@@ -529,7 +734,7 @@ namespace hpx { namespace parallel { namespace util {
     HPX_FORCEINLINE constexpr Iter loop_with_cleanup_n(
         Iter it, std::size_t count, F&& f, Cleanup&& cleanup)
     {
-        typedef typename std::iterator_traits<Iter>::iterator_category cat;
+        using cat = typename std::iterator_traits<Iter>::iterator_category;
         return detail::loop_with_cleanup_n<cat>::call(
             it, count, std::forward<F>(f), std::forward<Cleanup>(cleanup));
     }
@@ -538,7 +743,7 @@ namespace hpx { namespace parallel { namespace util {
     HPX_FORCEINLINE constexpr FwdIter loop_with_cleanup_n(
         Iter it, std::size_t count, FwdIter dest, F&& f, Cleanup&& cleanup)
     {
-        typedef typename std::iterator_traits<Iter>::iterator_category cat;
+        using cat = typename std::iterator_traits<Iter>::iterator_category;
         return detail::loop_with_cleanup_n<cat>::call(it, count, dest,
             std::forward<F>(f), std::forward<Cleanup>(cleanup));
     }
@@ -547,7 +752,7 @@ namespace hpx { namespace parallel { namespace util {
     HPX_FORCEINLINE constexpr Iter loop_with_cleanup_n_with_token(
         Iter it, std::size_t count, CancelToken& tok, F&& f, Cleanup&& cleanup)
     {
-        typedef typename std::iterator_traits<Iter>::iterator_category cat;
+        using cat = typename std::iterator_traits<Iter>::iterator_category;
         return detail::loop_with_cleanup_n<cat>::call_with_token(
             it, count, tok, std::forward<F>(f), std::forward<Cleanup>(cleanup));
     }
@@ -558,13 +763,14 @@ namespace hpx { namespace parallel { namespace util {
         std::size_t count, FwdIter dest, CancelToken& tok, F&& f,
         Cleanup&& cleanup)
     {
-        typedef typename std::iterator_traits<Iter>::iterator_category cat;
+        using cat = typename std::iterator_traits<Iter>::iterator_category;
         return detail::loop_with_cleanup_n<cat>::call_with_token(it, count,
             dest, tok, std::forward<F>(f), std::forward<Cleanup>(cleanup));
     }
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
+
         // Helper class to repeatedly call a function a given number of times
         // starting from a given iterator position.
         template <typename IterCat>
@@ -581,14 +787,14 @@ namespace hpx { namespace parallel { namespace util {
                 for (std::size_t i = 0; i < count;
                      (void) ++it, i += 4)    // -V112
                 {
-                    f(*it, base_idx++);
-                    f(*++it, base_idx++);
-                    f(*++it, base_idx++);
-                    f(*++it, base_idx++);
+                    HPX_INVOKE(f, *it, base_idx++);
+                    HPX_INVOKE(f, *++it, base_idx++);
+                    HPX_INVOKE(f, *++it, base_idx++);
+                    HPX_INVOKE(f, *++it, base_idx++);
                 }
                 for (/**/; count < num; (void) ++count, ++it, ++base_idx)
                 {
-                    f(*it, base_idx);
+                    HPX_INVOKE(f, *it, base_idx);
                 }
                 return it;
             }
@@ -604,7 +810,7 @@ namespace hpx { namespace parallel { namespace util {
                     {
                         break;
                     }
-                    f(*it, base_idx);
+                    HPX_INVOKE(f, *it, base_idx);
                 }
                 return it;
             }
@@ -621,10 +827,10 @@ namespace hpx { namespace parallel { namespace util {
             {
                 while (num >= 4)
                 {
-                    f(it[0], base_idx++);
-                    f(it[1], base_idx++);
-                    f(it[2], base_idx++);
-                    f(it[3], base_idx++);
+                    HPX_INVOKE(f, *it, base_idx++);
+                    HPX_INVOKE(f, *(it + 1), base_idx++);
+                    HPX_INVOKE(f, *(it + 2), base_idx++);
+                    HPX_INVOKE(f, *(it + 3), base_idx++);
 
                     it += 4;
                     num -= 4;
@@ -633,18 +839,18 @@ namespace hpx { namespace parallel { namespace util {
                 switch (num)
                 {
                 case 3:
-                    f(it[0], base_idx++);
-                    f(it[1], base_idx++);
-                    f(it[2], base_idx);
+                    HPX_INVOKE(f, *it, base_idx++);
+                    HPX_INVOKE(f, *(it + 1), base_idx++);
+                    HPX_INVOKE(f, *(it + 2), base_idx++);
                     break;
 
                 case 2:
-                    f(it[0], base_idx++);
-                    f(it[1], base_idx);
+                    HPX_INVOKE(f, *it, base_idx++);
+                    HPX_INVOKE(f, *(it + 1), base_idx++);
                     break;
 
                 case 1:
-                    f(it[0], base_idx);
+                    HPX_INVOKE(f, *it, base_idx);
                     break;
 
                 default:
@@ -664,10 +870,10 @@ namespace hpx { namespace parallel { namespace util {
                     if (tok.was_cancelled(base_idx))
                         return it;
 
-                    f(it[0], base_idx++);
-                    f(it[1], base_idx++);
-                    f(it[2], base_idx++);
-                    f(it[3], base_idx++);
+                    HPX_INVOKE(f, *it, base_idx++);
+                    HPX_INVOKE(f, *(it + 1), base_idx++);
+                    HPX_INVOKE(f, *(it + 2), base_idx++);
+                    HPX_INVOKE(f, *(it + 3), base_idx++);
 
                     it += 4;
                     num -= 4;
@@ -676,18 +882,18 @@ namespace hpx { namespace parallel { namespace util {
                 switch (num)
                 {
                 case 3:
-                    f(it[0], base_idx++);
-                    f(it[1], base_idx++);
-                    f(it[2], base_idx);
+                    HPX_INVOKE(f, *it, base_idx++);
+                    HPX_INVOKE(f, *(it + 1), base_idx++);
+                    HPX_INVOKE(f, *(it + 2), base_idx++);
                     break;
 
                 case 2:
-                    f(it[0], base_idx++);
-                    f(it[1], base_idx);
+                    HPX_INVOKE(f, *it, base_idx++);
+                    HPX_INVOKE(f, *(it + 1), base_idx++);
                     break;
 
                 case 1:
-                    f(it[0], base_idx);
+                    HPX_INVOKE(f, *it, base_idx);
                     break;
 
                 default:
@@ -704,7 +910,7 @@ namespace hpx { namespace parallel { namespace util {
     HPX_FORCEINLINE constexpr Iter loop_idx_n(
         std::size_t base_idx, Iter it, std::size_t count, F&& f)
     {
-        typedef typename std::iterator_traits<Iter>::iterator_category cat;
+        using cat = typename std::iterator_traits<Iter>::iterator_category;
         return detail::loop_idx_n<cat>::call(
             base_idx, it, count, std::forward<F>(f));
     }
@@ -713,7 +919,7 @@ namespace hpx { namespace parallel { namespace util {
     HPX_FORCEINLINE constexpr Iter loop_idx_n(std::size_t base_idx, Iter it,
         std::size_t count, CancelToken& tok, F&& f)
     {
-        typedef typename std::iterator_traits<Iter>::iterator_category cat;
+        using cat = typename std::iterator_traits<Iter>::iterator_category;
         return detail::loop_idx_n<cat>::call(
             base_idx, it, count, tok, std::forward<F>(f));
     }
@@ -729,7 +935,9 @@ namespace hpx { namespace parallel { namespace util {
             static T call(Iter it, std::size_t count, T init, Pred&& f)
             {
                 for (/**/; count != 0; (void) --count, ++it)
-                    init = f(init, *it);
+                {
+                    init = HPX_INVOKE(f, init, *it);
+                }
                 return init;
             }
         };
@@ -739,7 +947,7 @@ namespace hpx { namespace parallel { namespace util {
     template <typename Iter, typename T, typename Pred>
     HPX_FORCEINLINE T accumulate_n(Iter it, std::size_t count, T init, Pred&& f)
     {
-        typedef typename std::iterator_traits<Iter>::iterator_category cat;
+        using cat = typename std::iterator_traits<Iter>::iterator_category;
         return detail::accumulate_n<cat>::call(
             it, count, std::move(init), std::forward<Pred>(f));
     }

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/prefetching.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/prefetching.hpp
@@ -137,31 +137,20 @@ namespace hpx { namespace parallel { namespace util {
                 // round up distance to cover all of underlying range
                 return (idx_ - rhs.idx_ + chunk_size_ - 1) / chunk_size_;
             }
-            inline prefetching_iterator operator+(difference_type rhs) const
+
+            friend inline prefetching_iterator operator+(
+                prefetching_iterator const& lhs, difference_type rhs)
             {
-                prefetching_iterator tmp(*this);
+                prefetching_iterator tmp(lhs);
                 tmp += rhs;
                 return tmp;
             }
-
-            // FIXME: What happens if the distance is not divisible by the
-            //        chunk_size? Should enforce this?
-            inline prefetching_iterator operator-(difference_type rhs) const
+            friend inline prefetching_iterator operator-(
+                prefetching_iterator const& lhs, difference_type rhs)
             {
-                prefetching_iterator tmp(*this);
+                prefetching_iterator tmp(lhs);
                 tmp -= rhs;
                 return tmp;
-            }
-
-            friend inline prefetching_iterator operator+(
-                const prefetching_iterator& lhs, difference_type rhs)
-            {
-                return rhs + lhs;
-            }
-            friend inline prefetching_iterator operator-(
-                const prefetching_iterator& lhs, difference_type rhs)
-            {
-                return lhs - rhs;
             }
 
             // FIXME: should other members be compared too?

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/prefetching.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/prefetching.hpp
@@ -31,7 +31,9 @@
 #endif
 
 namespace hpx { namespace parallel { namespace util {
-    namespace detail {
+
+    namespace prefetching {
+
         template <typename Itr, typename... Ts>
         class prefetching_iterator
           : public std::iterator<std::random_access_iterator_tag,
@@ -268,10 +270,184 @@ namespace hpx { namespace parallel { namespace util {
 #endif
 
         ///////////////////////////////////////////////////////////////////////
-        template <typename Itr, typename... Ts>
-        struct loop<detail::prefetching_iterator<Itr, Ts...>>
+        struct loop_n_helper
         {
-            typedef detail::prefetching_iterator<Itr, Ts...> iterator_type;
+            template <typename Itr, typename... Ts, typename F, typename Pred>
+            static constexpr prefetching_iterator<Itr, Ts...> call(
+                prefetching_iterator<Itr, Ts...> it, std::size_t count, F&& f,
+                Pred)
+            {
+                using index_pack_type =
+                    typename hpx::util::make_index_pack<sizeof...(Ts)>::type;
+
+                for (/**/; count != 0; (void) --count, ++it)
+                {
+                    Itr base = it.base();
+                    std::size_t j = it.index();
+
+                    std::size_t last = (std::min)(
+                        it.index() + it.chunk_size(), it.range_size());
+
+                    for (/**/; j != last; (void) ++j, ++base)
+                    {
+                        f(base);
+                    }
+
+                    if (j != it.range_size())
+                    {
+                        prefetch_containers(it.ranges(), index_pack_type(), j);
+                    }
+                }
+                return it;
+            }
+
+            template <typename Itr, typename... Ts, typename CancelToken,
+                typename F, typename Pred>
+            static constexpr prefetching_iterator<Itr, Ts...> call(
+                prefetching_iterator<Itr, Ts...> it, std::size_t count,
+                CancelToken& tok, F&& f, Pred)
+            {
+                using index_pack_type =
+                    typename hpx::util::make_index_pack<sizeof...(Ts)>::type;
+
+                for (/**/; count != 0; (void) --count, ++it)
+                {
+                    if (tok.was_cancelled())
+                        break;
+
+                    Itr base = it.base();
+                    std::size_t j = it.index();
+
+                    std::size_t last = (std::min)(
+                        it.index() + it.chunk_size(), it.range_size());
+
+                    for (/**/; j != last; (void) ++j, ++base)
+                    {
+                        f(base);
+                    }
+
+                    if (j != it.range_size())
+                    {
+                        prefetch_containers(it.ranges(), index_pack_type(), j);
+                    }
+                }
+                return it;
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename ExPolicy, typename Itr, typename... Ts, typename F>
+        HPX_HOST_DEVICE
+            HPX_FORCEINLINE constexpr prefetching_iterator<Itr, Ts...>
+            tag_invoke(hpx::parallel::util::detail::loop_n_t<ExPolicy>,
+                prefetching_iterator<Itr, Ts...> it, std::size_t count, F&& f)
+        {
+            return loop_n_helper::call(
+                it, count, std::forward<F>(f), std::true_type());
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        struct loop_n_ind_helper
+        {
+            template <typename Itr, typename... Ts, typename F, typename Pred>
+            static constexpr prefetching_iterator<Itr, Ts...> call(
+                prefetching_iterator<Itr, Ts...> it, std::size_t count, F&& f,
+                Pred)
+            {
+                using index_pack_type =
+                    typename hpx::util::make_index_pack<sizeof...(Ts)>::type;
+
+                for (/**/; count != 0; (void) --count, ++it)
+                {
+                    Itr base = it.base();
+                    std::size_t j = it.index();
+
+                    std::size_t last = (std::min)(
+                        it.index() + it.chunk_size(), it.range_size());
+
+                    for (/**/; j != last; (void) ++j, ++base)
+                    {
+                        f(*base);
+                    }
+
+                    if (j != it.range_size())
+                    {
+                        prefetch_containers(it.ranges(), index_pack_type(), j);
+                    }
+                }
+                return it;
+            }
+
+            template <typename Itr, typename... Ts, typename CancelToken,
+                typename F, typename Pred>
+            static constexpr prefetching_iterator<Itr, Ts...> call(
+                prefetching_iterator<Itr, Ts...> it, std::size_t count,
+                CancelToken& tok, F&& f, Pred)
+            {
+                using index_pack_type =
+                    typename hpx::util::make_index_pack<sizeof...(Ts)>::type;
+
+                for (/**/; count != 0; (void) --count, ++it)
+                {
+                    if (tok.was_cancelled())
+                        break;
+
+                    Itr base = it.base();
+                    std::size_t j = it.index();
+
+                    std::size_t last = (std::min)(
+                        it.index() + it.chunk_size(), it.range_size());
+
+                    for (/**/; j != last; (void) ++j, ++base)
+                    {
+                        f(*base);
+                    }
+
+                    if (j != it.range_size())
+                    {
+                        prefetch_containers(it.ranges(), index_pack_type(), j);
+                    }
+                }
+                return it;
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename ExPolicy, typename Itr, typename... Ts, typename F>
+        HPX_HOST_DEVICE
+            HPX_FORCEINLINE constexpr prefetching_iterator<Itr, Ts...>
+            tag_invoke(hpx::parallel::util::detail::loop_n_ind_t<ExPolicy>,
+                prefetching_iterator<Itr, Ts...> it, std::size_t count, F&& f)
+        {
+            return loop_n_ind_helper::call(
+                it, count, std::forward<F>(f), std::true_type());
+        }
+    }    // namespace prefetching
+
+    ///////////////////////////////////////////////////////////////////////////
+    // function to create a prefetcher_context
+    template <typename Itr, typename... Ts>
+    prefetching::prefetcher_context<Itr, Ts const...> make_prefetcher_context(
+        Itr base_begin, Itr base_end, std::size_t p_factor, Ts const&... rngs)
+    {
+        static_assert(hpx::traits::is_random_access_iterator<Itr>::value,
+            "Iterators have to be of random access iterator category");
+        static_assert(hpx::util::all_of<hpx::traits::is_range<Ts>...>::value,
+            "All variadic parameters have to represent ranges");
+
+        using ranges_type = hpx::tuple<std::reference_wrapper<Ts const>...>;
+
+        auto&& ranges = ranges_type(std::cref(rngs)...);
+        return prefetching::prefetcher_context<Itr, Ts const...>(
+            base_begin, base_end, std::move(ranges), p_factor);
+    }
+
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Itr, typename... Ts>
+        struct loop<prefetching::prefetching_iterator<Itr, Ts...>>
+        {
+            typedef prefetching::prefetching_iterator<Itr, Ts...> iterator_type;
             typedef typename iterator_type::base_iterator type;
             typedef typename hpx::util::make_index_pack<sizeof...(Ts)>::type
                 index_pack_type;
@@ -323,9 +499,9 @@ namespace hpx { namespace parallel { namespace util {
 
         ///////////////////////////////////////////////////////////////////////
         template <typename Itr, typename... Ts>
-        struct loop_ind<detail::prefetching_iterator<Itr, Ts...>>
+        struct loop_ind<prefetching::prefetching_iterator<Itr, Ts...>>
         {
-            typedef detail::prefetching_iterator<Itr, Ts...> iterator_type;
+            typedef prefetching::prefetching_iterator<Itr, Ts...> iterator_type;
             typedef typename iterator_type::base_iterator type;
             typedef typename hpx::util::make_index_pack<sizeof...(Ts)>::type
                 index_pack_type;
@@ -355,116 +531,6 @@ namespace hpx { namespace parallel { namespace util {
                 iterator_type it, End end, CancelToken& tok, F&& f)
             {
                 for (/**/; it != end; ++it)
-                {
-                    if (tok.was_cancelled())
-                        break;
-
-                    Itr base = it.base();
-                    std::size_t j = it.index();
-
-                    std::size_t last = (std::min)(
-                        it.index() + it.chunk_size(), it.range_size());
-
-                    for (/**/; j != last; (void) ++j, ++base)
-                        f(*base);
-
-                    if (j != it.range_size())
-                        prefetch_containers(it.ranges(), index_pack_type(), j);
-                }
-                return it;
-            }
-        };
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename Itr, typename... Ts>
-        struct loop_n<detail::prefetching_iterator<Itr, Ts...>>
-        {
-            typedef detail::prefetching_iterator<Itr, Ts...> iterator_type;
-            typedef typename iterator_type::base_iterator type;
-            typedef typename hpx::util::make_index_pack<sizeof...(Ts)>::type
-                index_pack_type;
-
-            template <typename F, typename Pred>
-            static iterator_type call(
-                iterator_type it, std::size_t count, F&& f, Pred)
-            {
-                for (/**/; count != 0; (void) --count, ++it)
-                {
-                    Itr base = it.base();
-                    std::size_t j = it.index();
-
-                    std::size_t last = (std::min)(
-                        it.index() + it.chunk_size(), it.range_size());
-
-                    for (/**/; j != last; (void) ++j, ++base)
-                        f(base);
-
-                    if (j != it.range_size())
-                        prefetch_containers(it.ranges(), index_pack_type(), j);
-                }
-                return it;
-            }
-
-            template <typename CancelToken, typename F, typename Pred>
-            static iterator_type call(iterator_type it, std::size_t count,
-                CancelToken& tok, F&& f, Pred)
-            {
-                for (/**/; count != 0; (void) --count, ++it)
-                {
-                    if (tok.was_cancelled())
-                        break;
-
-                    Itr base = it.base();
-                    std::size_t j = it.index();
-
-                    std::size_t last = (std::min)(
-                        it.index() + it.chunk_size(), it.range_size());
-
-                    for (/**/; j != last; (void) ++j, ++base)
-                        f(base);
-
-                    if (j != it.range_size())
-                        prefetch_containers(it.ranges(), index_pack_type(), j);
-                }
-                return it;
-            }
-        };
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename Itr, typename... Ts>
-        struct loop_n_ind<detail::prefetching_iterator<Itr, Ts...>>
-        {
-            typedef detail::prefetching_iterator<Itr, Ts...> iterator_type;
-            typedef typename iterator_type::base_iterator type;
-            typedef typename hpx::util::make_index_pack<sizeof...(Ts)>::type
-                index_pack_type;
-
-            template <typename F, typename Pred>
-            static iterator_type call(
-                iterator_type it, std::size_t count, F&& f, Pred)
-            {
-                for (/**/; count != 0; (void) --count, ++it)
-                {
-                    Itr base = it.base();
-                    std::size_t j = it.index();
-
-                    std::size_t last = (std::min)(
-                        it.index() + it.chunk_size(), it.range_size());
-
-                    for (/**/; j != last; (void) ++j, ++base)
-                        f(*base);
-
-                    if (j != it.range_size())
-                        prefetch_containers(it.ranges(), index_pack_type(), j);
-                }
-                return it;
-            }
-
-            template <typename CancelToken, typename F, typename Pred>
-            static iterator_type call(iterator_type it, std::size_t count,
-                CancelToken& tok, F&& f, Pred)
-            {
-                for (/**/; count != 0; (void) --count, ++it)
                 {
                     if (tok.was_cancelled())
                         break;
@@ -485,22 +551,4 @@ namespace hpx { namespace parallel { namespace util {
             }
         };
     }    // namespace detail
-
-    ///////////////////////////////////////////////////////////////////////////
-    // function to create a prefetcher_context
-    template <typename Itr, typename... Ts>
-    detail::prefetcher_context<Itr, Ts const...> make_prefetcher_context(
-        Itr base_begin, Itr base_end, std::size_t p_factor, Ts const&... rngs)
-    {
-        static_assert(hpx::traits::is_random_access_iterator<Itr>::value,
-            "Iterators have to be of random access iterator category");
-        static_assert(hpx::util::all_of<hpx::traits::is_range<Ts>...>::value,
-            "All variadic parameters have to represent ranges");
-
-        typedef hpx::tuple<std::reference_wrapper<Ts const>...> ranges_type;
-
-        auto&& ranges = ranges_type(std::cref(rngs)...);
-        return detail::prefetcher_context<Itr, Ts const...>(
-            base_begin, base_end, std::move(ranges), p_factor);
-    }
-}}}    // namespace hpx::parallel::util
+}}}      // namespace hpx::parallel::util

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/prefetching.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/prefetching.hpp
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <functional>
 #include <iterator>
+#include <type_traits>
 #include <utility>
 #include <vector>
 

--- a/libs/parallelism/algorithms/tests/performance/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/performance/CMakeLists.txt
@@ -21,7 +21,8 @@ set(benchmarks
 )
 
 if(HPX_WITH_DISTRIBUTED_RUNTIME)
-  set(benchmarks ${benchmarks} transform_reduce_scaling)
+  set(benchmarks ${benchmarks} foreach_scaling transform_reduce_scaling)
+  set(foreach_scaling_FLAGS DEPENDENCIES iostreams_component)
   set(transform_reduce_scaling_FLAGS DEPENDENCIES iostreams_component)
 endif()
 

--- a/libs/parallelism/algorithms/tests/performance/foreach_scaling.cpp
+++ b/libs/parallelism/algorithms/tests/performance/foreach_scaling.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2014 Grant Mercer
+//  Copyright (c) 2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -74,16 +75,17 @@ namespace hpx { namespace parallel { namespace execution {
 ///////////////////////////////////////////////////////////////////////////////
 void measure_plain_for(std::vector<std::size_t> const& data_representation)
 {
-    std::size_t size = data_representation.size();
-    std::size_t i = 0;
-    for (/**/; i < size; i += 4)
+    std::size_t num = data_representation.size();
+
+    std::size_t size = num & std::size_t(-4);    // -V112
+    for (std::size_t i = 0; i < size; i += 4)
     {
         worker_timed(delay);
         worker_timed(delay);
         worker_timed(delay);
         worker_timed(delay);
     }
-    for (/**/; i < size; ++i)
+    for (/**/; size < num; ++size)
     {
         worker_timed(delay);
     }

--- a/libs/parallelism/algorithms/tests/performance/worker_timed.hpp
+++ b/libs/parallelism/algorithms/tests/performance/worker_timed.hpp
@@ -13,7 +13,7 @@
 
 #include <cstdint>
 
-inline void worker_timed(std::uint64_t delay_ns)
+HPX_FORCEINLINE void worker_timed(std::uint64_t delay_ns)
 {
     if (delay_ns == 0)
         return;

--- a/libs/parallelism/algorithms/tests/unit/algorithms/test_utils.hpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/test_utils.hpp
@@ -57,14 +57,15 @@ namespace test {
             base_type;
 
     public:
-        decorated_iterator() {}
+        HPX_HOST_DEVICE decorated_iterator() {}
 
-        decorated_iterator(BaseIterator base)
+        HPX_HOST_DEVICE decorated_iterator(BaseIterator base)
           : base_type(base)
         {
         }
 
-        decorated_iterator(BaseIterator base, std::function<void()> f)
+        HPX_HOST_DEVICE decorated_iterator(
+            BaseIterator base, std::function<void()> f)
           : base_type(base)
           , m_callback(f)
         {
@@ -73,7 +74,7 @@ namespace test {
     private:
         friend class hpx::util::iterator_core_access;
 
-        typename base_type::reference dereference() const
+        HPX_HOST_DEVICE typename base_type::reference dereference() const
         {
             if (m_callback)
                 m_callback();

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/detail/predicates.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/detail/predicates.hpp
@@ -166,14 +166,13 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             HPX_ASSERT(!std::is_signed<Stride>::value || !is_negative(offset));
 
             // NVCC seems to have a bug with std::min...
-            Stride count =
+            offset =
                 Stride(max_count < std::size_t(offset) ? max_count : offset);
 
             // advance through the end or max number of elements
-            for (/**/; count != 0; (void) ++iter, --count)
+            for (Stride count = offset; count != 0; (void) ++iter, --count)
                 /**/;
 
-            offset -= count;
             return iter;
         }
     };

--- a/tests/performance/local/CMakeLists.txt
+++ b/tests/performance/local/CMakeLists.txt
@@ -93,7 +93,6 @@ if(HPX_WITH_DISTRIBUTED_RUNTIME)
     APPEND
     benchmarks
     agas_cache_timings
-    foreach_scaling
     hpx_homogeneous_timed_task_spawn_executors
     hpx_heterogeneous_timed_task_spawn
     parent_vs_child_stealing
@@ -132,7 +131,6 @@ set(skynet_FLAGS DEPENDENCIES iostreams_component)
 set(wait_all_timings_FLAGS DEPENDENCIES iostreams_component)
 set(future_overhead_FLAGS DEPENDENCIES)
 set(sizeof_FLAGS DEPENDENCIES iostreams_component)
-set(foreach_scaling_FLAGS DEPENDENCIES iostreams_component)
 set(spinlock_overhead1_FLAGS DEPENDENCIES iostreams_component)
 set(spinlock_overhead2_FLAGS DEPENDENCIES iostreams_component)
 set(partitioned_vector_foreach_FLAGS DEPENDENCIES iostreams_component

--- a/tests/performance/local/foreach_scaling.cpp
+++ b/tests/performance/local/foreach_scaling.cpp
@@ -72,6 +72,33 @@ namespace hpx { namespace parallel { namespace execution {
 }}}    // namespace hpx::parallel::execution
 
 ///////////////////////////////////////////////////////////////////////////////
+void measure_plain_for(std::vector<std::size_t> const& data_representation)
+{
+    std::size_t size = data_representation.size();
+    std::size_t i = 0;
+    for (/**/; i < size; i += 4)
+    {
+        worker_timed(delay);
+        worker_timed(delay);
+        worker_timed(delay);
+        worker_timed(delay);
+    }
+    for (/**/; i < size; ++i)
+    {
+        worker_timed(delay);
+    }
+}
+
+void measure_plain_for_iter(std::vector<std::size_t> const& data_representation)
+{
+    for (auto&& v : data_representation)
+    {
+        (void) v;
+        worker_timed(delay);
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
 void measure_sequential_foreach(
     std::vector<std::size_t> const& data_representation)
 {
@@ -87,8 +114,8 @@ void measure_sequential_foreach(
     else
     {
         // invoke sequential for_each
-        hpx::ranges::for_each(hpx::execution::seq,
-            data_representation, [](std::size_t) { worker_timed(delay); });
+        hpx::ranges::for_each(hpx::execution::seq, data_representation,
+            [](std::size_t) { worker_timed(delay); });
     }
 }
 
@@ -105,8 +132,7 @@ void measure_parallel_foreach(
         disable_stealing_parameter dsp;
 
         // invoke parallel for_each
-        hpx::ranges::for_each(
-            hpx::execution::par.with(cs, dsp).on(exec),
+        hpx::ranges::for_each(hpx::execution::par.with(cs, dsp).on(exec),
             data_representation, [](std::size_t) { worker_timed(delay); });
     }
     else
@@ -132,9 +158,7 @@ hpx::future<void> measure_task_foreach(
 
         // invoke parallel for_each
         return hpx::ranges::for_each(
-            hpx::execution::par(hpx::execution::task)
-                .with(cs, dsp)
-                .on(exec),
+            hpx::execution::par(hpx::execution::task).with(cs, dsp).on(exec),
             *data_representation, [](std::size_t) { worker_timed(delay); })
             .then([data_representation](hpx::future<void>) {});
     }
@@ -142,9 +166,7 @@ hpx::future<void> measure_task_foreach(
     {
         // invoke parallel for_each
         return hpx::ranges::for_each(
-            hpx::execution::par(hpx::execution::task)
-                .with(cs)
-                .on(exec),
+            hpx::execution::par(hpx::execution::task).with(cs).on(exec),
             *data_representation, [](std::size_t) { worker_timed(delay); })
             .then([data_representation](hpx::future<void>) {});
     }
@@ -169,8 +191,8 @@ void measure_sequential_forloop(
     else
     {
         // invoke sequential for_loop
-        hpx::for_loop(hpx::execution::seq,
-            std::begin(data_representation), std::end(data_representation),
+        hpx::for_loop(hpx::execution::seq, std::begin(data_representation),
+            std::end(data_representation),
             [](iterator) { worker_timed(delay); });
     }
 }
@@ -220,9 +242,7 @@ hpx::future<void> measure_task_forloop(
 
         // invoke parallel for_looph
         return hpx::for_loop(
-            hpx::execution::par(hpx::execution::task)
-                .with(cs, dsp)
-                .on(exec),
+            hpx::execution::par(hpx::execution::task).with(cs, dsp).on(exec),
             std::begin(*data_representation), std::end(*data_representation),
             [](iterator) { worker_timed(delay); })
             .then([data_representation](hpx::future<void>) {});
@@ -231,13 +251,46 @@ hpx::future<void> measure_task_forloop(
     {
         // invoke parallel for_looph
         return hpx::for_loop(
-            hpx::execution::par(hpx::execution::task)
-                .with(cs)
-                .on(exec),
+            hpx::execution::par(hpx::execution::task).with(cs).on(exec),
             std::begin(*data_representation), std::end(*data_representation),
             [](iterator) { worker_timed(delay); })
             .then([data_representation](hpx::future<void>) {});
     }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+std::uint64_t averageout_plain_for(std::size_t vector_size)
+{
+    std::vector<std::size_t> data_representation(vector_size);
+    std::iota(
+        std::begin(data_representation), std::end(data_representation), gen());
+
+    std::uint64_t start = hpx::chrono::high_resolution_clock::now();
+
+    // average out 100 executions to avoid varying results
+    for (auto i = 0; i < test_count; i++)
+    {
+        measure_plain_for(data_representation);
+    }
+
+    return (hpx::chrono::high_resolution_clock::now() - start) / test_count;
+}
+
+std::uint64_t averageout_plain_for_iter(std::size_t vector_size)
+{
+    std::vector<std::size_t> data_representation(vector_size);
+    std::iota(
+        std::begin(data_representation), std::end(data_representation), gen());
+
+    std::uint64_t start = hpx::chrono::high_resolution_clock::now();
+
+    // average out 100 executions to avoid varying results
+    for (auto i = 0; i < test_count; i++)
+    {
+        measure_plain_for_iter(data_representation);
+    }
+
+    return (hpx::chrono::high_resolution_clock::now() - start) / test_count;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -385,13 +438,21 @@ int hpx_main(hpx::program_options::variables_map& vm)
 {
     // pull values from cmd
     std::size_t vector_size = vm["vector_size"].as<std::size_t>();
-    bool csvoutput = vm["csv_output"].as<int>() ? true : false;
+    bool csvoutput = vm.count("csv_output") != 0;
     delay = vm["work_delay"].as<int>();
     test_count = vm["test_count"].as<int>();
     chunk_size = vm["chunk_size"].as<int>();
     num_overlapping_loops = vm["overlapping_loops"].as<int>();
     disable_stealing = vm.count("disable_stealing");
     fast_idle_mode = vm.count("fast_idle_mode");
+
+    bool enable_all = vm.count("enable_all");
+    if (!vm.count("parallel_foreach") && !vm.count("task_foreach") &&
+        !vm.count("sequential_foreach") && !vm.count("parallel_forloop") &&
+        !vm.count("task_forloop") && !vm.count("sequential_forloop"))
+    {
+        enable_all = true;
+    }
 
     // verify that input is within domain of program
     if (test_count == 0 || test_count < 0)
@@ -416,37 +477,81 @@ int hpx_main(hpx::program_options::variables_map& vm)
         }
 
         // results
-        std::uint64_t par_time_foreach;
-        std::uint64_t task_time_foreach;
-        std::uint64_t seq_time_foreach;
+        std::uint64_t par_time_foreach = 0;
+        std::uint64_t task_time_foreach = 0;
+        std::uint64_t seq_time_foreach = 0;
 
-        std::uint64_t par_time_forloop;
-        std::uint64_t task_time_forloop;
-        std::uint64_t seq_time_forloop;
+        std::uint64_t par_time_forloop = 0;
+        std::uint64_t task_time_forloop = 0;
+        std::uint64_t seq_time_forloop = 0;
+
+        std::uint64_t plain_time_for = averageout_plain_for(vector_size);
+        std::uint64_t plain_time_for_iter =
+            averageout_plain_for_iter(vector_size);
 
         if (vm.count("aggregated") != 0)
         {
             hpx::parallel::execution::parallel_executor_aggregated par;
 
-            par_time_foreach = averageout_parallel_foreach(vector_size, par);
-            task_time_foreach = averageout_task_foreach(vector_size, par);
-            seq_time_foreach = averageout_sequential_foreach(vector_size);
+            if (enable_all || vm.count("parallel_foreach"))
+            {
+                par_time_foreach =
+                    averageout_parallel_foreach(vector_size, par);
+            }
+            if (enable_all || vm.count("task_foreach"))
+            {
+                task_time_foreach = averageout_task_foreach(vector_size, par);
+            }
+            if (enable_all || vm.count("sequential_foreach"))
+            {
+                seq_time_foreach = averageout_sequential_foreach(vector_size);
+            }
 
-            par_time_forloop = averageout_parallel_forloop(vector_size, par);
-            task_time_forloop = averageout_task_forloop(vector_size, par);
-            seq_time_forloop = averageout_sequential_forloop(vector_size);
+            if (enable_all || vm.count("parallel_forloop"))
+            {
+                par_time_forloop =
+                    averageout_parallel_forloop(vector_size, par);
+            }
+            if (enable_all || vm.count("task_forloop"))
+            {
+                task_time_forloop = averageout_task_forloop(vector_size, par);
+            }
+            if (enable_all || vm.count("sequential_forloop"))
+            {
+                seq_time_forloop = averageout_sequential_forloop(vector_size);
+            }
         }
         else
         {
             hpx::execution::parallel_executor par;
 
-            par_time_foreach = averageout_parallel_foreach(vector_size, par);
-            task_time_foreach = averageout_task_foreach(vector_size, par);
-            seq_time_foreach = averageout_sequential_foreach(vector_size);
+            if (enable_all || vm.count("parallel_foreach"))
+            {
+                par_time_foreach =
+                    averageout_parallel_foreach(vector_size, par);
+            }
+            if (enable_all || vm.count("task_foreach"))
+            {
+                task_time_foreach = averageout_task_foreach(vector_size, par);
+            }
+            if (enable_all || vm.count("sequential_foreach"))
+            {
+                seq_time_foreach = averageout_sequential_foreach(vector_size);
+            }
 
-            par_time_forloop = averageout_parallel_forloop(vector_size, par);
-            task_time_forloop = averageout_task_forloop(vector_size, par);
-            seq_time_forloop = averageout_sequential_forloop(vector_size);
+            if (enable_all || vm.count("parallel_forloop"))
+            {
+                par_time_forloop =
+                    averageout_parallel_forloop(vector_size, par);
+            }
+            if (enable_all || vm.count("task_forloop"))
+            {
+                task_time_forloop = averageout_task_forloop(vector_size, par);
+            }
+            if (enable_all || vm.count("sequential_forloop"))
+            {
+                seq_time_forloop = averageout_sequential_forloop(vector_size);
+            }
         }
 
         if (disable_stealing)
@@ -473,57 +578,72 @@ int hpx_main(hpx::program_options::variables_map& vm)
             // right justified
             hpx::cout << std::left
                       << "----------------Parameters---------------------\n"
-                      << std::left << "Vector size: " << std::right
-                      << std::setw(30) << vector_size << "\n"
-                      << std::left << "Number of tests" << std::right
-                      << std::setw(28) << test_count << "\n"
-                      << std::left << "Delay per iteration(nanoseconds)"
-                      << std::right << std::setw(11) << delay << "\n"
-                      << std::left << "Display time in: " << std::right
-                      << std::setw(27) << "Seconds\n"
+                      << std::left
+                      << "Vector size                       : " << std::right
+                      << std::setw(8) << vector_size << "\n"
+                      << std::left
+                      << "Number of tests                   : " << std::right
+                      << std::setw(8) << test_count << "\n"
+                      << std::left
+                      << "Delay per iteration (nanoseconds) : " << std::right
+                      << std::setw(8) << delay << "\n"
+                      << std::left
+                      << "Display time in                   : " << std::right
+                      << std::setw(8) << "Seconds\n"
                       << hpx::flush;
+
+            hpx::cout << "-------------Average-(for)---------------------\n"
+                      << std::left
+                      << "Average execution time (unrolled) : " << std::right
+                      << std::setw(8) << plain_time_for / 1e9 << "\n"
+                      << std::left
+                      << "Average execution time (iter)     : " << std::right
+                      << std::setw(8) << plain_time_for_iter / 1e9 << "\n";
 
             hpx::cout << "-------------Average-(for_each)----------------\n"
                       << std::left
-                      << "Average parallel execution time  : " << std::right
+                      << "Average parallel execution time   : " << std::right
                       << std::setw(8) << par_time_foreach / 1e9 << "\n"
                       << std::left
-                      << "Average task execution time      : " << std::right
+                      << "Average task execution time       : " << std::right
                       << std::setw(8) << task_time_foreach / 1e9 << "\n"
                       << std::left
-                      << "Average sequential execution time: " << std::right
+                      << "Average sequential execution time : " << std::right
                       << std::setw(8) << seq_time_foreach / 1e9 << "\n"
                       << hpx::flush;
 
             hpx::cout << "-----Execution Time Difference-(for_each)------\n"
-                      << std::left << "Parallel Scale: " << std::right
-                      << std::setw(27)
+                      << std::left
+                      << "Parallel Scale                    : " << std::right
+                      << std::setw(8)
                       << (double(seq_time_foreach) / par_time_foreach) << "\n"
-                      << std::left << "Task Scale    : " << std::right
-                      << std::setw(27)
+                      << std::left
+                      << "Task Scale                        : " << std::right
+                      << std::setw(8)
                       << (double(seq_time_foreach) / task_time_foreach) << "\n"
                       << hpx::flush;
 
             hpx::cout << "-------------Average-(for_loop)----------------\n"
                       << std::left
-                      << "Average parallel execution time  : " << std::right
+                      << "Average parallel execution time   : " << std::right
                       << std::setw(8) << par_time_forloop / 1e9 << "\n"
                       << std::left
-                      << "Average task execution time      : " << std::right
+                      << "Average task execution time       : " << std::right
                       << std::setw(8) << task_time_forloop / 1e9 << "\n"
                       << std::left
-                      << "Average sequential execution time: " << std::right
+                      << "Average sequential execution time : " << std::right
                       << std::setw(8) << seq_time_forloop / 1e9 << "\n"
                       << hpx::flush;
 
             hpx::cout << "-----Execution Time Difference-(for_loop)------\n"
-                      << std::left << "Parallel Scale: " << std::right
-                      << std::setw(27)
+                      << std::left
+                      << "Parallel Scale                    : " << std::right
+                      << std::setw(8)
                       << (double(seq_time_forloop) / par_time_forloop) << "\n"
-                      << std::left << "Task Scale    : " << std::right
-                      << std::setw(27)
-                      << (double(seq_time_forloop) / task_time_forloop) << "\n"
-                      << hpx::flush;
+                      << std::left
+                      << "Task Scale                        : " << std::right
+                      << std::setw(8)
+                      << (double(seq_time_forloop) / task_time_forloop) << "\n";
         }
     }
 
@@ -536,43 +656,34 @@ int main(int argc, char* argv[])
     //initialize program
     std::vector<std::string> const cfg = {"hpx.os_threads=all"};
 
-    hpx::program_options::options_description cmdline(
-        "usage: " HPX_APPLICATION_STRING " [options]");
+    using namespace hpx::program_options;
+
+    options_description cmdline("usage: " HPX_APPLICATION_STRING " [options]");
 
     // clang-format off
     cmdline.add_options()
-        ( "vector_size"
-        , hpx::program_options::value<std::size_t>()->default_value(1000)
-        , "size of vector")
+        ("vector_size", value<std::size_t>()->default_value(1000),
+            "size of vector")
+        ("work_delay", value<int>()->default_value(1),
+            "loop delay per element in nanoseconds")
+        ("test_count", value<int>()->default_value(100),
+            "number of tests to be averaged")
+        ("chunk_size", value<int>()->default_value(0),
+            "number of iterations to combine while parallelization")
+        ("overlapping_loops", value<int>()->default_value(0),
+            "number of overlapping task loops")
+        ("csv_output", "print results in csv format")
+        ("aggregated", "use aggregated executor")
+        ("disable_stealing", "disable thread stealing")
+        ("fast_idle_mode", "enable fast idle mode")
 
-        ("work_delay"
-        , hpx::program_options::value<int>()->default_value(1)
-        , "loop delay per element in nanoseconds")
-
-        ("test_count"
-        , hpx::program_options::value<int>()->default_value(100)
-        , "number of tests to be averaged")
-
-        ("chunk_size"
-        , hpx::program_options::value<int>()->default_value(0)
-        , "number of iterations to combine while parallelization")
-
-        ("overlapping_loops"
-        , hpx::program_options::value<int>()->default_value(0)
-        , "number of overlapping task loops")
-
-        ("csv_output"
-        , hpx::program_options::value<int>()->default_value(0)
-        ,"print results in csv format")
-
-        ("aggregated"
-        ,"use aggregated executor")
-
-        ("disable_stealing"
-        ,"disable thread stealing")
-
-        ("fast_idle_mode"
-        ,"enable fast idle mode")
+        ("enable_all", "enable all benchmarks")
+        ("parallel_foreach", "enable parallel_foreach")
+        ("task_foreach", "enable task_foreach")
+        ("sequential_foreach", "enable sequential_foreach")
+        ("parallel_forloop", "enable parallel_forloop")
+        ("task_forloop", "enable task_forloop")
+        ("sequential_forloop", "enable sequential_forloop")
         ;
     // clang-format on
 

--- a/tests/performance/local/worker_timed.hpp
+++ b/tests/performance/local/worker_timed.hpp
@@ -13,7 +13,7 @@
 
 #include <cstdint>
 
-inline void worker_timed(std::uint64_t delay_ns)
+HPX_FORCEINLINE void worker_timed(std::uint64_t delay_ns) noexcept
 {
     if (delay_ns == 0)
         return;


### PR DESCRIPTION
foreach_scaling_test on 10 cores:
```
----------------Parameters---------------------
Vector size:                       10000000
Number of tests                          10
Delay per iteration(nanoseconds)          0
Display time in:                    Seconds
-------------Average-(for)---------------------
Average execution time           : 0.00880673
Average execution time (iter)    : 0.00880363
-------------Average-(for_each)----------------
Average parallel execution time  : 0.00085571
Average task execution time      : 0.00067213
Average sequential execution time: 0.00537611
-----Execution Time Difference-(for_each)------
Parallel Scale:                     6.28263
Task Scale    :                     7.99862
-------------Average-(for_loop)----------------
Average parallel execution time  : 0.00059376
Average task execution time      : 0.00060955
Average sequential execution time: 0.00485463
-----Execution Time Difference-(for_loop)------
Parallel Scale:                     8.17608
Task Scale    :                     7.96429
```
Simple sequential `hpx::for_each` and `hpx::for_loop` are now almost twice as fast as plain equivalent `for()`