### PR TITLE
More P1897 algorithms

### DIFF
--- a/libs/core/assertion/include/hpx/modules/assertion.hpp
+++ b/libs/core/assertion/include/hpx/modules/assertion.hpp
@@ -20,6 +20,7 @@
 #if defined(HPX_COMPUTE_DEVICE_CODE)
 #include <assert.h>
 #endif
+#include <exception>
 #include <string>
 #include <type_traits>
 
@@ -78,4 +79,11 @@ namespace hpx { namespace assertion {
 #define HPX_ASSERT_MSG(expr, msg)
 #define HPX_NOEXCEPT_WITH_ASSERT noexcept
 #endif
+
+#define HPX_UNREACHABLE                                                        \
+    HPX_ASSERT_(false,                                                         \
+        "This code is meant to be unreachable. If you are seeing this error "  \
+        "message it means that you have found a bug in HPX. Please report it " \
+        "on the issue tracker: https://github.com/STEllAR-GROUP/hpx/issues."); \
+    std::terminate()
 #endif

--- a/libs/core/datastructures/include/hpx/datastructures/tuple.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/tuple.hpp
@@ -530,7 +530,7 @@ namespace hpx {
     };
 
     template <std::size_t I, typename... Ts>
-    struct tuple_element<I, tuple<Ts...>, void>
+    struct tuple_element<I, tuple<Ts...>>
     {
         using type = typename util::at_index<I, Ts...>::type;
 
@@ -548,7 +548,7 @@ namespace hpx {
     };
 
     template <typename T0, typename T1>
-    struct tuple_element<0, std::pair<T0, T1>, void>
+    struct tuple_element<0, std::pair<T0, T1>>
     {
         using type = T0;
 
@@ -566,7 +566,7 @@ namespace hpx {
     };
 
     template <typename T0, typename T1>
-    struct tuple_element<1, std::pair<T0, T1>, void>
+    struct tuple_element<1, std::pair<T0, T1>>
     {
         using type = T1;
 
@@ -584,7 +584,7 @@ namespace hpx {
     };
 
     template <std::size_t I, typename Type, std::size_t Size>
-    struct tuple_element<I, std::array<Type, Size>, void>
+    struct tuple_element<I, std::array<Type, Size>>
     {
         using type = Type;
 
@@ -610,7 +610,7 @@ namespace hpx {
 
 #if defined(HPX_DATASTRUCTURES_HAVE_ADAPT_STD_TUPLE)
     template <std::size_t I, typename... Ts>
-    struct tuple_element<I, std::tuple<Ts...>, void>
+    struct tuple_element<I, std::tuple<Ts...>>
     {
         using type = typename std::tuple_element<I, std::tuple<Ts...>>::type;
 

--- a/libs/core/datastructures/include/hpx/datastructures/tuple.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/tuple.hpp
@@ -37,7 +37,7 @@ namespace hpx {
     template <typename T>
     struct tuple_size;    // undefined
 
-    template <std::size_t I, typename T>
+    template <std::size_t I, typename T, typename Enable = void>
     struct tuple_element;    // undefined
 
     // Hide implementations of get<> inside an internal namespace to be able to
@@ -503,31 +503,34 @@ namespace hpx {
 
     // template <size_t I, class Tuple>
     // class tuple_element
-    template <std::size_t I, typename T>
+    template <std::size_t I, typename T, typename Enable>
     struct tuple_element
     {
     };
 
     template <std::size_t I, typename T>
-    struct tuple_element<I, const T>
+    struct tuple_element<I, const T,
+        typename util::always_void<typename tuple_element<I, T>::type>::type>
       : std::add_const<typename tuple_element<I, T>::type>
     {
     };
 
     template <std::size_t I, typename T>
-    struct tuple_element<I, volatile T>
+    struct tuple_element<I, volatile T,
+        typename util::always_void<typename tuple_element<I, T>::type>::type>
       : std::add_volatile<typename tuple_element<I, T>::type>
     {
     };
 
     template <std::size_t I, typename T>
-    struct tuple_element<I, const volatile T>
+    struct tuple_element<I, const volatile T,
+        typename util::always_void<typename tuple_element<I, T>::type>::type>
       : std::add_cv<typename tuple_element<I, T>::type>
     {
     };
 
     template <std::size_t I, typename... Ts>
-    struct tuple_element<I, tuple<Ts...>>
+    struct tuple_element<I, tuple<Ts...>, void>
     {
         using type = typename util::at_index<I, Ts...>::type;
 
@@ -545,7 +548,7 @@ namespace hpx {
     };
 
     template <typename T0, typename T1>
-    struct tuple_element<0, std::pair<T0, T1>>
+    struct tuple_element<0, std::pair<T0, T1>, void>
     {
         using type = T0;
 
@@ -563,7 +566,7 @@ namespace hpx {
     };
 
     template <typename T0, typename T1>
-    struct tuple_element<1, std::pair<T0, T1>>
+    struct tuple_element<1, std::pair<T0, T1>, void>
     {
         using type = T1;
 
@@ -581,7 +584,7 @@ namespace hpx {
     };
 
     template <std::size_t I, typename Type, std::size_t Size>
-    struct tuple_element<I, std::array<Type, Size>>
+    struct tuple_element<I, std::array<Type, Size>, void>
     {
         using type = Type;
 
@@ -607,7 +610,7 @@ namespace hpx {
 
 #if defined(HPX_DATASTRUCTURES_HAVE_ADAPT_STD_TUPLE)
     template <std::size_t I, typename... Ts>
-    struct tuple_element<I, std::tuple<Ts...>>
+    struct tuple_element<I, std::tuple<Ts...>, void>
     {
         using type = typename std::tuple_element<I, std::tuple<Ts...>>::type;
 

--- a/libs/core/execution_base/CMakeLists.txt
+++ b/libs/core/execution_base/CMakeLists.txt
@@ -9,6 +9,7 @@ set(execution_base_headers
     hpx/execution_base/agent_ref.hpp
     hpx/execution_base/context_base.hpp
     hpx/execution_base/detail/spinlock_deadlock_detection.hpp
+    hpx/execution_base/detail/try_catch_exception_ptr.hpp
     hpx/execution_base/execution.hpp
     hpx/execution_base/operation_state.hpp
     hpx/execution_base/receiver.hpp

--- a/libs/core/execution_base/include/hpx/execution_base/detail/try_catch_exception_ptr.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/detail/try_catch_exception_ptr.hpp
@@ -1,0 +1,44 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <exception>
+#include <utility>
+
+namespace hpx { namespace detail {
+    /// Helper function for a try-catch block where what would normally go in
+    /// the catch block should be called after the catch block. This is useful
+    /// for situations where the catch-block may yield, since the catch block
+    /// should be started and ended on the same worker thread (with yielding and
+    /// stealing, the catch block may end on a different worker thread than
+    /// where it was started). Because of this, the helper's catch block only
+    /// stores the exception pointer, and forwards it outside the catch block.
+    ///
+    /// Do not replace uses of try_catch_exception_ptr with a plain try-catch
+    /// without ensuring that the catch-block can never yield.
+    ///
+    /// Note: Windows does not seem to have problems resuming a catch block on a
+    /// different worker thread, but we use this nonetheless on Windows since it
+    /// doesn't hurt.
+    template <typename TryCallable, typename CatchCallable>
+    HPX_FORCEINLINE decltype(auto) try_catch_exception_ptr(
+        TryCallable&& t, CatchCallable&& c)
+    {
+        std::exception_ptr ep;
+        try
+        {
+            return t();
+        }
+        catch (...)
+        {
+            ep = std::current_exception();
+        }
+        return c(std::move(ep));
+    }
+}}    // namespace hpx::detail

--- a/libs/core/execution_base/include/hpx/execution_base/operation_state.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/operation_state.hpp
@@ -50,12 +50,11 @@ namespace hpx { namespace execution { namespace experimental {
     {
     private:
         template <typename OperationState>
-        friend constexpr HPX_FORCEINLINE auto
-        tag_override_invoke(start_t, OperationState& o) noexcept(
-            noexcept(std::declval<OperationState&&>().start()))
-            -> decltype(std::declval<OperationState&&>().start())
+        friend constexpr HPX_FORCEINLINE auto tag_override_invoke(
+            start_t, OperationState& o) noexcept(noexcept(o.start()))
+            -> decltype(o.start())
         {
-            return std::forward<OperationState>(o).start();
+            return o.start();
         }
     } start{};
 

--- a/libs/core/execution_base/include/hpx/execution_base/sender.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/sender.hpp
@@ -492,8 +492,8 @@ namespace hpx { namespace execution { namespace experimental {
 
                 template <typename... Ts,
                     typename = std::enable_if_t<is_receiver_of_v<R, Ts...>>>
-                void set_value(Ts&&... ts) && noexcept(
-                    is_nothrow_receiver_of_v<R, Ts...>)
+                    void set_value(Ts&&... ts) &&
+                    noexcept(is_nothrow_receiver_of_v<R, Ts...>)
                 {
                     hpx::execution::experimental::set_value(
                         std::move(p->r), std::forward<Ts>(ts)...);
@@ -502,7 +502,7 @@ namespace hpx { namespace execution { namespace experimental {
 
                 template <typename E,
                     typename = std::enable_if_t<is_receiver_v<R, E>>>
-                void set_error(E&& e) && noexcept
+                    void set_error(E&& e) && noexcept
                 {
                     hpx::execution::experimental::set_error(
                         std::move(p->r), std::forward<E>(e));

--- a/libs/core/functional/include/hpx/functional/invoke_result.hpp
+++ b/libs/core/functional/include/hpx/functional/invoke_result.hpp
@@ -54,4 +54,7 @@ namespace hpx { namespace util {
     struct invoke_result : detail::invoke_result_impl<F && (Ts && ...)>
     {
     };
+
+    template <typename F, typename... Ts>
+    using invoke_result_t = typename invoke_result<F, Ts...>::type;
 }}    // namespace hpx::util

--- a/libs/core/type_support/CMakeLists.txt
+++ b/libs/core/type_support/CMakeLists.txt
@@ -5,6 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(type_support_headers
+    hpx/type_support/detail/with_result_of.hpp
     hpx/type_support/detail/wrap_int.hpp
     hpx/type_support/always_void.hpp
     hpx/type_support/decay.hpp

--- a/libs/core/type_support/include/hpx/type_support/detail/with_result_of.hpp
+++ b/libs/core/type_support/include/hpx/type_support/detail/with_result_of.hpp
@@ -1,0 +1,45 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <utility>
+
+namespace hpx { namespace util { namespace detail {
+    // Based on
+    // https://quuxplusone.github.io/blog/2018/05/17/super-elider-round-2/ and
+    // https://akrzemi1.wordpress.com/2018/05/16/rvalues-redefined/.
+    //
+    // Useful for emplacing non-copyable and -movable types into e.g. variants.
+    // The wrapper delays the construction of the non-copyable and -movable type
+    // until it is required for conversion, and guaranteed copy elision in C++17
+    // ensures that a copy constructor is not called when returning from the
+    // conversion operator.
+    template <typename F>
+    class with_result_of_t
+    {
+        F&& f;
+
+    public:
+        using type = decltype(std::declval<F&&>()());
+
+        explicit with_result_of_t(F&& f)
+          : f(std::forward<F>(f))
+        {
+        }
+
+        operator type()
+        {
+            return f();
+        }
+    };
+
+    template <typename F>
+    inline with_result_of_t<F> with_result_of(F&& f)
+    {
+        return with_result_of_t<F>(std::forward<F>(f));
+    }
+}}}    // namespace hpx::util::detail

--- a/libs/core/type_support/include/hpx/type_support/detail/with_result_of.hpp
+++ b/libs/core/type_support/include/hpx/type_support/detail/with_result_of.hpp
@@ -33,7 +33,7 @@ namespace hpx { namespace util { namespace detail {
 
         operator type()
         {
-            return f();
+            return std::forward<F>(f)();
         }
     };
 

--- a/libs/core/type_support/include/hpx/type_support/pack.hpp
+++ b/libs/core/type_support/include/hpx/type_support/pack.hpp
@@ -204,6 +204,10 @@ namespace hpx { namespace util {
             using type = Pack<typename Transformer<Ts>::type...>;
         };
 
+        /// Apply a meta-function to each element in a pack.
+        template <typename Pack, template <typename> class Transformer>
+        using transform_t = typename transform<Pack, Transformer>::type;
+
         template <typename PackUnique, typename PackRest>
         struct unique_helper;
 
@@ -216,16 +220,9 @@ namespace hpx { namespace util {
         template <template <typename...> class Pack, typename... Ts, typename U,
             typename... Us>
         struct unique_helper<Pack<Ts...>, Pack<U, Us...>>
-          : std::conditional<contains<Ts..., U>::value,
+          : std::conditional<contains<U, Ts...>::value,
                 unique_helper<Pack<Ts...>, Pack<Us...>>,
                 unique_helper<Pack<Ts..., U>, Pack<Us...>>>::type
-        {
-        };
-
-        template <template <typename...> class Pack, typename... Ts,
-            typename... Us>
-        struct unique_helper<Pack<Ts...>, Pack<Us...>>
-          : unique_helper<Pack<>, Pack<Ts...>>
         {
         };
 
@@ -237,20 +234,72 @@ namespace hpx { namespace util {
         {
         };
 
+        /// Remove duplicate types in the given pack.
+        template <typename Pack>
+        using unique_t = typename unique<Pack>::type;
+
         template <typename... Packs>
-        struct cat;
+        struct concat;
 
         template <template <typename...> class Pack, typename... Ts>
-        struct cat<Pack<Ts...>>
+        struct concat<Pack<Ts...>>
         {
             using type = Pack<Ts...>;
         };
 
         template <template <typename...> class Pack, typename... Ts,
             typename... Us, typename... Rest>
-        struct cat<Pack<Ts...>, Pack<Us...>, Rest...>
-          : cat<Pack<Ts..., Us...>, Rest...>
+        struct concat<Pack<Ts...>, Pack<Us...>, Rest...>
+          : concat<Pack<Ts..., Us...>, Rest...>
         {
         };
+
+        /// Concatenate the elements in the given packs into a single pack. The
+        /// packs must be of the same type.
+        template <typename... Packs>
+        using concat_t = typename concat<Packs...>::type;
+
+        template <typename Pack>
+        struct concat_pack_of_packs;
+
+        template <template <typename...> class Pack, typename... Ts>
+        struct concat_pack_of_packs<Pack<Ts...>>
+        {
+            using type = typename concat<Ts...>::type;
+        };
+
+        template <typename... Packs>
+        using unique_concat_t = unique_t<concat_t<Packs...>>;
+
+        /// Concatenate the packs in the given pack into a single pack.
+        template <typename Pack>
+        using concat_pack_of_packs_t =
+            typename concat_pack_of_packs<Pack>::type;
+
+        template <typename Pack, typename T>
+        struct prepend;
+
+        template <typename T, template <typename...> class Pack, typename... Ts>
+        struct prepend<Pack<Ts...>, T>
+        {
+            using type = Pack<T, Ts...>;
+        };
+
+        /// Prepend a given type to the given pack.
+        template <typename Pack, typename T>
+        using prepend_t = typename prepend<Pack, T>::type;
+
+        template <typename Pack, typename T>
+        struct append;
+
+        template <typename T, template <typename...> class Pack, typename... Ts>
+        struct append<Pack<Ts...>, T>
+        {
+            using type = Pack<Ts..., T>;
+        };
+
+        /// Append a given type to the given pack.
+        template <typename Pack, typename T>
+        using append_t = typename prepend<Pack, T>::type;
     }    // namespace detail
 }}       // namespace hpx::util

--- a/libs/full/async_cuda/include/hpx/async_cuda/cublas_executor.hpp
+++ b/libs/full/async_cuda/include/hpx/async_cuda/cublas_executor.hpp
@@ -237,11 +237,8 @@ namespace hpx { namespace cuda { namespace experimental {
                         std::forward<Args>(args)...);
                     return get_future();
                 },
-                [&](std::exception_ptr ep) {
-                    hpx::future<void> result;
-                    auto state = traits::detail::get_shared_state(result);
-                    state->set_exception(std::move(ep));
-                    return result;
+                [&](std::exception_ptr&& ep) {
+                    return hpx::make_exceptional_future<void>(std::move(ep));
                 });
         }
 

--- a/libs/full/async_cuda/include/hpx/async_cuda/cuda_executor.hpp
+++ b/libs/full/async_cuda/include/hpx/async_cuda/cuda_executor.hpp
@@ -12,6 +12,7 @@
 #include <hpx/async_cuda/cuda_future.hpp>
 #include <hpx/async_cuda/target.hpp>
 #include <hpx/errors/exception.hpp>
+#include <hpx/execution_base/detail/try_catch_exception_ptr.hpp>
 #include <hpx/execution_base/execution.hpp>
 #include <hpx/execution_base/traits/is_executor.hpp>
 #include <hpx/futures/future.hpp>
@@ -163,29 +164,21 @@ namespace hpx { namespace cuda { namespace experimental {
         template <typename R, typename... Params, typename... Args>
         hpx::future<void> async(R (*cuda_kernel)(Params...), Args&&... args)
         {
-            hpx::future<void> result;
-            std::exception_ptr p;
-            try
-            {
-                // make sure we run on the correct device
-                check_cuda_error(cudaSetDevice(device_));
-                // insert the stream handle in the arg list and call the cuda function
-                detail::dispatch_helper<R, Params...> helper{};
-                helper(cuda_kernel, std::forward<Args>(args)..., stream_);
-                return get_future();
-            }
-            catch (const hpx::exception& e)
-            {
-                p = std::current_exception();
-            }
-
-            // The exception is set outside the catch block since
-            // set_exception may yield. Ending the catch block on a
-            // different worker thread than where it was started may lead
-            // to segfaults.
-            auto state = traits::detail::get_shared_state(result);
-            state->set_exception(std::move(p));
-            return result;
+            return hpx::detail::try_catch_exception_ptr(
+                [&]() {
+                    // make sure we run on the correct device
+                    check_cuda_error(cudaSetDevice(device_));
+                    // insert the stream handle in the arg list and call the cuda function
+                    detail::dispatch_helper<R, Params...> helper{};
+                    helper(cuda_kernel, std::forward<Args>(args)..., stream_);
+                    return get_future();
+                },
+                [&](std::exception_ptr ep) {
+                    hpx::future<void> result;
+                    auto state = traits::detail::get_shared_state(result);
+                    state->set_exception(std::move(ep));
+                    return result;
+                });
         }
     };
 

--- a/libs/full/async_cuda/include/hpx/async_cuda/cuda_executor.hpp
+++ b/libs/full/async_cuda/include/hpx/async_cuda/cuda_executor.hpp
@@ -173,11 +173,8 @@ namespace hpx { namespace cuda { namespace experimental {
                     helper(cuda_kernel, std::forward<Args>(args)..., stream_);
                     return get_future();
                 },
-                [&](std::exception_ptr ep) {
-                    hpx::future<void> result;
-                    auto state = traits::detail::get_shared_state(result);
-                    state->set_exception(std::move(ep));
-                    return result;
+                [&](std::exception_ptr&& ep) {
+                    return hpx::make_exceptional_future<void>(std::move(ep));
                 });
         }
     };

--- a/libs/parallelism/execution/CMakeLists.txt
+++ b/libs/parallelism/execution/CMakeLists.txt
@@ -7,41 +7,41 @@
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(execution_headers
+    hpx/execution/algorithms/detach.hpp
     hpx/execution/algorithms/detail/is_negative.hpp
     hpx/execution/algorithms/detail/partial_algorithm.hpp
     hpx/execution/algorithms/detail/predicates.hpp
     hpx/execution/algorithms/detail/single_result.hpp
-    hpx/execution/algorithms/detach.hpp
     hpx/execution/algorithms/ensure_started.hpp
     hpx/execution/algorithms/just.hpp
     hpx/execution/algorithms/just_on.hpp
-    hpx/execution/algorithms/let_value.hpp
     hpx/execution/algorithms/let_error.hpp
+    hpx/execution/algorithms/let_value.hpp
     hpx/execution/algorithms/on.hpp
     hpx/execution/algorithms/sync_wait.hpp
     hpx/execution/algorithms/transform.hpp
     hpx/execution/algorithms/when_all.hpp
     hpx/execution/detail/async_launch_policy_dispatch.hpp
-    hpx/execution/detail/future_exec.hpp
     hpx/execution/detail/execution_parameter_callbacks.hpp
+    hpx/execution/detail/future_exec.hpp
     hpx/execution/detail/post_policy_dispatch.hpp
     hpx/execution/detail/sync_launch_policy_dispatch.hpp
     hpx/execution/execution.hpp
-    hpx/execution/sender_future.hpp
     hpx/execution/executor_parameters.hpp
     hpx/execution/executors/auto_chunk_size.hpp
     hpx/execution/executors/dynamic_chunk_size.hpp
     hpx/execution/executors/execution.hpp
-    hpx/execution/executors/execution_information_fwd.hpp
     hpx/execution/executors/execution_information.hpp
-    hpx/execution/executors/execution_parameters_fwd.hpp
+    hpx/execution/executors/execution_information_fwd.hpp
     hpx/execution/executors/execution_parameters.hpp
+    hpx/execution/executors/execution_parameters_fwd.hpp
     hpx/execution/executors/fused_bulk_execute.hpp
     hpx/execution/executors/guided_chunk_size.hpp
     hpx/execution/executors/persistent_auto_chunk_size.hpp
     hpx/execution/executors/polymorphic_executor.hpp
     hpx/execution/executors/rebind_executor.hpp
     hpx/execution/executors/static_chunk_size.hpp
+    hpx/execution/sender_future.hpp
     hpx/execution/traits/detail/vc/vector_pack_alignment_size.hpp
     hpx/execution/traits/detail/vc/vector_pack_count_bits.hpp
     hpx/execution/traits/detail/vc/vector_pack_load_store.hpp

--- a/libs/parallelism/execution/CMakeLists.txt
+++ b/libs/parallelism/execution/CMakeLists.txt
@@ -11,8 +11,12 @@ set(execution_headers
     hpx/execution/algorithms/detail/partial_algorithm.hpp
     hpx/execution/algorithms/detail/predicates.hpp
     hpx/execution/algorithms/detail/single_result.hpp
+    hpx/execution/algorithms/detach.hpp
+    hpx/execution/algorithms/ensure_started.hpp
     hpx/execution/algorithms/just.hpp
     hpx/execution/algorithms/just_on.hpp
+    hpx/execution/algorithms/let_value.hpp
+    hpx/execution/algorithms/let_error.hpp
     hpx/execution/algorithms/on.hpp
     hpx/execution/algorithms/sync_wait.hpp
     hpx/execution/algorithms/transform.hpp

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/detach.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/detach.hpp
@@ -35,7 +35,7 @@ namespace hpx { namespace execution { namespace experimental {
                 hpx::intrusive_ptr<operation_state_holder> os;
 
                 template <typename E>
-                HPX_NORETURN void set_error(E&&) && noexcept
+                    HPX_NORETURN void set_error(E&&) && noexcept
                 {
                     HPX_ASSERT_MSG(false,
                         "set_error was called on the receiver of detach, "
@@ -51,7 +51,7 @@ namespace hpx { namespace execution { namespace experimental {
                 };
 
                 template <typename... Ts>
-                void set_value(Ts&&...) && noexcept
+                    void set_value(Ts&&...) && noexcept
                 {
                     os.reset();
                 }

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/detach.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/detach.hpp
@@ -35,8 +35,13 @@ namespace hpx { namespace execution { namespace experimental {
                 hpx::intrusive_ptr<operation_state_holder> os;
 
                 template <typename E>
-                void set_error(E&&) noexcept
+                HPX_NORETURN void set_error(E&&) && noexcept
                 {
+                    HPX_ASSERT_MSG(false,
+                        "set_error was called on the receiver of detach, "
+                        "terminating. If you want to allow errors from the "
+                        "predecessor sender, handle them first with e.g. "
+                        "let_error.");
                     std::terminate();
                 }
 

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/detach.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/detach.hpp
@@ -1,0 +1,115 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/allocator_support/allocator_deleter.hpp>
+#include <hpx/allocator_support/internal_allocator.hpp>
+#include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
+#include <hpx/execution_base/operation_state.hpp>
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/functional/invoke_result.hpp>
+#include <hpx/functional/tag_fallback_invoke.hpp>
+#include <hpx/modules/memory.hpp>
+#include <hpx/thread_support/atomic_count.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <exception>
+#include <memory>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace execution { namespace experimental {
+    namespace detail {
+        template <typename S>
+        struct operation_state_holder
+        {
+            struct detach_receiver
+            {
+                hpx::intrusive_ptr<operation_state_holder> os;
+
+                template <typename E>
+                void set_error(E&&) noexcept
+                {
+                    std::terminate();
+                }
+
+                void set_done() noexcept
+                {
+                    os.reset();
+                };
+
+                template <typename... Ts>
+                void set_value(Ts&&...) noexcept
+                {
+                    os.reset();
+                }
+            };
+
+            template <typename S_,
+                typename = std::enable_if_t<!std::is_same<std::decay_t<S_>,
+                    operation_state_holder>::value>>
+            explicit operation_state_holder(S_&& s)
+              : os(connect(std::forward<S_>(s), detach_receiver{this}))
+            {
+                start(os);
+            }
+
+        private:
+            hpx::util::atomic_count count{0};
+
+            using operation_state_type = connect_result_t<S, detach_receiver>;
+            std::decay_t<operation_state_type> os;
+
+            friend void intrusive_ptr_add_ref(operation_state_holder* p)
+            {
+                ++p->count;
+            }
+
+            friend void intrusive_ptr_release(operation_state_holder* p)
+            {
+                if (--p->count == 0)
+                {
+                    delete p;
+                }
+            }
+        };
+    }    // namespace detail
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct detach_t final
+      : hpx::functional::tag_fallback<detach_t>
+    {
+    private:
+        template <typename S,
+            typename Allocator = hpx::util::internal_allocator<>>
+        friend constexpr HPX_FORCEINLINE void tag_fallback_invoke(
+            detach_t, S&& s, Allocator&& a = Allocator{})
+        {
+            using allocator_type = Allocator;
+            using operation_state_type = detail::operation_state_holder<S>;
+            using other_allocator = typename std::allocator_traits<
+                allocator_type>::template rebind_alloc<operation_state_type>;
+            using allocator_traits = std::allocator_traits<other_allocator>;
+            using unique_ptr = std::unique_ptr<operation_state_type,
+                util::allocator_deleter<other_allocator>>;
+
+            other_allocator alloc(a);
+            unique_ptr p(allocator_traits::allocate(alloc, 1),
+                hpx::util::allocator_deleter<other_allocator>{alloc});
+
+            new (p.get()) operation_state_type{std::forward<S>(s)};
+            p.release();
+        }
+
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(detach_t)
+        {
+            return detail::partial_algorithm<detach_t>{};
+        }
+    } detach{};
+}}}    // namespace hpx::execution::experimental

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/detach.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/detach.hpp
@@ -9,6 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/allocator_support/allocator_deleter.hpp>
 #include <hpx/allocator_support/internal_allocator.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
 #include <hpx/execution_base/operation_state.hpp>
 #include <hpx/execution_base/sender.hpp>

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/detach.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/detach.hpp
@@ -45,13 +45,13 @@ namespace hpx { namespace execution { namespace experimental {
                     std::terminate();
                 }
 
-                void set_done() noexcept
+                void set_done() && noexcept
                 {
                     os.reset();
                 };
 
                 template <typename... Ts>
-                void set_value(Ts&&...) noexcept
+                void set_value(Ts&&...) && noexcept
                 {
                     os.reset();
                 }

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/detail/single_result.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/detail/single_result.hpp
@@ -6,9 +6,14 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
 #include <hpx/type_support/pack.hpp>
 
 #include <type_traits>
+
+#if defined(HPX_HAVE_CXX17_STD_VARIANT)
+#include <variant>
+#endif
 
 namespace hpx {
     namespace execution {

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
@@ -97,7 +97,7 @@ namespace hpx { namespace execution { namespace experimental {
                     hpx::intrusive_ptr<shared_state> st;
 
                     template <typename E>
-                    void set_error(E&& e) && noexcept
+                        void set_error(E&& e) && noexcept
                     {
                         st->v.template emplace<error_type>(
                             error_type(std::forward<E>(e)));
@@ -112,7 +112,7 @@ namespace hpx { namespace execution { namespace experimental {
                     };
 
                     template <typename... Ts>
-                    void set_value(Ts&&... ts) && noexcept
+                        void set_value(Ts&&... ts) && noexcept
                     {
                         st->v.template emplace<value_type>(
                             hpx::make_tuple<>(std::forward<Ts>(ts)...));

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
@@ -366,7 +366,7 @@ namespace hpx { namespace execution { namespace experimental {
             typename NewAllocator = hpx::util::internal_allocator<>>
         friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
             ensure_started_t, detail::ensure_started_sender<S, Allocator> s,
-            Allocator const& = {})
+            NewAllocator const& = {})
         {
             return s;
         }

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #if defined(HPX_HAVE_CXX17_STD_VARIANT)
+#include <hpx/assert.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
 #include <hpx/execution/algorithms/detail/single_result.hpp>

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
@@ -416,11 +416,10 @@ namespace hpx { namespace execution { namespace experimental {
                 std::forward<S>(s), a};
         }
 
-        template <typename S, typename Allocator,
-            typename NewAllocator = hpx::util::internal_allocator<>>
+        template <typename S, typename Allocator>
         friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
             ensure_started_t, detail::ensure_started_sender<S, Allocator> s,
-            NewAllocator const& = {})
+            Allocator const& = {})
         {
             return s;
         }

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
@@ -216,9 +216,10 @@ namespace hpx { namespace execution { namespace experimental {
                 }
 
             public:
-                template <typename R,
-                    typename =
-                        std::enable_if_t<std::is_rvalue_reference_v<R&&>>>
+                template <typename R>
+                void add_continuation(R& r) = delete;
+
+                template <typename R>
                 void add_continuation(R&& r)
                 {
                     if (predecessor_done)

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
@@ -193,7 +193,7 @@ namespace hpx { namespace execution { namespace experimental {
                         std::visit(value_visitor<R>{std::forward<R>(r)}, ts);
                     }
 
-                    void operator()(std::monostate)
+                    void operator()(std::monostate) const
                     {
                         std::terminate();
                     }

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
@@ -97,7 +97,7 @@ namespace hpx { namespace execution { namespace experimental {
                     hpx::intrusive_ptr<shared_state> st;
 
                     template <typename E>
-                    void set_error(E&& e) noexcept
+                    void set_error(E&& e) && noexcept
                     {
                         st->v.template emplace<error_type>(
                             error_type(std::forward<E>(e)));
@@ -105,14 +105,14 @@ namespace hpx { namespace execution { namespace experimental {
                         st.reset();
                     }
 
-                    void set_done() noexcept
+                    void set_done() && noexcept
                     {
                         st->set_predecessor_done();
                         st.reset();
                     };
 
                     template <typename... Ts>
-                    void set_value(Ts&&... ts) noexcept
+                    void set_value(Ts&&... ts) && noexcept
                     {
                         st->v.template emplace<value_type>(
                             hpx::make_tuple<>(std::forward<Ts>(ts)...));
@@ -238,20 +238,17 @@ namespace hpx { namespace execution { namespace experimental {
                         }
                         else
                         {
-                            continuations.emplace_back(
-                                [this,
-                                    // NOLINTNEXTLINE(bugprone-move-forwarding-reference)
-                                    r = std::move(r)]() {
-                                    std::visit(
-                                        done_error_value_visitor<R>{
-                                            std::move(r)},
-                                        v);
-                                });
+                            continuations.emplace_back([this,
+                                                           r = std::move(r)]() {
+                                std::visit(
+                                    done_error_value_visitor<R>{std::move(r)},
+                                    v);
+                            });
                         }
                     }
                 }
 
-                void start() noexcept
+                void start() & noexcept
                 {
                     if (!start_called.exchange(true))
                     {
@@ -327,7 +324,12 @@ namespace hpx { namespace execution { namespace experimental {
                 {
                 }
 
-                void start() noexcept
+                operation_state(operation_state&&) = delete;
+                operation_state& operator=(operation_state&&) = delete;
+                operation_state(operation_state const&) = delete;
+                operation_state& operator=(operation_state const&) = delete;
+
+                void start() & noexcept
                 {
                     st->add_continuation(std::move(r));
                 }

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
@@ -165,10 +165,10 @@ namespace hpx { namespace execution { namespace experimental {
 
                 ~shared_state()
                 {
-                    if (!start_called)
-                    {
-                        std::terminate();
-                    }
+                    HPX_ASSERT_MSG(start_called,
+                        "start was never called on the operation state of "
+                        "ensure_started. Did you forget to connect the sender "
+                        "to a receiver, or call start on the operation state?");
                 }
 
             private:
@@ -176,6 +176,11 @@ namespace hpx { namespace execution { namespace experimental {
                 struct done_error_value_visitor
                 {
                     std::decay_t<R> r;
+
+                    HPX_NORETURN void operator()(std::monostate) const
+                    {
+                        HPX_UNREACHABLE;
+                    }
 
                     void operator()(done_type)
                     {
@@ -190,11 +195,6 @@ namespace hpx { namespace execution { namespace experimental {
                     void operator()(value_type const& ts)
                     {
                         std::visit(value_visitor<R>{std::forward<R>(r)}, ts);
-                    }
-
-                    void operator()(std::monostate) const
-                    {
-                        std::terminate();
                     }
                 };
 

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
@@ -14,6 +14,7 @@
 #include <hpx/execution_base/operation_state.hpp>
 #include <hpx/execution_base/receiver.hpp>
 #include <hpx/execution_base/sender.hpp>
+#include <hpx/functional/bind_front.hpp>
 #include <hpx/functional/invoke_fused.hpp>
 #include <hpx/functional/tag_fallback_invoke.hpp>
 #include <hpx/modules/memory.hpp>

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/ensure_started.hpp
@@ -1,0 +1,376 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#if defined(HPX_HAVE_CXX17_STD_VARIANT)
+#include <hpx/datastructures/tuple.hpp>
+#include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
+#include <hpx/execution/algorithms/detail/single_result.hpp>
+#include <hpx/execution_base/operation_state.hpp>
+#include <hpx/execution_base/receiver.hpp>
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/functional/invoke_fused.hpp>
+#include <hpx/functional/tag_fallback_invoke.hpp>
+#include <hpx/modules/memory.hpp>
+#include <hpx/synchronization/mutex.hpp>
+#include <hpx/thread_support/atomic_count.hpp>
+#include <hpx/type_support/pack.hpp>
+
+#include <boost/container/small_vector.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <exception>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+namespace hpx { namespace execution { namespace experimental {
+    namespace detail {
+        template <typename R>
+        struct error_visitor
+        {
+            std::decay_t<R> r;
+
+            template <typename E>
+            void operator()(E const& e)
+            {
+                hpx::execution::experimental::set_error(std::move(r), e);
+            }
+        };
+
+        template <typename R>
+        struct value_visitor
+        {
+            std::decay_t<R> r;
+
+            template <typename Ts>
+            void operator()(Ts const& ts)
+            {
+                hpx::util::invoke_fused(
+                    hpx::util::bind_front(
+                        hpx::execution::experimental::set_value, std::move(r)),
+                    ts);
+            }
+        };
+
+        template <typename S, typename Allocator>
+        struct ensure_started_sender
+        {
+            template <typename Tuple>
+            struct value_types_helper
+            {
+                using const_type =
+                    hpx::util::detail::transform_t<Tuple, std::add_const>;
+                using type = hpx::util::detail::transform_t<const_type,
+                    std::add_lvalue_reference>;
+            };
+
+            template <template <typename...> class Tuple,
+                template <typename...> class Variant>
+            using value_types = hpx::util::detail::transform_t<
+                typename hpx::execution::experimental::sender_traits<
+                    S>::template value_types<Tuple, Variant>,
+                value_types_helper>;
+
+            template <template <typename...> class Variant>
+            using error_types =
+                hpx::util::detail::unique_t<hpx::util::detail::prepend_t<
+                    typename hpx::execution::experimental::sender_traits<
+                        S>::template error_types<Variant>,
+                    std::exception_ptr>>;
+
+            static constexpr bool sends_done = false;
+
+            struct shared_state
+            {
+            private:
+                struct ensure_started_receiver
+                {
+                    hpx::intrusive_ptr<shared_state> st;
+
+                    template <typename E>
+                    void set_error(E&& e) noexcept
+                    {
+                        st->v.template emplace<error_type>(
+                            error_type(std::forward<E>(e)));
+                        st->set_predecessor_done();
+                        st.reset();
+                    }
+
+                    void set_done() noexcept
+                    {
+                        st->set_predecessor_done();
+                        st.reset();
+                    };
+
+                    template <typename... Ts>
+                    void set_value(Ts&&... ts) noexcept
+                    {
+                        st->v.template emplace<value_type>(
+                            hpx::make_tuple<>(std::forward<Ts>(ts)...));
+
+                        st->set_predecessor_done();
+                        st.reset();
+                    }
+                };
+
+                using mutex_type = hpx::util::spinlock;
+                mutex_type mtx;
+                hpx::util::atomic_count reference_count{0};
+                std::atomic<bool> start_called{false};
+                std::atomic<bool> predecessor_done{false};
+
+                using operation_state_type =
+                    std::decay_t<connect_result_t<S, ensure_started_receiver>>;
+                operation_state_type os;
+
+                struct done_type
+                {
+                };
+                using value_type =
+                    typename hpx::execution::experimental::sender_traits<
+                        S>::template value_types<hpx::tuple, std::variant>;
+                using error_type =
+                    hpx::util::detail::unique_t<hpx::util::detail::prepend_t<
+                        error_types<std::variant>, std::exception_ptr>>;
+                std::variant<std::monostate, done_type, error_type, value_type>
+                    v;
+
+                using continuation_type =
+                    hpx::util::unique_function_nonser<void()>;
+                boost::container::small_vector<continuation_type, 1>
+                    continuations;
+
+            public:
+                template <typename S_,
+                    typename = std::enable_if_t<
+                        !std::is_same<std::decay_t<S_>, shared_state>::value>>
+                shared_state(S_&& s)
+                  : os(hpx::execution::experimental::connect(
+                        std::forward<S_>(s), ensure_started_receiver{this}))
+                {
+                }
+
+                ~shared_state()
+                {
+                    if (!start_called)
+                    {
+                        std::terminate();
+                    }
+
+                    if (--reference_count == 0)
+                    {
+                        delete this;
+                    }
+                }
+
+            private:
+                template <typename R>
+                struct done_error_value_visitor
+                {
+                    std::decay_t<R> r;
+
+                    void operator()(done_type)
+                    {
+                        hpx::execution::experimental::set_done(std::move(r));
+                    }
+
+                    void operator()(error_type const& e)
+                    {
+                        std::visit(error_visitor<R>{std::forward<R>(r)}, e);
+                    }
+
+                    void operator()(value_type const& ts)
+                    {
+                        std::visit(value_visitor<R>{std::forward<R>(r)}, ts);
+                    }
+
+                    void operator()(std::monostate)
+                    {
+                        std::terminate();
+                    }
+                };
+
+                void set_predecessor_done()
+                {
+                    predecessor_done = true;
+
+                    std::unique_lock<hpx::util::spinlock> l{mtx};
+                    if (!continuations.empty())
+                    {
+                        l.unlock();
+                        for (auto const& continuation : continuations)
+                        {
+                            continuation();
+                        }
+
+                        continuations.clear();
+                    }
+                }
+
+            public:
+                template <typename R,
+                    typename =
+                        std::enable_if_t<std::is_rvalue_reference_v<R&&>>>
+                void add_continuation(R&& r)
+                {
+                    if (predecessor_done)
+                    {
+                        std::visit(
+                            done_error_value_visitor<R>{std::move(r)}, v);
+                    }
+                    else
+                    {
+                        std::unique_lock<mutex_type> l{mtx};
+                        if (predecessor_done)
+                        {
+                            l.unlock();
+                            std::visit(
+                                done_error_value_visitor<R>{std::move(r)}, v);
+                        }
+                        else
+                        {
+                            continuations.emplace_back(
+                                [this,
+                                    // NOLINTNEXTLINE(bugprone-move-forwarding-reference)
+                                    r = std::move(r)]() {
+                                    std::visit(
+                                        done_error_value_visitor<R>{
+                                            std::move(r)},
+                                        v);
+                                });
+                        }
+                    }
+                }
+
+                void start() noexcept
+                {
+                    if (!start_called.exchange(true))
+                    {
+                        hpx::execution::experimental::start(os);
+                    }
+                }
+
+                friend void intrusive_ptr_add_ref(shared_state* p)
+                {
+                    ++p->reference_count;
+                }
+
+                friend void intrusive_ptr_release(shared_state* p)
+                {
+                    auto c = --p->reference_count;
+                    if (c == 0)
+                    {
+                        delete p;
+                    }
+                }
+            };
+
+            hpx::intrusive_ptr<shared_state> st;
+
+            template <typename S_>
+            ensure_started_sender(S_&& s, Allocator const& a)
+            {
+                using allocator_type = Allocator;
+                using other_allocator = typename std::allocator_traits<
+                    allocator_type>::template rebind_alloc<shared_state>;
+                using allocator_traits = std::allocator_traits<other_allocator>;
+                using unique_ptr = std::unique_ptr<shared_state,
+                    util::allocator_deleter<other_allocator>>;
+
+                other_allocator alloc(a);
+                unique_ptr p(allocator_traits::allocate(alloc, 1),
+                    hpx::util::allocator_deleter<other_allocator>{alloc});
+
+                new (p.get()) shared_state{std::forward<S_>(s)};
+                st = p.release();
+
+                // Eagerly start the work received until this point.
+                //
+                // P1897r3 says "When start is called on os2 [the operation
+                // state resulting from connecting the ensure_started_sender to
+                // a receiver], call execution::start(os [the operation state
+                // resulting from connecting S to ensure_started_receiver])",
+                // which would indicate that start should be called later.
+                // However, to fulfill the promise that ensure_started actually
+                // eagerly submits the sender S we call start already here.
+                st->start();
+            }
+
+            ensure_started_sender(ensure_started_sender const&) = default;
+            ensure_started_sender& operator=(
+                ensure_started_sender const&) = default;
+            ensure_started_sender(ensure_started_sender&&) = default;
+            ensure_started_sender& operator=(ensure_started_sender&&) = default;
+
+            template <typename R>
+            struct operation_state
+            {
+                std::decay_t<R> r;
+                hpx::intrusive_ptr<shared_state> st;
+
+                template <typename R_>
+                operation_state(R_&& r, hpx::intrusive_ptr<shared_state> st)
+                  : r(std::forward<R_>(r))
+                  , st(std::move(st))
+                {
+                }
+
+                void start() noexcept
+                {
+                    st->add_continuation(std::move(r));
+                }
+            };
+
+            template <typename R>
+            operation_state<R> connect(R&& r) &&
+            {
+                return {std::forward<R>(r), std::move(st)};
+            }
+
+            template <typename R>
+            operation_state<R> connect(R&& r) &
+            {
+                return {std::forward<R>(r), st};
+            }
+        };
+    }    // namespace detail
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct ensure_started_t final
+      : hpx::functional::tag_fallback<ensure_started_t>
+    {
+    private:
+        template <typename S,
+            typename Allocator = hpx::util::internal_allocator<>>
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            ensure_started_t, S&& s, Allocator const& a = {})
+        {
+            return detail::ensure_started_sender<S, Allocator>{
+                std::forward<S>(s), a};
+        }
+
+        template <typename S, typename Allocator,
+            typename NewAllocator = hpx::util::internal_allocator<>>
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            ensure_started_t, detail::ensure_started_sender<S, Allocator> s,
+            Allocator const& = {})
+        {
+            return s;
+        }
+
+        template <typename Allocator = hpx::util::internal_allocator<>>
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            ensure_started_t, Allocator const& a = {})
+        {
+            return detail::partial_algorithm<ensure_started_t, Allocator>{a};
+        }
+    } ensure_started{};
+}}}    // namespace hpx::execution::experimental
+#endif

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/just.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/just.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/datastructures/member_pack.hpp>
+#include <hpx/execution_base/detail/try_catch_exception_ptr.hpp>
 #include <hpx/execution_base/receiver.hpp>
 #include <hpx/execution_base/sender.hpp>
 #include <hpx/functional/tag_fallback_invoke.hpp>
@@ -64,16 +65,16 @@ namespace hpx { namespace execution { namespace experimental {
 
                 void start() noexcept
                 {
-                    try
-                    {
-                        hpx::execution::experimental::set_value(
-                            std::move(r), std::move(ts).template get<Is>()...);
-                    }
-                    catch (...)
-                    {
-                        hpx::execution::experimental::set_error(
-                            std::move(r), std::current_exception());
-                    }
+                    hpx::detail::try_catch_exception_ptr(
+                        [&]() {
+                            hpx::execution::experimental::set_value(
+                                std::move(r),
+                                std::move(ts).template get<Is>()...);
+                        },
+                        [&](std::exception_ptr ep) {
+                            hpx::execution::experimental::set_error(
+                                std::move(r), std::move(ep));
+                        });
                 }
             };
 

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/just.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/just.hpp
@@ -14,6 +14,8 @@
 #include <hpx/type_support/pack.hpp>
 
 #include <cstddef>
+#include <exception>
+#include <stdexcept>
 #include <utility>
 
 namespace hpx { namespace execution { namespace experimental {
@@ -24,7 +26,6 @@ namespace hpx { namespace execution { namespace experimental {
         template <typename std::size_t... Is, typename... Ts>
         struct just_sender<hpx::util::index_pack<Is...>, Ts...>
         {
-            // TODO: Are references allowed?
             hpx::util::member_pack_for<std::decay_t<Ts>...> ts;
 
             template <typename... Ts_>
@@ -38,7 +39,7 @@ namespace hpx { namespace execution { namespace experimental {
             using value_types = Variant<Tuple<Ts...>>;
 
             template <template <typename...> class Variant>
-            using error_types = Variant<>;
+            using error_types = Variant<std::exception_ptr>;
 
             static constexpr bool sends_done = false;
 
@@ -55,20 +56,37 @@ namespace hpx { namespace execution { namespace experimental {
                   , ts(std::move(ts))
                 {
                 }
+
                 operation_state(operation_state&&) = delete;
+                operation_state& operator=(operation_state&&) = delete;
                 operation_state(operation_state const&) = delete;
+                operation_state& operator=(operation_state const&) = delete;
 
                 void start() noexcept
                 {
-                    hpx::execution::experimental::set_value(
-                        std::move(r), std::move(ts).template get<Is>()...);
+                    try
+                    {
+                        hpx::execution::experimental::set_value(
+                            std::move(r), std::move(ts).template get<Is>()...);
+                    }
+                    catch (...)
+                    {
+                        hpx::execution::experimental::set_error(
+                            std::move(r), std::current_exception());
+                    }
                 }
             };
 
             template <typename R>
-            auto connect(R&& r)
+            auto connect(R&& r) &&
             {
-                return operation_state<R>(std::forward<R>(r), std::move(ts));
+                return operation_state<R>{std::forward<R>(r), std::move(ts)};
+            }
+
+            template <typename R>
+            auto connect(R&& r) &
+            {
+                return operation_state<R>{r, ts};
             }
         };
     }    // namespace detail

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/just.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/just.hpp
@@ -87,7 +87,7 @@ namespace hpx { namespace execution { namespace experimental {
             template <typename R>
             auto connect(R&& r) &
             {
-                return operation_state<R>{r, ts};
+                return operation_state<R>{std::forward<R>(r), ts};
             }
         };
     }    // namespace detail

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/just.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/just.hpp
@@ -63,7 +63,7 @@ namespace hpx { namespace execution { namespace experimental {
                 operation_state(operation_state const&) = delete;
                 operation_state& operator=(operation_state const&) = delete;
 
-                void start() noexcept
+                void start() & noexcept
                 {
                     hpx::detail::try_catch_exception_ptr(
                         [&]() {

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/just_on.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/just_on.hpp
@@ -6,8 +6,10 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
 #include <hpx/execution/algorithms/just.hpp>
 #include <hpx/execution/algorithms/on.hpp>
+#include <hpx/functional/tag_fallback_invoke.hpp>
 
 #include <utility>
 

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/just_on.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/just_on.hpp
@@ -6,19 +6,9 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
 #include <hpx/execution/algorithms/just.hpp>
 #include <hpx/execution/algorithms/on.hpp>
-#include <hpx/execution_base/receiver.hpp>
-#include <hpx/execution_base/sender.hpp>
-#include <hpx/functional/invoke_result.hpp>
-#include <hpx/functional/tag_fallback_invoke.hpp>
-#include <hpx/type_support/pack.hpp>
 
-#include <atomic>
-#include <cstddef>
-#include <exception>
-#include <type_traits>
 #include <utility>
 
 namespace hpx { namespace execution { namespace experimental {

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/let_error.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/let_error.hpp
@@ -164,7 +164,7 @@ namespace hpx { namespace execution { namespace experimental {
                     };
 
                     template <typename E>
-                    void set_error(E&& e) && noexcept
+                        void set_error(E&& e) && noexcept
                     {
                         hpx::detail::try_catch_exception_ptr(
                             [&]() {
@@ -188,7 +188,7 @@ namespace hpx { namespace execution { namespace experimental {
                     };
 
                     template <typename... Ts>
-                    void set_value(Ts&&... ts) && noexcept
+                        void set_value(Ts&&... ts) && noexcept
                     {
                         hpx::execution::experimental::set_value(
                             std::move(r), std::forward<Ts>(ts)...);

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/let_error.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/let_error.hpp
@@ -113,13 +113,13 @@ namespace hpx { namespace execution { namespace experimental {
 
                     struct start_visitor
                     {
-                        void operator()(std::monostate)
+                        void operator()(std::monostate) const
                         {
                             std::terminate();
                         }
 
                         template <typename OS_>
-                        void operator()(OS_& os)
+                        void operator()(OS_& os) const
                         {
                             hpx::execution::experimental::start(os);
                         }
@@ -131,12 +131,14 @@ namespace hpx { namespace execution { namespace experimental {
                         std::decay_t<F> f;
                         operation_state& os;
 
-                        void operator()(std::monostate)
+                        void operator()(std::monostate) const
                         {
                             std::terminate();
                         }
 
-                        template <typename E>
+                        template <typename E,
+                            typename = std::enable_if_t<!std::is_same_v<
+                                std::decay_t<E>, std::monostate>>>
                         void operator()(E& e)
                         {
                             using operation_state_type =

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/let_error.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/let_error.hpp
@@ -113,12 +113,14 @@ namespace hpx { namespace execution { namespace experimental {
 
                     struct start_visitor
                     {
-                        void operator()(std::monostate) const
+                        HPX_NORETURN void operator()(std::monostate) const
                         {
-                            std::terminate();
+                            HPX_UNREACHABLE;
                         }
 
-                        template <typename OS_>
+                        template <typename OS_,
+                            typename = std::enable_if_t<!std::is_same_v<
+                                std::decay_t<OS_>, std::monostate>>>
                         void operator()(OS_& os) const
                         {
                             hpx::execution::experimental::start(os);
@@ -131,9 +133,9 @@ namespace hpx { namespace execution { namespace experimental {
                         std::decay_t<F> f;
                         operation_state& os;
 
-                        void operator()(std::monostate) const
+                        HPX_NORETURN void operator()(std::monostate) const
                         {
-                            std::terminate();
+                            HPX_UNREACHABLE;
                         }
 
                         template <typename E,

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/let_error.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/let_error.hpp
@@ -1,0 +1,278 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#if defined(HPX_HAVE_CXX17_STD_VARIANT)
+#include <hpx/execution_base/receiver.hpp>
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/functional/invoke_result.hpp>
+#include <hpx/functional/tag_fallback_invoke.hpp>
+#include <hpx/type_support/detail/with_result_of.hpp>
+#include <hpx/type_support/pack.hpp>
+
+#include <exception>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+namespace hpx { namespace execution { namespace experimental {
+    namespace detail {
+        template <typename PS, typename F>
+        struct let_error_sender
+        {
+            typename std::decay_t<PS> ps;
+            typename std::decay_t<F> f;
+
+            // Type of the potential values returned from the predecessor sender
+            template <template <typename...> class Tuple,
+                template <typename...> class Variant>
+            using predecessor_value_types =
+                typename hpx::execution::experimental::sender_traits<
+                    std::decay_t<PS>>::template value_types<Tuple, Variant>;
+
+            // Type of the potential errors returned from the predecessor sender
+            template <template <typename...> class Variant>
+            using predecessor_error_types =
+                typename hpx::execution::experimental::sender_traits<
+                    std::decay_t<PS>>::template error_types<Variant>;
+            static_assert(
+                !std::is_same<predecessor_error_types<hpx::util::pack>,
+                    hpx::util::pack<>>::value,
+                "let_error used with a predecessor that has an empty "
+                "error_types. Is let_error misplaced?");
+
+            template <typename E>
+            struct successor_sender_types_helper
+            {
+                using type = hpx::util::invoke_result_t<F,
+                    std::add_lvalue_reference_t<E>>;
+                static_assert(hpx::execution::experimental::is_sender<
+                                  std::decay_t<type>>::value,
+                    "let_error expects the invocable sender factory to return "
+                    "a sender");
+            };
+
+            // Type of the potential senders returned from the sender factor F
+            template <template <typename...> class Variant>
+            using successor_sender_types = hpx::util::detail::unique_t<
+                hpx::util::detail::transform_t<predecessor_error_types<Variant>,
+                    successor_sender_types_helper>>;
+
+            // The workaround for clang is due to a parsing bug in clang < 11
+            // in CUDA mode (where >>> also has a different meaning in kernel
+            // launches).
+            template <template <typename...> class Tuple,
+                template <typename...> class Variant>
+            using value_types = hpx::util::detail::unique_concat_t<
+                predecessor_value_types<Tuple, Variant>,
+                hpx::util::detail::concat_pack_of_packs_t<hpx::util::detail::
+                        transform_t<successor_sender_types<Variant>,
+                            value_types<Tuple, Variant>::template apply
+#if defined(HPX_CLANG_VERSION) && HPX_CLANG_VERSION < 110000
+                            >
+                    //
+                    >>;
+#else
+                            >>>;
+#endif
+
+            template <template <typename...> class Variant>
+            using error_types =
+                hpx::util::detail::unique_t<hpx::util::detail::prepend_t<
+                    hpx::util::detail::concat_pack_of_packs_t<hpx::util::
+                            detail::transform_t<successor_sender_types<Variant>,
+                                error_types<Variant>::template apply>>,
+                    std::exception_ptr>>;
+
+            static constexpr bool sends_done = false;
+
+            template <typename R>
+            struct operation_state
+            {
+                struct let_error_predecessor_receiver
+                {
+                    std::decay_t<R> r;
+                    std::decay_t<F> f;
+                    operation_state& os;
+
+                    template <typename R_, typename F_>
+                    let_error_predecessor_receiver(
+                        R_&& r, F_&& f, operation_state& os)
+                      : r(std::forward<R_>(r))
+                      , f(std::forward<F_>(f))
+                      , os(os)
+                    {
+                    }
+
+                    struct start_visitor
+                    {
+                        void operator()(std::monostate)
+                        {
+                            std::terminate();
+                        }
+
+                        template <typename OS_>
+                        void operator()(OS_& os)
+                        {
+                            hpx::execution::experimental::start(os);
+                        }
+                    };
+
+                    struct set_error_visitor
+                    {
+                        std::decay_t<R> r;
+                        std::decay_t<F> f;
+                        operation_state& os;
+
+                        void operator()(std::monostate)
+                        {
+                            std::terminate();
+                        }
+
+                        template <typename E>
+                        void operator()(E& e)
+                        {
+                            using operation_state_type =
+                                decltype(hpx::execution::experimental::connect(
+                                    HPX_INVOKE(std::move(f), e),
+                                    std::declval<R>()));
+
+                            // with_result_of is used to emplace the operation state
+                            // returned from connect without any intermediate copy
+                            // construction (the operation state is not required to be
+                            // copyable nor movable.
+                            os.successor_os
+                                .template emplace<operation_state_type>(
+                                    hpx::util::detail::with_result_of([&]() {
+                                        return hpx::execution::experimental::
+                                            connect(HPX_INVOKE(std::move(f), e),
+                                                std::move(r));
+                                    }));
+                            std::visit(start_visitor{}, os.successor_os);
+                        }
+                    };
+
+                    template <typename E>
+                    void set_error(E&& e) noexcept
+                    {
+                        try
+                        {
+                            os.predecessor_e.template emplace<E>(
+                                std::forward<E>(e));
+                            std::visit(set_error_visitor{std::move(r),
+                                           std::move(f), os},
+                                os.predecessor_e);
+                        }
+                        catch (...)
+                        {
+                            hpx::execution::experimental::set_error(
+                                r, std::current_exception());
+                        }
+                    }
+
+                    void set_done() noexcept
+                    {
+                        hpx::execution::experimental::set_done(std::move(r));
+                    };
+
+                    template <typename... Ts>
+                    void set_value(Ts&&... ts) noexcept
+                    {
+                        hpx::execution::experimental::set_value(
+                            std::move(r), std::forward<Ts>(ts)...);
+                    }
+                };
+
+                // Type of the operation state returned when connecting the
+                // predecessor sender to the let_error_predecessor_receiver
+                using predecessor_operation_state_type = std::decay_t<
+                    connect_result_t<PS&&, let_error_predecessor_receiver>>;
+
+                // Type of the potential operation states returned when
+                // connecting a sender in successor_sender_types to the receiver
+                // connected to the let_error_sender
+                template <typename Sender>
+                struct successor_operation_state_types_helper
+                {
+                    using type = connect_result_t<Sender, R>;
+                };
+                template <template <typename...> class Variant>
+                using successor_operation_state_types =
+                    hpx::util::detail::transform_t<
+                        successor_sender_types<Variant>,
+                        successor_operation_state_types_helper>;
+
+                // Operation state from connecting predecessor sender to
+                // let_error_predecessor_receiver
+                predecessor_operation_state_type predecessor_os;
+
+                // Potential errors returned from the predecessor sender
+                hpx::util::detail::prepend_t<
+                    predecessor_error_types<std::variant>, std::monostate>
+                    predecessor_e;
+
+                // Potential operation states returned when connecting a sender
+                // in successor_sender_types to the receiver connected to the
+                // let_error_sender
+                hpx::util::detail::prepend_t<
+                    successor_operation_state_types<std::variant>,
+                    std::monostate>
+                    successor_os;
+
+                template <typename PS_, typename R_, typename F_>
+                operation_state(PS_&& ps, R_&& r, F_&& f)
+                  : predecessor_os{hpx::execution::experimental::connect(
+                        std::forward<PS_>(ps),
+                        let_error_predecessor_receiver(
+                            std::forward<R_>(r), std::forward<F_>(f), *this))}
+                {
+                }
+
+                operation_state(operation_state&&) = delete;
+                operation_state& operator=(operation_state&&) = delete;
+                operation_state(operation_state const&) = delete;
+                operation_state& operator=(operation_state const&) = delete;
+
+                void start() noexcept
+                {
+                    hpx::execution::experimental::start(predecessor_os);
+                }
+            };
+
+            template <typename R>
+            auto connect(R&& r) &&
+            {
+                return operation_state<R>(
+                    std::move(ps), std::forward<R>(r), std::move(f));
+            }
+        };
+    }    // namespace detail
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct let_error_t final
+      : hpx::functional::tag_fallback<let_error_t>
+    {
+    private:
+        template <typename PS, typename F>
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            let_error_t, PS&& ps, F&& f)
+        {
+            return detail::let_error_sender<PS, F>{
+                std::forward<PS>(ps), std::forward<F>(f)};
+        }
+
+        template <typename F>
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            let_error_t, F&& f)
+        {
+            return detail::partial_algorithm<let_error_t, F>{
+                std::forward<F>(f)};
+        }
+    } let_error{};
+}}}    // namespace hpx::execution::experimental
+#endif

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/let_error.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/let_error.hpp
@@ -164,12 +164,10 @@ namespace hpx { namespace execution { namespace experimental {
                     };
 
                     template <typename E>
-                    void set_error(E&& e) noexcept
+                    void set_error(E&& e) && noexcept
                     {
                         hpx::detail::try_catch_exception_ptr(
                             [&]() {
-                                // TODO: Don't need to store the predecessor
-                                // error?
                                 // TODO: r is moved before the visit, but the
                                 // invoke inside the visit may throw.
                                 os.predecessor_e.template emplace<E>(
@@ -184,13 +182,13 @@ namespace hpx { namespace execution { namespace experimental {
                             });
                     }
 
-                    void set_done() noexcept
+                    void set_done() && noexcept
                     {
                         hpx::execution::experimental::set_done(std::move(r));
                     };
 
                     template <typename... Ts>
-                    void set_value(Ts&&... ts) noexcept
+                    void set_value(Ts&&... ts) && noexcept
                     {
                         hpx::execution::experimental::set_value(
                             std::move(r), std::forward<Ts>(ts)...);
@@ -247,7 +245,7 @@ namespace hpx { namespace execution { namespace experimental {
                 operation_state(operation_state const&) = delete;
                 operation_state& operator=(operation_state const&) = delete;
 
-                void start() noexcept
+                void start() & noexcept
                 {
                     hpx::execution::experimental::start(predecessor_os);
                 }

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/let_value.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/let_value.hpp
@@ -1,0 +1,279 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#if defined(HPX_HAVE_CXX17_STD_VARIANT)
+#include <hpx/execution_base/receiver.hpp>
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/functional/invoke_result.hpp>
+#include <hpx/functional/tag_fallback_invoke.hpp>
+#include <hpx/type_support/detail/with_result_of.hpp>
+#include <hpx/type_support/pack.hpp>
+
+#include <exception>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+namespace hpx { namespace execution { namespace experimental {
+    namespace detail {
+        template <typename PS, typename F>
+        struct let_value_sender
+        {
+            typename std::decay_t<PS> ps;
+            typename std::decay_t<F> f;
+
+            // Type of the potential values returned from the predecessor sender
+            template <template <typename...> class Tuple,
+                template <typename...> class Variant>
+            using predecessor_value_types =
+                typename hpx::execution::experimental::sender_traits<
+                    std::decay_t<PS>>::template value_types<Tuple, Variant>;
+
+            template <typename Tuple>
+            struct successor_sender_types_helper;
+
+            template <template <typename...> class Tuple, typename... Ts>
+            struct successor_sender_types_helper<Tuple<Ts...>>
+            {
+                using type = hpx::util::invoke_result_t<F,
+                    std::add_lvalue_reference_t<Ts>...>;
+                static_assert(hpx::execution::experimental::is_sender<
+                                  std::decay_t<type>>::value,
+                    "let_value expects the invocable sender factory to return "
+                    "a sender");
+            };
+
+            // Type of the potential senders returned from the sender factor F
+            template <template <typename...> class Tuple,
+                template <typename...> class Variant>
+            using successor_sender_types =
+                hpx::util::detail::unique_t<hpx::util::detail::transform_t<
+                    predecessor_value_types<Tuple, Variant>,
+                    successor_sender_types_helper>>;
+
+            // The workaround for clang is due to a parsing bug in clang < 11
+            // in CUDA mode (where >>> also has a different meaning in kernel
+            // launches).
+            template <template <typename...> class Tuple,
+                template <typename...> class Variant>
+            using value_types = hpx::util::detail::unique_t<
+                hpx::util::detail::concat_pack_of_packs_t<hpx::util::detail::
+                        transform_t<successor_sender_types<Tuple, Variant>,
+                            value_types<Tuple, Variant>::template apply
+#if defined(HPX_CLANG_VERSION) && HPX_CLANG_VERSION < 110000
+                            >
+                    //
+                    >>;
+#else
+                            >>>;
+#endif
+
+            // hpx::util::pack acts as a concrete type in place of Tuple. It is
+            // required for computing successor_sender_types, but disappears
+            // from the final error_types.
+            template <template <typename...> class Variant>
+            using error_types =
+                hpx::util::detail::unique_t<hpx::util::detail::prepend_t<
+                    hpx::util::detail::concat_pack_of_packs_t<
+                        hpx::util::detail::transform_t<
+                            successor_sender_types<hpx::util::pack, Variant>,
+                            error_types<Variant>::template apply>>,
+                    std::exception_ptr>>;
+
+            static constexpr bool sends_done = false;
+
+            template <typename R>
+            struct operation_state
+            {
+                struct let_value_predecessor_receiver
+                {
+                    std::decay_t<R> r;
+                    std::decay_t<F> f;
+                    operation_state& os;
+
+                    template <typename R_, typename F_>
+                    let_value_predecessor_receiver(
+                        R_&& r, F_&& f, operation_state& os)
+                      : r(std::forward<R_>(r))
+                      , f(std::forward<F_>(f))
+                      , os(os)
+                    {
+                    }
+
+                    template <typename E>
+                    void set_error(E&& e) noexcept
+                    {
+                        hpx::execution::experimental::set_error(
+                            std::move(r), std::forward<E>(e));
+                    }
+
+                    void set_done() noexcept
+                    {
+                        hpx::execution::experimental::set_done(std::move(r));
+                    };
+
+                    struct start_visitor
+                    {
+                        void operator()(std::monostate)
+                        {
+                            std::terminate();
+                        }
+
+                        template <typename OS_>
+                        void operator()(OS_& os)
+                        {
+                            hpx::execution::experimental::start(os);
+                        }
+                    };
+
+                    struct set_value_visitor
+                    {
+                        std::decay_t<R> r;
+                        std::decay_t<F> f;
+                        operation_state& os;
+
+                        void operator()(std::monostate)
+                        {
+                            std::terminate();
+                        }
+
+                        template <typename T>
+                        void operator()(T& t)
+                        {
+                            using operation_state_type =
+                                decltype(hpx::execution::experimental::connect(
+                                    hpx::util::invoke_fused(std::move(f), t),
+                                    std::declval<R>()));
+
+                            // with_result_of is used to emplace the operation state
+                            // returned from connect without any intermediate copy
+                            // construction (the operation state is not required to be
+                            // copyable nor movable.
+                            os.successor_os
+                                .template emplace<operation_state_type>(
+                                    hpx::util::detail::with_result_of([&]() {
+                                        return hpx::execution::experimental::
+                                            connect(hpx::util::invoke_fused(
+                                                        std::move(f), t),
+                                                std::move(r));
+                                    }));
+                            std::visit(start_visitor{}, os.successor_os);
+                        }
+                    };
+
+                    template <typename... Ts>
+                    void set_value(Ts&&... ts) noexcept
+                    {
+                        try
+                        {
+                            os.predecessor_ts
+                                .template emplace<std::tuple<Ts...>>(
+                                    std::forward<Ts>(ts)...);
+                            std::visit(set_value_visitor{std::move(r),
+                                           std::move(f), os},
+                                os.predecessor_ts);
+                        }
+                        catch (...)
+                        {
+                            hpx::execution::experimental::set_error(
+                                r, std::current_exception());
+                        }
+                    }
+                };
+
+                // Type of the operation state returned when connecting the
+                // predecessor sender to the let_value_predecessor_receiver
+                using predecessor_operation_state_type = std::decay_t<
+                    connect_result_t<PS&&, let_value_predecessor_receiver>>;
+
+                // Type of the potential operation states returned when
+                // connecting a sender in successor_sender_types to the receiver
+                // connected to the let_value_sender
+                template <typename Sender>
+                struct successor_operation_state_types_helper
+                {
+                    using type = connect_result_t<Sender, R>;
+                };
+                template <template <typename...> class Tuple,
+                    template <typename...> class Variant>
+                using successor_operation_state_types =
+                    hpx::util::detail::transform_t<
+                        successor_sender_types<Tuple, Variant>,
+                        successor_operation_state_types_helper>;
+
+                // Operation state from connecting predecessor sender to
+                // let_value_predecessor_receiver
+                predecessor_operation_state_type predecessor_os;
+
+                // Potential values returned from the predecessor sender
+                hpx::util::detail::prepend_t<
+                    predecessor_value_types<std::tuple, std::variant>,
+                    std::monostate>
+                    predecessor_ts;
+
+                // Potential operation states returned when connecting a sender
+                // in successor_sender_types to the receiver connected to the
+                // let_value_sender
+                hpx::util::detail::prepend_t<
+                    successor_operation_state_types<std::tuple, std::variant>,
+                    std::monostate>
+                    successor_os;
+
+                template <typename PS_, typename R_, typename F_>
+                operation_state(PS_&& ps, R_&& r, F_&& f)
+                  : predecessor_os{hpx::execution::experimental::connect(
+                        std::forward<PS_>(ps),
+                        let_value_predecessor_receiver(
+                            std::forward<R_>(r), std::forward<F_>(f), *this))}
+                {
+                }
+
+                operation_state(operation_state&&) = delete;
+                operation_state& operator=(operation_state&&) = delete;
+                operation_state(operation_state const&) = delete;
+                operation_state& operator=(operation_state const&) = delete;
+
+                void start() noexcept
+                {
+                    hpx::execution::experimental::start(predecessor_os);
+                }
+            };
+
+            template <typename R>
+            auto connect(R&& r) &&
+            {
+                return operation_state<R>(
+                    std::move(ps), std::forward<R>(r), std::move(f));
+            }
+        };
+    }    // namespace detail
+
+    HPX_INLINE_CONSTEXPR_VARIABLE struct let_value_t final
+      : hpx::functional::tag_fallback<let_value_t>
+    {
+    private:
+        template <typename PS, typename F>
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            let_value_t, PS&& ps, F&& f)
+        {
+            return detail::let_value_sender<PS, F>{
+                std::forward<PS>(ps), std::forward<F>(f)};
+        }
+
+        template <typename F>
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            let_value_t, F&& f)
+        {
+            return detail::partial_algorithm<let_value_t, F>{
+                std::forward<F>(f)};
+        }
+    } let_value{};
+}}}    // namespace hpx::execution::experimental
+#endif

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/let_value.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/let_value.hpp
@@ -122,12 +122,14 @@ namespace hpx { namespace execution { namespace experimental {
 
                     struct start_visitor
                     {
-                        void operator()(std::monostate) const
+                        HPX_NORETURN void operator()(std::monostate) const
                         {
-                            std::terminate();
+                            HPX_UNREACHABLE;
                         }
 
-                        template <typename OS_>
+                        template <typename OS_,
+                            typename = std::enable_if_t<!std::is_same_v<
+                                std::decay_t<OS_>, std::monostate>>>
                         void operator()(OS_& os) const
                         {
                             hpx::execution::experimental::start(os);
@@ -140,9 +142,9 @@ namespace hpx { namespace execution { namespace experimental {
                         std::decay_t<F> f;
                         operation_state& os;
 
-                        void operator()(std::monostate) const
+                        HPX_NORETURN void operator()(std::monostate) const
                         {
-                            std::terminate();
+                            HPX_UNREACHABLE;
                         }
 
                         template <typename T,

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/let_value.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/let_value.hpp
@@ -109,7 +109,7 @@ namespace hpx { namespace execution { namespace experimental {
                     }
 
                     template <typename E>
-                    void set_error(E&& e) && noexcept
+                        void set_error(E&& e) && noexcept
                     {
                         hpx::execution::experimental::set_error(
                             std::move(r), std::forward<E>(e));
@@ -174,7 +174,7 @@ namespace hpx { namespace execution { namespace experimental {
                     };
 
                     template <typename... Ts>
-                    void set_value(Ts&&... ts) && noexcept
+                        void set_value(Ts&&... ts) && noexcept
                     {
                         hpx::detail::try_catch_exception_ptr(
                             [&]() {

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/let_value.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/let_value.hpp
@@ -122,13 +122,13 @@ namespace hpx { namespace execution { namespace experimental {
 
                     struct start_visitor
                     {
-                        void operator()(std::monostate)
+                        void operator()(std::monostate) const
                         {
                             std::terminate();
                         }
 
                         template <typename OS_>
-                        void operator()(OS_& os)
+                        void operator()(OS_& os) const
                         {
                             hpx::execution::experimental::start(os);
                         }
@@ -140,12 +140,14 @@ namespace hpx { namespace execution { namespace experimental {
                         std::decay_t<F> f;
                         operation_state& os;
 
-                        void operator()(std::monostate)
+                        void operator()(std::monostate) const
                         {
                             std::terminate();
                         }
 
-                        template <typename T>
+                        template <typename T,
+                            typename = std::enable_if_t<!std::is_same_v<
+                                std::decay_t<T>, std::monostate>>>
                         void operator()(T& t)
                         {
                             using operation_state_type =

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/let_value.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/let_value.hpp
@@ -109,13 +109,13 @@ namespace hpx { namespace execution { namespace experimental {
                     }
 
                     template <typename E>
-                    void set_error(E&& e) noexcept
+                    void set_error(E&& e) && noexcept
                     {
                         hpx::execution::experimental::set_error(
                             std::move(r), std::forward<E>(e));
                     }
 
-                    void set_done() noexcept
+                    void set_done() && noexcept
                     {
                         hpx::execution::experimental::set_done(std::move(r));
                     };
@@ -174,7 +174,7 @@ namespace hpx { namespace execution { namespace experimental {
                     };
 
                     template <typename... Ts>
-                    void set_value(Ts&&... ts) noexcept
+                    void set_value(Ts&&... ts) && noexcept
                     {
                         hpx::detail::try_catch_exception_ptr(
                             [&]() {
@@ -244,7 +244,7 @@ namespace hpx { namespace execution { namespace experimental {
                 operation_state(operation_state const&) = delete;
                 operation_state& operator=(operation_state const&) = delete;
 
-                void start() noexcept
+                void start() & noexcept
                 {
                     hpx::execution::experimental::start(predecessor_os);
                 }

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/on.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/on.hpp
@@ -96,6 +96,7 @@ namespace hpx { namespace execution { namespace experimental {
                         predecessor_sender_receiver{*this}))
                 {
                 }
+
                 operation_state(operation_state&&) = delete;
                 operation_state(operation_state const&) = delete;
                 operation_state& operator=(operation_state&&) = delete;
@@ -106,18 +107,18 @@ namespace hpx { namespace execution { namespace experimental {
                     operation_state& os;
 
                     template <typename E>
-                    void set_error(E&& e) noexcept
+                    void set_error(E&& e) && noexcept
                     {
                         os.set_error_predecessor_sender(std::forward<E>(e));
                     }
 
-                    void set_done() noexcept
+                    void set_done() && noexcept
                     {
                         os.set_done_predecessor_sender();
                     };
 
                     template <typename... Ts>
-                    void set_value(Ts&&... ts) noexcept
+                    void set_value(Ts&&... ts) && noexcept
                     {
                         os.set_value_predecessor_sender(
                             std::forward<Ts>(ts)...);
@@ -156,17 +157,17 @@ namespace hpx { namespace execution { namespace experimental {
                     operation_state& os;
 
                     template <typename E>
-                    void set_error(E&& e) noexcept
+                    void set_error(E&& e) && noexcept
                     {
                         os.set_error_scheduler_sender(std::forward<E>(e));
                     }
 
-                    void set_done() noexcept
+                    void set_done() && noexcept
                     {
                         os.set_done_scheduler_sender();
                     };
 
-                    void set_value() noexcept
+                    void set_value() && noexcept
                     {
                         os.set_value_scheduler_sender();
                     }
@@ -216,7 +217,7 @@ namespace hpx { namespace execution { namespace experimental {
                         std::move(ts));
                 }
 
-                void start() noexcept
+                void start() & noexcept
                 {
                     hpx::execution::experimental::start(sender_os);
                 }

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/on.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/on.hpp
@@ -24,8 +24,8 @@ namespace hpx { namespace execution { namespace experimental {
         template <typename R, typename Scheduler>
         struct on_receiver
         {
-            typename std::decay<R>::type r;
-            typename std::decay<Scheduler>::type scheduler;
+            std::decay_t<R> r;
+            std::decay_t<Scheduler> scheduler;
 
             template <typename R_, typename Scheduler_>
             on_receiver(R_&& r, Scheduler_&& scheduler)
@@ -67,8 +67,8 @@ namespace hpx { namespace execution { namespace experimental {
         template <typename S, typename Scheduler>
         struct on_sender
         {
-            typename std::decay<S>::type s;
-            typename std::decay<Scheduler>::type scheduler;
+            std::decay_t<S> s;
+            std::decay_t<Scheduler> scheduler;
 
             template <template <typename...> class Tuple,
                 template <typename...> class Variant>
@@ -84,11 +84,18 @@ namespace hpx { namespace execution { namespace experimental {
             static constexpr bool sends_done = false;
 
             template <typename R>
-            auto connect(R&& r)
+            auto connect(R&& r) &&
             {
                 return hpx::execution::experimental::connect(std::move(s),
                     on_receiver<R, Scheduler>(
                         std::forward<R>(r), std::move(scheduler)));
+            }
+
+            template <typename R>
+            auto connect(R&& r) &
+            {
+                return hpx::execution::experimental::connect(s,
+                    on_receiver<R, Scheduler>(std::forward<R>(r), scheduler));
             }
         };
     }    // namespace detail

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/on.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/on.hpp
@@ -176,12 +176,14 @@ namespace hpx { namespace execution { namespace experimental {
                 {
                     std::decay_t<Receiver> receiver;
 
-                    void operator()(std::monostate)
+                    void operator()(std::monostate) const
                     {
                         std::terminate();
                     }
 
-                    template <typename Ts>
+                    template <typename Ts,
+                        typename = std::enable_if_t<
+                            !std::is_same_v<std::decay_t<Ts>, std::monostate>>>
                     void operator()(Ts&& ts)
                     {
                         hpx::util::invoke_fused(

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/on.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/on.hpp
@@ -107,7 +107,7 @@ namespace hpx { namespace execution { namespace experimental {
                     operation_state& os;
 
                     template <typename E>
-                    void set_error(E&& e) && noexcept
+                        void set_error(E&& e) && noexcept
                     {
                         os.set_error_predecessor_sender(std::forward<E>(e));
                     }
@@ -118,7 +118,7 @@ namespace hpx { namespace execution { namespace experimental {
                     };
 
                     template <typename... Ts>
-                    void set_value(Ts&&... ts) && noexcept
+                        void set_value(Ts&&... ts) && noexcept
                     {
                         os.set_value_predecessor_sender(
                             std::forward<Ts>(ts)...);
@@ -157,7 +157,7 @@ namespace hpx { namespace execution { namespace experimental {
                     operation_state& os;
 
                     template <typename E>
-                    void set_error(E&& e) && noexcept
+                        void set_error(E&& e) && noexcept
                     {
                         os.set_error_scheduler_sender(std::forward<E>(e));
                     }

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/on.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/on.hpp
@@ -176,9 +176,9 @@ namespace hpx { namespace execution { namespace experimental {
                 {
                     std::decay_t<Receiver> receiver;
 
-                    void operator()(std::monostate) const
+                    HPX_NORETURN void operator()(std::monostate) const
                     {
-                        std::terminate();
+                        HPX_UNREACHABLE;
                     }
 
                     template <typename Ts,

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/on.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/on.hpp
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#if defined(HPX_HAVE_CXX17_STD_VARIANT)
+#include <hpx/datastructures/optional.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
 #include <hpx/execution_base/receiver.hpp>
@@ -14,6 +16,7 @@
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/functional/invoke_fused.hpp>
 #include <hpx/functional/tag_fallback_invoke.hpp>
+#include <hpx/type_support/detail/with_result_of.hpp>
 #include <hpx/type_support/pack.hpp>
 
 #include <atomic>
@@ -21,88 +24,214 @@
 #include <exception>
 #include <type_traits>
 #include <utility>
+#include <variant>
 
 namespace hpx { namespace execution { namespace experimental {
     namespace detail {
-        template <typename R, typename Scheduler>
-        struct on_receiver
-        {
-            std::decay_t<R> r;
-            std::decay_t<Scheduler> scheduler;
-
-            template <typename R_, typename Scheduler_>
-            on_receiver(R_&& r, Scheduler_&& scheduler)
-              : r(std::forward<R>(r))
-              , scheduler(std::forward<Scheduler>(scheduler))
-            {
-            }
-
-            template <typename E>
-            auto set_error(E&& e) noexcept
-                -> decltype(hpx::execution::experimental::set_error(
-                                std::move(r), std::forward<E>(e)),
-                    void())
-            {
-                hpx::execution::experimental::set_error(
-                    std::move(r), std::forward<E>(e));
-            }
-
-            auto set_done() noexcept -> decltype(
-                hpx::execution::experimental::set_done(std::move(r)), void())
-            {
-                hpx::execution::experimental::set_done(std::move(r));
-            };
-
-            template <typename... Ts>
-            auto set_value(Ts&&... ts) noexcept
-                -> decltype(hpx::execution::experimental::set_value(
-                                std::move(r), std::forward<Ts>(ts)...),
-                    void())
-            {
-                hpx::tuple<Ts...> ts_pack{std::forward<Ts>(ts)...};
-                hpx::execution::experimental::execute(scheduler,
-                    [r = std::move(r), ts_pack = std::move(ts_pack)]() mutable {
-                        hpx::util::invoke_fused(
-                            hpx::util::bind_front(
-                                hpx::execution::experimental::set_value,
-                                std::move(r)),
-                            std::move(ts_pack));
-                    });
-            }
-        };
-
-        template <typename S, typename Scheduler>
+        template <typename Sender, typename Scheduler>
         struct on_sender
         {
-            std::decay_t<S> s;
+            std::decay_t<Sender> predecessor_sender;
             std::decay_t<Scheduler> scheduler;
 
             template <template <typename...> class Tuple,
                 template <typename...> class Variant>
             using value_types =
                 typename hpx::execution::experimental::sender_traits<
-                    S>::template value_types<Tuple, Variant>;
+                    Sender>::template value_types<Tuple, Variant>;
 
             template <template <typename...> class Variant>
-            using error_types =
+            using predecessor_sender_error_types =
                 typename hpx::execution::experimental::sender_traits<
-                    S>::template error_types<Variant>;
+                    Sender>::template error_types<Variant>;
+
+            using scheduler_sender_type = typename hpx::util::invoke_result<
+                hpx::execution::experimental::schedule_t, Scheduler>::type;
+            template <template <typename...> class Variant>
+            using scheduler_sender_error_types =
+                typename hpx::execution::experimental::sender_traits<
+                    scheduler_sender_type>::template error_types<Variant>;
+
+            template <template <typename...> class Variant>
+            using error_types = hpx::util::detail::unique_concat_t<
+                predecessor_sender_error_types<Variant>,
+                scheduler_sender_error_types<Variant>>;
 
             static constexpr bool sends_done = false;
 
-            template <typename R>
-            auto connect(R&& r) &&
+            template <typename Receiver>
+            struct operation_state
             {
-                return hpx::execution::experimental::connect(std::move(s),
-                    on_receiver<R, Scheduler>(
-                        std::forward<R>(r), std::move(scheduler)));
+                std::decay_t<Scheduler> scheduler;
+                std::decay_t<Receiver> receiver;
+
+                struct predecessor_sender_receiver;
+                struct scheduler_sender_receiver;
+
+                using value_type = hpx::util::detail::prepend_t<
+                    typename hpx::execution::experimental::sender_traits<
+                        Sender>::template value_types<hpx::tuple, std::variant>,
+                    std::monostate>;
+                value_type ts;
+
+                using sender_operation_state_type =
+                    connect_result_t<Sender, predecessor_sender_receiver>;
+                sender_operation_state_type sender_os;
+
+                using scheduler_operation_state_type =
+                    connect_result_t<typename hpx::util::invoke_result<
+                                         schedule_t, Scheduler>::type,
+                        scheduler_sender_receiver>;
+                hpx::util::optional<scheduler_operation_state_type>
+                    scheduler_os;
+
+                template <typename Sender_, typename Scheduler_,
+                    typename Receiver_>
+                operation_state(Sender_&& predecessor_sender,
+                    Scheduler_&& scheduler, Receiver_&& receiver)
+                  : scheduler(std::forward<Scheduler>(scheduler))
+                  , receiver(std::forward<Receiver_>(receiver))
+                  , sender_os(hpx::execution::experimental::connect(
+                        std::forward<Sender_>(predecessor_sender),
+                        predecessor_sender_receiver{*this}))
+                {
+                }
+                operation_state(operation_state&&) = delete;
+                operation_state(operation_state const&) = delete;
+                operation_state& operator=(operation_state&&) = delete;
+                operation_state& operator=(operation_state const&) = delete;
+
+                struct predecessor_sender_receiver
+                {
+                    operation_state& os;
+
+                    template <typename E>
+                    void set_error(E&& e) noexcept
+                    {
+                        os.set_error_predecessor_sender(std::forward<E>(e));
+                    }
+
+                    void set_done() noexcept
+                    {
+                        os.set_done_predecessor_sender();
+                    };
+
+                    template <typename... Ts>
+                    void set_value(Ts&&... ts) noexcept
+                    {
+                        os.set_value_predecessor_sender(
+                            std::forward<Ts>(ts)...);
+                    }
+                };
+
+                template <typename E>
+                void set_error_predecessor_sender(E&& e) noexcept
+                {
+                    hpx::execution::experimental::set_error(
+                        std::move(receiver), std::forward<E>(e));
+                }
+
+                void set_done_predecessor_sender() noexcept
+                {
+                    hpx::execution::experimental::set_done(std::move(receiver));
+                }
+
+                template <typename... Us>
+                void set_value_predecessor_sender(Us&&... us) noexcept
+                {
+                    ts.template emplace<hpx::tuple<Us...>>(
+                        std::forward<Us>(us)...);
+                    scheduler_os.template emplace(
+                        hpx::util::detail::with_result_of([&]() {
+                            return hpx::execution::experimental::connect(
+                                hpx::execution::experimental::schedule(
+                                    std::move(scheduler)),
+                                scheduler_sender_receiver{*this});
+                        }));
+                    hpx::execution::experimental::start(scheduler_os.value());
+                }
+
+                struct scheduler_sender_receiver
+                {
+                    operation_state& os;
+
+                    template <typename E>
+                    void set_error(E&& e) noexcept
+                    {
+                        os.set_error_scheduler_sender(std::forward<E>(e));
+                    }
+
+                    void set_done() noexcept
+                    {
+                        os.set_done_scheduler_sender();
+                    };
+
+                    void set_value() noexcept
+                    {
+                        os.set_value_scheduler_sender();
+                    }
+                };
+
+                struct scheduler_sender_value_visitor
+                {
+                    std::decay_t<Receiver> receiver;
+
+                    void operator()(std::monostate)
+                    {
+                        std::terminate();
+                    }
+
+                    template <typename Ts>
+                    void operator()(Ts&& ts)
+                    {
+                        hpx::util::invoke_fused(
+                            hpx::util::bind_front(
+                                hpx::execution::experimental::set_value,
+                                std::move(receiver)),
+                            std::forward<Ts>(ts));
+                    }
+                };
+
+                template <typename E>
+                void set_error_scheduler_sender(E&& e) noexcept
+                {
+                    scheduler_os.reset();
+                    hpx::execution::experimental::set_error(
+                        std::move(receiver), std::forward<E>(e));
+                }
+
+                void set_done_scheduler_sender() noexcept
+                {
+                    scheduler_os.reset();
+                    hpx::execution::experimental::set_done(std::move(receiver));
+                }
+
+                void set_value_scheduler_sender() noexcept
+                {
+                    scheduler_os.reset();
+                    std::visit(
+                        scheduler_sender_value_visitor{std::move(receiver)},
+                        std::move(ts));
+                }
+
+                void start() noexcept
+                {
+                    hpx::execution::experimental::start(sender_os);
+                }
+            };
+
+            template <typename Receiver>
+            operation_state<Receiver> connect(Receiver&& receiver) &&
+            {
+                return {std::move(predecessor_sender), std::move(scheduler),
+                    std::forward<Receiver>(receiver)};
             }
 
-            template <typename R>
-            auto connect(R&& r) &
+            template <typename Receiver>
+            operation_state<Receiver> connect(Receiver&& receiver) &
             {
-                return hpx::execution::experimental::connect(s,
-                    on_receiver<R, Scheduler>(std::forward<R>(r), scheduler));
+                return {predecessor_sender, scheduler,
+                    std::forward<Receiver>(receiver)};
             }
         };
     }    // namespace detail
@@ -111,12 +240,13 @@ namespace hpx { namespace execution { namespace experimental {
       : hpx::functional::tag_fallback<on_t>
     {
     private:
-        template <typename S, typename Scheduler>
+        template <typename Sender, typename Scheduler>
         friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
-            on_t, S&& s, Scheduler&& scheduler)
+            on_t, Sender&& predecessor_sender, Scheduler&& scheduler)
         {
-            return detail::on_sender<S, Scheduler>{
-                std::forward<S>(s), std::forward<Scheduler>(scheduler)};
+            return detail::on_sender<Sender, Scheduler>{
+                std::forward<Sender>(predecessor_sender),
+                std::forward<Scheduler>(scheduler)};
         }
 
         template <typename Scheduler>
@@ -128,3 +258,4 @@ namespace hpx { namespace execution { namespace experimental {
         }
     } on{};
 }}}    // namespace hpx::execution::experimental
+#endif

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/sync_wait.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/sync_wait.hpp
@@ -134,25 +134,25 @@ namespace hpx { namespace execution { namespace experimental {
             }
 
             template <typename E>
-            void set_error(E&& e) noexcept
+            void set_error(E&& e) && noexcept
             {
                 st.v.template emplace<error_type>(std::forward<E>(e));
                 signal_set_called();
             }
 
-            void set_done() noexcept
+            void set_done() && noexcept
             {
                 signal_set_called();
             };
 
-            void set_value() noexcept
+            void set_value() && noexcept
             {
                 st.v.template emplace<value_type>();
                 signal_set_called();
             }
 
             template <typename U>
-            void set_value(U&& u) noexcept
+            void set_value(U&& u) && noexcept
             {
                 st.v.template emplace<value_type>(std::forward<U>(u));
                 signal_set_called();

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/sync_wait.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/sync_wait.hpp
@@ -134,7 +134,7 @@ namespace hpx { namespace execution { namespace experimental {
             }
 
             template <typename E>
-            void set_error(E&& e) && noexcept
+                void set_error(E&& e) && noexcept
             {
                 st.v.template emplace<error_type>(std::forward<E>(e));
                 signal_set_called();
@@ -152,7 +152,7 @@ namespace hpx { namespace execution { namespace experimental {
             }
 
             template <typename U>
-            void set_value(U&& u) && noexcept
+                void set_value(U&& u) && noexcept
             {
                 st.v.template emplace<value_type>(std::forward<U>(u));
                 signal_set_called();

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/sync_wait.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/sync_wait.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/datastructures/optional.hpp>
+#if defined(HPX_HAVE_CXX17_STD_VARIANT)
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
 #include <hpx/execution/algorithms/detail/single_result.hpp>
 #include <hpx/execution_base/operation_state.hpp>
@@ -21,146 +21,143 @@
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <variant>
 
 namespace hpx { namespace execution { namespace experimental {
     namespace detail {
-        template <typename T>
-        struct sync_wait_receiver
+        struct sync_wait_error_visitor
         {
-            struct state
+            void operator()(std::exception_ptr e)
             {
-                hpx::lcos::local::condition_variable cv;
-                hpx::lcos::local::mutex m;
-                bool done = false;
-                bool has_exception = false;
-                std::exception_ptr ep;
-                hpx::util::optional<T> result;
-            };
-
-            state& st;
-
-            void signal_done() noexcept
-            {
-                std::unique_lock<hpx::lcos::local::mutex> l(st.m);
-                st.done = true;
-                st.cv.notify_one();
+                std::rethrow_exception(e);
             }
 
-            void set_error(std::exception_ptr ep) noexcept
+            template <typename E>
+            void operator()(E& e)
             {
-                st.ep = ep;
-                st.has_exception = true;
-                signal_done();
-            }
-
-            void set_done() noexcept
-            {
-                signal_done();
-            };
-
-            template <typename T_>
-            void set_value(T_&& t) noexcept
-            {
-                st.result = std::forward<T_>(t);
-                signal_done();
+                throw e;
             }
         };
 
-        template <>
-        struct sync_wait_receiver<void>
+        template <typename S>
+        struct sync_wait_receiver
         {
+            // value and error_types of the predecessor sender
+            template <template <typename...> class Tuple,
+                template <typename...> class Variant>
+            using predecessor_value_types =
+                typename hpx::execution::experimental::sender_traits<
+                    S>::template value_types<Tuple, Variant>;
+
+            template <template <typename...> class Variant>
+            using predecessor_error_types =
+                typename hpx::execution::experimental::sender_traits<
+                    S>::template error_types<Variant>;
+
+            // The type of the single void or non-void result that we store. If
+            // there are multiple variants or multiple values sync_wait will
+            // fail to compile.
+            using result_type = std::decay_t<single_result_t<
+                predecessor_value_types<hpx::util::pack, hpx::util::pack>>>;
+
+            // Constant to indicate if the type of the result from the
+            // predecessor sender is void or not
+            static constexpr bool is_void_result =
+                std::is_same_v<result_type, void>;
+
+            // Dummy type to indicate that set_value with void has been called
+            struct void_value_type
+            {
+            };
+
+            // The type of the value to store in the variant, void_value_type if
+            // result_type is void, or result_type if it is not
+            using value_type = std::conditional_t<is_void_result,
+                void_value_type, result_type>;
+
+            // The type of errors to store in the variant. This in itself is a
+            // variant.
+            using error_type =
+                hpx::util::detail::unique_t<hpx::util::detail::prepend_t<
+                    predecessor_error_types<std::variant>, std::exception_ptr>>;
+
             struct state
             {
                 hpx::lcos::local::condition_variable cv;
                 hpx::lcos::local::mutex m;
-                bool done = false;
-                bool has_exception = false;
-                std::exception_ptr ep;
+                bool set_called = false;
+                std::variant<std::monostate, error_type, value_type> v;
+
+                void wait()
+                {
+                    {
+                        std::unique_lock<hpx::lcos::local::mutex> l(m);
+                        if (!set_called)
+                        {
+                            cv.wait(l);
+                        }
+                    }
+                }
+
+                auto get_value()
+                {
+                    if (std::holds_alternative<value_type>(v))
+                    {
+                        if constexpr (is_void_result)
+                        {
+                            return;
+                        }
+                        else
+                        {
+                            return std::move(std::get<value_type>(v));
+                        }
+                    }
+                    else if (std::holds_alternative<error_type>(v))
+                    {
+                        // The visit will throw or terminate
+                        std::visit(
+                            sync_wait_error_visitor{}, std::get<error_type>(v));
+                    }
+
+                    // If the variant holds a std::monostate we also terminate
+                    std::terminate();
+                }
             };
 
             state& st;
 
-            void signal_done() noexcept
+            void signal_set_called() noexcept
             {
                 std::unique_lock<hpx::lcos::local::mutex> l(st.m);
-                st.done = true;
+                st.set_called = true;
                 st.cv.notify_one();
             }
 
-            void set_error(std::exception_ptr ep) noexcept
+            template <typename E>
+            void set_error(E&& e) noexcept
             {
-                st.ep = ep;
-                st.has_exception = true;
-                signal_done();
+                st.v.template emplace<error_type>(e);
+                signal_set_called();
             }
 
             void set_done() noexcept
             {
-                signal_done();
+                signal_set_called();
             };
 
             void set_value() noexcept
             {
-                signal_done();
+                st.v.template emplace<value_type>();
+                signal_set_called();
+            }
+
+            template <typename U>
+            void set_value(U&& u) noexcept
+            {
+                st.v.template emplace<value_type>(std::forward<U>(u));
+                signal_set_called();
             }
         };
-
-        template <typename S>
-        auto sync_wait_impl(std::true_type, S&& s)
-        {
-            using state_type = typename detail::sync_wait_receiver<void>::state;
-
-            state_type st{};
-            auto os = hpx::execution::experimental::connect(
-                std::forward<S>(s), detail::sync_wait_receiver<void>{st});
-            hpx::execution::experimental::start(os);
-
-            {
-                std::unique_lock<hpx::lcos::local::mutex> l(st.m);
-                if (!st.done)
-                {
-                    st.cv.wait(l);
-                }
-            }
-
-            if (st.has_exception)
-            {
-                std::rethrow_exception(st.ep);
-            }
-        }
-
-        template <typename S>
-        auto sync_wait_impl(std::false_type, S&& s)
-        {
-            using value_types =
-                typename hpx::execution::experimental::sender_traits<
-                    S>::template value_types<hpx::util::pack, hpx::util::pack>;
-            using result_type = std::decay_t<single_result_t<value_types>>;
-            using state_type =
-                typename detail::sync_wait_receiver<result_type>::state;
-
-            state_type st{};
-            auto os = hpx::execution::experimental::connect(std::forward<S>(s),
-                detail::sync_wait_receiver<result_type>{st});
-            hpx::execution::experimental::start(os);
-
-            {
-                std::unique_lock<hpx::lcos::local::mutex> l(st.m);
-                if (!st.done)
-                {
-                    st.cv.wait(l);
-                }
-            }
-
-            if (st.has_exception)
-            {
-                std::rethrow_exception(st.ep);
-            }
-            else
-            {
-                return std::move(st.result.value());
-            }
-        }
     }    // namespace detail
 
     HPX_INLINE_CONSTEXPR_VARIABLE struct sync_wait_t final
@@ -171,13 +168,16 @@ namespace hpx { namespace execution { namespace experimental {
         friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
             sync_wait_t, S&& s)
         {
-            using value_types =
-                typename hpx::execution::experimental::sender_traits<
-                    S>::template value_types<hpx::util::pack, hpx::util::pack>;
-            using result_type = detail::single_result_t<value_types>;
+            using receiver_type = detail::sync_wait_receiver<S>;
+            using state_type = typename receiver_type::state;
 
-            return detail::sync_wait_impl(
-                std::is_void<result_type>{}, std::forward<S>(s));
+            state_type st{};
+            auto os = hpx::execution::experimental::connect(
+                std::forward<S>(s), receiver_type{st});
+            hpx::execution::experimental::start(os);
+
+            st.wait();
+            return st.get_value();
         }
 
         friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(sync_wait_t)
@@ -186,3 +186,4 @@ namespace hpx { namespace execution { namespace experimental {
         }
     } sync_wait{};
 }}}    // namespace hpx::execution::experimental
+#endif

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/sync_wait.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/sync_wait.hpp
@@ -114,13 +114,13 @@ namespace hpx { namespace execution { namespace experimental {
                     }
                     else if (std::holds_alternative<error_type>(v))
                     {
-                        // The visit will throw or terminate
                         std::visit(
                             sync_wait_error_visitor{}, std::get<error_type>(v));
                     }
 
-                    // If the variant holds a std::monostate we also terminate
-                    std::terminate();
+                    // If the variant holds a std::monostate something has gone
+                    // wrong and we terminate
+                    HPX_UNREACHABLE;
                 }
             };
 

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/sync_wait.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/sync_wait.hpp
@@ -27,13 +27,13 @@ namespace hpx { namespace execution { namespace experimental {
     namespace detail {
         struct sync_wait_error_visitor
         {
-            void operator()(std::exception_ptr e)
+            void operator()(std::exception_ptr e) const
             {
                 std::rethrow_exception(e);
             }
 
             template <typename E>
-            void operator()(E& e)
+            void operator()(E& e) const
             {
                 throw e;
             }

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/sync_wait.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/sync_wait.hpp
@@ -136,7 +136,7 @@ namespace hpx { namespace execution { namespace experimental {
             template <typename E>
             void set_error(E&& e) noexcept
             {
-                st.v.template emplace<error_type>(e);
+                st.v.template emplace<error_type>(std::forward<E>(e));
                 signal_set_called();
             }
 

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/transform.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/transform.hpp
@@ -34,7 +34,7 @@ namespace hpx { namespace execution { namespace experimental {
             }
 
             template <typename E>
-            void set_error(E&& e) && noexcept
+                void set_error(E&& e) && noexcept
             {
                 hpx::execution::experimental::set_error(
                     std::move(r), std::forward<E>(e));
@@ -76,7 +76,7 @@ namespace hpx { namespace execution { namespace experimental {
 
             template <typename... Ts,
                 typename = std::enable_if_t<hpx::is_invocable_v<F, Ts...>>>
-            void set_value(Ts&&... ts) && noexcept
+                void set_value(Ts&&... ts) && noexcept
             {
                 using is_void_result =
                     std::is_void<hpx::util::invoke_result_t<F, Ts...>>;

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/transform.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/transform.hpp
@@ -34,13 +34,13 @@ namespace hpx { namespace execution { namespace experimental {
             }
 
             template <typename E>
-            void set_error(E&& e) noexcept
+            void set_error(E&& e) && noexcept
             {
                 hpx::execution::experimental::set_error(
                     std::move(r), std::forward<E>(e));
             }
 
-            void set_done() noexcept
+            void set_done() && noexcept
             {
                 hpx::execution::experimental::set_done(std::move(r));
             };
@@ -76,7 +76,7 @@ namespace hpx { namespace execution { namespace experimental {
 
             template <typename... Ts,
                 typename = std::enable_if_t<hpx::is_invocable_v<F, Ts...>>>
-            void set_value(Ts&&... ts) noexcept
+            void set_value(Ts&&... ts) && noexcept
             {
                 using is_void_result =
                     std::is_void<hpx::util::invoke_result_t<F, Ts...>>;

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/when_all.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/when_all.hpp
@@ -39,7 +39,7 @@ namespace hpx { namespace execution { namespace experimental {
             }
 
             template <typename E>
-            void set_error(E&& e) noexcept
+            void set_error(E&& e) && noexcept
             {
                 if (!os.set_done_error_called.exchange(true))
                 {
@@ -56,14 +56,14 @@ namespace hpx { namespace execution { namespace experimental {
                 os.finish();
             }
 
-            void set_done() noexcept
+            void set_done() && noexcept
             {
                 os.set_done_error_called = true;
                 os.finish();
             };
 
             template <typename T>
-            void set_value(T&& t) noexcept
+            void set_value(T&& t) && noexcept
             {
                 if (!os.set_done_error_called)
                 {
@@ -159,9 +159,11 @@ namespace hpx { namespace execution { namespace experimental {
                 }
 
                 operation_state(operation_state&&) = delete;
+                operation_state& operator=(operation_state&&) = delete;
                 operation_state(operation_state const&) = delete;
+                operation_state& operator=(operation_state const&) = delete;
 
-                void start() noexcept
+                void start() & noexcept
                 {
                     hpx::execution::experimental::start(os);
                 }
@@ -225,9 +227,11 @@ namespace hpx { namespace execution { namespace experimental {
                 }
 
                 operation_state(operation_state&&) = delete;
+                operation_state& operator=(operation_state&&) = delete;
                 operation_state(operation_state const&) = delete;
+                operation_state& operator=(operation_state const&) = delete;
 
-                void start() noexcept
+                void start() & noexcept
                 {
                     base_type::start();
                     hpx::execution::experimental::start(os);

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/when_all.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/when_all.hpp
@@ -39,7 +39,7 @@ namespace hpx { namespace execution { namespace experimental {
             }
 
             template <typename E>
-            void set_error(E&& e) && noexcept
+                void set_error(E&& e) && noexcept
             {
                 if (!os.set_done_error_called.exchange(true))
                 {
@@ -63,7 +63,7 @@ namespace hpx { namespace execution { namespace experimental {
             };
 
             template <typename T>
-            void set_value(T&& t) && noexcept
+                void set_value(T&& t) && noexcept
             {
                 if (!os.set_done_error_called)
                 {

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/when_all.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/when_all.hpp
@@ -135,7 +135,7 @@ namespace hpx { namespace execution { namespace experimental {
                 std::atomic<std::size_t> predecessors_remaining =
                     num_predecessors;
                 hpx::util::member_pack_for<
-                    std::decay_t<value_types_helper_t<Ss>>...>
+                    std::optional<std::decay_t<value_types_helper_t<Ss>>>...>
                     ts;
                 std::optional<error_types<std::variant>> e;
                 std::atomic<bool> set_done_error_called{false};
@@ -172,7 +172,7 @@ namespace hpx { namespace execution { namespace experimental {
                         ts)
                 {
                     hpx::execution::experimental::set_value(
-                        std::move(r), std::move(ts.template get<Is>())...);
+                        std::move(r), std::move(*(ts.template get<Is>()))...);
                 }
 
                 void finish() noexcept

--- a/libs/parallelism/execution/include/hpx/execution/algorithms/when_all.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/algorithms/when_all.hpp
@@ -191,7 +191,7 @@ namespace hpx { namespace execution { namespace experimental {
                                         std::move(r),
                                         std::forward<decltype(e)>(e));
                                 },
-                                e.value());
+                                std::move(e.value()));
                         }
                         else
                         {

--- a/libs/parallelism/execution/tests/unit/CMakeLists.txt
+++ b/libs/parallelism/execution/tests/unit/CMakeLists.txt
@@ -26,8 +26,12 @@ if(HPX_CXX_STANDARD GREATER_EQUAL 17)
   list(
     APPEND
     tests
+    algorithm_detach
+    algorithm_ensure_started
     algorithm_just
     algorithm_just_on
+    algorithm_let_value
+    algorithm_let_error
     algorithm_on
     algorithm_sync_wait
     algorithm_transform

--- a/libs/parallelism/execution/tests/unit/algorithm_detach.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_detach.cpp
@@ -39,6 +39,40 @@ int main()
         HPX_TEST(!tag_invoke_overload_called);
     }
 
+    {
+        std::atomic<bool> start_called{false};
+        std::atomic<bool> connect_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        ex::detach(custom_typed_sender<int>{
+            0, start_called, connect_called, tag_invoke_overload_called});
+        HPX_TEST(start_called);
+        HPX_TEST(connect_called);
+        HPX_TEST(!tag_invoke_overload_called);
+    }
+
+    {
+        std::atomic<bool> start_called{false};
+        std::atomic<bool> connect_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        ex::detach(custom_typed_sender<custom_type_non_default_constructible>{
+            {0}, start_called, connect_called, tag_invoke_overload_called});
+        HPX_TEST(start_called);
+        HPX_TEST(connect_called);
+        HPX_TEST(!tag_invoke_overload_called);
+    }
+
+    {
+        std::atomic<bool> start_called{false};
+        std::atomic<bool> connect_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        ex::detach(custom_typed_sender<
+            custom_type_non_default_constructible_non_copyable>{
+            {0}, start_called, connect_called, tag_invoke_overload_called});
+        HPX_TEST(start_called);
+        HPX_TEST(connect_called);
+        HPX_TEST(!tag_invoke_overload_called);
+    }
+
     // operator| overload
     {
         std::atomic<bool> start_called{false};

--- a/libs/parallelism/execution/tests/unit/algorithm_detach.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_detach.cpp
@@ -55,7 +55,8 @@ int main()
         std::atomic<bool> connect_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
         ex::detach(custom_typed_sender<custom_type_non_default_constructible>{
-            {0}, start_called, connect_called, tag_invoke_overload_called});
+            custom_type_non_default_constructible{0}, start_called,
+            connect_called, tag_invoke_overload_called});
         HPX_TEST(start_called);
         HPX_TEST(connect_called);
         HPX_TEST(!tag_invoke_overload_called);
@@ -67,7 +68,8 @@ int main()
         std::atomic<bool> tag_invoke_overload_called{false};
         ex::detach(custom_typed_sender<
             custom_type_non_default_constructible_non_copyable>{
-            {0}, start_called, connect_called, tag_invoke_overload_called});
+            custom_type_non_default_constructible_non_copyable{0}, start_called,
+            connect_called, tag_invoke_overload_called});
         HPX_TEST(start_called);
         HPX_TEST(connect_called);
         HPX_TEST(!tag_invoke_overload_called);

--- a/libs/parallelism/execution/tests/unit/algorithm_ensure_started.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_ensure_started.cpp
@@ -1,0 +1,133 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include "algorithm_test_utils.hpp"
+
+#include <atomic>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace ex = hpx::execution::experimental;
+
+// This overload is only used to check dispatching. It is not a useful
+// implementation.
+template <typename Allocator = hpx::util::internal_allocator<>>
+auto tag_invoke(ex::ensure_started_t, custom_sender_tag_invoke s,
+    Allocator const& = Allocator{})
+{
+    s.tag_invoke_overload_called = true;
+    return void_sender{};
+}
+
+int main()
+{
+    // Success path
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s1 = void_sender{};
+        auto s2 = ex::ensure_started(std::move(s1));
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s2), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s1 = ex::just(0);
+        auto s2 = ex::ensure_started(std::move(s1));
+        auto f = [](int x) { HPX_TEST_EQ(x, 0); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s2), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    // operator| overload
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = void_sender{} | ex::ensure_started();
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    // tag_invoke overload
+    {
+        std::atomic<bool> receiver_set_value_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        auto s = custom_sender_tag_invoke{tag_invoke_overload_called} |
+            ex::ensure_started();
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, receiver_set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(receiver_set_value_called);
+        HPX_TEST(tag_invoke_overload_called);
+    }
+
+    // Failure path
+    {
+        std::atomic<bool> set_error_called{false};
+        auto s = error_sender{} | ex::ensure_started();
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, set_error_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_error_called);
+    }
+
+    {
+        std::atomic<bool> set_error_called{false};
+        auto s = error_sender{} | ex::ensure_started() | ex::ensure_started() |
+            ex::ensure_started();
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, set_error_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_error_called);
+    }
+
+    // Chained ensure_started calls do not create new shared states
+    {
+        std::atomic<bool> receiver_set_value_called{false};
+        auto s1 = ex::just() | ex::ensure_started();
+        auto s2 = ex::ensure_started(s1);
+        HPX_TEST_EQ(s1.st, s2.st);
+        auto s3 = ex::ensure_started(std::move(s2));
+        HPX_TEST_EQ(s1.st, s3.st);
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, receiver_set_value_called};
+        auto os = ex::connect(std::move(s3), std::move(r));
+        ex::start(os);
+        HPX_TEST(receiver_set_value_called);
+    }
+
+    {
+        std::atomic<bool> receiver_set_value_called{false};
+        auto s1 = ex::just(42) | ex::ensure_started();
+        auto s2 = ex::ensure_started(s1);
+        HPX_TEST_EQ(s1.st, s2.st);
+        auto s3 = ex::ensure_started(std::move(s2));
+        HPX_TEST_EQ(s1.st, s3.st);
+        auto f = [](int x) { HPX_TEST_EQ(x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, receiver_set_value_called};
+        auto os = ex::connect(std::move(s3), std::move(r));
+        ex::start(os);
+        HPX_TEST(receiver_set_value_called);
+    }
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/execution/tests/unit/algorithm_ensure_started.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_ensure_started.cpp
@@ -53,6 +53,29 @@ int main()
         HPX_TEST(set_value_called);
     }
 
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s1 = ex::just(custom_type_non_default_constructible{42});
+        auto s2 = ex::ensure_started(std::move(s1));
+        auto f = [](auto x) { HPX_TEST_EQ(x.x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s2), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s1 =
+            ex::just(custom_type_non_default_constructible_non_copyable{42});
+        auto s2 = ex::ensure_started(std::move(s1));
+        auto f = [](auto& x) { HPX_TEST_EQ(x.x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s2), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
     // operator| overload
     {
         std::atomic<bool> set_value_called{false};

--- a/libs/parallelism/execution/tests/unit/algorithm_just.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_just.cpp
@@ -7,6 +7,8 @@
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/testing.hpp>
 
+#include "algorithm_test_utils.hpp"
+
 #include <atomic>
 #include <string>
 #include <type_traits>
@@ -14,43 +16,12 @@
 
 namespace ex = hpx::execution::experimental;
 
-template <typename F>
-struct callback_receiver
-{
-    std::decay_t<F> f;
-    std::atomic<bool>& set_value_called;
-
-    template <typename E>
-    void set_error(E&&) noexcept
-    {
-        HPX_TEST(false);
-    }
-
-    void set_done() noexcept
-    {
-        HPX_TEST(false);
-    };
-
-    template <typename... Ts>
-    auto set_value(Ts&&... ts) noexcept
-        -> decltype(HPX_INVOKE(f, std::forward<Ts>(ts)...), void())
-    {
-        HPX_INVOKE(f, std::forward<Ts>(ts)...);
-        set_value_called = true;
-    }
-};
-
-template <typename T>
-struct custom_type
-{
-    std::atomic<bool>& called;
-    std::decay_t<T> x;
-};
-
+// This overload is only used to check dispatching. It is not a useful
+// implementation.
 template <typename T>
 auto tag_invoke(ex::just_t, custom_type<T> c)
 {
-    c.called = true;
+    c.tag_invoke_overload_called = true;
     return ex::just(c.x);
 }
 

--- a/libs/parallelism/execution/tests/unit/algorithm_just.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_just.cpp
@@ -49,6 +49,27 @@ int main()
 
     {
         std::atomic<bool> set_value_called{false};
+        auto s = ex::just(custom_type_non_default_constructible{42});
+        auto f = [](auto x) { HPX_TEST_EQ(x.x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s =
+            ex::just(custom_type_non_default_constructible_non_copyable{42});
+        auto f = [](auto x) { HPX_TEST_EQ(x.x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
         auto s = ex::just(std::string("hello"), 3);
         auto f = [](std::string s, int x) {
             HPX_TEST_EQ(s, std::string("hello"));

--- a/libs/parallelism/execution/tests/unit/algorithm_just_on.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_just_on.cpp
@@ -28,42 +28,51 @@ auto tag_invoke(ex::just_on_t, scheduler2 s, T&& t)
 
 int main()
 {
+    // Success path
     {
         std::atomic<bool> set_value_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
-        auto s = ex::just_on(
-            scheduler{scheduler_execute_called, tag_invoke_overload_called});
+        std::atomic<bool> tag_invoke_overload_called{false};
+        auto s = ex::just_on(scheduler{scheduler_schedule_called,
+            scheduler_execute_called, tag_invoke_overload_called});
         auto f = [] {};
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
         HPX_TEST(!tag_invoke_overload_called);
-        HPX_TEST(scheduler_execute_called);
+        HPX_TEST(scheduler_schedule_called);
+        HPX_TEST(!scheduler_execute_called);
     }
 
     {
         std::atomic<bool> set_value_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
         auto s = ex::just_on(
-            scheduler{scheduler_execute_called, tag_invoke_overload_called}, 3);
+            scheduler{scheduler_schedule_called, scheduler_execute_called,
+                tag_invoke_overload_called},
+            3);
         auto f = [](int x) { HPX_TEST_EQ(x, 3); };
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
         HPX_TEST(!tag_invoke_overload_called);
-        HPX_TEST(scheduler_execute_called);
+        HPX_TEST(scheduler_schedule_called);
+        HPX_TEST(!scheduler_execute_called);
     }
 
     {
         std::atomic<bool> set_value_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
         auto s = ex::just_on(
-            scheduler{scheduler_execute_called, tag_invoke_overload_called},
+            scheduler{scheduler_schedule_called, scheduler_execute_called,
+                tag_invoke_overload_called},
             custom_type_non_default_constructible{42});
         auto f = [](auto x) { HPX_TEST_EQ(x.x, 42); };
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
@@ -71,15 +80,18 @@ int main()
         ex::start(os);
         HPX_TEST(set_value_called);
         HPX_TEST(!tag_invoke_overload_called);
-        HPX_TEST(scheduler_execute_called);
+        HPX_TEST(scheduler_schedule_called);
+        HPX_TEST(!scheduler_execute_called);
     }
 
     {
         std::atomic<bool> set_value_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
         auto s = ex::just_on(
-            scheduler{scheduler_execute_called, tag_invoke_overload_called},
+            scheduler{scheduler_schedule_called, scheduler_execute_called,
+                tag_invoke_overload_called},
             custom_type_non_default_constructible_non_copyable{42});
         auto f = [](auto x) { HPX_TEST_EQ(x.x, 42); };
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
@@ -87,15 +99,18 @@ int main()
         ex::start(os);
         HPX_TEST(set_value_called);
         HPX_TEST(!tag_invoke_overload_called);
-        HPX_TEST(scheduler_execute_called);
+        HPX_TEST(scheduler_schedule_called);
+        HPX_TEST(!scheduler_execute_called);
     }
 
     {
         std::atomic<bool> set_value_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
         auto s = ex::just_on(
-            scheduler{scheduler_execute_called, tag_invoke_overload_called},
+            scheduler{scheduler_schedule_called, scheduler_execute_called,
+                tag_invoke_overload_called},
             std::string("hello"), 3);
         auto f = [](std::string s, int x) {
             HPX_TEST_EQ(s, std::string("hello"));
@@ -106,15 +121,19 @@ int main()
         ex::start(os);
         HPX_TEST(set_value_called);
         HPX_TEST(!tag_invoke_overload_called);
-        HPX_TEST(scheduler_execute_called);
+        HPX_TEST(scheduler_schedule_called);
+        HPX_TEST(!scheduler_execute_called);
     }
 
+    // tag_invoke overload
     {
         std::atomic<bool> set_value_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
-        auto s = ex::just_on(scheduler2{scheduler{scheduler_execute_called,
-                                 tag_invoke_overload_called}},
+        std::atomic<bool> tag_invoke_overload_called{false};
+        auto s = ex::just_on(
+            scheduler2{scheduler{scheduler_schedule_called,
+                scheduler_execute_called, tag_invoke_overload_called}},
             3);
         auto f = [](int x) { HPX_TEST_EQ(x, 3); };
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
@@ -122,7 +141,8 @@ int main()
         ex::start(os);
         HPX_TEST(set_value_called);
         HPX_TEST(tag_invoke_overload_called);
-        HPX_TEST(scheduler_execute_called);
+        HPX_TEST(scheduler_schedule_called);
+        HPX_TEST(!scheduler_execute_called);
     }
 
     return hpx::util::report_errors();

--- a/libs/parallelism/execution/tests/unit/algorithm_just_on.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_just_on.cpp
@@ -7,6 +7,8 @@
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/testing.hpp>
 
+#include "algorithm_test_utils.hpp"
+
 #include <atomic>
 #include <string>
 #include <type_traits>
@@ -14,128 +16,55 @@
 
 namespace ex = hpx::execution::experimental;
 
-struct scheduler
-{
-    std::atomic<bool>& execute_called;
-
-    template <typename F>
-    void execute(F&& f) const
-    {
-        execute_called = true;
-        HPX_INVOKE(std::forward<F>(f));
-    }
-
-    // The following are only here to make this a valid scheduler. The current
-    // implementation makes use of execute, but the implementation can be
-    // changed. If that happens the test for which function should be called
-    // should also be changed.
-    template <template <class...> class Tuple,
-        template <class...> class Variant>
-    using value_types = Variant<Tuple<>>;
-
-    static constexpr bool sends_done = false;
-
-    template <typename R>
-    struct operation_state
-    {
-        std::decay_t<R> r;
-
-        void start() noexcept
-        {
-            ex::set_value(std::move(r));
-        };
-    };
-
-    template <typename R>
-    auto connect(R&& r) &&
-    {
-        return operation_state<R>{std::forward<R>(r)};
-    }
-
-    constexpr void schedule() const {}
-
-    bool operator==(scheduler const&) const noexcept
-    {
-        return true;
-    }
-
-    bool operator!=(scheduler const&) const noexcept
-    {
-        return false;
-    }
-};
-
-template <typename F>
-struct callback_receiver
-{
-    std::decay_t<F> f;
-    std::atomic<bool>& set_value_called;
-
-    template <typename E>
-    void set_error(E&&) noexcept
-    {
-        HPX_TEST(false);
-    }
-
-    void set_done() noexcept
-    {
-        HPX_TEST(false);
-    };
-
-    template <typename... Ts>
-    auto set_value(Ts&&... ts) noexcept
-        -> decltype(HPX_INVOKE(f, std::forward<Ts>(ts)...), void())
-    {
-        HPX_INVOKE(f, std::forward<Ts>(ts)...);
-        set_value_called = true;
-    }
-};
-
+// This overload is only used to check dispatching. It is not a useful
+// implementation.
 template <typename T>
-struct custom_type
+auto tag_invoke(ex::just_on_t, scheduler2 s, T&& t)
 {
-    std::atomic<bool>& tag_invoke_overload_called;
-    std::decay_t<T> x;
-};
-
-template <typename S, typename T>
-auto tag_invoke(ex::just_on_t, S&& s, custom_type<T> c)
-{
-    c.tag_invoke_overload_called = true;
-    return ex::just_on(std::forward<S>(s), c.x);
+    s.tag_invoke_overload_called = true;
+    return ex::just_on(
+        std::move(static_cast<scheduler>(s)), std::forward<T>(t));
 }
 
 int main()
 {
     {
         std::atomic<bool> set_value_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
         std::atomic<bool> scheduler_execute_called{false};
-        auto s = ex::just_on(scheduler{scheduler_execute_called});
+        auto s = ex::just_on(
+            scheduler{scheduler_execute_called, tag_invoke_overload_called});
         auto f = [] {};
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
+        HPX_TEST(!tag_invoke_overload_called);
         HPX_TEST(scheduler_execute_called);
     }
 
     {
         std::atomic<bool> set_value_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
         std::atomic<bool> scheduler_execute_called{false};
-        auto s = ex::just_on(scheduler{scheduler_execute_called}, 3);
+        auto s = ex::just_on(
+            scheduler{scheduler_execute_called, tag_invoke_overload_called}, 3);
         auto f = [](int x) { HPX_TEST_EQ(x, 3); };
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
+        HPX_TEST(!tag_invoke_overload_called);
         HPX_TEST(scheduler_execute_called);
     }
 
     {
         std::atomic<bool> set_value_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
         std::atomic<bool> scheduler_execute_called{false};
         auto s = ex::just_on(
-            scheduler{scheduler_execute_called}, std::string("hello"), 3);
+            scheduler{scheduler_execute_called, tag_invoke_overload_called},
+            std::string("hello"), 3);
         auto f = [](std::string s, int x) {
             HPX_TEST_EQ(s, std::string("hello"));
             HPX_TEST_EQ(x, 3);
@@ -144,6 +73,7 @@ int main()
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
+        HPX_TEST(!tag_invoke_overload_called);
         HPX_TEST(scheduler_execute_called);
     }
 
@@ -151,8 +81,9 @@ int main()
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
         std::atomic<bool> scheduler_execute_called{false};
-        custom_type<int> c{tag_invoke_overload_called, 3};
-        auto s = ex::just_on(scheduler{scheduler_execute_called}, c);
+        auto s = ex::just_on(scheduler2{scheduler{scheduler_execute_called,
+                                 tag_invoke_overload_called}},
+            3);
         auto f = [](int x) { HPX_TEST_EQ(x, 3); };
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
         auto os = ex::connect(std::move(s), std::move(r));

--- a/libs/parallelism/execution/tests/unit/algorithm_just_on.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_just_on.cpp
@@ -64,6 +64,38 @@ int main()
         std::atomic<bool> scheduler_execute_called{false};
         auto s = ex::just_on(
             scheduler{scheduler_execute_called, tag_invoke_overload_called},
+            custom_type_non_default_constructible{42});
+        auto f = [](auto x) { HPX_TEST_EQ(x.x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(scheduler_execute_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> scheduler_execute_called{false};
+        auto s = ex::just_on(
+            scheduler{scheduler_execute_called, tag_invoke_overload_called},
+            custom_type_non_default_constructible_non_copyable{42});
+        auto f = [](auto x) { HPX_TEST_EQ(x.x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(scheduler_execute_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> scheduler_execute_called{false};
+        auto s = ex::just_on(
+            scheduler{scheduler_execute_called, tag_invoke_overload_called},
             std::string("hello"), 3);
         auto f = [](std::string s, int x) {
             HPX_TEST_EQ(s, std::string("hello"));

--- a/libs/parallelism/execution/tests/unit/algorithm_let_error.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_let_error.cpp
@@ -1,0 +1,126 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include "algorithm_test_utils.hpp"
+
+#include <atomic>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace ex = hpx::execution::experimental;
+
+// This overload is only used to check dispatching. It is not a useful
+// implementation.
+template <typename F>
+auto tag_invoke(ex::let_error_t, custom_sender_tag_invoke s, F&&)
+{
+    s.tag_invoke_overload_called = true;
+    return void_sender{};
+}
+
+int main()
+{
+    // "Success" path, i.e. let_error gets to handle the error
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> let_error_callback_called{false};
+        auto s1 = error_sender{};
+        auto s2 = ex::let_error(std::move(s1), [&](std::exception_ptr ep) {
+            check_exception_ptr(ep);
+            let_error_callback_called = true;
+            return void_sender();
+        });
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s2), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+        HPX_TEST(let_error_callback_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> let_error_callback_called{false};
+        auto s1 = error_sender{};
+        auto s2 = ex::let_error(std::move(s1), [&](std::exception_ptr ep) {
+            check_exception_ptr(ep);
+            let_error_callback_called = true;
+            return ex::just(42);
+        });
+        auto f = [](int x) { HPX_TEST_EQ(x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s2), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+        HPX_TEST(let_error_callback_called);
+    }
+
+    // operator| overload
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> let_error_callback_called{false};
+        auto s = error_sender{} | ex::let_error([&](std::exception_ptr ep) {
+            check_exception_ptr(ep);
+            let_error_callback_called = true;
+            return void_sender();
+        });
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+        HPX_TEST(let_error_callback_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> let_error_callback_called{false};
+        auto s = error_sender{} | ex::let_error([&](std::exception_ptr ep) {
+            check_exception_ptr(ep);
+            let_error_callback_called = true;
+            return ex::just(42);
+        });
+        auto f = [](int x) { HPX_TEST_EQ(x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+        HPX_TEST(let_error_callback_called);
+    }
+
+    // tag_invoke overload
+    {
+        std::atomic<bool> tag_invoke_overload_called{false};
+        custom_sender_tag_invoke{tag_invoke_overload_called} |
+            ex::let_error([&](std::exception_ptr) { return ex::just(); });
+        HPX_TEST(tag_invoke_overload_called);
+    }
+
+    // "Failure" path, i.e. let_error has no error to handle
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> let_error_callback_called{false};
+        auto s1 = ex::just(42);
+        auto s2 = ex::let_error(std::move(s1), [&](std::exception_ptr) {
+            HPX_TEST(false);
+            return ex::just(43);
+        });
+        auto f = [](int x) { HPX_TEST_EQ(x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s2), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+        HPX_TEST(!let_error_callback_called);
+    }
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/execution/tests/unit/algorithm_let_value.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_let_value.cpp
@@ -63,6 +63,41 @@ int main()
         HPX_TEST(let_value_callback_called);
     }
 
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> let_value_callback_called{false};
+        auto s1 = ex::just(custom_type_non_default_constructible{42});
+        auto s2 = ex::let_value(std::move(s1), [&](auto& x) {
+            HPX_TEST_EQ(x.x, 42);
+            let_value_callback_called = true;
+            return ex::just(x);
+        });
+        auto f = [](auto x) { HPX_TEST_EQ(x.x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s2), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+        HPX_TEST(let_value_callback_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> let_value_callback_called{false};
+        auto s1 =
+            ex::just(custom_type_non_default_constructible_non_copyable{42});
+        auto s2 = ex::let_value(std::move(s1), [&](auto& x) {
+            HPX_TEST_EQ(x.x, 42);
+            let_value_callback_called = true;
+            return ex::just(std::move(x));
+        });
+        auto f = [](auto x) { HPX_TEST_EQ(x.x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s2), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+        HPX_TEST(let_value_callback_called);
+    }
+
     // operator| overload
     {
         std::atomic<bool> set_value_called{false};

--- a/libs/parallelism/execution/tests/unit/algorithm_let_value.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_let_value.cpp
@@ -1,0 +1,144 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include "algorithm_test_utils.hpp"
+
+#include <atomic>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace ex = hpx::execution::experimental;
+
+// This overload is only used to check dispatching. It is not a useful
+// implementation.
+template <typename F>
+auto tag_invoke(ex::let_value_t, custom_sender_tag_invoke s, F&&)
+{
+    s.tag_invoke_overload_called = true;
+    return void_sender{};
+}
+
+int main()
+{
+    // Success path
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> let_value_callback_called{false};
+        auto s1 = void_sender{};
+        auto s2 = ex::let_value(std::move(s1), [&]() {
+            let_value_callback_called = true;
+            return void_sender();
+        });
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s2), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+        HPX_TEST(let_value_callback_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> let_value_callback_called{false};
+        auto s1 = ex::just(42);
+        auto s2 = ex::let_value(std::move(s1), [&](int& x) {
+            HPX_TEST_EQ(x, 42);
+            let_value_callback_called = true;
+            return ex::just(x);
+        });
+        auto f = [](int x) { HPX_TEST_EQ(x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s2), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+        HPX_TEST(let_value_callback_called);
+    }
+
+    // operator| overload
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> let_value_callback_called{false};
+        auto s = void_sender{} | ex::let_value([&]() {
+            let_value_callback_called = true;
+            return void_sender();
+        });
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+        HPX_TEST(let_value_callback_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> let_value_callback_called{false};
+        auto s = ex::just(42) | ex::let_value([&](int& x) {
+            HPX_TEST_EQ(x, 42);
+            let_value_callback_called = true;
+            return ex::just(x);
+        });
+        auto f = [](int x) { HPX_TEST_EQ(x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+        HPX_TEST(let_value_callback_called);
+    }
+
+    // tag_invoke overload
+    {
+        std::atomic<bool> tag_invoke_overload_called{false};
+        custom_sender_tag_invoke{tag_invoke_overload_called} |
+            ex::let_value([]() { return ex::just(); });
+        HPX_TEST(tag_invoke_overload_called);
+    }
+
+    // Failure path
+    {
+        std::atomic<bool> set_error_called{false};
+        std::atomic<bool> let_value_callback_called{false};
+        auto s1 = error_sender{};
+        auto s2 = ex::let_value(std::move(s1), [&]() {
+            let_value_callback_called = true;
+            return void_sender();
+        });
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, set_error_called};
+        auto os = ex::connect(std::move(s2), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_error_called);
+        HPX_TEST(!let_value_callback_called);
+    }
+
+    {
+        // Can have multiple value types (i.e. different for the predecessor
+        // sender, and the one produced by the factory), as long as the receiver
+        // connected to the let_value sender can handle them. In the test below
+        // value_types for the let_value sender is Variant<Tuple<int>, Tuple<>>.
+        std::atomic<bool> set_error_called{false};
+        std::atomic<bool> let_value_callback_called{false};
+        auto s1 = error_sender{};
+        auto s2 = ex::let_value(std::move(s1), [&]() {
+            let_value_callback_called = true;
+            return ex::just(42);
+        });
+        auto r = error_callback_receiver<decltype(check_exception_ptr)>{
+            check_exception_ptr, set_error_called};
+        auto os = ex::connect(std::move(s2), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_error_called);
+        HPX_TEST(!let_value_callback_called);
+    }
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/execution/tests/unit/algorithm_on.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_on.cpp
@@ -7,6 +7,8 @@
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/testing.hpp>
 
+#include "algorithm_test_utils.hpp"
+
 #include <atomic>
 #include <exception>
 #include <stdexcept>
@@ -16,187 +18,10 @@
 
 namespace ex = hpx::execution::experimental;
 
-struct scheduler
-{
-    std::atomic<bool>& execute_called;
-    std::atomic<bool>& tag_invoke_on_called;
-
-    template <typename F>
-    void execute(F&& f) const
-    {
-        execute_called = true;
-        HPX_INVOKE(std::forward<F>(f));
-    }
-
-    template <template <class...> class Tuple,
-        template <class...> class Variant>
-    using value_types = Variant<Tuple<>>;
-
-    template <template <class...> class Variant>
-    using error_types = Variant<std::exception_ptr>;
-
-    static constexpr bool sends_done = false;
-
-    template <typename R>
-    struct operation_state
-    {
-        std::decay_t<R> r;
-
-        void start() noexcept
-        {
-            ex::set_value(std::move(r));
-        };
-    };
-
-    template <typename R>
-    auto connect(R&& r) &&
-    {
-        return operation_state<R>{std::forward<R>(r)};
-    }
-
-    struct sender
-    {
-        template <template <class...> class Tuple,
-            template <class...> class Variant>
-        using value_types = Variant<Tuple<>>;
-
-        template <template <class...> class Variant>
-        using error_types = Variant<std::exception_ptr>;
-
-        static constexpr bool sends_done = false;
-
-        template <typename R>
-        auto connect(R&& r) &&
-        {
-            return operation_state<R>{std::forward<R>(r)};
-        }
-    };
-
-    constexpr sender schedule() const
-    {
-        return {};
-    }
-
-    bool operator==(scheduler const&) const noexcept
-    {
-        return true;
-    }
-
-    bool operator!=(scheduler const&) const noexcept
-    {
-        return false;
-    }
-};
-
-struct scheduler2 : scheduler
-{
-    explicit scheduler2(scheduler s)
-      : scheduler(std::move(s))
-    {
-    }
-};
-
-template <typename F>
-struct callback_receiver
-{
-    std::decay_t<F> f;
-    std::atomic<bool>& set_value_called;
-
-    template <typename E>
-    void set_error(E&&) noexcept
-    {
-        HPX_TEST(false);
-    }
-
-    void set_done() noexcept
-    {
-        HPX_TEST(false);
-    };
-
-    template <typename... Ts>
-    auto set_value(Ts&&... ts) noexcept
-        -> decltype(HPX_INVOKE(f, std::forward<Ts>(ts)...), void())
-    {
-        HPX_INVOKE(f, std::forward<Ts>(ts)...);
-        set_value_called = true;
-    }
-};
-
-struct error_sender
-{
-    template <template <class...> class Tuple,
-        template <class...> class Variant>
-    using value_types = Variant<Tuple<>>;
-
-    template <template <class...> class Variant>
-    using error_types = Variant<std::exception_ptr>;
-
-    static constexpr bool sends_done = false;
-
-    template <typename R>
-    struct operation_state
-    {
-        std::decay_t<R> r;
-        void start() noexcept
-        {
-            try
-            {
-                throw std::runtime_error("error");
-            }
-            catch (...)
-            {
-                ex::set_error(std::move(r), std::current_exception());
-            }
-        };
-    };
-
-    template <typename R>
-    auto connect(R&& r) &&
-    {
-        return operation_state<R>{std::forward<R>(r)};
-    }
-};
-
-template <typename F>
-struct error_callback_receiver
-{
-    std::decay_t<F> f;
-    std::atomic<bool>& set_error_called;
-
-    template <typename E>
-    void set_error(E&&) noexcept
-    {
-        set_error_called = true;
-    }
-
-    void set_done() noexcept
-    {
-        HPX_TEST(false);
-    };
-
-    template <typename... Ts>
-    void set_value(Ts&&...) noexcept
-    {
-        HPX_TEST(false);
-    }
-};
-
-void check_exception_ptr(std::exception_ptr eptr)
-{
-    try
-    {
-        std::rethrow_exception(eptr);
-    }
-    catch (const std::runtime_error& e)
-    {
-        HPX_TEST_EQ(std::string(e.what()), std::string("error"));
-    }
-};
-
 template <typename S>
 auto tag_invoke(ex::on_t, S&&, scheduler2&& s)
 {
-    s.tag_invoke_on_called = true;
+    s.tag_invoke_overload_called = true;
     return scheduler::sender{};
 }
 
@@ -264,7 +89,7 @@ int main()
             HPX_TEST_EQ(x, 3);
         };
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
-        auto os = ex::connect(s, r);
+        auto os = ex::connect(std::move(s), r);
         ex::start(os);
         HPX_TEST(set_value_called);
         HPX_TEST(!tag_invoke_overload_called);

--- a/libs/parallelism/execution/tests/unit/algorithm_on.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_on.cpp
@@ -30,71 +30,85 @@ int main()
     // Success path
     {
         std::atomic<bool> set_value_called{false};
+        std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
         auto s = ex::on(ex::just(),
-            scheduler{scheduler_execute_called, tag_invoke_overload_called});
+            scheduler{scheduler_schedule_called, scheduler_execute_called,
+                tag_invoke_overload_called});
         auto f = [] {};
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
         HPX_TEST(!tag_invoke_overload_called);
-        HPX_TEST(scheduler_execute_called);
+        HPX_TEST(scheduler_schedule_called);
+        HPX_TEST(!scheduler_execute_called);
     }
 
     {
         std::atomic<bool> set_value_called{false};
+        std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
         auto s = ex::on(ex::just(3),
-            scheduler{scheduler_execute_called, tag_invoke_overload_called});
+            scheduler{scheduler_schedule_called, scheduler_execute_called,
+                tag_invoke_overload_called});
         auto f = [](int x) { HPX_TEST_EQ(x, 3); };
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
         HPX_TEST(!tag_invoke_overload_called);
-        HPX_TEST(scheduler_execute_called);
+        HPX_TEST(scheduler_schedule_called);
+        HPX_TEST(!scheduler_execute_called);
     }
 
     {
         std::atomic<bool> set_value_called{false};
+        std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
         auto s = ex::on(ex::just(custom_type_non_default_constructible{42}),
-            scheduler{scheduler_execute_called, tag_invoke_overload_called});
+            scheduler{scheduler_schedule_called, scheduler_execute_called,
+                tag_invoke_overload_called});
         auto f = [](auto x) { HPX_TEST_EQ(x.x, 42); };
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
         HPX_TEST(!tag_invoke_overload_called);
-        HPX_TEST(scheduler_execute_called);
+        HPX_TEST(scheduler_schedule_called);
+        HPX_TEST(!scheduler_execute_called);
     }
 
     {
         std::atomic<bool> set_value_called{false};
+        std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
         auto s = ex::on(
             ex::just(custom_type_non_default_constructible_non_copyable{42}),
-            scheduler{scheduler_execute_called, tag_invoke_overload_called});
+            scheduler{scheduler_schedule_called, scheduler_execute_called,
+                tag_invoke_overload_called});
         auto f = [](auto x) { HPX_TEST_EQ(x.x, 42); };
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
         HPX_TEST(!tag_invoke_overload_called);
-        HPX_TEST(scheduler_execute_called);
+        HPX_TEST(scheduler_schedule_called);
+        HPX_TEST(!scheduler_execute_called);
     }
 
     {
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> scheduler_execute_called{false};
+        std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
         auto s = ex::on(ex::just(std::string("hello"), 3),
-            scheduler{scheduler_execute_called, tag_invoke_overload_called});
+            scheduler{scheduler_schedule_called, scheduler_execute_called,
+                tag_invoke_overload_called});
         auto f = [](std::string s, int x) {
             HPX_TEST_EQ(s, std::string("hello"));
             HPX_TEST_EQ(x, 3);
@@ -104,16 +118,18 @@ int main()
         ex::start(os);
         HPX_TEST(set_value_called);
         HPX_TEST(!tag_invoke_overload_called);
-        HPX_TEST(scheduler_execute_called);
+        HPX_TEST(!scheduler_execute_called);
+        HPX_TEST(scheduler_schedule_called);
     }
 
     // operator| overload
     {
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> scheduler_execute_called{false};
+        std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
         auto s = ex::just(std::string("hello"), 3) |
-            ex::on(scheduler{
+            ex::on(scheduler{scheduler_schedule_called,
                 scheduler_execute_called, tag_invoke_overload_called});
         auto f = [](std::string s, int x) {
             HPX_TEST_EQ(s, std::string("hello"));
@@ -124,16 +140,18 @@ int main()
         ex::start(os);
         HPX_TEST(set_value_called);
         HPX_TEST(!tag_invoke_overload_called);
-        HPX_TEST(scheduler_execute_called);
+        HPX_TEST(scheduler_schedule_called);
+        HPX_TEST(!scheduler_execute_called);
     }
 
     // tag_invoke overload
     {
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
         auto s = ex::on(ex::just(),
-            scheduler2{scheduler{
+            scheduler2{scheduler{scheduler_schedule_called,
                 scheduler_execute_called, tag_invoke_overload_called}});
         auto f = [] {};
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
@@ -141,6 +159,7 @@ int main()
         ex::start(os);
         HPX_TEST(set_value_called);
         HPX_TEST(tag_invoke_overload_called);
+        HPX_TEST(!scheduler_schedule_called);
         HPX_TEST(!scheduler_execute_called);
     }
 
@@ -148,15 +167,18 @@ int main()
     {
         std::atomic<bool> set_error_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
         auto s = ex::on(error_sender{},
-            scheduler{scheduler_execute_called, tag_invoke_overload_called});
+            scheduler{scheduler_schedule_called, scheduler_execute_called,
+                tag_invoke_overload_called});
         auto r = error_callback_receiver<decltype(check_exception_ptr)>{
             check_exception_ptr, set_error_called};
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_error_called);
         HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!scheduler_schedule_called);
         HPX_TEST(!scheduler_execute_called);
     }
 

--- a/libs/parallelism/execution/tests/unit/algorithm_on.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_on.cpp
@@ -62,6 +62,37 @@ int main()
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> scheduler_execute_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
+        auto s = ex::on(ex::just(custom_type_non_default_constructible{42}),
+            scheduler{scheduler_execute_called, tag_invoke_overload_called});
+        auto f = [](auto x) { HPX_TEST_EQ(x.x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(scheduler_execute_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> scheduler_execute_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
+        auto s = ex::on(
+            ex::just(custom_type_non_default_constructible_non_copyable{42}),
+            scheduler{scheduler_execute_called, tag_invoke_overload_called});
+        auto f = [](auto x) { HPX_TEST_EQ(x.x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(scheduler_execute_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        std::atomic<bool> scheduler_execute_called{false};
+        std::atomic<bool> tag_invoke_overload_called{false};
         auto s = ex::on(ex::just(std::string("hello"), 3),
             scheduler{scheduler_execute_called, tag_invoke_overload_called});
         auto f = [](std::string s, int x) {

--- a/libs/parallelism/execution/tests/unit/algorithm_sync_wait.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_sync_wait.cpp
@@ -44,6 +44,22 @@ int main()
         HPX_TEST_EQ(ex::sync_wait(ex::just(3)), 3);
     }
 
+    {
+        HPX_TEST_EQ(
+            ex::sync_wait(ex::just(custom_type_non_default_constructible{42}))
+                .x,
+            42);
+    }
+
+    {
+        HPX_TEST_EQ(
+            ex::sync_wait(
+                ex::just(
+                    custom_type_non_default_constructible_non_copyable{42}))
+                .x,
+            42);
+    }
+
     // operator| overload
     {
         std::atomic<bool> start_called{false};

--- a/libs/parallelism/execution/tests/unit/algorithm_test_utils.hpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_test_utils.hpp
@@ -1,0 +1,342 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <atomic>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#pragma once
+
+struct void_sender
+{
+    template <template <typename...> class Tuple,
+        template <typename...> class Variant>
+    using value_types = Variant<Tuple<>>;
+
+    template <template <typename...> class Variant>
+    using error_types = Variant<>;
+
+    static constexpr bool sends_done = false;
+
+    template <typename R>
+    struct operation_state
+    {
+        std::decay_t<R> r;
+        void start() noexcept
+        {
+            hpx::execution::experimental::set_value(std::move(r));
+        }
+    };
+
+    template <typename R>
+    operation_state<R> connect(R&& r)
+    {
+        return {std::forward<R>(r)};
+    }
+};
+
+struct error_sender
+{
+    template <template <typename...> class Tuple,
+        template <typename...> class Variant>
+    using value_types = Variant<Tuple<>>;
+
+    template <template <typename...> class Variant>
+    using error_types = Variant<std::exception_ptr>;
+
+    static constexpr bool sends_done = false;
+
+    template <typename R>
+    struct operation_state
+    {
+        std::decay_t<R> r;
+        void start() noexcept
+        {
+            try
+            {
+                throw std::runtime_error("error");
+            }
+            catch (...)
+            {
+                hpx::execution::experimental::set_error(
+                    std::move(r), std::current_exception());
+            }
+        }
+    };
+
+    template <typename R>
+    operation_state<R> connect(R&& r)
+    {
+        return {std::forward<R>(r)};
+    }
+};
+
+template <typename F>
+struct callback_receiver
+{
+    std::decay_t<F> f;
+    std::atomic<bool>& set_value_called;
+
+    template <typename E>
+    void set_error(E&&) noexcept
+    {
+        HPX_TEST(false);
+    }
+
+    void set_done() noexcept
+    {
+        HPX_TEST(false);
+    };
+
+    template <typename... Ts>
+    auto set_value(Ts&&... ts) noexcept
+        -> decltype(HPX_INVOKE(f, std::forward<Ts>(ts)...), void())
+    {
+        HPX_INVOKE(f, std::forward<Ts>(ts)...);
+        set_value_called = true;
+    }
+};
+
+template <typename F>
+struct error_callback_receiver
+{
+    std::decay_t<F> f;
+    std::atomic<bool>& set_error_called;
+
+    template <typename E>
+    void set_error(E&& e) noexcept
+    {
+        HPX_INVOKE(f, std::forward<E>(e));
+        set_error_called = true;
+    }
+
+    void set_done() noexcept
+    {
+        HPX_TEST(false);
+    };
+
+    template <typename... Ts>
+    void set_value(Ts&&...) noexcept
+    {
+        HPX_TEST(false);
+    }
+};
+
+template <typename T>
+struct error_typed_sender
+{
+    template <template <class...> class Tuple,
+        template <class...> class Variant>
+    using value_types = Variant<Tuple<T>>;
+
+    template <template <class...> class Variant>
+    using error_types = Variant<std::exception_ptr>;
+
+    static constexpr bool sends_done = false;
+
+    template <typename R>
+    struct operation_state
+    {
+        std::decay_t<R> r;
+
+        void start() noexcept
+        {
+            try
+            {
+                throw std::runtime_error("error");
+            }
+            catch (...)
+            {
+                hpx::execution::experimental::set_error(
+                    std::move(r), std::current_exception());
+            }
+        };
+    };
+
+    template <typename R>
+    auto connect(R&& r) &&
+    {
+        return operation_state<R>{std::forward<R>(r)};
+    }
+};
+
+void check_exception_ptr(std::exception_ptr eptr)
+{
+    try
+    {
+        std::rethrow_exception(eptr);
+    }
+    catch (const std::runtime_error& e)
+    {
+        HPX_TEST_EQ(std::string(e.what()), std::string("error"));
+    }
+};
+
+struct custom_sender_tag_invoke
+{
+    std::atomic<bool>& tag_invoke_overload_called;
+
+    template <template <typename...> class Tuple,
+        template <typename...> class Variant>
+    using value_types = Variant<Tuple<>>;
+
+    template <template <typename...> class Variant>
+    using error_types = Variant<>;
+
+    static constexpr bool sends_done = false;
+
+    template <typename R>
+    struct operation_state
+    {
+        std::decay_t<R> r;
+        void start() noexcept
+        {
+            hpx::execution::experimental::set_value(std::move(r));
+        }
+    };
+
+    template <typename R>
+    operation_state<R> connect(R&& r)
+    {
+        return {std::forward<R>(r)};
+    }
+};
+
+struct custom_sender
+{
+    std::atomic<bool>& start_called;
+    std::atomic<bool>& connect_called;
+    std::atomic<bool>& tag_invoke_overload_called;
+
+    template <template <class...> class Tuple,
+        template <class...> class Variant>
+    using value_types = Variant<Tuple<>>;
+
+    template <template <class...> class Variant>
+    using error_types = Variant<std::exception_ptr>;
+
+    static constexpr bool sends_done = false;
+
+    template <typename R>
+    struct operation_state
+    {
+        std::atomic<bool>& start_called;
+        std::decay_t<R> r;
+        void start() noexcept
+        {
+            start_called = true;
+            hpx::execution::experimental::set_value(std::move(r));
+        };
+    };
+
+    template <typename R>
+    auto connect(R&& r) &&
+    {
+        connect_called = true;
+        return operation_state<R>{start_called, std::forward<R>(r)};
+    }
+};
+
+struct custom_sender2 : custom_sender
+{
+    explicit custom_sender2(custom_sender s)
+      : custom_sender(std::move(s))
+    {
+    }
+};
+
+template <typename T>
+struct custom_type
+{
+    std::atomic<bool>& tag_invoke_overload_called;
+    std::decay_t<T> x;
+};
+
+struct scheduler
+{
+    std::atomic<bool>& execute_called;
+    std::atomic<bool>& tag_invoke_overload_called;
+
+    template <typename F>
+    void execute(F&& f) const
+    {
+        execute_called = true;
+        HPX_INVOKE(std::forward<F>(f));
+    }
+
+    template <template <class...> class Tuple,
+        template <class...> class Variant>
+    using value_types = Variant<Tuple<>>;
+
+    template <template <class...> class Variant>
+    using error_types = Variant<std::exception_ptr>;
+
+    static constexpr bool sends_done = false;
+
+    template <typename R>
+    struct operation_state
+    {
+        std::decay_t<R> r;
+
+        void start() noexcept
+        {
+            hpx::execution::experimental::set_value(std::move(r));
+        };
+    };
+
+    template <typename R>
+    auto connect(R&& r) &&
+    {
+        return operation_state<R>{std::forward<R>(r)};
+    }
+
+    struct sender
+    {
+        template <template <class...> class Tuple,
+            template <class...> class Variant>
+        using value_types = Variant<Tuple<>>;
+
+        template <template <class...> class Variant>
+        using error_types = Variant<std::exception_ptr>;
+
+        static constexpr bool sends_done = false;
+
+        template <typename R>
+        auto connect(R&& r) &&
+        {
+            return operation_state<R>{std::forward<R>(r)};
+        }
+    };
+
+    constexpr sender schedule() const
+    {
+        return {};
+    }
+
+    bool operator==(scheduler const&) const noexcept
+    {
+        return true;
+    }
+
+    bool operator!=(scheduler const&) const noexcept
+    {
+        return false;
+    }
+};
+
+struct scheduler2 : scheduler
+{
+    explicit scheduler2(scheduler s)
+      : scheduler(std::move(s))
+    {
+    }
+};

--- a/libs/parallelism/execution/tests/unit/algorithm_test_utils.hpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_test_utils.hpp
@@ -335,6 +335,7 @@ struct custom_type_non_default_constructible_non_copyable
 
 struct scheduler
 {
+    std::atomic<bool>& schedule_called;
     std::atomic<bool>& execute_called;
     std::atomic<bool>& tag_invoke_overload_called;
 
@@ -389,8 +390,9 @@ struct scheduler
         }
     };
 
-    constexpr sender schedule() const
+    sender schedule()
     {
+        schedule_called = true;
         return {};
     }
 

--- a/libs/parallelism/execution/tests/unit/algorithm_test_utils.hpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_test_utils.hpp
@@ -305,7 +305,7 @@ struct custom_type_non_default_constructible
 {
     int x;
     custom_type_non_default_constructible() = delete;
-    custom_type_non_default_constructible(int x)
+    explicit custom_type_non_default_constructible(int x)
       : x(x){};
     custom_type_non_default_constructible(
         custom_type_non_default_constructible&&) = default;
@@ -321,7 +321,7 @@ struct custom_type_non_default_constructible_non_copyable
 {
     int x;
     custom_type_non_default_constructible_non_copyable() = delete;
-    custom_type_non_default_constructible_non_copyable(int x)
+    explicit custom_type_non_default_constructible_non_copyable(int x)
       : x(x){};
     custom_type_non_default_constructible_non_copyable(
         custom_type_non_default_constructible_non_copyable&&) = default;

--- a/libs/parallelism/execution/tests/unit/algorithm_transform.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_transform.cpp
@@ -66,6 +66,35 @@ int main()
 
     {
         std::atomic<bool> set_value_called{false};
+        auto s = ex::transform(
+            ex::just(custom_type_non_default_constructible{0}), [](auto x) {
+                ++(x.x);
+                return x;
+            });
+        auto f = [](auto x) { HPX_TEST_EQ(x.x, 1); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::transform(
+            ex::just(custom_type_non_default_constructible_non_copyable{0}),
+            [](auto x) {
+                ++(x.x);
+                return x;
+            });
+        auto f = [](auto x) { HPX_TEST_EQ(x.x, 1); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
         auto s1 = ex::transform(ex::just(0), [](int x) { return ++x; });
         auto s2 = ex::transform(std::move(s1), [](int x) { return ++x; });
         auto s3 = ex::transform(std::move(s2), [](int x) { return ++x; });

--- a/libs/parallelism/execution/tests/unit/algorithm_when_all.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_when_all.cpp
@@ -9,6 +9,8 @@
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/testing.hpp>
 
+#include "algorithm_test_utils.hpp"
+
 #include <atomic>
 #include <exception>
 #include <stdexcept>
@@ -18,117 +20,14 @@
 
 namespace ex = hpx::execution::experimental;
 
-template <typename F>
-struct callback_receiver
-{
-    std::decay_t<F> f;
-    std::atomic<bool>& set_value_called;
-
-    template <typename E>
-    void set_error(E&&) noexcept
-    {
-        HPX_TEST(false);
-    }
-
-    void set_done() noexcept
-    {
-        HPX_TEST(false);
-    };
-
-    template <typename... Ts>
-    auto set_value(Ts&&... ts) noexcept
-        -> decltype(HPX_INVOKE(f, std::forward<Ts>(ts)...), void())
-    {
-        HPX_INVOKE(f, std::forward<Ts>(ts)...);
-        set_value_called = true;
-    }
-};
-
-template <typename F>
-struct error_callback_receiver
-{
-    std::decay_t<F> f;
-    std::atomic<bool>& set_error_called;
-
-    template <typename E>
-    void set_error(E&& e) noexcept
-    {
-        HPX_INVOKE(f, std::forward<E>(e));
-        set_error_called = true;
-    }
-
-    void set_done() noexcept
-    {
-        HPX_TEST(false);
-    };
-
-    template <typename... Ts>
-    void set_value(Ts&&...) noexcept
-    {
-        HPX_TEST(false);
-    }
-};
-
-struct custom_type
-{
-    std::atomic<bool>& tag_invoke_overload_called;
-};
-
+// This overload is only used to check dispatching. It is not a useful
+// implementation.
 template <typename... Ss>
-auto tag_invoke(ex::when_all_t, custom_type s, Ss&&... ss)
+auto tag_invoke(ex::when_all_t, custom_sender_tag_invoke s, Ss&&... ss)
 {
     s.tag_invoke_overload_called = true;
     return ex::when_all(std::forward<Ss>(ss)...);
 }
-
-template <typename T>
-struct error_sender
-{
-    template <template <class...> class Tuple,
-        template <class...> class Variant>
-    using value_types = Variant<Tuple<T>>;
-
-    template <template <class...> class Variant>
-    using error_types = Variant<std::exception_ptr>;
-
-    static constexpr bool sends_done = false;
-
-    template <typename R>
-    struct operation_state
-    {
-        std::decay_t<R> r;
-
-        void start() noexcept
-        {
-            try
-            {
-                throw std::runtime_error("error");
-            }
-            catch (...)
-            {
-                ex::set_error(std::move(r), std::current_exception());
-            }
-        };
-    };
-
-    template <typename R>
-    auto connect(R&& r) &&
-    {
-        return operation_state<R>{std::forward<R>(r)};
-    }
-};
-
-void check_exception_ptr(std::exception_ptr eptr)
-{
-    try
-    {
-        std::rethrow_exception(eptr);
-    }
-    catch (const std::runtime_error& e)
-    {
-        HPX_TEST_EQ(std::string(e.what()), std::string("error"));
-    }
-};
 
 int main()
 {
@@ -161,8 +60,8 @@ int main()
     {
         std::atomic<bool> receiver_set_value_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
-        auto s =
-            ex::when_all(custom_type{tag_invoke_overload_called}, ex::just(42));
+        auto s = ex::when_all(
+            custom_sender_tag_invoke{tag_invoke_overload_called}, ex::just(42));
         auto f = [](int x) { HPX_TEST_EQ(x, 42); };
         auto r = callback_receiver<decltype(f)>{f, receiver_set_value_called};
         auto os = ex::connect(std::move(s), std::move(r));
@@ -174,7 +73,7 @@ int main()
     // Failure path
     {
         std::atomic<bool> set_error_called{false};
-        auto s = ex::when_all(error_sender<double>{});
+        auto s = ex::when_all(error_typed_sender<double>{});
         auto r = error_callback_receiver<decltype(check_exception_ptr)>{
             check_exception_ptr, set_error_called};
         auto os = ex::connect(std::move(s), std::move(r));
@@ -184,7 +83,7 @@ int main()
 
     {
         std::atomic<bool> set_error_called{false};
-        auto s = ex::when_all(ex::just(42), error_sender<double>{});
+        auto s = ex::when_all(ex::just(42), error_typed_sender<double>{});
         auto r = error_callback_receiver<decltype(check_exception_ptr)>{
             check_exception_ptr, set_error_called};
         auto os = ex::connect(std::move(s), std::move(r));
@@ -194,7 +93,7 @@ int main()
 
     {
         std::atomic<bool> set_error_called{false};
-        auto s = ex::when_all(error_sender<double>{}, ex::just(42));
+        auto s = ex::when_all(error_typed_sender<double>{}, ex::just(42));
         auto r = error_callback_receiver<decltype(check_exception_ptr)>{
             check_exception_ptr, set_error_called};
         auto os = ex::connect(std::move(s), std::move(r));

--- a/libs/parallelism/execution/tests/unit/algorithm_when_all.cpp
+++ b/libs/parallelism/execution/tests/unit/algorithm_when_all.cpp
@@ -58,6 +58,28 @@ int main()
     }
 
     {
+        std::atomic<bool> set_value_called{false};
+        auto s =
+            ex::when_all(ex::just(custom_type_non_default_constructible(42)));
+        auto f = [](auto x) { HPX_TEST_EQ(x.x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::when_all(
+            ex::just(custom_type_non_default_constructible_non_copyable(42)));
+        auto f = [](auto x) { HPX_TEST_EQ(x.x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    {
         std::atomic<bool> receiver_set_value_called{false};
         std::atomic<bool> tag_invoke_overload_called{false};
         auto s = ex::when_all(

--- a/libs/parallelism/executors/include/hpx/executors/p0443_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/p0443_executor.hpp
@@ -144,6 +144,12 @@ namespace hpx { namespace execution { namespace experimental {
             {
                 return {std::move(exec), std::forward<R>(r)};
             }
+
+            template <typename R>
+            operation_state<Executor, R> connect(R&& r) &
+            {
+                return {exec, std::forward<R>(r)};
+            }
         };
 
         template <template <class...> class Tuple,

--- a/libs/parallelism/executors/tests/unit/p0443_executor.cpp
+++ b/libs/parallelism/executors/tests/unit/p0443_executor.cpp
@@ -9,12 +9,15 @@
 #include <hpx/functional.hpp>
 #include <hpx/init.hpp>
 #include <hpx/modules/testing.hpp>
+#include <hpx/mutex.hpp>
 #include <hpx/thread.hpp>
 
 #include <array>
 #include <atomic>
 #include <chrono>
 #include <cstddef>
+#include <exception>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <type_traits>
@@ -154,6 +157,7 @@ void test_sender_receiver_transform_wait()
             executed = true;
         });
     ex::sync_wait(std::move(work2));
+
     HPX_TEST_EQ(transform_count, std::size_t(2));
     HPX_TEST(executed);
 }
@@ -515,42 +519,40 @@ void test_just_on_two_args()
 
 void test_when_all()
 {
-#if defined(HPX_HAVE_CXX17_STD_VARIANT)
     ex::executor exec{};
 
     {
         hpx::thread::id parent_id = hpx::this_thread::get_id();
 
-        auto begin1 = ex::schedule(exec);
-        auto work1 = ex::transform(begin1, [parent_id]() {
+        auto work1 = ex::schedule(exec) | ex::transform([parent_id]() {
             HPX_TEST_NEQ(parent_id, hpx::this_thread::get_id());
             return 42;
         });
 
-        auto begin2 = ex::schedule(exec);
-        auto work2 = ex::transform(begin2, [parent_id]() {
+        auto work2 = ex::schedule(exec) | ex::transform([parent_id]() {
             HPX_TEST_NEQ(parent_id, hpx::this_thread::get_id());
             return std::string("hello");
         });
 
-        auto begin3 = ex::schedule(exec);
-        auto work3 = ex::transform(begin3, [parent_id]() {
+        auto work3 = ex::schedule(exec) | ex::transform([parent_id]() {
             HPX_TEST_NEQ(parent_id, hpx::this_thread::get_id());
             return 3.14;
         });
 
-        auto when1 = ex::when_all(work1, work2, work3);
+        auto when1 =
+            ex::when_all(std::move(work1), std::move(work2), std::move(work3));
 
         std::atomic<bool> executed{false};
-        auto transform1 = ex::transform(
-            when1, [parent_id, &executed](int x, std::string y, double z) {
-                HPX_TEST_NEQ(parent_id, hpx::this_thread::get_id());
-                HPX_TEST_EQ(x, 42);
-                HPX_TEST_EQ(y, std::string("hello"));
-                HPX_TEST_EQ(z, 3.14);
-                executed = true;
-            });
-        ex::sync_wait(transform1);
+        std::move(when1) |
+            ex::transform(
+                [parent_id, &executed](int x, std::string y, double z) {
+                    HPX_TEST_NEQ(parent_id, hpx::this_thread::get_id());
+                    HPX_TEST_EQ(x, 42);
+                    HPX_TEST_EQ(y, std::string("hello"));
+                    HPX_TEST_EQ(z, 3.14);
+                    executed = true;
+                }) |
+            ex::sync_wait();
         HPX_TEST(executed);
     }
 
@@ -559,33 +561,29 @@ void test_when_all()
 
         // The exception is likely to be thrown before set_value from the second
         // sender is called because the second sender sleeps.
-        auto begin1 = ex::schedule(exec);
-        auto work1 = ex::transform(begin1, [parent_id]() {
+        auto work1 = ex::schedule(exec) | ex::transform([parent_id]() {
             HPX_TEST_NEQ(parent_id, hpx::this_thread::get_id());
             throw std::runtime_error("error");
             return 42;
         });
 
-        auto begin2 = ex::schedule(exec);
-        auto work2 = ex::transform(begin2, [parent_id]() {
+        auto work2 = ex::schedule(exec) | ex::transform([parent_id]() {
             HPX_TEST_NEQ(parent_id, hpx::this_thread::get_id());
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
             return std::string("hello");
         });
 
-        auto when1 = ex::when_all(work1, work2);
-        auto transform1 =
-            ex::transform(when1, [parent_id](int x, std::string y) {
-                HPX_TEST_NEQ(parent_id, hpx::this_thread::get_id());
-                HPX_TEST_EQ(x, 42);
-                HPX_TEST_EQ(y, std::string("hello"));
-            });
-
         bool exception_thrown = false;
 
         try
         {
-            ex::sync_wait(transform1);
+            ex::when_all(std::move(work1), std::move(work2)) |
+                ex::transform([parent_id](int x, std::string y) {
+                    HPX_TEST_NEQ(parent_id, hpx::this_thread::get_id());
+                    HPX_TEST_EQ(x, 42);
+                    HPX_TEST_EQ(y, std::string("hello"));
+                }) |
+                ex::sync_wait();
         }
         catch (std::runtime_error const& e)
         {
@@ -601,33 +599,29 @@ void test_when_all()
 
         // The exception is likely to be thrown after set_value from the second
         // sender is called because the first sender sleeps before throwing.
-        auto begin1 = ex::schedule(exec);
-        auto work1 = ex::transform(begin1, [parent_id]() {
+        auto work1 = ex::schedule(exec) | ex::transform([parent_id]() {
             HPX_TEST_NEQ(parent_id, hpx::this_thread::get_id());
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
             throw std::runtime_error("error");
             return 42;
         });
 
-        auto begin2 = ex::schedule(exec);
-        auto work2 = ex::transform(begin2, [parent_id]() {
+        auto work2 = ex::schedule(exec) | ex::transform([parent_id]() {
             HPX_TEST_NEQ(parent_id, hpx::this_thread::get_id());
             return std::string("hello");
         });
-
-        auto when1 = ex::when_all(work1, work2);
-        auto transform1 =
-            ex::transform(when1, [parent_id](int x, std::string y) {
-                HPX_TEST_NEQ(parent_id, hpx::this_thread::get_id());
-                HPX_TEST_EQ(x, 42);
-                HPX_TEST_EQ(y, std::string("hello"));
-            });
 
         bool exception_thrown = false;
 
         try
         {
-            ex::sync_wait(transform1);
+            ex::when_all(std::move(work1), std::move(work2)) |
+                ex::transform([parent_id](int x, std::string y) {
+                    HPX_TEST_NEQ(parent_id, hpx::this_thread::get_id());
+                    HPX_TEST_EQ(x, 42);
+                    HPX_TEST_EQ(y, std::string("hello"));
+                }) |
+                ex::sync_wait();
         }
         catch (std::runtime_error const& e)
         {
@@ -637,7 +631,6 @@ void test_when_all()
 
         HPX_TEST(exception_thrown);
     }
-#endif
 }
 
 void test_future_sender()
@@ -782,7 +775,6 @@ void test_future_sender()
         HPX_TEST(called);
     }
 
-#if defined(HPX_HAVE_CXX17_STD_VARIANT)
     {
         auto s1 = ex::just_on(ex::executor{}, std::size_t(42));
         auto s2 = ex::just_on(ex::executor{}, 3.14);
@@ -792,7 +784,6 @@ void test_future_sender()
             [](std::size_t x, double, std::string z) { return z.size() + x; }));
         HPX_TEST_EQ(f.get(), std::size_t(47));
     }
-#endif
 
     // mixing senders and futures
     {
@@ -808,7 +799,6 @@ void test_future_sender()
             42);
     }
 
-#if defined(HPX_HAVE_CXX17_STD_VARIANT)
     {
         auto s1 = ex::just_on(ex::executor{}, std::size_t(42));
         auto s2 = ex::just_on(ex::executor{}, 3.14);
@@ -829,7 +819,370 @@ void test_future_sender()
 
         HPX_TEST_EQ(last.get(), std::size_t(18));
     }
-#endif
+}
+
+void test_ensure_started()
+{
+    ex::executor exec{};
+
+    {
+        ex::schedule(exec) | ex::ensure_started() | ex::sync_wait();
+    }
+
+    {
+        auto s = ex::just_on(exec, 42) | ex::ensure_started();
+        HPX_TEST_EQ(ex::sync_wait(std::move(s)), 42);
+    }
+
+    {
+        auto s = ex::just_on(exec, 42) | ex::ensure_started() | ex::on(exec);
+        HPX_TEST_EQ(ex::sync_wait(std::move(s)), 42);
+    }
+
+    {
+        auto s = ex::just_on(exec, 42) | ex::ensure_started();
+        HPX_TEST_EQ(ex::sync_wait(s), 42);
+        HPX_TEST_EQ(ex::sync_wait(s), 42);
+        HPX_TEST_EQ(ex::sync_wait(s), 42);
+        HPX_TEST_EQ(ex::sync_wait(std::move(s)), 42);
+    }
+}
+
+void test_ensure_started_when_all()
+{
+    ex::executor exec{};
+
+    {
+        std::atomic<std::size_t> first_task_calls{0};
+        std::atomic<std::size_t> successor_task_calls{0};
+        auto s = ex::schedule(exec) |
+            ex::transform([&]() { ++first_task_calls; }) | ex::ensure_started();
+        auto succ1 = s | ex::transform([&]() {
+            ++successor_task_calls;
+            return 1;
+        });
+        auto succ2 = s | ex::transform([&]() {
+            ++successor_task_calls;
+            return 2;
+        });
+        HPX_TEST_EQ(ex::when_all(succ1, succ2) |
+                ex::transform(
+                    [](int const& x, int const& y) { return x + y; }) |
+                ex::sync_wait(),
+            3);
+        HPX_TEST_EQ(first_task_calls, std::size_t(1));
+        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
+    }
+
+    {
+        std::atomic<std::size_t> first_task_calls{0};
+        std::atomic<std::size_t> successor_task_calls{0};
+        auto s = ex::schedule(exec) | ex::transform([&]() {
+            ++first_task_calls;
+            return 3;
+        }) | ex::ensure_started();
+        auto succ1 = s | ex::transform([&](int const& x) {
+            ++successor_task_calls;
+            return x + 1;
+        });
+        auto succ2 = s | ex::transform([&](int const& x) {
+            ++successor_task_calls;
+            return x + 2;
+        });
+        HPX_TEST_EQ(ex::when_all(succ1, succ2) |
+                ex::transform(
+                    [](int const& x, int const& y) { return x + y; }) |
+                ex::sync_wait(),
+            9);
+        HPX_TEST_EQ(first_task_calls, std::size_t(1));
+        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
+    }
+
+    {
+        std::atomic<std::size_t> first_task_calls{0};
+        std::atomic<std::size_t> successor_task_calls{0};
+        auto s = ex::schedule(exec) | ex::transform([&]() {
+            ++first_task_calls;
+            return 3;
+        }) | ex::ensure_started();
+        auto succ1 = s | ex::on(exec) | ex::transform([&](int const& x) {
+            ++successor_task_calls;
+            return x + 1;
+        });
+        auto succ2 = s | ex::on(exec) | ex::transform([&](int const& x) {
+            ++successor_task_calls;
+            return x + 2;
+        });
+        HPX_TEST_EQ(ex::when_all(succ1, succ2) |
+                ex::transform(
+                    [](int const& x, int const& y) { return x + y; }) |
+                ex::sync_wait(),
+            9);
+        HPX_TEST_EQ(first_task_calls, std::size_t(1));
+        HPX_TEST_EQ(successor_task_calls, std::size_t(2));
+    }
+}
+
+void test_let_value()
+{
+    ex::executor exec{};
+
+    // void predecessor
+    {
+        auto result = ex::schedule(exec) |
+            ex::let_value([]() { return ex::just(42); }) | ex::sync_wait();
+        HPX_TEST_EQ(result, 42);
+    }
+
+    {
+        auto result = ex::schedule(exec) |
+            ex::let_value([=]() { return ex::just_on(exec, 42); }) |
+            ex::sync_wait();
+        HPX_TEST_EQ(result, 42);
+    }
+
+    {
+        auto result = ex::just() |
+            ex::let_value([=]() { return ex::just_on(exec, 42); }) |
+            ex::sync_wait();
+        HPX_TEST_EQ(result, 42);
+    }
+
+    // int predecessor, value ignored
+    {
+        auto result = ex::just_on(exec, 43) |
+            ex::let_value([](int&) { return ex::just(42); }) | ex::sync_wait();
+        HPX_TEST_EQ(result, 42);
+    }
+
+    {
+        auto result = ex::just_on(exec, 43) |
+            ex::let_value([=](int&) { return ex::just_on(exec, 42); }) |
+            ex::sync_wait();
+        HPX_TEST_EQ(result, 42);
+    }
+
+    {
+        auto result = ex::just(43) |
+            ex::let_value([=](int&) { return ex::just_on(exec, 42); }) |
+            ex::sync_wait();
+        HPX_TEST_EQ(result, 42);
+    }
+
+    // int predecessor, value used
+    {
+        auto result = ex::just_on(exec, 43) | ex::let_value([](int& x) {
+            return ex::just(42) | ex::transform([&](int y) { return x + y; });
+        }) | ex::sync_wait();
+        HPX_TEST_EQ(result, 85);
+    }
+
+    {
+        auto result = ex::just_on(exec, 43) | ex::let_value([=](int& x) {
+            return ex::just_on(exec, 42) |
+                ex::transform([&](int y) { return x + y; });
+        }) | ex::sync_wait();
+        HPX_TEST_EQ(result, 85);
+    }
+
+    {
+        auto result = ex::just(43) | ex::let_value([=](int& x) {
+            return ex::just_on(exec, 42) |
+                ex::transform([&](int y) { return x + y; });
+        }) | ex::sync_wait();
+        HPX_TEST_EQ(result, 85);
+    }
+
+    // predecessor throws, let sender is ignored
+    {
+        bool exception_thrown = false;
+
+        try
+        {
+            ex::just_on(exec, 43) | ex::transform([](int x) {
+                throw std::runtime_error("error");
+                return x;
+            }) | ex::let_value([](int&) {
+                HPX_TEST(false);
+                return ex::just(0);
+            }) | ex::sync_wait();
+        }
+        catch (std::runtime_error const& e)
+        {
+            HPX_TEST_EQ(std::string(e.what()), std::string("error"));
+            exception_thrown = true;
+        }
+
+        HPX_TEST(exception_thrown);
+    }
+}
+
+void check_exception_ptr_message(
+    std::exception_ptr ep, std::string const& message)
+{
+    try
+    {
+        std::rethrow_exception(ep);
+    }
+    catch (std::runtime_error const& e)
+    {
+        HPX_TEST_EQ(std::string(e.what()), message);
+        return;
+    }
+
+    HPX_TEST(false);
+}
+
+void test_let_error()
+{
+    ex::executor exec{};
+
+    // void predecessor
+    {
+        std::atomic<bool> called{false};
+        ex::schedule(exec) | ex::transform([]() {
+            throw std::runtime_error("error");
+        }) | ex::let_error([&called](std::exception_ptr& ep) {
+            called = true;
+            check_exception_ptr_message(ep, "error");
+            return ex::just();
+        }) | ex::sync_wait();
+        HPX_TEST(called);
+    }
+
+    {
+        std::atomic<bool> called{false};
+        ex::schedule(exec) | ex::transform([]() {
+            throw std::runtime_error("error");
+        }) | ex::let_error([=, &called](std::exception_ptr& ep) {
+            called = true;
+            check_exception_ptr_message(ep, "error");
+            return ex::just_on(exec);
+        }) | ex::sync_wait();
+        HPX_TEST(called);
+    }
+
+    {
+        std::atomic<bool> called{false};
+        ex::just() | ex::transform([]() {
+            throw std::runtime_error("error");
+        }) | ex::let_error([=, &called](std::exception_ptr& ep) {
+            called = true;
+            check_exception_ptr_message(ep, "error");
+            return ex::just_on(exec);
+        }) | ex::sync_wait();
+        HPX_TEST(called);
+    }
+
+    // int predecessor
+    {
+        auto result = ex::schedule(exec) | ex::transform([]() {
+            throw std::runtime_error("error");
+            return 43;
+        }) | ex::let_error([](std::exception_ptr& ep) {
+            check_exception_ptr_message(ep, "error");
+            return ex::just(42);
+        }) | ex::sync_wait();
+        HPX_TEST_EQ(result, 42);
+    }
+
+    {
+        auto result = ex::schedule(exec) | ex::transform([]() {
+            throw std::runtime_error("error");
+            return 43;
+        }) | ex::let_error([=](std::exception_ptr& ep) {
+            check_exception_ptr_message(ep, "error");
+            return ex::just_on(exec, 42);
+        }) | ex::sync_wait();
+        HPX_TEST_EQ(result, 42);
+    }
+
+    {
+        auto result = ex::just() | ex::transform([]() {
+            throw std::runtime_error("error");
+            return 43;
+        }) | ex::let_error([=](std::exception_ptr& ep) {
+            check_exception_ptr_message(ep, "error");
+            return ex::just_on(exec, 42);
+        }) | ex::sync_wait();
+        HPX_TEST_EQ(result, 42);
+    }
+
+    // predecessor doesn't throw, let sender is ignored
+    {
+        auto result = ex::just_on(exec, 42) |
+            ex::let_error([](std::exception_ptr) {
+                HPX_TEST(false);
+                return ex::just(43);
+            }) |
+            ex::sync_wait();
+        HPX_TEST_EQ(result, 42);
+    }
+
+    {
+        auto result = ex::just_on(exec, 42) |
+            ex::let_error([=](std::exception_ptr) {
+                HPX_TEST(false);
+                return ex::just_on(exec, 43);
+            }) |
+            ex::sync_wait();
+        HPX_TEST_EQ(result, 42);
+    }
+
+    {
+        auto result = ex::just(42) | ex::let_error([=](std::exception_ptr) {
+            HPX_TEST(false);
+            return ex::just_on(exec, 43);
+        }) | ex::sync_wait();
+        HPX_TEST_EQ(result, 42);
+    }
+}
+
+void test_detach()
+{
+    ex::executor exec{};
+
+    {
+        bool called = false;
+        hpx::mutex m;
+        hpx::condition_variable cv;
+        ex::schedule(exec) | ex::transform([&]() {
+            std::unique_lock<hpx::mutex> l(m);
+            called = true;
+            cv.notify_one();
+        }) | ex::detach();
+
+        {
+            std::unique_lock<hpx::mutex> l(m);
+            while (!called)
+            {
+                cv.wait_for(l, std::chrono::seconds(1));
+            }
+        }
+        HPX_TEST(called);
+    }
+
+    // Values passed to set_value are ignored
+    {
+        bool called = false;
+        hpx::mutex m;
+        hpx::condition_variable cv;
+        ex::schedule(exec) | ex::transform([&]() {
+            std::unique_lock<hpx::mutex> l(m);
+            called = true;
+            cv.notify_one();
+            return 42;
+        }) | ex::detach();
+
+        {
+            std::unique_lock<hpx::mutex> l(m);
+            while (!called)
+            {
+                cv.wait_for(l, std::chrono::seconds(1));
+            }
+        }
+        HPX_TEST(called);
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -853,6 +1206,11 @@ int hpx_main()
     test_just_on_two_args();
     test_when_all();
     test_future_sender();
+    test_ensure_started();
+    test_ensure_started_when_all();
+    test_let_value();
+    test_let_error();
+    test_detach();
 
     return hpx::finalize();
 }

--- a/libs/parallelism/futures/include/hpx/futures/future.hpp
+++ b/libs/parallelism/futures/include/hpx/futures/future.hpp
@@ -884,7 +884,8 @@ namespace hpx { namespace lcos {
             template <typename...> class Variant>
         using value_types = std::conditional_t<std::is_void<result_type>::value,
             Variant<Tuple<>>,
-            Variant<Tuple<std::add_rvalue_reference_t<result_type>>>>;
+            Variant<Tuple<
+                typename hpx::traits::future_traits<future>::result_type>>>;
 
         template <template <typename...> class Variant>
         using error_types = Variant<std::exception_ptr>;
@@ -1221,7 +1222,8 @@ namespace hpx { namespace lcos {
             template <typename...> class Variant>
         using value_types = std::conditional_t<std::is_void<result_type>::value,
             Variant<Tuple<>>,
-            Variant<Tuple<std::add_rvalue_reference_t<result_type>>>>;
+            Variant<Tuple<typename hpx::traits::future_traits<
+                shared_future>::result_type>>>;
 
         template <template <typename...> class Variant>
         using error_types = Variant<std::exception_ptr>;


### PR DESCRIPTION
I've added the following missing algorithms from P1897:

* `ensure_started`: The returned sender acts similarly to a `shared_future`, i.e. can be connected and started multiple times, with the predecessor only being started once. I'm not 100% sure this is the intended use case, but the wording in P1897 is unclear enough (to me) that this could be intended.
* `let_error`: Adds an error handler to be used in cases of error. The handler returns a new sender and the error from the predecessor sender is kept alive for the duration of the new sender. Done and value signals are propagated normally without going through the handler.
* `let_value`: Adds a value handler. The handler returns a new sender and the value from the predecessor sender is kept alive for the duration of the new sender. Done and error signals are propagate normally withouth going through the handler.

I've added the following which is not in P1897, but which I think is a useful/necessary addition:
* `detach`: Submits a sender for execution and returns after calling start without waiting for completion (unlike `sync_wait`, which blocks until completion). Terminates on error signals, ignores done and value signals.

This also makes various smaller modifications to the existing algorithms.

Contains #5255.

This is still a draft but looking for early feedback on the implementations. I definitely still have some rearranging/renaming to do with the metaprogramming helpers, and most likely with other parts as well. This uses `std::variant` in more places, which will need some more guards until we require C++17 support.