### PR TITLE
Future/sender adapters

### DIFF
--- a/libs/parallelism/execution/CMakeLists.txt
+++ b/libs/parallelism/execution/CMakeLists.txt
@@ -23,6 +23,7 @@ set(execution_headers
     hpx/execution/detail/post_policy_dispatch.hpp
     hpx/execution/detail/sync_launch_policy_dispatch.hpp
     hpx/execution/execution.hpp
+    hpx/execution/sender_future.hpp
     hpx/execution/executor_parameters.hpp
     hpx/execution/executors/auto_chunk_size.hpp
     hpx/execution/executors/dynamic_chunk_size.hpp

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/detail/single_result.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/detail/single_result.hpp
@@ -15,79 +15,54 @@ namespace hpx {
         namespace experimental {
             namespace detail {
     template <typename Variants>
-    struct sync_wait_single_result
+    struct single_result
     {
         static_assert(sizeof(Variants) == 0,
-            "sync_wait expects the predecessor sender to have a single variant "
-            "with a single type in sender_traits<>::value_types");
+            "expected a single variant with a single type in "
+            "sender_traits<>::value_types");
     };
 
     template <>
-    struct sync_wait_single_result<hpx::util::pack<hpx::util::pack<>>>
+    struct single_result<hpx::util::pack<hpx::util::pack<>>>
     {
         using type = void;
     };
 
     template <typename T>
-    struct sync_wait_single_result<hpx::util::pack<hpx::util::pack<T>>>
+    struct single_result<hpx::util::pack<hpx::util::pack<T>>>
     {
         using type = T;
     };
 
     template <typename T, typename U, typename... Ts>
-    struct sync_wait_single_result<
-        hpx::util::pack<hpx::util::pack<T, U, Ts...>>>
+    struct single_result<hpx::util::pack<hpx::util::pack<T, U, Ts...>>>
     {
         static_assert(sizeof(T) == 0,
-            "sync_wait expects the predecessor sender to have a single variant "
-            "with a single type in sender_traits<>::value_types (single "
-            "variant with two or more types given)");
+            "expected a single variant with a single type in "
+            "sender_traits<>::value_types (single variant with two or more "
+            "types given)");
     };
 
     template <typename T, typename U, typename... Ts>
-    struct sync_wait_single_result<hpx::util::pack<T, U, Ts...>>
+    struct single_result<hpx::util::pack<T, U, Ts...>>
     {
         static_assert(sizeof(T) == 0,
-            "sync_wait expects the predecessor sender to have a single variant "
-            "with a single type in sender_traits<>::value_types (two or more "
-            "variants given)");
+            "expected a single variant with a single type in "
+            "sender_traits<>::value_types (two or more variants)");
     };
 
     template <typename Variants>
-    struct when_all_single_result
+    using single_result_t = typename single_result<Variants>::type;
+
+    template <typename Variants>
+    struct single_result_non_void
     {
-        static_assert(sizeof(Variants) == 0,
-            "when_all expects the predecessor sender to have a single variant "
-            "with a single non-void type in sender_traits<>::value_types");
+        using type = typename single_result<Variants>::type;
+        static_assert(!std::is_void<type>::value,
+            "expected a non-void type in single_result");
     };
 
-    template <typename T>
-    struct when_all_single_result<hpx::util::pack<hpx::util::pack<T>>>
-    {
-        static_assert(!std::is_void<T>::value,
-            "when_all expects the predecessor sender to have a single variant "
-            "with a single non-void type in sender_traits<>::value_types (void "
-            "given)");
-
-        using type = T;
-    };
-
-    template <typename T, typename U, typename... Ts>
-    struct when_all_single_result<hpx::util::pack<hpx::util::pack<T, U, Ts...>>>
-    {
-        static_assert(sizeof(T) == 0,
-            "when_all expects the predecessor sender to have a single variant "
-            "with a single non-void type in sender_traits<>::value_types "
-            "(single variant with two or more types given)");
-    };
-
-    template <typename T, typename U, typename... Ts>
-    struct when_all_single_result<hpx::util::pack<T, U, Ts...>>
-    {
-        static_assert(sizeof(T) == 0,
-            "when_all expects the predecessor sender to have a single variant "
-            "with a single non-void type in sender_traits<>::value_types (two "
-            "or more "
-            "variants given)");
-    };
+    template <typename Variants>
+    using single_result_non_void_t =
+        typename single_result_non_void<Variants>::type;
 }}}}    // namespace hpx::execution::experimental::detail

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/sync_wait.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/sync_wait.hpp
@@ -135,8 +135,7 @@ namespace hpx { namespace execution { namespace experimental {
             using value_types =
                 typename hpx::execution::experimental::sender_traits<
                     S>::template value_types<hpx::util::pack, hpx::util::pack>;
-            using result_type =
-                typename sync_wait_single_result<value_types>::type;
+            using result_type = std::decay_t<single_result_t<value_types>>;
             using state_type =
                 typename detail::sync_wait_receiver<result_type>::state;
 
@@ -175,8 +174,7 @@ namespace hpx { namespace execution { namespace experimental {
             using value_types =
                 typename hpx::execution::experimental::sender_traits<
                     S>::template value_types<hpx::util::pack, hpx::util::pack>;
-            using result_type =
-                typename detail::sync_wait_single_result<value_types>::type;
+            using result_type = detail::single_result_t<value_types>;
 
             return detail::sync_wait_impl(
                 std::is_void<result_type>{}, std::forward<S>(s));

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/when_all.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/when_all.hpp
@@ -102,8 +102,7 @@ namespace hpx { namespace execution { namespace experimental {
                     typename hpx::execution::experimental::sender_traits<
                         Sender>::template value_types<hpx::util::pack,
                         hpx::util::pack>;
-                using type =
-                    typename detail::when_all_single_result<value_types>::type;
+                using type = detail::single_result_non_void_t<value_types>;
             };
 
             template <template <typename...> class Tuple,

--- a/libs/parallelism/execution/include/hpx/execution/sender_future.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/sender_future.hpp
@@ -1,0 +1,139 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/allocator_support/allocator_deleter.hpp>
+#include <hpx/allocator_support/internal_allocator.hpp>
+#include <hpx/execution/algorithms/detail/single_result.hpp>
+#include <hpx/execution_base/operation_state.hpp>
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/functional/invoke_result.hpp>
+#include <hpx/futures/detail/future_data.hpp>
+#include <hpx/futures/promise.hpp>
+#include <hpx/modules/memory.hpp>
+#include <hpx/type_support/pack.hpp>
+#include <hpx/type_support/unused.hpp>
+
+#include <exception>
+#include <memory>
+#include <utility>
+
+namespace hpx { namespace execution { namespace experimental {
+    namespace detail {
+        template <typename T, typename Allocator>
+        struct make_future_receiver
+        {
+            hpx::intrusive_ptr<
+                hpx::lcos::detail::future_data_allocator<T, Allocator>>
+                data;
+
+            void set_error(std::exception_ptr e) noexcept
+            {
+                data->set_exception(e);
+                data.reset();
+            }
+
+            void set_done() noexcept
+            {
+                std::terminate();
+            }
+
+            template <typename U>
+            void set_value(U&& u) noexcept
+            {
+                data->set_value(std::forward<U>(u));
+                data.reset();
+            }
+        };
+
+        template <typename Allocator>
+        struct make_future_receiver<void, Allocator>
+        {
+            hpx::intrusive_ptr<
+                hpx::lcos::detail::future_data_allocator<void, Allocator>>
+                data;
+
+            void set_error(std::exception_ptr e) noexcept
+            {
+                data->set_exception(e);
+                data.reset();
+            }
+
+            void set_done() noexcept
+            {
+                std::terminate();
+            }
+
+            void set_value() noexcept
+            {
+                data->set_value(hpx::util::unused);
+                data.reset();
+            }
+        };
+
+        template <typename T, typename Allocator, typename OS>
+        struct future_data
+          : hpx::lcos::detail::future_data_allocator<T, Allocator>
+        {
+            HPX_NON_COPYABLE(future_data);
+
+            using operation_state_type = std::decay_t<OS>;
+            using init_no_addref =
+                typename hpx::lcos::detail::future_data_allocator<T,
+                    Allocator>::init_no_addref;
+            using other_allocator = typename std::allocator_traits<
+                Allocator>::template rebind_alloc<future_data>;
+
+            operation_state_type os;
+
+            template <typename S>
+            future_data(
+                init_no_addref no_addref, other_allocator const& alloc, S&& s)
+              : hpx::lcos::detail::future_data_allocator<T, Allocator>(
+                    no_addref, alloc)
+              , os(hpx::execution::experimental::connect(std::forward<S>(s),
+                    detail::make_future_receiver<T, Allocator>{this}))
+            {
+                hpx::execution::experimental::start(os);
+            }
+        };
+    }    // namespace detail
+
+    template <typename S, typename Allocator = hpx::util::internal_allocator<>,
+        typename = std::enable_if_t<is_sender_v<S>>>
+    auto make_future(S&& s, Allocator const& a = Allocator{})
+    {
+        using allocator_type = Allocator;
+
+        using value_types =
+            typename hpx::execution::experimental::sender_traits<std::decay_t<
+                S>>::template value_types<hpx::util::pack, hpx::util::pack>;
+        using result_type = std::decay_t<detail::single_result_t<value_types>>;
+        using operation_state_type = typename hpx::util::invoke_result<
+            hpx::execution::experimental::connect_t, S,
+            detail::make_future_receiver<result_type, allocator_type>>::type;
+
+        using shared_state = detail::future_data<result_type, allocator_type,
+            operation_state_type>;
+        using init_no_addref = typename shared_state::init_no_addref;
+        using other_allocator = typename std::allocator_traits<
+            allocator_type>::template rebind_alloc<shared_state>;
+        using allocator_traits = std::allocator_traits<other_allocator>;
+        using unique_ptr = std::unique_ptr<shared_state,
+            util::allocator_deleter<other_allocator>>;
+
+        other_allocator alloc(a);
+        unique_ptr p(allocator_traits::allocate(alloc, 1),
+            hpx::util::allocator_deleter<other_allocator>{alloc});
+
+        allocator_traits::construct(
+            alloc, p.get(), init_no_addref{}, alloc, std::forward<S>(s));
+
+        return hpx::traits::future_access<future<result_type>>::create(
+            p.release(), false);
+    }
+}}}    // namespace hpx::execution::experimental


### PR DESCRIPTION
Makes futures senders by adding the required member typedefs and `connect`. Also adds a `hpx::execution::experimental::make_future` function for turning senders into futures. ~Especially the latter could likely be optimized as it's currently using an explicit promise/future pair for the implementation.~ Updated to a single heap allocation with a custom allocator.

I think these two additions will take care of most of the interoperability concerns with futures and senders, and doesn't require us to change the internals of futures (much... only what's in this PR).