### PR TITLE
Allow for HPX algorithms being invoked with std execution policies

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -537,6 +537,15 @@ function(hpx_check_for_cxx20_std_endian)
 endfunction()
 
 # ##############################################################################
+function(hpx_check_for_cxx20_std_execution_policies)
+  add_hpx_config_test(
+    HPX_WITH_CXX20_STD_EXECUTION_POLICES
+    SOURCE cmake/tests/cxx20_std_execution_policies.cpp
+    FILE ${ARGN}
+  )
+endfunction()
+
+# ##############################################################################
 function(hpx_check_for_builtin_integer_pack)
   add_hpx_config_test(
     HPX_WITH_BUILTIN_INTEGER_PACK

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -320,6 +320,14 @@ function(hpx_check_for_cxx17_std_aligned_alloc)
   )
 endfunction()
 
+function(hpx_check_for_cxx17_std_execution_policies)
+  add_hpx_config_test(
+    HPX_WITH_CXX17_STD_EXECUTION_POLICES
+    SOURCE cmake/tests/cxx17_std_execution_policies.cpp
+    FILE ${ARGN}
+  )
+endfunction()
+
 # ##############################################################################
 function(hpx_check_for_cxx11_std_quick_exit)
   add_hpx_config_test(

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -109,6 +109,10 @@ function(hpx_perform_cxx_feature_tests)
 
   hpx_check_for_cxx20_std_endian(DEFINITIONS HPX_HAVE_CXX20_STD_ENDIAN)
 
+  hpx_check_for_cxx20_std_execution_policies(
+    DEFINITIONS HPX_HAVE_CXX20_STD_EXECUTION_POLICES
+  )
+
   # Check the availability of certain C++ builtins
   hpx_check_for_builtin_integer_pack(DEFINITIONS HPX_HAVE_BUILTIN_INTEGER_PACK)
 

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -33,6 +33,10 @@ function(hpx_perform_cxx_feature_tests)
     DEFINITIONS HPX_HAVE_CXX17_STD_ALIGNED_ALLOC
   )
 
+  hpx_check_for_cxx17_std_execution_policies(
+    DEFINITIONS HPX_HAVE_CXX17_STD_EXECUTION_POLICES
+  )
+
   hpx_check_for_cxx17_filesystem(DEFINITIONS HPX_HAVE_CXX17_FILESYSTEM)
 
   hpx_check_for_cxx17_fold_expressions(

--- a/cmake/tests/cxx17_std_execution_policies.cpp
+++ b/cmake/tests/cxx17_std_execution_policies.cpp
@@ -1,0 +1,18 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// test for availability of std::execution::<policies> (C++17)
+
+#include <execution>
+
+int main()
+{
+    std::execution::sequenced_policy seq;
+    std::execution::parallel_policy par;
+    std::execution::parallel_unsequenced_policy par_unseq;
+
+    return 0;
+}

--- a/cmake/tests/cxx20_std_execution_policies.cpp
+++ b/cmake/tests/cxx20_std_execution_policies.cpp
@@ -4,20 +4,14 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// test for availability of std::execution::<policies> (C++17)
+// test for availability of std::execution::<policies> (C++20)
 
 #include <execution>
 
 int main()
 {
-    std::execution::sequenced_policy seq;
-    (void) seq;
-
-    std::execution::parallel_policy par;
-    (void) par;
-
-    std::execution::parallel_unsequenced_policy par_unseq;
-    (void) par_unseq;
+    std::execution::unsequenced_policy unseq;
+    (void) unseq;
 
     return 0;
 }

--- a/libs/core/execution_base/include/hpx/execution_base/execution.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/execution.hpp
@@ -48,7 +48,7 @@ namespace hpx { namespace execution {
     /// \cond NOINTERNAL
     struct task_policy_tag
     {
-        constexpr task_policy_tag() {}
+        constexpr task_policy_tag() = default;
     };
 }}    // namespace hpx::execution
 

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
@@ -28,12 +28,13 @@
 #include <utility>
 
 namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename T, typename Enable = void>
     struct algorithm_result_helper
     {
         template <typename T_>
-        static HPX_FORCEINLINE T_ call(T_&& val)
+        HPX_FORCEINLINE static constexpr T_ call(T_&& val)
         {
             return std::forward<T_>(val);
         }
@@ -42,7 +43,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     template <>
     struct algorithm_result_helper<future<void>>
     {
-        static HPX_FORCEINLINE future<void> call(future<void>&& f)
+        HPX_FORCEINLINE static future<void> call(future<void>&& f)
         {
             return std::move(f);
         }
@@ -53,9 +54,9 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         typename std::enable_if<
             hpx::traits::is_segmented_local_iterator<Iterator>::value>::type>
     {
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator> traits;
+        using traits = hpx::traits::segmented_local_iterator_traits<Iterator>;
 
-        static HPX_FORCEINLINE Iterator call(
+        HPX_FORCEINLINE static Iterator call(
             typename traits::local_raw_iterator&& it)
         {
             return traits::remote(std::move(it));
@@ -68,10 +69,10 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             hpx::traits::is_segmented_local_iterator<Iterator1>::value ||
             hpx::traits::is_segmented_local_iterator<Iterator2>::value>::type>
     {
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator1> traits1;
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator2> traits2;
+        using traits1 = hpx::traits::segmented_local_iterator_traits<Iterator1>;
+        using traits2 = hpx::traits::segmented_local_iterator_traits<Iterator2>;
 
-        static HPX_FORCEINLINE std::pair<typename traits1::local_iterator,
+        HPX_FORCEINLINE static std::pair<typename traits1::local_iterator,
             typename traits2::local_iterator>
         call(std::pair<typename traits1::local_raw_iterator,
             typename traits2::local_raw_iterator>&& p)
@@ -87,10 +88,10 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             hpx::traits::is_segmented_local_iterator<Iterator1>::value ||
             hpx::traits::is_segmented_local_iterator<Iterator2>::value>::type>
     {
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator1> traits1;
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator2> traits2;
+        using traits1 = hpx::traits::segmented_local_iterator_traits<Iterator1>;
+        using traits2 = hpx::traits::segmented_local_iterator_traits<Iterator2>;
 
-        static HPX_FORCEINLINE util::in_out_result<
+        HPX_FORCEINLINE static util::in_out_result<
             typename traits1::local_iterator, typename traits2::local_iterator>
         call(util::in_out_result<typename traits1::local_raw_iterator,
             typename traits2::local_raw_iterator>&& p)
@@ -109,11 +110,11 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             hpx::traits::is_segmented_local_iterator<Iterator2>::value ||
             hpx::traits::is_segmented_local_iterator<Iterator3>::value>::type>
     {
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator1> traits1;
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator2> traits2;
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator3> traits3;
+        using traits1 = hpx::traits::segmented_local_iterator_traits<Iterator1>;
+        using traits2 = hpx::traits::segmented_local_iterator_traits<Iterator2>;
+        using traits3 = hpx::traits::segmented_local_iterator_traits<Iterator3>;
 
-        static HPX_FORCEINLINE hpx::tuple<typename traits1::local_iterator,
+        HPX_FORCEINLINE static hpx::tuple<typename traits1::local_iterator,
             typename traits2::local_iterator, typename traits3::local_iterator>
         call(hpx::tuple<typename traits1::local_raw_iterator,
             typename traits2::local_raw_iterator,
@@ -133,11 +134,11 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             hpx::traits::is_segmented_local_iterator<Iterator2>::value ||
             hpx::traits::is_segmented_local_iterator<Iterator3>::value>::type>
     {
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator1> traits1;
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator2> traits2;
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator3> traits3;
+        using traits1 = hpx::traits::segmented_local_iterator_traits<Iterator1>;
+        using traits2 = hpx::traits::segmented_local_iterator_traits<Iterator2>;
+        using traits3 = hpx::traits::segmented_local_iterator_traits<Iterator3>;
 
-        static HPX_FORCEINLINE util::in_in_out_result<
+        HPX_FORCEINLINE static util::in_in_out_result<
             typename traits1::local_iterator, typename traits2::local_iterator,
             typename traits3::local_iterator>
         call(util::in_in_out_result<typename traits1::local_raw_iterator,
@@ -158,12 +159,12 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         typename std::enable_if<
             hpx::traits::is_segmented_local_iterator<Iterator>::value>::type>
     {
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator> traits;
+        using traits = hpx::traits::segmented_local_iterator_traits<Iterator>;
 
-        static HPX_FORCEINLINE future<Iterator> call(
+        HPX_FORCEINLINE static future<Iterator> call(
             future<typename traits::local_raw_iterator>&& f)
         {
-            typedef future<typename traits::local_raw_iterator> argtype;
+            using argtype = future<typename traits::local_raw_iterator>;
             return f.then(hpx::launch::sync, [](argtype&& f) -> Iterator {
                 return traits::remote(f.get());
             });
@@ -176,14 +177,13 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             hpx::traits::is_segmented_local_iterator<Iterator1>::value ||
             hpx::traits::is_segmented_local_iterator<Iterator2>::value>::type>
     {
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator1> traits1;
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator2> traits2;
+        using traits1 = hpx::traits::segmented_local_iterator_traits<Iterator1>;
+        using traits2 = hpx::traits::segmented_local_iterator_traits<Iterator2>;
 
-        typedef std::pair<typename traits1::local_raw_iterator,
-            typename traits2::local_raw_iterator>
-            arg_type;
+        using arg_type = std::pair<typename traits1::local_raw_iterator,
+            typename traits2::local_raw_iterator>;
 
-        static HPX_FORCEINLINE future<std::pair<
+        HPX_FORCEINLINE static future<std::pair<
             typename traits1::local_iterator, typename traits2::local_iterator>>
         call(future<arg_type>&& f)
         {
@@ -208,14 +208,14 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             hpx::traits::is_segmented_local_iterator<Iterator1>::value ||
             hpx::traits::is_segmented_local_iterator<Iterator2>::value>::type>
     {
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator1> traits1;
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator2> traits2;
+        using traits1 = hpx::traits::segmented_local_iterator_traits<Iterator1>;
+        using traits2 = hpx::traits::segmented_local_iterator_traits<Iterator2>;
 
-        typedef util::in_out_result<typename traits1::local_raw_iterator,
-            typename traits2::local_raw_iterator>
-            arg_type;
+        using arg_type =
+            util::in_out_result<typename traits1::local_raw_iterator,
+                typename traits2::local_raw_iterator>;
 
-        static HPX_FORCEINLINE future<util::in_out_result<
+        HPX_FORCEINLINE static future<util::in_out_result<
             typename traits1::local_iterator, typename traits2::local_iterator>>
         call(future<arg_type>&& f)
         {
@@ -242,16 +242,15 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             hpx::traits::is_segmented_local_iterator<Iterator2>::value ||
             hpx::traits::is_segmented_local_iterator<Iterator3>::value>::type>
     {
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator1> traits1;
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator2> traits2;
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator3> traits3;
+        using traits1 = hpx::traits::segmented_local_iterator_traits<Iterator1>;
+        using traits2 = hpx::traits::segmented_local_iterator_traits<Iterator2>;
+        using traits3 = hpx::traits::segmented_local_iterator_traits<Iterator3>;
 
-        typedef hpx::tuple<typename traits1::local_raw_iterator,
+        using arg_type = hpx::tuple<typename traits1::local_raw_iterator,
             typename traits2::local_raw_iterator,
-            typename traits3::local_raw_iterator>
-            arg_type;
+            typename traits3::local_raw_iterator>;
 
-        static HPX_FORCEINLINE future<hpx::tuple<
+        HPX_FORCEINLINE static future<hpx::tuple<
             typename traits1::local_iterator, typename traits2::local_iterator,
             typename traits3::local_iterator>>
         call(future<arg_type>&& f)
@@ -281,16 +280,16 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             hpx::traits::is_segmented_local_iterator<Iterator2>::value ||
             hpx::traits::is_segmented_local_iterator<Iterator3>::value>::type>
     {
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator1> traits1;
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator2> traits2;
-        typedef hpx::traits::segmented_local_iterator_traits<Iterator3> traits3;
+        using traits1 = hpx::traits::segmented_local_iterator_traits<Iterator1>;
+        using traits2 = hpx::traits::segmented_local_iterator_traits<Iterator2>;
+        using traits3 = hpx::traits::segmented_local_iterator_traits<Iterator3>;
 
-        typedef util::in_in_out_result<typename traits1::local_raw_iterator,
-            typename traits2::local_raw_iterator,
-            typename traits3::local_raw_iterator>
-            arg_type;
+        using arg_type =
+            util::in_in_out_result<typename traits1::local_raw_iterator,
+                typename traits2::local_raw_iterator,
+                typename traits3::local_raw_iterator>;
 
-        static HPX_FORCEINLINE future<util::in_in_out_result<
+        HPX_FORCEINLINE static future<util::in_in_out_result<
             typename traits1::local_iterator, typename traits2::local_iterator,
             typename traits3::local_iterator>>
         call(future<arg_type>&& f)
@@ -319,25 +318,25 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     struct dispatcher_helper
     {
         template <typename ExPolicy, typename... Args>
-        static HPX_FORCEINLINE R sequential(
+        HPX_FORCEINLINE static R sequential(
             Algo const& algo, ExPolicy&& policy, Args&&... args)
         {
             using hpx::traits::segmented_local_iterator_traits;
             return detail::algorithm_result_helper<R>::call(
-                algo.call(std::forward<ExPolicy>(policy), std::true_type(),
-                    segmented_local_iterator_traits<typename std::decay<
-                        Args>::type>::local(std::forward<Args>(args))...));
+                algo.call2(std::forward<ExPolicy>(policy), std::true_type(),
+                    segmented_local_iterator_traits<std::decay_t<Args>>::local(
+                        std::forward<Args>(args))...));
         }
 
         template <typename ExPolicy, typename... Args>
-        static HPX_FORCEINLINE R parallel(
+        HPX_FORCEINLINE static R parallel(
             Algo const& algo, ExPolicy&& policy, Args&&... args)
         {
             using hpx::traits::segmented_local_iterator_traits;
             return detail::algorithm_result_helper<R>::call(
-                algo.call(std::forward<ExPolicy>(policy), std::false_type(),
-                    segmented_local_iterator_traits<typename std::decay<
-                        Args>::type>::local(std::forward<Args>(args))...));
+                algo.call2(std::forward<ExPolicy>(policy), std::false_type(),
+                    segmented_local_iterator_traits<std::decay_t<Args>>::local(
+                        std::forward<Args>(args))...));
         }
     };
 
@@ -345,25 +344,25 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     struct dispatcher_helper<void, Algo>
     {
         template <typename ExPolicy, typename... Args>
-        static HPX_FORCEINLINE
+        HPX_FORCEINLINE static
             typename parallel::util::detail::algorithm_result<ExPolicy>::type
             sequential(Algo const& algo, ExPolicy&& policy, Args&&... args)
         {
             using hpx::traits::segmented_local_iterator_traits;
-            return algo.call(std::forward<ExPolicy>(policy), std::true_type(),
-                segmented_local_iterator_traits<typename std::decay<
-                    Args>::type>::local(std::forward<Args>(args))...);
+            return algo.call2(std::forward<ExPolicy>(policy), std::true_type(),
+                segmented_local_iterator_traits<std::decay_t<Args>>::local(
+                    std::forward<Args>(args))...);
         }
 
         template <typename ExPolicy, typename... Args>
-        static HPX_FORCEINLINE
+        HPX_FORCEINLINE static
             typename parallel::util::detail::algorithm_result<ExPolicy>::type
             parallel(Algo const& algo, ExPolicy&& policy, Args&&... args)
         {
             using hpx::traits::segmented_local_iterator_traits;
-            return algo.call(std::forward<ExPolicy>(policy), std::false_type(),
-                segmented_local_iterator_traits<typename std::decay<
-                    Args>::type>::local(std::forward<Args>(args))...);
+            return algo.call2(std::forward<ExPolicy>(policy), std::false_type(),
+                segmented_local_iterator_traits<std::decay_t<Args>>::local(
+                    std::forward<Args>(args))...);
         }
     };
 
@@ -371,19 +370,20 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     template <typename Algo, typename ExPolicy, typename... Args>
     struct dispatcher
     {
-        typedef typename parallel::util::detail::algorithm_result<ExPolicy,
-            typename std::decay<Algo>::type::result_type>::type result_type;
+        using result_type =
+            typename parallel::util::detail::algorithm_result<ExPolicy,
+                typename std::decay_t<Algo>::result_type>::type;
 
-        typedef dispatcher_helper<result_type, Algo> base_dispatcher;
+        using base_dispatcher = dispatcher_helper<result_type, Algo>;
 
-        static HPX_FORCEINLINE result_type sequential(
+        HPX_FORCEINLINE static result_type sequential(
             Algo const& algo, ExPolicy policy, Args... args)
         {
             return base_dispatcher::sequential(
                 algo, std::move(policy), std::move(args)...);
         }
 
-        static HPX_FORCEINLINE result_type parallel(
+        HPX_FORCEINLINE static result_type parallel(
             Algo const& algo, ExPolicy policy, Args... args)
         {
             return base_dispatcher::parallel(
@@ -418,16 +418,17 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Algo, typename ExPolicy, typename IsSeq,
         typename... Args>
-    HPX_FORCEINLINE future<typename std::decay<Algo>::type::result_type>
+    HPX_FORCEINLINE future<typename std::decay_t<Algo>::result_type>
     dispatch_async(id_type const& id, Algo&& algo, ExPolicy const& policy,
         IsSeq, Args&&... args)
     {
-        typedef typename std::decay<Algo>::type algo_type;
-        typedef typename parallel::util::detail::algorithm_result<ExPolicy,
-            typename algo_type::result_type>::type result_type;
+        using algo_type = std::decay_t<Algo>;
+        using result_type =
+            typename parallel::util::detail::algorithm_result<ExPolicy,
+                typename algo_type::result_type>::type;
 
         algorithm_invoker_action<algo_type, ExPolicy, typename IsSeq::type,
-            result_type(typename std::decay<Args>::type...)>
+            result_type(std::decay_t<Args>...)>
             act;
 
         return hpx::async(act, hpx::colocated(id), std::forward<Algo>(algo),
@@ -436,12 +437,12 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 
     template <typename Algo, typename ExPolicy, typename IsSeq,
         typename... Args>
-    HPX_FORCEINLINE typename std::decay<Algo>::type::result_type dispatch(
+    HPX_FORCEINLINE typename std::decay_t<Algo>::result_type dispatch(
         id_type const& id, Algo&& algo, ExPolicy const& policy, IsSeq is_seq,
         Args&&... args)
     {
         // synchronously invoke remote operation
-        future<typename std::decay<Algo>::type::result_type> f =
+        future<typename std::decay_t<Algo>::result_type> f =
             dispatch_async(id, std::forward<Algo>(algo), policy, is_seq,
                 std::forward<Args>(args)...);
         f.wait();

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
@@ -114,10 +114,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return detail::adjacent_difference<FwdIter2>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
+                std::forward<ExPolicy>(policy), first, last, dest,
                 std::forward<Op>(op));
         }
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_find.hpp
@@ -230,14 +230,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
         adjacent_find(ExPolicy&& policy, FwdIter first, FwdIter last,
             Pred&& pred = Pred())
     {
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return detail::adjacent_find<FwdIter, FwdIter>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last,
+            std::forward<ExPolicy>(policy), first, last,
             std::forward<Pred>(pred),
             hpx::parallel::util::projection_identity{});
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
@@ -265,8 +263,7 @@ namespace hpx {
                 "Requires at least input iterator.");
 
             return parallel::v1::detail::adjacent_find<InIter, InIter>().call(
-                hpx::execution::seq, std::true_type(), first, last,
-                std::forward<Pred>(pred),
+                hpx::execution::seq, first, last, std::forward<Pred>(pred),
                 hpx::parallel::util::projection_identity{});
         }
 
@@ -286,10 +283,8 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Requires at least a forward iterator");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return parallel::v1::detail::adjacent_find<FwdIter, FwdIter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
+                std::forward<ExPolicy>(policy), first, last,
                 std::forward<Pred>(pred),
                 hpx::parallel::util::projection_identity{});
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
@@ -341,14 +341,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
             "Required at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return hpx::parallel::v1::detail::none_of().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last,
-            std::forward<F>(f), std::forward<Proj>(proj));
+            std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+            std::forward<Proj>(proj));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
 #endif
@@ -441,14 +440,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
             "Required at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return hpx::parallel::v1::detail::any_of().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last,
-            std::forward<F>(f), std::forward<Proj>(proj));
+            std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+            std::forward<Proj>(proj));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
 #endif
@@ -541,14 +539,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
             "Required at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return hpx::parallel::v1::detail::all_of().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last,
-            std::forward<F>(f), std::forward<Proj>(proj));
+            std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+            std::forward<Proj>(proj));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
 #endif
@@ -578,11 +575,9 @@ namespace hpx {
             static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
                 "Required at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::none_of().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
-                std::forward<F>(f), hpx::parallel::util::projection_identity{});
+                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                hpx::parallel::util::projection_identity{});
         }
 
         // clang-format off
@@ -598,8 +593,8 @@ namespace hpx {
                 "Required at least input iterator.");
 
             return hpx::parallel::v1::detail::none_of().call(
-                hpx::execution::seq, std::true_type(), first, last,
-                std::forward<F>(f), hpx::parallel::util::projection_identity{});
+                hpx::execution::seq, first, last, std::forward<F>(f),
+                hpx::parallel::util::projection_identity{});
         }
     } none_of{};
 
@@ -624,11 +619,9 @@ namespace hpx {
             static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
                 "Required at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::any_of().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
-                std::forward<F>(f), hpx::parallel::util::projection_identity{});
+                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                hpx::parallel::util::projection_identity{});
         }
 
         // clang-format off
@@ -644,7 +637,7 @@ namespace hpx {
                 "Required at least input iterator.");
 
             return hpx::parallel::v1::detail::any_of().call(hpx::execution::seq,
-                std::true_type(), first, last, std::forward<F>(f),
+                first, last, std::forward<F>(f),
                 hpx::parallel::util::projection_identity{});
         }
     } any_of{};
@@ -670,11 +663,9 @@ namespace hpx {
             static_assert(hpx::traits::is_forward_iterator<FwdIter>::value,
                 "Required at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::all_of().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
-                std::forward<F>(f), hpx::parallel::util::projection_identity());
+                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                hpx::parallel::util::projection_identity());
         }
 
         // clang-format off
@@ -690,7 +681,7 @@ namespace hpx {
                 "Required at least input iterator.");
 
             return hpx::parallel::v1::detail::all_of().call(hpx::execution::seq,
-                std::true_type(), first, last, std::forward<F>(f),
+                first, last, std::forward<F>(f),
                 hpx::parallel::util::projection_identity{});
         }
     } all_of{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -431,8 +431,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         // if count is representing a negative value, we do nothing
         if (detail::is_negative(count))
         {
@@ -446,8 +444,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return detail::copy_n<util::in_out_result<FwdIter1, FwdIter2>>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, std::size_t(count),
-            dest);
+            std::forward<ExPolicy>(policy), first, std::size_t(count), dest);
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
 #endif
@@ -615,14 +612,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return detail::copy_if<util::in_out_result<FwdIter1, FwdIter2>>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
+            std::forward<ExPolicy>(policy), first, last, dest,
             std::forward<Pred>(pred), util::projection_identity{});
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
@@ -708,12 +703,10 @@ namespace hpx {
                     FwdIter2>::get(std::move(dest));
             }
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::util::get_second_element(
                 hpx::parallel::v1::detail::copy_n<
                     hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
-                    .call(std::forward<ExPolicy>(policy), is_seq(), first,
+                    .call(std::forward<ExPolicy>(policy), first,
                         std::size_t(count), dest));
         }
 
@@ -743,8 +736,8 @@ namespace hpx {
             return hpx::parallel::util::get_second_element(
                 hpx::parallel::v1::detail::copy_n<
                     hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
-                    .call(hpx::execution::seq, std::true_type{}, first,
-                        std::size_t(count), dest));
+                    .call(
+                        hpx::execution::seq, first, std::size_t(count), dest));
         }
     } copy_n{};
 
@@ -778,13 +771,11 @@ namespace hpx {
                         hpx::traits::is_output_iterator<FwdIter2>::value),
                 "Requires at least forward iterator or sequential execution.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::util::get_second_element(
                 hpx::parallel::v1::detail::copy_if<
                     hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
-                    .call(std::forward<ExPolicy>(policy), is_seq(), first, last,
-                        dest, std::forward<Pred>(pred),
+                    .call(std::forward<ExPolicy>(policy), first, last, dest,
+                        std::forward<Pred>(pred),
                         hpx::parallel::util::projection_identity{}));
         }
 
@@ -809,8 +800,8 @@ namespace hpx {
             return hpx::parallel::util::get_second_element(
                 hpx::parallel::v1::detail::copy_if<
                     hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
-                    .call(hpx::execution::seq, std::true_type{}, first, last,
-                        dest, std::forward<Pred>(pred),
+                    .call(hpx::execution::seq, first, last, dest,
+                        std::forward<Pred>(pred),
                         hpx::parallel::util::projection_identity{}));
         }
     } copy_if{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/count.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/count.hpp
@@ -323,8 +323,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIterB>::value),
             "Required at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
         using difference_type =
             typename std::iterator_traits<FwdIterB>::difference_type;
 
@@ -333,7 +331,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return hpx::parallel::v1::detail::count<difference_type>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last, value,
+            std::forward<ExPolicy>(policy), first, last, value,
             std::forward<Proj>(proj));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
@@ -422,8 +420,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIterB>::value),
             "Required at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
         using difference_type =
             typename std::iterator_traits<FwdIterB>::difference_type;
 
@@ -432,8 +428,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return hpx::parallel::v1::detail::count_if<difference_type>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last,
-            std::forward<F>(f), std::forward<Proj>(proj));
+            std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+            std::forward<Proj>(proj));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
 #endif
@@ -463,13 +459,11 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Required at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             using difference_type =
                 typename std::iterator_traits<FwdIter>::difference_type;
 
             return hpx::parallel::v1::detail::count<difference_type>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last, value,
+                std::forward<ExPolicy>(policy), first, last, value,
                 hpx::parallel::util::projection_identity{});
         }
 
@@ -489,7 +483,7 @@ namespace hpx {
                 typename std::iterator_traits<InIter>::difference_type;
 
             return hpx::parallel::v1::detail::count<difference_type>().call(
-                hpx::execution::seq, std::true_type(), first, last, value,
+                hpx::execution::seq, first, last, value,
                 hpx::parallel::util::projection_identity{});
         }
     } count{};
@@ -518,14 +512,12 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Required at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             using difference_type =
                 typename std::iterator_traits<FwdIter>::difference_type;
 
             return hpx::parallel::v1::detail::count_if<difference_type>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
-                std::forward<F>(f), hpx::parallel::util::projection_identity{});
+                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                hpx::parallel::util::projection_identity{});
         }
 
         // clang-format off
@@ -547,8 +539,8 @@ namespace hpx {
                 typename std::iterator_traits<InIter>::difference_type;
 
             return hpx::parallel::v1::detail::count_if<difference_type>().call(
-                hpx::execution::seq, std::true_type(), first, last,
-                std::forward<F>(f), hpx::parallel::util::projection_identity{});
+                hpx::execution::seq, first, last, std::forward<F>(f),
+                hpx::parallel::util::projection_identity{});
         }
     } count_if{};
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/destroy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/destroy.hpp
@@ -345,7 +345,7 @@ namespace hpx {
                 "Required at least forward iterator.");
 
             hpx::parallel::v1::detail::destroy<FwdIter>().call(
-                hpx::execution::seq, std::false_type{}, first, last);
+                hpx::execution::seq, first, last);
         }
     } destroy{};
 
@@ -398,8 +398,7 @@ namespace hpx {
             }
 
             return hpx::parallel::v1::detail::destroy_n<FwdIter>().call(
-                hpx::execution::seq, std::false_type{}, first,
-                std::size_t(count));
+                hpx::execution::seq, first, std::size_t(count));
         }
     } destroy_n{};
 }    // namespace hpx

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/destroy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/destroy.hpp
@@ -215,14 +215,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return detail::destroy<FwdIter>().call(
-            std::forward<ExPolicy>(policy), is_seq{}, first, last);
+            std::forward<ExPolicy>(policy), first, last);
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
 #endif
