### PR TITLE
Adding resize() to serialize_buffer allowing to shrink its size

### DIFF
--- a/libs/core/serialization/include/hpx/serialization/serialize_buffer.hpp
+++ b/libs/core/serialization/include/hpx/serialization/serialize_buffer.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/datastructures/traits/supports_streaming_with_any.hpp>
 #include <hpx/modules/errors.hpp>
 
@@ -281,6 +282,17 @@ namespace hpx { namespace serialization {
         std::size_t size() const
         {
             return size_;
+        }
+
+        void resize_norealloc(std::size_t newsize)
+        {
+            HPX_ASSERT_MSG(newsize <= size_,
+                "serialize_buffer::resize_norealloc: new size shouldn't be "
+                "larger than current size");
+            if (newsize < size_)
+            {
+                size_ = newsize;
+            }
         }
 
     private:


### PR DESCRIPTION
This is needed for @NanmiaoWu's work on the SHAD backend.