### PR TITLE
Adding generic require, require_concept, and query properties

### DIFF
--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The STE||AR-Group
+# Copyright (c) 2020-2021 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/functional/CMakeLists.txt
+++ b/libs/core/functional/CMakeLists.txt
@@ -32,6 +32,7 @@ set(functional_headers
     hpx/functional/protect.hpp
     hpx/functional/tag_fallback_invoke.hpp
     hpx/functional/tag_invoke.hpp
+    hpx/functional/tag_invoke_is_applicable.hpp
     hpx/functional/tag_priority_invoke.hpp
     hpx/functional/unique_function.hpp
     hpx/functional/serialization/detail/serializable_basic_function.hpp

--- a/libs/core/functional/include/hpx/functional/tag_fallback_invoke.hpp
+++ b/libs/core/functional/include/hpx/functional/tag_fallback_invoke.hpp
@@ -106,6 +106,7 @@ namespace hpx { namespace functional {
 #include <hpx/config.hpp>
 #include <hpx/functional/invoke_result.hpp>
 #include <hpx/functional/tag_invoke.hpp>
+#include <hpx/functional/tag_invoke_is_applicable.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>
 
 #include <type_traits>
@@ -241,6 +242,10 @@ namespace hpx { namespace functional {
             noexcept(is_nothrow_tag_invocable_v<Tag, Args...>)
                 -> tag_invoke_result_t<Tag, Args&&...>
         {
+            static_assert(
+                hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>,
+                "hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>");
+
             return hpx::functional::tag_invoke(
                 static_cast<Tag const&>(*this), std::forward<Args>(args)...);
         }
@@ -253,6 +258,10 @@ namespace hpx { namespace functional {
             noexcept(is_nothrow_tag_fallback_invocable_v<Tag, Args...>)
                 -> tag_fallback_invoke_result_t<Tag, Args&&...>
         {
+            static_assert(
+                hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>,
+                "hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>");
+
             return hpx::functional::tag_fallback_invoke(
                 static_cast<Tag const&>(*this), std::forward<Args>(args)...);
         }
@@ -283,6 +292,10 @@ namespace hpx { namespace functional {
         constexpr HPX_FORCEINLINE auto operator()(Args&&... args) const noexcept
             -> tag_invoke_result_t<Tag, Args&&...>
         {
+            static_assert(
+                hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>,
+                "hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>");
+
             return hpx::functional::tag_invoke(
                 static_cast<Tag const&>(*this), std::forward<Args>(args)...);
         }
@@ -297,6 +310,10 @@ namespace hpx { namespace functional {
             -> decltype(tag_fallback_invoke_impl(
                 IsFallbackInvocable{}, std::forward<Args>(args)...))
         {
+            static_assert(
+                hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>,
+                "hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>");
+
             return tag_fallback_invoke_impl(
                 IsFallbackInvocable{}, std::forward<Args>(args)...);
         }

--- a/libs/core/functional/include/hpx/functional/tag_invoke.hpp
+++ b/libs/core/functional/include/hpx/functional/tag_invoke.hpp
@@ -100,6 +100,7 @@ namespace hpx { namespace functional {
 
 #include <hpx/config.hpp>
 #include <hpx/functional/invoke_result.hpp>
+#include <hpx/functional/tag_invoke_is_applicable.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>
 
 #include <type_traits>
@@ -203,6 +204,10 @@ namespace hpx { namespace functional {
             noexcept(is_nothrow_tag_invocable_v<Tag, Args...>)
                 -> tag_invoke_result_t<Tag, Args...>
         {
+            static_assert(
+                hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>,
+                "hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>");
+
             return hpx::functional::tag_invoke(
                 static_cast<Tag const&>(*this), std::forward<Args>(args)...);
         }
@@ -217,6 +222,10 @@ namespace hpx { namespace functional {
         constexpr HPX_FORCEINLINE auto operator()(Args&&... args) const noexcept
             -> tag_invoke_result_t<Tag, decltype(args)...>
         {
+            static_assert(
+                hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>,
+                "hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>");
+
             return hpx::functional::tag_invoke(
                 static_cast<Tag const&>(*this), std::forward<Args>(args)...);
         }

--- a/libs/core/functional/include/hpx/functional/tag_invoke_is_applicable.hpp
+++ b/libs/core/functional/include/hpx/functional/tag_invoke_is_applicable.hpp
@@ -1,0 +1,71 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/type_support/always_void.hpp>
+#include <hpx/type_support/pack.hpp>
+
+#include <type_traits>
+
+#if defined(DOXYGEN)
+namespace hpx { namespace functional {
+
+    /// The `hpx::functional::is_tag_invoke_applicable` trait is used to impose
+    /// general constraints onto the object that is derived from
+    /// `hpx::functional::tag`, `hpx::functional::tag_fallback`, or
+    /// `hpx::functional::tag_priority_fallback`, or their noexcept variations
+    /// (in the following referred to as 'the CPO'). The value of this trait
+    /// is either `std::true_type` (if the CPO does not expose any additional
+    /// constraints), or evaluates to the value that is exposed by the CPO using
+    /// a constant bool variable named `is_applicable_v`. For instance:
+    ///
+    /// struct my_cpo_t : hpx::functional::tag<my_cpo_t>
+    /// {
+    ///     template <typename... Args>
+    ///     static constexpr bool is_applicable_v = ...;
+    /// } my_cpo{};
+    ///
+    /// where `Args...` are the types of the arguments the CPO was invoked with.
+    /// The tag_invoke machinery will static_assert if this trait evaluates to
+    /// `std::false_type`.
+
+}}    // namespace hpx::functional
+
+#else
+
+namespace hpx { namespace functional {
+
+    namespace detail {
+
+        template <typename Tag, typename Pack, typename Enable = void>
+        struct is_tag_invoke_applicable : std::true_type
+        {
+        };
+
+        template <typename Tag, typename... Args>
+        struct is_tag_invoke_applicable<Tag, util::pack<Args...>,
+            util::always_void_t<decltype(
+                Tag::template is_applicable_v<Args...>)>>
+          : std::integral_constant<bool, Tag::template is_applicable_v<Args...>>
+        {
+        };
+    }    // namespace detail
+
+    template <typename Tag, typename... Args>
+    struct is_tag_invoke_applicable
+      : detail::is_tag_invoke_applicable<Tag, util::pack<std::decay_t<Args>...>>
+    {
+    };
+
+    template <typename Tag, typename... Args>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_tag_invoke_applicable_v =
+        is_tag_invoke_applicable<Tag, Args...>::value;
+
+}}    // namespace hpx::functional
+
+#endif

--- a/libs/core/functional/include/hpx/functional/tag_priority_invoke.hpp
+++ b/libs/core/functional/include/hpx/functional/tag_priority_invoke.hpp
@@ -108,6 +108,7 @@ namespace hpx { namespace functional {
 #include <hpx/functional/invoke_result.hpp>
 #include <hpx/functional/tag_fallback_invoke.hpp>
 #include <hpx/functional/tag_invoke.hpp>
+#include <hpx/functional/tag_invoke_is_applicable.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>
 
 #include <type_traits>
@@ -204,6 +205,27 @@ namespace hpx { namespace functional {
         typename tag_override_invoke_result<Tag, Args...>::type;
 
     ///////////////////////////////////////////////////////////////////////////
+    template <typename Tag, typename... Args>
+    using is_tag_priority_invocable = std::integral_constant<bool,
+        is_tag_override_invocable<Tag, Args...>::value ||
+            is_tag_invocable<Tag, Args...>::value ||
+            is_tag_fallback_invocable<Tag, Args...>::value>;
+
+    template <typename Tag, typename... Args>
+    constexpr bool is_tag_priority_invocable_v =
+        is_tag_priority_invocable<Tag, Args...>::value;
+
+    template <typename Tag, typename... Args>
+    using is_nothrow_tag_priority_invocable = std::integral_constant<bool,
+        is_nothrow_tag_override_invocable<Tag, Args...>::value ||
+            is_nothrow_tag_invocable<Tag, Args...>::value ||
+            is_nothrow_tag_fallback_invocable<Tag, Args...>::value>;
+
+    template <typename Tag, typename... Args>
+    constexpr bool is_nothrow_tag_priority_invocable_v =
+        is_nothrow_tag_priority_invocable<Tag, Args...>::value;
+
+    ///////////////////////////////////////////////////////////////////////////
     /// Helper base class implementing the tag_invoke logic for CPOs that allow
     /// overriding user-defined tag_invoke overloads with tag_override_invoke,
     /// and that allow setting a fallback with tag_fallback_invoke.
@@ -227,6 +249,10 @@ namespace hpx { namespace functional {
             noexcept(is_nothrow_tag_override_invocable_v<Tag, Args...>)
                 -> tag_override_invoke_result_t<Tag, Args&&...>
         {
+            static_assert(
+                hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>,
+                "hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>");
+
             return hpx::functional::tag_override_invoke(
                 static_cast<Tag const&>(*this), std::forward<Args>(args)...);
         }
@@ -240,6 +266,10 @@ namespace hpx { namespace functional {
             noexcept(is_nothrow_tag_invocable_v<Tag, Args...>)
                 -> tag_invoke_result_t<Tag, Args&&...>
         {
+            static_assert(
+                hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>,
+                "hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>");
+
             return hpx::functional::tag_invoke(
                 static_cast<Tag const&>(*this), std::forward<Args>(args)...);
         }
@@ -255,6 +285,10 @@ namespace hpx { namespace functional {
             noexcept(is_nothrow_tag_fallback_invocable_v<Tag, Args...>)
                 -> tag_fallback_invoke_result_t<Tag, Args&&...>
         {
+            static_assert(
+                hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>,
+                "hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>");
+
             return hpx::functional::tag_fallback_invoke(
                 static_cast<Tag const&>(*this), std::forward<Args>(args)...);
         }
@@ -275,6 +309,10 @@ namespace hpx { namespace functional {
         constexpr HPX_FORCEINLINE auto operator()(Args&&... args) const noexcept
             -> tag_override_invoke_result_t<Tag, Args&&...>
         {
+            static_assert(
+                hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>,
+                "hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>");
+
             return hpx::functional::tag_override_invoke(
                 static_cast<Tag const&>(*this), std::forward<Args>(args)...);
         }
@@ -287,6 +325,10 @@ namespace hpx { namespace functional {
         constexpr HPX_FORCEINLINE auto operator()(Args&&... args) const noexcept
             -> tag_invoke_result_t<Tag, Args&&...>
         {
+            static_assert(
+                hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>,
+                "hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>");
+
             return hpx::functional::tag_invoke(
                 static_cast<Tag const&>(*this), std::forward<Args>(args)...);
         }
@@ -301,6 +343,10 @@ namespace hpx { namespace functional {
         constexpr HPX_FORCEINLINE auto operator()(Args&&... args) const noexcept
             -> tag_fallback_invoke_result_t<Tag, Args&&...>
         {
+            static_assert(
+                hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>,
+                "hpx::functional::is_tag_invoke_applicable_v<Tag, Args...>");
+
             return hpx::functional::tag_fallback_invoke(
                 static_cast<Tag const&>(*this), std::forward<Args>(args)...);
         }

--- a/libs/core/modules.rst
+++ b/libs/core/modules.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright (c) 2018-2020 The STE||AR-Group
+    Copyright (c) 2018-2021 The STE||AR-Group
 
     SPDX-License-Identifier: BSL-1.0
     Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -38,7 +38,6 @@ Core modules
    /libs/core/itt_notify/docs/index.rst
    /libs/core/logging/docs/index.rst
    /libs/core/memory/docs/index.rst
-   /libs/core/naming_base/docs/index.rst
    /libs/core/plugin/docs/index.rst
    /libs/core/prefix/docs/index.rst
    /libs/core/preprocessor/docs/index.rst

--- a/libs/core/properties/CMakeLists.txt
+++ b/libs/core/properties/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020 The STE||AR-Group
+# Copyright (c) 2019-2021 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,7 +6,11 @@
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-set(properties_headers hpx/property.hpp hpx/properties/property.hpp)
+set(properties_headers
+    hpx/properties/is_applicable_property.hpp hpx/properties/prefer.hpp
+    hpx/properties/query.hpp hpx/properties/require.hpp
+    hpx/properties/require_concept.hpp hpx/properties/static_query.hpp
+)
 
 include(HPX_AddModule)
 add_hpx_module(

--- a/libs/core/properties/README.rst
+++ b/libs/core/properties/README.rst
@@ -1,6 +1,6 @@
 
 ..
-    Copyright (c) 2020 The STE||AR-Group
+    Copyright (c) 2020-2021 The STE||AR-Group
 
     SPDX-License-Identifier: BSL-1.0
     Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/properties/docs/index.rst
+++ b/libs/core/properties/docs/index.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright (c) 2020 The STE||AR-Group
+    Copyright (c) 2020-2021 The STE||AR-Group
 
     SPDX-License-Identifier: BSL-1.0
     Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/properties/examples/CMakeLists.txt
+++ b/libs/core/properties/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The STE||AR-Group
+# Copyright (c) 2020-2021 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/properties/include/hpx/properties/is_applicable_property.hpp
+++ b/libs/core/properties/include/hpx/properties/is_applicable_property.hpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 Hartmut Kaiser
+//
+// SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/type_support/always_void.hpp>
+
+#include <type_traits>
+
+namespace hpx { namespace experimental {
+
+    namespace detail {
+
+        template <typename T, typename Property, typename = void>
+        struct is_applicable_property : std::false_type
+        {
+        };
+
+        template <typename T, typename Property>
+        struct is_applicable_property<T, Property,
+            util::always_void_t<std::enable_if_t<
+                Property::template is_applicable_property_v<T>>>>
+          : std::true_type
+        {
+        };
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T, typename Property, typename Enable = void>
+    struct is_applicable_property
+      : detail::is_applicable_property<std::decay_t<T>, std::decay_t<Property>>
+    {
+    };
+
+    template <typename T, typename Property>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_applicable_property_v =
+        is_applicable_property<T, Property>::value;
+
+}}    // namespace hpx::experimental

--- a/libs/core/properties/include/hpx/properties/prefer.hpp
+++ b/libs/core/properties/include/hpx/properties/prefer.hpp
@@ -8,12 +8,12 @@
 
 #include <hpx/config.hpp>
 #include <hpx/functional/tag_fallback_invoke.hpp>
-#include <hpx/functional/traits/is_invocable.hpp>
 
 #include <type_traits>
 #include <utility>
 
 namespace hpx { namespace experimental {
+
     HPX_INLINE_CONSTEXPR_VARIABLE struct prefer_t
       : hpx::functional::tag_fallback<prefer_t>
     {
@@ -31,11 +31,11 @@ namespace hpx { namespace experimental {
 
         template <typename Tag, typename T0, typename... Tn>
         friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(prefer_t,
-            Tag&&, T0&& t0, Tn&&...) noexcept(noexcept(std::forward<T0>(t0))) ->
-            typename std::enable_if<!hpx::functional::is_tag_invocable<prefer_t,
-                                        Tag, T0, Tn...>::value &&
+            Tag&&, T0&& t0, Tn&&...) noexcept(noexcept(std::forward<T0>(t0)))
+            -> std::enable_if_t<!hpx::functional::is_tag_invocable<prefer_t,
+                                    Tag, T0, Tn...>::value &&
                     !hpx::functional::is_tag_invocable<Tag, T0, Tn...>::value,
-                decltype(std::forward<T0>(t0))>::type
+                decltype(std::forward<T0>(t0))>
         {
             return std::forward<T0>(t0);
         }

--- a/libs/core/properties/include/hpx/properties/query.hpp
+++ b/libs/core/properties/include/hpx/properties/query.hpp
@@ -1,0 +1,98 @@
+// Copyright (c) 2021 Hartmut Kaiser
+//
+// SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/functional/tag_priority_invoke.hpp>
+#include <hpx/properties/is_applicable_property.hpp>
+#include <hpx/properties/static_query.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace experimental {
+
+    namespace detail {
+
+        template <typename E, typename T>
+        struct query_is_applicable
+        {
+            static constexpr bool value =
+                hpx::experimental::is_applicable_property_v<E, T>;
+        };
+    }    // namespace detail
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct query_t
+      : hpx::functional::tag_priority<query_t>
+    {
+        // This flag enforces the common requirement for the query CPO that the
+        // given property T has to be applicable to the type E. The tag_invoke
+        // machinery will static_assert if this flag evaluates to false.
+        template <typename E, typename T>
+        static constexpr bool is_applicable_v =
+            detail::query_is_applicable<E, T>::value;
+
+    private:
+        // clang-format off
+        template <typename E, typename T>
+        static constexpr HPX_FORCEINLINE
+        auto invoke_impl(std::true_type, E&&, T&&)
+            noexcept(noexcept(static_query<E, T>::property_value()))
+            -> decltype(static_query<E, T>::property_value())
+        {
+            return static_query<E, T>::property_value();
+        }
+
+        template <typename E, typename T>
+        static constexpr HPX_FORCEINLINE
+        auto invoke_impl(std::false_type, E&& e, T&& t)
+            noexcept(noexcept(
+                std::declval<E&&>().query(std::forward<T>(t))))
+            -> decltype(std::declval<E&&>().query(std::forward<T>(t)))
+        {
+            return std::forward<E>(e).query(std::forward<T>(t));
+        }
+
+        template <typename E, typename T>
+        friend constexpr HPX_FORCEINLINE
+        auto tag_override_invoke(query_t, E&& e, T&& t)
+            noexcept(noexcept(invoke_impl(static_query_t<E, T>(),
+                std::forward<E>(e), std::forward<T>(t))))
+            -> decltype(invoke_impl(static_query_t<E, T>(),
+                std::forward<E>(e), std::forward<T>(t)))
+        {
+            return invoke_impl(static_query_t<E, T>(),
+                std::forward<E>(e), std::forward<T>(t));
+        }
+        // clang-format on
+    } query{};
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename E, typename T>
+    struct can_query
+      : std::integral_constant<bool,
+            functional::is_tag_priority_invocable_v<query_t, E, T> &&
+                detail::query_is_applicable<E, T>::value>
+    {
+    };
+
+    template <typename E, typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool can_query_v = can_query<E, T>::value;
+
+    template <typename E, typename T>
+    struct is_nothrow_query
+      : std::integral_constant<bool,
+            functional::is_nothrow_tag_priority_invocable_v<query_t, E, T> &&
+                detail::query_is_applicable<E, T>::value>
+    {
+    };
+
+    template <typename E, typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_nothrow_query_v =
+        is_nothrow_query<E, T>::value;
+
+}}    // namespace hpx::experimental

--- a/libs/core/properties/include/hpx/properties/require.hpp
+++ b/libs/core/properties/include/hpx/properties/require.hpp
@@ -1,0 +1,171 @@
+// Copyright (c) 2021 Hartmut Kaiser
+//
+// SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// 'require' is a dangerous Apple macro, silence inspect about this
+// hpxinspect:noapple_macros:require
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/functional/tag_priority_invoke.hpp>
+#include <hpx/properties/is_applicable_property.hpp>
+#include <hpx/properties/static_query.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace experimental {
+
+    namespace detail {
+
+        template <typename E, typename... T>
+        struct require_is_applicable;
+
+        template <typename T, typename Enable = void>
+        struct is_requirable
+        {
+            static constexpr bool value = false;
+        };
+
+        template <typename T>
+        struct is_requirable<T, std::enable_if_t<T::is_requirable>>
+        {
+            static constexpr bool value = true;
+        };
+
+        template <typename E, typename T>
+        struct require_is_applicable<E, T>
+        {
+            static constexpr bool value =
+                hpx::experimental::is_applicable_property_v<E, T> &&
+                is_requirable<std::decay_t<T>>::value;
+        };
+    }    // namespace detail
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct require_t
+      : hpx::functional::tag_priority<require_t>
+    {
+        // This flag enforces the common requirement for the requires CPO that
+        // the given property T has to be applicable to the type E and that the
+        // property T is marked as requirable. The tag_invoke machinery will
+        // static_assert if this flag evaluates to false.
+        template <typename E, typename... Tn>
+        static constexpr bool is_applicable_v =
+            detail::require_is_applicable<E, Tn...>::value;
+
+    private:
+        // clang-format off
+        template <typename E, typename T>
+        static constexpr HPX_FORCEINLINE
+        auto invoke_impl(std::true_type, E&& e, T&&)
+            noexcept(noexcept(std::forward<E>(e)))
+            -> decltype(std::forward<E>(e))
+        {
+            return std::forward<E>(e);
+        }
+
+        template <typename E, typename T>
+        static constexpr HPX_FORCEINLINE
+        auto invoke_impl(std::false_type, E&& e, T&& t)
+            noexcept(noexcept(std::declval<E&&>().require(std::forward<T>(t))))
+            -> decltype(std::declval<E&&>().require(std::forward<T>(t)))
+        {
+            return std::forward<E>(e).require(std::forward<T>(t));
+        }
+
+        template <typename E, typename T>
+        friend constexpr HPX_FORCEINLINE
+        auto tag_override_invoke(require_t, E&& e, T&& t)
+            noexcept(noexcept(invoke_impl(static_query_value_t<E, T>(),
+                std::forward<E>(e), std::forward<T>(t))))
+            -> decltype(invoke_impl(static_query_value_t<E, T>(),
+                std::forward<E>(e), std::forward<T>(t)))
+        {
+            return invoke_impl(static_query_value_t<E, T>(),
+                std::forward<E>(e), std::forward<T>(t));
+        }
+        // clang-format on
+    } require{};
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Specialization for the case that require was invoked with at least two
+    // properties.
+
+    // clang-format off
+    namespace detail {
+
+        template <typename E, typename T0, typename T1, typename Pack,
+            typename Enable = void>
+        struct require_is_applicable_helper
+        {
+            static constexpr bool value = false;
+        };
+
+        template <typename E, typename T0, typename T1, typename... Tn>
+        struct require_is_applicable_helper<E, T0, T1, util::pack<Tn...>,
+            std::enable_if_t<
+                functional::is_tag_priority_invocable_v<require_t, E, T0> &&
+                require_is_applicable<E, T0>::value>>
+        {
+            static constexpr bool value =
+                require_is_applicable<decltype(require(
+                                  std::declval<E&&>(), std::declval<T0&&>())),
+                    T1, Tn...>::value;
+        };
+
+        template <typename E, typename T0, typename T1, typename... Tn>
+        struct require_is_applicable<E, T0, T1, Tn...>
+        {
+            static constexpr bool value = require_is_applicable_helper<
+                E, T0, T1, util::pack<Tn...>>::value;
+        };
+    }    // namespace detail
+
+    template <typename E, typename T0, typename T1, typename... Tn>
+    constexpr HPX_FORCEINLINE
+    auto tag_fallback_invoke(require_t, E&& e, T0&& t0, T1&& t1, Tn&&... tn)
+        noexcept(noexcept(
+            require(
+                require(std::forward<E>(e), std::forward<T0>(t0)),
+                std::forward<T1>(t1), std::forward<Tn>(tn)...)
+        ))
+        -> decltype(require(
+                require(std::forward<E>(e), std::forward<T0>(t0)),
+                std::forward<T1>(t1), std::forward<Tn>(tn)...))
+    {
+        return require(
+            require(std::forward<E>(e), std::forward<T0>(t0)),
+            std::forward<T1>(t1), std::forward<Tn>(tn)...);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T, typename... Tn>
+    struct can_require
+      : std::integral_constant<bool,
+            functional::is_tag_priority_invocable_v<require_t, T, Tn...> &&
+            detail::require_is_applicable<T, Tn...>::value>
+    {
+    };
+
+    template <typename T, typename... Tn>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool can_require_v =
+        can_require<T, Tn...>::value;
+
+    template <typename T, typename... Tn>
+    struct is_nothrow_require
+      : std::integral_constant<bool,
+            functional::is_nothrow_tag_priority_invocable_v<require_t, T, Tn...> &&
+            detail::require_is_applicable<T, Tn...>::value>
+    {
+    };
+
+    template <typename T, typename... Tn>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_nothrow_require_v =
+        is_nothrow_require<T, Tn...>::value;
+
+    // clang-format on
+
+}}    // namespace hpx::experimental

--- a/libs/core/properties/include/hpx/properties/require_concept.hpp
+++ b/libs/core/properties/include/hpx/properties/require_concept.hpp
@@ -1,0 +1,119 @@
+// Copyright (c) 2021 Hartmut Kaiser
+//
+// SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/functional/tag_priority_invoke.hpp>
+#include <hpx/properties/is_applicable_property.hpp>
+#include <hpx/properties/static_query.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace experimental {
+
+    namespace detail {
+
+        template <typename T, typename Enable = void>
+        struct is_requirable_concept
+        {
+            static constexpr bool value = false;
+        };
+
+        template <typename T>
+        struct is_requirable_concept<T,
+            std::enable_if_t<T::is_requirable_concept>>
+        {
+            static constexpr bool value = true;
+        };
+
+        template <typename E, typename T>
+        struct require_concept_is_applicable
+        {
+            static constexpr bool value =
+                hpx::experimental::is_applicable_property_v<E, T> &&
+                is_requirable_concept<std::decay_t<T>>::value;
+        };
+    }    // namespace detail
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct require_concept_t
+      : hpx::functional::tag_priority<require_concept_t>
+    {
+        // This flag enforces the common requirement for the require_concepts
+        // CPO that the given property T has to be applicable to the type E and
+        // that the property T is marked as is_requirable_concept. The
+        // tag_invoke machinery will static_assert if this flag evaluates to
+        // false.
+        template <typename E, typename T>
+        static constexpr bool is_applicable_v =
+            detail::require_concept_is_applicable<E, T>::value;
+
+    private:
+        // clang-format off
+        template <typename E, typename T>
+        static constexpr HPX_FORCEINLINE
+        auto invoke_impl(std::true_type, E&& e, T&&)
+            noexcept(noexcept(std::forward<E>(e)))
+            -> decltype(std::forward<E>(e))
+        {
+            return std::forward<E>(e);
+        }
+
+        template <typename E, typename T>
+        static constexpr HPX_FORCEINLINE
+        auto invoke_impl(std::false_type, E&& e, T&& t)
+            noexcept(noexcept(
+                std::declval<E&&>().require_concept(std::forward<T>(t))))
+            -> decltype(std::declval<E&&>().require_concept(std::forward<T>(t)))
+        {
+            return std::forward<E>(e).require_concept(std::forward<T>(t));
+        }
+
+        template <typename E, typename T>
+        friend constexpr HPX_FORCEINLINE
+        auto tag_override_invoke(require_concept_t, E&& e, T&& t)
+            noexcept(noexcept(invoke_impl(static_query_value_t<E, T>(),
+                std::forward<E>(e), std::forward<T>(t))))
+            -> decltype(invoke_impl(static_query_value_t<E, T>(),
+                std::forward<E>(e), std::forward<T>(t)))
+        {
+            return invoke_impl(static_query_value_t<E, T>(),
+                std::forward<E>(e), std::forward<T>(t));
+        }
+        // clang-format on
+    } require_concept{};
+
+    ///////////////////////////////////////////////////////////////////////////
+    // clang-format off
+    template <typename E, typename T>
+    struct can_require_concept
+      : std::integral_constant<bool,
+            functional::is_tag_priority_invocable_v<require_concept_t, E, T> &&
+            detail::require_concept_is_applicable<E, T>::value>
+    {
+    };
+
+    // clang-format off
+    template <typename E, typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool can_require_concept_v =
+        can_require_concept<E, T>::value;
+
+    template <typename E, typename T>
+    struct is_nothrow_require_concept
+      : std::integral_constant<bool,
+        functional::is_nothrow_tag_priority_invocable_v<require_concept_t, E, T> &&
+        detail::require_concept_is_applicable<E, T>::value>
+    {
+    };
+
+    template <typename E, typename T>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool is_nothrow_require_concept_v =
+        is_nothrow_require_concept<E, T>::value;
+
+    // clang-format on
+
+}}    // namespace hpx::experimental

--- a/libs/core/properties/include/hpx/properties/static_query.hpp
+++ b/libs/core/properties/include/hpx/properties/static_query.hpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2021 Hartmut Kaiser
+//
+// SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/type_support/always_void.hpp>
+
+#include <type_traits>
+
+namespace hpx { namespace experimental {
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail {
+
+        template <typename T, typename Property, typename = void>
+        struct static_query : std::false_type
+        {
+        };
+
+        template <typename T, typename Property>
+        struct static_query<T, Property,
+            util::always_void_t<decltype(Property::template static_query_v<T>)>>
+          : std::true_type
+        {
+            using result_type = decltype(Property::template static_query_v<T>);
+
+            static constexpr result_type property_value() noexcept(
+                noexcept(Property::template static_query_v<T>))
+            {
+                return Property::template static_query_v<T>;
+            }
+        };
+
+        template <typename T, typename Property, typename = void>
+        struct static_query_value : std::false_type
+        {
+        };
+
+        template <typename T, typename Property>
+        struct static_query_value<T, Property,
+            util::always_void_t<decltype(
+                Property::template static_query_v<T> == Property::value())>>
+          : std::integral_constant<bool,
+                Property::template static_query_v<T> == Property::value()>
+        {
+        };
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T, typename Property, typename Enable = void>
+    struct static_query
+      : detail::static_query<std::decay_t<T>, std::decay_t<Property>>
+    {
+    };
+
+    template <typename T, typename Property>
+    using static_query_t = typename static_query<T, Property>::type;
+
+    template <typename T, typename Property>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool static_query_v =
+        static_query<T, Property>::value;
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T, typename Property, typename Enable = void>
+    struct static_query_value
+      : detail::static_query_value<std::decay_t<T>, std::decay_t<Property>>
+    {
+    };
+
+    template <typename T, typename Property>
+    using static_query_value_t = typename static_query_value<T, Property>::type;
+
+    template <typename T, typename Property>
+    HPX_INLINE_CONSTEXPR_VARIABLE bool static_query_value_v =
+        static_query_value<T, Property>::value;
+
+}}    // namespace hpx::experimental

--- a/libs/core/properties/include/hpx/property.hpp
+++ b/libs/core/properties/include/hpx/property.hpp
@@ -1,9 +1,0 @@
-//  Copyright (c) 2020 ETH Zurich
-//
-//  SPDX-License-Identifier: BSL-1.0
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-
-#pragma once
-
-#include <hpx/properties/property.hpp>

--- a/libs/core/properties/tests/CMakeLists.txt
+++ b/libs/core/properties/tests/CMakeLists.txt
@@ -1,11 +1,10 @@
-# Copyright (c) 2020 The STE||AR-Group
+# Copyright (c) 2020-2021 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 include(HPX_Message)
-include(HPX_Option)
 
 if(NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
   return()

--- a/libs/core/properties/tests/performance/CMakeLists.txt
+++ b/libs/core/properties/tests/performance/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The STE||AR-Group
+# Copyright (c) 2020-2021 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/properties/tests/regressions/CMakeLists.txt
+++ b/libs/core/properties/tests/regressions/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The STE||AR-Group
+# Copyright (c) 2020-2021 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/properties/tests/unit/CMakeLists.txt
+++ b/libs/core/properties/tests/unit/CMakeLists.txt
@@ -1,10 +1,26 @@
-# Copyright (c) 2020 ETH Zurich
+# Copyright (c) 2020-2021 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests properties)
+set(tests
+    can_query
+    can_require
+    can_require_concept
+    prefer
+    query_free
+    query_member
+    query_static
+    require
+    require_concept
+    require_concept_free
+    require_concept_member
+    require_concept_static
+    require_free
+    require_member
+    require_static
+)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/core/properties/tests/unit/can_query.cpp
+++ b/libs/core/properties/tests/unit/can_query.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2003-2020 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+// Copyright (c) 2021 Hartmut Kaiser
+//
+// SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/properties.hpp>
+#include <hpx/modules/testing.hpp>
+
+struct prop
+{
+    template <typename>
+    static constexpr bool is_applicable_property_v = true;
+};
+
+struct prop_not_applicable
+{
+};
+
+struct prop_static
+{
+    template <typename>
+    static constexpr int static_query_v = 123;
+};
+
+struct object_free
+{
+    friend constexpr int tag_invoke(
+        hpx::experimental::query_t, object_free const&, prop)
+    {
+        return 123;
+    }
+};
+
+struct object_member
+{
+    constexpr int query(prop) const
+    {
+        return 123;
+    }
+};
+
+struct object_static
+{
+};
+
+int main()
+{
+    using namespace hpx::experimental;
+
+    static_assert(can_query_v<object_free, prop>, "");
+    static_assert(can_query_v<object_free const, prop>, "");
+
+    static_assert(can_query_v<object_member, prop>, "");
+    static_assert(can_query_v<object_member const, prop>, "");
+
+    static_assert(!can_query_v<object_free, prop_not_applicable>, "");
+    static_assert(!can_query_v<object_free const, prop_not_applicable>, "");
+
+    static_assert(!can_query_v<object_member, prop_not_applicable>, "");
+    static_assert(!can_query_v<object_member const, prop_not_applicable>, "");
+
+    static_assert(!can_query_v<object_static, prop_static>, "");
+    static_assert(!can_query_v<object_static const, prop_static>, "");
+
+    static_assert(!can_query_v<object_static, prop>, "");
+    static_assert(!can_query_v<object_static const, prop>, "");
+
+    static_assert(!can_query_v<object_static, prop_not_applicable>, "");
+    static_assert(!can_query_v<object_static const, prop_not_applicable>, "");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/properties/tests/unit/can_require.cpp
+++ b/libs/core/properties/tests/unit/can_require.cpp
@@ -1,0 +1,187 @@
+// Copyright (c) 2003-2020 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+// Copyright (c) 2021 Hartmut Kaiser
+//
+// SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/properties.hpp>
+#include <hpx/modules/testing.hpp>
+
+template <int>
+struct prop
+{
+    template <typename>
+    static constexpr bool is_applicable_property_v = true;
+
+    static constexpr bool is_requirable = true;
+};
+
+template <int>
+struct prop_not_applicable
+{
+    static constexpr bool is_requirable = true;
+};
+
+template <int>
+struct prop_unsupported
+{
+};
+
+template <int>
+struct prop_static
+{
+    template <typename>
+    static constexpr bool is_applicable_property_v = true;
+
+    static constexpr bool is_requirable = true;
+
+    template <typename>
+    static constexpr bool static_query_v = true;
+
+    static constexpr bool value()
+    {
+        return true;
+    }
+};
+
+template <int>
+struct object_free
+{
+    template <int N>
+    friend constexpr object_free<N> tag_invoke(
+        hpx::experimental::require_t, object_free const&, prop<N>)
+    {
+        return object_free<N>();
+    }
+
+    template <int N>
+    friend constexpr object_free<N> tag_invoke(hpx::experimental::require_t,
+        object_free const&, prop_not_applicable<N>)
+    {
+        return object_free<N>();
+    }
+};
+
+template <int>
+struct object_member
+{
+    template <int N>
+    constexpr object_member<N> require(prop<N>) const
+    {
+        return object_member<N>();
+    }
+
+    template <int N>
+    constexpr object_member<N> require(prop_not_applicable<N>) const
+    {
+        return object_member<N>();
+    }
+};
+
+template <int>
+struct object_static
+{
+};
+
+int main()
+{
+    using namespace hpx::experimental;
+
+    static_assert(can_require_v<object_free<1>, prop<2>>, "");
+    static_assert(can_require_v<object_free<1>, prop<2>, prop<3>>, "");
+    static_assert(can_require_v<object_free<1>, prop<2>, prop<3>, prop<4>>, "");
+    static_assert(can_require_v<object_free<1> const, prop<2>>, "");
+    static_assert(can_require_v<object_free<1> const, prop<2>, prop<3>>, "");
+    static_assert(
+        can_require_v<object_free<1> const, prop<2>, prop<3>, prop<4>>, "");
+
+    static_assert(can_require_v<object_member<1>, prop<2>>, "");
+    static_assert(can_require_v<object_member<1>, prop<2>, prop<3>>, "");
+    static_assert(
+        can_require_v<object_member<1>, prop<2>, prop<3>, prop<4>>, "");
+    static_assert(can_require_v<object_member<1> const, prop<2>>, "");
+    static_assert(can_require_v<object_member<1> const, prop<2>, prop<3>>, "");
+    static_assert(
+        can_require_v<object_member<1> const, prop<2>, prop<3>, prop<4>>, "");
+
+    static_assert(can_require_v<object_static<1>, prop_static<1>>, "");
+    static_assert(
+        can_require_v<object_static<1>, prop_static<1>, prop_static<1>>, "");
+    static_assert(can_require_v<object_static<1>, prop_static<1>,
+                      prop_static<1>, prop_static<1>>,
+        "");
+    static_assert(can_require_v<object_static<1> const, prop_static<1>>, "");
+    static_assert(
+        can_require_v<object_static<1> const, prop_static<1>, prop_static<1>>,
+        "");
+    static_assert(can_require_v<object_static<1> const, prop_static<1>,
+                      prop_static<1>, prop_static<1>>,
+        "");
+
+    static_assert(!can_require_v<object_free<1>, prop_not_applicable<2>>, "");
+    static_assert(!can_require_v<object_free<1>, prop_not_applicable<2>,
+                      prop_not_applicable<3>>,
+        "");
+    static_assert(!can_require_v<object_free<1>, prop_not_applicable<2>,
+                      prop_not_applicable<3>, prop_not_applicable<4>>,
+        "");
+    static_assert(
+        !can_require_v<object_free<1> const, prop_not_applicable<2>>, "");
+    static_assert(!can_require_v<object_free<1> const, prop_not_applicable<2>,
+                      prop_not_applicable<3>>,
+        "");
+    static_assert(!can_require_v<object_free<1> const, prop_not_applicable<2>,
+                      prop_not_applicable<3>, prop_not_applicable<4>>,
+        "");
+
+    static_assert(!can_require_v<object_member<1>, prop_not_applicable<2>>, "");
+    static_assert(!can_require_v<object_member<1>, prop_not_applicable<2>,
+                      prop_not_applicable<3>>,
+        "");
+    static_assert(!can_require_v<object_member<1>, prop_not_applicable<2>,
+                      prop_not_applicable<3>, prop_not_applicable<4>>,
+        "");
+    static_assert(
+        !can_require_v<object_member<1> const, prop_not_applicable<2>>, "");
+    static_assert(!can_require_v<object_member<1> const, prop_not_applicable<2>,
+                      prop_not_applicable<3>>,
+        "");
+    static_assert(!can_require_v<object_member<1> const, prop_not_applicable<2>,
+                      prop_not_applicable<3>, prop_not_applicable<4>>,
+        "");
+
+    static_assert(!can_require_v<object_static<1>, prop_not_applicable<1>>, "");
+    static_assert(!can_require_v<object_static<1>, prop_not_applicable<1>,
+                      prop_not_applicable<1>>,
+        "");
+    static_assert(!can_require_v<object_static<1>, prop_not_applicable<1>,
+                      prop_not_applicable<1>, prop_not_applicable<1>>,
+        "");
+    static_assert(
+        !can_require_v<object_static<1> const, prop_not_applicable<1>>, "");
+    static_assert(!can_require_v<object_static<1> const, prop_not_applicable<1>,
+                      prop_not_applicable<1>>,
+        "");
+    static_assert(!can_require_v<object_static<1> const, prop_not_applicable<1>,
+                      prop_not_applicable<1>, prop_not_applicable<1>>,
+        "");
+
+    static_assert(!can_require_v<object_static<1>, prop_unsupported<2>>, "");
+    static_assert(!can_require_v<object_static<1>, prop_unsupported<2>,
+                      prop_unsupported<3>>,
+        "");
+    static_assert(!can_require_v<object_static<1>, prop_unsupported<2>,
+                      prop_unsupported<3>, prop_unsupported<4>>,
+        "");
+    static_assert(
+        !can_require_v<object_static<1> const, prop_unsupported<2>>, "");
+    static_assert(!can_require_v<object_static<1> const, prop_unsupported<2>,
+                      prop_unsupported<3>>,
+        "");
+    static_assert(!can_require_v<object_static<1> const, prop_unsupported<2>,
+                      prop_unsupported<3>, prop_unsupported<4>>,
+        "");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/properties/tests/unit/can_require_concept.cpp
+++ b/libs/core/properties/tests/unit/can_require_concept.cpp
@@ -1,0 +1,127 @@
+// Copyright (c) 2003-2020 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+// Copyright (c) 2021 Hartmut Kaiser
+//
+// SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/properties.hpp>
+#include <hpx/modules/testing.hpp>
+
+template <int>
+struct prop
+{
+    template <typename>
+    static constexpr bool is_applicable_property_v = true;
+
+    static constexpr bool is_requirable_concept = true;
+};
+
+template <int>
+struct prop_not_applicable
+{
+    static constexpr bool is_requirable_concept = true;
+};
+
+template <int>
+struct prop_unsupported
+{
+};
+
+template <int>
+struct prop_static
+{
+    template <typename>
+    static constexpr bool is_applicable_property_v = true;
+
+    static constexpr bool is_requirable_concept = true;
+
+    template <typename>
+    static constexpr bool static_query_v = true;
+
+    static constexpr bool value()
+    {
+        return true;
+    }
+};
+
+template <int>
+struct object_free
+{
+    template <int N>
+    friend constexpr object_free<N> tag_invoke(
+        hpx::experimental::require_concept_t, object_free const&, prop<N>)
+    {
+        return object_free<N>();
+    }
+
+    template <int N>
+    friend constexpr object_free<N> tag_invoke(
+        hpx::experimental::require_concept_t, object_free const&,
+        prop_not_applicable<N>)
+    {
+        return object_free<N>();
+    }
+};
+
+template <int>
+struct object_member
+{
+    template <int N>
+    constexpr object_member<N> require_concept(prop<N>) const
+    {
+        return object_member<N>();
+    }
+
+    template <int N>
+    constexpr object_member<N> require_concept(prop_not_applicable<N>) const
+    {
+        return object_member<N>();
+    }
+};
+
+template <int>
+struct object_static
+{
+};
+
+int main()
+{
+    using namespace hpx::experimental;
+
+    static_assert(can_require_concept_v<object_free<1>, prop<2>>, "");
+    static_assert(can_require_concept_v<object_free<1> const, prop<2>>, "");
+
+    static_assert(can_require_concept_v<object_member<1>, prop<2>>, "");
+    static_assert(can_require_concept_v<object_member<1> const, prop<2>>, "");
+
+    static_assert(can_require_concept_v<object_static<1>, prop_static<1>>, "");
+    static_assert(
+        can_require_concept_v<object_static<1> const, prop_static<1>>, "");
+
+    static_assert(
+        !can_require_concept_v<object_free<1>, prop_not_applicable<2>>, "");
+    static_assert(
+        !can_require_concept_v<object_free<1> const, prop_not_applicable<2>>,
+        "");
+
+    static_assert(
+        !can_require_concept_v<object_member<1>, prop_not_applicable<2>>, "");
+    static_assert(
+        !can_require_concept_v<object_member<1> const, prop_not_applicable<2>>,
+        "");
+
+    static_assert(
+        !can_require_concept_v<object_static<1>, prop_not_applicable<1>>, "");
+    static_assert(
+        !can_require_concept_v<object_static<1> const, prop_not_applicable<1>>,
+        "");
+
+    static_assert(
+        !can_require_concept_v<object_static<1>, prop_unsupported<2>>, "");
+    static_assert(
+        !can_require_concept_v<object_static<1> const, prop_unsupported<2>>,
+        "");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/properties/tests/unit/prefer.cpp
+++ b/libs/core/properties/tests/unit/prefer.cpp
@@ -4,6 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/modules/functional.hpp>
 #include <hpx/modules/properties.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/libs/core/properties/tests/unit/query_free.cpp
+++ b/libs/core/properties/tests/unit/query_free.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2003-2020 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+// Copyright (c) 2021 Hartmut Kaiser
+//
+// SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/properties.hpp>
+#include <hpx/modules/testing.hpp>
+
+struct prop
+{
+    template <typename>
+    static constexpr bool is_applicable_property_v = true;
+};
+
+struct object
+{
+    friend constexpr int tag_invoke(
+        hpx::experimental::query_t, object const&, prop)
+    {
+        return 123;
+    }
+};
+
+int main()
+{
+    object o1 = {};
+    int result1 = hpx::experimental::query(o1, prop());
+    HPX_TEST(result1 == 123);
+
+    object const o2 = {};
+    int result2 = hpx::experimental::query(o2, prop());
+    HPX_TEST(result2 == 123);
+
+    constexpr object o3 = {};
+    constexpr int result3 = hpx::experimental::query(o3, prop());
+    HPX_TEST(result3 == 123);
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/properties/tests/unit/query_member.cpp
+++ b/libs/core/properties/tests/unit/query_member.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2003-2020 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+// Copyright (c) 2021 Hartmut Kaiser
+//
+// SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/properties.hpp>
+#include <hpx/modules/testing.hpp>
+
+struct prop
+{
+    template <typename>
+    static constexpr bool is_applicable_property_v = true;
+};
+
+struct object
+{
+    constexpr int query(prop) const
+    {
+        return 123;
+    }
+};
+
+int main()
+{
+    object o1 = {};
+    int result1 = hpx::experimental::query(o1, prop());
+    HPX_TEST(result1 == 123);
+
+    object const o2 = {};
+    int result2 = hpx::experimental::query(o2, prop());
+    HPX_TEST(result2 == 123);
+
+    constexpr object o3 = {};
+    constexpr int result3 = hpx::experimental::query(o3, prop());
+    HPX_TEST(result3 == 123);
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/properties/tests/unit/query_static.cpp
+++ b/libs/core/properties/tests/unit/query_static.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2003-2020 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+// Copyright (c) 2021 Hartmut Kaiser
+//
+// SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/properties.hpp>
+#include <hpx/modules/testing.hpp>
+
+struct prop
+{
+    template <typename>
+    static constexpr bool is_applicable_property_v = true;
+
+    template <typename>
+    static constexpr int static_query_v = 123;
+};
+
+struct object
+{
+};
+
+int main()
+{
+    object o1 = {};
+    int result1 = hpx::experimental::query(o1, prop());
+    HPX_TEST(result1 == 123);
+
+    object const o2 = {};
+    int result2 = hpx::experimental::query(o2, prop());
+    HPX_TEST(result2 == 123);
+
+    constexpr object o3 = {};
+    constexpr int result3 = hpx::experimental::query(o3, prop());
+    HPX_TEST(result3 == 123);
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/properties/tests/unit/require.cpp
+++ b/libs/core/properties/tests/unit/require.cpp
@@ -1,0 +1,355 @@
+//  Copyright (c) 2020 ETH Zurich
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// 'require' is a dangerous Apple macro, silence inspect about this
+// hpxinspect:noapple_macros:require
+
+#include <hpx/modules/functional.hpp>
+#include <hpx/modules/properties.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <type_traits>
+
+///////////////////////////////////////////////////////////////////////////////
+struct property1
+{
+    static constexpr bool is_requirable = true;
+
+    template <typename T>
+    static constexpr bool is_applicable_property_v = true;
+
+    int v = 0;
+};
+
+struct type1
+{
+    property1 p1{};
+};
+
+type1 tag_invoke(hpx::experimental::require_t, type1 const& t, property1 p)
+{
+    auto tt = t;
+    tt.p1 = p;
+    return tt;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+struct type2;
+
+template <typename T>
+struct is_type2 : std::is_same<type2, std::decay_t<T>>
+{
+};
+
+struct type3;
+
+template <typename T>
+struct is_type3 : std::is_same<type3, std::decay_t<T>>
+{
+};
+
+///////////////////////////////////////////////////////////////////////////////
+struct property2
+{
+    static constexpr bool is_requirable = true;
+
+    template <typename T>
+    static constexpr bool is_applicable_property_v =
+        is_type2<T>::value || is_type3<T>::value;
+
+    int v = 0;
+};
+
+struct type2
+{
+    property2 p2{};
+};
+
+type2 tag_invoke(hpx::experimental::require_t, type2 const& t, property2 p)
+{
+    auto tt = t;
+    tt.p2 = p;
+    return tt;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+struct property3
+{
+    static constexpr bool is_requirable = true;
+
+    template <typename T>
+    static constexpr bool is_applicable_property_v = is_type3<T>::value;
+
+    int v = 0;
+};
+
+struct type3
+{
+    property3 p3{};
+
+    type3 require(property3 p) const
+    {
+        auto tt = *this;
+        tt.p3 = p;
+        return tt;
+    }
+
+    type3& operator=(property2 p2)
+    {
+        p3.v = p2.v;
+        return *this;
+    }
+};
+
+type3 tag_invoke(hpx::experimental::require_t, type3 const& t, property2 p)
+{
+    auto tt = t;
+    tt = p;
+    return tt;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+struct type4;
+
+template <typename T>
+struct is_type4 : std::is_same<type4, std::decay_t<T>>
+{
+};
+
+struct property4
+{
+    static constexpr bool is_requirable = true;
+
+    template <typename T>
+    static constexpr bool is_applicable_property_v = is_type4<T>::value;
+
+    template <typename T>
+    static constexpr bool static_query_v = is_type4<T>::value;
+
+    static constexpr bool value()
+    {
+        return true;
+    }
+
+    int v = 0;
+};
+
+struct type4
+{
+    property4 p4{};
+};
+
+type4 tag_invoke(hpx::experimental::require_t, type4 const& t, property4 p)
+{
+    auto tt = t;
+    tt.p4 = p;
+    return tt;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main()
+{
+    // This property is accessed through a free function
+    {
+        static_assert(hpx::experimental::can_require_v<type1, property1>,
+            "Should be requirable");
+        static_assert(hpx::is_invocable<hpx::experimental::require_t, type1,
+                          property1>::value,
+            "Should be invocable");
+
+        static_assert(!hpx::experimental::can_require_v<type2, property1>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_t, type2,
+                          property1>::value,
+            "Should not be invocable");
+
+        static_assert(!hpx::experimental::can_require_v<type3, property1>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_t, type3,
+                          property1>::value,
+            "Should not be invocable");
+
+        static_assert(!hpx::experimental::can_require_v<type4, property1>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_t, type4,
+                          property1>::value,
+            "Should not be invocable");
+
+        type1 t1_1{};
+
+        type1 t1_2 = hpx::experimental::require(t1_1, property1{1});
+        HPX_TEST_EQ(t1_1.p1.v, 0);
+        HPX_TEST_EQ(t1_2.p1.v, 1);
+
+        property1 p1_1{2};
+        type1 t1_3 = hpx::experimental::require(t1_2, p1_1);
+        HPX_TEST_EQ(t1_2.p1.v, 1);
+        HPX_TEST_EQ(t1_3.p1.v, 2);
+
+        property1 const p1_2{3};
+        type1 t1_4 = hpx::experimental::require(t1_2, p1_2);
+        HPX_TEST_EQ(t1_3.p1.v, 2);
+        HPX_TEST_EQ(t1_4.p1.v, 3);
+    }
+
+    // This property is accessed through a member function
+    {
+        static_assert(!hpx::experimental::can_require_v<type1, property2>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_t, type1,
+                          property2>::value,
+            "Should not be invocable");
+
+        static_assert(hpx::experimental::can_require_v<type2, property2>,
+            "Should be requirable");
+        static_assert(hpx::is_invocable<hpx::experimental::require_t, type2,
+                          property2>::value,
+            "Should be invocable");
+
+        static_assert(hpx::experimental::can_require_v<type3, property2>,
+            "Should be requirable");
+        static_assert(hpx::is_invocable<hpx::experimental::require_t, type3,
+                          property2>::value,
+            "Should be invocable");
+
+        static_assert(!hpx::experimental::can_require_v<type4, property2>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_t, type4,
+                          property2>::value,
+            "Should not be invocable");
+
+        type2 t2_1{};
+
+        type2 t2_2 = hpx::experimental::require(t2_1, property2{1});
+        HPX_TEST_EQ(t2_1.p2.v, 0);
+        HPX_TEST_EQ(t2_2.p2.v, 1);
+
+        property2 p2_1{2};
+        type2 t2_3 = hpx::experimental::require(t2_2, p2_1);
+        HPX_TEST_EQ(t2_2.p2.v, 1);
+        HPX_TEST_EQ(t2_3.p2.v, 2);
+
+        property2 const p2_2{3};
+        type2 t2_4 = hpx::experimental::require(t2_2, p2_2);
+        HPX_TEST_EQ(t2_3.p2.v, 2);
+        HPX_TEST_EQ(t2_4.p2.v, 3);
+    }
+
+    {
+        static_assert(!hpx::experimental::can_require_v<type1, property3>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_t, type1,
+                          property3>::value,
+            "Should not be invocable");
+
+        static_assert(!hpx::experimental::can_require_v<type2, property3>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_t, type2,
+                          property3>::value,
+            "Should not be invocable");
+
+        static_assert(hpx::experimental::can_require_v<type3, property3>,
+            "Should be requirable");
+        static_assert(hpx::is_invocable<hpx::experimental::require_t, type3,
+                          property3>::value,
+            "Should be invocable");
+
+        static_assert(!hpx::experimental::can_require_v<type4, property3>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_t, type4,
+                          property3>::value,
+            "Should not be invocable");
+
+        type3 t3_1{};
+
+        type3 t3_2 = hpx::experimental::require(t3_1, property3{1});
+        HPX_TEST_EQ(t3_1.p3.v, 0);
+        HPX_TEST_EQ(t3_2.p3.v, 1);
+
+        property3 p3_1{2};
+        type3 t3_3 = hpx::experimental::require(t3_2, p3_1);
+        HPX_TEST_EQ(t3_2.p3.v, 1);
+        HPX_TEST_EQ(t3_3.p3.v, 2);
+
+        property3 const p3_2{3};
+        type3 t3_4 = hpx::experimental::require(t3_3, p3_2);
+        HPX_TEST_EQ(t3_3.p3.v, 2);
+        HPX_TEST_EQ(t3_4.p3.v, 3);
+
+        type3 t3_5 = hpx::experimental::require(t3_4, property2{1});
+        HPX_TEST_EQ(t3_4.p3.v, 3);
+        HPX_TEST_EQ(t3_5.p3.v, 1);
+
+        property2 p2_1{2};
+        type3 t3_6 = hpx::experimental::require(t3_5, p2_1);
+        HPX_TEST_EQ(t3_5.p3.v, 1);
+        HPX_TEST_EQ(t3_6.p3.v, 2);
+
+        property2 const p2_2{3};
+        type3 t3_7 = hpx::experimental::require(t3_6, p2_2);
+        HPX_TEST_EQ(t3_6.p3.v, 2);
+        HPX_TEST_EQ(t3_7.p3.v, 3);
+    }
+
+    {
+        static_assert(!hpx::experimental::can_require_v<type1, property4>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_t, type1,
+                          property4>::value,
+            "Should not be invocable");
+
+        static_assert(!hpx::experimental::can_require_v<type2, property4>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_t, type2,
+                          property4>::value,
+            "Should not be invocable");
+
+        static_assert(!hpx::experimental::can_require_v<type3, property4>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_t, type3,
+                          property4>::value,
+            "Should not be invocable");
+
+        static_assert(hpx::experimental::can_require_v<type4, property4>,
+            "Should be requirable");
+        static_assert(hpx::is_invocable<hpx::experimental::require_t, type4,
+                          property4>::value,
+            "Should be invocable");
+
+        type4 t4_1{};
+
+        type4 t4_2 = hpx::experimental::require(t4_1, property4{1});
+        HPX_TEST_EQ(t4_1.p4.v, 0);
+        HPX_TEST_EQ(t4_2.p4.v, 0);
+
+        property4 p4_1{2};
+        type4 t4_3 = hpx::experimental::require(t4_2, p4_1);
+        HPX_TEST_EQ(t4_2.p4.v, 0);
+        HPX_TEST_EQ(t4_3.p4.v, 0);
+
+        property4 const p4_2{4};
+        type4 t4_4 = hpx::experimental::require(t4_3, p4_2);
+        HPX_TEST_EQ(t4_3.p4.v, 0);
+        HPX_TEST_EQ(t4_4.p4.v, 0);
+    }
+
+    {
+        type3 t3_1{};
+
+        type3 t3_2 =
+            hpx::experimental::require(t3_1, property3{1}, property2{2});
+        HPX_TEST_EQ(t3_1.p3.v, 0);
+        HPX_TEST_EQ(t3_2.p3.v, 2);
+
+        type3 t3_3 = hpx::experimental::require(
+            t3_2, property3{1}, property2{3}, property2{2});
+        HPX_TEST_EQ(t3_1.p3.v, 0);
+        HPX_TEST_EQ(t3_2.p3.v, 2);
+    }
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/properties/tests/unit/require_concept.cpp
+++ b/libs/core/properties/tests/unit/require_concept.cpp
@@ -1,0 +1,358 @@
+//  Copyright (c) 2020 ETH Zurich
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/functional.hpp>
+#include <hpx/modules/properties.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <type_traits>
+
+///////////////////////////////////////////////////////////////////////////////
+struct property1
+{
+    static constexpr bool is_requirable_concept = true;
+
+    template <typename T>
+    static constexpr bool is_applicable_property_v = true;
+
+    int v = 0;
+};
+
+struct type1
+{
+    property1 p1{};
+};
+
+type1 tag_invoke(
+    hpx::experimental::require_concept_t, type1 const& t, property1 p)
+{
+    auto tt = t;
+    tt.p1 = p;
+    return tt;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+struct type2;
+
+template <typename T>
+struct is_type2 : std::is_same<type2, std::decay_t<T>>
+{
+};
+
+struct type3;
+
+template <typename T>
+struct is_type3 : std::is_same<type3, std::decay_t<T>>
+{
+};
+
+///////////////////////////////////////////////////////////////////////////////
+struct property2
+{
+    static constexpr bool is_requirable_concept = true;
+
+    template <typename T>
+    static constexpr bool is_applicable_property_v =
+        is_type2<T>::value || is_type3<T>::value;
+
+    int v = 0;
+};
+
+struct type2
+{
+    property2 p2{};
+};
+
+type2 tag_invoke(
+    hpx::experimental::require_concept_t, type2 const& t, property2 p)
+{
+    auto tt = t;
+    tt.p2 = p;
+    return tt;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+struct property3
+{
+    static constexpr bool is_requirable_concept = true;
+
+    template <typename T>
+    static constexpr bool is_applicable_property_v = is_type3<T>::value;
+
+    int v = 0;
+};
+
+struct type3
+{
+    property3 p3{};
+
+    type3 require_concept(property3 p) const
+    {
+        auto tt = *this;
+        tt.p3 = p;
+        return tt;
+    }
+
+    type3& operator=(property2 p2)
+    {
+        p3.v = p2.v;
+        return *this;
+    }
+};
+
+type3 tag_invoke(
+    hpx::experimental::require_concept_t, type3 const& t, property2 p)
+{
+    auto tt = t;
+    tt = p;
+    return tt;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+struct type4;
+
+template <typename T>
+struct is_type4 : std::is_same<type4, std::decay_t<T>>
+{
+};
+
+struct property4
+{
+    static constexpr bool is_requirable_concept = true;
+
+    template <typename T>
+    static constexpr bool is_applicable_property_v = is_type4<T>::value;
+
+    template <typename T>
+    static constexpr bool static_query_v = is_type4<T>::value;
+
+    static constexpr bool value()
+    {
+        return true;
+    }
+
+    int v = 0;
+};
+
+struct type4
+{
+    property4 p4{};
+};
+
+type4 tag_invoke(
+    hpx::experimental::require_concept_t, type4 const& t, property4 p)
+{
+    auto tt = t;
+    tt.p4 = p;
+    return tt;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main()
+{
+    // This property is accessed through a free function
+    {
+        static_assert(
+            hpx::experimental::can_require_concept_v<type1, property1>,
+            "Should be requirable");
+        static_assert(hpx::is_invocable<hpx::experimental::require_concept_t,
+                          type1, property1>::value,
+            "Should be invocable");
+
+        static_assert(
+            !hpx::experimental::can_require_concept_v<type2, property1>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_concept_t,
+                          type2, property1>::value,
+            "Should not be invocable");
+
+        static_assert(
+            !hpx::experimental::can_require_concept_v<type3, property1>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_concept_t,
+                          type3, property1>::value,
+            "Should not be invocable");
+
+        static_assert(
+            !hpx::experimental::can_require_concept_v<type4, property1>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_concept_t,
+                          type4, property1>::value,
+            "Should not be invocable");
+
+        type1 t1_1{};
+
+        type1 t1_2 = hpx::experimental::require_concept(t1_1, property1{1});
+        HPX_TEST_EQ(t1_1.p1.v, 0);
+        HPX_TEST_EQ(t1_2.p1.v, 1);
+
+        property1 p1_1{2};
+        type1 t1_3 = hpx::experimental::require_concept(t1_2, p1_1);
+        HPX_TEST_EQ(t1_2.p1.v, 1);
+        HPX_TEST_EQ(t1_3.p1.v, 2);
+
+        property1 const p1_2{3};
+        type1 t1_4 = hpx::experimental::require_concept(t1_2, p1_2);
+        HPX_TEST_EQ(t1_3.p1.v, 2);
+        HPX_TEST_EQ(t1_4.p1.v, 3);
+    }
+
+    // This property is accessed through a member function
+    {
+        static_assert(
+            !hpx::experimental::can_require_concept_v<type1, property2>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_concept_t,
+                          type1, property2>::value,
+            "Should not be invocable");
+
+        static_assert(
+            hpx::experimental::can_require_concept_v<type2, property2>,
+            "Should be requirable");
+        static_assert(hpx::is_invocable<hpx::experimental::require_concept_t,
+                          type2, property2>::value,
+            "Should be invocable");
+
+        static_assert(
+            hpx::experimental::can_require_concept_v<type3, property2>,
+            "Should be requirable");
+        static_assert(hpx::is_invocable<hpx::experimental::require_concept_t,
+                          type3, property2>::value,
+            "Should be invocable");
+
+        static_assert(
+            !hpx::experimental::can_require_concept_v<type4, property2>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_concept_t,
+                          type4, property2>::value,
+            "Should not be invocable");
+
+        type2 t2_1{};
+
+        type2 t2_2 = hpx::experimental::require_concept(t2_1, property2{1});
+        HPX_TEST_EQ(t2_1.p2.v, 0);
+        HPX_TEST_EQ(t2_2.p2.v, 1);
+
+        property2 p2_1{2};
+        type2 t2_3 = hpx::experimental::require_concept(t2_2, p2_1);
+        HPX_TEST_EQ(t2_2.p2.v, 1);
+        HPX_TEST_EQ(t2_3.p2.v, 2);
+
+        property2 const p2_2{3};
+        type2 t2_4 = hpx::experimental::require_concept(t2_2, p2_2);
+        HPX_TEST_EQ(t2_3.p2.v, 2);
+        HPX_TEST_EQ(t2_4.p2.v, 3);
+    }
+
+    {
+        static_assert(
+            !hpx::experimental::can_require_concept_v<type1, property3>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_concept_t,
+                          type1, property3>::value,
+            "Should not be invocable");
+
+        static_assert(
+            !hpx::experimental::can_require_concept_v<type2, property3>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_concept_t,
+                          type2, property3>::value,
+            "Should not be invocable");
+
+        static_assert(
+            hpx::experimental::can_require_concept_v<type3, property3>,
+            "Should be requirable");
+        static_assert(hpx::is_invocable<hpx::experimental::require_concept_t,
+                          type3, property3>::value,
+            "Should be invocable");
+
+        static_assert(
+            !hpx::experimental::can_require_concept_v<type4, property3>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_concept_t,
+                          type4, property3>::value,
+            "Should not be invocable");
+
+        type3 t3_1{};
+
+        type3 t3_2 = hpx::experimental::require_concept(t3_1, property3{1});
+        HPX_TEST_EQ(t3_1.p3.v, 0);
+        HPX_TEST_EQ(t3_2.p3.v, 1);
+
+        property3 p3_1{2};
+        type3 t3_3 = hpx::experimental::require_concept(t3_2, p3_1);
+        HPX_TEST_EQ(t3_2.p3.v, 1);
+        HPX_TEST_EQ(t3_3.p3.v, 2);
+
+        property3 const p3_2{3};
+        type3 t3_4 = hpx::experimental::require_concept(t3_3, p3_2);
+        HPX_TEST_EQ(t3_3.p3.v, 2);
+        HPX_TEST_EQ(t3_4.p3.v, 3);
+
+        type3 t3_5 = hpx::experimental::require_concept(t3_4, property2{1});
+        HPX_TEST_EQ(t3_4.p3.v, 3);
+        HPX_TEST_EQ(t3_5.p3.v, 1);
+
+        property2 p2_1{2};
+        type3 t3_6 = hpx::experimental::require_concept(t3_5, p2_1);
+        HPX_TEST_EQ(t3_5.p3.v, 1);
+        HPX_TEST_EQ(t3_6.p3.v, 2);
+
+        property2 const p2_2{3};
+        type3 t3_7 = hpx::experimental::require_concept(t3_6, p2_2);
+        HPX_TEST_EQ(t3_6.p3.v, 2);
+        HPX_TEST_EQ(t3_7.p3.v, 3);
+    }
+
+    {
+        static_assert(
+            !hpx::experimental::can_require_concept_v<type1, property4>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_concept_t,
+                          type1, property4>::value,
+            "Should not be invocable");
+
+        static_assert(
+            !hpx::experimental::can_require_concept_v<type2, property4>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_concept_t,
+                          type2, property4>::value,
+            "Should not be invocable");
+
+        static_assert(
+            !hpx::experimental::can_require_concept_v<type3, property4>,
+            "Should not be requirable");
+        static_assert(!hpx::is_invocable<hpx::experimental::require_concept_t,
+                          type3, property4>::value,
+            "Should not be invocable");
+
+        static_assert(
+            hpx::experimental::can_require_concept_v<type4, property4>,
+            "Should be requirable");
+        static_assert(hpx::is_invocable<hpx::experimental::require_concept_t,
+                          type4, property4>::value,
+            "Should be invocable");
+
+        type4 t4_1{};
+
+        type4 t4_2 = hpx::experimental::require_concept(t4_1, property4{1});
+        HPX_TEST_EQ(t4_1.p4.v, 0);
+        HPX_TEST_EQ(t4_2.p4.v, 0);
+
+        property4 p4_1{2};
+        type4 t4_3 = hpx::experimental::require_concept(t4_2, p4_1);
+        HPX_TEST_EQ(t4_2.p4.v, 0);
+        HPX_TEST_EQ(t4_3.p4.v, 0);
+
+        property4 const p4_2{4};
+        type4 t4_4 = hpx::experimental::require_concept(t4_3, p4_2);
+        HPX_TEST_EQ(t4_3.p4.v, 0);
+        HPX_TEST_EQ(t4_4.p4.v, 0);
+    }
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/properties/tests/unit/require_concept_free.cpp
+++ b/libs/core/properties/tests/unit/require_concept_free.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2003-2020 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+// Copyright (c) 2021 Hartmut Kaiser
+//
+// SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/properties.hpp>
+#include <hpx/modules/testing.hpp>
+
+template <int>
+struct prop
+{
+    template <typename>
+    static constexpr bool is_applicable_property_v = true;
+
+    static constexpr bool is_requirable_concept = true;
+};
+
+template <int>
+struct object
+{
+    template <int N>
+    friend constexpr object<N> tag_invoke(
+        hpx::experimental::require_concept_t, object const&, prop<N>)
+    {
+        return object<N>();
+    }
+};
+
+int main()
+{
+    object<1> o1 = {};
+    object<2> o2 = hpx::experimental::require_concept(o1, prop<2>());
+    (void) o2;
+
+    object<1> const o3 = {};
+    object<2> o4 = hpx::experimental::require_concept(o3, prop<2>());
+    (void) o4;
+
+    constexpr object<2> o5 =
+        hpx::experimental::require_concept(object<1>(), prop<2>());
+    (void) o5;
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/properties/tests/unit/require_concept_member.cpp
+++ b/libs/core/properties/tests/unit/require_concept_member.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2003-2020 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+// Copyright (c) 2021 Hartmut Kaiser
+//
+// SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/properties.hpp>
+#include <hpx/modules/testing.hpp>
+
+template <int>
+struct prop
+{
+    template <typename>
+    static constexpr bool is_applicable_property_v = true;
+
+    static constexpr bool is_requirable_concept = true;
+};
+
+template <int>
+struct object
+{
+    template <int N>
+    constexpr object<N> require_concept(prop<N>) const
+    {
+        return object<N>();
+    }
+};
+
+int main()
+{
+    object<1> o1 = {};
+    object<2> o2 = hpx::experimental::require_concept(o1, prop<2>());
+    (void) o2;
+
+    object<1> const o3 = {};
+    object<2> o4 = hpx::experimental::require_concept(o3, prop<2>());
+    (void) o4;
+
+    constexpr object<2> o5 =
+        hpx::experimental::require_concept(object<1>(), prop<2>());
+    (void) o5;
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/properties/tests/unit/require_concept_static.cpp
+++ b/libs/core/properties/tests/unit/require_concept_static.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2003-2020 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+// Copyright (c) 2021 Hartmut Kaiser
+//
+// SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/properties.hpp>
+#include <hpx/modules/testing.hpp>
+
+template <int>
+struct prop
+{
+    template <typename>
+    static constexpr bool is_applicable_property_v = true;
+
+    static constexpr bool is_requirable_concept = true;
+
+    template <typename>
+    static constexpr bool static_query_v = true;
+
+    static constexpr bool value()
+    {
+        return true;
+    }
+};
+
+template <int>
+struct object
+{
+};
+
+int main()
+{
+    object<1> o1 = {};
+    object<1> const& o2 = hpx::experimental::require_concept(o1, prop<1>());
+    HPX_TEST(&o1 == &o2);
+    (void) o2;
+
+    object<1> const o3 = {};
+    object<1> const& o4 = hpx::experimental::require_concept(o3, prop<1>());
+    HPX_TEST(&o3 == &o4);
+    (void) o4;
+
+    constexpr object<1> o5 =
+        hpx::experimental::require_concept(object<1>(), prop<1>());
+    (void) o5;
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/properties/tests/unit/require_free.cpp
+++ b/libs/core/properties/tests/unit/require_free.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) 2003-2020 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+// Copyright (c) 2021 Hartmut Kaiser
+//
+// SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// 'require' is a dangerous Apple macro, silence inspect about this
+// hpxinspect:noapple_macros:require
+
+#include <hpx/modules/properties.hpp>
+#include <hpx/modules/testing.hpp>
+
+template <int>
+struct prop
+{
+    template <typename>
+    static constexpr bool is_applicable_property_v = true;
+
+    static constexpr bool is_requirable = true;
+};
+
+template <int>
+struct object
+{
+    template <int N>
+    friend constexpr object<N> tag_invoke(
+        hpx::experimental::require_t, object const&, prop<N>)
+    {
+        return object<N>();
+    }
+};
+
+int main()
+{
+    object<1> o1 = {};
+    object<2> o2 = hpx::experimental::require(o1, prop<2>());
+    object<3> o3 = hpx::experimental::require(o1, prop<2>(), prop<3>());
+    object<4> o4 =
+        hpx::experimental::require(o1, prop<2>(), prop<3>(), prop<4>());
+    (void) o2;
+    (void) o3;
+    (void) o4;
+
+    object<1> const o5 = {};
+    object<2> o6 = hpx::experimental::require(o5, prop<2>());
+    object<3> o7 = hpx::experimental::require(o5, prop<2>(), prop<3>());
+    object<4> o8 =
+        hpx::experimental::require(o5, prop<2>(), prop<3>(), prop<4>());
+    (void) o6;
+    (void) o7;
+    (void) o8;
+
+    constexpr object<2> o9 = hpx::experimental::require(object<1>(), prop<2>());
+    constexpr object<3> o10 =
+        hpx::experimental::require(object<1>(), prop<2>(), prop<3>());
+    constexpr object<4> o11 = hpx::experimental::require(
+        object<1>(), prop<2>(), prop<3>(), prop<4>());
+    (void) o9;
+    (void) o10;
+    (void) o11;
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/properties/tests/unit/require_member.cpp
+++ b/libs/core/properties/tests/unit/require_member.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) 2003-2020 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+// Copyright (c) 2021 Hartmut Kaiser
+//
+// SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// 'require' is a dangerous Apple macro, silence inspect about this
+// hpxinspect:noapple_macros:require
+
+#include <hpx/modules/properties.hpp>
+#include <hpx/modules/testing.hpp>
+
+template <int>
+struct prop
+{
+    template <typename>
+    static constexpr bool is_applicable_property_v = true;
+
+    static constexpr bool is_requirable = true;
+};
+
+template <int>
+struct object
+{
+    template <int N>
+    constexpr object<N> require(prop<N>) const
+    {
+        return object<N>();
+    }
+};
+
+int main()
+{
+    object<1> o1 = {};
+    object<2> o2 = hpx::experimental::require(o1, prop<2>());
+    object<3> o3 = hpx::experimental::require(o1, prop<2>(), prop<3>());
+    object<4> o4 =
+        hpx::experimental::require(o1, prop<2>(), prop<3>(), prop<4>());
+    (void) o2;
+    (void) o3;
+    (void) o4;
+
+    object<1> const o5 = {};
+    object<2> o6 = hpx::experimental::require(o5, prop<2>());
+    object<3> o7 = hpx::experimental::require(o5, prop<2>(), prop<3>());
+    object<4> o8 =
+        hpx::experimental::require(o5, prop<2>(), prop<3>(), prop<4>());
+    (void) o6;
+    (void) o7;
+    (void) o8;
+
+    constexpr object<2> o9 = hpx::experimental::require(object<1>(), prop<2>());
+    constexpr object<3> o10 =
+        hpx::experimental::require(object<1>(), prop<2>(), prop<3>());
+    constexpr object<4> o11 = hpx::experimental::require(
+        object<1>(), prop<2>(), prop<3>(), prop<4>());
+    (void) o9;
+    (void) o10;
+    (void) o11;
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/properties/tests/unit/require_static.cpp
+++ b/libs/core/properties/tests/unit/require_static.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2003-2020 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+// Copyright (c) 2021 Hartmut Kaiser
+//
+// SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// 'require' is a dangerous Apple macro, silence inspect about this
+// hpxinspect:noapple_macros:require
+
+#include <hpx/modules/properties.hpp>
+#include <hpx/modules/testing.hpp>
+
+template <int>
+struct prop
+{
+    template <typename>
+    static constexpr bool is_applicable_property_v = true;
+
+    static constexpr bool is_requirable = true;
+
+    template <typename>
+    static constexpr bool static_query_v = true;
+
+    static constexpr bool value()
+    {
+        return true;
+    }
+};
+
+template <int>
+struct object
+{
+};
+
+int main()
+{
+    object<1> o1 = {};
+    object<1> const& o2 = hpx::experimental::require(o1, prop<1>());
+    HPX_TEST(&o1 == &o2);
+    object<1> const& o3 = hpx::experimental::require(o1, prop<1>(), prop<1>());
+    HPX_TEST(&o1 == &o3);
+    object<1> const& o4 =
+        hpx::experimental::require(o1, prop<1>(), prop<1>(), prop<1>());
+    HPX_TEST(&o1 == &o4);
+
+    object<1> const o5 = {};
+    object<1> const& o6 = hpx::experimental::require(o5, prop<1>());
+    HPX_TEST(&o5 == &o6);
+    object<1> const& o7 = hpx::experimental::require(o5, prop<1>(), prop<1>());
+    HPX_TEST(&o5 == &o7);
+    object<1> const& o8 =
+        hpx::experimental::require(o5, prop<1>(), prop<1>(), prop<1>());
+    HPX_TEST(&o5 == &o8);
+
+    constexpr object<1> o9 = hpx::experimental::require(object<1>(), prop<1>());
+    constexpr object<1> o10 =
+        hpx::experimental::require(object<1>(), prop<1>(), prop<1>());
+    constexpr object<1> o11 = hpx::experimental::require(
+        object<1>(), prop<1>(), prop<1>(), prop<1>());
+    (void) o9;
+    (void) o10;
+    (void) o11;
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/type_support/include/hpx/type_support/always_void.hpp
+++ b/libs/core/type_support/include/hpx/type_support/always_void.hpp
@@ -10,6 +10,9 @@ namespace hpx { namespace util {
     template <typename... T>
     struct always_void
     {
-        typedef void type;
+        using type = void;
     };
+
+    template <typename... T>
+    using always_void_t = typename always_void<T...>::type;
 }}    // namespace hpx::util


### PR DESCRIPTION
- adding is_applicable_property and static_query traits
- renaming property.hpp to prefer.hpp
- adding support for is_tag_invoke_applicable trait

Essentially, this implements [P1393](http://wg21.link/p1393) with the change that it uses `tag_invoke` CPOs.