### PR TITLE
Banish <iostream> from library headers

### DIFF
--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_component_impl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_component_impl.hpp
@@ -24,7 +24,6 @@
 #include <hpx/components/containers/partitioned_vector/partitioned_vector_decl.hpp>
 
 #include <cstddef>
-#include <iostream>
 #include <memory>
 #include <string>
 #include <tuple>

--- a/components/containers/unordered/include/hpx/components/containers/unordered/partition_unordered_map_component.hpp
+++ b/components/containers/unordered/include/hpx/components/containers/unordered/partition_unordered_map_component.hpp
@@ -38,7 +38,6 @@
 #include <hpx/type_support/unused.hpp>
 
 #include <cstddef>
-#include <iostream>
 #include <memory>
 #include <string>
 #include <tuple>

--- a/components/iostreams/include/hpx/components/iostreams/ostream.hpp
+++ b/components/iostreams/include/hpx/components/iostreams/ostream.hpp
@@ -23,9 +23,9 @@
 #include <atomic>
 #include <cstdint>
 #include <ios>
-#include <iostream>
 #include <iterator>
 #include <mutex>
+#include <ostream>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -91,14 +91,18 @@ namespace hpx { namespace iostreams
         };
 
         ///////////////////////////////////////////////////////////////////////
+        std::ostream& get_coutstream() noexcept;
+
         inline std::ostream& get_outstream(cout_tag)
         {
-            return std::cout;
+            return get_coutstream();
         }
+
+        std::ostream& get_cerrstream() noexcept;
 
         inline std::ostream& get_outstream(cerr_tag)
         {
-            return std::cerr;
+            return get_cerrstream();
         }
 
         std::stringstream& get_consolestream();

--- a/components/iostreams/src/standard_streams.cpp
+++ b/components/iostreams/src/standard_streams.cpp
@@ -19,6 +19,7 @@
 #include <hpx/components/iostreams/standard_streams.hpp>
 
 #include <functional>
+#include <iostream>
 #include <sstream>
 #include <string>
 #include <type_traits>
