### PR TITLE
Fixed source file line statements in examples documentation

### DIFF
--- a/docs/sphinx/examples/1d_stencil.rst
+++ b/docs/sphinx/examples/1d_stencil.rst
@@ -45,7 +45,9 @@ The first example is straight serial code. In this code we instantiate a vector
 ``stepper``.
 
 .. literalinclude:: ../../examples/1d_stencil/1d_stencil_1.cpp
-   :lines: 32-75
+   :language: c++
+   :start-after: //[stepper_1
+   :end-before: //]
 
 Each element in the vector of doubles represents a single grid point. To
 calculate the change in heat distribution, the temperature of each grid point,
@@ -64,7 +66,9 @@ and adding a ``.get()`` at the point where a value is actually needed. The code
 below shows how this technique was applied to the ``struct stepper``.
 
 .. literalinclude:: ../../examples/1d_stencil/1d_stencil_2.cpp
-   :lines: 51-107
+   :language: c++
+   :start-after: //[stepper_2
+   :end-before: //]
 
 In example 2, we redefine our partition type as a ``shared_future`` and, in
 ``main``, create the object ``result``, which is a future to a vector of
@@ -166,7 +170,9 @@ is accomplished in ``stepper::do_work()`` by passing the GID of the
 constructor.
 
 .. literalinclude:: ../../examples/1d_stencil/1d_stencil_6.cpp
-   :lines: 328-329
+   :language: c++
+   :start-after: //[do_work_6
+   :end-before: //]
 
 We distribute the partitions evenly based on the number of localities used,
 which is described in the function ``locidx``. Because some of the data needed
@@ -188,7 +194,9 @@ on the middle partition with that of the possibly remote call of ``get_data()``.
 This algorithmic change, which was implemented in example 7, can be seen below:
 
 .. literalinclude:: ../../examples/1d_stencil/1d_stencil_7.cpp
-   :lines: 257-310
+   :language: c++
+   :start-after: //[stepper_7
+   :end-before: //]
 
 Example 8 completes the futurization process and utilizes the full potential of
 |hpx| by distributing the program flow to multiple localities, usually defined as

--- a/docs/sphinx/examples/accumulator.rst
+++ b/docs/sphinx/examples/accumulator.rst
@@ -130,18 +130,18 @@ Our accumulator class will need a data member to store its value in, so let's
 declare a data member:
 
 .. literalinclude:: ../../examples/accumulators/server/accumulator.hpp
-   :lines: 95
+   :lines: 97
 
 The constructor for this class simply initializes ``value_`` to 0:
 
 .. literalinclude:: ../../examples/accumulators/server/accumulator.hpp
-   :lines: 54
+   :lines: 56
 
 Next, let's look at the three methods of this component that we will be exposing
 as component actions:
 
 .. literalinclude:: ../../examples/accumulators/server/accumulator.hpp
-   :lines: 61-80
+   :lines: 61-83
 
 Here are the action types. These types wrap the methods we're exposing. The
 wrapping technique is very similar to the one used in the

--- a/docs/sphinx/examples/accumulator.rst
+++ b/docs/sphinx/examples/accumulator.rst
@@ -124,37 +124,49 @@ template argument passed to locking_hook is used as its base class). The
 following snippet shows the corresponding code:
 
 .. literalinclude:: ../../examples/accumulators/server/accumulator.hpp
-   :lines: 45-47
+   :language: c++
+   :start-after: //[accumulator_server_inherit
+   :end-before: //]
 
 Our accumulator class will need a data member to store its value in, so let's
 declare a data member:
 
 .. literalinclude:: ../../examples/accumulators/server/accumulator.hpp
-   :lines: 97
+   :language: c++
+   :start-after: //[accumulator_server_data_member
+   :end-before: //]
 
 The constructor for this class simply initializes ``value_`` to 0:
 
 .. literalinclude:: ../../examples/accumulators/server/accumulator.hpp
-   :lines: 56
+   :language: c++
+   :start-after: //[accumulator_server_ctor
+   :end-before: //]
 
 Next, let's look at the three methods of this component that we will be exposing
 as component actions:
 
 .. literalinclude:: ../../examples/accumulators/server/accumulator.hpp
