### PR TITLE
Add GCC 11 builder to jenkins

### DIFF
--- a/.jenkins/cscs/Jenkinsfile
+++ b/.jenkins/cscs/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
                 axes {
                     axis {
                         name 'configuration_name'
-                        values 'gcc-newest', 'gcc-oldest', 'gcc-cuda', 'clang-newest', 'clang-10', 'clang-9', 'clang-8', 'clang-oldest', 'clang-cuda', 'clang-apex', 'icc'
+                        values 'gcc-newest', 'gcc-10', 'gcc-oldest', 'gcc-cuda', 'clang-newest', 'clang-10', 'clang-9', 'clang-8', 'clang-oldest', 'clang-cuda', 'clang-apex', 'icc'
                     }
                 }
                 stages {

--- a/.jenkins/cscs/env-gcc-10.sh
+++ b/.jenkins/cscs/env-gcc-10.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 ETH Zurich
+# Copyright (c) 2020 ETH Zurich
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,9 +8,9 @@ source $SPACK_ROOT/share/spack/setup-env.sh
 
 export CRAYPE_LINK_TYPE=dynamic
 export APPS_ROOT="/apps/daint/SSL/HPX/packages"
-export GCC_VER="11.1.0"
+export GCC_VER="10.1.0"
 export CXX_STD="17"
-export BOOST_VER="1.76.0"
+export BOOST_VER="1.75.0"
 export HWLOC_VER="2.2.0"
 export GCC_ROOT="${APPS_ROOT}/gcc-${GCC_VER}"
 export BOOST_ROOT="${APPS_ROOT}/boost-${BOOST_VER}-gcc-${GCC_VER}-c++${CXX_STD}-debug"
@@ -28,6 +28,9 @@ configure_extra_options="-DCMAKE_BUILD_TYPE=Debug"
 configure_extra_options+=" -DHPX_WITH_MAX_CPU_COUNT=128"
 configure_extra_options+=" -DHPX_WITH_MALLOC=system"
 configure_extra_options+=" -DHPX_WITH_CXX${CXX_STD}=ON"
+configure_extra_options+=" -DHPX_WITH_NETWORKING=OFF"
+configure_extra_options+=" -DHPX_WITH_DISTRIBUTED_RUNTIME=OFF"
 configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS=ON"
 configure_extra_options+=" -DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON"
 configure_extra_options+=" -DHPX_WITH_SPINLOCK_DEADLOCK_DETECTION=ON"
+

--- a/.jenkins/cscs/slurm-constraint-gcc-10.sh
+++ b/.jenkins/cscs/slurm-constraint-gcc-10.sh
@@ -1,0 +1,7 @@
+# Copyright (c) 2020 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+configuration_slurm_constraint="mc"

--- a/examples/transpose/transpose_serial_vector.cpp
+++ b/examples/transpose/transpose_serial_vector.cpp
@@ -86,7 +86,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
                         std::uint64_t j_max = (std::min)(order, j + tile_size);
                         for(std::uint64_t jt = j; jt < j_max; ++jt)
                         {
-                            B[it + order * jt] = A[jt + order * it];
+                            B[it + order * jt] = double(A[jt + order * it]);
                         }
                     }
                 }
@@ -98,7 +98,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
             {
                 for(std::uint64_t j = 0; j < order; ++j)
                 {
-                    B[i + order * j] = A[j + order * i];
+                    B[i + order * j] = double(A[j + order * i]);
                 }
             }
         }


### PR DESCRIPTION
This also triggered the error reported in https://github.com/STEllAR-GROUP/hpx/issues/5275. I've simply made the conversion explicit, but I don't know if there's a more proper fix for the issue.