### PR TITLE
Add get member functions to async_rw_mutex proxy objects for explicitly getting the wrapped value

### DIFF
--- a/libs/core/synchronization/include/hpx/synchronization/async_rw_mutex.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/async_rw_mutex.hpp
@@ -177,11 +177,16 @@ namespace hpx { namespace experimental {
             async_rw_mutex_access_wrapper& operator=(
                 async_rw_mutex_access_wrapper const&) = default;
 
-            operator ReadT&()
+            ReadT& get() const
             {
                 HPX_ASSERT(state);
                 HPX_ASSERT(state->value);
                 return state->value.value();
+            }
+
+            operator ReadT&() const
+            {
+                return get();
             }
         };
 
@@ -218,11 +223,16 @@ namespace hpx { namespace experimental {
             async_rw_mutex_access_wrapper& operator=(
                 async_rw_mutex_access_wrapper const&) = default;
 
-            operator ReadWriteT&()
+            ReadWriteT& get()
             {
                 HPX_ASSERT(state);
                 HPX_ASSERT(state->value);
                 return state->value.value();
+            }
+
+            operator ReadWriteT&()
+            {
+                return get();
             }
         };
 

--- a/libs/core/synchronization/include/hpx/synchronization/async_rw_mutex.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/async_rw_mutex.hpp
@@ -219,9 +219,9 @@ namespace hpx { namespace experimental {
             async_rw_mutex_access_wrapper& operator=(
                 async_rw_mutex_access_wrapper&&) = default;
             async_rw_mutex_access_wrapper(
-                async_rw_mutex_access_wrapper const&) = default;
+                async_rw_mutex_access_wrapper const&) = delete;
             async_rw_mutex_access_wrapper& operator=(
-                async_rw_mutex_access_wrapper const&) = default;
+                async_rw_mutex_access_wrapper const&) = delete;
 
             ReadWriteT& get()
             {
@@ -284,9 +284,9 @@ namespace hpx { namespace experimental {
             async_rw_mutex_access_wrapper& operator=(
                 async_rw_mutex_access_wrapper&&) = default;
             async_rw_mutex_access_wrapper(
-                async_rw_mutex_access_wrapper const&) = default;
+                async_rw_mutex_access_wrapper const&) = delete;
             async_rw_mutex_access_wrapper& operator=(
-                async_rw_mutex_access_wrapper const&) = default;
+                async_rw_mutex_access_wrapper const&) = delete;
         };
     }    // namespace detail
 

--- a/libs/core/synchronization/include/hpx/synchronization/async_rw_mutex.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/async_rw_mutex.hpp
@@ -545,9 +545,9 @@ namespace hpx { namespace experimental {
             typename = std::enable_if_t<
                 !std::is_same<std::decay_t<U>, async_rw_mutex>::value>>
         explicit async_rw_mutex(U&& u, allocator_type const& alloc = {})
-          : alloc(alloc)
+          : value(std::forward<U>(u))
+          , alloc(alloc)
         {
-            value = std::forward<U>(u);
         }
         async_rw_mutex(async_rw_mutex&&) = default;
         async_rw_mutex& operator=(async_rw_mutex&&) = default;


### PR DESCRIPTION
Just a little convenience for the cases when one doesn't want to/can't use the implicit conversion.

Edit: Flyby: initialize the `value` member in `async_rw_mutex` in the member initializer list instead of in the constructor body, to have it work for non-default constructible types.