### PR TITLE
Fix is_sender trait and other small fixes to p0443 traits

### DIFF
--- a/libs/core/execution_base/tests/unit/basic_sender.cpp
+++ b/libs/core/execution_base/tests/unit/basic_sender.cpp
@@ -265,6 +265,14 @@ constexpr bool unspecialized(
 
 int main()
 {
+    static_assert(
+        unspecialized<void>(nullptr), "void should not have sender_traits");
+    static_assert(unspecialized<std::nullptr_t>(nullptr),
+        "std::nullptr_t should not have sender_traits");
+    static_assert(unspecialized<int>(nullptr),
+        "non_sender_1 should not have sender_traits");
+    static_assert(unspecialized<double>(nullptr),
+        "non_sender_1 should not have sender_traits");
     static_assert(unspecialized<non_sender_1>(nullptr),
         "non_sender_1 should not have sender_traits");
     static_assert(unspecialized<non_sender_2>(nullptr),
@@ -289,6 +297,11 @@ int main()
     using hpx::execution::experimental::is_sender;
     using hpx::execution::experimental::is_sender_to;
 
+    static_assert(!is_sender<void>::value, "void is not a sender");
+    static_assert(
+        !is_sender<std::nullptr_t>::value, "std::nullptr_t is not a sender");
+    static_assert(!is_sender<int>::value, "int is not a sender");
+    static_assert(!is_sender<double>::value, "double is not a sender");
     static_assert(
         !is_sender<non_sender_1>::value, "non_sender_1 is not a sender");
     static_assert(


### PR DESCRIPTION
Mainly fixes the `is_sender` trait. It was returning true for things like `int`. The reason was a missing constraint in the fallback which was meant to apply for executors. It was treating `int` as an executor. Purely my mistake, but in the interest of simplicity I've removed the fallback completely. In my understanding there's already been quite some discussion about how executors should not be treated as schedulers, and especially not as senders, implicitly.

I've also applied small fixes to the `is_executor` trait and the schedule CPO (which was using `is_executor` rather than `is_scheduler` as a constraint).