@@ -296,14 +294,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 std::move(first));
         }
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
-        return detail::destroy_n<FwdIter>().call(std::forward<ExPolicy>(policy),
-            is_seq{}, first, std::size_t(count));
+        return detail::destroy_n<FwdIter>().call(
+            std::forward<ExPolicy>(policy), first, std::size_t(count));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
 #endif
@@ -332,11 +328,9 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Required at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::util::detail::algorithm_result<ExPolicy>::get(
                 hpx::parallel::v1::detail::destroy<FwdIter>().call(
-                    std::forward<ExPolicy>(policy), is_seq{}, first, last));
+                    std::forward<ExPolicy>(policy), first, last));
         }
 
         // clang-format off
@@ -382,11 +376,8 @@ namespace hpx {
                     FwdIter>::get(std::move(first));
             }
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::destroy_n<FwdIter>().call(
-                std::forward<ExPolicy>(policy), is_seq{}, first,
-                std::size_t(count));
+                std::forward<ExPolicy>(policy), first, std::size_t(count));
         }
 
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -304,6 +304,18 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             return call2(hpx::execution::par_unseq, std::false_type(),
                 std::forward<Args>(args)...);
         }
+
+#if defined(HPX_HAVE_CXX20_STD_EXECUTION_POLICES)
+        template <typename... Args>
+        HPX_FORCEINLINE constexpr
+            typename parallel::util::detail::algorithm_result<
+                hpx::execution::unsequenced_policy, local_result_type>::type
+            call(std::execution::unsequenced_policy, Args&&... args)
+        {
+            return call2(hpx::execution::unseq, std::false_type(),
+                std::forward<Args>(args)...);
+        }
+#endif
 #endif
 
     private:

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/dispatch.hpp
@@ -9,84 +9,88 @@
 
 #include <hpx/config.hpp>
 #include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
-#include <hpx/futures/future.hpp>
-#include <hpx/modules/errors.hpp>
-#include <hpx/serialization/serialization_fwd.hpp>
-
+#include <hpx/concepts/concepts.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/execution/executors/execution.hpp>
 #include <hpx/executors/exception_list.hpp>
 #include <hpx/executors/execution_policy.hpp>
+#include <hpx/futures/future.hpp>
+#include <hpx/modules/errors.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/scoped_executor_parameters.hpp>
 #include <hpx/parallel/util/result_types.hpp>
+#include <hpx/serialization/serialization_fwd.hpp>
 
+#if defined(HPX_HAVE_CXX17_STD_EXECUTION_POLICES)
+#include <execution>
+#endif
 #include <string>
 #include <type_traits>
 #include <utility>
 
 namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename Result>
     struct local_algorithm_result
     {
-        typedef typename hpx::traits::segmented_local_iterator_traits<
-            Result>::local_raw_iterator type;
+        using type = typename hpx::traits::segmented_local_iterator_traits<
+            Result>::local_raw_iterator;
     };
 
     template <typename Result1, typename Result2>
     struct local_algorithm_result<std::pair<Result1, Result2>>
     {
-        typedef typename hpx::traits::segmented_local_iterator_traits<
-            Result1>::local_raw_iterator type1;
-        typedef typename hpx::traits::segmented_local_iterator_traits<
-            Result2>::local_raw_iterator type2;
+        using type1 = typename hpx::traits::segmented_local_iterator_traits<
+            Result1>::local_raw_iterator;
+        using type2 = typename hpx::traits::segmented_local_iterator_traits<
+            Result2>::local_raw_iterator;
 
-        typedef std::pair<type1, type2> type;
+        using type = std::pair<type1, type2>;
     };
 
     template <typename Result1, typename Result2>
     struct local_algorithm_result<util::in_out_result<Result1, Result2>>
     {
-        typedef typename hpx::traits::segmented_local_iterator_traits<
-            Result1>::local_raw_iterator type1;
-        typedef typename hpx::traits::segmented_local_iterator_traits<
-            Result2>::local_raw_iterator type2;
+        using type1 = typename hpx::traits::segmented_local_iterator_traits<
+            Result1>::local_raw_iterator;
+        using type2 = typename hpx::traits::segmented_local_iterator_traits<
+            Result2>::local_raw_iterator;
 
-        typedef util::in_out_result<type1, type2> type;
+        using type = util::in_out_result<type1, type2>;
     };
 
     template <typename Result1, typename Result2, typename Result3>
     struct local_algorithm_result<hpx::tuple<Result1, Result2, Result3>>
     {
-        typedef typename hpx::traits::segmented_local_iterator_traits<
-            Result1>::local_raw_iterator type1;
-        typedef typename hpx::traits::segmented_local_iterator_traits<
-            Result2>::local_raw_iterator type2;
-        typedef typename hpx::traits::segmented_local_iterator_traits<
-            Result3>::local_raw_iterator type3;
+        using type1 = typename hpx::traits::segmented_local_iterator_traits<
+            Result1>::local_raw_iterator;
+        using type2 = typename hpx::traits::segmented_local_iterator_traits<
+            Result2>::local_raw_iterator;
+        using type3 = typename hpx::traits::segmented_local_iterator_traits<
+            Result3>::local_raw_iterator;
 
-        typedef hpx::tuple<type1, type2, type3> type;
+        using type = hpx::tuple<type1, type2, type3>;
     };
 
     template <typename Result1, typename Result2, typename Result3>
     struct local_algorithm_result<
         util::in_in_out_result<Result1, Result2, Result3>>
     {
-        typedef typename hpx::traits::segmented_local_iterator_traits<
-            Result1>::local_raw_iterator type1;
-        typedef typename hpx::traits::segmented_local_iterator_traits<
-            Result2>::local_raw_iterator type2;
-        typedef typename hpx::traits::segmented_local_iterator_traits<
-            Result3>::local_raw_iterator type3;
+        using type1 = typename hpx::traits::segmented_local_iterator_traits<
+            Result1>::local_raw_iterator;
+        using type2 = typename hpx::traits::segmented_local_iterator_traits<
+            Result2>::local_raw_iterator;
+        using type3 = typename hpx::traits::segmented_local_iterator_traits<
+            Result3>::local_raw_iterator;
 
-        typedef util::in_in_out_result<type1, type2, type3> type;
+        using type = util::in_in_out_result<type1, type2, type3>;
     };
 
     template <>
     struct local_algorithm_result<void>
     {
-        typedef void type;
+        using type = void;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -100,9 +104,9 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         }
 
     public:
-        typedef Result result_type;
-        typedef typename local_algorithm_result<result_type>::type
-            local_result_type;
+        using result_type = Result;
+        using local_result_type =
+            typename local_algorithm_result<result_type>::type;
 
         explicit algorithm(char const* const name)
           : name_(name)
@@ -110,6 +114,7 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
         }
 
         ///////////////////////////////////////////////////////////////////////
+        // this equivalent to sequential execution
         template <typename ExPolicy, typename... Args>
         HPX_HOST_DEVICE
             typename parallel::util::detail::algorithm_result<ExPolicy,
@@ -120,10 +125,10 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             try
             {
 #endif
-                typedef typename std::decay<
-                    ExPolicy>::type::executor_parameters_type parameters_type;
-                typedef typename std::decay<ExPolicy>::type::executor_type
-                    executor_type;
+                using parameters_type = typename std::decay<
+                    ExPolicy>::type::executor_parameters_type;
+                using executor_type =
+                    typename std::decay<ExPolicy>::type::executor_type;
 
                 parallel::util::detail::scoped_executor_parameters_ref<
                     parameters_type, executor_type>
@@ -144,49 +149,31 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
 #endif
         }
 
+    protected:
         ///////////////////////////////////////////////////////////////////////
         template <typename ExPolicy, typename... Args>
-        typename parallel::util::detail::algorithm_result<ExPolicy,
+        constexpr typename parallel::util::detail::algorithm_result<ExPolicy,
             local_result_type>::type
         call_execute(ExPolicy&& policy, std::false_type, Args&&... args) const
         {
-            return parallel::util::detail::algorithm_result<ExPolicy,
-                local_result_type>::get(execution::sync_execute(policy
-                                                                    .executor(),
+            using result = parallel::util::detail::algorithm_result<ExPolicy,
+                local_result_type>;
+
+            return result::get(execution::sync_execute(policy.executor(),
                 derived(), std::forward<ExPolicy>(policy),
                 std::forward<Args>(args)...));
         }
 
         template <typename ExPolicy, typename... Args>
-        typename parallel::util::detail::algorithm_result<ExPolicy>::type
-        call_execute(ExPolicy&& policy, std::true_type, Args&&... args) const
+        constexpr
+            typename parallel::util::detail::algorithm_result<ExPolicy>::type
+            call_execute(
+                ExPolicy&& policy, std::true_type, Args&&... args) const
         {
             execution::sync_execute(policy.executor(), derived(),
                 std::forward<ExPolicy>(policy), std::forward<Args>(args)...);
 
             return parallel::util::detail::algorithm_result<ExPolicy>::get();
-        }
-
-        template <typename ExPolicy, typename... Args>
-        typename parallel::util::detail::algorithm_result<ExPolicy,
-            local_result_type>::type
-        call(ExPolicy&& policy, std::true_type, Args&&... args) const
-        {
-            try
-            {
-                typedef std::is_void<local_result_type> is_void;
-                return call_execute(std::forward<ExPolicy>(policy), is_void(),
-                    std::forward<Args>(args)...);
-            }
-            catch (std::bad_alloc const& ba)
-            {
-                throw ba;
-            }
-            catch (...)
-            {
-                return detail::handle_exception<ExPolicy,
-                    local_result_type>::call();
-            }
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -217,178 +204,107 @@ namespace hpx { namespace parallel { inline namespace v1 { namespace detail {
             }
         }
 
-        template <typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            hpx::execution::sequenced_task_policy, local_result_type>::type
-        call(hpx::execution::sequenced_task_policy policy, std::true_type,
-            Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
-
-        template <typename Executor, typename Parameters, typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            hpx::execution::sequenced_task_policy_shim<Executor, Parameters>,
-            local_result_type>::type
-        call(hpx::execution::sequenced_task_policy_shim<Executor, Parameters>&
-                 policy,
-            std::true_type, Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
-
-        template <typename Executor, typename Parameters, typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            hpx::execution::sequenced_task_policy_shim<Executor, Parameters>,
-            local_result_type>::type
-        call(hpx::execution::sequenced_task_policy_shim<Executor, Parameters>&&
-                 policy,
-            std::true_type, Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
-
-        template <typename Executor, typename Parameters, typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            hpx::execution::sequenced_task_policy_shim<Executor, Parameters>,
-            local_result_type>::type
-        call(hpx::execution::sequenced_task_policy_shim<Executor,
-                 Parameters> const& policy,
-            std::true_type, Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
-
-#if defined(HPX_HAVE_DATAPAR)
-        template <typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            hpx::execution::dataseq_task_policy, local_result_type>::type
-        call(hpx::execution::dataseq_task_policy policy, std::true_type,
-            Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
-
-        template <typename Executor, typename Parameters, typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            hpx::execution::dataseq_task_policy_shim<Executor, Parameters>,
-            local_result_type>::type
-        call(hpx::execution::dataseq_task_policy_shim<Executor, Parameters>&
-                 policy,
-            std::true_type, Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
-
-        template <typename Executor, typename Parameters, typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            hpx::execution::dataseq_task_policy_shim<Executor, Parameters>,
-            local_result_type>::type
-        call(hpx::execution::dataseq_task_policy_shim<Executor, Parameters>&&
-                 policy,
-            std::true_type, Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
-
-        template <typename Executor, typename Parameters, typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            hpx::execution::dataseq_task_policy_shim<Executor, Parameters>,
-            local_result_type>::type
-        call(hpx::execution::dataseq_task_policy_shim<Executor,
-                 Parameters> const& policy,
-            std::true_type, Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
-#endif
-
+    public:
         ///////////////////////////////////////////////////////////////////////
-        template <typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            hpx::execution::parallel_task_policy, local_result_type>::type
-        call(hpx::execution::parallel_task_policy policy, std::true_type,
-            Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
+        // main sequential dispatch entry points
 
-        template <typename Executor, typename Parameters, typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            hpx::execution::parallel_task_policy_shim<Executor, Parameters>,
+        // specialization for all task-based (asynchronous) execution policies
+        // clang-format off
+        template <typename ExPolicy, typename... Args,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_async_execution_policy_v<std::decay_t<ExPolicy>>
+            )>
+        // clang-format on
+        constexpr typename parallel::util::detail::algorithm_result<ExPolicy,
             local_result_type>::type
-        call(hpx::execution::parallel_task_policy_shim<Executor, Parameters>&
-                 policy,
-            std::true_type, Args&&... args) const
+        call2(ExPolicy&& policy, std::true_type, Args&&... args) const
         {
-            return call_sequential(policy, std::forward<Args>(args)...);
+            return call_sequential(
+                std::forward<ExPolicy>(policy), std::forward<Args>(args)...);
         }
 
-        template <typename Executor, typename Parameters, typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            hpx::execution::parallel_task_policy_shim<Executor, Parameters>,
-            local_result_type>::type
-        call(hpx::execution::parallel_task_policy_shim<Executor, Parameters>&&
-                 policy,
-            std::true_type, Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
-
-        template <typename Executor, typename Parameters, typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            hpx::execution::parallel_task_policy_shim<Executor, Parameters>,
-            local_result_type>::type
-        call(hpx::execution::parallel_task_policy_shim<Executor,
-                 Parameters> const& policy,
-            std::true_type, Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
-
-#if defined(HPX_HAVE_DATAPAR)
-        template <typename Executor, typename Parameters, typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            hpx::execution::datapar_task_policy_shim<Executor, Parameters>,
-            local_result_type>::type
-        call(hpx::execution::datapar_task_policy_shim<Executor, Parameters>&
-                 policy,
-            std::true_type, Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
-
-        template <typename Executor, typename Parameters, typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            hpx::execution::datapar_task_policy_shim<Executor, Parameters>,
-            local_result_type>::type
-        call(hpx::execution::datapar_task_policy_shim<Executor, Parameters>&&
-                 policy,
-            std::true_type, Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
-
-        template <typename Executor, typename Parameters, typename... Args>
-        typename parallel::util::detail::algorithm_result<
-            hpx::execution::datapar_task_policy_shim<Executor, Parameters>,
-            local_result_type>::type
-        call(hpx::execution::datapar_task_policy_shim<Executor,
-                 Parameters> const& policy,
-            std::true_type, Args&&... args) const
-        {
-            return call_sequential(policy, std::forward<Args>(args)...);
-        }
-#endif
-
-        template <typename ExPolicy, typename... Args>
+        // clang-format off
+        template <typename ExPolicy, typename... Args,
+            HPX_CONCEPT_REQUIRES_(
+                !hpx::is_async_execution_policy_v<std::decay_t<ExPolicy>>
+            )>
+        // clang-format on
         typename parallel::util::detail::algorithm_result<ExPolicy,
             local_result_type>::type
-        call(ExPolicy&& policy, std::false_type, Args&&... args) const
+        call2(ExPolicy&& policy, std::true_type, Args&&... args) const
+        {
+            try
+            {
+                using is_void = std::is_void<local_result_type>;
+                return call_execute(std::forward<ExPolicy>(policy), is_void(),
+                    std::forward<Args>(args)...);
+            }
+            catch (std::bad_alloc const& ba)
+            {
+                throw ba;
+            }
+            catch (...)
+            {
+                return detail::handle_exception<ExPolicy,
+                    local_result_type>::call();
+            }
+        }
+
+        // main parallel dispatch entry point
+        template <typename ExPolicy, typename... Args>
+        static constexpr
+            typename parallel::util::detail::algorithm_result<ExPolicy,
+                local_result_type>::type
+            call2(ExPolicy&& policy, std::false_type, Args&&... args)
         {
             return Derived::parallel(
                 std::forward<ExPolicy>(policy), std::forward<Args>(args)...);
         }
+
+        template <typename ExPolicy, typename... Args>
+        HPX_FORCEINLINE constexpr
+            typename parallel::util::detail::algorithm_result<ExPolicy,
+                local_result_type>::type
+            call(ExPolicy&& policy, Args&&... args)
+        {
+            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
+            return call2(std::forward<ExPolicy>(policy), is_seq(),
+                std::forward<Args>(args)...);
+        }
+
+#if defined(HPX_HAVE_CXX17_STD_EXECUTION_POLICES)
+        // main dispatch entry points for std execution policies
+        template <typename... Args>
+        HPX_FORCEINLINE constexpr
+            typename parallel::util::detail::algorithm_result<
+                hpx::execution::sequenced_policy, local_result_type>::type
+            call(std::execution::sequenced_policy, Args&&... args)
+        {
+            return call2(hpx::execution::seq, std::true_type(),
+                std::forward<Args>(args)...);
+        }
+
+        template <typename... Args>
+        HPX_FORCEINLINE constexpr
+            typename parallel::util::detail::algorithm_result<
+                hpx::execution::parallel_policy, local_result_type>::type
+            call(std::execution::parallel_policy, Args&&... args)
+        {
+            return call2(hpx::execution::par, std::false_type(),
+                std::forward<Args>(args)...);
+        }
+
+        template <typename... Args>
+        HPX_FORCEINLINE constexpr
+            typename parallel::util::detail::algorithm_result<
+                hpx::execution::parallel_unsequenced_policy,
+                local_result_type>::type
+            call(std::execution::parallel_unsequenced_policy, Args&&... args)
+        {
+            return call2(hpx::execution::par_unseq, std::false_type(),
+                std::forward<Args>(args)...);
+        }
+#endif
 
     private:
         char const* const name_;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/transfer.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/detail/transfer.hpp
@@ -57,10 +57,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         transfer_(ExPolicy&& policy, FwdIter1 first, Sent1 last, FwdIter2 dest,
             std::false_type)
         {
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return Algo().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last, dest);
+                std::forward<ExPolicy>(policy), first, last, dest);
         }
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/equal.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/equal.hpp
@@ -336,14 +336,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return detail::equal_binary().call(std::forward<ExPolicy>(policy),
-            is_seq{}, first1, last1, first2, last2, std::forward<Pred>(op),
+            first1, last1, first2, last2, std::forward<Pred>(op),
             util::projection_identity{}, util::projection_identity{});
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
@@ -442,14 +440,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return hpx::parallel::v1::detail::equal().call(
-            std::forward<ExPolicy>(policy), is_seq{}, first1, last1, first2,
+            std::forward<ExPolicy>(policy), first1, last1, first2,
             std::forward<Pred>(op));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
@@ -488,11 +484,9 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::equal_binary().call(
-                std::forward<ExPolicy>(policy), is_seq{}, first1, last1, first2,
-                last2, std::forward<Pred>(op),
+                std::forward<ExPolicy>(policy), first1, last1, first2, last2,
+                std::forward<Pred>(op),
                 hpx::parallel::util::projection_identity{},
                 hpx::parallel::util::projection_identity{});
         }
@@ -515,11 +509,9 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::equal_binary().call(
-                std::forward<ExPolicy>(policy), is_seq{}, first1, last1, first2,
-                last2, hpx::parallel::v1::detail::equal_to{},
+                std::forward<ExPolicy>(policy), first1, last1, first2, last2,
+                hpx::parallel::v1::detail::equal_to{},
                 hpx::parallel::util::projection_identity{},
                 hpx::parallel::util::projection_identity{});
         }
@@ -547,10 +539,8 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::equal().call(
-                std::forward<ExPolicy>(policy), is_seq{}, first1, last1, first2,
+                std::forward<ExPolicy>(policy), first1, last1, first2,
                 std::forward<Pred>(op));
         }
 
@@ -572,10 +562,8 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::equal().call(
-                std::forward<ExPolicy>(policy), is_seq{}, first1, last1, first2,
+                std::forward<ExPolicy>(policy), first1, last1, first2,
                 hpx::parallel::v1::detail::equal_to{});
         }
 
@@ -599,8 +587,8 @@ namespace hpx {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::equal_binary().call(
-                hpx::execution::seq, std::true_type{}, first1, last1, first2,
-                last2, std::forward<Pred>(op),
+                hpx::execution::seq, first1, last1, first2, last2,
+                std::forward<Pred>(op),
                 hpx::parallel::util::projection_identity{},
                 hpx::parallel::util::projection_identity{});
         }
@@ -621,8 +609,8 @@ namespace hpx {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::equal_binary().call(
-                hpx::execution::seq, std::true_type{}, first1, last1, first2,
-                last2, hpx::parallel::v1::detail::equal_to{},
+                hpx::execution::seq, first1, last1, first2, last2,
+                hpx::parallel::v1::detail::equal_to{},
                 hpx::parallel::util::projection_identity{},
                 hpx::parallel::util::projection_identity{});
         }
@@ -647,8 +635,7 @@ namespace hpx {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::equal().call(hpx::execution::seq,
-                std::true_type{}, first1, last1, first2,
-                std::forward<Pred>(op));
+                first1, last1, first2, std::forward<Pred>(op));
         }
 
         // clang-format off
@@ -667,8 +654,7 @@ namespace hpx {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::equal().call(hpx::execution::seq,
-                std::true_type{}, first1, last1, first2,
-                hpx::parallel::v1::detail::equal_to{});
+                first1, last1, first2, hpx::parallel::v1::detail::equal_to{});
         }
     } equal{};
 }    // namespace hpx

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/exclusive_scan.hpp
@@ -171,10 +171,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         exclusive_scan_(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
             FwdIter2 dest, T&& init, Op&& op, std::false_type, Conv&&)
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return exclusive_scan<FwdIter2>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
+                std::forward<ExPolicy>(policy), first, last, dest,
                 std::forward<T>(init), std::forward<Op>(op));
         }
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/fill.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/fill.hpp
@@ -197,10 +197,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         fill_(ExPolicy&& policy, FwdIter first, Sent last, T const& value,
             std::false_type)
         {
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return detail::fill<FwdIter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last, value);
+                std::forward<ExPolicy>(policy), first, last, value);
         }
 
         // forward declare the segmented version of this algorithm
@@ -290,8 +288,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         // if count is representing a negative value, we do nothing
         if (detail::is_negative(count))
         {
@@ -303,8 +299,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
-        return detail::fill_n<FwdIter>().call(std::forward<ExPolicy>(policy),
-            is_seq(), first, std::size_t(count), value);
+        return detail::fill_n<FwdIter>().call(
+            std::forward<ExPolicy>(policy), first, std::size_t(count), value);
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
 #endif
@@ -383,8 +379,6 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             // if count is representing a negative value, we do nothing
             if (hpx::parallel::v1::detail::is_negative(count))
             {
@@ -393,8 +387,8 @@ namespace hpx {
             }
 
             return hpx::parallel::v1::detail::fill_n<FwdIter>().call(
-                std::forward<ExPolicy>(policy), is_seq{}, first,
-                std::size_t(count), value);
+                std::forward<ExPolicy>(policy), first, std::size_t(count),
+                value);
         }
 
         // clang-format off
@@ -416,8 +410,7 @@ namespace hpx {
             }
 
             return hpx::parallel::v1::detail::fill_n<FwdIter>().call(
-                hpx::execution::seq, std::true_type{}, first,
-                std::size_t(count), value);
+                hpx::execution::seq, first, std::size_t(count), value);
         }
     } fill_n{};
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/fill.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/fill.hpp
@@ -185,7 +185,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 }
 
                 return for_each_n<FwdIter>().call(
-                    std::forward<ExPolicy>(policy), std::false_type(), first,
+                    std::forward<ExPolicy>(policy), first,
                     detail::distance(first, last), fill_iteration<T>{val},
                     util::projection_identity());
             }
@@ -265,8 +265,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 typedef typename std::iterator_traits<FwdIter>::value_type type;
 
                 return for_each_n<FwdIter>().call(
-                    std::forward<ExPolicy>(policy), std::false_type(), first,
-                    count, [val](type& v) -> void { v = val; },
+                    std::forward<ExPolicy>(policy), first, count,
+                    [val](type& v) -> void { v = val; },
                     util::projection_identity());
             }
         };

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/find.hpp
@@ -484,10 +484,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static_assert((hpx::traits::is_forward_iterator<Iter>::value),
                 "Requires at least forward iterator.");
 
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return detail::find<Iter>().call(std::forward<ExPolicy>(policy),
-                is_seq(), first, last, val, std::forward<Proj>(proj));
+                first, last, val, std::forward<Proj>(proj));
         }
 
         template <typename ExPolicy, typename FwdIter, typename T,
@@ -606,11 +604,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static_assert((hpx::traits::is_forward_iterator<Iter>::value),
                 "Requires at least forward iterator.");
 
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return detail::find_if<Iter>().call(std::forward<ExPolicy>(policy),
-                is_seq(), first, last, std::forward<F>(f),
-                std::forward<Proj>(proj));
+                first, last, std::forward<F>(f), std::forward<Proj>(proj));
         }
 
         template <typename ExPolicy, typename FwdIter, typename F,
@@ -733,11 +728,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static_assert((hpx::traits::is_forward_iterator<Iter>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return detail::find_if_not<Iter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
-                std::forward<F>(f), std::forward<Proj>(proj));
+                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                std::forward<Proj>(proj));
         }
 
         template <typename ExPolicy, typename FwdIter, typename F,
@@ -973,14 +966,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return detail::find_end<FwdIter1>().call(std::forward<ExPolicy>(policy),
-            is_seq(), first1, last1, first2, last2, std::forward<Pred>(op),
+            first1, last1, first2, last2, std::forward<Pred>(op),
             std::forward<Proj>(proj));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
@@ -1125,15 +1116,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Subsequence requires at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return detail::find_first_of<FwdIter1>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last, s_first,
-            s_last, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+            std::forward<ExPolicy>(policy), first, last, s_first, s_last,
+            std::forward<Pred>(op), std::forward<Proj1>(proj1),
             std::forward<Proj2>(proj2));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
@@ -1306,11 +1295,9 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::find_end<FwdIter1>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
-                last2, std::forward<Pred>(op),
+                std::forward<ExPolicy>(policy), first1, last1, first2, last2,
+                std::forward<Pred>(op),
                 hpx::parallel::util::projection_identity(),
                 hpx::parallel::util::projection_identity());
         }
@@ -1333,11 +1320,9 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::find_end<FwdIter1>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
-                last2, hpx::parallel::v1::detail::equal_to{},
+                std::forward<ExPolicy>(policy), first1, last1, first2, last2,
+                hpx::parallel::v1::detail::equal_to{},
                 hpx::parallel::util::projection_identity(),
                 hpx::parallel::util::projection_identity());
         }
@@ -1363,8 +1348,8 @@ namespace hpx {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::find_end<FwdIter1>().call(
-                hpx::execution::seq, std::true_type(), first1, last1, first2,
-                last2, std::forward<Pred>(op),
+                hpx::execution::seq, first1, last1, first2, last2,
+                std::forward<Pred>(op),
                 hpx::parallel::util::projection_identity(),
                 hpx::parallel::util::projection_identity());
         }
@@ -1385,8 +1370,8 @@ namespace hpx {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::find_end<FwdIter1>().call(
-                hpx::execution::seq, std::true_type(), first1, last1, first2,
-                last2, hpx::parallel::v1::detail::equal_to{},
+                hpx::execution::seq, first1, last1, first2, last2,
+                hpx::parallel::v1::detail::equal_to{},
                 hpx::parallel::util::projection_identity(),
                 hpx::parallel::util::projection_identity());
         }
@@ -1421,11 +1406,9 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Subsequence requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::find_first_of<FwdIter1>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last, s_first,
-                s_last, std::forward<Pred>(op),
+                std::forward<ExPolicy>(policy), first, last, s_first, s_last,
+                std::forward<Pred>(op),
                 hpx::parallel::util::projection_identity(),
                 hpx::parallel::util::projection_identity());
         }
@@ -1448,11 +1431,9 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Subsequence requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::find_first_of<FwdIter1>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last, s_first,
-                s_last, hpx::parallel::v1::detail::equal_to{},
+                std::forward<ExPolicy>(policy), first, last, s_first, s_last,
+                hpx::parallel::v1::detail::equal_to{},
                 hpx::parallel::util::projection_identity(),
                 hpx::parallel::util::projection_identity());
         }
@@ -1477,8 +1458,8 @@ namespace hpx {
                 "Subsequence requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::find_first_of<FwdIter1>().call(
-                hpx::execution::seq, std::true_type(), first, last, s_first,
-                s_last, std::forward<Pred>(op),
+                hpx::execution::seq, first, last, s_first, s_last,
+                std::forward<Pred>(op),
                 hpx::parallel::util::projection_identity(),
                 hpx::parallel::util::projection_identity());
         }
