### PR TITLE
Add async_rw_mutex based on senders

### DIFF
--- a/libs/core/synchronization/CMakeLists.txt
+++ b/libs/core/synchronization/CMakeLists.txt
@@ -15,6 +15,7 @@ set(synchronization_headers
     hpx/semaphore.hpp
     hpx/shared_mutex.hpp
     hpx/stop_token.hpp
+    hpx/synchronization/async_rw_mutex.hpp
     hpx/synchronization/barrier.hpp
     hpx/synchronization/channel_mpmc.hpp
     hpx/synchronization/channel_mpsc.hpp

--- a/libs/core/synchronization/include/hpx/synchronization/async_rw_mutex.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/async_rw_mutex.hpp
@@ -1,0 +1,695 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/allocator_support/internal_allocator.hpp>
+#include <hpx/assert.hpp>
+#include <hpx/datastructures/optional.hpp>
+#include <hpx/execution_base/receiver.hpp>
+#include <hpx/functional/unique_function.hpp>
+#include <hpx/synchronization/mutex.hpp>
+
+#include <boost/container/small_vector.hpp>
+
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace experimental {
+    namespace detail {
+        enum class async_rw_mutex_access_type
+        {
+            read,
+            readwrite
+        };
+
+        template <typename T>
+        struct async_rw_mutex_shared_state
+        {
+            using shared_state_ptr_type =
+                std::shared_ptr<async_rw_mutex_shared_state>;
+            hpx::util::optional<T> value;
+            shared_state_ptr_type next_state;
+            hpx::lcos::local::mutex mtx;
+            boost::container::small_vector<
+                hpx::util::unique_function_nonser<void(shared_state_ptr_type)>,
+                1>
+                continuations;
+
+            async_rw_mutex_shared_state() = default;
+            async_rw_mutex_shared_state(async_rw_mutex_shared_state&&) = delete;
+            async_rw_mutex_shared_state& operator=(
+                async_rw_mutex_shared_state&&) = delete;
+            async_rw_mutex_shared_state(
+                async_rw_mutex_shared_state const&) = delete;
+            async_rw_mutex_shared_state& operator=(
+                async_rw_mutex_shared_state const&) = delete;
+
+            ~async_rw_mutex_shared_state()
+            {
+                // The last state does not have a next state. If this state has
+                // a next state it must always have continuations.
+                HPX_ASSERT((continuations.empty() && !next_state) ||
+                    (!continuations.empty() && next_state));
+
+                // This state must always have the value set by the time it is
+                // destructed. If there is no next state the value is destructed
+                // with this state.
+                HPX_ASSERT(value);
+
+                if (HPX_LIKELY(next_state))
+                {
+                    // The current state has now finished all accesses to the
+                    // wrapped value, so we move the value to the next state.
+                    next_state->set_value(std::move(value.value()));
+
+                    for (auto& continuation : continuations)
+                    {
+                        continuation(next_state);
+                    }
+                }
+            }
+
+            template <typename U>
+            void set_value(U&& u)
+            {
+                HPX_ASSERT(!value);
+                value.emplace(std::forward<U>(u));
+            }
+
+            void set_next_state(
+                std::shared_ptr<async_rw_mutex_shared_state> state)
+            {
+                // The next state should only be set once
+                HPX_ASSERT(!next_state);
+                next_state = std::move(state);
+            }
+
+            template <typename F>
+            void add_continuation(F&& continuation)
+            {
+                std::lock_guard<hpx::lcos::local::mutex> l(mtx);
+                continuations.emplace_back(std::forward<F>(continuation));
+            }
+        };
+
+        template <>
+        struct async_rw_mutex_shared_state<void>
+        {
+            using shared_state_ptr_type =
+                std::shared_ptr<async_rw_mutex_shared_state>;
+            shared_state_ptr_type next_state;
+            hpx::lcos::local::mutex mtx;
+            boost::container::small_vector<
+                hpx::util::unique_function_nonser<void(shared_state_ptr_type)>,
+                1>
+                continuations;
+
+            async_rw_mutex_shared_state() = default;
+            async_rw_mutex_shared_state(async_rw_mutex_shared_state&&) = delete;
+            async_rw_mutex_shared_state& operator=(
+                async_rw_mutex_shared_state&&) = delete;
+            async_rw_mutex_shared_state(
+                async_rw_mutex_shared_state const&) = delete;
+            async_rw_mutex_shared_state& operator=(
+                async_rw_mutex_shared_state const&) = delete;
+
+            ~async_rw_mutex_shared_state()
+            {
+                // The last state does not have a next state. If this state has
+                // a next state it must always have continuations.
+                HPX_ASSERT((continuations.empty() && !next_state) ||
+                    (!continuations.empty() && next_state));
+
+                for (auto& continuation : continuations)
+                {
+                    continuation(next_state);
+                }
+            }
+
+            void set_next_state(
+                std::shared_ptr<async_rw_mutex_shared_state> state)
+            {
+                // The next state should only be set once
+                HPX_ASSERT(!next_state);
+                next_state = std::move(state);
+            }
+
+            template <typename F>
+            void add_continuation(F&& continuation)
+            {
+                std::lock_guard<hpx::lcos::local::mutex> l(mtx);
+                continuations.emplace_back(std::forward<F>(continuation));
+            }
+        };
+
+        template <typename ReadWriteT, typename ReadT,
+            async_rw_mutex_access_type AccessType>
+        struct async_rw_mutex_access_wrapper;
+
+        template <typename ReadWriteT, typename ReadT>
+        struct async_rw_mutex_access_wrapper<ReadWriteT, ReadT,
+            async_rw_mutex_access_type::read>
+        {
+        private:
+            using shared_state_type =
+                std::shared_ptr<async_rw_mutex_shared_state<ReadWriteT>>;
+            shared_state_type state;
+
+        public:
+            async_rw_mutex_access_wrapper() = delete;
+            async_rw_mutex_access_wrapper(shared_state_type state)
+              : state(std::move(state))
+            {
+            }
+            async_rw_mutex_access_wrapper(
+                async_rw_mutex_access_wrapper&&) = default;
+            async_rw_mutex_access_wrapper& operator=(
+                async_rw_mutex_access_wrapper&&) = default;
+            async_rw_mutex_access_wrapper(
+                async_rw_mutex_access_wrapper const&) = default;
+            async_rw_mutex_access_wrapper& operator=(
+                async_rw_mutex_access_wrapper const&) = default;
+
+            operator ReadT&()
+            {
+                HPX_ASSERT(state);
+                HPX_ASSERT(state->value);
+                return state->value.value();
+            }
+        };
+
+        template <typename ReadWriteT, typename ReadT>
+        struct async_rw_mutex_access_wrapper<ReadWriteT, ReadT,
+            async_rw_mutex_access_type::readwrite>
+        {
+        private:
+            static_assert(!std::is_void<ReadWriteT>::value,
+                "Cannot mix void and non-void type in "
+                "async_rw_mutex_access_wrapper wrapper (ReadWriteT is void, "
+                "ReadT is non-void)");
+            static_assert(!std::is_void<ReadT>::value,
+                "Cannot mix void and non-void type in "
+                "async_rw_mutex_access_wrapper wrapper (ReadT is void, "
+                "ReadWriteT is non-void)");
+
+            using shared_state_type =
+                std::shared_ptr<async_rw_mutex_shared_state<ReadWriteT>>;
+            shared_state_type state;
+
+        public:
+            async_rw_mutex_access_wrapper() = delete;
+            async_rw_mutex_access_wrapper(shared_state_type state)
+              : state(std::move(state))
+            {
+            }
+            async_rw_mutex_access_wrapper(
+                async_rw_mutex_access_wrapper&&) = default;
+            async_rw_mutex_access_wrapper& operator=(
+                async_rw_mutex_access_wrapper&&) = default;
+            async_rw_mutex_access_wrapper(
+                async_rw_mutex_access_wrapper const&) = default;
+            async_rw_mutex_access_wrapper& operator=(
+                async_rw_mutex_access_wrapper const&) = default;
+
+            operator ReadWriteT&()
+            {
+                HPX_ASSERT(state);
+                HPX_ASSERT(state->value);
+                return state->value.value();
+            }
+        };
+
+        // The void wrappers for read and readwrite are identical, but must be
+        // specialized separately to avoid ambiguity with the non-void
+        // specializations above.
+        template <>
+        struct async_rw_mutex_access_wrapper<void, void,
+            async_rw_mutex_access_type::read>
+        {
+        private:
+            using shared_state_type =
+                std::shared_ptr<async_rw_mutex_shared_state<void>>;
+            shared_state_type state;
+
+        public:
+            async_rw_mutex_access_wrapper() = delete;
+            explicit async_rw_mutex_access_wrapper(shared_state_type state)
+              : state(std::move(state))
+            {
+            }
+            async_rw_mutex_access_wrapper(
+                async_rw_mutex_access_wrapper&&) = default;
+            async_rw_mutex_access_wrapper& operator=(
+                async_rw_mutex_access_wrapper&&) = default;
+            async_rw_mutex_access_wrapper(
+                async_rw_mutex_access_wrapper const&) = default;
+            async_rw_mutex_access_wrapper& operator=(
+                async_rw_mutex_access_wrapper const&) = default;
+        };
+
+        template <>
+        struct async_rw_mutex_access_wrapper<void, void,
+            async_rw_mutex_access_type::readwrite>
+        {
+        private:
+            using shared_state_type =
+                std::shared_ptr<async_rw_mutex_shared_state<void>>;
+            shared_state_type state;
+
+        public:
+            async_rw_mutex_access_wrapper() = delete;
+            explicit async_rw_mutex_access_wrapper(shared_state_type state)
+              : state(std::move(state))
+            {
+            }
+            async_rw_mutex_access_wrapper(
+                async_rw_mutex_access_wrapper&&) = default;
+            async_rw_mutex_access_wrapper& operator=(
+                async_rw_mutex_access_wrapper&&) = default;
+            async_rw_mutex_access_wrapper(
+                async_rw_mutex_access_wrapper const&) = default;
+            async_rw_mutex_access_wrapper& operator=(
+                async_rw_mutex_access_wrapper const&) = default;
+        };
+    }    // namespace detail
+
+    /// Read-write mutex where access is granted to a value through senders.
+    ///
+    /// The wrapped value is accessed through read and readwrite, both of which
+    /// return senders which call set_value on a connected receiver when the
+    /// wrapped value is safe to read or write. The senders send the value
+    /// through a wrapper type which is implicitly convertible to a reference of
+    /// the wrapped value. Read-only senders send wrappers that are convertible
+    /// to const references.
+    ///
+    /// A read-write sender gives exclusive access to the wrapped value, while a
+    /// read-only sender gives shared (with other read-only senders) access to
+    /// the value.
+    ///
+    /// A void mutex acts as a mutex around some user-managed resource, i.e. the
+    /// void mutex does not manage any value and the types sent by the senders
+    /// are not convertible. The sent types are copyable and release access to
+    /// the protected resource when released.
+    ///
+    /// The order in which senders call set_value is determined by the order in
+    /// which the senders are retrieved from the mutex. Connecting and starting
+    /// the senders is thread-safe.
+    ///
+    /// Retrieving senders from the mutex is not thread-safe.
+    ///
+    /// The mutex is movable and non-copyable.
+    template <typename ReadWriteT = void, typename ReadT = ReadWriteT,
+        typename Allocator = hpx::util::internal_allocator<>>
+    class async_rw_mutex;
+
+    // Implementation details:
+    //
+    // The async_rw_mutex protects access to a given resource using two
+    // reference counted shared states, the current and the previous state. Each
+    // shared state guards access to the next stage; when the shared state goes
+    // out of scope it triggers continuations for the next stage.
+    //
+    // When read-write access is required a sender is created which holds on to
+    // the newly created shared state for the read-write access and the previous
+    // state. When the sender is connected to a receiver, a callback is added to
+    // the previous shared state's destructor. The callback holds the new state,
+    // and passes a wrapper holding the shared state to set_value. Once the
+    // receiver which receives the wrapper has let the wrapper go out of scope
+    // (and all other references to the shared state are out of scope), the new
+    // shared state will again trigger its continuations.
+    //
+    // When read-only access is required and the previous access was read-only
+    // the procedure is the same as for read-write access. When read-only access
+    // follows a previous read-only access the shared state is reused between
+    // all consecutive read-only accesses, such that multiple read-only accesses
+    // can run concurrently, and the next access (which must be read-write) is
+    // triggered once all instances of that shared state have gone out of scope.
+    //
+    // The protected value is moved from state to state and is released when the
+    // last shared state is destroyed.
+
+    template <typename Allocator>
+    class async_rw_mutex<void, void, Allocator>
+    {
+    private:
+        template <detail::async_rw_mutex_access_type AccessType>
+        struct sender;
+
+        using shared_state_type = detail::async_rw_mutex_shared_state<void>;
+        using shared_state_ptr_type = std::shared_ptr<shared_state_type>;
+
+    public:
+        using read_type = void;
+        using readwrite_type = void;
+
+        using read_access_type =
+            detail::async_rw_mutex_access_wrapper<readwrite_type, read_type,
+                detail::async_rw_mutex_access_type::read>;
+        using readwrite_access_type =
+            detail::async_rw_mutex_access_wrapper<readwrite_type, read_type,
+                detail::async_rw_mutex_access_type::readwrite>;
+
+        using allocator_type = Allocator;
+
+        explicit async_rw_mutex(allocator_type const& alloc = {})
+          : alloc(alloc)
+        {
+        }
+        async_rw_mutex(async_rw_mutex&&) = default;
+        async_rw_mutex& operator=(async_rw_mutex&&) = default;
+        async_rw_mutex(async_rw_mutex const&) = delete;
+        async_rw_mutex& operator=(async_rw_mutex const&) = delete;
+
+        sender<detail::async_rw_mutex_access_type::read> read()
+        {
+            if (prev_access == detail::async_rw_mutex_access_type::readwrite)
+            {
+                prev_state = std::move(state);
+                state = std::allocate_shared<shared_state_type, allocator_type>(
+                    alloc);
+                prev_access = detail::async_rw_mutex_access_type::read;
+
+                // Only the first access has no previous shared state. When
+                // there is a previous state we set the next state so that the
+                // value can be passed from the previous state to the next
+                // state.
+                if (HPX_LIKELY(prev_state))
+                {
+                    prev_state->set_next_state(state);
+                }
+            }
+            return {prev_state, state};
+        }
+
+        sender<detail::async_rw_mutex_access_type::readwrite> readwrite()
+        {
+            prev_state = std::move(state);
+            state =
+                std::allocate_shared<shared_state_type, allocator_type>(alloc);
+            prev_access = detail::async_rw_mutex_access_type::readwrite;
+
+            // Only the first access has no previous shared state. When there is
+            // a previous state we set the next state so that the value can be
+            // passed from the previous state to the next state.
+            if (HPX_LIKELY(prev_state))
+            {
+                prev_state->set_next_state(state);
+            }
+            return {std::move(prev_state), state};
+        }
+
+    private:
+        template <detail::async_rw_mutex_access_type AccessType>
+        struct sender
+        {
+            shared_state_ptr_type prev_state;
+            shared_state_ptr_type state;
+
+            using access_type =
+                detail::async_rw_mutex_access_wrapper<readwrite_type, read_type,
+                    AccessType>;
+            template <template <typename...> class Tuple,
+                template <typename...> class Variant>
+            using value_types = Variant<Tuple<access_type>>;
+
+            template <template <typename...> class Variant>
+            using error_types = Variant<std::exception_ptr>;
+
+            static constexpr bool sends_done = false;
+
+            template <typename R>
+            struct operation_state
+            {
+                std::decay_t<R> r;
+                shared_state_ptr_type prev_state;
+                shared_state_ptr_type state;
+
+                template <typename R_>
+                operation_state(R_&& r, shared_state_ptr_type prev_state,
+                    shared_state_ptr_type state)
+                  : r(std::forward<R_>(r))
+                  , prev_state(std::move(prev_state))
+                  , state(std::move(state))
+                {
+                }
+
+                operation_state(operation_state&&) = delete;
+                operation_state& operator=(operation_state&&) = delete;
+                operation_state(operation_state const&) = delete;
+                operation_state& operator=(operation_state const&) = delete;
+
+                void start() noexcept
+                {
+                    HPX_ASSERT_MSG(state,
+                        "async_rw_lock::sender::operation_state state is "
+                        "empty, was the sender already started?");
+
+                    auto continuation =
+                        [r = std::move(r)](
+                            shared_state_ptr_type state) mutable {
+                            try
+                            {
+                                hpx::execution::experimental::set_value(
+                                    std::move(r),
+                                    access_type{std::move(state)});
+                            }
+                            catch (...)
+                            {
+                                hpx::execution::experimental::set_error(
+                                    std::move(r), std::current_exception());
+                            }
+                        };
+
+                    if (prev_state)
+                    {
+                        prev_state->add_continuation(std::move(continuation));
+
+                        // We release prev_state here to allow continuations to
+                        // run. The operation state may otherwise keep it alive
+                        // longer than needed.
+                        prev_state.reset();
+                    }
+                    else
+                    {
+                        // There is no previous state on the first access. We
+                        // can immediately trigger the continuation.
+                        continuation(std::move(state));
+                    }
+                }
+            };
+
+            template <typename R>
+            auto connect(R&& r) &&
+            {
+                return operation_state<R>{std::forward<R>(r),
+                    std::move(prev_state), std::move(state)};
+            }
+        };
+
+        allocator_type alloc;
+
+        detail::async_rw_mutex_access_type prev_access =
+            detail::async_rw_mutex_access_type::readwrite;
+
+        shared_state_ptr_type prev_state;
+        shared_state_ptr_type state;
+    };
+
+    template <typename ReadWriteT, typename ReadT, typename Allocator>
+    class async_rw_mutex
+    {
+    private:
+        static_assert(!std::is_void<ReadWriteT>::value,
+            "Cannot mix void and non-void type in async_rw_mutex (ReadWriteT "
+            "is void, ReadT is non-void)");
+        static_assert(!std::is_void<ReadT>::value,
+            "Cannot mix void and non-void type in async_rw_mutex (ReadT is "
+            "void, ReadWriteT is non-void)");
+
+        template <detail::async_rw_mutex_access_type AccessType>
+        struct sender;
+
+    public:
+        using read_type = std::decay_t<ReadT> const;
+        using readwrite_type = std::decay_t<ReadWriteT>;
+        using value_type = readwrite_type;
+
+        using read_access_type =
+            detail::async_rw_mutex_access_wrapper<readwrite_type, read_type,
+                detail::async_rw_mutex_access_type::read>;
+        using readwrite_access_type =
+            detail::async_rw_mutex_access_wrapper<readwrite_type, read_type,
+                detail::async_rw_mutex_access_type::readwrite>;
+
+        using allocator_type = Allocator;
+
+        async_rw_mutex() = delete;
+        template <typename U,
+            typename = std::enable_if_t<
+                !std::is_same<std::decay_t<U>, async_rw_mutex>::value>>
+        explicit async_rw_mutex(U&& u, allocator_type const& alloc = {})
+          : alloc(alloc)
+        {
+            value = std::forward<U>(u);
+        }
+        async_rw_mutex(async_rw_mutex&&) = default;
+        async_rw_mutex& operator=(async_rw_mutex&&) = default;
+        async_rw_mutex(async_rw_mutex const&) = delete;
+        async_rw_mutex& operator=(async_rw_mutex const&) = delete;
+
+        sender<detail::async_rw_mutex_access_type::read> read()
+        {
+            if (prev_access == detail::async_rw_mutex_access_type::readwrite)
+            {
+                prev_state = std::move(state);
+                state = std::allocate_shared<shared_state_type, allocator_type>(
+                    alloc);
+                prev_access = detail::async_rw_mutex_access_type::read;
+
+                // Only the first access has no previous shared state. When
+                // there is a previous state we set the next state so that the
+                // value can be passed from the previous state to the next
+                // state. When there is no previous state we need to move the
+                // value to the first state.
+                if (HPX_LIKELY(prev_state))
+                {
+                    prev_state->set_next_state(state);
+                }
+                else
+                {
+                    state->set_value(std::move(value));
+                }
+            }
+            return {prev_state, state};
+        }
+
+        sender<detail::async_rw_mutex_access_type::readwrite> readwrite()
+        {
+            prev_state = std::move(state);
+            state =
+                std::allocate_shared<shared_state_type, allocator_type>(alloc);
+
+            // Only the first access has no previous shared state. When there is
+            // a previous state we set the next state so that the value can be
+            // passed from the previous state to the next state. When there is
+            // no previous state we need to move the value to the first state.
+            if (HPX_LIKELY(prev_state))
+            {
+                prev_state->set_next_state(state);
+            }
+            else
+            {
+                state->set_value(std::move(value));
+            }
+            prev_access = detail::async_rw_mutex_access_type::readwrite;
+            return {std::move(prev_state), state};
+        }
+
+    private:
+        using shared_state_type =
+            detail::async_rw_mutex_shared_state<value_type>;
+        using shared_state_ptr_type = std::shared_ptr<shared_state_type>;
+
+        template <detail::async_rw_mutex_access_type AccessType>
+        struct sender
+        {
+            shared_state_ptr_type prev_state;
+            shared_state_ptr_type state;
+
+            using access_type =
+                detail::async_rw_mutex_access_wrapper<readwrite_type, read_type,
+                    AccessType>;
+            template <template <typename...> class Tuple,
+                template <typename...> class Variant>
+            using value_types = Variant<Tuple<access_type>>;
+
+            template <template <typename...> class Variant>
+            using error_types = Variant<std::exception_ptr>;
+
+            static constexpr bool sends_done = false;
+
+            template <typename R>
+            struct operation_state
+            {
+                std::decay_t<R> r;
+                shared_state_ptr_type prev_state;
+                shared_state_ptr_type state;
+
+                template <typename R_>
+                operation_state(R_&& r, shared_state_ptr_type prev_state,
+                    shared_state_ptr_type state)
+                  : r(std::forward<R_>(r))
+                  , prev_state(std::move(prev_state))
+                  , state(std::move(state))
+                {
+                }
+
+                operation_state(operation_state&&) = delete;
+                operation_state& operator=(operation_state&&) = delete;
+                operation_state(operation_state const&) = delete;
+                operation_state& operator=(operation_state const&) = delete;
+
+                void start() noexcept
+                {
+                    HPX_ASSERT_MSG(state,
+                        "async_rw_lock::sender::operation_state state is "
+                        "empty, was the sender already started?");
+
+                    auto continuation =
+                        [r = std::move(r)](
+                            shared_state_ptr_type state) mutable {
+                            try
+                            {
+                                hpx::execution::experimental::set_value(
+                                    std::move(r),
+                                    access_type{std::move(state)});
+                            }
+                            catch (...)
+                            {
+                                hpx::execution::experimental::set_error(
+                                    std::move(r), std::current_exception());
+                            }
+                        };
+
+                    if (prev_state)
+                    {
+                        prev_state->add_continuation(std::move(continuation));
+                        // We release prev_state here to allow continuations to
+                        // run. The operation state may otherwise keep it alive
+                        // longer than needed.
+                        prev_state.reset();
+                    }
+                    else
+                    {
+                        // There is no previous state on the first access. We
+                        // can immediately trigger the continuation.
+                        continuation(std::move(state));
+                    }
+                }
+            };
+
+            template <typename R>
+            auto connect(R&& r) &&
+            {
+                return operation_state<R>{std::forward<R>(r),
+                    std::move(prev_state), std::move(state)};
+            }
+        };
+
+        value_type value;
+        allocator_type alloc;
+
+        detail::async_rw_mutex_access_type prev_access =
+            detail::async_rw_mutex_access_type::readwrite;
+
+        shared_state_ptr_type prev_state;
+        shared_state_ptr_type state;
+    };
+}}    // namespace hpx::experimental