-   :lines: 61-83
+   :language: c++
+   :start-after: //[accumulator_components
+   :end-before: //]
 
 Here are the action types. These types wrap the methods we're exposing. The
 wrapping technique is very similar to the one used in the
 :ref:`examples_fibonacci` and the :ref:`examples_hello_world`:
 
 .. literalinclude:: ../../examples/accumulators/server/accumulator.hpp
-   :lines: 88-90
+   :language: c++
+   :start-after: //[accumulator_action_types
+   :end-before: //]
 
 The last piece of code in the server class header is the declaration of the
 action type registration code:
 
 .. literalinclude:: ../../examples/accumulators/server/accumulator.hpp
-   :lines: 101-111
+   :language: c++
+   :start-after: //[accumulator_registration_declarations
+   :end-before: //]
 
 .. note::
 
@@ -164,7 +176,10 @@ The rest of the registration code is in
 :download:`accumulator.cpp <../../examples/accumulators/accumulator.cpp>`
 
 .. literalinclude:: ../../examples/accumulators/accumulator.cpp
-   :lines: 13-34
+   :language: c++
+   :start-after: //[accumulator_registration_definitions
+   :end-before: //]
+
 
 .. note::
 
@@ -190,12 +205,16 @@ Clients, like servers, need to inherit from a base class, this time,
 :cpp:class:`hpx::components::client_base`:
 
 .. literalinclude:: ../../examples/accumulators/accumulator.hpp
-   :lines: 22-25
+   :language: c++
+   :start-after: //[accumulator_client_inherit
+   :end-before: //]
 
 For readability, we typedef the base class like so:
 
 .. literalinclude:: ../../examples/accumulators/accumulator.hpp
-   :lines: 29-31
+   :language: c++
+   :start-after: //[accumulator_base_type
+   :end-before: //]
 
 Here are examples of how to expose actions through a client class:
 
@@ -208,7 +227,9 @@ There are a few different ways of invoking actions:
   We use :cpp:func:`hpx::apply` to invoke an action in a non-blocking fashion.
 
 .. literalinclude:: ../../examples/accumulators/accumulator.hpp
-   :lines: 59-65
+   :language: c++
+   :start-after: //[accumulator_client_reset_non_blocking
+   :end-before: //]
 
 * **Asynchronous**: Futures, as demonstrated in :ref:`examples_fibonacci_local`,
   :ref:`examples_fibonacci`, and the :ref:`examples_hello_world`, enable
@@ -216,7 +237,9 @@ There are a few different ways of invoking actions:
   class:
 
 .. literalinclude:: ../../examples/accumulators/accumulator.hpp
