### PR TITLE
Remove PRIVATE flag that was propagated into the LANGUAGES

### DIFF
--- a/cmake/HPX_AddCompileFlag.cmake
+++ b/cmake/HPX_AddCompileFlag.cmake
@@ -174,7 +174,7 @@ endfunction()
 
 function(hpx_add_compile_flag)
   set(one_value_args)
-  hpx_add_target_compile_option(${ARGN} PRIVATE)
+  hpx_add_target_compile_option(${ARGN})
 endfunction()
 
 function(hpx_add_compile_flag_if_available FLAG)


### PR DESCRIPTION
The `PRIVATE` flag is not parsed by `hpx_add_target_compile_option` and was therefore propagated as a `LANGUAGE`.
The flag is private by default if `PUBLIC` is omitted, so removing it is sufficient.