@@ -1499,8 +1480,8 @@ namespace hpx {
                 "Subsequence requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::find_first_of<FwdIter1>().call(
-                hpx::execution::seq, std::true_type(), first, last, s_first,
-                s_last, hpx::parallel::v1::detail::equal_to{},
+                hpx::execution::seq, first, last, s_first, s_last,
+                hpx::parallel::v1::detail::equal_to{},
                 hpx::parallel::util::projection_identity(),
                 hpx::parallel::util::projection_identity());
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -511,8 +511,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
         // if count is representing a negative value or zero, we do nothing
         if (detail::is_negative(count) || count == 0)
         {
@@ -525,7 +523,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return parallel::v1::detail::for_each_n<FwdIter>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, std::size_t(count),
+            std::forward<ExPolicy>(policy), first, std::size_t(count),
             std::forward<F>(f), std::forward<Proj>(proj));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
@@ -557,8 +555,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIterB>::value),
             "Requires at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
         if (first == last)
         {
             using result =
@@ -567,8 +563,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         }
 
         return parallel::v1::detail::for_each<FwdIterB>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last,
-            std::forward<F>(f), std::forward<Proj>(proj));
+            std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+            std::forward<Proj>(proj));
     }
 }}}    // namespace hpx::parallel::v1
 
@@ -601,7 +597,7 @@ namespace hpx {
             if (first != last)
             {
                 hpx::parallel::v1::detail::for_each<InIter>().call(
-                    hpx::execution::seq, std::true_type(), first, last, f,
+                    hpx::execution::seq, first, last, f,
                     hpx::parallel::util::projection_identity());
             }
             return std::forward<F>(f);
@@ -623,8 +619,6 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             if (first == last)
             {
                 using result =
@@ -634,7 +628,7 @@ namespace hpx {
 
             return hpx::parallel::util::detail::algorithm_result<ExPolicy>::get(
                 hpx::parallel::v1::detail::for_each<FwdIter>().call(
-                    std::forward<ExPolicy>(policy), is_seq(), first, last,
+                    std::forward<ExPolicy>(policy), first, last,
                     std::forward<F>(f),
                     hpx::parallel::util::projection_identity()));
         }
@@ -664,9 +658,8 @@ namespace hpx {
             }
 
             return hpx::parallel::v1::detail::for_each_n<InIter>().call(
-                hpx::execution::seq, std::true_type(), first,
-                std::size_t(count), std::forward<F>(f),
-                parallel::util::projection_identity());
+                hpx::execution::seq, first, std::size_t(count),
+                std::forward<F>(f), parallel::util::projection_identity());
         }
 
         // clang-format off
@@ -692,12 +685,9 @@ namespace hpx {
                 return result::get(std::move(first));
             }
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::for_each_n<FwdIter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first,
-                std::size_t(count), std::forward<F>(f),
-                parallel::util::projection_identity());
+                std::forward<ExPolicy>(policy), first, std::size_t(count),
+                std::forward<F>(f), parallel::util::projection_identity());
         }
     } for_each_n{};
 }    // namespace hpx

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -1019,14 +1019,12 @@ namespace hpx {
                     "Requires at least forward iterator or integral loop "
                     "boundaries.");
 
-                typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
                 std::size_t size = parallel::v1::detail::distance(first, last);
                 auto&& t = hpx::forward_as_tuple(std::forward<Args>(args)...);
 
                 return for_loop_algo().call(std::forward<ExPolicy>(policy),
-                    is_seq(), first, size, stride,
-                    hpx::get<sizeof...(Args) - 1>(t), hpx::get<Is>(t)...);
+                    first, size, stride, hpx::get<sizeof...(Args) - 1>(t),
+                    hpx::get<Is>(t)...);
             }
 
             // reshuffle arguments, last argument is function object, will go first
@@ -1055,13 +1053,11 @@ namespace hpx {
                     "Requires at least forward iterator or integral loop "
                     "boundaries.");
 
-                typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
                 auto&& t = hpx::forward_as_tuple(std::forward<Args>(args)...);
 
                 return for_loop_algo().call(std::forward<ExPolicy>(policy),
-                    is_seq(), first, size, stride,
-                    hpx::get<sizeof...(Args) - 1>(t), hpx::get<Is>(t)...);
+                    first, size, stride, hpx::get<sizeof...(Args) - 1>(t),
+                    hpx::get<Is>(t)...);
             }
             /// \endcond
         }    // namespace detail

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/generate.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/generate.hpp
@@ -201,10 +201,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         generate_(
             ExPolicy&& policy, Iter first, Sent last, F&& f, std::false_type)
         {
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return detail::generate<Iter>().call(std::forward<ExPolicy>(policy),
-                is_seq(), first, last, std::forward<F>(f));
+                first, last, std::forward<F>(f));
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -295,8 +293,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
         if (detail::is_negative(count))
         {
             return util::detail::algorithm_result<ExPolicy, FwdIter>::get(
@@ -308,7 +304,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return detail::generate_n<FwdIter>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, std::size_t(count),
+            std::forward<ExPolicy>(policy), first, std::size_t(count),
             std::forward<F>(f));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
@@ -384,8 +380,6 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Required at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             if (hpx::parallel::v1::detail::is_negative(count))
             {
                 return hpx::parallel::util::detail::algorithm_result<ExPolicy,
@@ -393,8 +387,8 @@ namespace hpx {
             }
 
             return hpx::parallel::v1::detail::generate_n<FwdIter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first,
-                std::size_t(count), std::forward<F>(f));
+                std::forward<ExPolicy>(policy), first, std::size_t(count),
+                std::forward<F>(f));
         }
 
         // clang-format off
@@ -415,8 +409,8 @@ namespace hpx {
             }
 
             return hpx::parallel::v1::detail::generate_n<FwdIter>().call(
-                hpx::execution::seq, std::true_type(), first,
-                std::size_t(count), std::forward<F>(f));
+                hpx::execution::seq, first, std::size_t(count),
+                std::forward<F>(f));
         }
     } generate_n{};
 }    // namespace hpx

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/generate.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/generate.hpp
@@ -187,7 +187,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 using type = typename std::iterator_traits<Iter>::value_type;
 
                 return for_each_n<Iter>().call(
-                    std::forward<ExPolicy>(policy), std::false_type(), first,
+                    std::forward<ExPolicy>(policy), first,
                     detail::distance(first, last),
                     [f = std::forward<F>(f)](type& v) mutable { v = f(); },
                     util::projection_identity());
@@ -270,8 +270,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 typedef typename std::iterator_traits<FwdIter>::value_type type;
 
                 return for_each_n<FwdIter>().call(
-                    std::forward<ExPolicy>(policy), std::false_type(), first,
-                    count,
+                    std::forward<ExPolicy>(policy), first, count,
                     [f = std::forward<F>(f)](type& v) mutable { v = f(); },
                     util::projection_identity());
             }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/includes.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/includes.hpp
@@ -326,14 +326,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
-        return detail::includes().call(std::forward<ExPolicy>(policy), is_seq(),
-            first1, last1, first2, last2, std::forward<Pred>(op),
+        return detail::includes().call(std::forward<ExPolicy>(policy), first1,
+            last1, first2, last2, std::forward<Pred>(op),
             util::projection_identity(), util::projection_identity());
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
@@ -372,11 +370,9 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::includes().call(
-                std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
-                last2, std::forward<Pred>(op),
+                std::forward<ExPolicy>(policy), first1, last1, first2, last2,
+                std::forward<Pred>(op),
                 hpx::parallel::util::projection_identity(),
                 hpx::parallel::util::projection_identity());
         }
@@ -402,8 +398,8 @@ namespace hpx {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::includes().call(
-                hpx::execution::seq, std::true_type(), first1, last1, first2,
-                last2, std::forward<Pred>(op),
+                hpx::execution::seq, first1, last1, first2, last2,
+                std::forward<Pred>(op),
                 hpx::parallel::util::projection_identity(),
                 hpx::parallel::util::projection_identity());
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/inclusive_scan.hpp
@@ -210,10 +210,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         inclusive_scan_(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
             FwdIter2 dest, T&& init, Op&& op, std::false_type, Conv&&)
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return inclusive_scan<FwdIter2>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
+                std::forward<ExPolicy>(policy), first, last, dest,
                 std::forward<T>(init), std::forward<Op>(op));
         }
 
@@ -223,10 +221,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         inclusive_scan_(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
             FwdIter2 dest, Op&& op, std::false_type, Conv&&)
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return inclusive_scan<FwdIter2>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
+                std::forward<ExPolicy>(policy), first, last, dest,
                 std::forward<Op>(op));
         }
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_heap.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_heap.hpp
@@ -288,15 +288,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_random_access_iterator<RandIter>::value),
             "Requires a random access iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return detail::is_heap<RandIter>().call(std::forward<ExPolicy>(policy),
-            is_seq(), first, last, std::forward<Comp>(comp),
-            std::forward<Proj>(proj));
+            first, last, std::forward<Comp>(comp), std::forward<Proj>(proj));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
 #endif
@@ -436,14 +433,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_random_access_iterator<RandIter>::value),
             "Requires a random access iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return detail::is_heap_until<RandIter>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last,
+            std::forward<ExPolicy>(policy), first, last,
             std::forward<Comp>(comp), std::forward<Proj>(proj));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
@@ -480,10 +475,8 @@ namespace hpx {
                 (hpx::traits::is_random_access_iterator<RandIter>::value),
                 "Requires a random access iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::is_heap<RandIter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
+                std::forward<ExPolicy>(policy), first, last,
                 std::forward<Comp>(comp),
                 hpx::parallel::util::projection_identity{});
         }
@@ -507,8 +500,7 @@ namespace hpx {
                 "Requires a random access iterator.");
 
             return hpx::parallel::v1::detail::is_heap<RandIter>().call(
-                hpx::execution::seq, std::true_type(), first, last,
-                std::forward<Comp>(comp),
+                hpx::execution::seq, first, last, std::forward<Comp>(comp),
                 hpx::parallel::util::projection_identity{});
         }
     } is_heap{};
@@ -540,10 +532,8 @@ namespace hpx {
                 (hpx::traits::is_random_access_iterator<RandIter>::value),
                 "Requires a random access iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::is_heap_until<RandIter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
+                std::forward<ExPolicy>(policy), first, last,
                 std::forward<Comp>(comp),
                 hpx::parallel::util::projection_identity{});
         }
@@ -567,8 +557,7 @@ namespace hpx {
                 "Requires a random access iterator.");
 
             return hpx::parallel::v1::detail::is_heap_until<RandIter>().call(
-                hpx::execution::seq, std::true_type(), first, last,
-                std::forward<Comp>(comp),
+                hpx::execution::seq, first, last, std::forward<Comp>(comp),
                 hpx::parallel::util::projection_identity{});
         }
     } is_heap_until{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_partitioned.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_partitioned.hpp
@@ -267,7 +267,7 @@ namespace hpx {
             hpx::is_partitioned_t, FwdIter first, FwdIter last, Pred&& pred)
         {
             return hpx::parallel::v1::detail::is_partitioned<FwdIter, FwdIter>()
-                .call(hpx::execution::seq, std::false_type(), first, last,
+                .call(hpx::execution::seq, first, last,
                     std::forward<Pred>(pred),
                     hpx::parallel::util::projection_identity());
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_partitioned.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_partitioned.hpp
@@ -239,14 +239,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return detail::is_partitioned<FwdIter, FwdIter>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last,
+            std::forward<ExPolicy>(policy), first, last,
             std::forward<Pred>(pred), util::projection_identity());
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
@@ -287,10 +285,8 @@ namespace hpx {
         tag_invoke(hpx::is_partitioned_t, ExPolicy&& policy, FwdIter first,
             FwdIter last, Pred&& pred)
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::is_partitioned<FwdIter, FwdIter>()
-                .call(std::forward<ExPolicy>(policy), is_seq(), first, last,
+                .call(std::forward<ExPolicy>(policy), first, last,
                     std::forward<Pred>(pred),
                     hpx::parallel::util::projection_identity());
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
@@ -336,10 +336,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::is_sorted<FwdIter, FwdIter>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last,
+            std::forward<ExPolicy>(policy), first, last,
             std::forward<Pred>(pred), util::projection_identity());
     }
 
@@ -440,10 +438,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::is_sorted_until<FwdIter, FwdIter>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last,
+            std::forward<ExPolicy>(policy), first, last,
             std::forward<Pred>(pred), util::projection_identity());
     }
 }}}    // namespace hpx::parallel::v1
@@ -469,7 +465,7 @@ namespace hpx {
             hpx::is_sorted_t, FwdIter first, FwdIter last, Pred&& pred = Pred())
         {
             return hpx::parallel::v1::detail::is_sorted<FwdIter, FwdIter>()
-                .call(hpx::execution::seq, std::true_type(), first, last,
+                .call(hpx::execution::seq, first, last,
                     std::forward<Pred>(pred),
                     hpx::parallel::util::projection_identity());
         }
@@ -492,10 +488,8 @@ namespace hpx {
         tag_invoke(hpx::is_sorted_t, ExPolicy&& policy, FwdIter first,
             FwdIter last, Pred&& pred = Pred())
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::is_sorted<FwdIter, FwdIter>()
-                .call(std::forward<ExPolicy>(policy), is_seq(), first, last,
+                .call(std::forward<ExPolicy>(policy), first, last,
                     std::forward<Pred>(pred),
                     hpx::parallel::util::projection_identity());
         }
@@ -522,7 +516,7 @@ namespace hpx {
         {
             return hpx::parallel::v1::detail::is_sorted_until<FwdIter,
                 FwdIter>()
-                .call(hpx::execution::seq, std::true_type(), first, last,
+                .call(hpx::execution::seq, first, last,
                     std::forward<Pred>(pred),
                     hpx::parallel::util::projection_identity());
         }
@@ -545,11 +539,9 @@ namespace hpx {
         tag_invoke(hpx::is_sorted_until_t, ExPolicy&& policy, FwdIter first,
             FwdIter last, Pred&& pred = Pred())
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::is_sorted_until<FwdIter,
                 FwdIter>()
-                .call(std::forward<ExPolicy>(policy), is_seq(), first, last,
+                .call(std::forward<ExPolicy>(policy), first, last,
                     std::forward<Pred>(pred),
                     hpx::parallel::util::projection_identity());
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
@@ -207,10 +207,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::lexicographical_compare().call(
-            std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
-            last2, std::forward<Pred>(pred));
+            std::forward<ExPolicy>(policy), first1, last1, first2, last2,
+            std::forward<Pred>(pred));
     }
 }}}    // namespace hpx::parallel::v1

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
@@ -437,11 +437,9 @@ namespace hpx {
                 hpx::traits::is_random_access_iterator<RndIter>::value,
                 "Requires random access iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::util::detail::algorithm_result<ExPolicy>::get(
                 hpx::parallel::v1::detail::make_heap<RndIter>().call(
-                    std::forward<ExPolicy>(policy), is_seq{}, first, last,
+                    std::forward<ExPolicy>(policy), first, last,
                     std::forward<Comp>(comp),
                     hpx::parallel::util::projection_identity{}));
         }
@@ -461,13 +459,12 @@ namespace hpx {
                 hpx::traits::is_random_access_iterator<RndIter>::value,
                 "Requires random access iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
             using value_type =
                 typename std::iterator_traits<RndIter>::value_type;
 
             return hpx::parallel::util::detail::algorithm_result<ExPolicy>::get(
                 hpx::parallel::v1::detail::make_heap<RndIter>().call(
-                    std::forward<ExPolicy>(policy), is_seq{}, first, last,
+                    std::forward<ExPolicy>(policy), first, last,
                     std::less<value_type>(),
                     hpx::parallel::util::projection_identity{}));
         }
@@ -490,8 +487,7 @@ namespace hpx {
                 "Requires random access iterator.");
 
             hpx::parallel::v1::detail::make_heap<RndIter>().call(
-                hpx::execution::seq, std::true_type{}, first, last,
-                std::forward<Comp>(comp),
+                hpx::execution::seq, first, last, std::forward<Comp>(comp),
                 hpx::parallel::util::projection_identity{});
         }
 
@@ -511,8 +507,7 @@ namespace hpx {
                 typename std::iterator_traits<RndIter>::value_type;
 
             hpx::parallel::v1::detail::make_heap<RndIter>().call(
-                hpx::execution::seq, std::true_type{}, first, last,
-                std::less<value_type>(),
+                hpx::execution::seq, first, last, std::less<value_type>(),
                 hpx::parallel::util::projection_identity{});
         }
     } make_heap{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/merge.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/merge.hpp
@@ -504,7 +504,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
             (hpx::traits::is_random_access_iterator<RandIter3>::value),
             "Requires at least random access iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
         using result_type =
             util::in_in_out_result<RandIter1, RandIter2, RandIter3>;
 
@@ -513,9 +512,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return detail::merge<result_type>().call(std::forward<ExPolicy>(policy),
-            is_seq(), first1, last1, first2, last2, dest,
-            std::forward<Comp>(comp), std::forward<Proj1>(proj1),
-            std::forward<Proj2>(proj2));
+            first1, last1, first2, last2, dest, std::forward<Comp>(comp),
+            std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
 #endif
@@ -778,14 +776,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_random_access_iterator<RandIter>::value),
             "Required at least random access iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return detail::inplace_merge<RandIter>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, middle, last,
+            std::forward<ExPolicy>(policy), first, middle, last,
             std::forward<Comp>(comp), std::forward<Proj>(proj));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
@@ -831,14 +827,13 @@ namespace hpx {
                 (hpx::traits::is_random_access_iterator<RandIter3>::value),
                 "Requires at least random access iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
             using result_type = hpx::parallel::util::in_in_out_result<RandIter1,
                 RandIter2, RandIter3>;
 
             return hpx::parallel::util::get_third_element(
                 hpx::parallel::v1::detail::merge<result_type>().call(
-                    std::forward<ExPolicy>(policy), is_seq(), first1, last1,
-                    first2, last2, dest, std::forward<Comp>(comp),
+                    std::forward<ExPolicy>(policy), first1, last1, first2,
+                    last2, dest, std::forward<Comp>(comp),
                     hpx::parallel::util::projection_identity(),
                     hpx::parallel::util::projection_identity()));
         }
@@ -875,8 +870,8 @@ namespace hpx {
 
             return hpx::parallel::util::get_third_element(
                 hpx::parallel::v1::detail::merge<result_type>().call(
-                    hpx::execution::seq, std::true_type(), first1, last1,
-                    first2, last2, dest, std::forward<Comp>(comp),
+                    hpx::execution::seq, first1, last1, first2, last2, dest,
+                    std::forward<Comp>(comp),
                     hpx::parallel::util::projection_identity(),
                     hpx::parallel::util::projection_identity()));
         }
@@ -909,12 +904,10 @@ namespace hpx {
                 (hpx::traits::is_random_access_iterator<RandIter>::value),
                 "Required at least random access iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::get_void_result(
                 hpx::parallel::v1::detail::inplace_merge<RandIter>().call(
-                    std::forward<ExPolicy>(policy), is_seq(), first, middle,
-                    last, std::forward<Comp>(comp),
+                    std::forward<ExPolicy>(policy), first, middle, last,
+                    std::forward<Comp>(comp),
                     hpx::parallel::util::projection_identity()));
         }
 
@@ -938,7 +931,7 @@ namespace hpx {
 
             return hpx::parallel::v1::detail::get_void_result(
                 hpx::parallel::v1::detail::inplace_merge<RandIter>().call(
-                    hpx::execution::seq, std::true_type(), first, middle, last,
+                    hpx::execution::seq, first, middle, last,
                     std::forward<Comp>(comp),
                     hpx::parallel::util::projection_identity()));
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/minmax.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/minmax.hpp
@@ -148,11 +148,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         min_element_(ExPolicy&& policy, FwdIter first, FwdIter last, F&& f,
             Proj&& proj, std::false_type)
         {
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return detail::min_element<FwdIter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
-                std::forward<F>(f), std::forward<Proj>(proj));
+                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                std::forward<Proj>(proj));
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -363,11 +361,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         max_element_(ExPolicy&& policy, FwdIter first, FwdIter last, F&& f,
             Proj&& proj, std::false_type)
         {
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return detail::max_element<FwdIter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
-                std::forward<F>(f), std::forward<Proj>(proj));
+                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                std::forward<Proj>(proj));
         }
 
         ///////////////////////////////////////////////////////////////////////
@@ -600,11 +596,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         minmax_element_(ExPolicy&& policy, FwdIter first, FwdIter last, F&& f,
             Proj&& proj, std::false_type)
         {
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return detail::minmax_element<FwdIter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
-                std::forward<F>(f), std::forward<Proj>(proj));
+                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                std::forward<Proj>(proj));
         }
 
         ///////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
@@ -361,16 +361,14 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return detail::get_pair(
             detail::mismatch_binary<util::in_in_result<FwdIter1, FwdIter2>>()
-                .call(std::forward<ExPolicy>(policy), is_seq{}, first1, last1,
-                    first2, last2, std::forward<Pred>(op)));
+                .call(std::forward<ExPolicy>(policy), first1, last1, first2,
+                    last2, std::forward<Pred>(op)));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
 #endif
@@ -477,8 +475,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         typedef std::pair<FwdIter1, FwdIter2> result_type;
 
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
@@ -486,7 +482,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return detail::mismatch<result_type>().call(
-            std::forward<ExPolicy>(policy), is_seq{}, first1, last1, first2,
+            std::forward<ExPolicy>(policy), first1, last1, first2,
             std::forward<Pred>(op));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
@@ -526,13 +522,11 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::get_pair(
                 hpx::parallel::v1::detail::mismatch_binary<
                     hpx::parallel::util::in_in_result<FwdIter1, FwdIter2>>()
-                    .call(std::forward<ExPolicy>(policy), is_seq{}, first1,
-                        last1, first2, last2, std::forward<Pred>(op),
+                    .call(std::forward<ExPolicy>(policy), first1, last1, first2,
+                        last2, std::forward<Pred>(op),
                         hpx::parallel::util::projection_identity{},
                         hpx::parallel::util::projection_identity{}));
         }
@@ -555,14 +549,11 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::get_pair(
                 hpx::parallel::v1::detail::mismatch_binary<
                     hpx::parallel::util::in_in_result<FwdIter1, FwdIter2>>()
-                    .call(std::forward<ExPolicy>(policy), is_seq{}, first1,
-                        last1, first2, last2,
-                        hpx::parallel::v1::detail::equal_to{},
+                    .call(std::forward<ExPolicy>(policy), first1, last1, first2,
+                        last2, hpx::parallel::v1::detail::equal_to{},
                         hpx::parallel::util::projection_identity{},
                         hpx::parallel::util::projection_identity{}));
         }
@@ -590,12 +581,10 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::mismatch<
                 std::pair<FwdIter1, FwdIter2>>()
-                .call(std::forward<ExPolicy>(policy), is_seq{}, first1, last1,
-                    first2, std::forward<Pred>(op));
+                .call(std::forward<ExPolicy>(policy), first1, last1, first2,
+                    std::forward<Pred>(op));
         }
 
         // clang-format off
@@ -616,12 +605,10 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::mismatch<
                 std::pair<FwdIter1, FwdIter2>>()
-                .call(std::forward<ExPolicy>(policy), is_seq{}, first1, last1,
-                    first2, hpx::parallel::v1::detail::equal_to{});
+                .call(std::forward<ExPolicy>(policy), first1, last1, first2,
+                    hpx::parallel::v1::detail::equal_to{});
         }
 
         // clang-format off
@@ -648,8 +635,8 @@ namespace hpx {
             return hpx::parallel::v1::detail::get_pair(
                 hpx::parallel::v1::detail::mismatch_binary<
                     hpx::parallel::util::in_in_result<FwdIter1, FwdIter2>>()
-                    .call(hpx::execution::seq, std::true_type{}, first1, last1,
-                        first2, last2, std::forward<Pred>(op),
+                    .call(hpx::execution::seq, first1, last1, first2, last2,
+                        std::forward<Pred>(op),
                         hpx::parallel::util::projection_identity{},
                         hpx::parallel::util::projection_identity{}));
         }
@@ -672,8 +659,8 @@ namespace hpx {
             return hpx::parallel::v1::detail::get_pair(
                 hpx::parallel::v1::detail::mismatch_binary<
                     hpx::parallel::util::in_in_result<FwdIter1, FwdIter2>>()
-                    .call(hpx::execution::seq, std::true_type{}, first1, last1,
-                        first2, last2, hpx::parallel::v1::detail::equal_to{},
+                    .call(hpx::execution::seq, first1, last1, first2, last2,
+                        hpx::parallel::v1::detail::equal_to{},
                         hpx::parallel::util::projection_identity{},
                         hpx::parallel::util::projection_identity{}));
         }
@@ -700,8 +687,8 @@ namespace hpx {
 
             return hpx::parallel::v1::detail::mismatch<
                 std::pair<FwdIter1, FwdIter2>>()
-                .call(hpx::execution::seq, std::true_type{}, first1, last1,
-                    first2, std::forward<Pred>(op));
+                .call(hpx::execution::seq, first1, last1, first2,
+                    std::forward<Pred>(op));
         }
 
         // clang-format off
@@ -721,8 +708,8 @@ namespace hpx {
 
             return hpx::parallel::v1::detail::mismatch<
                 std::pair<FwdIter1, FwdIter2>>()
-                .call(hpx::execution::seq, std::true_type{}, first1, last1,
-                    first2, hpx::parallel::v1::detail::equal_to{});
+                .call(hpx::execution::seq, first1, last1, first2,
+                    hpx::parallel::v1::detail::equal_to{});
         }
 
     } mismatch{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partial_sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partial_sort.hpp
@@ -495,7 +495,7 @@ namespace hpx {
                 "Requires at least random access iterator.");
 
             return parallel::v1::partial_sort<RandIter>().call(
-                hpx::execution::seq, std::true_type(), first, middle, last,
+                hpx::execution::seq, first, middle, last,
                 std::forward<Comp>(comp),
                 parallel::util::projection_identity());
         }
@@ -523,12 +523,11 @@ namespace hpx {
 
             using algorithm_result =
                 parallel::util::detail::algorithm_result<ExPolicy, RandIter>;
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 
             return algorithm_result::get(
                 parallel::v1::partial_sort<RandIter>().call(
-                    std::forward<ExPolicy>(policy), is_seq(), first, middle,
-                    last, std::forward<Comp>(comp),
+                    std::forward<ExPolicy>(policy), first, middle, last,
+                    std::forward<Comp>(comp),
                     parallel::util::projection_identity()));
         }
     } partial_sort{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partition.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partition.hpp
@@ -298,7 +298,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             hpx::is_sequenced_execution_policy<ExPolicy>::value ||
                 !hpx::traits::is_random_access_iterator<BidirIter>::value>;
 
-        return detail::stable_partition<BidirIter>().call(
+        return detail::stable_partition<BidirIter>().call2(
             std::forward<ExPolicy>(policy), is_seq(), first, last,
             std::forward<F>(f), std::forward<Proj>(proj));
     }
@@ -1067,11 +1067,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
         return detail::partition<FwdIter>().call(std::forward<ExPolicy>(policy),
-            is_seq(), first, last, std::forward<Pred>(pred),
-            std::forward<Proj>(proj));
+            first, last, std::forward<Pred>(pred), std::forward<Proj>(proj));
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -1350,13 +1347,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
             "Requires at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
         using result_type = hpx::tuple<FwdIter1, FwdIter2, FwdIter3>;
 
         return hpx::util::make_tagged_tuple<tag::in, tag::out1, tag::out2>(
             detail::partition_copy<result_type>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
-                dest_true, dest_false, std::forward<Pred>(pred),
+                std::forward<ExPolicy>(policy), first, last, dest_true,
+                dest_false, std::forward<Pred>(pred),
                 std::forward<Proj>(proj)));
     }
 }}}    // namespace hpx::parallel::v1

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -300,10 +300,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static_assert((hpx::traits::is_forward_iterator<FwdIterB>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return detail::reduce<T>().call(std::forward<ExPolicy>(policy),
-                is_seq(), first, last, std::move(init), std::forward<F>(f));
+                first, last, std::move(init), std::forward<F>(f));
         }
 
         // Forward Declaration of Segmented Reduce

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce_by_key.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce_by_key.hpp
@@ -214,6 +214,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
         };
 
         template <>
