### PR TITLE
Small fixes and improvements to CUDA/MPI polling

### DIFF
--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
@@ -977,7 +977,11 @@ namespace hpx { namespace threads { namespace detail {
                 }
             }
 
-            scheduler.custom_polling_function();
+            if (scheduler.custom_polling_function() ==
+                policies::detail::polling_status::busy)
+            {
+                idle_loop_count = params.max_idle_loop_count_;
+            }
 
             // something went badly wrong, give up
             if (HPX_UNLIKELY(this_state.load() == state_terminating))

--- a/libs/full/async_cuda/include/hpx/async_cuda/custom_gpu_api.hpp
+++ b/libs/full/async_cuda/include/hpx/async_cuda/custom_gpu_api.hpp
@@ -51,6 +51,7 @@
     #define cudaLaunchDevice hipLaunchDevice
     #define cudaLaunchKernel hipLaunchKernel
     #define cudaMalloc hipMalloc
+    #define cudaMallocHost hipHostMalloc
     #define cudaMemcpy hipMemcpy
     #define cudaMemcpyAsync hipMemcpyAsync
     #define cudaMemcpyDeviceToDevice hipMemcpyDeviceToDevice

--- a/libs/full/async_cuda/src/cuda_future.cpp
+++ b/libs/full/async_cuda/src/cuda_future.cpp
@@ -184,48 +184,49 @@ namespace hpx { namespace cuda { namespace experimental { namespace detail {
             hpx::cuda::experimental::cuda_event_pool::get_event_pool();
 
         // iterate over our list of events and see if any have completed
-        detail::future_data_ptr fdp;
-        using i_type = std::vector<future_data_ptr>::iterator;
-        for (i_type it = future_vec.begin(); it != future_vec.end();)
-        {
-            fdp = *it;
-            cudaError_t status = cudaEventQuery(fdp->event_);
-            if (status == cudaErrorNotReady)
-            {
-                // this event has not been triggered yet
-                ++it;
-                continue;
-            }
-            else if (status == cudaSuccess)
-            {
-                fdp->set_data(hpx::util::unused);
-                // clang-format off
+        future_vec.erase(
+            std::remove_if(future_vec.begin(), future_vec.end(),
+                [&](detail::future_data_ptr fdp) {
+                    cudaError_t status = cudaEventQuery(fdp->event_);
+                    if (status == cudaErrorNotReady)
+                    {
+                        // this event has not been triggered yet
+                        return false;
+                    }
+                    else if (status == cudaSuccess)
+                    {
+                        fdp->set_data(hpx::util::unused);
+                        // clang-format off
                 cud_debug.debug(debug::str<>("set ready vector")
                     , "event", debug::hex<8>(fdp->event_)
                     , "futures", debug::dec<3>(get_active_futures().size()));
-                // clang-format on
-                // drop future and reuse event
-                it = future_vec.erase(it);
-                pool.push(fdp->event_);
-            }
-            else
-            {
-                // clang-format off
+                        // clang-format on
+                        // drop future and reuse event
+                        pool.push(fdp->event_);
+                        return true;
+                    }
+                    else
+                    {
+                        // clang-format off
                 cud_debug.debug(debug::str<>("set exception vector")
                     , "event", debug::hex<8>(fdp->event_)
                     , "futures", debug::dec<3>(get_active_futures().size()));
-                // clang-format on
-                fdp->set_exception(std::make_exception_ptr(cuda_exception(
-                    std::string("cuda function returned error code :") +
-                        cudaGetErrorString(status),
-                    status)));
-                ++it;
-            }
-        }
+                        // clang-format on
+                        fdp->set_exception(
+                            std::make_exception_ptr(cuda_exception(
+                                std::string(
+                                    "cuda function returned error code :") +
+                                    cudaGetErrorString(status),
+                                status)));
+                        return true;
+                    }
+                }),
+            future_vec.end());
 
         // have any requests been made that need to be handled?
         // if so, move them all from the lockfree request list, onto the
         // polling list
+        detail::future_data_ptr fdp;
         while (detail::get_event_queue().try_dequeue(fdp))
         {
             cudaError_t status = cudaEventQuery(fdp->event_);

--- a/libs/full/async_cuda/src/cuda_future.cpp
+++ b/libs/full/async_cuda/src/cuda_future.cpp
@@ -144,8 +144,10 @@ namespace hpx { namespace cuda { namespace experimental { namespace detail {
     // We process outstanding futures in the polling list first,
     // then any new future requests are polled and if not ready
     // added to the polling list (for next time)
-    void poll()
+    hpx::threads::policies::detail::polling_status poll()
     {
+        using hpx::threads::policies::detail::polling_status;
+
         // don't poll if another thread is already polling
         std::unique_lock<hpx::cuda::experimental::detail::mutex_type> lk(
             detail::get_list_mtx(), std::try_to_lock);
@@ -161,7 +163,7 @@ namespace hpx { namespace cuda { namespace experimental { namespace detail {
                     "futures", debug::dec<3>(get_active_futures().size()));
                 // clang-format on
             }
-            return;
+            return polling_status::idle;
         }
 
         auto& future_vec = detail::get_active_futures();
@@ -256,6 +258,9 @@ namespace hpx { namespace cuda { namespace experimental { namespace detail {
                     status)));
             }
         }
+
+        return get_active_futures().empty() ? polling_status::idle :
+                                              polling_status::busy;
     }
 
     // -------------------------------------------------------------

--- a/libs/full/async_cuda/src/cuda_future.cpp
+++ b/libs/full/async_cuda/src/cuda_future.cpp
@@ -193,6 +193,7 @@ namespace hpx { namespace cuda { namespace experimental { namespace detail {
             if (status == cudaErrorNotReady)
             {
                 // this event has not been triggered yet
+                ++it;
                 continue;
             }
             else if (status == cudaSuccess)

--- a/libs/full/async_cuda/tests/unit/cuda_future.cpp
+++ b/libs/full/async_cuda/tests/unit/cuda_future.cpp
@@ -42,10 +42,14 @@ int test_saxpy(hpx::cuda::experimental::cuda_executor& cudaexec)
 {
     int N = 1 << 20;
 
-    // host arrays
-    std::vector<float> h_A(N);
-    std::vector<float> h_B(N);
+    // host arrays (CUDA pinned host memory for asynchronous data transfers)
+    float *h_A, *h_B;
+    hpx::cuda::experimental::check_cuda_error(
+        cudaMallocHost((void**) &h_A, N * sizeof(float)));
+    hpx::cuda::experimental::check_cuda_error(
+        cudaMallocHost((void**) &h_B, N * sizeof(float)));
 
+    // device arrays
     float *d_A, *d_B;
     hpx::cuda::experimental::check_cuda_error(
         cudaMalloc((void**) &d_A, N * sizeof(float)));
@@ -62,9 +66,9 @@ int test_saxpy(hpx::cuda::experimental::cuda_executor& cudaexec)
 
     // copy both arrays from cpu to gpu, putting both copies onto the stream
     // no need to get a future back yet
-    hpx::apply(cudaexec, cudaMemcpyAsync, d_A, h_A.data(), N * sizeof(float),
+    hpx::apply(cudaexec, cudaMemcpyAsync, d_A, h_A, N * sizeof(float),
         cudaMemcpyHostToDevice);
-    hpx::apply(cudaexec, cudaMemcpyAsync, d_B, h_B.data(), N * sizeof(float),
+    hpx::apply(cudaexec, cudaMemcpyAsync, d_B, h_B, N * sizeof(float),
         cudaMemcpyHostToDevice);
 
     unsigned int threads = 256;
@@ -83,7 +87,7 @@ int test_saxpy(hpx::cuda::experimental::cuda_executor& cudaexec)
 
     // finally, perform a copy from the gpu back to the cpu all on the same stream
     // grab a future to when this completes
-    auto cuda_future = hpx::async(cudaexec, cudaMemcpyAsync, h_B.data(), d_B,
+    auto cuda_future = hpx::async(cudaexec, cudaMemcpyAsync, h_B, d_B,
         N * sizeof(float), cudaMemcpyDeviceToHost);
 
     // we can add a continuation to the memcpy future, so that when the

--- a/libs/full/async_mpi/include/hpx/async_mpi/mpi_future.hpp
+++ b/libs/full/async_mpi/include/hpx/async_mpi/mpi_future.hpp
@@ -178,7 +178,7 @@ namespace hpx { namespace mpi { namespace experimental {
     // Background progress function for MPI async operations
     // Checks for completed MPI_Requests and sets mpi::experimental::future ready
     // when found
-    HPX_EXPORT void poll();
+    HPX_EXPORT hpx::threads::policies::detail::polling_status poll();
 
     // -----------------------------------------------------------------
     // This is not completely safe as it will return when the request vector is

--- a/libs/full/async_mpi/src/mpi_future.cpp
+++ b/libs/full/async_mpi/src/mpi_future.cpp
@@ -180,8 +180,10 @@ namespace hpx { namespace mpi { namespace experimental {
     // Background progress function for MPI async operations
     // Checks for completed MPI_Requests and sets mpi::experimental::future
     // ready when found
-    void poll()
+    hpx::threads::policies::detail::polling_status poll()
     {
+        using hpx::threads::policies::detail::polling_status;
+
         std::unique_lock<detail::mutex_type> lk(
             detail::get_vector_mtx(), std::try_to_lock);
         if (!lk.owns_lock())
@@ -197,7 +199,7 @@ namespace hpx { namespace mpi { namespace experimental {
                     "futures",
                     debug::dec<>(detail::get_active_futures().size()));
             }
-            return;
+            return polling_status::idle;
         }
 
         if (mpi_debug.is_enabled())
@@ -333,6 +335,9 @@ namespace hpx { namespace mpi { namespace experimental {
                     "nulls ", debug::dec<>(nulls));
             }
         }
+
+        return detail::get_active_futures().empty() ? polling_status::idle :
+                                                      polling_status::busy;
     }
 
     namespace detail {


### PR DESCRIPTION
- Return a status enum from the polling functions to indicate if the scheduler should call the idle callback (useful if polling is the only thing done on a separate pool, and the pool would otherwise call the idle callback even if there's polling to be done).
- The CUDA polling function used to spin waiting for events to complete. As far as I can tell this was unintentional (@biddisco? the iterator was not incremented on `cudaErrorNotReady`).
- Avoid quadratic worst-case complexity in the CUDA polling function in terms of the number of active futures (if every future is ready every iteration would shift the remaining elements to the front when calling `vector::erase`).
- Use CUDA host pinned memory in the `cuda_future` test to actually enable asynchronous data transfers.