### PR TITLE
Allow splitting of futures holding std::tuple

### DIFF
--- a/libs/parallelism/lcos_local/tests/unit/split_future.cpp
+++ b/libs/parallelism/lcos_local/tests/unit/split_future.cpp
@@ -12,6 +12,7 @@
 #include <array>
 #include <chrono>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -89,6 +90,29 @@ void test_split_future3()
     HPX_TEST_EQ(hpx::get<1>(result).get(), 43);
     HPX_TEST_EQ(hpx::get<2>(result).get(), 44);
 }
+
+///////////////////////////////////////////////////////////////////////////////
+#if defined(HPX_DATASTRUCTURES_HAVE_ADAPT_STD_TUPLE)
+std::tuple<int, int, int> make_std_tuple_slowly()
+{
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
+    return std::make_tuple(42, 43, 44);
+}
+
+void test_split_std_future()
+{
+    hpx::lcos::local::futures_factory<std::tuple<int, int, int>()> pt(
+        make_std_tuple_slowly);
+    pt.apply();
+
+    std::tuple<hpx::future<int>, hpx::future<int>, hpx::future<int>> result =
+        hpx::split_future(pt.get_future());
+
+    HPX_TEST_EQ(std::get<0>(result).get(), 42);
+    HPX_TEST_EQ(std::get<1>(result).get(), 43);
+    HPX_TEST_EQ(std::get<2>(result).get(), 44);
+}
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 std::pair<int, int> make_pair_slowly()
@@ -177,6 +201,10 @@ int hpx_main()
     test_split_future1();
     test_split_future2();
     test_split_future3();
+
+#if defined(HPX_DATASTRUCTURES_HAVE_ADAPT_STD_TUPLE)
+    test_split_std_future();
+#endif
 
     test_split_future_pair();
 


### PR DESCRIPTION
Analogous to the case of std::pair, it should be possible to split a `hpx::future<std::tuple<Ts...>>` into `std::tuple<hpx::future<Ts>...>`.