+        struct remove_asynchronous<hpx::execution::unsequenced_policy>
+        {
+            typedef hpx::execution::sequenced_policy type;
+        };
+
+        template <>
         struct remove_asynchronous<hpx::execution::sequenced_task_policy>
         {
             typedef hpx::execution::sequenced_policy type;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce_by_key.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce_by_key.hpp
@@ -595,11 +595,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 keys_output, values_output});
         }
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::reduce_by_key<FwdIter1, FwdIter2>().call(
-            std::forward<ExPolicy>(policy), is_seq(), key_first, key_last,
-            values_first, keys_output, values_output,
-            std::forward<Compare>(comp), std::forward<Func>(func));
+            std::forward<ExPolicy>(policy), key_first, key_last, values_first,
+            keys_output, values_output, std::forward<Compare>(comp),
+            std::forward<Func>(func));
     }
 }}}    // namespace hpx::parallel::v1

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
@@ -424,11 +424,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::remove_if<FwdIter>().call(std::forward<ExPolicy>(policy),
-            is_seq(), first, last, std::forward<Pred>(pred),
-            std::forward<Proj>(proj));
+            first, last, std::forward<Pred>(pred), std::forward<Proj>(proj));
     }
 
     // clang-format off
@@ -448,11 +445,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
     {
         typedef typename std::iterator_traits<FwdIter>::value_type Type;
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         // Just utilize existing parallel remove_if.
         return detail::remove_if<FwdIter>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last,
+            std::forward<ExPolicy>(policy), first, last,
             [value](Type const& a) -> bool { return value == a; },
             std::forward<Proj>(proj));
     }
@@ -480,8 +475,8 @@ namespace hpx {
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::remove_if<FwdIter>().call(
-                hpx::execution::sequenced_policy{}, std::true_type{}, first,
-                last, std::forward<Pred>(pred),
+                hpx::execution::sequenced_policy{}, first, last,
+                std::forward<Pred>(pred),
                 hpx::parallel::util::projection_identity());
         }
 
@@ -503,10 +498,8 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Required at least forward iterator.");
 
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return hpx::parallel::v1::detail::remove_if<FwdIter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
+                std::forward<ExPolicy>(policy), first, last,
                 std::forward<Pred>(pred),
                 hpx::parallel::util::projection_identity());
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
@@ -321,8 +321,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 FwdIter2 dest, T const& val, Proj&& proj)
             {
                 return copy_if<IterPair>().call(
-                    std::forward<ExPolicy>(policy), std::false_type(), first,
-                    last, dest,
+                    std::forward<ExPolicy>(policy), first, last, dest,
                     [val](T const& a) -> bool { return !(a == val); },
                     std::forward<Proj>(proj));
             }
@@ -411,8 +410,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     value_type;
 
                 return copy_if<IterPair>().call(
-                    std::forward<ExPolicy>(policy), std::false_type(), first,
-                    last, dest,
+                    std::forward<ExPolicy>(policy), first, last, dest,
                     [f = std::forward<F>(f)](value_type const& a) -> bool {
                         return !hpx::util::invoke(f, a);
                     },

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
@@ -355,11 +355,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::remove_copy<util::in_out_result<FwdIter1, FwdIter2>>()
-            .call(std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
-                val, std::forward<Proj>(proj));
+            .call(std::forward<ExPolicy>(policy), first, last, dest, val,
+                std::forward<Proj>(proj));
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -448,10 +446,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::remove_copy_if<util::in_out_result<FwdIter1, FwdIter2>>()
-            .call(std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
+            .call(std::forward<ExPolicy>(policy), first, last, dest,
                 std::forward<F>(f), std::forward<Proj>(proj));
     }
 }}}    // namespace hpx::parallel::v1
@@ -481,12 +477,11 @@ namespace hpx {
             static_assert((hpx::traits::is_output_iterator<InIter>::value),
                 "Required output iterator.");
 
-            auto&& res =
-                hpx::parallel::v1::detail::remove_copy_if<
-                    hpx::parallel::util::in_out_result<InIter, OutIter>>()
-                    .call(hpx::execution::sequenced_policy{}, std::true_type{},
-                        first, last, dest, std::forward<Pred>(pred),
-                        hpx::parallel::util::projection_identity());
+            auto&& res = hpx::parallel::v1::detail::remove_copy_if<
+                hpx::parallel::util::in_out_result<InIter, OutIter>>()
+                             .call(hpx::execution::sequenced_policy{}, first,
+                                 last, dest, std::forward<Pred>(pred),
+                                 hpx::parallel::util::projection_identity());
 
             return hpx::parallel::util::get_second_element(std::move(res));
         }
@@ -513,12 +508,10 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Required at least forward iterator.");
 
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             auto&& res = hpx::parallel::v1::detail::remove_copy_if<
                 hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
-                             .call(std::forward<ExPolicy>(policy), is_seq(),
-                                 first, last, dest, std::forward<Pred>(pred),
+                             .call(std::forward<ExPolicy>(policy), first, last,
+                                 dest, std::forward<Pred>(pred),
                                  hpx::parallel::util::projection_identity());
 
             return hpx::parallel::util::get_second_element(std::move(res));

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/replace.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/replace.hpp
@@ -575,11 +575,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::replace<FwdIter>().call(std::forward<ExPolicy>(policy),
-            is_seq(), first, last, old_value, new_value,
-            std::forward<Proj>(proj));
+            first, last, old_value, new_value, std::forward<Proj>(proj));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -665,11 +662,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::replace_if<FwdIter>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last,
-            std::forward<F>(f), new_value, std::forward<Proj>(proj));
+            std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+            new_value, std::forward<Proj>(proj));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -771,11 +766,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::replace_copy<util::in_out_result<FwdIter1, FwdIter2>>()
-            .call(std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
-                old_value, new_value, std::forward<Proj>(proj));
+            .call(std::forward<ExPolicy>(policy), first, last, dest, old_value,
+                new_value, std::forward<Proj>(proj));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -876,11 +869,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::replace_copy_if<
             util::in_out_result<FwdIter1, FwdIter2>>()
-            .call(std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
+            .call(std::forward<ExPolicy>(policy), first, last, dest,
                 std::forward<F>(f), new_value, std::forward<Proj>(proj));
     }
 }}}    // namespace hpx::parallel::v1
@@ -907,8 +898,8 @@ namespace hpx {
                 "Required at least input iterator.");
 
             hpx::parallel::v1::detail::replace_if<Iter>().call(
-                hpx::execution::sequenced_policy{}, std::true_type{}, first,
-                last, std::forward<Pred>(pred), new_value,
+                hpx::execution::sequenced_policy{}, first, last,
+                std::forward<Pred>(pred), new_value,
                 hpx::parallel::util::projection_identity());
         }
 
@@ -930,11 +921,9 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Required at least forward iterator.");
 
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return parallel::util::detail::algorithm_result<ExPolicy>::get(
                 hpx::parallel::v1::detail::replace_if<FwdIter>().call(
-                    std::forward<ExPolicy>(policy), is_seq(), first, last,
+                    std::forward<ExPolicy>(policy), first, last,
                     std::forward<Pred>(pred), new_value,
                     hpx::parallel::util::projection_identity()));
         }
@@ -1017,8 +1006,8 @@ namespace hpx {
             return parallel::util::get_second_element(
                 hpx::parallel::v1::detail::replace_copy_if<
                     hpx::parallel::util::in_out_result<InIter, OutIter>>()
-                    .call(hpx::execution::sequenced_policy{}, std::true_type{},
-                        first, last, dest, std::forward<Pred>(pred), new_value,
+                    .call(hpx::execution::sequenced_policy{}, first, last, dest,
+                        std::forward<Pred>(pred), new_value,
                         hpx::parallel::util::projection_identity()));
         }
 
@@ -1045,13 +1034,11 @@ namespace hpx {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Required at least forward iterator.");
 
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return parallel::util::get_second_element(
                 hpx::parallel::v1::detail::replace_copy_if<
                     hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
-                    .call(std::forward<ExPolicy>(policy), is_seq(), first, last,
-                        dest, std::forward<Pred>(pred), new_value,
+                    .call(std::forward<ExPolicy>(policy), first, last, dest,
+                        std::forward<Pred>(pred), new_value,
                         hpx::parallel::util::projection_identity()));
         }
     } replace_copy_if{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/replace.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/replace.hpp
@@ -538,7 +538,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 typedef typename std::iterator_traits<FwdIter>::value_type type;
 
                 return for_each_n<FwdIter>().call(
-                    std::forward<ExPolicy>(policy), std::false_type(), first,
+                    std::forward<ExPolicy>(policy), first,
                     std::distance(first, last),
                     [old_value, new_value, proj = std::forward<Proj>(proj)](
                         type& t) -> void {
@@ -628,7 +628,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 typedef typename std::iterator_traits<FwdIter>::value_type type;
 
                 return for_each_n<FwdIter>().call(
-                    std::forward<ExPolicy>(policy), std::false_type(), first,
+                    std::forward<ExPolicy>(policy), first,
                     detail::distance(first, last),
                     [new_value, f = std::forward<F>(f),
                         proj = std::forward<Proj>(proj)](type& t) -> void {
@@ -722,7 +722,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 return util::detail::get_in_out_result(
                     for_each_n<zip_iterator>().call(
-                        std::forward<ExPolicy>(policy), std::false_type(),
+                        std::forward<ExPolicy>(policy),
                         hpx::util::make_zip_iterator(first, dest),
                         detail::distance(first, sent),
                         [old_value, new_value, proj = std::forward<Proj>(proj)](
@@ -826,7 +826,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 return util::detail::get_in_out_result(
                     for_each_n<zip_iterator>().call(
-                        std::forward<ExPolicy>(policy), std::false_type(),
+                        std::forward<ExPolicy>(policy),
                         hpx::util::make_zip_iterator(first, dest),
                         detail::distance(first, sent),
                         [new_value, f = std::forward<F>(f),

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reverse.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reverse.hpp
@@ -61,7 +61,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 return util::detail::convert_to_result(
                     for_each_n<zip_iterator>().call(
-                        std::forward<ExPolicy>(policy), std::false_type(),
+                        std::forward<ExPolicy>(policy),
                         hpx::util::make_zip_iterator(
                             first, destination_iterator(last)),
                         std::distance(first, last) / 2,
@@ -172,8 +172,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
                 return util::detail::convert_to_result(
                     detail::copy<util::in_out_result<iterator, FwdIter>>().call(
-                        std::forward<ExPolicy>(policy), std::false_type(),
-                        iterator(last), iterator(first), dest_first),
+                        std::forward<ExPolicy>(policy), iterator(last),
+                        iterator(first), dest_first),
                     [](util::in_out_result<iterator, FwdIter> const& p)
                         -> util::in_out_result<BidirIter, FwdIter> {
                         return util::in_out_result<BidirIter, FwdIter>{

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reverse.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reverse.hpp
@@ -124,10 +124,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             (hpx::traits::is_bidirectional_iterator<BidirIter>::value),
             "Requires at least bidirectional iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::reverse<BidirIter>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last);
+            std::forward<ExPolicy>(policy), first, last);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -256,10 +254,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::reverse_copy<util::in_out_result<BidirIter, FwdIter>>()
-            .call(std::forward<ExPolicy>(policy), is_seq(), first, last,
-                dest_first);
+            .call(std::forward<ExPolicy>(policy), first, last, dest_first);
     }
 }}}    // namespace hpx::parallel::v1

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/rotate.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/rotate.hpp
@@ -158,7 +158,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 !hpx::traits::is_bidirectional_iterator<FwdIter>::value>
             is_seq;
 
-        return detail::rotate<util::in_out_result<FwdIter, FwdIter>>().call(
+        return detail::rotate<util::in_out_result<FwdIter, FwdIter>>().call2(
             std::forward<ExPolicy>(policy), is_seq(), first, new_first, last);
     }
 
@@ -304,7 +304,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             is_seq;
 
         return detail::rotate_copy<util::in_out_result<FwdIter1, FwdIter2>>()
-            .call(std::forward<ExPolicy>(policy), is_seq(), first, new_first,
+            .call2(std::forward<ExPolicy>(policy), is_seq(), first, new_first,
                 last, dest_first);
     }
 }}}    // namespace hpx::parallel::v1

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/rotate.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/rotate.hpp
@@ -40,7 +40,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         hpx::future<util::in_out_result<FwdIter, FwdIter>> rotate_helper(
             ExPolicy policy, FwdIter first, FwdIter new_first, FwdIter last)
         {
-            typedef std::false_type non_seq;
+            using non_seq = std::false_type;
 
             auto p = hpx::execution::parallel_task_policy()
                          .on(policy.executor())
@@ -55,7 +55,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     f1.get();
                     f2.get();
 
-                    hpx::future<FwdIter> f = r.call(p, non_seq(), first, last);
+                    hpx::future<FwdIter> f = r.call2(p, non_seq(), first, last);
                     return f.then([=](hpx::future<FwdIter>&& f) mutable
                         -> util::in_out_result<FwdIter, FwdIter> {
                         f.get();    // propagate exceptions
@@ -64,8 +64,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                             first, last};
                     });
                 },
-                r.call(p, non_seq(), first, new_first),
-                r.call(p, non_seq(), new_first, last));
+                r.call2(p, non_seq(), first, new_first),
+                r.call2(p, non_seq(), new_first, last));
         }
 
         template <typename IterPair>
@@ -194,13 +194,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
             typedef util::in_out_result<FwdIter1, FwdIter2> copy_return_type;
 
             hpx::future<copy_return_type> f =
-                detail::copy<copy_return_type>().call(
+                detail::copy<copy_return_type>().call2(
                     p, non_seq(), new_first, last, dest_first);
 
             return f.then([=](hpx::future<copy_return_type>&& result)
                               -> hpx::future<copy_return_type> {
                 copy_return_type p1 = result.get();
-                return detail::copy<copy_return_type>().call(
+                return detail::copy<copy_return_type>().call2(
                     p, non_seq(), first, new_first, p1.out);
             });
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/search.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/search.hpp
@@ -327,11 +327,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Subsequence requires at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
         return hpx::parallel::v1::detail::search<FwdIter, FwdIter>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last, s_first,
-            s_last, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+            std::forward<ExPolicy>(policy), first, last, s_first, s_last,
+            std::forward<Pred>(op), std::forward<Proj1>(proj1),
             std::forward<Proj2>(proj2));
     }
 
@@ -360,11 +358,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Subsequence requires at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
         return detail::search_n<FwdIter, FwdIter>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, count, s_first,
-            s_last, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+            std::forward<ExPolicy>(policy), first, count, s_first, s_last,
+            std::forward<Pred>(op), std::forward<Proj1>(proj1),
             std::forward<Proj2>(proj2));
     }
 }}}    // namespace hpx::parallel::v1
@@ -391,8 +387,8 @@ namespace hpx {
             FwdIter2 s_first, FwdIter2 s_last, Pred&& op = Pred())
         {
             return hpx::parallel::v1::detail::search<FwdIter, FwdIter>().call(
-                hpx::execution::seq, std::true_type{}, first, last, s_first,
-                s_last, std::forward<Pred>(op),
+                hpx::execution::seq, first, last, s_first, s_last,
+                std::forward<Pred>(op),
                 hpx::parallel::util::projection_identity{},
                 hpx::parallel::util::projection_identity{});
         }
@@ -415,11 +411,9 @@ namespace hpx {
         tag_invoke(hpx::search_t, ExPolicy&& policy, FwdIter first,
             FwdIter last, FwdIter2 s_first, FwdIter2 s_last, Pred&& op = Pred())
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::search<FwdIter, FwdIter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last, s_first,
-                s_last, std::forward<Pred>(op),
+                std::forward<ExPolicy>(policy), first, last, s_first, s_last,
+                std::forward<Pred>(op),
                 hpx::parallel::util::projection_identity{},
                 hpx::parallel::util::projection_identity{});
         }
@@ -447,8 +441,8 @@ namespace hpx {
             Pred&& op = Pred())
         {
             return hpx::parallel::v1::detail::search_n<FwdIter, FwdIter>().call(
-                hpx::execution::seq, std::true_type{}, first, count, s_first,
-                s_last, std::forward<Pred>(op),
+                hpx::execution::seq, first, count, s_first, s_last,
+                std::forward<Pred>(op),
                 hpx::parallel::util::projection_identity{},
                 hpx::parallel::util::projection_identity{});
         }
@@ -472,11 +466,9 @@ namespace hpx {
             std::size_t count, FwdIter2 s_first, FwdIter2 s_last,
             Pred&& op = Pred())
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::search_n<FwdIter, FwdIter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, count, s_first,
-                s_last, std::forward<Pred>(op),
+                std::forward<ExPolicy>(policy), first, count, s_first, s_last,
+                std::forward<Pred>(op),
                 hpx::parallel::util::projection_identity{},
                 hpx::parallel::util::projection_identity{});
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
@@ -214,8 +214,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 if (first2 == last2)
                 {
                     return detail::copy<result_type>().call(
-                        std::forward<ExPolicy>(policy), std::false_type(),
-                        first1, last1, dest);
+                        std::forward<ExPolicy>(policy), first1, last1, dest);
                 }
 
                 using buffer_type = typename set_operations_buffer<Iter3>::type;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
@@ -294,7 +294,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #endif
         return hpx::parallel::util::get_second_element(
             detail::set_difference<util::in_out_result<FwdIter1, FwdIter3>>()
-                .call(std::forward<ExPolicy>(policy), is_seq(), first1, last1,
+                .call2(std::forward<ExPolicy>(policy), is_seq(), first1, last1,
                     first2, last2, dest, std::forward<Pred>(op),
                     util::projection_identity(), util::projection_identity()));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
@@ -349,7 +349,7 @@ namespace hpx {
                 hpx::parallel::util::in_out_result<FwdIter1, FwdIter3>;
 
             return hpx::parallel::util::get_second_element(
-                hpx::parallel::v1::detail::set_difference<result_type>().call(
+                hpx::parallel::v1::detail::set_difference<result_type>().call2(
                     std::forward<ExPolicy>(policy), is_seq(), first1, last1,
                     first2, last2, dest, std::forward<Pred>(op),
                     hpx::parallel::util::projection_identity(),
@@ -385,8 +385,8 @@ namespace hpx {
 
             return hpx::parallel::util::get_second_element(
                 hpx::parallel::v1::detail::set_difference<result_type>().call(
-                    hpx::execution::seq, std::true_type(), first1, last1,
-                    first2, last2, dest, std::forward<Pred>(op),
+                    hpx::execution::seq, first1, last1, first2, last2, dest,
+                    std::forward<Pred>(op),
                     hpx::parallel::util::projection_identity(),
                     hpx::parallel::util::projection_identity()));
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_intersection.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_intersection.hpp
@@ -271,7 +271,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
         return util::get_third_element(
-            detail::set_intersection<result_type>().call(
+            detail::set_intersection<result_type>().call2(
                 std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
                 last2, dest, std::forward<Pred>(op),
                 util::projection_identity(), util::projection_identity()));
@@ -327,11 +327,11 @@ namespace hpx {
                 FwdIter2, FwdIter3>;
 
             return hpx::parallel::util::get_third_element(
-                hpx::parallel::v1::detail::set_intersection<result_type>().call(
-                    std::forward<ExPolicy>(policy), is_seq(), first1, last1,
-                    first2, last2, dest, std::forward<Pred>(op),
-                    hpx::parallel::util::projection_identity(),
-                    hpx::parallel::util::projection_identity()));
+                hpx::parallel::v1::detail::set_intersection<result_type>()
+                    .call2(std::forward<ExPolicy>(policy), is_seq(), first1,
+                        last1, first2, last2, dest, std::forward<Pred>(op),
+                        hpx::parallel::util::projection_identity(),
+                        hpx::parallel::util::projection_identity()));
         }
 
         // clang-format off
@@ -363,8 +363,8 @@ namespace hpx {
 
             return hpx::parallel::util::get_third_element(
                 hpx::parallel::v1::detail::set_intersection<result_type>().call(
-                    hpx::execution::seq, std::true_type(), first1, last1,
-                    first2, last2, dest, std::forward<Pred>(op),
+                    hpx::execution::seq, first1, last1, first2, last2, dest,
+                    std::forward<Pred>(op),
                     hpx::parallel::util::projection_identity(),
                     hpx::parallel::util::projection_identity()));
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
@@ -220,8 +220,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 {
                     return util::detail::convert_to_result(
                         detail::copy<util::in_out_result<Iter2, Iter3>>().call(
-                            std::forward<ExPolicy>(policy), std::false_type(),
-                            first2, last2, dest),
+                            std::forward<ExPolicy>(policy), first2, last2,
+                            dest),
                         [first1](util::in_out_result<Iter2, Iter3> const& p)
                             -> result_type {
                             return {first1, p.in, p.out};
@@ -232,8 +232,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 {
                     return util::detail::convert_to_result(
                         detail::copy<util::in_out_result<Iter1, Iter3>>().call(
-                            std::forward<ExPolicy>(policy), std::false_type(),
-                            first1, last1, dest),
+                            std::forward<ExPolicy>(policy), first1, last1,
+                            dest),
                         [first2](util::in_out_result<Iter1, Iter3> const& p)
                             -> result_type {
                             return {p.in, first2, p.out};

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
@@ -308,7 +308,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             parallel::util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>;
 
         return util::get_third_element(
-            detail::set_symmetric_difference<result_type>().call(
+            detail::set_symmetric_difference<result_type>().call2(
                 std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
                 last2, dest, std::forward<Pred>(op),
                 util::projection_identity(), util::projection_identity()));
@@ -366,7 +366,7 @@ namespace hpx {
             return hpx::parallel::util::get_third_element(
                 hpx::parallel::v1::detail::set_symmetric_difference<
                     result_type>()
-                    .call(std::forward<ExPolicy>(policy), is_seq(), first1,
+                    .call2(std::forward<ExPolicy>(policy), is_seq(), first1,
                         last1, first2, last2, dest, std::forward<Pred>(op),
                         hpx::parallel::util::projection_identity(),
                         hpx::parallel::util::projection_identity()));
@@ -402,8 +402,8 @@ namespace hpx {
             return hpx::parallel::util::get_third_element(
                 hpx::parallel::v1::detail::set_symmetric_difference<
                     result_type>()
-                    .call(hpx::execution::seq, std::true_type(), first1, last1,
-                        first2, last2, dest, std::forward<Pred>(op),
+                    .call(hpx::execution::seq, first1, last1, first2, last2,
+                        dest, std::forward<Pred>(op),
                         hpx::parallel::util::projection_identity(),
                         hpx::parallel::util::projection_identity()));
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_union.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_union.hpp
@@ -210,8 +210,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 {
                     return util::detail::convert_to_result(
                         detail::copy<util::in_out_result<Iter2, Iter3>>().call(
-                            std::forward<ExPolicy>(policy), std::false_type(),
-                            first2, last2, dest),
+                            std::forward<ExPolicy>(policy), first2, last2,
+                            dest),
                         [first1](util::in_out_result<Iter2, Iter3> const& p)
                             -> result_type {
                             return {first1, p.in, p.out};
@@ -222,8 +222,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 {
                     return util::detail::convert_to_result(
                         detail::copy<util::in_out_result<Iter1, Iter3>>().call(
-                            std::forward<ExPolicy>(policy), std::false_type(),
-                            first1, last1, dest),
+                            std::forward<ExPolicy>(policy), first1, last1,
+                            dest),
                         [first2](util::in_out_result<Iter1, Iter3> const& p)
                             -> result_type {
                             return {p.in, first2, p.out};

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_union.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_union.hpp
@@ -295,7 +295,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         using result_type =
             parallel::util::in_in_out_result<FwdIter1, FwdIter2, FwdIter3>;
 
-        return util::get_third_element(detail::set_union<result_type>().call(
+        return util::get_third_element(detail::set_union<result_type>().call2(
             std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
             last2, dest, std::forward<Pred>(op), util::projection_identity(),
             util::projection_identity()));
@@ -351,7 +351,7 @@ namespace hpx {
                 FwdIter2, FwdIter3>;
 
             return hpx::parallel::util::get_third_element(
-                hpx::parallel::v1::detail::set_union<result_type>().call(
+                hpx::parallel::v1::detail::set_union<result_type>().call2(
                     std::forward<ExPolicy>(policy), is_seq(), first1, last1,
                     first2, last2, dest, std::forward<Pred>(op),
                     hpx::parallel::util::projection_identity(),
@@ -386,8 +386,8 @@ namespace hpx {
 
             return hpx::parallel::util::get_third_element(
                 hpx::parallel::v1::detail::set_union<result_type>().call(
-                    hpx::execution::seq, std::true_type(), first1, last1,
-                    first2, last2, dest, std::forward<Pred>(op),
+                    hpx::execution::seq, first1, last1, first2, last2, dest,
+                    std::forward<Pred>(op),
                     hpx::parallel::util::projection_identity(),
                     hpx::parallel::util::projection_identity()));
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/sort.hpp
@@ -383,10 +383,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_random_access_iterator<RandomIt>::value),
             "Requires a random access iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::sort<RandomIt>().call(std::forward<ExPolicy>(policy),
-            is_seq(), first, last, std::forward<Comp>(comp),
-            std::forward<Proj>(proj));
+            first, last, std::forward<Comp>(comp), std::forward<Proj>(proj));
     }
 }}}    // namespace hpx::parallel::v1

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/stable_sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/stable_sort.hpp
@@ -218,10 +218,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_random_access_iterator<RandomIt>::value),
             "Requires a random access iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::stable_sort<RandomIt>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last,
+            std::forward<ExPolicy>(policy), first, last,
             std::forward<Compare>(comp), std::forward<Proj>(proj));
     }
 }}}    // namespace hpx::parallel::v1

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/swap_ranges.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/swap_ranges.hpp
@@ -127,9 +127,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::swap_ranges<FwdIter2>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2);
+            std::forward<ExPolicy>(policy), first1, last1, first2);
     }
 }}}    // namespace hpx::parallel::v1

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/swap_ranges.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/swap_ranges.hpp
@@ -57,7 +57,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     FwdIter2>::type result_type;
 
                 return get_iter<1, result_type>(for_each_n<zip_iterator>().call(
-                    std::forward<ExPolicy>(policy), std::false_type(),
+                    std::forward<ExPolicy>(policy),
                     hpx::util::make_zip_iterator(first1, first2),
                     std::distance(first1, last1),
                     [](reference t) -> void {

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
@@ -349,11 +349,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return detail::transform<util::in_out_result<FwdIter1B, FwdIter2>>()
-                .call(std::forward<ExPolicy>(policy), is_seq(), first, last,
-                    dest, std::forward<F>(f), std::forward<Proj>(proj));
+                .call(std::forward<ExPolicy>(policy), first, last, dest,
+                    std::forward<F>(f), std::forward<Proj>(proj));
         }
 
         /// forward declare the segmented version
@@ -551,13 +549,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
                 "Requires at least forward iterator.");
 
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
             typedef util::in_in_out_result<FwdIter1B, FwdIter2, FwdIter3>
                 result_type;
 
             return detail::transform_binary<result_type>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
-                dest, std::forward<F>(f), std::forward<Proj1>(proj1),
+                std::forward<ExPolicy>(policy), first1, last1, first2, dest,
+                std::forward<F>(f), std::forward<Proj1>(proj1),
                 std::forward<Proj2>(proj2));
         }
 
@@ -679,13 +676,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static_assert((hpx::traits::is_forward_iterator<FwdIter3>::value),
                 "Requires at least forward iterator.");
 
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
             typedef util::in_in_out_result<FwdIter1B, FwdIter2E, FwdIter3>
                 result_type;
 
             return detail::transform_binary2<result_type>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
-                last2, dest, std::forward<F>(f), std::forward<Proj1>(proj1),
+                std::forward<ExPolicy>(policy), first1, last1, first2, last2,
+                dest, std::forward<F>(f), std::forward<Proj1>(proj1),
                 std::forward<Proj2>(proj2));
         }
         template <typename ExPolicy, typename FwdIter1, typename FwdIter2,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_exclusive_scan.hpp
@@ -177,10 +177,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return detail::transform_exclusive_scan<FwdIter2>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
+                std::forward<ExPolicy>(policy), first, last, dest,
                 std::forward<Conv>(conv), std::forward<T>(init),
                 std::forward<Op>(op));
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_inclusive_scan.hpp
@@ -221,10 +221,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return detail::transform_inclusive_scan<FwdIter2>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
+                std::forward<ExPolicy>(policy), first, last, dest,
                 std::forward<Conv>(conv), std::forward<T>(init),
                 std::forward<Op>(op));
         }
@@ -240,10 +238,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return detail::transform_inclusive_scan<FwdIter2>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
+                std::forward<ExPolicy>(policy), first, last, dest,
                 std::forward<Conv>(conv), std::forward<Op>(op));
         }
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
@@ -355,11 +355,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
         transform_reduce_(ExPolicy&& policy, Iter first, Sent last, T&& init,
             Reduce&& red_op, Convert&& conv_op, std::false_type)
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
             using init_type = typename std::decay<T>::type;
 
             return transform_reduce<init_type>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
