### PR TITLE
Specify exact cmake and ninja versions when loading them in jenkins jobs

### DIFF
--- a/.jenkins/cscs/env-clang-10.sh
+++ b/.jenkins/cscs/env-clang-10.sh
@@ -22,8 +22,8 @@ export CC="${CLANG_ROOT}/bin/clang"
 export CPP="${CLANG_ROOT}/bin/clang -E"
 
 module load daint-mc
-spack load cmake
-spack load ninja
+spack load cmake@3.17.3
+spack load ninja@1.10.0
 
 configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"
 configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT=128"

--- a/.jenkins/cscs/env-clang-8.sh
+++ b/.jenkins/cscs/env-clang-8.sh
@@ -22,8 +22,8 @@ export CC="${CLANG_ROOT}/bin/clang"
 export CPP="${CLANG_ROOT}/bin/clang -E"
 
 module load daint-mc
-spack load cmake
-spack load ninja
+spack load cmake@3.17.3
+spack load ninja@1.10.0
 
 configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"
 configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT=128"

--- a/.jenkins/cscs/env-clang-9.sh
+++ b/.jenkins/cscs/env-clang-9.sh
@@ -22,8 +22,8 @@ export CC="${CLANG_ROOT}/bin/clang"
 export CPP="${CLANG_ROOT}/bin/clang -E"
 
 module load daint-mc
-spack load cmake
-spack load ninja
+spack load cmake@3.17.3
+spack load ninja@1.10.0
 
 configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"
 configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT=128"

--- a/.jenkins/cscs/env-clang-apex.sh
+++ b/.jenkins/cscs/env-clang-apex.sh
@@ -23,8 +23,8 @@ export CC="${CLANG_ROOT}/bin/clang"
 export CPP="${CLANG_ROOT}/bin/clang -E"
 
 module load daint-mc
-spack load cmake
-spack load ninja
+spack load cmake@3.17.3
+spack load ninja@1.10.0
 
 configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"
 configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT=128"

--- a/.jenkins/cscs/env-clang-cuda.sh
+++ b/.jenkins/cscs/env-clang-cuda.sh
@@ -14,8 +14,8 @@ export HWLOC_ROOT="${APPS_ROOT}/hwloc-2.0.3-gcc-8.3.0"
 module load daint-gpu
 module load cudatoolkit/10.2.89_3.29-7.0.2.1_3.5__g67354b4
 module load Boost/1.75.0-CrayCCE-20.11
-spack load cmake
-spack load ninja
+spack load cmake@3.17.3
+spack load ninja@1.10.0
 
 export CXX=`which CC`
 export CC=`which cc`

--- a/.jenkins/cscs/env-clang-newest.sh
+++ b/.jenkins/cscs/env-clang-newest.sh
@@ -22,8 +22,8 @@ export CC="${CLANG_ROOT}/bin/clang"
 export CPP="${CLANG_ROOT}/bin/clang -E"
 
 module load daint-mc
-spack load cmake
-spack load ninja
+spack load cmake@3.17.3
+spack load ninja@1.10.0
 
 configure_extra_options="-DCMAKE_BUILD_TYPE=Release"
 configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT=128"

--- a/.jenkins/cscs/env-clang-oldest.sh
+++ b/.jenkins/cscs/env-clang-oldest.sh
@@ -22,8 +22,8 @@ export CC="${CLANG_ROOT}/bin/clang"
 export CPP="${CLANG_ROOT}/bin/clang -E"
 
 module load daint-mc
-spack load cmake
-spack load ninja
+spack load cmake@3.17.3
+spack load ninja@1.10.0
 
 configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"
 configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT="

--- a/.jenkins/cscs/env-gcc-cuda.sh
+++ b/.jenkins/cscs/env-gcc-cuda.sh
@@ -14,8 +14,8 @@ module switch PrgEnv-cray PrgEnv-gnu
 module load cudatoolkit
 module load Boost/1.75.0-CrayGNU-20.11
 module load hwloc/.2.0.3
-spack load cmake
-spack load ninja
+spack load cmake@3.17.3
+spack load ninja@1.10.0
 
 export CXX=`which CC`
 export CC=`which cc`

--- a/.jenkins/cscs/env-gcc-newest.sh
+++ b/.jenkins/cscs/env-gcc-newest.sh
@@ -21,8 +21,8 @@ export CXX=${GCC_ROOT}/bin/g++
 export CC=${GCC_ROOT}/bin/gcc
 
 module load daint-mc
-spack load cmake
-spack load ninja
+spack load cmake@3.17.3
+spack load ninja@1.10.0
 
 configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"
 configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT=128"

--- a/.jenkins/cscs/env-gcc-oldest.sh
+++ b/.jenkins/cscs/env-gcc-oldest.sh
@@ -22,8 +22,8 @@ export CXX=${GCC_ROOT}/bin/g++
 export CC=${GCC_ROOT}/bin/gcc
 
 module load daint-mc
-spack load cmake
-spack load ninja
+spack load cmake@3.17.3
+spack load ninja@1.10.0
 
 configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"
 configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT=128"

--- a/.jenkins/cscs/env-icc.sh
+++ b/.jenkins/cscs/env-icc.sh
@@ -12,8 +12,8 @@ module load daint-mc
 module switch PrgEnv-cray PrgEnv-intel
 module load Boost/1.75.0-CrayIntel-20.11
 module load hwloc/.2.0.3
-spack load cmake
-spack load ninja
+spack load cmake@3.17.3
+spack load ninja@1.10.0
 
 export CXX=`which CC`
 export CC=`which cc`


### PR DESCRIPTION
Helps with upgrades (spack does not know which version to load if there are multiple matching specs).