### PR TITLE
"Fix" termination detection

### DIFF
--- a/libs/core/execution_base/include/hpx/execution_base/this_thread.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/this_thread.hpp
@@ -22,6 +22,9 @@
 #include <cstdint>
 
 namespace hpx { namespace execution_base {
+    namespace detail {
+        HPX_CORE_EXPORT agent_base& get_default_agent();
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     namespace this_thread {

--- a/libs/core/execution_base/src/this_thread.cpp
+++ b/libs/core/execution_base/src/this_thread.cpp
@@ -201,13 +201,15 @@ namespace hpx { namespace execution_base {
         {
             std::this_thread::sleep_until(sleep_time.value());
         }
+    }    // namespace
 
+    namespace detail {
         agent_base& get_default_agent()
         {
             static thread_local default_agent agent;
             return agent;
         }
-    }    // namespace
+    }    // namespace detail
 
     namespace this_thread {
 
@@ -216,7 +218,7 @@ namespace hpx { namespace execution_base {
             struct agent_storage
             {
                 agent_storage()
-                  : impl_(&get_default_agent())
+                  : impl_(&hpx::execution_base::detail::get_default_agent())
                 {
                 }
 

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool.hpp
@@ -135,6 +135,10 @@ namespace hpx { namespace threads { namespace detail {
         void stop(
             std::unique_lock<std::mutex>& l, bool blocking = true) override;
 
+        void wait() override;
+        bool is_busy() override;
+        bool is_idle() override;
+
         void suspend_direct(error_code& ec = throws) override;
         void resume_direct(error_code& ec = throws) override;
 
@@ -392,6 +396,7 @@ namespace hpx { namespace threads { namespace detail {
         std::size_t max_background_threads_;
         std::size_t max_idle_loop_count_;
         std::size_t max_busy_loop_count_;
+        std::size_t shutdown_check_count_;
     };
 }}}    // namespace hpx::threads::detail
 

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
@@ -104,6 +104,7 @@ namespace hpx { namespace threads { namespace detail {
       , max_background_threads_(init.max_background_threads_)
       , max_idle_loop_count_(init.max_idle_loop_count_)
       , max_busy_loop_count_(init.max_busy_loop_count_)
+      , shutdown_check_count_(init.shutdown_check_count_)
     {
         sched_->set_parent_pool(this);
     }
@@ -178,6 +179,37 @@ namespace hpx { namespace threads { namespace detail {
     }
 
     template <typename Scheduler>
+    bool scheduled_thread_pool<Scheduler>::is_busy()
+    {
+        // If we are currently on an HPX thread, which runs on the current pool,
+        // we ignore it for the purposes of checking if the pool is busy (i.e.
+        // this returns true only if there is *other* work left on this pool).
+        std::int64_t hpx_thread_offset =
+            (threads::get_self_ptr() && this_thread::get_pool() == this) ? 1 :
+                                                                           0;
+        bool have_hpx_threads =
+            get_thread_count_unknown(std::size_t(-1), false) >
+            sched_->Scheduler::get_background_thread_count() +
+                hpx_thread_offset;
+        bool have_polling_work =
+            sched_->Scheduler::get_polling_work_count() > 0;
+        return have_hpx_threads || have_polling_work;
+    }
+
+    template <typename Scheduler>
+    bool scheduled_thread_pool<Scheduler>::is_idle()
+    {
+        return !is_busy();
+    }
+
+    template <typename Scheduler>
+    void scheduled_thread_pool<Scheduler>::wait()
+    {
+        hpx::util::detail::yield_while_count(
+            [this]() { return is_busy(); }, shutdown_check_count_);
+    }
+
+    template <typename Scheduler>
     template <typename Lock>
     void scheduled_thread_pool<Scheduler>::stop_locked(Lock& l, bool blocking)
     {
@@ -185,6 +217,13 @@ namespace hpx { namespace threads { namespace detail {
 
         if (!threads_.empty())
         {
+            // wait for all work to be done before requesting threads to shut
+            // down
+            if (blocking)
+            {
+                wait();
+            }
+
             // wake up if suspended
             resume_internal(blocking, throws);
 

--- a/libs/core/threading_base/include/hpx/threading_base/thread_pool_base.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_pool_base.hpp
@@ -127,6 +127,7 @@ namespace hpx { namespace threads {
         std::size_t max_background_threads_;
         std::size_t max_idle_loop_count_;
         std::size_t max_busy_loop_count_;
+        std::size_t shutdown_check_count_;
 
         thread_pool_init_parameters(std::string const& name, std::size_t index,
             policies::scheduler_mode mode, std::size_t num_threads,
@@ -138,7 +139,8 @@ namespace hpx { namespace threads {
                     hpx::threads::detail::network_background_callback_type(),
             std::size_t max_background_threads = std::size_t(-1),
             std::size_t max_idle_loop_count = HPX_IDLE_LOOP_COUNT_MAX,
-            std::size_t max_busy_loop_count = HPX_BUSY_LOOP_COUNT_MAX)
+            std::size_t max_busy_loop_count = HPX_BUSY_LOOP_COUNT_MAX,
+            std::size_t shutdown_check_count = 10)
           : name_(name)
           , index_(index)
           , mode_(mode)
@@ -150,6 +152,7 @@ namespace hpx { namespace threads {
           , max_background_threads_(max_background_threads)
           , max_idle_loop_count_(max_idle_loop_count)
           , max_busy_loop_count_(max_busy_loop_count)
+          , shutdown_check_count_(shutdown_check_count)
         {
         }
     };
@@ -173,6 +176,10 @@ namespace hpx { namespace threads {
 
         virtual void stop(
             std::unique_lock<std::mutex>& l, bool blocking = true) = 0;
+
+        virtual void wait() = 0;
+        virtual bool is_busy() = 0;
+        virtual bool is_idle() = 0;
 
         virtual void print_pool(std::ostream&) = 0;
 

--- a/libs/core/threading_base/src/scheduler_base.cpp
+++ b/libs/core/threading_base/src/scheduler_base.cpp
@@ -47,6 +47,8 @@ namespace hpx { namespace threads { namespace policies {
       , background_thread_count_(0)
       , polling_function_mpi_(&null_polling_function)
       , polling_function_cuda_(&null_polling_function)
+      , polling_work_count_function_mpi_(&null_polling_work_count_function)
+      , polling_work_count_function_cuda_(&null_polling_work_count_function)
     {
         set_scheduler_mode(mode);
 

--- a/libs/full/command_line_handling_local/examples/CMakeLists.txt
+++ b/libs/full/command_line_handling_local/examples/CMakeLists.txt
@@ -9,10 +9,7 @@ if(HPX_WITH_EXAMPLES)
   add_hpx_pseudo_dependencies(
     examples.modules examples.modules.command_line_handling_local
   )
-  if(HPX_WITH_TESTS
-     AND HPX_WITH_TESTS_EXAMPLES
-     AND HPX_COMMAND_LINE_HANDLING_LOCAL_WITH_TESTS
-  )
+  if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
     add_hpx_pseudo_target(tests.examples.modules.command_line_handling_local)
     add_hpx_pseudo_dependencies(
       tests.examples.modules tests.examples.modules.command_line_handling_local

--- a/libs/full/command_line_handling_local/tests/CMakeLists.txt
+++ b/libs/full/command_line_handling_local/tests/CMakeLists.txt
@@ -8,48 +8,41 @@ include(HPX_Message)
 include(HPX_Option)
 
 if(NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
-  hpx_set_option(
-    HPX_COMMAND_LINE_HANDLING_LOCAL_WITH_TESTS
-    VALUE OFF
-    FORCE
-  )
   return()
 endif()
 
-if(HPX_COMMAND_LINE_HANDLING_LOCAL_WITH_TESTS)
-  if(HPX_WITH_TESTS_UNIT)
-    add_hpx_pseudo_target(tests.unit.modules.command_line_handling_local)
-    add_hpx_pseudo_dependencies(
-      tests.unit.modules tests.unit.modules.command_line_handling_local
-    )
-    add_subdirectory(unit)
-  endif()
+if(HPX_WITH_TESTS_UNIT)
+  add_hpx_pseudo_target(tests.unit.modules.command_line_handling_local)
+  add_hpx_pseudo_dependencies(
+    tests.unit.modules tests.unit.modules.command_line_handling_local
+  )
+  add_subdirectory(unit)
+endif()
 
-  if(HPX_WITH_TESTS_REGRESSIONS)
-    add_hpx_pseudo_target(tests.regressions.modules.command_line_handling_local)
-    add_hpx_pseudo_dependencies(
-      tests.regressions.modules
-      tests.regressions.modules.command_line_handling_local
-    )
-    add_subdirectory(regressions)
-  endif()
+if(HPX_WITH_TESTS_REGRESSIONS)
+  add_hpx_pseudo_target(tests.regressions.modules.command_line_handling_local)
+  add_hpx_pseudo_dependencies(
+    tests.regressions.modules
+    tests.regressions.modules.command_line_handling_local
+  )
+  add_subdirectory(regressions)
+endif()
 
-  if(HPX_WITH_TESTS_BENCHMARKS)
-    add_hpx_pseudo_target(tests.performance.modules.command_line_handling_local)
-    add_hpx_pseudo_dependencies(
-      tests.performance.modules
-      tests.performance.modules.command_line_handling_local
-    )
-    add_subdirectory(performance)
-  endif()
+if(HPX_WITH_TESTS_BENCHMARKS)
+  add_hpx_pseudo_target(tests.performance.modules.command_line_handling_local)
+  add_hpx_pseudo_dependencies(
+    tests.performance.modules
+    tests.performance.modules.command_line_handling_local
+  )
+  add_subdirectory(performance)
+endif()
 
-  if(HPX_WITH_TESTS_HEADERS)
-    add_hpx_header_tests(
-      modules.command_line_handling_local
-      HEADERS ${command_line_handling_local_headers}
-      HEADER_ROOT ${PROJECT_SOURCE_DIR}/include
-      NOLIBS
-      DEPENDENCIES hpx_command_line_handling_local
-    )
-  endif()
+if(HPX_WITH_TESTS_HEADERS)
+  add_hpx_header_tests(
+    modules.command_line_handling_local
+    HEADERS ${command_line_handling_local_headers}
+    HEADER_ROOT ${PROJECT_SOURCE_DIR}/include
+    NOLIBS
+    DEPENDENCIES hpx_command_line_handling_local
+  )
 endif()

--- a/libs/full/init_runtime/tests/unit/CMakeLists.txt
+++ b/libs/full/init_runtime/tests/unit/CMakeLists.txt
@@ -5,7 +5,9 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests runtime_type parcel_pool start_stop_callbacks)
+set(tests runtime_type parcel_pool shutdown_suspended_thread
+          start_stop_callbacks
+)
 
 if(HPX_WITH_DISTRIBUTED_RUNTIME)
   set(tests ${tests} handled_exception unhandled_exception)

--- a/libs/full/init_runtime/tests/unit/shutdown_suspended_thread.cpp
+++ b/libs/full/init_runtime/tests/unit/shutdown_suspended_thread.cpp
@@ -1,0 +1,31 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// This test checks that the runtime takes into account suspended threads before
+// initiating full shutdown.
+
+#include <hpx/config.hpp>
+#include <hpx/future.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/thread.hpp>
+
+#include <chrono>
+
+int hpx_main()
+{
+    hpx::apply(
+        [] { hpx::this_thread::sleep_for(std::chrono::milliseconds(500)); });
+
+    return hpx::finalize();
+}
+
+int main(int argc, char** argv)
+{
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+
+    return hpx::util::report_errors();
+}

--- a/libs/full/init_runtime_local/tests/CMakeLists.txt
+++ b/libs/full/init_runtime_local/tests/CMakeLists.txt
@@ -8,46 +8,39 @@ include(HPX_Message)
 include(HPX_Option)
 
 if(NOT HPX_WITH_TESTS AND HPX_TOP_LEVEL)
-  hpx_set_option(
-    HPX_INIT_RUNTIME_LOCAL_WITH_TESTS
-    VALUE OFF
-    FORCE
-  )
   return()
 endif()
 
-if(HPX_INIT_RUNTIME_LOCAL_WITH_TESTS)
-  if(HPX_WITH_TESTS_UNIT)
-    add_hpx_pseudo_target(tests.unit.modules.init_runtime_local)
-    add_hpx_pseudo_dependencies(
-      tests.unit.modules tests.unit.modules.init_runtime_local
-    )
-    add_subdirectory(unit)
-  endif()
+if(HPX_WITH_TESTS_UNIT)
+  add_hpx_pseudo_target(tests.unit.modules.init_runtime_local)
+  add_hpx_pseudo_dependencies(
+    tests.unit.modules tests.unit.modules.init_runtime_local
+  )
+  add_subdirectory(unit)
+endif()
 
-  if(HPX_WITH_TESTS_REGRESSIONS)
-    add_hpx_pseudo_target(tests.regressions.modules.init_runtime_local)
-    add_hpx_pseudo_dependencies(
-      tests.regressions.modules tests.regressions.modules.init_runtime_local
-    )
-    add_subdirectory(regressions)
-  endif()
+if(HPX_WITH_TESTS_REGRESSIONS)
+  add_hpx_pseudo_target(tests.regressions.modules.init_runtime_local)
+  add_hpx_pseudo_dependencies(
+    tests.regressions.modules tests.regressions.modules.init_runtime_local
+  )
+  add_subdirectory(regressions)
+endif()
 
-  if(HPX_WITH_TESTS_BENCHMARKS)
-    add_hpx_pseudo_target(tests.performance.modules.init_runtime_local)
-    add_hpx_pseudo_dependencies(
-      tests.performance.modules tests.performance.modules.init_runtime_local
-    )
-    add_subdirectory(performance)
-  endif()
+if(HPX_WITH_TESTS_BENCHMARKS)
+  add_hpx_pseudo_target(tests.performance.modules.init_runtime_local)
+  add_hpx_pseudo_dependencies(
+    tests.performance.modules tests.performance.modules.init_runtime_local
+  )
+  add_subdirectory(performance)
+endif()
 
-  if(HPX_WITH_TESTS_HEADERS)
-    add_hpx_header_tests(
-      modules.init_runtime_local
-      HEADERS ${init_runtime_local_headers}
-      HEADER_ROOT ${PROJECT_SOURCE_DIR}/include
-      NOLIBS
-      DEPENDENCIES hpx_init_runtime_local
-    )
-  endif()
+if(HPX_WITH_TESTS_HEADERS)
+  add_hpx_header_tests(
+    modules.init_runtime_local
+    HEADERS ${init_runtime_local_headers}
+    HEADER_ROOT ${PROJECT_SOURCE_DIR}/include
+    NOLIBS
+    DEPENDENCIES hpx_init_runtime_local
+  )
 endif()

--- a/libs/full/init_runtime_local/tests/unit/CMakeLists.txt
+++ b/libs/full/init_runtime_local/tests/unit/CMakeLists.txt
@@ -1,5 +1,28 @@
 # Copyright (c) 2020 The STE||AR-Group
+#               2011 Bryce Adelstein-Lelbach
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests shutdown_suspended_thread_local)
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  set(${test}_PARAMETERS ${${test}_PARAMETERS} THREADS_PER_LOCALITY 4)
+
+  source_group("Source Files" FILES ${sources})
+
+  set(folder_name "Tests/Unit/Modules/Full/InitRuntimeLocal")
+
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER ${folder_name}
+  )
+
+  add_hpx_unit_test("modules.init_runtime_local" ${test} ${${test}_PARAMETERS})
+endforeach()

--- a/libs/full/init_runtime_local/tests/unit/shutdown_suspended_thread_local.cpp
+++ b/libs/full/init_runtime_local/tests/unit/shutdown_suspended_thread_local.cpp
@@ -1,0 +1,31 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// This test checks that the runtime takes into account suspended threads before
+// initiating full shutdown.
+
+#include <hpx/config.hpp>
+#include <hpx/local/future.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/local/thread.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <chrono>
+
+int hpx_main()
+{
+    hpx::apply(
+        [] { hpx::this_thread::sleep_for(std::chrono::milliseconds(500)); });
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char** argv)
+{
+    HPX_TEST_EQ(hpx::local::init(hpx_main, argc, argv), 0);
+
+    return hpx::util::report_errors();
+}

--- a/libs/full/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/full/runtime_configuration/src/runtime_configuration.cpp
@@ -123,6 +123,7 @@ namespace hpx { namespace util {
 #endif
             "finalize_wait_time = ${HPX_FINALIZE_WAIT_TIME:-1.0}",
             "shutdown_timeout = ${HPX_SHUTDOWN_TIMEOUT:-1.0}",
+            "shutdown_check_count = ${HPX_SHUTDOWN_CHECK_COUNT:10}",
 #ifdef HPX_HAVE_VERIFY_LOCKS
 #if defined(HPX_DEBUG)
             "lock_detection = ${HPX_LOCK_DETECTION:1}",

--- a/libs/full/runtime_local/src/runtime_local.cpp
+++ b/libs/full/runtime_local/src/runtime_local.cpp
@@ -1491,13 +1491,7 @@ namespace hpx {
         // block main thread
         t.join();
 
-        util::yield_while(
-            [this]() {
-                return thread_manager_->get_thread_count() >
-                    1 + thread_manager_->get_background_thread_count() &&
-                    state_.load() < state_shutdown;
-            },
-            "runtime::wait");
+        thread_manager_->wait();
 
         LRT_(info).format("runtime_local: exiting wait state");
         return result_;
@@ -1599,13 +1593,6 @@ namespace hpx {
                 "Can only suspend runtime from running state");
             return -1;
         }
-
-        util::yield_while(
-            [this]() {
-                return thread_manager_->get_thread_count() >
-                    thread_manager_->get_background_thread_count();
-            },
-            "runtime::suspend");
 
         thread_manager_->suspend();
 

--- a/libs/full/threadmanager/include/hpx/modules/threadmanager.hpp
+++ b/libs/full/threadmanager/include/hpx/modules/threadmanager.hpp
@@ -137,6 +137,10 @@ namespace hpx { namespace threads {
         ///
         void stop(bool blocking = true);
 
+        bool is_busy();
+        bool is_idle();
+        void wait();
+
         // \brief Suspend all thread pools.
         void suspend();
 

--- a/libs/parallelism/execution/tests/unit/standalone_thread_pool_executor.cpp
+++ b/libs/parallelism/execution/tests/unit/standalone_thread_pool_executor.cpp
@@ -198,10 +198,7 @@ int main()
         // run the tests for us.
         hpx::apply(exec, &test_thread_pool_os_executor, exec);
 
-        // Stop the pool. First wait for all tasks to run.
-        hpx::util::yield_while([&pool]() {
-            return pool.get_thread_count_unknown(std::size_t(-1), false) != 0;
-        });
+        // Stop the pool.
         pool.stop(l, true);
     }
 

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -203,44 +203,6 @@ void measure_function_futures_wait_all(
 }
 
 template <typename Executor>
-void measure_function_futures_thread_count(
-    std::uint64_t count, bool csv, Executor& exec)
-{
-    std::atomic<std::uint64_t> sanity_check(count);
-    auto this_pool = hpx::this_thread::get_pool();
-
-    // start the clock
-    high_resolution_timer walltime;
-    for (std::uint64_t i = 0; i < count; ++i)
-    {
-        hpx::apply(exec, [&sanity_check]() {
-            null_function();
-            sanity_check--;
-        });
-    }
-
-    // Yield until there is only this and background threads left.
-    hpx::util::yield_while([this_pool]() {
-        auto u = this_pool->get_thread_count_unknown(std::size_t(-1), false);
-        auto b = this_pool->get_background_thread_count() + 1;
-        return u > b;
-    });
-
-    // stop the clock
-    const double duration = walltime.elapsed();
-
-    if (sanity_check != 0)
-    {
-        auto count =
-            this_pool->get_thread_count_unknown(std::size_t(-1), false);
-        throw std::runtime_error(
-            "This test is faulty " + std::to_string(count));
-    }
-
-    print_stats("apply", "ThreadCount", exec_name(exec), count, duration, csv);
-}
-
-template <typename Executor>
 void measure_function_futures_limiting_executor(
     std::uint64_t count, bool csv, Executor exec)
 {
@@ -564,7 +526,6 @@ int hpx_main(variables_map& vm)
 #endif
                 measure_function_futures_wait_each(count, csv, par);
                 measure_function_futures_wait_all(count, csv, par);
-                measure_function_futures_thread_count(count, csv, par);
                 measure_function_futures_sliding_semaphore(count, csv, par);
                 measure_function_futures_for_loop(count, csv, par);
                 measure_function_futures_for_loop(count, csv, par_agg);


### PR DESCRIPTION
Fixes (or at least improves) the termination detection used in the occasionally timing-out `standalone_thread_pool_executor` test.

Using the thread-local task counts to decide if it's ok to stop a thread pool is racey since the total count can come out to zero even if there are tasks remaining (if stealing is enabled). This introduces a pool-global thread count that can be used instead to check if there are tasks remaining.

However, there are further problems which is why I'm leaving this as a draft:
- I think the interaction between the new task count and background task count is also racey (but less likely to fail).
- Scheduling tasks from one thread pool to another may lead to similar races when checking if the full runtime can be shutdown.
- MPI/CUDA polling is not taken into account when deciding whether to stop a pool (there should be no remaining events/requests when the pool is fully stopped, but some worker threads may be shut down before all events/requests have been processed).
- A global count increases cache misses (see plot below for timings). Without padding on the counts the hit is quite big (in the future overhead test). With padding the hit reduced quite significantly but the benchmark still runs noticeably slower than with the thread local counts. (`local-thread-count` is current master, `global-thread-count` is after the first commit on this PR, and `global-thread-count-padding` is after the second commit.)

![termination_detection](https://user-images.githubusercontent.com/42977/114390533-ad4f7f00-9b96-11eb-8c2f-8ca95c275d01.png)

Update:

I changed this to use the approach of checking the counts multiple times suggested by @hkaiser. With the additional requirements of all of the following needing to be non-racy: comparing the thread count to the background thread count, comparing thread counts across pools, checking CUDA and MPI polling work; I gave in and thought this would actually be the most sensible approach. It still allows for false positives to happen, but the rate at which they happen is tunable.

More concretely, I've added:
- `yield_while_count`: like `yield_while` but requires the predicate to return false n times before returning.
- `yield_while_count_timeout`: like the above but with a timeout (used in `runtime_support_server`)
- `wait`, `is_busy`, `is_idle` functions to `threadmanager` and the `thread_pool_base`/`scheduled_thread_pool`; `is_busy` and `is_idle` can return the opposite of the true state with a small probability (as before with comparing thread counts); `wait` uses `yield_while_count` to reduce the false positive probability
- a configuration option `hpx.shutdown_check_count` to adjust how many times `yield_while` should check the predicate before returning

I've removed the `x_thread_count` variants from the `future_overhead` and the libcds equivalent tests since we know that approach is racy.