-   :lines: 115-121
+   :language: c++
+   :start-after: //[accumulator_client_query_async
+   :end-before: //]
 
 * **Synchronous**: To invoke an action in a fully synchronous manner, we can
   simply call :cpp:func:`hpx::async`\ ``().get()`` (i.e., create a future and
@@ -224,7 +247,9 @@ There are a few different ways of invoking actions:
   client class:
 
 .. literalinclude:: ../../examples/accumulators/accumulator.hpp
-   :lines: 97-103
+   :language: c++
+   :start-after: //[accumulator_client_add_sync
+   :end-before: //]
 
 Note that ``this->get_id()`` references a data member of the
 :cpp:class:`hpx::components::client_base` base class which identifies the server

--- a/docs/sphinx/examples/fibonacci.rst
+++ b/docs/sphinx/examples/fibonacci.rst
@@ -71,7 +71,10 @@ The code needed to initialize the |hpx| runtime is the same as in the
 :ref:`previous example <examples_fibonacci_local>`:
 
 .. literalinclude:: ../../examples/quickstart/fibonacci.cpp
-   :lines: 80-99
+   :language: c++
+   :start-after: //[fib_main
+   :end-before: //]
+
 
 The :cpp:func:`hpx::init` function in ``main()`` starts the runtime system, and
 invokes ``hpx_main()`` as the first |hpx|-thread. The command line option
@@ -81,7 +84,9 @@ takes to do the computation, the ``fibonacci`` :term:`action` is invoked
 synchronously, and the answer is printed out.
 
 .. literalinclude:: ../../examples/quickstart/fibonacci.cpp
-   :lines: 57-77
+   :language: c++
+   :start-after: //[fib_hpx_main
+   :end-before: //]
 
 Upon a closer look we see that we've created a ``std::uint64_t`` to store the
 result of invoking our ``fibonacci_action`` ``fib``. This :term:`action` will
@@ -98,7 +103,9 @@ further understand this we turn to the code to find where ``fibonacci_action``
 was defined:
 
 .. literalinclude:: ../../examples/quickstart/fibonacci.cpp
-   :lines: 23-30
+   :language: c++
+   :start-after: //[fib_action
+   :end-before: //]
 
 A plain :term:`action` is the most basic form of :term:`action`. Plain
 :term:`action`\ s wrap simple global functions which are not associated with any
@@ -116,7 +123,9 @@ result of the function ``fibonacci()``. Now, let's look at the function
 ``fibonacci()``:
 
 .. literalinclude:: ../../examples/quickstart/fibonacci.cpp
-   :lines: 33-54
+   :language: c++
+   :start-after: //[fib_func
+   :end-before: //]
 
 This block of code is much more straightforward and should look familiar from
 the :ref:`previous example <examples_fibonacci_local>`. First, ``if (n < 2)``,

--- a/docs/sphinx/examples/fibonacci.rst
+++ b/docs/sphinx/examples/fibonacci.rst
@@ -71,7 +71,7 @@ The code needed to initialize the |hpx| runtime is the same as in the
 :ref:`previous example <examples_fibonacci_local>`:
 
 .. literalinclude:: ../../examples/quickstart/fibonacci.cpp
-   :lines: 77-91
+   :lines: 80-99
 
 The :cpp:func:`hpx::init` function in ``main()`` starts the runtime system, and
 invokes ``hpx_main()`` as the first |hpx|-thread. The command line option
@@ -81,7 +81,7 @@ takes to do the computation, the ``fibonacci`` :term:`action` is invoked
 synchronously, and the answer is printed out.
 
 .. literalinclude:: ../../examples/quickstart/fibonacci.cpp
-   :lines: 54-72
+   :lines: 57-77
 
 Upon a closer look we see that we've created a ``std::uint64_t`` to store the
 result of invoking our ``fibonacci_action`` ``fib``. This :term:`action` will
@@ -98,7 +98,7 @@ further understand this we turn to the code to find where ``fibonacci_action``
 was defined:
 
 .. literalinclude:: ../../examples/quickstart/fibonacci.cpp
-   :lines: 20-25
+   :lines: 23-30
 
 A plain :term:`action` is the most basic form of :term:`action`. Plain
 :term:`action`\ s wrap simple global functions which are not associated with any
@@ -116,7 +116,7 @@ result of the function ``fibonacci()``. Now, let's look at the function
 ``fibonacci()``:
 
 .. literalinclude:: ../../examples/quickstart/fibonacci.cpp
-   :lines: 30-49
+   :lines: 33-54
 
 This block of code is much more straightforward and should look familiar from
 the :ref:`previous example <examples_fibonacci_local>`. First, ``if (n < 2)``,

--- a/docs/sphinx/examples/interest_calculator.rst
+++ b/docs/sphinx/examples/interest_calculator.rst
@@ -89,12 +89,17 @@ rate, compound period, and time. It is important to note that the units of time
 for ``cp`` and ``time`` must be the same.
 
 .. literalinclude:: ../../examples/quickstart/interest_calculator.cpp
-   :lines: 102-115
+   :language: c++
+   :start-after: //[interest_main
+   :end-before: //]
 
 Next we look at hpx_main.
 
 .. literalinclude:: ../../examples/quickstart/interest_calculator.cpp
-   :lines: 47-97
+   :language: c++
+   :start-after: //[interest_hpx_main
+   :end-before: //]
+
 
 Here we find our command line variables read in, the rate is converted from a
 percent to a decimal, the number of calculation iterations is determined, and
@@ -115,7 +120,9 @@ To see how ``interest`` and ``principal`` are calculated in the loop, let us loo
 at ``calc_action`` and ``add_action``:
 
 .. literalinclude:: ../../examples/quickstart/interest_calculator.cpp
-   :lines: 31-42
+   :language: c++
+   :start-after: //[interest_calc_add_action
+   :end-before: //]
 
 After the shared future dependencies have been defined in hpx_main, we see the
 following statement:


### PR DESCRIPTION
Updated the source code includes in the examples documentation, because the source files are not exactly the same anymore.
Worst case, source code blocks are empty: [accumulator examples](https://hpx-docs.stellar-group.org/latest/html/examples/accumulator.html)
