### PR TITLE
Use old Piz Daint modules after upgrade

### DIFF
--- a/.jenkins/cscs/env-clang-cuda.sh
+++ b/.jenkins/cscs/env-clang-cuda.sh
@@ -13,7 +13,8 @@ export BOOST_ROOT="${APPS_ROOT}/boost-1.73.0-gcc-8.3.0-c++17-release"
 export HWLOC_ROOT="${APPS_ROOT}/hwloc-2.0.3-gcc-8.3.0"
 
 module load daint-gpu
-module load cudatoolkit
+module load cudatoolkit/10.2.89_3.29-7.0.2.1_3.5__g67354b4
+module switch cce cce/10.0.2
 spack load cmake
 spack load ninja
 

--- a/.jenkins/cscs/env-gcc-cuda.sh
+++ b/.jenkins/cscs/env-gcc-cuda.sh
@@ -9,6 +9,10 @@ source $SPACK_ROOT/share/spack/setup-env.sh
 export CRAYPE_LINK_TYPE=dynamic
 export CXX_STD="14"
 
+# This makes deprecated modules available. This should be removed when a newer
+# Boost is available on CrayGNU-20.11.
+module use /apps/daint/UES/jenkins/7.0.UP02/gpu/easybuild/modules/all
+
 module load daint-gpu
 module switch PrgEnv-cray PrgEnv-gnu
 module load cudatoolkit


### PR DESCRIPTION
This reverts to use (some of) the old defaults on Piz Daint from before the upgrade this week.

The cray clang compiler was updated to be based on clang 11 (instead of 10), and the new compiler does not like to link one of our CUDA tests that needs to be looked into separately.

In case it sounds familiar to someone, it does not find a `__global__` CUDA function compiled in a separate translation unit. My attempts at enabling relocatable device code did not help. @G-071 pinging you since I think this is exactly the same issue you had trying to compile octotiger.