--- a/libs/core/synchronization/tests/unit/CMakeLists.txt
+++ b/libs/core/synchronization/tests/unit/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020 The STE||AR-Group
+# Copyright (c) 2019-2021 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -28,6 +28,11 @@ set(tests
     stop_token_cb2
 )
 
+if(HPX_CXX_STANDARD GREATER_EQUAL 17)
+  list(APPEND tests async_rw_mutex)
+endif()
+
+set(async_rw_mutex_PARAMETERS THREADS_PER_LOCALITY 4)
 set(barrier_cpp20_PARAMETERS THREADS_PER_LOCALITY 4)
 set(binary_semaphore_cpp20_PARAMETERS THREADS_PER_LOCALITY 4)
 set(channel_mpmc_fib_PARAMETERS THREADS_PER_LOCALITY 4)

--- a/libs/core/synchronization/tests/unit/async_rw_mutex.cpp
+++ b/libs/core/synchronization/tests/unit/async_rw_mutex.cpp
@@ -1,0 +1,297 @@
+//  Copyright (c) 2021 ETH Zurich
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/assert.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/mutex.hpp>
+#include <hpx/synchronization/async_rw_mutex.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <random>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+using hpx::execution::experimental::execute;
+using hpx::execution::experimental::executor;
+using hpx::execution::experimental::on;
+using hpx::execution::experimental::sync_wait;
+using hpx::execution::experimental::transform;
+using hpx::experimental::async_rw_mutex;
+
+unsigned int seed = std::random_device{}();
+
+///////////////////////////////////////////////////////////////////////////////
+// Custom type with a more restricted interface in the base class. Used for
+// testing that the read-only type of async_rw_mutex can be customized.
+class mytype_base
+{
+protected:
+    std::size_t x = 0;
+
+public:
+    mytype_base() = default;
+    mytype_base(mytype_base&&) = default;
+    mytype_base& operator=(mytype_base&&) = default;
+    mytype_base(mytype_base const&) = delete;
+    mytype_base& operator=(mytype_base const&) = delete;
+
+    std::size_t const& read() const
+    {
+        return x;
+    }
+};
+
+class mytype : public mytype_base
+{
+public:
+    mytype() = default;
+    mytype(mytype&&) = default;
+    mytype& operator=(mytype&&) = default;
+    mytype(mytype const&) = delete;
+    mytype& operator=(mytype const&) = delete;
+
+    std::size_t& readwrite()
+    {
+        return x;
+    }
+};
+
+// Struct with call operators used for checking that the correct types are sent
+// from the async_rw_mutex senders.
+struct checker
+{
+    bool expect_readonly;
+    std::size_t expected_predecessor_value;
+    std::atomic<std::size_t>& count;
+    std::size_t count_min;
+    std::size_t count_max = count_min;
+
+    // Access types are differently tagged for read-only and read-write access.
+    using void_read_access_type =
+        typename async_rw_mutex<void>::read_access_type;
+    using void_readwrite_access_type =
+        typename async_rw_mutex<void>::readwrite_access_type;
+
+    void operator()(void_read_access_type)
+    {
+        HPX_ASSERT(expect_readonly);
+        HPX_TEST_RANGE(++count, count_min, count_max);
+    }
+
+    void operator()(void_readwrite_access_type)
+    {
+        HPX_ASSERT(!expect_readonly);
+        HPX_TEST_RANGE(++count, count_min, count_max);
+    }
+
+    // Non-void access types must be convertible to (const) references of the
+    // types on which the async_rw_mutex is templated.
+    using size_t_read_access_type =
+        typename async_rw_mutex<std::size_t>::read_access_type;
+    using size_t_readwrite_access_type =
+        typename async_rw_mutex<std::size_t>::readwrite_access_type;
+
+    static_assert(
+        std::is_convertible<size_t_read_access_type, std::size_t const&>::value,
+        "The given access type must be convertible to a const reference of "
+        "given template type");
+    static_assert(
+        std::is_convertible<size_t_readwrite_access_type, std::size_t&>::value,
+        "The given access type must be convertible to a reference of given "
+        "template type");
+
+    void operator()(std::size_t const& x)
+    {
+        HPX_TEST(expect_readonly);
+        HPX_TEST_EQ(x, expected_predecessor_value);
+        HPX_TEST_RANGE(++count, count_min, count_max);
+    }
+
+    void operator()(std::size_t& x)
+    {
+        HPX_ASSERT(!expect_readonly);
+        HPX_TEST_EQ(x, expected_predecessor_value);
+        HPX_TEST_RANGE(++count, count_min, count_max);
+        ++x;
+    }
+
+    // Non-void access types must be convertible to (const) references of the
+    // types on which the async_rw_mutex is templated.
+    using mytype_read_access_type =
+        typename async_rw_mutex<mytype, mytype_base>::read_access_type;
+    using mytype_readwrite_access_type =
+        typename async_rw_mutex<mytype, mytype_base>::readwrite_access_type;
+
+    static_assert(
+        std::is_convertible<mytype_read_access_type, mytype_base const&>::value,
+        "The given access type must be convertible to a const reference of "
+        "given template type");
+    static_assert(
+        std::is_convertible<mytype_readwrite_access_type, mytype&>::value,
+        "The given access type must be convertible to a reference of given "
+        "template type");
+
+    void operator()(mytype_base const& x)
+    {
+        HPX_TEST(expect_readonly);
+        HPX_TEST_EQ(x.read(), expected_predecessor_value);
+        HPX_TEST_RANGE(++count, count_min, count_max);
+    }
+
+    void operator()(mytype& x)
+    {
+        HPX_ASSERT(!expect_readonly);
+        HPX_TEST_EQ(x.read(), expected_predecessor_value);
+        HPX_TEST_RANGE(++count, count_min, count_max);
+        ++(x.readwrite());
+    }
+};
+
+template <typename Executor, typename Senders>
+void submit_senders(Executor&& exec, Senders& senders)
+{
+    for (auto& sender : senders)
+    {
+        execute(exec, [sender = std::move(sender)]() mutable {
+            sync_wait(std::move(sender));
+        });
+    }
+}
+
+template <typename ReadWriteT, typename ReadT = ReadWriteT>
+void test_single_read_access(async_rw_mutex<ReadWriteT, ReadT> rwm)
+{
+    std::atomic<bool> called{false};
+    rwm.read() | transform([&](auto) { called = true; }) | sync_wait();
+    HPX_TEST(called);
+}
+
+template <typename ReadWriteT, typename ReadT = ReadWriteT>
+void test_single_readwrite_access(async_rw_mutex<ReadWriteT, ReadT> rwm)
+{
+    std::atomic<bool> called{false};
+    rwm.readwrite() | transform([&](auto) { called = true; }) | sync_wait();
+    HPX_TEST(called);
+}
+
+template <typename ReadWriteT, typename ReadT = ReadWriteT>
+void test_moved(async_rw_mutex<ReadWriteT, ReadT> rwm)
+{
+    // The destructor of an empty async_rw_mutex should not attempt to keep any
+    // values alive
+    auto rwm2 = std::move(rwm);
+    std::atomic<bool> called{false};
+    rwm2.read() | transform([&](auto) { called = true; }) | sync_wait();
+    HPX_TEST(called);
+}
+
+template <typename ReadWriteT, typename ReadT = ReadWriteT>
+void test_multiple_accesses(
+    async_rw_mutex<ReadWriteT, ReadT> rwm, std::size_t iterations)
+{
+    executor exec{};
+
+    std::atomic<std::size_t> count{0};
+
+    // Read-only and read-write access return senders of different types
+    using r_sender_type = std::decay_t<decltype(
+        rwm.read() | on(exec) | transform(checker{true, 0, count, 0}))>;
+    using rw_sender_type = std::decay_t<decltype(
+        rwm.readwrite() | on(exec) | transform(checker{false, 0, count, 0}))>;
+    std::vector<r_sender_type> r_senders;
+    std::vector<rw_sender_type> rw_senders;
+
+    std::mt19937 r(seed);
+    std::uniform_int_distribution<std::size_t> d_senders(1, 10);
+
+    std::size_t expected_count = 0;
+    std::size_t expected_predecessor_count = 0;
+
+    auto sender_helper = [&](bool readonly) {
+        std::size_t const num_senders = d_senders(r);
+        std::size_t const min_expected_count = expected_count + 1;
+        std::size_t const max_expected_count = expected_count + num_senders;
+        expected_count += num_senders;
+        for (std::size_t j = 0; j < num_senders; ++j)
+        {
+            if (readonly)
+            {
+                r_senders.push_back(rwm.read() | on(exec) |
+                    transform(checker{readonly, expected_predecessor_count,
+                        count, min_expected_count, max_expected_count}));
+            }
+            else
+            {
+                rw_senders.push_back(rwm.readwrite() | on(exec) |
+                    transform(checker{readonly, expected_predecessor_count,
+                        count, min_expected_count, max_expected_count}));
+                // Only read-write access is allowed to change the value
+                ++expected_predecessor_count;
+            }
+        }
+    };
+
+    for (std::size_t i = 0; i < iterations; ++i)
+    {
+        // Alternate between read-only and read-write access
+        sender_helper(true);
+        sender_helper(false);
+    }
+
+    // Asynchronously submit the senders
+    submit_senders(exec, r_senders);
+    submit_senders(exec, rw_senders);
+
+    // The destructor does not block, so we block here manually
+    rwm.readwrite() | sync_wait();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    if (vm.count("seed"))
+    {
+        seed = vm["seed"].as<unsigned int>();
+    }
+
+    test_single_read_access(async_rw_mutex<void>{});
+    test_single_read_access(async_rw_mutex<std::size_t>{0});
+    test_single_read_access(async_rw_mutex<mytype, mytype_base>{mytype{}});
+
+    test_single_readwrite_access(async_rw_mutex<void>{});
+    test_single_readwrite_access(async_rw_mutex<std::size_t>{0});
+    test_single_readwrite_access(async_rw_mutex<mytype, mytype_base>{mytype{}});
+
+    test_moved(async_rw_mutex<void>{});
+    test_moved(async_rw_mutex<std::size_t>{0});
+    test_moved(async_rw_mutex<mytype, mytype_base>{mytype{}});
+
+    std::size_t iterations = 100;
+    test_multiple_accesses(async_rw_mutex<void>{}, iterations);
+    test_multiple_accesses(async_rw_mutex<std::size_t>{0}, iterations);
+    test_multiple_accesses(
+        async_rw_mutex<mytype, mytype_base>{mytype{}}, iterations);
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    hpx::init_params i;
+    hpx::program_options::options_description desc_cmdline(
+        "usage: " HPX_APPLICATION_STRING " [options]");
+    desc_cmdline.add_options()("seed,s",
+        hpx::program_options::value<unsigned int>(),
+        "the random number generator seed to use for this run");
+    i.desc_cmdline = desc_cmdline;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, i), 0);
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Adds an `async_rw_mutex` (name not finalized, but I think this describes it fairly well). Instead of directly locking a mutex, the async mutex returns senders that give access to a resource when scheduled. The `rw` part means that access can be read-only (shared, multiple concurrent readers allowed), or exclusively read-write.

This is based on an implementation used in DLA-Future where they protect access to tiles of a matrix in this fashion. That mechanism is based on futures/promises and custom for their matrix class. This is an attempt at a more generic version.

Contains #5274 so the diff is rather large.