+                std::forward<ExPolicy>(policy), first, last,
                 std::forward<T>(init), std::forward<Reduce>(red_op),
                 std::forward<Convert>(conv_op));
         }
@@ -619,10 +618,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             static_assert((hpx::traits::is_forward_iterator<Iter>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return detail::transform_reduce_binary<T>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
+                std::forward<ExPolicy>(policy), first1, last1, first2,
                 std::move(init), std::forward<Reduce>(red_op),
                 std::forward<Convert>(conv_op));
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
@@ -214,10 +214,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::uninitialized_copy<FwdIter2>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last, dest);
+            std::forward<ExPolicy>(policy), first, last, dest);
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -316,8 +314,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         // if count is representing a negative value, we do nothing
         if (detail::is_negative(count))
         {
@@ -326,7 +322,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         }
 
         return detail::uninitialized_copy_n<FwdIter2>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, std::size_t(count),
-            dest);
+            std::forward<ExPolicy>(policy), first, std::size_t(count), dest);
     }
 }}}    // namespace hpx::parallel::v1

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_default_construct.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_default_construct.hpp
@@ -201,10 +201,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::uninitialized_default_construct<FwdIter>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last);
+            std::forward<ExPolicy>(policy), first, last);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -332,10 +330,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 std::move(first));
         }
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::uninitialized_default_construct_n<FwdIter>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first,
-            std::size_t(count));
+            std::forward<ExPolicy>(policy), first, std::size_t(count));
     }
 }}}    // namespace hpx::parallel::v1

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_fill.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_fill.hpp
@@ -99,7 +99,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                 it, part_size, value, tok));
                     },
                     // finalize, called once if no error occurred
-                    [](std::vector<hpx::future<partition_result_type>> &&)
+                    [](std::vector<hpx::future<partition_result_type>>&&)
                         -> void {},
                     // cleanup function, called for each partition which
                     // didn't fail, but only if at least one failed
@@ -192,10 +192,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::uninitialized_fill().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last, value);
+            std::forward<ExPolicy>(policy), first, last, value);
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -318,10 +316,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
             return util::detail::algorithm_result<ExPolicy>::get();
         }
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::uninitialized_fill_n().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, std::size_t(count),
-            value);
+            std::forward<ExPolicy>(policy), first, std::size_t(count), value);
     }
 }}}    // namespace hpx::parallel::v1

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_fill.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_fill.hpp
@@ -99,7 +99,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                                 it, part_size, value, tok));
                     },
                     // finalize, called once if no error occurred
-                    [](std::vector<hpx::future<partition_result_type>>&&)
+                    [](std::vector<hpx::future<partition_result_type>> &&)
                         -> void {},
                     // cleanup function, called for each partition which
                     // didn't fail, but only if at least one failed

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_move.hpp
@@ -228,10 +228,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::uninitialized_move<FwdIter2>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last, dest);
+            std::forward<ExPolicy>(policy), first, last, dest);
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -365,8 +363,6 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         // if count is representing a negative value, we do nothing
         if (detail::is_negative(count))
         {
@@ -378,7 +374,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
         return hpx::util::make_tagged_pair<tag::in, tag::out>(
             detail::uninitialized_move_n<std::pair<FwdIter1, FwdIter2>>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first,
-                std::size_t(count), dest));
+                std::forward<ExPolicy>(policy), first, std::size_t(count),
+                dest));
     }
 }}}    // namespace hpx::parallel::v1

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_value_construct.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_value_construct.hpp
@@ -202,10 +202,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::uninitialized_value_construct<FwdIter>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first, last);
+            std::forward<ExPolicy>(policy), first, last);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -334,10 +332,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 std::move(first));
         }
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::uninitialized_value_construct_n<FwdIter>().call(
-            std::forward<ExPolicy>(policy), is_seq(), first,
-            std::size_t(count));
+            std::forward<ExPolicy>(policy), first, std::size_t(count));
     }
 }}}    // namespace hpx::parallel::v1

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/unique.hpp
@@ -294,11 +294,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
             "Required at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return detail::unique<FwdIter>().call(std::forward<ExPolicy>(policy),
-            is_seq(), first, last, std::forward<Pred>(pred),
-            std::forward<Proj>(proj));
+            first, last, std::forward<Pred>(pred), std::forward<Proj>(proj));
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -582,12 +579,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
             "Requires at least forward iterator.");
 
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
         typedef std::pair<FwdIter1, FwdIter2> result_type;
 
         return hpx::util::make_tagged_pair<tag::in, tag::out>(
             detail::unique_copy<result_type>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last, dest,
+                std::forward<ExPolicy>(policy), first, last, dest,
                 std::forward<Pred>(pred), std::forward<Proj>(proj)));
     }
 }}}    // namespace hpx::parallel::v1

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/adjacent_find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/adjacent_find.hpp
@@ -294,7 +294,7 @@ namespace hpx { namespace ranges {
             Proj&& proj = Proj())
         {
             return hpx::parallel::v1::detail::adjacent_find<FwdIter, FwdIter>()
-                .call(hpx::execution::seq, std::true_type(), first, last,
+                .call(hpx::execution::seq, first, last,
                     std::forward<Pred>(pred), std::forward<Proj>(proj));
         }
 
@@ -320,10 +320,8 @@ namespace hpx { namespace ranges {
             FwdIter first, Sent last, Pred&& pred = Pred(),
             Proj&& proj = Proj())
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::adjacent_find<FwdIter, FwdIter>()
-                .call(std::forward<ExPolicy>(policy), is_seq(), first, last,
+                .call(std::forward<ExPolicy>(policy), first, last,
                     std::forward<Pred>(pred), std::forward<Proj>(proj));
         }
 
@@ -354,9 +352,8 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::adjacent_find<iterator_type,
                 iterator_type>()
-                .call(hpx::execution::seq, std::true_type(), std::begin(rng),
-                    std::end(rng), std::forward<Pred>(pred),
-                    std::forward<Proj>(proj));
+                .call(hpx::execution::seq, std::begin(rng), std::end(rng),
+                    std::forward<Pred>(pred), std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -386,11 +383,9 @@ namespace hpx { namespace ranges {
                 (hpx::traits::is_forward_iterator<iterator_type>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::adjacent_find<iterator_type,
                 iterator_type>()
-                .call(std::forward<ExPolicy>(policy), is_seq(), std::begin(rng),
+                .call(std::forward<ExPolicy>(policy), std::begin(rng),
                     std::end(rng), std::forward<Pred>(pred),
                     std::forward<Proj>(proj));
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/all_any_none.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/all_any_none.hpp
@@ -350,8 +350,6 @@ namespace hpx { namespace ranges {
         tag_fallback_invoke(none_of_t, ExPolicy&& policy, Rng&& rng, F&& f,
             Proj&& proj = Proj())
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             using iterator_type =
                 typename hpx::traits::range_iterator<Rng>::type;
 
@@ -360,7 +358,7 @@ namespace hpx { namespace ranges {
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::none_of().call(
-                std::forward<ExPolicy>(policy), is_seq(), hpx::util::begin(rng),
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
                 hpx::util::end(rng), std::forward<F>(f),
                 std::forward<Proj>(proj));
         }
@@ -383,14 +381,12 @@ namespace hpx { namespace ranges {
         tag_fallback_invoke(none_of_t, ExPolicy&& policy, Iter first, Sent last,
             F&& f, Proj&& proj = Proj())
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             static_assert(hpx::traits::is_forward_iterator<Iter>::value,
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::none_of().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
-                std::forward<F>(f), std::forward<Proj>(proj));
+                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -415,9 +411,8 @@ namespace hpx { namespace ranges {
                 "Required at least input iterator.");
 
             return hpx::parallel::v1::detail::none_of().call(
-                hpx::execution::seq, std::true_type(), hpx::util::begin(rng),
-                hpx::util::end(rng), std::forward<F>(f),
-                std::forward<Proj>(proj));
+                hpx::execution::seq, hpx::util::begin(rng), hpx::util::end(rng),
+                std::forward<F>(f), std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -440,8 +435,8 @@ namespace hpx { namespace ranges {
                 "Required at least input iterator.");
 
             return hpx::parallel::v1::detail::none_of().call(
-                hpx::execution::seq, std::true_type(), first, last,
-                std::forward<F>(f), std::forward<Proj>(proj));
+                hpx::execution::seq, first, last, std::forward<F>(f),
+                std::forward<Proj>(proj));
         }
     } none_of{};
 
@@ -471,14 +466,12 @@ namespace hpx { namespace ranges {
             using iterator_type =
                 typename hpx::traits::range_iterator<Rng>::type;
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             static_assert(
                 hpx::traits::is_forward_iterator<iterator_type>::value,
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::any_of().call(
-                std::forward<ExPolicy>(policy), is_seq(), hpx::util::begin(rng),
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
                 hpx::util::end(rng), std::forward<F>(f),
                 std::forward<Proj>(proj));
         }
@@ -501,14 +494,12 @@ namespace hpx { namespace ranges {
         tag_fallback_invoke(any_of_t, ExPolicy&& policy, Iter first, Sent last,
             F&& f, Proj&& proj = Proj())
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             static_assert(hpx::traits::is_forward_iterator<Iter>::value,
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::any_of().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
-                std::forward<F>(f), std::forward<Proj>(proj));
+                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -533,8 +524,8 @@ namespace hpx { namespace ranges {
                 "Required at least input iterator.");
 
             return hpx::parallel::v1::detail::any_of().call(hpx::execution::seq,
-                std::true_type(), hpx::util::begin(rng), hpx::util::end(rng),
-                std::forward<F>(f), std::forward<Proj>(proj));
+                hpx::util::begin(rng), hpx::util::end(rng), std::forward<F>(f),
+                std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -557,8 +548,7 @@ namespace hpx { namespace ranges {
                 "Required at least input iterator.");
 
             return hpx::parallel::v1::detail::any_of().call(hpx::execution::seq,
-                std::true_type(), first, last, std::forward<F>(f),
-                std::forward<Proj>(proj));
+                first, last, std::forward<F>(f), std::forward<Proj>(proj));
         }
     } any_of{};
 
@@ -588,14 +578,12 @@ namespace hpx { namespace ranges {
             using iterator_type =
                 typename hpx::traits::range_iterator<Rng>::type;
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             static_assert(
                 hpx::traits::is_forward_iterator<iterator_type>::value,
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::all_of().call(
-                std::forward<ExPolicy>(policy), is_seq(), hpx::util::begin(rng),
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
                 hpx::util::end(rng), std::forward<F>(f),
                 std::forward<Proj>(proj));
         }
@@ -618,14 +606,12 @@ namespace hpx { namespace ranges {
         tag_fallback_invoke(all_of_t, ExPolicy&& policy, Iter first, Sent last,
             F&& f, Proj&& proj = Proj())
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             static_assert(hpx::traits::is_forward_iterator<Iter>::value,
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::all_of().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
-                std::forward<F>(f), std::forward<Proj>(proj));
+                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -650,8 +636,8 @@ namespace hpx { namespace ranges {
                 "Required at least input iterator.");
 
             return hpx::parallel::v1::detail::all_of().call(hpx::execution::seq,
-                std::true_type(), hpx::util::begin(rng), hpx::util::end(rng),
-                std::forward<F>(f), std::forward<Proj>(proj));
+                hpx::util::begin(rng), hpx::util::end(rng), std::forward<F>(f),
+                std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -674,8 +660,7 @@ namespace hpx { namespace ranges {
                 "Required at least input iterator.");
 
             return hpx::parallel::v1::detail::all_of().call(hpx::execution::seq,
-                std::true_type(), first, last, std::forward<F>(f),
-                std::forward<Proj>(proj));
+                first, last, std::forward<F>(f), std::forward<Proj>(proj));
         }
     } all_of{};
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/copy.hpp
@@ -500,12 +500,10 @@ namespace hpx { namespace ranges {
                         std::move(first), std::move(dest)});
             }
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::copy_n<
                 ranges::copy_n_result<FwdIter1, FwdIter2>>()
-                .call(std::forward<ExPolicy>(policy), is_seq{}, first,
-                    std::size_t(count), dest);
+                .call(std::forward<ExPolicy>(policy), first, std::size_t(count),
+                    dest);
         }
 
         // clang-format off
@@ -531,8 +529,7 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::copy_n<
                 ranges::copy_n_result<FwdIter1, FwdIter2>>()
-                .call(hpx::execution::seq, std::true_type{}, first,
-                    std::size_t(count), dest);
+                .call(hpx::execution::seq, first, std::size_t(count), dest);
         }
     } copy_n{};
 
@@ -571,12 +568,10 @@ namespace hpx { namespace ranges {
                         hpx::traits::is_output_iterator<FwdIter>::value),
                 "Requires at least forward iterator or sequential execution.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::copy_if<
                 hpx::parallel::util::in_out_result<FwdIter1, FwdIter>>()
-                .call(std::forward<ExPolicy>(policy), is_seq{}, iter, sent,
-                    dest, std::forward<Pred>(pred), std::forward<Proj>(proj));
+                .call(std::forward<ExPolicy>(policy), iter, sent, dest,
+                    std::forward<Pred>(pred), std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -605,15 +600,13 @@ namespace hpx { namespace ranges {
                         hpx::traits::is_output_iterator<FwdIter>::value),
                 "Requires at least forward iterator or sequential execution.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::copy_if<
                 hpx::parallel::util::in_out_result<
                     typename hpx::traits::range_traits<Rng>::iterator_type,
                     FwdIter>>()
-                .call(std::forward<ExPolicy>(policy), is_seq(),
-                    hpx::util::begin(rng), hpx::util::end(rng), dest,
-                    std::forward<Pred>(pred), std::forward<Proj>(proj));
+                .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                    hpx::util::end(rng), dest, std::forward<Pred>(pred),
+                    std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -643,7 +636,7 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::copy_if<
                 hpx::parallel::util::in_out_result<FwdIter1, FwdIter>>()
-                .call(hpx::execution::seq, std::true_type{}, iter, sent, dest,
+                .call(hpx::execution::seq, iter, sent, dest,
                     std::forward<Pred>(pred), std::forward<Proj>(proj));
         }
 
@@ -672,9 +665,9 @@ namespace hpx { namespace ranges {
                 hpx::parallel::util::in_out_result<
                     typename hpx::traits::range_traits<Rng>::iterator_type,
                     FwdIter>>()
-                .call(hpx::execution::seq, std::true_type{},
-                    hpx::util::begin(rng), hpx::util::end(rng), dest,
-                    std::forward<Pred>(pred), std::forward<Proj>(proj));
+                .call(hpx::execution::seq, hpx::util::begin(rng),
+                    hpx::util::end(rng), dest, std::forward<Pred>(pred),
+                    std::forward<Proj>(proj));
         }
 
     } copy_if{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/count.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/count.hpp
@@ -189,15 +189,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<iterator_type>::value),
             "Required at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
         using difference_type =
             typename std::iterator_traits<iterator_type>::difference_type;
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
 #endif
         return hpx::parallel::v1::detail::count<difference_type>().call(
-            std::forward<ExPolicy>(policy), is_seq(), hpx::util::begin(rng),
+            std::forward<ExPolicy>(policy), hpx::util::begin(rng),
             hpx::util::end(rng), value, std::forward<Proj>(proj));
     }
 
@@ -231,15 +229,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert((hpx::traits::is_forward_iterator<iterator_type>::value),
             "Required at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
         using difference_type =
             typename std::iterator_traits<iterator_type>::difference_type;
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
 #endif
         return hpx::parallel::v1::detail::count_if<difference_type>().call(
-            std::forward<ExPolicy>(policy), is_seq(), hpx::util::begin(rng),
+            std::forward<ExPolicy>(policy), hpx::util::begin(rng),
             hpx::util::end(rng), std::forward<F>(f), std::forward<Proj>(proj));
     }
 }}}    // namespace hpx::parallel::v1
@@ -274,13 +270,11 @@ namespace hpx { namespace ranges {
                 (hpx::traits::is_forward_iterator<iterator_type>::value),
                 "Required at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             using difference_type =
                 typename std::iterator_traits<iterator_type>::difference_type;
 
             return hpx::parallel::v1::detail::count<difference_type>().call(
-                std::forward<ExPolicy>(policy), is_seq(), hpx::util::begin(rng),
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
                 hpx::util::end(rng), value, std::forward<Proj>(proj));
         }
 
@@ -300,13 +294,11 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_forward_iterator<Iter>::value),
                 "Required at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             using difference_type =
                 typename std::iterator_traits<Iter>::difference_type;
 
             return hpx::parallel::v1::detail::count<difference_type>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last, value,
+                std::forward<ExPolicy>(policy), first, last, value,
                 std::forward<Proj>(proj));
         }
 
@@ -334,8 +326,8 @@ namespace hpx { namespace ranges {
                 typename std::iterator_traits<iterator_type>::difference_type;
 
             return hpx::parallel::v1::detail::count<difference_type>().call(
-                hpx::execution::seq, std::true_type(), hpx::util::begin(rng),
-                hpx::util::end(rng), value, std::forward<Proj>(proj));
+                hpx::execution::seq, hpx::util::begin(rng), hpx::util::end(rng),
+                value, std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -356,7 +348,7 @@ namespace hpx { namespace ranges {
                 typename std::iterator_traits<Iter>::difference_type;
 
             return hpx::parallel::v1::detail::count<difference_type>().call(
-                hpx::execution::seq, std::true_type(), first, last, value,
+                hpx::execution::seq, first, last, value,
                 std::forward<Proj>(proj));
         }
     } count{};
@@ -392,13 +384,11 @@ namespace hpx { namespace ranges {
                 (hpx::traits::is_forward_iterator<iterator_type>::value),
                 "Required at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             using difference_type =
                 typename std::iterator_traits<iterator_type>::difference_type;
 
             return hpx::parallel::v1::detail::count_if<difference_type>().call(
-                std::forward<ExPolicy>(policy), is_seq(), hpx::util::begin(rng),
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
                 hpx::util::end(rng), std::forward<F>(f),
                 std::forward<Proj>(proj));
         }
@@ -423,14 +413,12 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_forward_iterator<Iter>::value),
                 "Required at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             using difference_type =
                 typename std::iterator_traits<Iter>::difference_type;
 
             return hpx::parallel::v1::detail::count_if<difference_type>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
-                std::forward<F>(f), std::forward<Proj>(proj));
+                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -460,9 +448,8 @@ namespace hpx { namespace ranges {
                 typename std::iterator_traits<iterator_type>::difference_type;
 
             return hpx::parallel::v1::detail::count_if<difference_type>().call(
-                hpx::execution::seq, std::true_type(), hpx::util::begin(rng),
-                hpx::util::end(rng), std::forward<F>(f),
-                std::forward<Proj>(proj));
+                hpx::execution::seq, hpx::util::begin(rng), hpx::util::end(rng),
+                std::forward<F>(f), std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -488,8 +475,8 @@ namespace hpx { namespace ranges {
                 typename std::iterator_traits<Iter>::difference_type;
 
             return hpx::parallel::v1::detail::count_if<difference_type>().call(
-                hpx::execution::seq, std::true_type(), first, last,
-                std::forward<F>(f), std::forward<Proj>(proj));
+                hpx::execution::seq, first, last, std::forward<F>(f),
+                std::forward<Proj>(proj));
         }
     } count_if{};
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/destroy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/destroy.hpp
@@ -192,7 +192,7 @@ namespace hpx { namespace ranges {
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::destroy<iterator_type>().call(
-                hpx::execution::seq, std::false_type{}, hpx::util::begin(rng),
+                hpx::execution::seq, hpx::util::begin(rng),
                 hpx::util::end(rng));
         }
 
@@ -208,7 +208,7 @@ namespace hpx { namespace ranges {
                 "Required at least forward iterator.");
 
             return hpx::parallel::v1::detail::destroy<Iter>().call(
-                hpx::execution::seq, std::false_type{}, first, last);
+                hpx::execution::seq, first, last);
         }
     } destroy{};
 
@@ -261,8 +261,7 @@ namespace hpx { namespace ranges {
             }
 
             return hpx::parallel::v1::detail::destroy_n<FwdIter>().call(
-                hpx::execution::seq, std::false_type{}, first,
-                std::size_t(count));
+                hpx::execution::seq, first, std::size_t(count));
         }
     } destroy_n{};
 }}    // namespace hpx::ranges

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/destroy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/destroy.hpp
@@ -152,10 +152,8 @@ namespace hpx { namespace ranges {
                 (hpx::traits::is_forward_iterator<iterator_type>::value),
                 "Required at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::destroy<iterator_type>().call(
-                std::forward<ExPolicy>(policy), is_seq{}, hpx::util::begin(rng),
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
                 hpx::util::end(rng));
         }
 
@@ -173,10 +171,8 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_forward_iterator<Iter>::value),
                 "Required at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::destroy<Iter>().call(
-                std::forward<ExPolicy>(policy), is_seq{}, first, last);
+                std::forward<ExPolicy>(policy), first, last);
         }
 
         // clang-format off
@@ -243,11 +239,8 @@ namespace hpx { namespace ranges {
                     FwdIter>::get(std::move(first));
             }
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::destroy_n<FwdIter>().call(
-                std::forward<ExPolicy>(policy), is_seq{}, first,
-                std::size_t(count));
+                std::forward<ExPolicy>(policy), first, std::size_t(count));
         }
 
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/equal.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/equal.hpp
@@ -257,11 +257,9 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::equal_binary().call(
-                std::forward<ExPolicy>(policy), is_seq{}, first1, last1, first2,
-                last2, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                std::forward<ExPolicy>(policy), first1, last1, first2, last2,
+                std::forward<Pred>(op), std::forward<Proj1>(proj1),
                 std::forward<Proj2>(proj2));
         }
 
@@ -297,14 +295,11 @@ namespace hpx { namespace ranges {
                         range_traits<Rng2>::iterator_type>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::equal_binary().call(
-                std::forward<ExPolicy>(policy), is_seq{},
-                hpx::util::begin(rng1), hpx::util::end(rng1),
-                hpx::util::begin(rng2), hpx::util::end(rng2),
-                std::forward<Pred>(op), std::forward<Proj1>(proj1),
-                std::forward<Proj2>(proj2));
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng1),
+                hpx::util::end(rng1), hpx::util::begin(rng2),
+                hpx::util::end(rng2), std::forward<Pred>(op),
+                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
 
         // clang-format off
@@ -332,8 +327,8 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::equal_binary().call(
-                hpx::execution::seq, std::true_type{}, first1, last1, first2,
-                last2, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                hpx::execution::seq, first1, last1, first2, last2,
+                std::forward<Pred>(op), std::forward<Proj1>(proj1),
                 std::forward<Proj2>(proj2));
         }
 
@@ -367,7 +362,7 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::equal_binary().call(
-                hpx::execution::seq, std::true_type{}, hpx::util::begin(rng1),
+                hpx::execution::seq, hpx::util::begin(rng1),
                 hpx::util::end(rng1), hpx::util::begin(rng2),
                 hpx::util::end(rng2), std::forward<Pred>(op),
                 std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/fill.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/fill.hpp
@@ -275,8 +275,6 @@ namespace hpx { namespace ranges {
                 (hpx::traits::is_forward_iterator<iterator_type>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             // if count is representing a negative value, we do nothing
             if (hpx::parallel::v1::detail::is_negative(hpx::util::size(rng)))
             {
@@ -286,7 +284,7 @@ namespace hpx { namespace ranges {
             }
 
             return hpx::parallel::v1::detail::fill_n<iterator_type>().call(
-                std::forward<ExPolicy>(policy), is_seq{}, hpx::util::begin(rng),
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
                 hpx::util::size(rng), value);
         }
 
@@ -305,8 +303,6 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             // if count is representing a negative value, we do nothing
             if (hpx::parallel::v1::detail::is_negative(count))
             {
@@ -315,8 +311,8 @@ namespace hpx { namespace ranges {
             }
 
             return hpx::parallel::v1::detail::fill_n<FwdIter>().call(
-                std::forward<ExPolicy>(policy), is_seq{}, first,
-                std::size_t(count), value);
+                std::forward<ExPolicy>(policy), first, std::size_t(count),
+                value);
         }
 
         // clang-format off
@@ -342,7 +338,7 @@ namespace hpx { namespace ranges {
             }
 
             return hpx::parallel::v1::detail::fill_n<iterator_type>().call(
-                hpx::execution::seq, std::true_type{}, hpx::util::begin(rng),
+                hpx::execution::seq, hpx::util::begin(rng),
                 hpx::util::size(rng), value);
         }
 
@@ -365,8 +361,7 @@ namespace hpx { namespace ranges {
             }
 
             return hpx::parallel::v1::detail::fill_n<FwdIter>().call(
-                hpx::execution::seq, std::true_type{}, first,
-                std::size_t(count), value);
+                hpx::execution::seq, first, std::size_t(count), value);
         }
     } fill_n{};
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/find.hpp
@@ -576,10 +576,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 typename hpx::traits::range_iterator<Rng2>::type>::value),
             "Requires at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
         return hpx::parallel::v1::detail::find_end<iterator_type>().call(
-            std::forward<ExPolicy>(policy), is_seq(), hpx::util::begin(rng1),
+            std::forward<ExPolicy>(policy), hpx::util::begin(rng1),
             hpx::util::end(rng1), hpx::util::begin(rng2), hpx::util::end(rng2),
             std::forward<Pred>(op), proj, proj);
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
@@ -627,10 +625,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 typename hpx::traits::range_iterator<Rng2>::type>::value),
             "Subsequence requires at least forward iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
         return hpx::parallel::v1::detail::find_first_of<iterator_type>().call(
-            std::forward<ExPolicy>(policy), is_seq(), hpx::util::begin(rng1),
+            std::forward<ExPolicy>(policy), hpx::util::begin(rng1),
             hpx::util::end(rng1), hpx::util::begin(rng2), hpx::util::end(rng2),
             std::forward<Pred>(op), std::forward<Proj1>(proj1),
             std::forward<Proj2>(proj2));
@@ -965,14 +961,11 @@ namespace hpx { namespace ranges {
                     typename hpx::traits::range_iterator<Rng2>::type>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::find_end<iterator_type>().call(
-                std::forward<ExPolicy>(policy), is_seq(),
-                hpx::util::begin(rng1), hpx::util::end(rng1),
-                hpx::util::begin(rng2), hpx::util::end(rng2),
-                std::forward<Pred>(op), std::forward<Proj1>(proj1),
-                std::forward<Proj2>(proj2));
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng1),
+                hpx::util::end(rng1), hpx::util::begin(rng2),
+                hpx::util::end(rng2), std::forward<Pred>(op),
+                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
 
         // clang-format off
@@ -1001,11 +994,9 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::find_end<Iter1>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
-                last2, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                std::forward<ExPolicy>(policy), first1, last1, first2, last2,
+                std::forward<Pred>(op), std::forward<Proj1>(proj1),
                 std::forward<Proj2>(proj2));
         }
 
@@ -1039,7 +1030,7 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::find_end<iterator_type>().call(
-                hpx::execution::seq, std::true_type(), hpx::util::begin(rng1),
+                hpx::execution::seq, hpx::util::begin(rng1),
                 hpx::util::end(rng1), hpx::util::begin(rng2),
                 hpx::util::end(rng2), std::forward<Pred>(op),
                 std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
@@ -1070,8 +1061,8 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::find_end<Iter1>().call(
-                hpx::execution::seq, std::true_type(), first1, last1, first2,
-                last2, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                hpx::execution::seq, first1, last1, first2, last2,
+                std::forward<Pred>(op), std::forward<Proj1>(proj1),
                 std::forward<Proj2>(proj2));
         }
     } find_end{};
@@ -1114,14 +1105,11 @@ namespace hpx { namespace ranges {
                     typename hpx::traits::range_iterator<Rng2>::type>::value),
                 "Subsequence requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::find_first_of<iterator_type>()
-                .call(std::forward<ExPolicy>(policy), is_seq(),
-                    hpx::util::begin(rng1), hpx::util::end(rng1),
-                    hpx::util::begin(rng2), hpx::util::end(rng2),
-                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
-                    std::forward<Proj2>(proj2));
+                .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng1),
+                    hpx::util::end(rng1), hpx::util::begin(rng2),
+                    hpx::util::end(rng2), std::forward<Pred>(op),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
 
         // clang-format off
@@ -1150,11 +1138,9 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
                 "Subsequence requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::find_first_of<Iter1>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
-                last2, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                std::forward<ExPolicy>(policy), first1, last1, first2, last2,
+                std::forward<Pred>(op), std::forward<Proj1>(proj1),
                 std::forward<Proj2>(proj2));
         }
 