@@ -26,6 +27,16 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace iostreams { namespace detail
 {
+    std::ostream& get_coutstream() noexcept
+    {
+        return std::cout;
+    }
+
+    std::ostream& get_cerrstream() noexcept
+    {
+        return std::cerr;
+    }
+
     std::stringstream& get_consolestream()
     {
         static std::stringstream console_stream;

--- a/components/performance_counters/memory/src/mem_counter_linux.cpp
+++ b/components/performance_counters/memory/src/mem_counter_linux.cpp
@@ -28,7 +28,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <fstream>
-#include <iostream>
 #include <iterator>
 #include <string>
 #include <vector>

--- a/components/process/include/hpx/components/process/util/posix/wait_for_exit.hpp
+++ b/components/process/include/hpx/components/process/util/posix/wait_for_exit.hpp
@@ -18,8 +18,6 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
-#include <iostream>
-
 namespace hpx { namespace components { namespace process { namespace posix {
 
 template <class Process>

--- a/libs/core/assertion/src/source_location.cpp
+++ b/libs/core/assertion/src/source_location.cpp
@@ -6,7 +6,7 @@
 
 #include <hpx/assertion/source_location.hpp>
 
-#include <iostream>
+#include <ostream>
 
 namespace hpx { namespace assertion {
     std::ostream& operator<<(std::ostream& os, source_location const& loc)

--- a/libs/core/config_registry/src/config_registry.cpp
+++ b/libs/core/config_registry/src/config_registry.cpp
@@ -7,8 +7,6 @@
 
 #include <hpx/modules/config_registry.hpp>
 
-#include <iostream>
-#include <string>
 #include <vector>
 
 namespace hpx { namespace config_registry {

--- a/libs/core/coroutines/include/hpx/coroutines/thread_enums.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/thread_enums.hpp
@@ -13,7 +13,7 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <iostream>
+#include <ostream>
 
 namespace hpx { namespace threads {
 

--- a/libs/core/errors/src/exception.cpp
+++ b/libs/core/errors/src/exception.cpp
@@ -25,9 +25,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <exception>
-#include <iostream>
 #include <memory>
-#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <system_error>

--- a/libs/core/execution_base/src/agent_ref.cpp
+++ b/libs/core/execution_base/src/agent_ref.cpp
@@ -13,7 +13,7 @@
 #include <hpx/modules/format.hpp>
 
 #include <cstddef>
-#include <iostream>
+#include <ostream>
 
 namespace hpx { namespace execution_base {
 

--- a/libs/core/plugin/include/hpx/plugin/detail/dll_dlopen.hpp
+++ b/libs/core/plugin/include/hpx/plugin/detail/dll_dlopen.hpp
@@ -12,7 +12,6 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/filesystem.hpp>
 
-#include <iostream>
 #include <memory>
 #include <mutex>
 #include <sstream>
@@ -291,7 +290,6 @@ namespace hpx { namespace util { namespace plugin {
                 ::dlerror();    // Clear the error state.
                 dll_handle = MyLoadLibrary(
                     (dll_name.empty() ? nullptr : dll_name.c_str()));
-                // std::cout << "open\n";
                 if (!dll_handle)
                 {
                     std::ostringstream str;
@@ -356,8 +354,6 @@ namespace hpx { namespace util { namespace plugin {
                             ((intptr_t) probe_handle & (-4)))
                         {
                             result = path(image_name).parent_path().string();
-                            std::cout << "found directory: " << result
-                                      << std::endl;
                             break;
                         }
                     }

--- a/libs/core/plugin/include/hpx/plugin/detail/dll_windows.hpp
+++ b/libs/core/plugin/include/hpx/plugin/detail/dll_windows.hpp
@@ -12,7 +12,6 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/filesystem.hpp>
 
-#include <iostream>
 #include <sstream>
 #include <stdexcept>
 #include <string>

--- a/libs/core/serialization/include/hpx/serialization/basic_archive.hpp
+++ b/libs/core/serialization/include/hpx/serialization/basic_archive.hpp
@@ -14,7 +14,6 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <iostream>
 #include <map>
 #include <type_traits>
 #include <utility>

--- a/libs/core/testing/include/hpx/modules/testing.hpp
+++ b/libs/core/testing/include/hpx/modules/testing.hpp
@@ -21,8 +21,8 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
-#include <iostream>
 #include <mutex>
+#include <ostream>
 #include <sstream>
 
 namespace hpx { namespace util {
@@ -178,7 +178,8 @@ namespace hpx { namespace util {
     }    // namespace detail
 
     ////////////////////////////////////////////////////////////////////////////
-    HPX_CORE_EXPORT int report_errors(std::ostream& stream = std::cerr);
+    HPX_CORE_EXPORT int report_errors();
+    HPX_CORE_EXPORT int report_errors(std::ostream& stream);
     HPX_CORE_EXPORT void print_cdash_timing(const char* name, double time);
     HPX_CORE_EXPORT void print_cdash_timing(
         const char* name, std::uint64_t time);

--- a/libs/core/testing/src/testing.cpp
+++ b/libs/core/testing/src/testing.cpp
@@ -71,6 +71,11 @@ namespace hpx { namespace util {
     }    // namespace detail
 
     ////////////////////////////////////////////////////////////////////////////
+    int report_errors()
+    {
+        return report_errors(std::cerr);
+    }
+
     int report_errors(std::ostream& stream)
     {
         std::size_t sanity = detail::global_fixture.get(counter_sanity),

--- a/libs/core/threading_base/src/thread_description.cpp
+++ b/libs/core/threading_base/src/thread_description.cpp
@@ -11,7 +11,7 @@
 #include <hpx/type_support/unused.hpp>
 #include <hpx/util/to_string.hpp>
 
-#include <iostream>
+#include <ostream>
 #include <sstream>
 #include <string>
 

--- a/libs/full/components_base/include/hpx/components_base/server/wrapper_heap_list.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/wrapper_heap_list.hpp
@@ -12,7 +12,6 @@
 #include <hpx/naming_base/id_type.hpp>
 #include <hpx/thread_support/unlock_guard.hpp>
 
-#include <iostream>
 #include <type_traits>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/components_base/src/address_ostream.cpp
+++ b/libs/full/components_base/src/address_ostream.cpp
@@ -9,7 +9,7 @@
 #include <hpx/util/ios_flags_saver.hpp>
 
 #include <iomanip>
-#include <iostream>
+#include <ostream>
 
 namespace hpx { namespace naming {
 

--- a/libs/full/compute/include/hpx/compute/host/numa_binding_allocator.hpp
+++ b/libs/full/compute/include/hpx/compute/host/numa_binding_allocator.hpp
@@ -17,20 +17,19 @@
 #include <hpx/runtime_local/thread_pool_helpers.hpp>
 #include <hpx/topology/topology.hpp>
 
+#include <cstddef>
+#include <memory>
 #include <sstream>
 #include <string>
-#include <vector>
-
-#include <cstddef>
-#include <iostream>
-#include <memory>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 #if defined(__linux) || defined(linux) || defined(__linux__)
 #include <linux/unistd.h>
 #include <sys/mman.h>
 #define NUMA_ALLOCATOR_LINUX
+#include <iostream>
 #endif
 
 // Can be used to enable debugging of the allocator page mapping
@@ -379,7 +378,6 @@ namespace hpx { namespace compute { namespace host {
                 {
                     return status[0];
                 }
-                // if (status[0]<0) std::cout << "." << decnumber(status[0]) << ".";
                 return -1;
             }
             HPX_THROW_EXCEPTION(kernel_error, "get_numa_domain",

--- a/libs/full/naming_base/src/gid_type.cpp
+++ b/libs/full/naming_base/src/gid_type.cpp
@@ -15,9 +15,9 @@
 #include <cstdint>
 #include <functional>
 #include <iomanip>
-#include <iostream>
 #include <memory>
 #include <mutex>
+#include <ostream>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/libs/full/naming_base/src/id_type.cpp
+++ b/libs/full/naming_base/src/id_type.cpp
@@ -10,7 +10,7 @@
 #include <hpx/naming_base/id_type.hpp>
 
 #include <iomanip>
-#include <iostream>
+#include <ostream>
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/program_options/src/cmdline.cpp
+++ b/libs/full/program_options/src/cmdline.cpp
@@ -20,7 +20,6 @@
 #include <cstdio>
 #include <cstring>
 #include <functional>
-#include <iostream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/libs/full/program_options/src/config_file.cpp
+++ b/libs/full/program_options/src/config_file.cpp
@@ -13,7 +13,6 @@
 #include <hpx/program_options/errors.hpp>
 
 #include <fstream>
-#include <iostream>
 #include <set>
 #include <string>
 

--- a/libs/full/program_options/src/convert.cpp
+++ b/libs/full/program_options/src/convert.cpp
@@ -12,7 +12,6 @@
 
 #include <fstream>
 #include <functional>
-#include <iostream>
 #include <locale.h>
 #include <locale>
 #include <stdexcept>

--- a/libs/full/program_options/src/parsers.cpp
+++ b/libs/full/program_options/src/parsers.cpp
@@ -20,7 +20,6 @@
 #include <cctype>
 #include <fstream>
 #include <functional>
-#include <iostream>
 #include <string>
 #include <utility>
 

--- a/libs/full/runtime_configuration/include/hpx/runtime_configuration/ini.hpp
+++ b/libs/full/runtime_configuration/include/hpx/runtime_configuration/ini.hpp
@@ -14,9 +14,9 @@
 #include <hpx/serialization/serialization_fwd.hpp>
 #include <hpx/util/to_string.hpp>
 
-#include <iostream>
 #include <map>
 #include <mutex>
+#include <ostream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -134,7 +134,8 @@ namespace hpx { namespace util {
         void read(std::string const& filename);
         void merge(std::string const& second);
         void merge(section& second);
-        void dump(int ind = 0, std::ostream& strm = std::cout) const;
+        void dump(int ind = 0) const;
+        void dump(int ind, std::ostream& strm) const;
 
         void add_section(
             std::string const& sec_name, section& sec, section* root = nullptr)

--- a/libs/full/runtime_configuration/src/ini.cpp
+++ b/libs/full/runtime_configuration/src/ini.cpp
@@ -694,6 +694,11 @@ namespace hpx { namespace util {
             strm << "  ";
     }
 
+    void section::dump(int ind) const
+    {
+        return dump(ind, std::cout);
+    }
+
     void section::dump(int ind, std::ostream& strm) const
     {
         std::unique_lock<mutex_type> l(mtx_);

--- a/libs/full/thread_executors/src/thread_pool_os_executors.cpp
+++ b/libs/full/thread_executors/src/thread_pool_os_executors.cpp
@@ -26,7 +26,6 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
-#include <iostream>
 #include <memory>
 #include <mutex>
 #include <string>

--- a/libs/parallelism/executors/include/hpx/executors/limiting_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/limiting_executor.hpp
@@ -18,7 +18,6 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
-#include <iostream>
 #include <string>
 #include <type_traits>
 #include <utility>


### PR DESCRIPTION
This header adds the global std::cin/cout/cerr and wide counterparts to the users' translation unit.