### PR TITLE
Fix cmake bug, now propagate flag with right language

### DIFF
--- a/cmake/HPX_AddCompileFlag.cmake
+++ b/cmake/HPX_AddCompileFlag.cmake
@@ -40,9 +40,7 @@ function(hpx_add_target_compile_option FLAG)
             "$<$<AND:$<CONFIG:${_config}>,$<COMPILE_LANGUAGE:${_lang}>>:${FLAG}>"
         )
       else()
-        set(_conf
-            "$<$<COMPILE_LANGUAGE:${_lang}>:${FLAG}>"
-        )
+        set(_conf "$<$<COMPILE_LANGUAGE:${_lang}>:${FLAG}>")
       endif()
       target_compile_options(${_dest} INTERFACE "${_conf}")
     endforeach()

--- a/cmake/HPX_AddCompileFlag.cmake
+++ b/cmake/HPX_AddCompileFlag.cmake
@@ -35,10 +35,13 @@ function(hpx_add_target_compile_option FLAG)
 
   foreach(_lang ${_languages})
     foreach(_config ${_configurations})
-      set(_conf "${FLAG}")
       if(NOT _config STREQUAL "none")
         set(_conf
             "$<$<AND:$<CONFIG:${_config}>,$<COMPILE_LANGUAGE:${_lang}>>:${FLAG}>"
+        )
+      else()
+        set(_conf
+            "$<$<COMPILE_LANGUAGE:${_lang}>:${FLAG}>"
         )
       endif()
       target_compile_options(${_dest} INTERFACE "${_conf}")


### PR DESCRIPTION
Issue: `CXX` compile flags were also propagated to `nvcc`, which caused build problems with the new CUDA setup necessary for #5283
Solution: Add the flag with the compile language generator expression even when no config (Release/Debug...) is specified.