### PR TITLE
Fix compilation of sender CPOs with nvcc

### DIFF
--- a/libs/core/execution_base/include/hpx/execution_base/sender.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/sender.hpp
@@ -352,7 +352,7 @@ namespace hpx { namespace execution { namespace experimental {
         {
             return std::forward<Executor>(executor).execute(std::forward<F>(f));
         }
-    } execute;
+    } execute{};
 
     namespace detail {
         template <typename R, typename>
@@ -570,7 +570,7 @@ namespace hpx { namespace execution { namespace experimental {
                        std::forward<S>(s), std::forward<R>(r)})
                       ->state);
         }
-    } submit;
+    } submit{};
 
     namespace detail {
         template <typename F, typename E>


### PR DESCRIPTION
Same problem as https://github.com/STEllAR-GROUP/hpx/pull/4912. I've set a reminder for myself to come back and add an actual regression test for this.