### PR TITLE
Fix Clang 11 cuda_future test bug

### DIFF
--- a/.jenkins/cscs/env-clang-cuda.sh
+++ b/.jenkins/cscs/env-clang-cuda.sh
@@ -14,7 +14,6 @@ export HWLOC_ROOT="${APPS_ROOT}/hwloc-2.0.3-gcc-8.3.0"
 module load daint-gpu
 module load cudatoolkit/10.2.89_3.29-7.0.2.1_3.5__g67354b4
 module load Boost/1.75.0-CrayCCE-20.11
-module switch cce cce/10.0.2
 spack load cmake
 spack load ninja
 

--- a/libs/full/async_cuda/tests/unit/saxpy.cu
+++ b/libs/full/async_cuda/tests/unit/saxpy.cu
@@ -21,11 +21,13 @@ __global__ void saxpy(int n, float a, float* x, float* y)
 void launch_saxpy_kernel(hpx::cuda::experimental::cuda_executor& cudaexec,
         unsigned int& blocks, unsigned int& threads, void** args)
 {
+    // Invoking hpx::apply with cudaLaunchKernel<void> directly result in an
+    // error for NVCC with gcc configuration
 #ifdef HPX_HAVE_HIP
-    hpx::apply(cudaexec, cudaLaunchKernel,
+    auto launch_kernel = cudaLaunchKernel;
 #else
-    hpx::apply(cudaexec, cudaLaunchKernel<void>,
+    auto launch_kernel = cudaLaunchKernel<void>;
 #endif
-        reinterpret_cast<const void*>(&saxpy), dim3(blocks), dim3(threads),
-        args, std::size_t(0));
+    hpx::apply(cudaexec, launch_kernel, reinterpret_cast<const void*>(&saxpy),
+        dim3(blocks), dim3(threads), args, std::size_t(0));
 }

--- a/libs/full/async_cuda/tests/unit/saxpy.cu
+++ b/libs/full/async_cuda/tests/unit/saxpy.cu
@@ -4,11 +4,28 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/local/future.hpp>
+
+#include <hpx/async_cuda/cuda_executor.hpp>
 #include <hpx/async_cuda/custom_gpu_api.hpp>
+
+#include <cstddef>
 
 __global__ void saxpy(int n, float a, float* x, float* y)
 {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i < n)
         y[i] = a * x[i] + y[i];
+}
+
+void launch_saxpy_kernel(hpx::cuda::experimental::cuda_executor& cudaexec,
+        unsigned int& blocks, unsigned int& threads, void** args)
+{
+#ifdef HPX_HAVE_HIP
+    hpx::apply(cudaexec, cudaLaunchKernel,
+#else
+    hpx::apply(cudaexec, cudaLaunchKernel<void>,
+#endif
+        reinterpret_cast<const void*>(&saxpy), dim3(blocks), dim3(threads),
+        args, std::size_t(0));
 }


### PR DESCRIPTION
Updating clang cuda config to use Clang 11 resulted in a undefined symbol for `saxpy` in `cuda_future.cpp` unit test, `nm` shows:
```
Clang 11                                                                        
saxpy.cu.o:0000000000000000 T __device_stub__saxpy(int, float, float *, float *)                         
Clang 10                                                                        
saxpy.cu.o:0000000000000000 T saxpy(int, float, float *, float *)
```
Not sure if it's a bug in Clang / Clang cuda or our own cmake config.
The temporary fix is just moving the apply function in the `saxpy.cu` file.