@@ -1188,11 +1174,10 @@ namespace hpx { namespace ranges {
                 "Subsequence requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::find_first_of<iterator_type>()
-                .call(hpx::execution::seq, std::true_type(),
-                    hpx::util::begin(rng1), hpx::util::end(rng1),
-                    hpx::util::begin(rng2), hpx::util::end(rng2),
-                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
-                    std::forward<Proj2>(proj2));
+                .call(hpx::execution::seq, hpx::util::begin(rng1),
+                    hpx::util::end(rng1), hpx::util::begin(rng2),
+                    hpx::util::end(rng2), std::forward<Pred>(op),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
 
         // clang-format off
@@ -1220,8 +1205,8 @@ namespace hpx { namespace ranges {
                 "Subsequence requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::find_first_of<Iter1>().call(
-                hpx::execution::seq, std::true_type(), first1, last1, first2,
-                last2, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                hpx::execution::seq, first1, last1, first2, last2,
+                std::forward<Pred>(op), std::forward<Proj1>(proj1),
                 std::forward<Proj2>(proj2));
         }
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/for_each.hpp
@@ -442,8 +442,7 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
 
             auto it = parallel::v1::detail::for_each<InIter>().call(
-                hpx::execution::seq, std::true_type(), first, last, f,
-                std::forward<Proj>(proj));
+                hpx::execution::seq, first, last, f, std::forward<Proj>(proj));
             return {std::move(it), std::forward<F>(f)};
         }
 
@@ -470,8 +469,8 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
 
             auto it = parallel::v1::detail::for_each<iterator_type>().call(
-                hpx::execution::seq, std::true_type(), hpx::util::begin(rng),
-                hpx::util::end(rng), f, std::forward<Proj>(proj));
+                hpx::execution::seq, hpx::util::begin(rng), hpx::util::end(rng),
+                std::forward<F>(f), std::forward<Proj>(proj));
             return {std::move(it), std::forward<F>(f)};
         }
 
@@ -494,11 +493,9 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return parallel::v1::detail::for_each<FwdIter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
-                std::forward<F>(f), std::forward<Proj>(proj));
+                std::forward<ExPolicy>(policy), first, last, std::forward<F>(f),
+                std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -523,10 +520,8 @@ namespace hpx { namespace ranges {
                 (hpx::traits::is_forward_iterator<iterator_type>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return parallel::v1::detail::for_each<iterator_type>().call(
-                std::forward<ExPolicy>(policy), is_seq(), hpx::util::begin(rng),
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
                 hpx::util::end(rng), std::forward<F>(f),
                 std::forward<Proj>(proj));
         }
@@ -561,8 +556,7 @@ namespace hpx { namespace ranges {
             }
 
             auto it = parallel::v1::detail::for_each_n<InIter>().call(
-                hpx::execution::seq, std::true_type(), first, count, f,
-                std::forward<Proj>(proj));
+                hpx::execution::seq, first, count, f, std::forward<Proj>(proj));
             return {std::move(it), std::forward<F>(f)};
         }
 
@@ -591,10 +585,8 @@ namespace hpx { namespace ranges {
                     FwdIter>::get(std::move(first));
             }
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return parallel::v1::detail::for_each_n<FwdIter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, count,
+                std::forward<ExPolicy>(policy), first, count,
                 std::forward<F>(f), std::forward<Proj>(proj));
         }
     } for_each_n{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/generate.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/generate.hpp
@@ -349,8 +349,6 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Required at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             if (hpx::parallel::v1::detail::is_negative(count))
             {
                 return hpx::parallel::util::detail::algorithm_result<ExPolicy,
@@ -358,8 +356,8 @@ namespace hpx { namespace ranges {
             }
 
             return hpx::parallel::v1::detail::generate_n<FwdIter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first,
-                std::size_t(count), std::forward<F>(f));
+                std::forward<ExPolicy>(policy), first, std::size_t(count),
+                std::forward<F>(f));
         }
 
         // clang-format off
@@ -380,8 +378,8 @@ namespace hpx { namespace ranges {
             }
 
             return hpx::parallel::v1::detail::generate_n<FwdIter>().call(
-                hpx::execution::seq, std::true_type(), first,
-                std::size_t(count), std::forward<F>(f));
+                hpx::execution::seq, first, std::size_t(count),
+                std::forward<F>(f));
         }
     } generate_n{};
 }}    // namespace hpx::ranges

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/includes.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/includes.hpp
@@ -259,11 +259,9 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::includes().call(
-                std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
-                last2, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                std::forward<ExPolicy>(policy), first1, last1, first2, last2,
+                std::forward<Pred>(op), std::forward<Proj1>(proj1),
                 std::forward<Proj2>(proj2));
         }
 
@@ -294,8 +292,8 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::includes().call(
-                hpx::execution::seq, std::true_type(), first1, last1, first2,
-                last2, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                hpx::execution::seq, first1, last1, first2, last2,
+                std::forward<Pred>(op), std::forward<Proj1>(proj1),
                 std::forward<Proj2>(proj2));
         }
 
@@ -334,14 +332,11 @@ namespace hpx { namespace ranges {
                 (hpx::traits::is_forward_iterator<iterator_type2>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::includes().call(
-                std::forward<ExPolicy>(policy), is_seq(),
-                hpx::util::begin(rng1), hpx::util::end(rng1),
-                hpx::util::begin(rng2), hpx::util::end(rng2),
-                std::forward<Pred>(op), std::forward<Proj1>(proj1),
-                std::forward<Proj2>(proj2));
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng1),
+                hpx::util::end(rng1), hpx::util::begin(rng2),
+                hpx::util::end(rng2), std::forward<Pred>(op),
+                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
 
         // clang-format off
@@ -378,7 +373,7 @@ namespace hpx { namespace ranges {
                 "Requires at least forward iterator.");
 
             return hpx::parallel::v1::detail::includes().call(
-                hpx::execution::seq, std::true_type(), hpx::util::begin(rng1),
+                hpx::execution::seq, hpx::util::begin(rng1),
                 hpx::util::end(rng1), hpx::util::begin(rng2),
                 hpx::util::end(rng2), std::forward<Pred>(op),
                 std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/is_heap.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/is_heap.hpp
@@ -333,10 +333,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             (hpx::traits::is_random_access_iterator<iterator_type>::value),
             "Requires a random access iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
         return hpx::parallel::v1::detail::is_heap<iterator_type>().call(
-            std::forward<ExPolicy>(policy), is_seq(), hpx::util::begin(rng),
+            std::forward<ExPolicy>(policy), hpx::util::begin(rng),
             hpx::util::end(rng), std::forward<Comp>(comp),
             std::forward<Proj>(proj));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
@@ -374,10 +372,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
             (hpx::traits::is_random_access_iterator<iterator_type>::value),
             "Requires a random access iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
         return hpx::parallel::v1::detail::is_heap_until<iterator_type>().call(
-            std::forward<ExPolicy>(policy), is_seq(), hpx::util::begin(rng),
+            std::forward<ExPolicy>(policy), hpx::util::begin(rng),
             hpx::util::end(rng), std::forward<Comp>(comp),
             std::forward<Proj>(proj));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
@@ -420,10 +416,8 @@ namespace hpx { namespace ranges {
                 (hpx::traits::is_random_access_iterator<iterator_type>::value),
                 "Requires a random access iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::is_heap<iterator_type>().call(
-                std::forward<ExPolicy>(policy), is_seq(), hpx::util::begin(rng),
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
                 hpx::util::end(rng), std::forward<Comp>(comp),
                 std::forward<Proj>(proj));
         }
@@ -449,10 +443,8 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_random_access_iterator<Iter>::value),
                 "Requires a random access iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::is_heap<Iter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
+                std::forward<ExPolicy>(policy), first, last,
                 std::forward<Comp>(comp), std::forward<Proj>(proj));
         }
 
@@ -481,9 +473,8 @@ namespace hpx { namespace ranges {
                 "Requires a random access iterator.");
 
             return hpx::parallel::v1::detail::is_heap<iterator_type>().call(
-                hpx::execution::seq, std::true_type(), hpx::util::begin(rng),
-                hpx::util::end(rng), std::forward<Comp>(comp),
-                std::forward<Proj>(proj));
+                hpx::execution::seq, hpx::util::begin(rng), hpx::util::end(rng),
+                std::forward<Comp>(comp), std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -506,8 +497,8 @@ namespace hpx { namespace ranges {
                 "Requires a random access iterator.");
 
             return hpx::parallel::v1::detail::is_heap<Iter>().call(
-                hpx::execution::seq, std::true_type(), first, last,
-                std::forward<Comp>(comp), std::forward<Proj>(proj));
+                hpx::execution::seq, first, last, std::forward<Comp>(comp),
+                std::forward<Proj>(proj));
         }
     } is_heap{};
 
@@ -543,12 +534,10 @@ namespace hpx { namespace ranges {
                 (hpx::traits::is_random_access_iterator<iterator_type>::value),
                 "Requires a random access iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::is_heap_until<iterator_type>()
-                .call(std::forward<ExPolicy>(policy), is_seq(),
-                    hpx::util::begin(rng), hpx::util::end(rng),
-                    std::forward<Comp>(comp), std::forward<Proj>(proj));
+                .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                    hpx::util::end(rng), std::forward<Comp>(comp),
+                    std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -572,10 +561,8 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_random_access_iterator<Iter>::value),
                 "Requires a random access iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::is_heap_until<Iter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
+                std::forward<ExPolicy>(policy), first, last,
                 std::forward<Comp>(comp), std::forward<Proj>(proj));
         }
 
@@ -605,9 +592,9 @@ namespace hpx { namespace ranges {
                 "Requires a random access iterator.");
 
             return hpx::parallel::v1::detail::is_heap_until<iterator_type>()
-                .call(hpx::execution::seq, std::true_type(),
-                    hpx::util::begin(rng), hpx::util::end(rng),
-                    std::forward<Comp>(comp), std::forward<Proj>(proj));
+                .call(hpx::execution::seq, hpx::util::begin(rng),
+                    hpx::util::end(rng), std::forward<Comp>(comp),
+                    std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -630,8 +617,8 @@ namespace hpx { namespace ranges {
                 "Requires a random access iterator.");
 
             return hpx::parallel::v1::detail::is_heap_until<Iter>().call(
-                hpx::execution::seq, std::true_type(), first, last,
-                std::forward<Comp>(comp), std::forward<Proj>(proj));
+                hpx::execution::seq, first, last, std::forward<Comp>(comp),
+                std::forward<Proj>(proj));
         }
     } is_heap_until{};
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/is_partitioned.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/is_partitioned.hpp
@@ -273,7 +273,7 @@ namespace hpx { namespace ranges {
             Sent last, Pred&& pred, Proj&& proj = Proj())
         {
             return hpx::parallel::v1::detail::is_partitioned<FwdIter, Sent>()
-                .call(hpx::execution::seq, std::false_type(), first, last,
+                .call(hpx::execution::seq, first, last,
                     std::forward<Pred>(pred), std::forward<Proj>(proj));
         }
 
@@ -320,9 +320,8 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::is_partitioned<iterator_type,
                 iterator_type>()
-                .call(hpx::execution::seq, std::false_type(), std::begin(rng),
-                    std::end(rng), std::forward<Pred>(pred),
-                    std::forward<Proj>(proj));
+                .call(hpx::execution::seq, std::begin(rng), std::end(rng),
+                    std::forward<Pred>(pred), std::forward<Proj>(proj));
         }
 
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/is_partitioned.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/is_partitioned.hpp
@@ -295,10 +295,8 @@ namespace hpx { namespace ranges {
         tag_invoke(hpx::ranges::is_partitioned_t, ExPolicy&& policy,
             FwdIter first, Sent last, Pred&& pred, Proj&& proj = Proj())
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::is_partitioned<FwdIter, Sent>()
-                .call(std::forward<ExPolicy>(policy), is_seq(), first, last,
+                .call(std::forward<ExPolicy>(policy), first, last,
                     std::forward<Pred>(pred), std::forward<Proj>(proj));
         }
 
@@ -347,11 +345,10 @@ namespace hpx { namespace ranges {
         {
             using iterator_type =
                 typename hpx::traits::range_traits<Rng>::iterator_type;
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
 
             return hpx::parallel::v1::detail::is_partitioned<iterator_type,
                 iterator_type>()
-                .call(std::forward<ExPolicy>(policy), is_seq(), std::begin(rng),
+                .call(std::forward<ExPolicy>(policy), std::begin(rng),
                     std::end(rng), std::forward<Pred>(pred),
                     std::forward<Proj>(proj));
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/is_sorted.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/is_sorted.hpp
@@ -525,8 +525,8 @@ namespace hpx { namespace ranges {
             Sent last, Pred&& pred = Pred(), Proj&& proj = Proj())
         {
             return hpx::parallel::v1::detail::is_sorted<FwdIter, Sent>().call(
-                hpx::execution::seq, std::true_type(), first, last,
-                std::forward<Pred>(pred), std::forward<Proj>(proj));
+                hpx::execution::seq, first, last, std::forward<Pred>(pred),
+                std::forward<Proj>(proj));
         }
 
         template <typename ExPolicy, typename FwdIter, typename Sent,
@@ -550,10 +550,8 @@ namespace hpx { namespace ranges {
         tag_invoke(hpx::ranges::is_sorted_t, ExPolicy&& policy, FwdIter first,
             Sent last, Pred&& pred = Pred(), Proj&& proj = Proj())
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::is_sorted<FwdIter, Sent>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last,
+                std::forward<ExPolicy>(policy), first, last,
                 std::forward<Pred>(pred), std::forward<Proj>(proj));
         }
 
@@ -576,9 +574,9 @@ namespace hpx { namespace ranges {
             return hpx::parallel::v1::detail::is_sorted<
                 typename hpx::traits::range_iterator<Rng>::type,
                 typename hpx::traits::range_iterator<Rng>::type>()
-                .call(hpx::execution::seq, std::true_type(),
-                    hpx::util::begin(rng), hpx::util::end(rng),
-                    std::forward<Pred>(pred), std::forward<Proj>(proj));
+                .call(hpx::execution::seq, hpx::util::begin(rng),
+                    hpx::util::end(rng), std::forward<Pred>(pred),
+                    std::forward<Proj>(proj));
         }
 
         template <typename ExPolicy, typename Rng,
@@ -601,14 +599,12 @@ namespace hpx { namespace ranges {
         tag_invoke(hpx::ranges::is_sorted_t, ExPolicy&& policy, Rng&& rng,
             Pred&& pred = Pred(), Proj&& proj = Proj())
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::is_sorted<
                 typename hpx::traits::range_iterator<Rng>::type,
                 typename hpx::traits::range_iterator<Rng>::type>()
-                .call(std::forward<ExPolicy>(policy), is_seq(),
-                    hpx::util::begin(rng), hpx::util::end(rng),
-                    std::forward<Pred>(pred), std::forward<Proj>(proj));
+                .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                    hpx::util::end(rng), std::forward<Pred>(pred),
+                    std::forward<Proj>(proj));
         }
     } is_sorted{};
 
@@ -635,7 +631,7 @@ namespace hpx { namespace ranges {
             Sent last, Pred&& pred = Pred(), Proj&& proj = Proj())
         {
             return hpx::parallel::v1::detail::is_sorted_until<FwdIter, Sent>()
-                .call(hpx::execution::seq, std::true_type(), first, last,
+                .call(hpx::execution::seq, first, last,
                     std::forward<Pred>(pred), std::forward<Proj>(proj));
         }
 
@@ -661,10 +657,8 @@ namespace hpx { namespace ranges {
             FwdIter first, Sent last, Pred&& pred = Pred(),
             Proj&& proj = Proj())
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::is_sorted_until<FwdIter, Sent>()
-                .call(std::forward<ExPolicy>(policy), is_seq(), first, last,
+                .call(std::forward<ExPolicy>(policy), first, last,
                     std::forward<Pred>(pred), std::forward<Proj>(proj));
         }
 
@@ -688,9 +682,9 @@ namespace hpx { namespace ranges {
             return hpx::parallel::v1::detail::is_sorted_until<
                 typename hpx::traits::range_iterator<Rng>::type,
                 typename hpx::traits::range_iterator<Rng>::type>()
-                .call(hpx::execution::seq, std::true_type(),
-                    hpx::util::begin(rng), hpx::util::end(rng),
-                    std::forward<Pred>(pred), std::forward<Proj>(proj));
+                .call(hpx::execution::seq, hpx::util::begin(rng),
+                    hpx::util::end(rng), std::forward<Pred>(pred),
+                    std::forward<Proj>(proj));
         }
 
         template <typename ExPolicy, typename Rng,
@@ -713,14 +707,12 @@ namespace hpx { namespace ranges {
         tag_invoke(hpx::ranges::is_sorted_until_t, ExPolicy&& policy, Rng&& rng,
             Pred&& pred = Pred(), Proj&& proj = Proj())
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::is_sorted_until<
                 typename hpx::traits::range_iterator<Rng>::type,
                 typename hpx::traits::range_iterator<Rng>::type>()
-                .call(std::forward<ExPolicy>(policy), is_seq(),
-                    hpx::util::begin(rng), hpx::util::end(rng),
-                    std::forward<Pred>(pred), std::forward<Proj>(proj));
+                .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                    hpx::util::end(rng), std::forward<Pred>(pred),
+                    std::forward<Proj>(proj));
         }
     } is_sorted_until{};
 }}    // namespace hpx::ranges

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/make_heap.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/make_heap.hpp
@@ -167,10 +167,8 @@ namespace hpx { namespace ranges {
             static_assert(hpx::traits::is_random_access_iterator<Iter>::value,
                 "Requires random access iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::make_heap<Iter>().call(
-                std::forward<ExPolicy>(policy), is_seq{}, first, last,
+                std::forward<ExPolicy>(policy), first, last,
                 std::forward<Comp>(comp), std::forward<Proj>(proj));
         }
 
@@ -198,10 +196,8 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_random_access_iterator<iterator_type>::value,
                 "Requires random access iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::make_heap<iterator_type>().call(
-                std::forward<ExPolicy>(policy), is_seq{}, hpx::util::begin(rng),
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
                 hpx::util::end(rng), std::forward<Comp>(comp),
                 std::forward<Proj>(proj));
         }
@@ -227,11 +223,10 @@ namespace hpx { namespace ranges {
             static_assert(hpx::traits::is_random_access_iterator<Iter>::value,
                 "Requires random access iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
             using value_type = typename std::iterator_traits<Iter>::value_type;
 
             return hpx::parallel::v1::detail::make_heap<Iter>().call(
-                std::forward<ExPolicy>(policy), is_seq{}, first, last,
+                std::forward<ExPolicy>(policy), first, last,
                 std::less<value_type>(), std::forward<Proj>(proj));
         }
 
@@ -262,12 +257,11 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_random_access_iterator<iterator_type>::value,
                 "Requires random access iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
             using value_type =
                 typename std::iterator_traits<iterator_type>::value_type;
 
             return hpx::parallel::v1::detail::make_heap<iterator_type>().call(
-                std::forward<ExPolicy>(policy), is_seq{}, hpx::util::begin(rng),
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng),
                 hpx::util::end(rng), std::less<value_type>(),
                 std::forward<Proj>(proj));
         }
@@ -291,8 +285,8 @@ namespace hpx { namespace ranges {
                 "Requires random access iterator.");
 
             return hpx::parallel::v1::detail::make_heap<Iter>().call(
-                hpx::execution::seq, std::true_type{}, first, last,
-                std::forward<Comp>(comp), std::forward<Proj>(proj));
+                hpx::execution::seq, first, last, std::forward<Comp>(comp),
+                std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -318,9 +312,8 @@ namespace hpx { namespace ranges {
                 "Requires random access iterator.");
 
             return hpx::parallel::v1::detail::make_heap<iterator_type>().call(
-                hpx::execution::seq, std::true_type{}, hpx::util::begin(rng),
-                hpx::util::end(rng), std::forward<Comp>(comp),
-                std::forward<Proj>(proj));
+                hpx::execution::seq, hpx::util::begin(rng), hpx::util::end(rng),
+                std::forward<Comp>(comp), std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -345,8 +338,8 @@ namespace hpx { namespace ranges {
             using value_type = typename std::iterator_traits<Iter>::value_type;
 
             return hpx::parallel::v1::detail::make_heap<Iter>().call(
-                hpx::execution::seq, std::true_type{}, first, last,
-                std::less<value_type>(), std::forward<Proj>(proj));
+                hpx::execution::seq, first, last, std::less<value_type>(),
+                std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -378,9 +371,8 @@ namespace hpx { namespace ranges {
                 typename std::iterator_traits<iterator_type>::value_type;
 
             return hpx::parallel::v1::detail::make_heap<iterator_type>().call(
-                hpx::execution::seq, std::true_type{}, hpx::util::begin(rng),
-                hpx::util::end(rng), std::less<value_type>(),
-                std::forward<Proj>(proj));
+                hpx::execution::seq, hpx::util::begin(rng), hpx::util::end(rng),
+                std::less<value_type>(), std::forward<Proj>(proj));
         }
     } make_heap{};
 }}    // namespace hpx::ranges

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/merge.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/merge.hpp
@@ -450,13 +450,12 @@ namespace hpx { namespace parallel { inline namespace v1 {
             (hpx::traits::is_random_access_iterator<RandIter3>::value),
             "Requires at least random access iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
         using result_type =
             hpx::parallel::util::in_in_out_result<iterator_type1,
                 iterator_type2, RandIter3>;
 
         return hpx::parallel::v1::detail::merge<result_type>().call(
-            std::forward<ExPolicy>(policy), is_seq(), hpx::util::begin(rng1),
+            std::forward<ExPolicy>(policy), hpx::util::begin(rng1),
             hpx::util::end(rng1), hpx::util::begin(rng2), hpx::util::end(rng2),
             dest, std::forward<Comp>(comp), std::forward<Proj1>(proj1),
             std::forward<Proj2>(proj2));
@@ -501,11 +500,9 @@ namespace hpx { namespace parallel { inline namespace v1 {
             hpx::traits::is_random_access_iterator<iterator_type>::value,
             "Required at least random access iterator.");
 
-        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
         return hpx::parallel::v1::detail::inplace_merge<RandIter>().call(
-            std::forward<ExPolicy>(policy), is_seq(), hpx::util::begin(rng),
-            middle, hpx::util::end(rng), std::forward<Comp>(comp),
+            std::forward<ExPolicy>(policy), hpx::util::begin(rng), middle,
+            hpx::util::end(rng), std::forward<Comp>(comp),
             std::forward<Proj>(proj));
 #if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
 #pragma GCC diagnostic pop
@@ -564,16 +561,14 @@ namespace hpx { namespace ranges {
             static_assert(hpx::traits::is_random_access_iterator<Iter3>::value,
                 "Requires at least random access iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
             using result_type = hpx::ranges::merge_result<iterator_type1,
                 iterator_type2, Iter3>;
 
             return hpx::parallel::v1::detail::merge<result_type>().call(
-                std::forward<ExPolicy>(policy), is_seq(),
-                hpx::util::begin(rng1), hpx::util::end(rng1),
-                hpx::util::begin(rng2), hpx::util::end(rng2), dest,
-                std::forward<Comp>(comp), std::forward<Proj1>(proj1),
-                std::forward<Proj2>(proj2));
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng1),
+                hpx::util::end(rng1), hpx::util::begin(rng2),
+                hpx::util::end(rng2), dest, std::forward<Comp>(comp),
+                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
 
         // clang-format off
@@ -608,13 +603,12 @@ namespace hpx { namespace ranges {
             static_assert(hpx::traits::is_random_access_iterator<Iter3>::value,
                 "Requires at least random access iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
             using result_type = hpx::ranges::merge_result<Iter1, Iter2, Iter3>;
 
             return hpx::parallel::v1::detail::merge<result_type>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
-                last2, dest, std::forward<Comp>(comp),
-                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+                std::forward<ExPolicy>(policy), first1, last1, first2, last2,
+                dest, std::forward<Comp>(comp), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
         }
 
         // clang-format off
@@ -660,7 +654,7 @@ namespace hpx { namespace ranges {
                 iterator_type2, Iter3>;
 
             return hpx::parallel::v1::detail::merge<result_type>().call(
-                hpx::execution::seq, std::true_type(), hpx::util::begin(rng1),
+                hpx::execution::seq, hpx::util::begin(rng1),
                 hpx::util::end(rng1), hpx::util::begin(rng2),
                 hpx::util::end(rng2), dest, std::forward<Comp>(comp),
                 std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
@@ -700,9 +694,9 @@ namespace hpx { namespace ranges {
             using result_type = hpx::ranges::merge_result<Iter1, Iter2, Iter3>;
 
             return hpx::parallel::v1::detail::merge<result_type>().call(
-                hpx::execution::seq, std::true_type(), first1, last1, first2,
-                last2, dest, std::forward<Comp>(comp),
-                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+                hpx::execution::seq, first1, last1, first2, last2, dest,
+                std::forward<Comp>(comp), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
         }
     } merge{};
 
@@ -742,11 +736,9 @@ namespace hpx { namespace ranges {
             static_assert(hpx::traits::is_random_access_iterator<Iter>::value,
                 "Required at least random access iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::inplace_merge<Iter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), hpx::util::begin(rng),
-                middle, hpx::util::end(rng), std::forward<Comp>(comp),
+                std::forward<ExPolicy>(policy), hpx::util::begin(rng), middle,
+                hpx::util::end(rng), std::forward<Comp>(comp),
                 std::forward<Proj>(proj));
         }
 
@@ -772,10 +764,8 @@ namespace hpx { namespace ranges {
             static_assert(hpx::traits::is_random_access_iterator<Iter>::value,
                 "Required at least random access iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::inplace_merge<Iter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, middle, last,
+                std::forward<ExPolicy>(policy), first, middle, last,
                 std::forward<Comp>(comp), std::forward<Proj>(proj));
         }
 
@@ -808,8 +798,8 @@ namespace hpx { namespace ranges {
                 "Required at least random access iterator.");
 
             return hpx::parallel::v1::detail::inplace_merge<Iter>().call(
-                hpx::execution::seq, std::true_type(), hpx::util::begin(rng),
-                middle, hpx::util::end(rng), std::forward<Comp>(comp),
+                hpx::execution::seq, hpx::util::begin(rng), middle,
+                hpx::util::end(rng), std::forward<Comp>(comp),
                 std::forward<Proj>(proj));
         }
 
@@ -834,7 +824,7 @@ namespace hpx { namespace ranges {
                 "Required at least random access iterator.");
 
             return hpx::parallel::v1::detail::inplace_merge<Iter>().call(
-                hpx::execution::seq, std::true_type(), first, middle, last,
+                hpx::execution::seq, first, middle, last,
                 std::forward<Comp>(comp), std::forward<Proj>(proj));
         }
     } inplace_merge{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/mismatch.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/mismatch.hpp
@@ -264,13 +264,11 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_forward_iterator<Iter2>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::mismatch_binary<
                 mismatch_result<Iter1, Iter2>>()
-                .call(std::forward<ExPolicy>(policy), is_seq{}, first1, last1,
-                    first2, last2, std::forward<Pred>(op),
-                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+                .call(std::forward<ExPolicy>(policy), first1, last1, first2,
+                    last2, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2));
         }
 
         // clang-format off
@@ -307,17 +305,15 @@ namespace hpx { namespace ranges {
                         range_traits<Rng2>::iterator_type>::value),
                 "Requires at least forward iterator.");
 
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
             using result_type = mismatch_result<
                 typename hpx::traits::range_traits<Rng1>::iterator_type,
                 typename hpx::traits::range_traits<Rng2>::iterator_type>;
 
             return hpx::parallel::v1::detail::mismatch_binary<result_type>()
-                .call(std::forward<ExPolicy>(policy), is_seq{},
-                    hpx::util::begin(rng1), hpx::util::end(rng1),
-                    hpx::util::begin(rng2), hpx::util::end(rng2),
-                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
-                    std::forward<Proj2>(proj2));
+                .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng1),
+                    hpx::util::end(rng1), hpx::util::begin(rng2),
+                    hpx::util::end(rng2), std::forward<Pred>(op),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
 
         // clang-format off
@@ -347,9 +343,9 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::mismatch_binary<
                 mismatch_result<Iter1, Iter2>>()
-                .call(hpx::execution::seq, std::true_type{}, first1, last1,
-                    first2, last2, std::forward<Pred>(op),
-                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+                .call(hpx::execution::seq, first1, last1, first2, last2,
+                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2));
         }
 
         // clang-format off
@@ -388,11 +384,10 @@ namespace hpx { namespace ranges {
                 typename hpx::traits::range_traits<Rng2>::iterator_type>;
 
             return hpx::parallel::v1::detail::mismatch_binary<result_type>()
-                .call(hpx::execution::seq, std::true_type{},
-                    hpx::util::begin(rng1), hpx::util::end(rng1),
-                    hpx::util::begin(rng2), hpx::util::end(rng2),
-                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
-                    std::forward<Proj2>(proj2));
+                .call(hpx::execution::seq, hpx::util::begin(rng1),
+                    hpx::util::end(rng1), hpx::util::begin(rng2),
+                    hpx::util::end(rng2), std::forward<Pred>(op),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
 
     } mismatch{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove.hpp
@@ -501,13 +501,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
         remove(
             ExPolicy&& policy, Rng&& rng, T const& value, Proj&& proj = Proj())
     {
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return hpx::parallel::v1::detail::remove_if<
             typename hpx::traits::range_iterator<Rng>::type>()
-            .call(std::forward<ExPolicy>(policy), is_seq(),
-                hpx::util::begin(rng), hpx::util::end(rng), value,
-                std::forward<Proj>(proj));
+            .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                hpx::util::end(rng), value, std::forward<Proj>(proj));
     }
 
     // clang-format off
@@ -528,13 +525,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
         remove_if(
             ExPolicy&& policy, Rng&& rng, Pred&& pred, Proj&& proj = Proj())
     {
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return hpx::parallel::v1::detail::remove_if<
             typename hpx::traits::range_iterator<Rng>::type>()
-            .call(std::forward<ExPolicy>(policy), is_seq(),
-                hpx::util::begin(rng), hpx::util::end(rng),
-                std::forward<Pred>(pred), std::forward<Proj>(proj));
+            .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                hpx::util::end(rng), std::forward<Pred>(pred),
+                std::forward<Proj>(proj));
     }
 }}}    // namespace hpx::parallel::v1
 
@@ -568,8 +563,8 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::util::make_subrange<Iter, Sent>(
                 hpx::parallel::v1::detail::remove_if<Iter>().call(
-                    hpx::execution::seq, std::true_type{}, first, sent,
-                    std::forward<Pred>(pred), std::forward<Proj>(proj)),
+                    hpx::execution::seq, first, sent, std::forward<Pred>(pred),
+                    std::forward<Proj>(proj)),
                 sent);
         }
 
@@ -600,9 +595,9 @@ namespace hpx { namespace ranges {
                 typename hpx::traits::range_sentinel<Rng>::type>(
                 hpx::parallel::v1::detail::remove_if<
                     typename hpx::traits::range_iterator<Rng>::type>()
-                    .call(hpx::execution::seq, std::true_type{},
-                        hpx::util::begin(rng), hpx::util::end(rng),
-                        std::forward<Pred>(pred), std::forward<Proj>(proj)),
+                    .call(hpx::execution::seq, hpx::util::begin(rng),
+                        hpx::util::end(rng), std::forward<Pred>(pred),
+                        std::forward<Proj>(proj)),
                 hpx::util::end(rng));
         }
 
@@ -626,11 +621,9 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Required at least forward iterator.");
 
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return hpx::parallel::util::make_subrange<FwdIter, Sent>(
                 hpx::parallel::v1::detail::remove_if<FwdIter>().call(
-                    std::forward<ExPolicy>(policy), is_seq(), first, sent,
+                    std::forward<ExPolicy>(policy), first, sent,
                     std::forward<Pred>(pred), std::forward<Proj>(proj)),
                 sent);
         }
@@ -656,16 +649,14 @@ namespace hpx { namespace ranges {
                     typename hpx::traits::range_iterator<Rng>::type>::value),
                 "Required at least forward iterator.");
 
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return hpx::parallel::util::make_subrange<
                 typename hpx::traits::range_iterator<Rng>::type,
                 typename hpx::traits::range_sentinel<Rng>::type>(
                 hpx::parallel::v1::detail::remove_if<
                     typename hpx::traits::range_iterator<Rng>::type>()
-                    .call(std::forward<ExPolicy>(policy), is_seq(),
-                        hpx::util::begin(rng), hpx::util::end(rng),
-                        std::forward<Pred>(pred), std::forward<Proj>(proj)),
+                    .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                        hpx::util::end(rng), std::forward<Pred>(pred),
+                        std::forward<Proj>(proj)),
                 hpx::util::end(rng));
         }
     } remove_if{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove_copy.hpp
@@ -615,13 +615,10 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 OutIter>>::type remove_copy(ExPolicy&& policy, Rng&& rng,
             OutIter dest, T const& val, Proj&& proj = Proj())
     {
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return hpx::parallel::v1::detail::remove_copy<util::in_out_result<
             typename hpx::traits::range_traits<Rng>::iterator_type, OutIter>>()
-            .call(std::forward<ExPolicy>(policy), is_seq(),
-                hpx::util::begin(rng), hpx::util::end(rng), dest, val,
-                std::forward<Proj>(proj));
+            .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                hpx::util::end(rng), dest, val, std::forward<Proj>(proj));
     }
 
     // clang-format off
@@ -646,13 +643,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
                 OutIter>>::type remove_copy_if(ExPolicy&& policy, Rng&& rng,
             OutIter dest, F&& f, Proj&& proj = Proj())
     {
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return hpx::parallel::v1::detail::remove_copy_if<util::in_out_result<
             typename hpx::traits::range_traits<Rng>::iterator_type, OutIter>>()
-            .call(std::forward<ExPolicy>(policy), is_seq(),
-                hpx::util::begin(rng), hpx::util::end(rng), dest,
-                std::forward<F>(f), std::forward<Proj>(proj));
+            .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                hpx::util::end(rng), dest, std::forward<F>(f),
+                std::forward<Proj>(proj));
     }
 }}}    // namespace hpx::parallel::v1
 
@@ -694,7 +689,7 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::remove_copy_if<
                 hpx::parallel::util::in_out_result<I, O>>()
-                .call(hpx::execution::seq, std::true_type{}, first, last, dest,
+                .call(hpx::execution::seq, first, last, dest,
                     std::forward<Pred>(pred), std::forward<Proj>(proj));
         }
 
@@ -724,9 +719,9 @@ namespace hpx { namespace ranges {
             return hpx::parallel::v1::detail::remove_copy_if<
                 hpx::parallel::util::in_out_result<
                     typename hpx::traits::range_iterator<Rng>::type, O>>()
-                .call(hpx::execution::seq, std::true_type{},
-                    hpx::util::begin(rng), hpx::util::end(rng), dest,
-                    std::forward<Pred>(pred), std::forward<Proj>(proj));
+                .call(hpx::execution::seq, hpx::util::begin(rng),
+                    hpx::util::end(rng), dest, std::forward<Pred>(pred),
+                    std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -754,12 +749,10 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_forward_iterator<O>::value),
                 "Required at least forward iterator.");
 
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return hpx::parallel::v1::detail::remove_copy_if<
                 hpx::parallel::util::in_out_result<I, O>>()
-                .call(std::forward<ExPolicy>(policy), is_seq(), first, last,
-                    dest, std::forward<Pred>(pred), std::forward<Proj>(proj));
+                .call(std::forward<ExPolicy>(policy), first, last, dest,
+                    std::forward<Pred>(pred), std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -787,14 +780,12 @@ namespace hpx { namespace ranges {
                     typename hpx::traits::range_iterator<Rng>::type>::value),
                 "Required at least forward iterator.");
 
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return hpx::parallel::v1::detail::remove_copy_if<
                 hpx::parallel::util::in_out_result<
                     typename hpx::traits::range_iterator<Rng>::type, O>>()
-                .call(std::forward<ExPolicy>(policy), is_seq(),
-                    hpx::util::begin(rng), hpx::util::end(rng), dest,
-                    std::forward<Pred>(pred), std::forward<Proj>(proj));
+                .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                    hpx::util::end(rng), dest, std::forward<Pred>(pred),
+                    std::forward<Proj>(proj));
         }
     } remove_copy_if{};
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/replace.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/replace.hpp
@@ -1103,13 +1103,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
         replace(ExPolicy&& policy, Rng&& rng, T1 const& old_value,
             T2 const& new_value, Proj&& proj = Proj())
     {
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return hpx::parallel::v1::detail::replace<
             typename hpx::traits::range_traits<Rng>::iterator_type>()
-            .call(std::forward<ExPolicy>(policy), is_seq(),
-                hpx::util::begin(rng), hpx::util::end(rng), old_value,
-                new_value, std::forward<Proj>(proj));
+            .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                hpx::util::end(rng), old_value, new_value,
+                std::forward<Proj>(proj));
     }
 
     // clang-format off
@@ -1130,13 +1128,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
         replace_if(ExPolicy&& policy, Rng&& rng, F&& f, T const& new_value,
             Proj&& proj = Proj())
     {
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return hpx::parallel::v1::detail::replace_if<
             typename hpx::traits::range_traits<Rng>::iterator_type>()
-            .call(std::forward<ExPolicy>(policy), is_seq(),
-                hpx::util::begin(rng), hpx::util::end(rng), std::forward<F>(f),
-                new_value, std::forward<Proj>(proj));
+            .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                hpx::util::end(rng), std::forward<F>(f), new_value,
+                std::forward<Proj>(proj));
     }
 
     // clang-format off
@@ -1160,13 +1156,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
         type replace_copy(ExPolicy&& policy, Rng&& rng, OutIter dest,
             T1 const& old_value, T2 const& new_value, Proj&& proj = Proj())
     {
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return hpx::parallel::v1::detail::replace_copy<util::in_out_result<
             typename hpx::traits::range_traits<Rng>::iterator_type, OutIter>>()
-            .call(std::forward<ExPolicy>(policy), is_seq(),
-                hpx::util::begin(rng), hpx::util::end(rng), dest, old_value,
-                new_value, std::forward<Proj>(proj));
+            .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                hpx::util::end(rng), dest, old_value, new_value,
+                std::forward<Proj>(proj));
     }
 
     // clang-format off
@@ -1189,13 +1183,11 @@ namespace hpx { namespace parallel { inline namespace v1 {
             OutIter>>::type replace_copy_if(ExPolicy&& policy, Rng&& rng,
         OutIter dest, F&& f, T const& new_value, Proj&& proj = Proj())
     {
-        typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
         return hpx::parallel::v1::detail::replace_copy_if<util::in_out_result<
             typename hpx::traits::range_traits<Rng>::iterator_type, OutIter>>()
-            .call(std::forward<ExPolicy>(policy), is_seq(),
-                hpx::util::begin(rng), hpx::util::end(rng), dest,
-                std::forward<F>(f), new_value, std::forward<Proj>(proj));
+            .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                hpx::util::end(rng), dest, std::forward<F>(f), new_value,
+                std::forward<Proj>(proj));
     }
 }}}    // namespace hpx::parallel::v1
 
@@ -1236,8 +1228,8 @@ namespace hpx { namespace ranges {
                 "Required at least input iterator.");
 
             return hpx::parallel::v1::detail::replace_if<Iter>().call(
-                hpx::execution::seq, std::true_type{}, first, sent,
-                std::forward<Pred>(pred), new_value, std::forward<Proj>(proj));
+                hpx::execution::seq, first, sent, std::forward<Pred>(pred),
+                new_value, std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -1264,9 +1256,8 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::replace_if<
                 typename hpx::traits::range_iterator<Rng>::type>()
-                .call(hpx::execution::seq, std::true_type{},
-                    hpx::util::begin(rng), hpx::util::end(rng),
-                    std::forward<Pred>(pred), new_value,
+                .call(hpx::execution::seq, hpx::util::begin(rng),
+                    hpx::util::end(rng), std::forward<Pred>(pred), new_value,
                     std::forward<Proj>(proj));
         }
 
@@ -1291,10 +1282,8 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_forward_iterator<Iter>::value),
                 "Required at least forward iterator.");
 
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return hpx::parallel::v1::detail::replace_if<Iter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, sent,
+                std::forward<ExPolicy>(policy), first, sent,
                 std::forward<Pred>(pred), new_value, std::forward<Proj>(proj));
         }
 
@@ -1319,13 +1308,10 @@ namespace hpx { namespace ranges {
                     typename hpx::traits::range_iterator<Rng>::type>::value),
                 "Required at least forward iterator.");
 
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return hpx::parallel::v1::detail::replace_if<
                 typename hpx::traits::range_iterator<Rng>::type>()
-                .call(std::forward<ExPolicy>(policy), is_seq(),
-                    hpx::util::begin(rng), hpx::util::end(rng),
-                    std::forward<Pred>(pred), new_value,
+                .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                    hpx::util::end(rng), std::forward<Pred>(pred), new_value,
                     std::forward<Proj>(proj));
         }
     } replace_if{};
