### PR TITLE
Fix a race condition in async mpi affecting limiting executor

### DIFF
--- a/libs/core/debugging/src/print.cpp
+++ b/libs/core/debugging/src/print.cpp
@@ -59,6 +59,8 @@ namespace hpx { namespace debug {
 
         template HPX_CORE_EXPORT void print_dec(
             std::ostream&, std::atomic<int> const&, int);
+        template HPX_CORE_EXPORT void print_dec(
+            std::ostream&, std::atomic<unsigned int> const&, int);
     }    // namespace detail
 
     // ------------------------------------------------------------------

--- a/libs/full/async_mpi/include/hpx/async_mpi/mpi_executor.hpp
+++ b/libs/full/async_mpi/include/hpx/async_mpi/mpi_executor.hpp
@@ -60,8 +60,8 @@ namespace hpx { namespace mpi { namespace experimental {
 
         std::size_t in_flight_estimate() const
         {
-            return detail::get_number_of_enqueued_requests() +
-                detail::get_number_of_active_requests();
+            return detail::get_mpi_info().active_futures_size_ +
+                detail::get_mpi_info().request_queue_size_;
         }
 
     private:

--- a/libs/full/async_mpi/include/hpx/async_mpi/mpi_future.hpp
+++ b/libs/full/async_mpi/include/hpx/async_mpi/mpi_future.hpp
@@ -80,6 +80,17 @@ namespace hpx { namespace mpi { namespace experimental {
             bool error_handler_initialized_ = false;
             int rank_ = -1;
             int size_ = -1;
+            // active futures holds the size of the future vector
+            // which is always the same as the mpi request vector
+            std::atomic<std::uint32_t> active_futures_size_;
+            // active requests returns the size of the request queue
+            std::atomic<std::uint32_t> request_queue_size_;
+            //
+            mpi_info()
+              : active_futures_size_{0}
+              , request_queue_size_{0}
+            {
+            }
         };
 
         // an instance of mpi_info that we store data in
@@ -126,7 +137,7 @@ namespace hpx { namespace mpi { namespace experimental {
         // too many mpi requests are being spawned at once
         // unfortunately, the lock-free queue can only return an estimate
         // of the queue size, so this is not guaranteed to be precise
-        HPX_EXPORT std::size_t get_number_of_enqueued_requests();
+        //        HPX_EXPORT std::size_t get_number_of_enqueued_requests();
 
         // -----------------------------------------------------------------
         // used internally to add a request to the main polling vector
@@ -193,7 +204,7 @@ namespace hpx { namespace mpi { namespace experimental {
             {
                 return true;
             }
-            return (detail::get_active_futures().size() > 0);
+            return (detail::get_mpi_info().active_futures_size_ > 0);
         });
     }
 
@@ -207,7 +218,7 @@ namespace hpx { namespace mpi { namespace experimental {
             {
                 return true;
             }
-            return (detail::get_active_futures().size() > 0) || f();
+            return (detail::get_mpi_info().active_futures_size_ > 0) || f();
         });
     }
 

--- a/libs/full/async_mpi/include/hpx/async_mpi/mpi_future.hpp
+++ b/libs/full/async_mpi/include/hpx/async_mpi/mpi_future.hpp
@@ -82,15 +82,9 @@ namespace hpx { namespace mpi { namespace experimental {
             int size_ = -1;
             // active futures holds the size of the future vector
             // which is always the same as the mpi request vector
-            std::atomic<std::uint32_t> active_futures_size_;
+            std::atomic<std::uint32_t> active_futures_size_{0};
             // active requests returns the size of the request queue
-            std::atomic<std::uint32_t> request_queue_size_;
-            //
-            mpi_info()
-              : active_futures_size_{0}
-              , request_queue_size_{0}
-            {
-            }
+            std::atomic<std::uint32_t> request_queue_size_{0};
         };
 
         // an instance of mpi_info that we store data in
@@ -130,14 +124,6 @@ namespace hpx { namespace mpi { namespace experimental {
         // that will be used by the polling routines to check when requests
         // have completed
         HPX_EXPORT void add_to_request_queue(future_data_ptr data);
-
-        // -----------------------------------------------------------------
-        // used internally to query how many requests are 'in flight'
-        // the limiting executor can use this to throttle back a task if
-        // too many mpi requests are being spawned at once
-        // unfortunately, the lock-free queue can only return an estimate
-        // of the queue size, so this is not guaranteed to be precise
-        //        HPX_EXPORT std::size_t get_number_of_enqueued_requests();
 
         // -----------------------------------------------------------------
         // used internally to add a request to the main polling vector

--- a/libs/full/async_mpi/include/hpx/async_mpi/mpi_future.hpp
+++ b/libs/full/async_mpi/include/hpx/async_mpi/mpi_future.hpp
@@ -15,7 +15,9 @@
 #include <hpx/mpi_base/mpi.hpp>
 #include <hpx/runtime_local/thread_pool_helpers.hpp>
 
+#include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <iosfwd>
 #include <string>
 #include <utility>

--- a/libs/full/async_mpi/tests/unit/mpi_ring_async_executor.cpp
+++ b/libs/full/async_mpi/tests/unit/mpi_ring_async_executor.cpp
@@ -17,6 +17,7 @@
 
 #include <array>
 #include <atomic>
+#include <iomanip>
 #include <iostream>
 #include <sstream>
 


### PR DESCRIPTION
The mpi_ring_async_executor_test occasionally failed because
the limiting executor was calling find_if on a vector that
was modified by the mpi polling thread.

Instead of allowing external checks (limiting executor) to
access the vector, we use an atomic counter that only the mpi
polling thread increments/decrements and stores the number
of futures/requests in flight. The limiting executor can safely
read this value from any thread.
