### PR TITLE
Fix missing ifdef HPX_SMT_PAUSE

### DIFF
--- a/libs/core/thread_support/src/spinlock.cpp
+++ b/libs/core/thread_support/src/spinlock.cpp
@@ -20,11 +20,13 @@ namespace hpx { namespace util { namespace detail {
         // Experiments on Windows and Fedora 32 show that a single pause,
         // followed by an immediate sleep, is best.
 
+#if defined(HPX_SMT_PAUSE)
         if (k == 0)
         {
             HPX_SMT_PAUSE;
         }
         else
+#endif
         {
             std::this_thread::sleep_for(std::chrono::microseconds(1));
         }


### PR DESCRIPTION
Due to the missing definition of `HPX_SMT_PAUSE` in `compiler_fence.hpp`, source file `spinlock.cpp` cannot be compiled with the Intel compiler.

https://github.com/STEllAR-GROUP/hpx/blob/c320e11a3c1771c8accd446362d245da33016b15/libs/core/config/include/hpx/config/compiler_fence.hpp#L22-L26