@@ -1476,7 +1462,7 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::replace_copy_if<
                 hpx::parallel::util::in_out_result<InIter, OutIter>>()
-                .call(hpx::execution::seq, std::true_type{}, first, sent, dest,
+                .call(hpx::execution::seq, first, sent, dest,
                     std::forward<Pred>(pred), new_value,
                     std::forward<Proj>(proj));
         }
@@ -1511,10 +1497,9 @@ namespace hpx { namespace ranges {
             return hpx::parallel::v1::detail::replace_copy_if<
                 hpx::parallel::util::in_out_result<
                     typename hpx::traits::range_iterator<Rng>::type, OutIter>>()
-                .call(hpx::execution::seq, std::true_type{},
-                    hpx::util::begin(rng), hpx::util::end(rng), dest,
-                    std::forward<Pred>(pred), new_value,
-                    std::forward<Proj>(proj));
+                .call(hpx::execution::seq, hpx::util::begin(rng),
+                    hpx::util::end(rng), dest, std::forward<Pred>(pred),
+                    new_value, std::forward<Proj>(proj));
         }
 
         // clang-format off
@@ -1543,12 +1528,10 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
                 "Required at least forward iterator.");
 
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return hpx::parallel::v1::detail::replace_copy_if<
                 hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
-                .call(std::forward<ExPolicy>(policy), is_seq(), first, sent,
-                    dest, std::forward<Pred>(pred), new_value,
+                .call(std::forward<ExPolicy>(policy), first, sent, dest,
+                    std::forward<Pred>(pred), new_value,
                     std::forward<Proj>(proj));
         }
 
