### PR TITLE
Replacing util::function_nonser on std::function in hpx_init

### DIFF
--- a/libs/full/init_runtime/include/hpx/hpx_init.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_init.hpp
@@ -63,7 +63,7 @@ namespace hpx {
     ///                     Otherwise it will be executed as specified by the
     ///                     parameter\p mode.
     inline int init(
-        std::function<int(hpx::program_options::variables_map&)>&&
+        std::function<int(hpx::program_options::variables_map&)>
             f,
         int argc, char** argv, init_params const& params = init_params());
 
@@ -99,7 +99,7 @@ namespace hpx {
     ///                     command line arguments passed in `argc`/`argv`.
     ///                     Otherwise it will be executed as specified by the
     ///                     parameter\p mode.
-    inline int init(std::function<int(int, char**)>&& f, int argc,
+    inline int init(std::function<int(int, char**)> f, int argc,
         char** argv, init_params const& params = init_params());
 
     /// \brief Main entry point for launching the HPX runtime system.
@@ -254,7 +254,7 @@ namespace hpx {
     ///                     Otherwise it will be executed as specified by the
     ///                     parameter\p mode.
     inline int init(std::function<int(
-                        hpx::program_options::variables_map& vm)>&& f,
+                        hpx::program_options::variables_map& vm)> f,
         hpx::program_options::options_description const& desc_cmdline, int argc,
         char** argv, std::vector<std::string> const& cfg,
         startup_function_type startup = startup_function_type(),
@@ -742,7 +742,7 @@ namespace hpx {
     /// \note               The created runtime system instance will be
     ///                     executed in console or worker mode depending on the
     ///                     command line arguments passed in `argc`/`argv`.
-    inline int init(std::function<int(int, char**)>&& f,
+    inline int init(std::function<int(int, char**)> f,
         std::string const& app_name, int argc, char** argv,
         hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
@@ -786,7 +786,7 @@ namespace hpx {
     /// \note               The created runtime system instance will be
     ///                     executed in console or worker mode depending on the
     ///                     command line arguments passed in `argc`/`argv`.
-    inline int init(std::function<int(int, char**)>&& f, int argc,
+    inline int init(std::function<int(int, char**)> f, int argc,
         char** argv, std::vector<std::string> const& cfg,
         hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
@@ -824,7 +824,7 @@ namespace hpx {
     /// \note               The created runtime system instance will be
     ///                     executed in console or worker mode depending on the
     ///                     configuration passed in `cfg`.
-    inline int init(std::function<int(int, char**)>&& f,
+    inline int init(std::function<int(int, char**)> f,
         std::vector<std::string> const& cfg,
         hpx::runtime_mode mode = hpx::runtime_mode::default_);
 

--- a/libs/full/init_runtime/include/hpx/hpx_init.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_init.hpp
@@ -12,7 +12,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/functional/function.hpp>
 #include <hpx/hpx_finalize.hpp>
 #include <hpx/hpx_init_params.hpp>
 #include <hpx/hpx_suspend.hpp>
@@ -24,6 +23,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -63,7 +63,7 @@ namespace hpx {
     ///                     Otherwise it will be executed as specified by the
     ///                     parameter\p mode.
     inline int init(
-        util::function_nonser<int(hpx::program_options::variables_map&)> const&
+        std::function<int(hpx::program_options::variables_map&)>&&
             f,
         int argc, char** argv, init_params const& params = init_params());
 
@@ -99,7 +99,7 @@ namespace hpx {
     ///                     command line arguments passed in `argc`/`argv`.
     ///                     Otherwise it will be executed as specified by the
     ///                     parameter\p mode.
-    inline int init(util::function_nonser<int(int, char**)> const& f, int argc,
+    inline int init(std::function<int(int, char**)>&& f, int argc,
         char** argv, init_params const& params = init_params());
 
     /// \brief Main entry point for launching the HPX runtime system.
@@ -253,8 +253,8 @@ namespace hpx {
     ///                     command line arguments passed in `argc`/`argv`.
     ///                     Otherwise it will be executed as specified by the
     ///                     parameter\p mode.
-    inline int init(util::function_nonser<int(
-                        hpx::program_options::variables_map& vm)> const& f,
+    inline int init(std::function<int(
+                        hpx::program_options::variables_map& vm)>&& f,
         hpx::program_options::options_description const& desc_cmdline, int argc,
         char** argv, std::vector<std::string> const& cfg,
         startup_function_type startup = startup_function_type(),
@@ -742,7 +742,7 @@ namespace hpx {
     /// \note               The created runtime system instance will be
     ///                     executed in console or worker mode depending on the
     ///                     command line arguments passed in `argc`/`argv`.
-    inline int init(util::function_nonser<int(int, char**)> const& f,
+    inline int init(std::function<int(int, char**)>&& f,
         std::string const& app_name, int argc, char** argv,
         hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
@@ -786,7 +786,7 @@ namespace hpx {
     /// \note               The created runtime system instance will be
     ///                     executed in console or worker mode depending on the
     ///                     command line arguments passed in `argc`/`argv`.
-    inline int init(util::function_nonser<int(int, char**)> const& f, int argc,
+    inline int init(std::function<int(int, char**)>&& f, int argc,
         char** argv, std::vector<std::string> const& cfg,
         hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
@@ -824,7 +824,7 @@ namespace hpx {
     /// \note               The created runtime system instance will be
     ///                     executed in console or worker mode depending on the
     ///                     configuration passed in `cfg`.
-    inline int init(util::function_nonser<int(int, char**)> const& f,
+    inline int init(std::function<int(int, char**)>&& f,
         std::vector<std::string> const& cfg,
         hpx::runtime_mode mode = hpx::runtime_mode::default_);
 

--- a/libs/full/init_runtime/include/hpx/hpx_init.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_init.hpp
@@ -22,8 +22,8 @@
 #include <hpx/runtime_local/startup_function.hpp>
 
 #include <cstddef>
-#include <memory>
 #include <functional>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -62,9 +62,7 @@ namespace hpx {
     ///                     command line arguments passed in `argc`/`argv`.
     ///                     Otherwise it will be executed as specified by the
     ///                     parameter\p mode.
-    inline int init(
-        std::function<int(hpx::program_options::variables_map&)>
-            f,
+    inline int init(std::function<int(hpx::program_options::variables_map&)> f,
         int argc, char** argv, init_params const& params = init_params());
 
     /// \brief Main entry point for launching the HPX runtime system.
@@ -99,8 +97,8 @@ namespace hpx {
     ///                     command line arguments passed in `argc`/`argv`.
     ///                     Otherwise it will be executed as specified by the
     ///                     parameter\p mode.
-    inline int init(std::function<int(int, char**)> f, int argc,
-        char** argv, init_params const& params = init_params());
+    inline int init(std::function<int(int, char**)> f, int argc, char** argv,
+        init_params const& params = init_params());
 
     /// \brief Main entry point for launching the HPX runtime system.
     ///
@@ -253,8 +251,8 @@ namespace hpx {
     ///                     command line arguments passed in `argc`/`argv`.
     ///                     Otherwise it will be executed as specified by the
     ///                     parameter\p mode.
-    inline int init(std::function<int(
-                        hpx::program_options::variables_map& vm)> f,
+    inline int init(
+        std::function<int(hpx::program_options::variables_map& vm)> f,
         hpx::program_options::options_description const& desc_cmdline, int argc,
         char** argv, std::vector<std::string> const& cfg,
         startup_function_type startup = startup_function_type(),
@@ -786,8 +784,8 @@ namespace hpx {
     /// \note               The created runtime system instance will be
     ///                     executed in console or worker mode depending on the
     ///                     command line arguments passed in `argc`/`argv`.
-    inline int init(std::function<int(int, char**)> f, int argc,
-        char** argv, std::vector<std::string> const& cfg,
+    inline int init(std::function<int(int, char**)> f, int argc, char** argv,
+        std::vector<std::string> const& cfg,
         hpx::runtime_mode mode = hpx::runtime_mode::default_);
 
     /// \brief Main entry point for launching the HPX runtime system.

--- a/libs/full/init_runtime/include/hpx/hpx_init_impl.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_init_impl.hpp
@@ -50,9 +50,7 @@ namespace hpx {
     /// (or one of its overloads below) should be called from the users `main()`
     /// function. It will set up the HPX runtime environment and schedule the
     /// function given by \p f as a HPX thread.
-    inline int init(
-        std::function<int(hpx::program_options::variables_map&)>
-            f,
+    inline int init(std::function<int(hpx::program_options::variables_map&)> f,
         int argc, char** argv, init_params const& params)
     {
 #if defined(HPX_WINDOWS)
@@ -82,15 +80,15 @@ namespace hpx {
     /// (or one of its overloads below) should be called from the users `main()`
     /// function. It will set up the HPX runtime environment and schedule the
     /// function given by \p f as a HPX thread.
-    inline int init(std::function<int(int, char**)> f, int argc,
-        char** argv, init_params const& params)
+    inline int init(std::function<int(int, char**)> f, int argc, char** argv,
+        init_params const& params)
     {
-        std::function<int(hpx::program_options::variables_map&)>
-            main_f = util::bind_back(detail::init_helper, f);
+        std::function<int(hpx::program_options::variables_map&)> main_f =
+            util::bind_back(detail::init_helper, f);
         if (argc == 0 || argv == nullptr)
         {
             return init(std::move(main_f), detail::dummy_argc,
-                    detail::dummy_argv, params);
+                detail::dummy_argv, params);
         }
         return init(std::move(main_f), argc, argv, params);
     }
@@ -103,12 +101,12 @@ namespace hpx {
     /// function given by \p f as a HPX thread.
     inline int init(int argc, char** argv, init_params const& params)
     {
-        std::function<int(hpx::program_options::variables_map&)>
-            main_f = static_cast<hpx_main_type>(::hpx_main);
+        std::function<int(hpx::program_options::variables_map&)> main_f =
+            static_cast<hpx_main_type>(::hpx_main);
         if (argc == 0 || argv == nullptr)
         {
             return init(std::move(main_f), detail::dummy_argc,
-                    detail::dummy_argv, params);
+                detail::dummy_argv, params);
         }
         return init(std::move(main_f), argc, argv, params);
     }
@@ -126,7 +124,7 @@ namespace hpx {
         if (argc == 0 || argv == nullptr)
         {
             return init(std::move(main_f), detail::dummy_argc,
-                    detail::dummy_argv, params);
+                detail::dummy_argv, params);
         }
         return init(std::move(main_f), argc, argv, params);
     }
@@ -138,9 +136,10 @@ namespace hpx {
     /// console mode or worker mode depending on the command line settings).
     inline int init(init_params const& params)
     {
-        std::function<int(hpx::program_options::variables_map&)>
-            main_f = static_cast<hpx_main_type>(::hpx_main);
-        return init(std::move(main_f), detail::dummy_argc, detail::dummy_argv, params);
+        std::function<int(hpx::program_options::variables_map&)> main_f =
+            static_cast<hpx_main_type>(::hpx_main);
+        return init(
+            std::move(main_f), detail::dummy_argc, detail::dummy_argv, params);
     }
 
 #if defined(HPX_HAVE_INIT_START_OVERLOADS_COMPATIBILITY)
@@ -153,8 +152,8 @@ namespace hpx {
     HPX_DEPRECATED_V(1, 6,
         "The init overload used is deprecated. Please use"
         "the init overloads using the hpx::init_params struct.")
-    inline int init(std::function<int(
-                        hpx::program_options::variables_map& vm)> f,
+    inline int init(
+        std::function<int(hpx::program_options::variables_map& vm)> f,
         hpx::program_options::options_description const& desc_cmdline, int argc,
         char** argv, std::vector<std::string> const& cfg,
         startup_function_type startup, shutdown_function_type shutdown,
@@ -415,9 +414,8 @@ namespace hpx {
     HPX_DEPRECATED_V(1, 6,
         "The init overload used is deprecated. Please use"
         "the init overloads using the hpx::init_params struct.")
-    inline int init(std::function<int(int, char**)> f, int argc,
-        char** argv, std::vector<std::string> const& cfg,
-        hpx::runtime_mode mode)
+    inline int init(std::function<int(int, char**)> f, int argc, char** argv,
+        std::vector<std::string> const& cfg, hpx::runtime_mode mode)
     {
         HPX_ASSERT(argc != 0 && argv != nullptr);
 
@@ -436,7 +434,8 @@ namespace hpx {
         hpx::init_params iparams;
         iparams.cfg = cfg;
         iparams.mode = mode;
-        return init(std::move(f), detail::dummy_argc, detail::dummy_argv, iparams);
+        return init(
+            std::move(f), detail::dummy_argc, detail::dummy_argv, iparams);
     }
 
     HPX_DEPRECATED_V(1, 6,
@@ -499,7 +498,8 @@ namespace hpx {
         hpx::init_params iparams;
         iparams.cfg = cfg;
         iparams.mode = mode;
-        return init(std::move(main_f), detail::dummy_argc, detail::dummy_argv, iparams);
+        return init(
+            std::move(main_f), detail::dummy_argc, detail::dummy_argv, iparams);
     }
 #endif
 

--- a/libs/full/init_runtime/include/hpx/hpx_init_impl.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_init_impl.hpp
@@ -51,7 +51,7 @@ namespace hpx {
     /// function. It will set up the HPX runtime environment and schedule the
     /// function given by \p f as a HPX thread.
     inline int init(
-        std::function<int(hpx::program_options::variables_map&)>&&
+        std::function<int(hpx::program_options::variables_map&)>
             f,
         int argc, char** argv, init_params const& params)
     {
@@ -82,7 +82,7 @@ namespace hpx {
     /// (or one of its overloads below) should be called from the users `main()`
     /// function. It will set up the HPX runtime environment and schedule the
     /// function given by \p f as a HPX thread.
-    inline int init(std::function<int(int, char**)>&& f, int argc,
+    inline int init(std::function<int(int, char**)> f, int argc,
         char** argv, init_params const& params)
     {
         std::function<int(hpx::program_options::variables_map&)>
@@ -151,7 +151,7 @@ namespace hpx {
         "The init overload used is deprecated. Please use"
         "the init overloads using the hpx::init_params struct.")
     inline int init(std::function<int(
-                        hpx::program_options::variables_map& vm)>&& f,
+                        hpx::program_options::variables_map& vm)> f,
         hpx::program_options::options_description const& desc_cmdline, int argc,
         char** argv, std::vector<std::string> const& cfg,
         startup_function_type startup, shutdown_function_type shutdown,
@@ -394,7 +394,7 @@ namespace hpx {
     HPX_DEPRECATED_V(1, 6,
         "The init overload used is deprecated. Please use"
         "the init overloads using the hpx::init_params struct.")
-    inline int init(std::function<int(int, char**)>&& f,
+    inline int init(std::function<int(int, char**)> f,
         std::string const& app_name, int argc, char** argv,
         hpx::runtime_mode mode)
     {
@@ -412,7 +412,7 @@ namespace hpx {
     HPX_DEPRECATED_V(1, 6,
         "The init overload used is deprecated. Please use"
         "the init overloads using the hpx::init_params struct.")
-    inline int init(std::function<int(int, char**)>&& f, int argc,
+    inline int init(std::function<int(int, char**)> f, int argc,
         char** argv, std::vector<std::string> const& cfg,
         hpx::runtime_mode mode)
     {
@@ -427,7 +427,7 @@ namespace hpx {
     HPX_DEPRECATED_V(1, 6,
         "The init overload used is deprecated. Please use"
         "the init overloads using the hpx::init_params struct.")
-    inline int init(std::function<int(int, char**)>&& f,
+    inline int init(std::function<int(int, char**)> f,
         std::vector<std::string> const& cfg, hpx::runtime_mode mode)
     {
         hpx::init_params iparams;

--- a/libs/full/init_runtime/include/hpx/hpx_init_impl.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_init_impl.hpp
@@ -89,7 +89,8 @@ namespace hpx {
             main_f = util::bind_back(detail::init_helper, f);
         if (argc == 0 || argv == nullptr)
         {
-            return init(std::move(main_f), detail::dummy_argc, detail::dummy_argv, params);
+            return init(std::move(main_f), detail::dummy_argc,
+                    detail::dummy_argv, params);
         }
         return init(std::move(main_f), argc, argv, params);
     }
@@ -106,7 +107,8 @@ namespace hpx {
             main_f = static_cast<hpx_main_type>(::hpx_main);
         if (argc == 0 || argv == nullptr)
         {
-            return init(std::move(main_f), detail::dummy_argc, detail::dummy_argv, params);
+            return init(std::move(main_f), detail::dummy_argc,
+                    detail::dummy_argv, params);
         }
         return init(std::move(main_f), argc, argv, params);
     }
@@ -123,7 +125,8 @@ namespace hpx {
         std::function<int(hpx::program_options::variables_map&)> main_f;
         if (argc == 0 || argv == nullptr)
         {
-            return init(std::move(main_f), detail::dummy_argc, detail::dummy_argv, params);
+            return init(std::move(main_f), detail::dummy_argc,
+                    detail::dummy_argv, params);
         }
         return init(std::move(main_f), argc, argv, params);
     }

--- a/libs/full/init_runtime/include/hpx/hpx_init_impl.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_init_impl.hpp
@@ -10,7 +10,6 @@
 
 #include <hpx/assert.hpp>
 #include <hpx/functional/bind_back.hpp>
-#include <hpx/functional/function.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/hpx_main_winsocket.hpp>
 #include <hpx/hpx_user_main_config.hpp>
@@ -25,6 +24,7 @@
 #include <csignal>
 #include <cstddef>
 #include <cstdlib>
+#include <functional>
 #include <memory>
 #include <string>
 #include <utility>
@@ -51,7 +51,7 @@ namespace hpx {
     /// function. It will set up the HPX runtime environment and schedule the
     /// function given by \p f as a HPX thread.
     inline int init(
-        util::function_nonser<int(hpx::program_options::variables_map&)> const&
+        std::function<int(hpx::program_options::variables_map&)>&&
             f,
         int argc, char** argv, init_params const& params)
     {
@@ -82,16 +82,16 @@ namespace hpx {
     /// (or one of its overloads below) should be called from the users `main()`
     /// function. It will set up the HPX runtime environment and schedule the
     /// function given by \p f as a HPX thread.
-    inline int init(util::function_nonser<int(int, char**)> const& f, int argc,
+    inline int init(std::function<int(int, char**)>&& f, int argc,
         char** argv, init_params const& params)
     {
-        util::function_nonser<int(hpx::program_options::variables_map&)>
+        std::function<int(hpx::program_options::variables_map&)>
             main_f = util::bind_back(detail::init_helper, f);
         if (argc == 0 || argv == nullptr)
         {
-            return init(main_f, detail::dummy_argc, detail::dummy_argv, params);
+            return init(std::move(main_f), detail::dummy_argc, detail::dummy_argv, params);
         }
-        return init(main_f, argc, argv, params);
+        return init(std::move(main_f), argc, argv, params);
     }
 
     /// \brief Main entry point for launching the HPX runtime system.
@@ -102,13 +102,13 @@ namespace hpx {
     /// function given by \p f as a HPX thread.
     inline int init(int argc, char** argv, init_params const& params)
     {
-        util::function_nonser<int(hpx::program_options::variables_map&)>
+        std::function<int(hpx::program_options::variables_map&)>
             main_f = static_cast<hpx_main_type>(::hpx_main);
         if (argc == 0 || argv == nullptr)
         {
-            return init(main_f, detail::dummy_argc, detail::dummy_argv, params);
+            return init(std::move(main_f), detail::dummy_argc, detail::dummy_argv, params);
         }
-        return init(main_f, argc, argv, params);
+        return init(std::move(main_f), argc, argv, params);
     }
 
     /// \brief Main entry point for launching the HPX runtime system.
@@ -120,12 +120,12 @@ namespace hpx {
     inline int init(
         std::nullptr_t, int argc, char** argv, init_params const& params)
     {
-        util::function_nonser<int(hpx::program_options::variables_map&)> main_f;
+        std::function<int(hpx::program_options::variables_map&)> main_f;
         if (argc == 0 || argv == nullptr)
         {
-            return init(main_f, detail::dummy_argc, detail::dummy_argv, params);
+            return init(std::move(main_f), detail::dummy_argc, detail::dummy_argv, params);
         }
-        return init(main_f, argc, argv, params);
+        return init(std::move(main_f), argc, argv, params);
     }
 
     /// \brief Main entry point for launching the HPX runtime system.
@@ -135,9 +135,9 @@ namespace hpx {
     /// console mode or worker mode depending on the command line settings).
     inline int init(init_params const& params)
     {
-        util::function_nonser<int(hpx::program_options::variables_map&)>
+        std::function<int(hpx::program_options::variables_map&)>
             main_f = static_cast<hpx_main_type>(::hpx_main);
-        return init(main_f, detail::dummy_argc, detail::dummy_argv, params);
+        return init(std::move(main_f), detail::dummy_argc, detail::dummy_argv, params);
     }
 
 #if defined(HPX_HAVE_INIT_START_OVERLOADS_COMPATIBILITY)
@@ -150,8 +150,8 @@ namespace hpx {
     HPX_DEPRECATED_V(1, 6,
         "The init overload used is deprecated. Please use"
         "the init overloads using the hpx::init_params struct.")
-    inline int init(util::function_nonser<int(
-                        hpx::program_options::variables_map& vm)> const& f,
+    inline int init(std::function<int(
+                        hpx::program_options::variables_map& vm)>&& f,
         hpx::program_options::options_description const& desc_cmdline, int argc,
         char** argv, std::vector<std::string> const& cfg,
         startup_function_type startup, shutdown_function_type shutdown,
@@ -163,7 +163,7 @@ namespace hpx {
         iparams.startup = std::move(startup);
         iparams.shutdown = std::move(shutdown);
         iparams.mode = mode;
-        return init(f, argc, argv, iparams);
+        return init(std::move(f), argc, argv, iparams);
     }
 
     /// \brief Main entry point for launching the HPX runtime system.
@@ -394,7 +394,7 @@ namespace hpx {
     HPX_DEPRECATED_V(1, 6,
         "The init overload used is deprecated. Please use"
         "the init overloads using the hpx::init_params struct.")
-    inline int init(util::function_nonser<int(int, char**)> const& f,
+    inline int init(std::function<int(int, char**)>&& f,
         std::string const& app_name, int argc, char** argv,
         hpx::runtime_mode mode)
     {
@@ -406,13 +406,13 @@ namespace hpx {
         hpx::init_params iparams;
         iparams.desc_cmdline = desc_cmdline;
         iparams.mode = mode;
-        return init(f, argc, argv, iparams);
+        return init(std::move(f), argc, argv, iparams);
     }
 
     HPX_DEPRECATED_V(1, 6,
         "The init overload used is deprecated. Please use"
         "the init overloads using the hpx::init_params struct.")
-    inline int init(util::function_nonser<int(int, char**)> const& f, int argc,
+    inline int init(std::function<int(int, char**)>&& f, int argc,
         char** argv, std::vector<std::string> const& cfg,
         hpx::runtime_mode mode)
     {
@@ -421,19 +421,19 @@ namespace hpx {
         hpx::init_params iparams;
         iparams.cfg = cfg;
         iparams.mode = mode;
-        return init(f, argc, argv, iparams);
+        return init(std::move(f), argc, argv, iparams);
     }
 
     HPX_DEPRECATED_V(1, 6,
         "The init overload used is deprecated. Please use"
         "the init overloads using the hpx::init_params struct.")
-    inline int init(util::function_nonser<int(int, char**)> const& f,
+    inline int init(std::function<int(int, char**)>&& f,
         std::vector<std::string> const& cfg, hpx::runtime_mode mode)
     {
         hpx::init_params iparams;
         iparams.cfg = cfg;
         iparams.mode = mode;
-        return init(f, detail::dummy_argc, detail::dummy_argv, iparams);
+        return init(std::move(f), detail::dummy_argc, detail::dummy_argv, iparams);
     }
 
     HPX_DEPRECATED_V(1, 6,
@@ -445,14 +445,14 @@ namespace hpx {
         using hpx::program_options::options_description;
         options_description desc_cmdline("Usage: " + app_name + " [options]");
 
-        util::function_nonser<int(hpx::program_options::variables_map&)> main_f;
+        std::function<int(hpx::program_options::variables_map&)> main_f;
 
         HPX_ASSERT(argc != 0 && argv != nullptr);
 
         hpx::init_params iparams;
         iparams.desc_cmdline = desc_cmdline;
         iparams.mode = mode;
-        return init(main_f, argc, argv, iparams);
+        return init(std::move(main_f), argc, argv, iparams);
     }
 
     HPX_DEPRECATED_V(1, 6,
@@ -463,11 +463,11 @@ namespace hpx {
     {
         HPX_ASSERT(argc != 0 && argv != nullptr);
 
-        util::function_nonser<int(hpx::program_options::variables_map&)> main_f;
+        std::function<int(hpx::program_options::variables_map&)> main_f;
 
         hpx::init_params iparams;
         iparams.mode = mode;
-        return init(main_f, argc, argv, iparams);
+        return init(std::move(main_f), argc, argv, iparams);
     }
 
     HPX_DEPRECATED_V(1, 6,
@@ -478,12 +478,12 @@ namespace hpx {
     {
         HPX_ASSERT(argc != 0 && argv != nullptr);
 
-        util::function_nonser<int(hpx::program_options::variables_map&)> main_f;
+        std::function<int(hpx::program_options::variables_map&)> main_f;
 
         hpx::init_params iparams;
         iparams.cfg = cfg;
         iparams.mode = mode;
-        return init(main_f, argc, argv, iparams);
+        return init(std::move(main_f), argc, argv, iparams);
     }
 
     HPX_DEPRECATED_V(1, 6,
@@ -492,11 +492,11 @@ namespace hpx {
     inline int init(std::nullptr_t, std::vector<std::string> const& cfg,
         hpx::runtime_mode mode)
     {
-        util::function_nonser<int(hpx::program_options::variables_map&)> main_f;
+        std::function<int(hpx::program_options::variables_map&)> main_f;
         hpx::init_params iparams;
         iparams.cfg = cfg;
         iparams.mode = mode;
-        return init(main_f, detail::dummy_argc, detail::dummy_argv, iparams);
+        return init(std::move(main_f), detail::dummy_argc, detail::dummy_argv, iparams);
     }
 #endif
 

--- a/libs/full/init_runtime/tests/unit/runtime_type.cpp
+++ b/libs/full/init_runtime/tests/unit/runtime_type.cpp
@@ -51,8 +51,8 @@ int main(int argc, char* argv[])
         iparams.mode = hpx::runtime_mode::local;
         ran_hpx_main = false;
 
-        hpx::util::function_nonser<int(hpx::program_options::variables_map&)> func =
-                static_cast<hpx::hpx_main_type>(::hpx_main);
+        hpx::util::function_nonser<int(hpx::program_options::variables_map&)>
+            func = static_cast<hpx::hpx_main_type>(::hpx_main);
 
         hpx::init(func, argc, argv, iparams);
         HPX_TEST(ran_hpx_main);
@@ -64,7 +64,7 @@ int main(int argc, char* argv[])
         ran_hpx_main = false;
 
         std::function<int(hpx::program_options::variables_map&)> func =
-                static_cast<hpx::hpx_main_type>(::hpx_main);
+            static_cast<hpx::hpx_main_type>(::hpx_main);
 
         hpx::init(func, argc, argv, iparams);
         HPX_TEST(ran_hpx_main);
@@ -76,7 +76,7 @@ int main(int argc, char* argv[])
         ran_hpx_main = false;
 
         std::function<int(hpx::program_options::variables_map&)> func =
-                static_cast<hpx::hpx_main_type>(::hpx_main);
+            static_cast<hpx::hpx_main_type>(::hpx_main);
 
         hpx::init(std::move(func), argc, argv, iparams);
         HPX_TEST(ran_hpx_main);

--- a/libs/full/init_runtime/tests/unit/runtime_type.cpp
+++ b/libs/full/init_runtime/tests/unit/runtime_type.cpp
@@ -44,6 +44,43 @@ int main(int argc, char* argv[])
         HPX_TEST(ran_hpx_main);
     }
 
+    // Back compatibility test
+    {
+        hpx::init_params iparams;
+        iparams.mode = hpx::runtime_mode::local;
+        ran_hpx_main = false;
+
+        hpx::util::function_nonser<int(hpx::program_options::variables_map&)> func =
+                static_cast<hpx::hpx_main_type>(::hpx_main);
+
+        hpx::init(func, argc, argv, iparams);
+        HPX_TEST(ran_hpx_main);
+    }
+
+    {
+        hpx::init_params iparams;
+        iparams.mode = hpx::runtime_mode::local;
+        ran_hpx_main = false;
+
+        std::function<int(hpx::program_options::variables_map&)> func =
+                static_cast<hpx::hpx_main_type>(::hpx_main);
+
+        hpx::init(func, argc, argv, iparams);
+        HPX_TEST(ran_hpx_main);
+    }
+
+    {
+        hpx::init_params iparams;
+        iparams.mode = hpx::runtime_mode::local;
+        ran_hpx_main = false;
+
+        std::function<int(hpx::program_options::variables_map&)> func =
+                static_cast<hpx::hpx_main_type>(::hpx_main);
+
+        hpx::init(std::move(func), argc, argv, iparams);
+        HPX_TEST(ran_hpx_main);
+    }
+
     // The distributed runtime (i.e. any non-runtime_mode::local mode) can only
     // be started when the distributed runtime has been enabled
     {

--- a/libs/full/init_runtime/tests/unit/runtime_type.cpp
+++ b/libs/full/init_runtime/tests/unit/runtime_type.cpp
@@ -7,6 +7,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/runtime.hpp>
 #include <hpx/modules/testing.hpp>
+#include <utility>
 
 static bool ran_hpx_main;
 


### PR DESCRIPTION
## Proposed Changes

    Use std::function in public APIs

## Any background context you want to provide?

  Use std::function in public APIs: https://github.com/STEllAR-GROUP/hpx/issues/4987