### PR TITLE
Avoid modulo by zero in counting_iterator test

### DIFF
--- a/libs/core/iterator_support/tests/unit/counting_iterator.cpp
+++ b/libs/core/iterator_support/tests/unit/counting_iterator.cpp
@@ -183,7 +183,7 @@ template <typename Container>
 void test_container(
     Container* = nullptr)    // default arg works around MSVC bug
 {
-    Container c(1 + (unsigned) rand() % 1673);
+    Container c(2 + (unsigned) rand() % 1673);
 
     typename Container::iterator const start = c.begin();
 


### PR DESCRIPTION
With certain seeds the test would attempt to compute the remainder of division by zero.