@@ -1579,15 +1562,12 @@ namespace hpx { namespace ranges {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Required at least forward iterator.");
 
-            typedef hpx::is_sequenced_execution_policy<ExPolicy> is_seq;
-
             return hpx::parallel::v1::detail::replace_copy_if<
                 hpx::parallel::util::in_out_result<
                     typename hpx::traits::range_iterator<Rng>::type, FwdIter>>()
-                .call(std::forward<ExPolicy>(policy), is_seq(),
-                    hpx::util::begin(rng), hpx::util::end(rng), dest,
-                    std::forward<Pred>(pred), new_value,
-                    std::forward<Proj>(proj));
+                .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng),
+                    hpx::util::end(rng), dest, std::forward<Pred>(pred),
+                    new_value, std::forward<Proj>(proj));
         }
     } replace_copy_if{};
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/search.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/search.hpp
@@ -789,8 +789,8 @@ namespace hpx { namespace ranges {
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
             return hpx::parallel::v1::detail::search<FwdIter, Sent>().call(
-                hpx::execution::seq, std::true_type{}, first, last, s_first,
-                s_last, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                hpx::execution::seq, first, last, s_first, s_last,
+                std::forward<Pred>(op), std::forward<Proj1>(proj1),
                 std::forward<Proj2>(proj2));
         }
 
@@ -821,11 +821,9 @@ namespace hpx { namespace ranges {
             Sent last, FwdIter2 s_first, Sent2 s_last, Pred&& op = Pred(),
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::search<FwdIter, Sent>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, last, s_first,
-                s_last, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                std::forward<ExPolicy>(policy), first, last, s_first, s_last,
+                std::forward<Pred>(op), std::forward<Proj1>(proj1),
                 std::forward<Proj2>(proj2));
         }
 
@@ -855,11 +853,10 @@ namespace hpx { namespace ranges {
             using sent_type = typename hpx::traits::range_sentinel<Rng1>::type;
 
             return hpx::parallel::v1::detail::search<fwditer_type, sent_type>()
-                .call(hpx::execution::seq, std::true_type{},
-                    hpx::util::begin(rng1), hpx::util::end(rng1),
-                    hpx::util::begin(rng2), hpx::util::end(rng2),
-                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
-                    std::forward<Proj2>(proj2));
+                .call(hpx::execution::seq, hpx::util::begin(rng1),
+                    hpx::util::end(rng1), hpx::util::begin(rng2),
+                    hpx::util::end(rng2), std::forward<Pred>(op),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
 
         // clang-format off
@@ -885,17 +882,15 @@ namespace hpx { namespace ranges {
             Rng2&& rng2, Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
             using fwditer_type =
                 typename hpx::traits::range_iterator<Rng1>::type;
             using sent_type = typename hpx::traits::range_sentinel<Rng1>::type;
 
             return hpx::parallel::v1::detail::search<fwditer_type, sent_type>()
-                .call(std::forward<ExPolicy>(policy), is_seq(),
-                    hpx::util::begin(rng1), hpx::util::end(rng1),
-                    hpx::util::begin(rng2), hpx::util::end(rng2),
-                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
-                    std::forward<Proj2>(proj2));
+                .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng1),
+                    hpx::util::end(rng1), hpx::util::begin(rng2),
+                    hpx::util::end(rng2), std::forward<Pred>(op),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
 
     } search{};
@@ -928,8 +923,8 @@ namespace hpx { namespace ranges {
             Proj2&& proj2 = Proj2())
         {
             return hpx::parallel::v1::detail::search_n<FwdIter, FwdIter>().call(
-                hpx::execution::seq, std::true_type{}, first, count, s_first,
-                s_last, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                hpx::execution::seq, first, count, s_first, s_last,
+                std::forward<Pred>(op), std::forward<Proj1>(proj1),
                 std::forward<Proj2>(proj2));
         }
 
@@ -959,11 +954,9 @@ namespace hpx { namespace ranges {
             Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
-
             return hpx::parallel::v1::detail::search_n<FwdIter, FwdIter>().call(
-                std::forward<ExPolicy>(policy), is_seq(), first, count, s_first,
-                s_last, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                std::forward<ExPolicy>(policy), first, count, s_first, s_last,
+                std::forward<Pred>(op), std::forward<Proj1>(proj1),
                 std::forward<Proj2>(proj2));
         }
 
@@ -995,10 +988,10 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::search_n<fwditer_type,
                 sent_type>()
-                .call(hpx::execution::seq, std::true_type{},
-                    hpx::util::begin(rng1), count, hpx::util::begin(rng2),
-                    hpx::util::end(rng2), std::forward<Pred>(op),
-                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+                .call(hpx::execution::seq, hpx::util::begin(rng1), count,
+                    hpx::util::begin(rng2), hpx::util::end(rng2),
+                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2));
         }
 
         // clang-format off
@@ -1024,17 +1017,16 @@ namespace hpx { namespace ranges {
             std::size_t count, Rng2&& rng2, Pred&& op = Pred(),
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
-            using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
             using fwditer_type =
                 typename hpx::traits::range_iterator<Rng1>::type;
             using sent_type = typename hpx::traits::range_sentinel<Rng1>::type;
 
             return hpx::parallel::v1::detail::search_n<fwditer_type,
                 sent_type>()
-                .call(std::forward<ExPolicy>(policy), is_seq(),
-                    hpx::util::begin(rng1), count, hpx::util::begin(rng2),
-                    hpx::util::end(rng2), std::forward<Pred>(op),
-                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+                .call(std::forward<ExPolicy>(policy), hpx::util::begin(rng1),
+                    count, hpx::util::begin(rng2), hpx::util::end(rng2),
+                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2));
         }
 
     } search_n{};

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_difference.hpp
@@ -312,7 +312,7 @@ namespace hpx { namespace ranges {
             using result_type = set_difference_result<Iter1, Iter3>;
 
             return hpx::parallel::v1::detail::set_difference<result_type>()
-                .call(std::forward<ExPolicy>(policy), is_seq(), first1, last1,
+                .call2(std::forward<ExPolicy>(policy), is_seq(), first1, last1,
                     first2, last2, dest, std::forward<Pred>(op),
                     std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
@@ -368,7 +368,7 @@ namespace hpx { namespace ranges {
             using result_type = set_difference_result<iterator_type1, Iter3>;
 
             return hpx::parallel::v1::detail::set_difference<result_type>()
-                .call(std::forward<ExPolicy>(policy), is_seq(),
+                .call2(std::forward<ExPolicy>(policy), is_seq(),
                     hpx::util::begin(rng1), hpx::util::end(rng1),
                     hpx::util::begin(rng2), hpx::util::end(rng2), dest,
                     std::forward<Pred>(op), std::forward<Proj1>(proj1),
@@ -408,9 +408,9 @@ namespace hpx { namespace ranges {
             using result_type = set_difference_result<Iter1, Iter3>;
 
             return hpx::parallel::v1::detail::set_difference<result_type>()
-                .call(hpx::execution::seq, std::true_type(), first1, last1,
-                    first2, last2, dest, std::forward<Pred>(op),
-                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+                .call(hpx::execution::seq, first1, last1, first2, last2, dest,
+                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2));
         }
 
         // clang-format off
@@ -454,11 +454,10 @@ namespace hpx { namespace ranges {
             using result_type = set_difference_result<iterator_type1, Iter3>;
 
             return hpx::parallel::v1::detail::set_difference<result_type>()
-                .call(hpx::execution::seq, std::true_type(),
-                    hpx::util::begin(rng1), hpx::util::end(rng1),
-                    hpx::util::begin(rng2), hpx::util::end(rng2), dest,
-                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
-                    std::forward<Proj2>(proj2));
+                .call(hpx::execution::seq, hpx::util::begin(rng1),
+                    hpx::util::end(rng1), hpx::util::begin(rng2),
+                    hpx::util::end(rng2), dest, std::forward<Pred>(op),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
     } set_difference{};
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_intersection.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_intersection.hpp
@@ -313,7 +313,7 @@ namespace hpx { namespace ranges {
             using result_type = set_intersection_result<Iter1, Iter2, Iter3>;
 
             return hpx::parallel::v1::detail::set_intersection<result_type>()
-                .call(std::forward<ExPolicy>(policy), is_seq(), first1, last1,
+                .call2(std::forward<ExPolicy>(policy), is_seq(), first1, last1,
                     first2, last2, dest, std::forward<Pred>(op),
                     std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
@@ -371,7 +371,7 @@ namespace hpx { namespace ranges {
                 set_intersection_result<iterator_type1, iterator_type2, Iter3>;
 
             return hpx::parallel::v1::detail::set_intersection<result_type>()
-                .call(std::forward<ExPolicy>(policy), is_seq(),
+                .call2(std::forward<ExPolicy>(policy), is_seq(),
                     hpx::util::begin(rng1), hpx::util::end(rng1),
                     hpx::util::begin(rng2), hpx::util::end(rng2), dest,
                     std::forward<Pred>(op), std::forward<Proj1>(proj1),
@@ -411,9 +411,9 @@ namespace hpx { namespace ranges {
             using result_type = set_intersection_result<Iter1, Iter2, Iter3>;
 
             return hpx::parallel::v1::detail::set_intersection<result_type>()
-                .call(hpx::execution::seq, std::true_type(), first1, last1,
-                    first2, last2, dest, std::forward<Pred>(op),
-                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+                .call(hpx::execution::seq, first1, last1, first2, last2, dest,
+                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2));
         }
 
         // clang-format off
@@ -459,11 +459,10 @@ namespace hpx { namespace ranges {
                 set_intersection_result<iterator_type1, iterator_type2, Iter3>;
 
             return hpx::parallel::v1::detail::set_intersection<result_type>()
-                .call(hpx::execution::seq, std::true_type(),
-                    hpx::util::begin(rng1), hpx::util::end(rng1),
-                    hpx::util::begin(rng2), hpx::util::end(rng2), dest,
-                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
-                    std::forward<Proj2>(proj2));
+                .call(hpx::execution::seq, hpx::util::begin(rng1),
+                    hpx::util::end(rng1), hpx::util::begin(rng2),
+                    hpx::util::end(rng2), dest, std::forward<Pred>(op),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
     } set_intersection{};
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_symmetric_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_symmetric_difference.hpp
@@ -323,7 +323,7 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::set_symmetric_difference<
                 result_type>()
-                .call(std::forward<ExPolicy>(policy), is_seq(), first1, last1,
+                .call2(std::forward<ExPolicy>(policy), is_seq(), first1, last1,
                     first2, last2, dest, std::forward<Pred>(op),
                     std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
@@ -382,7 +382,7 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::set_symmetric_difference<
                 result_type>()
-                .call(std::forward<ExPolicy>(policy), is_seq(),
+                .call2(std::forward<ExPolicy>(policy), is_seq(),
                     hpx::util::begin(rng1), hpx::util::end(rng1),
                     hpx::util::begin(rng2), hpx::util::end(rng2), dest,
                     std::forward<Pred>(op), std::forward<Proj1>(proj1),
@@ -424,9 +424,9 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::set_symmetric_difference<
                 result_type>()
-                .call(hpx::execution::seq, std::true_type(), first1, last1,
-                    first2, last2, dest, std::forward<Pred>(op),
-                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+                .call(hpx::execution::seq, first1, last1, first2, last2, dest,
+                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                    std::forward<Proj2>(proj2));
         }
 
         // clang-format off
@@ -473,11 +473,10 @@ namespace hpx { namespace ranges {
 
             return hpx::parallel::v1::detail::set_symmetric_difference<
                 result_type>()
-                .call(hpx::execution::seq, std::true_type(),
-                    hpx::util::begin(rng1), hpx::util::end(rng1),
-                    hpx::util::begin(rng2), hpx::util::end(rng2), dest,
-                    std::forward<Pred>(op), std::forward<Proj1>(proj1),
-                    std::forward<Proj2>(proj2));
+                .call(hpx::execution::seq, hpx::util::begin(rng1),
+                    hpx::util::end(rng1), hpx::util::begin(rng2),
+                    hpx::util::end(rng2), dest, std::forward<Pred>(op),
+                    std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
         }
     } set_symmetric_difference{};
 

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_union.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_union.hpp
@@ -311,7 +311,7 @@ namespace hpx { namespace ranges {
 
             using result_type = set_union_result<Iter1, Iter2, Iter3>;
 
-            return hpx::parallel::v1::detail::set_union<result_type>().call(
+            return hpx::parallel::v1::detail::set_union<result_type>().call2(
                 std::forward<ExPolicy>(policy), is_seq(), first1, last1, first2,
                 last2, dest, std::forward<Pred>(op), std::forward<Proj1>(proj1),
                 std::forward<Proj2>(proj2));
@@ -368,7 +368,7 @@ namespace hpx { namespace ranges {
             using result_type =
                 set_union_result<iterator_type1, iterator_type2, Iter3>;
 
-            return hpx::parallel::v1::detail::set_union<result_type>().call(
+            return hpx::parallel::v1::detail::set_union<result_type>().call2(
                 std::forward<ExPolicy>(policy), is_seq(),
                 hpx::util::begin(rng1), hpx::util::end(rng1),
                 hpx::util::begin(rng2), hpx::util::end(rng2), dest,
@@ -409,8 +409,8 @@ namespace hpx { namespace ranges {
             using result_type = set_union_result<Iter1, Iter2, Iter3>;
 
             return hpx::parallel::v1::detail::set_union<result_type>().call(
-                hpx::execution::seq, std::true_type(), first1, last1, first2,
-                last2, dest, std::forward<Pred>(op), std::forward<Proj1>(proj1),
+                hpx::execution::seq, first1, last1, first2, last2, dest,
+                std::forward<Pred>(op), std::forward<Proj1>(proj1),
                 std::forward<Proj2>(proj2));
         }
 
@@ -457,7 +457,7 @@ namespace hpx { namespace ranges {
                 set_union_result<iterator_type1, iterator_type2, Iter3>;
 
             return hpx::parallel::v1::detail::set_union<result_type>().call(
-                hpx::execution::seq, std::true_type(), hpx::util::begin(rng1),
+                hpx::execution::seq, hpx::util::begin(rng1),
                 hpx::util::end(rng1), hpx::util::begin(rng2),
                 hpx::util::end(rng2), dest, std::forward<Pred>(op),
                 std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
@@ -25,13 +25,13 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         typedef T type;
 
         // Obtain initiating function's return type.
-        static type get()
+        static constexpr type get()
         {
             return T();
         }
 
         template <typename T_>
-        static type get(T_&& t)
+        static constexpr type get(T_&& t)
         {
             return std::forward<T_>(t);
         }
@@ -50,9 +50,9 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
         typedef void type;
 
         // Obtain initiating function's return type.
-        static void get() {}
+        static constexpr void get() {}
 
-        static void get(hpx::util::unused_type) {}
+        static constexpr void get(hpx::util::unused_type) {}
 
         static void get(hpx::future<void>&& t)
         {
@@ -256,8 +256,8 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename U, typename Conv,
         HPX_CONCEPT_REQUIRES_(hpx::is_invocable_v<Conv, U>)>
-    typename hpx::util::invoke_result<Conv, U>::type convert_to_result(
-        U&& val, Conv&& conv)
+    constexpr typename hpx::util::invoke_result<Conv, U>::type
+    convert_to_result(U&& val, Conv&& conv)
     {
         return HPX_INVOKE(conv, val);
     }

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/handle_exception_termination_handler.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/handle_exception_termination_handler.hpp
@@ -12,8 +12,10 @@
 namespace hpx { namespace parallel { namespace util { namespace detail {
     using parallel_exception_termination_handler_type =
         hpx::util::function_nonser<void()>;
+
     HPX_PARALLELISM_EXPORT void set_parallel_exception_termination_handler(
         parallel_exception_termination_handler_type f);
+
     HPX_NORETURN HPX_PARALLELISM_EXPORT void
     parallel_exception_termination_handler();
 }}}}    // namespace hpx::parallel::util::detail

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/handle_local_exceptions.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/handle_local_exceptions.hpp
@@ -21,6 +21,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace parallel { namespace util { namespace detail {
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename ExPolicy>
     struct handle_local_exceptions
@@ -213,7 +214,9 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             for (hpx::future<T> const& f : workitems)
             {
                 if (f.has_exception())
+                {
                     parallel_exception_termination_handler();
+                }
             }
 #endif
         }
@@ -229,7 +232,9 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             for (hpx::shared_future<T> const& f : workitems)
             {
                 if (f.has_exception())
+                {
                     parallel_exception_termination_handler();
+                }
             }
 #endif
         }
@@ -246,7 +251,95 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
             for (hpx::future<T> const& f : workitems)
             {
                 if (f.has_exception())
+                {
                     parallel_exception_termination_handler();
+                }
+            }
+#endif
+        }
+    };
+
+    template <>
+    struct handle_local_exceptions<hpx::execution::unsequenced_policy>
+    {
+        ///////////////////////////////////////////////////////////////////////
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+        static void call(std::exception_ptr const&)
+        {
+            HPX_ASSERT(false);
+        }
+#else
+        HPX_NORETURN static void call(std::exception_ptr const&)
+        {
+            parallel_exception_termination_handler();
+        }
+#endif
+
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+        static void call(
+            std::exception_ptr const&, std::list<std::exception_ptr>&)
+        {
+            HPX_ASSERT(false);
+        }
+#else
+        HPX_NORETURN static void call(
+            std::exception_ptr const&, std::list<std::exception_ptr>&)
+        {
+            parallel_exception_termination_handler();
+        }
+#endif
+
+        template <typename T>
+        static void call(std::vector<hpx::future<T>> const& workitems,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(workitems);
+            HPX_ASSERT(false);
+#else
+            for (hpx::future<T> const& f : workitems)
+            {
+                if (f.has_exception())
+                {
+                    parallel_exception_termination_handler();
+                }
+            }
+#endif
+        }
+
+        template <typename T>
+        static void call(std::vector<hpx::shared_future<T>> const& workitems,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(workitems);
+            HPX_ASSERT(false);
+#else
+            for (hpx::shared_future<T> const& f : workitems)
+            {
+                if (f.has_exception())
+                {
+                    parallel_exception_termination_handler();
+                }
+            }
+#endif
+        }
+
+        template <typename T, typename Cleanup>
+        static void call_with_cleanup(
+            std::vector<hpx::future<T>> const& workitems,
+            std::list<std::exception_ptr>&, Cleanup&&, bool = true)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(workitems);
+            HPX_ASSERT(false);
+#else
+            for (hpx::future<T> const& f : workitems)
+            {
+                if (f.has_exception())
+                {
+                    parallel_exception_termination_handler();
+                }
             }
 #endif
         }

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/handle_remote_exceptions.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/handle_remote_exceptions.hpp
@@ -19,6 +19,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace parallel { namespace util { namespace detail {
+
     ///////////////////////////////////////////////////////////////////////
     template <typename ExPolicy>
     struct handle_remote_exceptions
@@ -77,6 +78,38 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 
     template <>
     struct handle_remote_exceptions<hpx::execution::parallel_unsequenced_policy>
+    {
+        HPX_NORETURN static void call(
+            std::exception_ptr const&, std::list<std::exception_ptr>&)
+        {
+            parallel_exception_termination_handler();
+        }
+
+        template <typename T>
+        static void call(std::vector<hpx::future<T>> const& workitems,
+            std::list<std::exception_ptr>&)
+        {
+            for (hpx::future<T> const& f : workitems)
+            {
+                if (f.has_exception())
+                    parallel_exception_termination_handler();
+            }
+        }
+
+        template <typename T>
+        static void call(std::vector<hpx::shared_future<T>> const& workitems,
+            std::list<std::exception_ptr>&)
+        {
+            for (hpx::shared_future<T> const& f : workitems)
+            {
+                if (f.has_exception())
+                    parallel_exception_termination_handler();
+            }
+        }
+    };
+
+    template <>
+    struct handle_remote_exceptions<hpx::execution::unsequenced_policy>
     {
         HPX_NORETURN static void call(
             std::exception_ptr const&, std::list<std::exception_ptr>&)

--- a/libs/parallelism/algorithms/tests/unit/algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/CMakeLists.txt
@@ -149,6 +149,10 @@ set(tests
     unique_copy
 )
 
+if(HPX_WITH_CXX17_STD_EXECUTION_POLICES)
+  set(tests ${tests} foreach_std_policies)
+endif()
+
 foreach(test ${tests})
   set(sources ${test}.cpp)
 

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreach_std_policies.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreach_std_policies.cpp
@@ -21,6 +21,9 @@ void test_for_each()
     test_for_each(std::execution::seq, IteratorTag());
     test_for_each(std::execution::par, IteratorTag());
     test_for_each(std::execution::par_unseq, IteratorTag());
+#if defined(HPX_HAVE_CXX20_STD_EXECUTION_POLICES)
+    test_for_each(std::execution::unseq, IteratorTag());
+#endif
 }
 
 void for_each_test()

--- a/libs/parallelism/algorithms/tests/unit/algorithms/foreach_std_policies.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/foreach_std_policies.cpp
@@ -1,0 +1,98 @@
+//  Copyright (c) 2014-2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+
+#include <execution>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "foreach_tests.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_for_each()
+{
+    test_for_each(std::execution::seq, IteratorTag());
+    test_for_each(std::execution::par, IteratorTag());
+    test_for_each(std::execution::par_unseq, IteratorTag());
+}
+
+void for_each_test()
+{
+    test_for_each<std::random_access_iterator_tag>();
+    test_for_each<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_for_each_exception()
+{
+    test_for_each_exception(std::execution::seq, IteratorTag());
+    test_for_each_exception(std::execution::par, IteratorTag());
+}
+
+void for_each_exception_test()
+{
+    test_for_each_exception<std::random_access_iterator_tag>();
+    test_for_each_exception<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_for_each_bad_alloc()
+{
+    test_for_each_bad_alloc(std::execution::seq, IteratorTag());
+    test_for_each_bad_alloc(std::execution::par, IteratorTag());
+}
+
+void for_each_bad_alloc_test()
+{
+    test_for_each_bad_alloc<std::random_access_iterator_tag>();
+    test_for_each_bad_alloc<std::forward_iterator_tag>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    for_each_test();
+    for_each_exception_test();
+    for_each_bad_alloc_test();
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/executors/CMakeLists.txt
+++ b/libs/parallelism/executors/CMakeLists.txt
@@ -27,6 +27,7 @@ set(executors_headers
     hpx/executors/restricted_thread_pool_executor.hpp
     hpx/executors/sequenced_executor.hpp
     hpx/executors/service_executors.hpp
+    hpx/executors/std_execution_policy.hpp
     hpx/executors/sync.hpp
     hpx/executors/thread_pool_attached_executors.hpp
     hpx/executors/thread_pool_executor.hpp

--- a/libs/parallelism/executors/include/hpx/executors/datapar/execution_policy.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/datapar/execution_policy.hpp
@@ -58,7 +58,7 @@ namespace hpx { namespace execution { inline namespace v1 {
         };
 
         /// \cond NOINTERNAL
-        constexpr dataseq_task_policy() {}
+        constexpr dataseq_task_policy() = default;
         /// \endcond
 
         /// Create a new dataseq_task_policy from itself
@@ -157,7 +157,7 @@ namespace hpx { namespace execution { inline namespace v1 {
         friend class hpx::serialization::access;
 
         template <typename Archive>
-        void serialize(Archive& ar, const unsigned int version)
+        constexpr void serialize(Archive&, const unsigned int)
         {
         }
 
@@ -294,7 +294,7 @@ namespace hpx { namespace execution { inline namespace v1 {
         }
 
         /// \cond NOINTERNAL
-        constexpr dataseq_task_policy_shim() {}
+        constexpr dataseq_task_policy_shim() = default;
 
         template <typename Executor_, typename Parameters_>
         constexpr dataseq_task_policy_shim(
@@ -310,7 +310,9 @@ namespace hpx { namespace execution { inline namespace v1 {
         template <typename Archive>
         void serialize(Archive& ar, const unsigned int version)
         {
-            ar& exec_& params_;
+            // clang-format off
+            ar & exec_ & params_;
+            // clang-format on
         }
 
     private:
@@ -348,11 +350,7 @@ namespace hpx { namespace execution { inline namespace v1 {
         };
 
         /// \cond NOINTERNAL
-        constexpr dataseq_policy()
-          : exec_{}
-          , params_{}
-        {
-        }
+        constexpr dataseq_policy() = default;
         /// \endcond
 
         /// Create a new dataseq_task_policy.
@@ -462,7 +460,7 @@ namespace hpx { namespace execution { inline namespace v1 {
     };
 
     /// Default sequential execution policy object.
-    HPX_STATIC_CONSTEXPR dataseq_policy dataseq;
+    static constexpr dataseq_policy dataseq{};
 
     /// The class dataseq_policy is an execution policy type used
     /// as a unique type to disambiguate parallel algorithm overloading and
@@ -586,7 +584,7 @@ namespace hpx { namespace execution { inline namespace v1 {
         }
 
         /// \cond NOINTERNAL
-        constexpr dataseq_policy_shim() {}
+        constexpr dataseq_policy_shim() = default;
 
         template <typename Executor_, typename Parameters_>
         constexpr dataseq_policy_shim(Executor_&& exec, Parameters_&& params)
@@ -601,7 +599,9 @@ namespace hpx { namespace execution { inline namespace v1 {
         template <typename Archive>
         void serialize(Archive& ar, const unsigned int version)
         {
-            ar& exec_& params_;
+            // clang-format off
+            ar & exec_ & params_;
+            // clang-format on
         }
 
     private:
@@ -643,7 +643,7 @@ namespace hpx { namespace execution { inline namespace v1 {
         };
 
         /// \cond NOINTERNAL
-        constexpr datapar_task_policy() {}
+        constexpr datapar_task_policy() = default;
         /// \endcond
 
         /// Create a new datapar_task_policy from itself
@@ -779,11 +779,7 @@ namespace hpx { namespace execution { inline namespace v1 {
         };
 
         /// \cond NOINTERNAL
-        constexpr datapar_policy()
-          : exec_{}
-          , params_{}
-        {
-        }
+        constexpr datapar_policy() = default;
         /// \endcond
 
         /// Create a new datapar_policy referencing a chunk size.
@@ -886,7 +882,7 @@ namespace hpx { namespace execution { inline namespace v1 {
     };
 
     /// Default data-parallel execution policy object.
-    HPX_STATIC_CONSTEXPR datapar_policy datapar;
+    static constexpr datapar_policy datapar{};
 
     /// The class datapar_policy_shim is an execution policy type
     /// used as a unique type to disambiguate parallel algorithm overloading
@@ -1009,7 +1005,7 @@ namespace hpx { namespace execution { inline namespace v1 {
         }
 
         /// \cond NOINTERNAL
-        constexpr datapar_policy_shim() {}
+        constexpr datapar_policy_shim() = default;
 
         template <typename Executor_, typename Parameters_>
         constexpr datapar_policy_shim(Executor_&& exec, Parameters_&& params)
@@ -1024,7 +1020,9 @@ namespace hpx { namespace execution { inline namespace v1 {
         template <typename Archive>
         void serialize(Archive& ar, const unsigned int version)
         {
-            ar& exec_& params_;
+            // clang-format off
+            ar & exec_ & params_;
+            // clang-format on
         }
 
     private:
@@ -1155,7 +1153,7 @@ namespace hpx { namespace execution { inline namespace v1 {
         }
 
         /// \cond NOINTERNAL
-        constexpr datapar_task_policy_shim() {}
+        constexpr datapar_task_policy_shim() = default;
 
         template <typename Executor_, typename Parameters_>
         constexpr datapar_task_policy_shim(
@@ -1171,7 +1169,9 @@ namespace hpx { namespace execution { inline namespace v1 {
         template <typename Archive>
         void serialize(Archive& ar, const unsigned int version)
         {
-            ar& exec_& params_;
+            // clang-format off
+            ar & exec_ & params_;
+            // clang-format on
         }
 
     private:

--- a/libs/parallelism/executors/include/hpx/executors/execution_policy.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/execution_policy.hpp
@@ -5,7 +5,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file parallel/execution_policy.hpp
+/// \file hpx/execution/execution_policy.hpp
 
 #pragma once
 
@@ -29,9 +29,10 @@
 #include <utility>
 
 namespace hpx { namespace execution {
+
     ///////////////////////////////////////////////////////////////////////////
     /// Default sequential execution policy object.
-    static constexpr task_policy_tag task;
+    static constexpr task_policy_tag task{};
 
     ///////////////////////////////////////////////////////////////////////////
     /// Extension: The class sequenced_task_policy is an execution
@@ -67,7 +68,7 @@ namespace hpx { namespace execution {
         };
 
         /// \cond NOINTERNAL
-        constexpr sequenced_task_policy() {}
+        constexpr sequenced_task_policy() = default;
         /// \endcond
 
         /// Create a new sequenced_task_policy from itself
@@ -177,7 +178,7 @@ namespace hpx { namespace execution {
         friend class hpx::serialization::access;
 
         template <typename Archive>
-        void serialize(Archive& /* ar */, const unsigned int /* version */)
+        constexpr void serialize(Archive&, const unsigned int)
         {
         }
 
@@ -346,7 +347,7 @@ namespace hpx { namespace execution {
         friend class hpx::serialization::access;
 
         template <typename Archive>
-        void serialize(Archive& ar, const unsigned int /* version */)
+        void serialize(Archive& ar, const unsigned int)
         {
             // clang-format off
             ar & exec_ & params_;
@@ -388,11 +389,7 @@ namespace hpx { namespace execution {
         };
 
         /// \cond NOINTERNAL
-        constexpr sequenced_policy()
-          : exec_{}
-          , params_{}
-        {
-        }
+        constexpr sequenced_policy() = default;
         /// \endcond
 
         /// Create a new sequenced_task_policy.
@@ -503,7 +500,7 @@ namespace hpx { namespace execution {
         friend class hpx::serialization::access;
 
         template <typename Archive>
-        void serialize(Archive& /* ar */, const unsigned int /* version */)
+        constexpr void serialize(Archive&, const unsigned int)
         {
         }
 
@@ -513,7 +510,7 @@ namespace hpx { namespace execution {
     };
 
     /// Default sequential execution policy object.
-    HPX_STATIC_CONSTEXPR sequenced_policy seq;
+    static constexpr sequenced_policy seq{};
 
     /// The class sequenced_policy is an execution policy type used
     /// as a unique type to disambiguate parallel algorithm overloading and
@@ -667,7 +664,7 @@ namespace hpx { namespace execution {
         friend class hpx::serialization::access;
 
         template <typename Archive>
-        void serialize(Archive& ar, const unsigned int /* version */)
+        void serialize(Archive& ar, const unsigned int)
         {
             // clang-format off
             ar & exec_ & params_;
@@ -713,7 +710,7 @@ namespace hpx { namespace execution {
         };
 
         /// \cond NOINTERNAL
-        constexpr parallel_task_policy() {}
+        constexpr parallel_task_policy() = default;
         /// \endcond
 
         /// Create a new parallel_task_policy from itself
@@ -821,7 +818,7 @@ namespace hpx { namespace execution {
         friend class hpx::serialization::access;
 
         template <typename Archive>
-        void serialize(Archive& /* ar */, const unsigned int /* version */)
+        constexpr void serialize(Archive&, const unsigned int)
         {
         }
 
@@ -984,7 +981,7 @@ namespace hpx { namespace execution {
         friend class hpx::serialization::access;
 
         template <typename Archive>
-        void serialize(Archive& ar, const unsigned int /* version */)
+        void serialize(Archive& ar, const unsigned int)
         {
             // clang-format off
             ar & exec_ & params_;
@@ -1026,11 +1023,7 @@ namespace hpx { namespace execution {
         };
 
         /// \cond NOINTERNAL
-        constexpr parallel_policy()
-          : exec_{}
-          , params_{}
-        {
-        }
+        constexpr parallel_policy() = default;
         /// \endcond
 
         /// Create a new parallel_policy referencing a chunk size.
@@ -1133,7 +1126,7 @@ namespace hpx { namespace execution {
         friend class hpx::serialization::access;
 
         template <typename Archive>
-        void serialize(Archive& /* ar */, const unsigned int /* version */)
+        constexpr void serialize(Archive&, const unsigned int)
         {
         }
 
@@ -1143,7 +1136,7 @@ namespace hpx { namespace execution {
     };
 
     /// Default parallel execution policy object.
-    HPX_STATIC_CONSTEXPR parallel_policy par;
+    static constexpr parallel_policy par{};
 
     /// The class parallel_policy_shim is an execution policy type
     /// used as a unique type to disambiguate parallel algorithm overloading
@@ -1296,7 +1289,7 @@ namespace hpx { namespace execution {
         friend class hpx::serialization::access;
 
         template <typename Archive>
-        void serialize(Archive& ar, const unsigned int /* version */)
+        void serialize(Archive& ar, const unsigned int)
         {
             // clang-format off
             ar & exec_ & params_;
@@ -1328,11 +1321,7 @@ namespace hpx { namespace execution {
         typedef parallel_execution_tag execution_category;
 
         /// \cond NOINTERNAL
-        constexpr parallel_unsequenced_policy()
-          : exec_{}
-          , params_{}
-        {
-        }
+        constexpr parallel_unsequenced_policy() = default;
         /// \endcond
 
         /// Create a new parallel_unsequenced_policy from itself
@@ -1374,7 +1363,7 @@ namespace hpx { namespace execution {
         friend class hpx::serialization::access;
 
         template <typename Archive>
-        void serialize(Archive& /* ar */, const unsigned int /* version */)
+        constexpr void serialize(Archive&, const unsigned int)
         {
         }
 
@@ -1384,26 +1373,26 @@ namespace hpx { namespace execution {
     };
 
     /// Default vector execution policy object.
-    HPX_STATIC_CONSTEXPR parallel_unsequenced_policy par_unseq;
+    static constexpr parallel_unsequenced_policy par_unseq{};
 }}    // namespace hpx::execution
 
 namespace hpx { namespace parallel { namespace execution {
     HPX_DEPRECATED_V(1, 6,
         "hpx::parallel::execution::par is deprecated. Please use "
         "hpx::execution::par instead.")
-    static constexpr hpx::execution::parallel_policy par;
+    static constexpr hpx::execution::parallel_policy par{};
     HPX_DEPRECATED_V(1, 6,
         "hpx::parallel::execution::par_unseq is deprecated. Please use "
         "hpx::execution::par_unseq instead.")
-    static constexpr hpx::execution::parallel_policy par_unseq;
+    static constexpr hpx::execution::parallel_policy par_unseq{};
     HPX_DEPRECATED_V(1, 6,
         "hpx::parallel::execution::seq is deprecated. Please use "
         "hpx::execution::seq instead.")
-    static constexpr hpx::execution::sequenced_policy seq;
+    static constexpr hpx::execution::sequenced_policy seq{};
     HPX_DEPRECATED_V(1, 6,
         "hpx::parallel::execution::task is deprecated. Please use "
         "hpx::execution::task instead.")
-    static constexpr hpx::execution::task_policy_tag task;
+    static constexpr hpx::execution::task_policy_tag task{};
     using parallel_executor HPX_DEPRECATED_V(1, 6,
         "hpx::parallel::execution::parallel_executor is deprecated. Please use "
         "hpx::execution::parallel_executor instead.") =

--- a/libs/parallelism/executors/include/hpx/executors/execution_policy_fwd.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/execution_policy_fwd.hpp
@@ -35,4 +35,6 @@ namespace hpx { namespace execution {
     struct parallel_task_policy_shim;
 
     struct parallel_unsequenced_policy;
+
+    struct unsequenced_policy;
 }}    // namespace hpx::execution

--- a/libs/parallelism/executors/include/hpx/executors/std_execution_policy.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/std_execution_policy.hpp
@@ -1,0 +1,61 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file hpx/execution/std_execution_policy.hpp
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_CXX17_STD_EXECUTION_POLICES)
+
+#include <execution>
+#include <type_traits>
+
+namespace hpx { namespace detail {
+
+    // Specialize our is_execution_policy traits for the corresponding std
+    // versions
+
+    /// \cond NOINTERNAL
+    template <>
+    struct is_execution_policy<std::execution::sequenced_policy>
+      : std::true_type
+    {
+    };
+
+    template <>
+    struct is_execution_policy<std::execution::parallel_policy> : std::true_type
+    {
+    };
+
+    template <>
+    struct is_execution_policy<std::execution::parallel_unsequenced_policy>
+      : std::true_type
+    {
+    };
+
+    template <>
+    struct is_parallel_execution_policy<std::execution::parallel_policy>
+      : std::true_type
+    {
+    };
+
+    template <>
+    struct is_parallel_execution_policy<
+        std::execution::parallel_unsequenced_policy> : std::true_type
+    {
+    };
+
+    template <>
+    struct is_sequenced_execution_policy<std::execution::sequenced_policy>
+      : std::true_type
+    {
+    };
+    /// \endcond
+}}    // namespace hpx::detail
+
+#endif

--- a/libs/parallelism/executors/include/hpx/executors/std_execution_policy.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/std_execution_policy.hpp
@@ -55,6 +55,20 @@ namespace hpx { namespace detail {
       : std::true_type
     {
     };
+
+#if defined(HPX_HAVE_CXX20_STD_EXECUTION_POLICES)
+    template <>
+    struct is_execution_policy<std::execution::unsequenced_policy>
+      : std::true_type
+    {
+    };
+
+    template <>
+    struct is_sequenced_execution_policy<std::execution::unsequenced_policy>
+      : std::true_type
+    {
+    };
+#endif
     /// \endcond
 }}    // namespace hpx::detail
 

--- a/libs/parallelism/executors/tests/unit/CMakeLists.txt
+++ b/libs/parallelism/executors/tests/unit/CMakeLists.txt
@@ -12,6 +12,10 @@ if(HPX_WITH_THREAD_EXECUTORS_COMPATIBILITY)
   set(tests ${tests} thread_pool_attached_executors)
 endif()
 
+if(HPX_WITH_CXX17_STD_EXECUTION_POLICES)
+  set(tests ${tests} std_execution_policies)
+endif()
+
 foreach(test ${tests})
   set(sources ${test}.cpp)
 

--- a/libs/parallelism/executors/tests/unit/std_execution_policies.cpp
+++ b/libs/parallelism/executors/tests/unit/std_execution_policies.cpp
@@ -48,6 +48,20 @@ void static_checks()
                       std::execution::parallel_unsequenced_policy>::value,
         "hpx::is_parallel_execution_policy<std::execution::parallel_"
         "unsequenced_policy>::value");
+
+#if defined(HPX_HAVE_CXX20_STD_EXECUTION_POLICES)
+    static_assert(
+        hpx::is_execution_policy<std::execution::unsequenced_policy>::value,
+        "hpx::is_execution_policy<std::execution::unsequenced_policy>::value");
+    static_assert(hpx::is_sequenced_execution_policy<
+                      std::execution::unsequenced_policy>::value,
+        "hpx::is_sequenced_execution_policy<std::execution::unsequenced_policy>"
+        "::value");
+    static_assert(!hpx::is_parallel_execution_policy<
+                      std::execution::unsequenced_policy>::value,
+        "!hpx::is_parallel_execution_policy<std::execution::unsequenced_policy>"
+        "::value");
+#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/parallelism/executors/tests/unit/std_execution_policies.cpp
+++ b/libs/parallelism/executors/tests/unit/std_execution_policies.cpp
@@ -1,0 +1,68 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/parallel_executors.hpp>
+#include <hpx/modules/testing.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+void static_checks()
+{
+    static_assert(
+        hpx::is_execution_policy<std::execution::sequenced_policy>::value,
+        "hpx::is_execution_policy<std::execution::sequenced_policy>::value");
+    static_assert(
+        hpx::is_execution_policy<std::execution::parallel_policy>::value,
+        "hpx::is_execution_policy<std::execution::parallel_policy>::value");
+    static_assert(hpx::is_execution_policy<
+                      std::execution::parallel_unsequenced_policy>::value,
+        "hpx::is_execution_policy<std::execution::parallel_unsequenced_policy>:"
+        ":value");
+
+    static_assert(hpx::is_sequenced_execution_policy<
+                      std::execution::sequenced_policy>::value,
+        "hpx::is_sequenced_execution_policy<std::execution::sequenced_policy>::"
+        "value");
+    static_assert(!hpx::is_sequenced_execution_policy<
+                      std::execution::parallel_policy>::value,
+        "!hpx::is_sequenced_execution_policy<std::execution::parallel_policy>::"
+        "value");
+    static_assert(!hpx::is_sequenced_execution_policy<
+                      std::execution::parallel_unsequenced_policy>::value,
+        "!hpx::is_sequenced_execution_policy<std::execution::parallel_"
+        "unsequenced_policy>::value");
+
+    static_assert(!hpx::is_parallel_execution_policy<
+                      std::execution::sequenced_policy>::value,
+        "!hpx::is_sequenced_execution_policy<std::execution::sequenced_policy>:"
+        ":value");
+    static_assert(hpx::is_parallel_execution_policy<
+                      std::execution::parallel_policy>::value,
+        "hpx::is_parallel_execution_policy<std::execution::parallel_policy>::"
+        "value");
+    static_assert(hpx::is_parallel_execution_policy<
+                      std::execution::parallel_unsequenced_policy>::value,
+        "hpx::is_parallel_execution_policy<std::execution::parallel_"
+        "unsequenced_policy>::value");
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main()
+{
+    static_checks();
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(
+        hpx::init(argc, argv), 0, "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
- flyby: significantly simplify algorithm dispatch helper

Should this be guarded by a special option (currently this will be enabled as soon as the standard execution policies are available)?

This also adds `hpx::execution::unsequenced_policy`, which currently maps to `hpx::execution::sequenced_policy`.