### PR TITLE
Adapt data parallel support using std-simd

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -532,13 +532,11 @@ endfunction()
 
 # ##############################################################################
 function(hpx_check_for_cxx20_experimental_simd)
-  if(CMAKE_COMPILER_IS_GNUCXX)
-    add_hpx_config_test(
-      HPX_WITH_CXX20_EXPERIMENTAL_SIMD
-      SOURCE cmake/tests/cxx20_experimental_simd.cpp
-      FILE ${ARGN}
-    )
-  endif()
+  add_hpx_config_test(
+    HPX_WITH_CXX20_EXPERIMENTAL_SIMD
+    SOURCE cmake/tests/cxx20_experimental_simd.cpp
+    FILE ${ARGN}
+  )
 endfunction()
 
 # ##############################################################################

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -532,11 +532,13 @@ endfunction()
 
 # ##############################################################################
 function(hpx_check_for_cxx20_experimental_simd)
-  add_hpx_config_test(
-    HPX_WITH_CXX20_EXPERIMENTAL_SIMD
-    SOURCE cmake/tests/cxx20_experimental_simd.cpp
-    FILE ${ARGN}
-  )
+  if(CMAKE_COMPILER_IS_GNUCXX)
+    add_hpx_config_test(
+      HPX_WITH_CXX20_EXPERIMENTAL_SIMD
+      SOURCE cmake/tests/cxx20_experimental_simd.cpp
+      FILE ${ARGN}
+    )
+  endif()
 endfunction()
 
 # ##############################################################################

--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -531,6 +531,15 @@ function(hpx_check_for_cxx20_lambda_capture)
 endfunction()
 
 # ##############################################################################
+function(hpx_check_for_cxx20_experimental_simd)
+  add_hpx_config_test(
+    HPX_WITH_CXX20_EXPERIMENTAL_SIMD
+    SOURCE cmake/tests/cxx20_experimental_simd.cpp
+    FILE ${ARGN}
+  )
+endfunction()
+
+# ##############################################################################
 function(hpx_check_for_cxx20_no_unique_address_attribute)
   add_hpx_config_test(
     HPX_WITH_CXX20_NO_UNIQUE_ADDRESS_ATTRIBUTE

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -103,6 +103,10 @@ function(hpx_perform_cxx_feature_tests)
   # C++20 feature tests
   hpx_check_for_cxx20_coroutines(DEFINITIONS HPX_HAVE_CXX20_COROUTINES)
 
+  hpx_check_for_cxx20_experimental_simd(
+    DEFINITIONS HPX_HAVE_CXX20_EXPERIMENTAL_SIMD HPX_HAVE_DATAPAR
+  )
+
   hpx_check_for_cxx20_lambda_capture(DEFINITIONS HPX_HAVE_CXX20_LAMBDA_CAPTURE)
 
   hpx_check_for_cxx20_no_unique_address_attribute(

--- a/cmake/tests/cxx20_experimental_simd.cpp
+++ b/cmake/tests/cxx20_experimental_simd.cpp
@@ -6,7 +6,11 @@
 
 // test for availability of std experimental simd (C++20)
 
+// Enable this test only for GCC Compilers as simd header is not
+// completely implemented for other compilers.
+#if defined(__GNUC__) && !defined(__clang__)
 #include <experimental/simd>
+#endif
 
 int main()
 {

--- a/cmake/tests/cxx20_experimental_simd.cpp
+++ b/cmake/tests/cxx20_experimental_simd.cpp
@@ -8,7 +8,7 @@
 
 #include <experimental/simd>
 
-int main() 
+int main()
 {
     std::experimental::simd<int> s = std::experimental::simd<int>();
     (void) s;

--- a/cmake/tests/cxx20_experimental_simd.cpp
+++ b/cmake/tests/cxx20_experimental_simd.cpp
@@ -1,0 +1,16 @@
+//  Copyright (c) 2021 Srinivas Yadav
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// test for availability of std experimental simd (C++20)
+
+#include <experimental/simd>
+
+int main() 
+{
+    std::experimental::simd<int> s = std::experimental::simd<int>();
+    (void) s;
+    return 0;
+}

--- a/libs/parallelism/algorithms/include/hpx/parallel/datapar/loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/datapar/loop.hpp
@@ -426,7 +426,7 @@ namespace hpx { namespace parallel { namespace util {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Begin, typename End, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Begin tag_dispatch(
-        hpx::parallel::util::loop_t, hpx::execution::datapar_policy,
+        hpx::parallel::util::loop_t, hpx::execution::simdpar_policy,
         Begin begin, End end, F&& f)
     {
         return detail::datapar_loop<Begin>::call(
@@ -435,7 +435,7 @@ namespace hpx { namespace parallel { namespace util {
 
     template <typename Begin, typename End, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Begin tag_dispatch(
-        hpx::parallel::util::loop_t, hpx::execution::datapar_task_policy,
+        hpx::parallel::util::loop_t, hpx::execution::simdpar_task_policy,
         Begin begin, End end, F&& f)
     {
         return detail::datapar_loop<Begin>::call(
@@ -445,7 +445,7 @@ namespace hpx { namespace parallel { namespace util {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Begin, typename End, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Begin tag_dispatch(
-        hpx::parallel::util::loop_ind_t, hpx::execution::dataseq_policy,
+        hpx::parallel::util::loop_ind_t, hpx::execution::simd_policy,
         Begin begin, End end, F&& f)
     {
         return detail::datapar_loop_ind<Begin>::call(
@@ -454,7 +454,7 @@ namespace hpx { namespace parallel { namespace util {
 
     template <typename Begin, typename End, typename F>
     HPX_HOST_DEVICE HPX_FORCEINLINE Begin tag_dispatch(
-        hpx::parallel::util::loop_ind_t, hpx::execution::dataseq_task_policy,
+        hpx::parallel::util::loop_ind_t, hpx::execution::simd_task_policy,
         Begin begin, End end, F&& f)
     {
         return detail::datapar_loop_ind<Begin>::call(

--- a/libs/parallelism/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
@@ -229,8 +229,8 @@ namespace hpx { namespace parallel { namespace util {
     HPX_HOST_DEVICE
         HPX_FORCEINLINE constexpr util::in_out_result<IterB, OutIter>
         tag_dispatch(hpx::parallel::util::transform_loop_t,
-            hpx::execution::simd_task_policy, IterB it, IterE end,
-            OutIter dest, F&& f)
+            hpx::execution::simd_task_policy, IterB it, IterE end, OutIter dest,
+            F&& f)
     {
         auto ret = detail::datapar_transform_loop<IterB>::call(
             it, end, dest, std::forward<F>(f));
@@ -259,9 +259,9 @@ namespace hpx { namespace parallel { namespace util {
                 std::pair<InIter, OutIter>>::type
             call(InIter first, InIter last, OutIter dest, F&& f)
             {
-                return util::transform_loop_n_ind<
-                    hpx::execution::simd_policy>(first,
-                    std::distance(first, last), dest, std::forward<F>(f));
+                return util::transform_loop_n_ind<hpx::execution::simd_policy>(
+                    first, std::distance(first, last), dest,
+                    std::forward<F>(f));
             }
 
             template <typename InIter, typename OutIter, typename F>
@@ -298,8 +298,8 @@ namespace hpx { namespace parallel { namespace util {
     HPX_HOST_DEVICE
         HPX_FORCEINLINE constexpr util::in_out_result<IterB, OutIter>
         tag_dispatch(hpx::parallel::util::transform_loop_ind_t,
-            hpx::execution::simd_task_policy, IterB it, IterE end,
-            OutIter dest, F&& f)
+            hpx::execution::simd_task_policy, IterB it, IterE end, OutIter dest,
+            F&& f)
     {
         auto ret = detail::datapar_transform_loop_ind<IterB>::call(
             it, end, dest, std::forward<F>(f));

--- a/libs/parallelism/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
@@ -190,7 +190,7 @@ namespace hpx { namespace parallel { namespace util {
                 std::pair<InIter, OutIter>>::type
             call(InIter first, InIter last, OutIter dest, F&& f)
             {
-                return util::transform_loop_n<hpx::execution::dataseq_policy>(
+                return util::transform_loop_n<hpx::execution::simd_policy>(
                     first, std::distance(first, last), dest,
                     std::forward<F>(f));
             }
@@ -214,7 +214,7 @@ namespace hpx { namespace parallel { namespace util {
     HPX_HOST_DEVICE
         HPX_FORCEINLINE constexpr util::in_out_result<IterB, OutIter>
         tag_dispatch(hpx::parallel::util::transform_loop_t,
-            hpx::execution::dataseq_policy, IterB it, IterE end, OutIter dest,
+            hpx::execution::simd_policy, IterB it, IterE end, OutIter dest,
             F&& f)
     {
         auto ret = detail::datapar_transform_loop<IterB>::call(
@@ -229,7 +229,7 @@ namespace hpx { namespace parallel { namespace util {
     HPX_HOST_DEVICE
         HPX_FORCEINLINE constexpr util::in_out_result<IterB, OutIter>
         tag_dispatch(hpx::parallel::util::transform_loop_t,
-            hpx::execution::dataseq_task_policy, IterB it, IterE end,
+            hpx::execution::simd_task_policy, IterB it, IterE end,
             OutIter dest, F&& f)
     {
         auto ret = detail::datapar_transform_loop<IterB>::call(
@@ -260,7 +260,7 @@ namespace hpx { namespace parallel { namespace util {
             call(InIter first, InIter last, OutIter dest, F&& f)
             {
                 return util::transform_loop_n_ind<
-                    hpx::execution::dataseq_policy>(first,
+                    hpx::execution::simd_policy>(first,
                     std::distance(first, last), dest, std::forward<F>(f));
             }
 
@@ -283,7 +283,7 @@ namespace hpx { namespace parallel { namespace util {
     HPX_HOST_DEVICE
         HPX_FORCEINLINE constexpr util::in_out_result<IterB, OutIter>
         tag_dispatch(hpx::parallel::util::transform_loop_ind_t,
-            hpx::execution::dataseq_policy, IterB it, IterE end, OutIter dest,
+            hpx::execution::simd_policy, IterB it, IterE end, OutIter dest,
             F&& f)
     {
         auto ret = detail::datapar_transform_loop_ind<IterB>::call(
@@ -298,7 +298,7 @@ namespace hpx { namespace parallel { namespace util {
     HPX_HOST_DEVICE
         HPX_FORCEINLINE constexpr util::in_out_result<IterB, OutIter>
         tag_dispatch(hpx::parallel::util::transform_loop_ind_t,
-            hpx::execution::dataseq_task_policy, IterB it, IterE end,
+            hpx::execution::simd_task_policy, IterB it, IterE end,
             OutIter dest, F&& f)
     {
         auto ret = detail::datapar_transform_loop_ind<IterB>::call(
@@ -423,7 +423,7 @@ namespace hpx { namespace parallel { namespace util {
                 F&& f)
             {
                 auto ret = util::transform_binary_loop_n<
-                    hpx::execution::datapar_policy>(first1,
+                    hpx::execution::simdpar_policy>(first1,
                     std::distance(first1, last1), first2, dest,
                     std::forward<F>(f));
 
@@ -464,7 +464,7 @@ namespace hpx { namespace parallel { namespace util {
                     std::distance(first1, last1), std::distance(first2, last2));
 
                 auto ret = util::transform_binary_loop_n<
-                    hpx::execution::datapar_policy>(
+                    hpx::execution::simdpar_policy>(
                     first1, count, first2, dest, std::forward<F>(f));
 
                 return util::in_in_out_result<InIter1, InIter2, OutIter>{

--- a/libs/parallelism/algorithms/include/hpx/parallel/datapar/zip_iterator.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/datapar/zip_iterator.hpp
@@ -112,7 +112,7 @@ namespace hpx { namespace parallel { namespace traits {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
         template <typename Tuple, typename... Iter, std::size_t... Is>
-        void aligned_pack(Tuple const& value,
+        void aligned_pack(Tuple& value,
             hpx::util::zip_iterator<Iter...> const& iter,
             hpx::util::index_pack<Is...>)
         {
@@ -126,7 +126,7 @@ namespace hpx { namespace parallel { namespace traits {
         }
 
         template <typename Tuple, typename... Iter, std::size_t... Is>
-        void unaligned_pack(Tuple const& value,
+        void unaligned_pack(Tuple& value,
             hpx::util::zip_iterator<Iter...> const& iter,
             hpx::util::index_pack<Is...>)
         {
@@ -145,7 +145,7 @@ namespace hpx { namespace parallel { namespace traits {
     {
         template <typename V, typename... Iter>
         static void aligned(
-            V const& value, hpx::util::zip_iterator<Iter...> const& iter)
+            V& value, hpx::util::zip_iterator<Iter...> const& iter)
         {
             traits::detail::aligned_pack(value, iter,
                 typename hpx::util::make_index_pack<sizeof...(Iter)>::type());
@@ -153,7 +153,7 @@ namespace hpx { namespace parallel { namespace traits {
 
         template <typename V, typename... Iter>
         static void unaligned(
-            V const& value, hpx::util::zip_iterator<Iter...> const& iter)
+            V& value, hpx::util::zip_iterator<Iter...> const& iter)
         {
             traits::detail::unaligned_pack(value, iter,
                 typename hpx::util::make_index_pack<sizeof...(Iter)>::type());

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/algorithm_result.hpp
@@ -192,53 +192,53 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 #if defined(HPX_HAVE_DATAPAR)
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    struct algorithm_result_impl<hpx::execution::dataseq_task_policy, T>
+    struct algorithm_result_impl<hpx::execution::simd_task_policy, T>
       : algorithm_result_impl<hpx::execution::sequenced_task_policy, T>
     {
     };
 
     template <>
-    struct algorithm_result_impl<hpx::execution::dataseq_task_policy, void>
+    struct algorithm_result_impl<hpx::execution::simd_task_policy, void>
       : algorithm_result_impl<hpx::execution::sequenced_task_policy, void>
     {
     };
 
     template <typename Executor, typename Parameters, typename T>
     struct algorithm_result_impl<
-        hpx::execution::dataseq_task_policy_shim<Executor, Parameters>, T>
+        hpx::execution::simd_task_policy_shim<Executor, Parameters>, T>
       : algorithm_result_impl<hpx::execution::sequenced_task_policy, T>
     {
     };
 
     template <typename Executor, typename Parameters>
     struct algorithm_result_impl<
-        hpx::execution::dataseq_task_policy_shim<Executor, Parameters>, void>
+        hpx::execution::simd_task_policy_shim<Executor, Parameters>, void>
       : algorithm_result_impl<hpx::execution::sequenced_task_policy, void>
     {
     };
 
     template <typename T>
-    struct algorithm_result_impl<hpx::execution::datapar_task_policy, T>
+    struct algorithm_result_impl<hpx::execution::simdpar_task_policy, T>
       : algorithm_result_impl<hpx::execution::parallel_task_policy, T>
     {
     };
 
     template <>
-    struct algorithm_result_impl<hpx::execution::datapar_task_policy, void>
+    struct algorithm_result_impl<hpx::execution::simdpar_task_policy, void>
       : algorithm_result_impl<hpx::execution::parallel_task_policy, void>
     {
     };
 
     template <typename Executor, typename Parameters, typename T>
     struct algorithm_result_impl<
-        hpx::execution::datapar_task_policy_shim<Executor, Parameters>, T>
+        hpx::execution::simdpar_task_policy_shim<Executor, Parameters>, T>
       : algorithm_result_impl<hpx::execution::parallel_task_policy, T>
     {
     };
 
     template <typename Executor, typename Parameters>
     struct algorithm_result_impl<
-        hpx::execution::datapar_task_policy_shim<Executor, Parameters>, void>
+        hpx::execution::simdpar_task_policy_shim<Executor, Parameters>, void>
       : algorithm_result_impl<hpx::execution::parallel_task_policy, void>
     {
     };

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/select_partitioner.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/select_partitioner.hpp
@@ -48,12 +48,12 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
 #if defined(HPX_HAVE_DATAPAR)
     template <template <typename...> class Partitioner,
         template <typename...> class TaskPartitioner>
-    struct select_partitioner<hpx::execution::datapar_task_policy, Partitioner,
+    struct select_partitioner<hpx::execution::simdpar_task_policy, Partitioner,
         TaskPartitioner>
     {
         template <typename... Args>
         using apply =
-            TaskPartitioner<hpx::execution::datapar_task_policy, Args...>;
+            TaskPartitioner<hpx::execution::simdpar_task_policy, Args...>;
     };
 #endif
 }}}}    // namespace hpx::parallel::util::detail

--- a/libs/parallelism/algorithms/tests/regressions/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/regressions/CMakeLists.txt
@@ -23,7 +23,7 @@ set(tests
     ranges_facilities
 )
 
-if(HPX_WITH_DATAPAR_VC)
+if(HPX_WITH_DATAPAR_VC OR HPX_WITH_CXX20_EXPERIMENTAL_SIMD)
   list(APPEND tests for_each_datapar)
 endif()
 

--- a/libs/parallelism/algorithms/tests/regressions/for_each_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/regressions/for_each_datapar.cpp
@@ -36,8 +36,8 @@ void test_for_each(ExPolicy&& policy)
 void for_each_test()
 {
     using namespace hpx::execution;
-    test_for_each(dataseq);
-    test_for_each(datapar);
+    test_for_each(simd);
+    test_for_each(simdpar);
 }
 
 int hpx_main()

--- a/libs/parallelism/algorithms/tests/unit/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/unit/CMakeLists.txt
@@ -7,7 +7,7 @@
 # add subdirectories
 set(subdirs algorithms block container_algorithms)
 
-if(HPX_WITH_DATAPAR_VC)
+if(HPX_WITH_DATAPAR_VC OR HPX_WITH_CXX20_EXPERIMENTAL_SIMD)
   set(subdirs ${subdirs} datapar_algorithms)
 endif()
 

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 set(tests)
 
-if(HPX_WITH_DATAPAR_VC)
+if(HPX_WITH_DATAPAR_VC OR HPX_WITH_CXX20_EXPERIMENTAL_SIMD)
   set(tests
       ${tests}
       count_datapar

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/count_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/count_datapar.cpp
@@ -18,11 +18,11 @@ template <typename IteratorTag>
 void test_count()
 {
     using namespace hpx::execution;
-    test_count(dataseq, IteratorTag());
-    test_count(datapar, IteratorTag());
+    test_count(simd, IteratorTag());
+    test_count(simdpar, IteratorTag());
 
-    test_count_async(dataseq(task), IteratorTag());
-    test_count_async(datapar(task), IteratorTag());
+    test_count_async(simd(task), IteratorTag());
+    test_count_async(simdpar(task), IteratorTag());
 }
 
 void count_test()
@@ -37,11 +37,11 @@ void test_count_exception()
 {
     using namespace hpx::execution;
 
-    test_count_exception(dataseq, IteratorTag());
-    test_count_exception(datapar, IteratorTag());
+    test_count_exception(simd, IteratorTag());
+    test_count_exception(simdpar, IteratorTag());
 
-    test_count_exception_async(dataseq(task), IteratorTag());
-    test_count_exception_async(datapar(task), IteratorTag());
+    test_count_exception_async(simd(task), IteratorTag());
+    test_count_exception_async(simdpar(task), IteratorTag());
 }
 
 void count_exception_test()
@@ -56,11 +56,11 @@ void test_count_bad_alloc()
 {
     using namespace hpx::execution;
 
-    test_count_bad_alloc(dataseq, IteratorTag());
-    test_count_bad_alloc(datapar, IteratorTag());
+    test_count_bad_alloc(simd, IteratorTag());
+    test_count_bad_alloc(simdpar, IteratorTag());
 
-    test_count_bad_alloc_async(dataseq(task), IteratorTag());
-    test_count_bad_alloc_async(datapar(task), IteratorTag());
+    test_count_bad_alloc_async(simd(task), IteratorTag());
+    test_count_bad_alloc_async(simdpar(task), IteratorTag());
 }
 
 void count_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/countif_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/countif_datapar.cpp
@@ -19,11 +19,11 @@ void test_count_if()
 {
     using namespace hpx::execution;
 
-    test_count_if(dataseq, IteratorTag());
-    test_count_if(datapar, IteratorTag());
+    test_count_if(simd, IteratorTag());
+    test_count_if(simdpar, IteratorTag());
 
-    test_count_if_async(dataseq(task), IteratorTag());
-    test_count_if_async(datapar(task), IteratorTag());
+    test_count_if_async(simd(task), IteratorTag());
+    test_count_if_async(simdpar(task), IteratorTag());
 }
 
 void count_if_test()
@@ -38,11 +38,11 @@ void test_count_if_exception()
 {
     using namespace hpx::execution;
 
-    test_count_if_exception(dataseq, IteratorTag());
-    test_count_if_exception(datapar, IteratorTag());
+    test_count_if_exception(simd, IteratorTag());
+    test_count_if_exception(simdpar, IteratorTag());
 
-    test_count_if_exception_async(dataseq(task), IteratorTag());
-    test_count_if_exception_async(datapar(task), IteratorTag());
+    test_count_if_exception_async(simd(task), IteratorTag());
+    test_count_if_exception_async(simdpar(task), IteratorTag());
 }
 
 void count_if_exception_test()
@@ -57,11 +57,11 @@ void test_count_if_bad_alloc()
 {
     using namespace hpx::execution;
 
-    test_count_if_bad_alloc(dataseq, IteratorTag());
-    test_count_if_bad_alloc(datapar, IteratorTag());
+    test_count_if_bad_alloc(simd, IteratorTag());
+    test_count_if_bad_alloc(simdpar, IteratorTag());
 
-    test_count_if_bad_alloc_async(dataseq(task), IteratorTag());
-    test_count_if_bad_alloc_async(datapar(task), IteratorTag());
+    test_count_if_bad_alloc_async(simd(task), IteratorTag());
+    test_count_if_bad_alloc_async(simdpar(task), IteratorTag());
 }
 
 void count_if_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_datapar.cpp
@@ -19,11 +19,11 @@ void test_for_each()
 {
     using namespace hpx::execution;
 
-    test_for_each(dataseq, IteratorTag());
-    test_for_each(datapar, IteratorTag());
+    test_for_each(simd, IteratorTag());
+    test_for_each(simdpar, IteratorTag());
 
-    test_for_each_async(dataseq(task), IteratorTag());
-    test_for_each_async(datapar(task), IteratorTag());
+    test_for_each_async(simd(task), IteratorTag());
+    test_for_each_async(simdpar(task), IteratorTag());
 }
 
 void for_each_test()
@@ -38,11 +38,11 @@ void test_for_each_exception()
 {
     using namespace hpx::execution;
 
-    test_for_each_exception(dataseq, IteratorTag());
-    test_for_each_exception(datapar, IteratorTag());
+    test_for_each_exception(simd, IteratorTag());
+    test_for_each_exception(simdpar, IteratorTag());
 
-    test_for_each_exception_async(dataseq(task), IteratorTag());
-    test_for_each_exception_async(datapar(task), IteratorTag());
+    test_for_each_exception_async(simd(task), IteratorTag());
+    test_for_each_exception_async(simdpar(task), IteratorTag());
 }
 
 void for_each_exception_test()
@@ -57,11 +57,11 @@ void test_for_each_bad_alloc()
 {
     using namespace hpx::execution;
 
-    test_for_each_bad_alloc(dataseq, IteratorTag());
-    test_for_each_bad_alloc(datapar, IteratorTag());
+    test_for_each_bad_alloc(simd, IteratorTag());
+    test_for_each_bad_alloc(simdpar, IteratorTag());
 
-    test_for_each_bad_alloc_async(dataseq(task), IteratorTag());
-    test_for_each_bad_alloc_async(datapar(task), IteratorTag());
+    test_for_each_bad_alloc_async(simd(task), IteratorTag());
+    test_for_each_bad_alloc_async(simdpar(task), IteratorTag());
 }
 
 void for_each_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_datapar_zipiter.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreach_datapar_zipiter.cpp
@@ -89,8 +89,8 @@ void for_each_zipiter_test()
 {
     using namespace hpx::execution;
 
-    for_each_zipiter_test(datapar, IteratorTag());
-    //     test_for_each_async(datapar(task), IteratorTag());
+    for_each_zipiter_test(simdpar, IteratorTag());
+    //     test_for_each_async(simdpar(task), IteratorTag());
 }
 
 void for_each_zipiter_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreachn_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/foreachn_datapar.cpp
@@ -20,11 +20,11 @@ void test_for_each_n()
 {
     using namespace hpx::execution;
 
-    test_for_each_n(dataseq, IteratorTag());
-    test_for_each_n(datapar, IteratorTag());
+    test_for_each_n(simd, IteratorTag());
+    test_for_each_n(simdpar, IteratorTag());
 
-    test_for_each_n_async(dataseq(task), IteratorTag());
-    test_for_each_n_async(datapar(task), IteratorTag());
+    test_for_each_n_async(simd(task), IteratorTag());
+    test_for_each_n_async(simdpar(task), IteratorTag());
 }
 
 void for_each_n_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_binary2_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_binary2_datapar.cpp
@@ -19,11 +19,11 @@ void test_transform_binary2()
 {
     using namespace hpx::execution;
 
-    test_transform_binary2(dataseq, IteratorTag());
-    test_transform_binary2(datapar, IteratorTag());
+    test_transform_binary2(simd, IteratorTag());
+    test_transform_binary2(simdpar, IteratorTag());
 
-    test_transform_binary2_async(dataseq(task), IteratorTag());
-    test_transform_binary2_async(datapar(task), IteratorTag());
+    test_transform_binary2_async(simd(task), IteratorTag());
+    test_transform_binary2_async(simdpar(task), IteratorTag());
 }
 
 void transform_binary2_test()
@@ -38,11 +38,11 @@ void test_transform_binary2_exception()
 {
     using namespace hpx::execution;
 
-    test_transform_binary2_exception(dataseq, IteratorTag());
-    test_transform_binary2_exception(datapar, IteratorTag());
+    test_transform_binary2_exception(simd, IteratorTag());
+    test_transform_binary2_exception(simdpar, IteratorTag());
 
-    test_transform_binary2_exception_async(dataseq(task), IteratorTag());
-    test_transform_binary2_exception_async(datapar(task), IteratorTag());
+    test_transform_binary2_exception_async(simd(task), IteratorTag());
+    test_transform_binary2_exception_async(simdpar(task), IteratorTag());
 }
 
 void transform_binary2_exception_test()
@@ -57,11 +57,11 @@ void test_transform_binary2_bad_alloc()
 {
     using namespace hpx::execution;
 
-    test_transform_binary2_bad_alloc(dataseq, IteratorTag());
-    test_transform_binary2_bad_alloc(datapar, IteratorTag());
+    test_transform_binary2_bad_alloc(simd, IteratorTag());
+    test_transform_binary2_bad_alloc(simdpar, IteratorTag());
 
-    test_transform_binary2_bad_alloc_async(dataseq(task), IteratorTag());
-    test_transform_binary2_bad_alloc_async(datapar(task), IteratorTag());
+    test_transform_binary2_bad_alloc_async(simd(task), IteratorTag());
+    test_transform_binary2_bad_alloc_async(simdpar(task), IteratorTag());
 }
 
 void transform_binary2_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_binary_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_binary_datapar.cpp
@@ -19,11 +19,11 @@ void test_transform_binary()
 {
     using namespace hpx::execution;
 
-    test_transform_binary(dataseq, IteratorTag());
-    test_transform_binary(datapar, IteratorTag());
+    test_transform_binary(simd, IteratorTag());
+    test_transform_binary(simdpar, IteratorTag());
 
-    test_transform_binary_async(dataseq(task), IteratorTag());
-    test_transform_binary_async(datapar(task), IteratorTag());
+    test_transform_binary_async(simd(task), IteratorTag());
+    test_transform_binary_async(simdpar(task), IteratorTag());
 }
 
 void transform_binary_test()
@@ -38,11 +38,11 @@ void test_transform_binary_exception()
 {
     using namespace hpx::execution;
 
-    test_transform_binary_exception(dataseq, IteratorTag());
-    test_transform_binary_exception(datapar, IteratorTag());
+    test_transform_binary_exception(simd, IteratorTag());
+    test_transform_binary_exception(simdpar, IteratorTag());
 
-    test_transform_binary_exception_async(dataseq(task), IteratorTag());
-    test_transform_binary_exception_async(datapar(task), IteratorTag());
+    test_transform_binary_exception_async(simd(task), IteratorTag());
+    test_transform_binary_exception_async(simdpar(task), IteratorTag());
 }
 
 void transform_binary_exception_test()
@@ -57,11 +57,11 @@ void test_transform_binary_bad_alloc()
 {
     using namespace hpx::execution;
 
-    test_transform_binary_bad_alloc(dataseq, IteratorTag());
-    test_transform_binary_bad_alloc(datapar, IteratorTag());
+    test_transform_binary_bad_alloc(simd, IteratorTag());
+    test_transform_binary_bad_alloc(simdpar, IteratorTag());
 
-    test_transform_binary_bad_alloc_async(dataseq(task), IteratorTag());
-    test_transform_binary_bad_alloc_async(datapar(task), IteratorTag());
+    test_transform_binary_bad_alloc_async(simd(task), IteratorTag());
+    test_transform_binary_bad_alloc_async(simdpar(task), IteratorTag());
 }
 
 void transform_binary_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_datapar.cpp
@@ -19,11 +19,11 @@ void test_transform()
 {
     using namespace hpx::execution;
 
-    test_transform(dataseq, IteratorTag());
-    test_transform(datapar, IteratorTag());
+    test_transform(simd, IteratorTag());
+    test_transform(simdpar, IteratorTag());
 
-    test_transform_async(dataseq(task), IteratorTag());
-    test_transform_async(datapar(task), IteratorTag());
+    test_transform_async(simd(task), IteratorTag());
+    test_transform_async(simdpar(task), IteratorTag());
 }
 
 void transform_test()
@@ -37,11 +37,11 @@ void test_transform_exception()
 {
     using namespace hpx::execution;
 
-    test_transform_exception(dataseq, IteratorTag());
-    test_transform_exception(datapar, IteratorTag());
+    test_transform_exception(simd, IteratorTag());
+    test_transform_exception(simdpar, IteratorTag());
 
-    test_transform_exception_async(dataseq(task), IteratorTag());
-    test_transform_exception_async(datapar(task), IteratorTag());
+    test_transform_exception_async(simd(task), IteratorTag());
+    test_transform_exception_async(simdpar(task), IteratorTag());
 }
 
 void transform_exception_test()
@@ -56,11 +56,11 @@ void test_transform_bad_alloc()
 {
     using namespace hpx::execution;
 
-    test_transform_bad_alloc(dataseq, IteratorTag());
-    test_transform_bad_alloc(datapar, IteratorTag());
+    test_transform_bad_alloc(simd, IteratorTag());
+    test_transform_bad_alloc(simdpar, IteratorTag());
 
-    test_transform_bad_alloc_async(dataseq(task), IteratorTag());
-    test_transform_bad_alloc_async(datapar(task), IteratorTag());
+    test_transform_bad_alloc_async(simd(task), IteratorTag());
+    test_transform_bad_alloc_async(simdpar(task), IteratorTag());
 }
 
 void transform_bad_alloc_test()

--- a/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_reduce_binary_datapar.cpp
+++ b/libs/parallelism/algorithms/tests/unit/datapar_algorithms/transform_reduce_binary_datapar.cpp
@@ -19,11 +19,11 @@ void test_transform_reduce_binary()
 {
     using namespace hpx::execution;
 
-    test_transform_reduce_binary(dataseq, IteratorTag());
-    test_transform_reduce_binary(datapar, IteratorTag());
+    test_transform_reduce_binary(simd, IteratorTag());
+    test_transform_reduce_binary(simdpar, IteratorTag());
 
-    test_transform_reduce_binary_async(dataseq(task), IteratorTag());
-    test_transform_reduce_binary_async(datapar(task), IteratorTag());
+    test_transform_reduce_binary_async(simd(task), IteratorTag());
+    test_transform_reduce_binary_async(simdpar(task), IteratorTag());
 }
 
 void transform_reduce_binary_test()

--- a/libs/parallelism/execution/CMakeLists.txt
+++ b/libs/parallelism/execution/CMakeLists.txt
@@ -42,6 +42,10 @@ set(execution_headers
     hpx/execution/executors/rebind_executor.hpp
     hpx/execution/executors/static_chunk_size.hpp
     hpx/execution/sender_future.hpp
+    hpx/execution/traits/detail/simd/vector_pack_alignment_size.hpp
+    hpx/execution/traits/detail/simd/vector_pack_count_bits.hpp
+    hpx/execution/traits/detail/simd/vector_pack_load_store.hpp
+    hpx/execution/traits/detail/simd/vector_pack_type.hpp
     hpx/execution/traits/detail/vc/vector_pack_alignment_size.hpp
     hpx/execution/traits/detail/vc/vector_pack_count_bits.hpp
     hpx/execution/traits/detail/vc/vector_pack_load_store.hpp

--- a/libs/parallelism/execution/include/hpx/execution/traits/detail/simd/vector_pack_alignment_size.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/traits/detail/simd/vector_pack_alignment_size.hpp
@@ -1,0 +1,125 @@
+//  Copyright (c) 2021 Srinivas Yadav
+//  Copyright (c) 2016-2017 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_CXX20_EXPERIMENTAL_SIMD)
+#include <cstddef>
+#include <type_traits>
+
+#include <experimental/simd>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace parallel { namespace traits {
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    struct is_vector_pack<std::experimental::native_simd<T>> : std::true_type
+    {
+    };
+
+    template <typename T>
+    struct is_vector_pack<
+        std::experimental::simd<T, std::experimental::simd_abi::fixed_size<1>>>
+      : std::false_type
+    {
+    };
+
+    template <typename T>
+    struct is_vector_pack<
+        std::experimental::simd<T, std::experimental::simd_abi::scalar>>
+      : std::false_type
+    {
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    struct is_scalar_vector_pack<std::experimental::native_simd<T>>
+      : std::false_type
+    {
+    };
+
+    template <typename T>
+    struct is_scalar_vector_pack<
+        std::experimental::simd<T, std::experimental::simd_abi::fixed_size<1>>>
+      : std::true_type
+    {
+    };
+
+    template <typename T>
+    struct is_scalar_vector_pack<
+        std::experimental::simd<T, std::experimental::simd_abi::scalar>>
+      : std::true_type
+    {
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T, typename Enable>
+    struct vector_pack_alignment
+    {
+        static std::size_t const value = std::experimental::memory_alignment_v<
+            std::experimental::native_simd<T>>;
+    };
+
+    template <typename T, typename Abi>
+    struct vector_pack_alignment<std::experimental::simd<T, Abi>>
+    {
+        static std::size_t const value = std::experimental::memory_alignment_v<
+            std::experimental::simd<T, Abi>>;
+    };
+
+    template <typename T>
+    struct vector_pack_alignment<
+        std::experimental::simd<T, std::experimental::simd_abi::scalar>>
+    {
+        static std::size_t const value = std::experimental::memory_alignment_v<
+            std::experimental::simd<T, std::experimental::simd_abi::scalar>>;
+    };
+
+    template <typename T>
+    struct vector_pack_alignment<
+        std::experimental::simd<T, std::experimental::simd_abi::fixed_size<1>>>
+    {
+        static std::size_t const value =
+            std::experimental::memory_alignment_v<std::experimental::simd<T,
+                std::experimental::simd_abi::fixed_size<1>>>;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T, typename Enable>
+    struct vector_pack_size
+    {
+        static std::size_t const value =
+            std::experimental::native_simd<T>::size();
+    };
+
+    template <typename T, typename Abi>
+    struct vector_pack_size<std::experimental::simd<T, Abi>>
+    {
+        static std::size_t const value =
+            std::experimental::simd<T, Abi>::size();
+    };
+
+    template <typename T>
+    struct vector_pack_size<
+        std::experimental::simd<T, std::experimental::simd_abi::scalar>>
+    {
+        static std::size_t const value = std::experimental::simd<T,
+            std::experimental::simd_abi::scalar>::size();
+    };
+
+    template <typename T>
+    struct vector_pack_size<
+        std::experimental::simd<T, std::experimental::simd_abi::fixed_size<1>>>
+    {
+        static std::size_t const value = std::experimental::simd<T,
+            std::experimental::simd_abi::fixed_size<1>>::size();
+    };
+}}}    // namespace hpx::parallel::traits
+
+#endif

--- a/libs/parallelism/execution/include/hpx/execution/traits/detail/simd/vector_pack_count_bits.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/traits/detail/simd/vector_pack_count_bits.hpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2021 Srinivas Yadav
 //  Copyright (c) 2016-2017 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -8,21 +9,19 @@
 
 #include <hpx/config.hpp>
 
+#if defined(HPX_HAVE_CXX20_EXPERIMENTAL_SIMD)
 #include <cstddef>
 
-///////////////////////////////////////////////////////////////////////////////
+#include <experimental/simd>
+
 namespace hpx { namespace parallel { namespace traits {
-    HPX_HOST_DEVICE HPX_FORCEINLINE std::size_t count_bits(bool value)
+    ///////////////////////////////////////////////////////////////////////
+    template <typename T, typename Abi>
+    HPX_HOST_DEVICE HPX_FORCEINLINE std::size_t count_bits(
+        std::experimental::simd_mask<T, Abi> const& mask)
     {
-        return value ? 1 : 0;
+        return std::experimental::popcount(mask);
     }
 }}}    // namespace hpx::parallel::traits
-
-#if defined(HPX_HAVE_DATAPAR)
-
-#if !defined(__CUDACC__)
-#include <hpx/execution/traits/detail/simd/vector_pack_count_bits.hpp>
-#include <hpx/execution/traits/detail/vc/vector_pack_count_bits.hpp>
-#endif
 
 #endif

--- a/libs/parallelism/execution/include/hpx/execution/traits/detail/simd/vector_pack_load_store.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/traits/detail/simd/vector_pack_load_store.hpp
@@ -25,13 +25,13 @@ namespace hpx { namespace parallel { namespace traits {
     struct vector_pack_load
     {
         template <typename Iter>
-        static V aligned(Iter& iter)
+        static V aligned(Iter const& iter)
         {
             return V(std::addressof(*iter), std::experimental::vector_aligned);
         }
 
         template <typename Iter>
-        static V unaligned(Iter& iter)
+        static V unaligned(Iter const& iter)
         {
             return V(std::addressof(*iter), std::experimental::element_aligned);
         }
@@ -42,14 +42,14 @@ namespace hpx { namespace parallel { namespace traits {
     struct vector_pack_store
     {
         template <typename Iter>
-        static void aligned(V& value, Iter& iter)
+        static void aligned(V& value, Iter const& iter)
         {
             value.copy_to(
                 std::addressof(*iter), std::experimental::vector_aligned);
         }
 
         template <typename Iter>
-        static void unaligned(V& value, Iter& iter)
+        static void unaligned(V& value, Iter const& iter)
         {
             value.copy_to(
                 std::addressof(*iter), std::experimental::element_aligned);

--- a/libs/parallelism/execution/include/hpx/execution/traits/detail/simd/vector_pack_load_store.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/traits/detail/simd/vector_pack_load_store.hpp
@@ -1,0 +1,60 @@
+//  Copyright (c) 2021 Srinivas Yadav
+//  Copyright (c) 2016-2017 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_CXX20_EXPERIMENTAL_SIMD)
+#include <cstddef>
+#include <iterator>
+#include <memory>
+
+#include <experimental/simd>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace parallel { namespace traits {
+    ///////////////////////////////////////////////////////////////////////////
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename V, typename ValueType, typename Enable>
+    struct vector_pack_load
+    {
+        template <typename Iter>
+        static V aligned(Iter& iter)
+        {
+            return V(std::addressof(*iter), std::experimental::vector_aligned);
+        }
+
+        template <typename Iter>
+        static V unaligned(Iter& iter)
+        {
+            return V(std::addressof(*iter), std::experimental::element_aligned);
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename V, typename ValueType, typename Enable>
+    struct vector_pack_store
+    {
+        template <typename Iter>
+        static void aligned(V& value, Iter& iter)
+        {
+            value.copy_to(
+                std::addressof(*iter), std::experimental::vector_aligned);
+        }
+
+        template <typename Iter>
+        static void unaligned(V& value, Iter& iter)
+        {
+            value.copy_to(
+                std::addressof(*iter), std::experimental::element_aligned);
+        }
+    };
+}}}    // namespace hpx::parallel::traits
+
+#endif

--- a/libs/parallelism/execution/include/hpx/execution/traits/detail/simd/vector_pack_type.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/traits/detail/simd/vector_pack_type.hpp
@@ -1,0 +1,54 @@
+//  Copyright (c) 2021 Srinivas Yadav
+//  Copyright (c) 2016-2017 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_CXX20_EXPERIMENTAL_SIMD)
+
+#include <experimental/simd>
+
+#include <cstddef>
+#include <type_traits>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace parallel { namespace traits {
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail {
+        template <typename T, std::size_t N, typename Abi>
+        struct vector_pack_type
+        {
+            typedef std::experimental::fixed_size_simd<T, N> type;
+        };
+
+        template <typename T, typename Abi>
+        struct vector_pack_type<T, 0, Abi>
+        {
+            typedef typename std::conditional<std::is_void<Abi>::value,
+                std::experimental::simd_abi::native<T>, Abi>::type abi_type;
+
+            typedef std::experimental::simd<T, abi_type> type;
+        };
+
+        template <typename T, typename Abi>
+        struct vector_pack_type<T, 1, Abi>
+        {
+            typedef std::experimental::simd<T,
+                std::experimental::simd_abi::scalar>
+                type;
+        };
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T, std::size_t N, typename Abi>
+    struct vector_pack_type : detail::vector_pack_type<T, N, Abi>
+    {
+    };
+}}}    // namespace hpx::parallel::traits
+
+#endif

--- a/libs/parallelism/execution/include/hpx/execution/traits/vector_pack_alignment_size.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/traits/vector_pack_alignment_size.hpp
@@ -69,6 +69,7 @@ namespace hpx { namespace parallel { namespace traits {
 }}}    // namespace hpx::parallel::traits
 
 #if !defined(__CUDACC__)
+#include <hpx/execution/traits/detail/simd/vector_pack_alignment_size.hpp>
 #include <hpx/execution/traits/detail/vc/vector_pack_alignment_size.hpp>
 #endif
 

--- a/libs/parallelism/execution/include/hpx/execution/traits/vector_pack_load_store.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/traits/vector_pack_load_store.hpp
@@ -25,6 +25,7 @@ namespace hpx { namespace parallel { namespace traits {
 }}}    // namespace hpx::parallel::traits
 
 #if !defined(__CUDACC__)
+#include <hpx/execution/traits/detail/simd/vector_pack_load_store.hpp>
 #include <hpx/execution/traits/detail/vc/vector_pack_load_store.hpp>
 #endif
 

--- a/libs/parallelism/execution/include/hpx/execution/traits/vector_pack_type.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/traits/vector_pack_type.hpp
@@ -36,6 +36,7 @@ namespace hpx { namespace parallel { namespace traits {
 }}}    // namespace hpx::parallel::traits
 
 #if !defined(__CUDACC__)
+#include <hpx/execution/traits/detail/simd/vector_pack_type.hpp>
 #include <hpx/execution/traits/detail/vc/vector_pack_type.hpp>
 #endif
 

--- a/libs/parallelism/execution/tests/regressions/lambda_arguments_2403.cpp
+++ b/libs/parallelism/execution/tests/regressions/lambda_arguments_2403.cpp
@@ -20,7 +20,7 @@ int hpx_main()
     auto zip_it_begin = hpx::util::make_zip_iterator(large.begin());
     auto zip_it_end = hpx::util::make_zip_iterator(large.end());
 
-    hpx::for_each(hpx::execution::datapar, zip_it_begin, zip_it_end,
+    hpx::for_each(hpx::execution::simdpar, zip_it_begin, zip_it_end,
         [](auto& t) -> void { hpx::get<0>(t) = 10.0; });
 
     HPX_TEST_EQ(std::count(large.begin(), large.end(), 10.0),

--- a/libs/parallelism/execution/tests/regressions/lambda_return_type_2402.cpp
+++ b/libs/parallelism/execution/tests/regressions/lambda_return_type_2402.cpp
@@ -22,7 +22,7 @@ int hpx_main()
     auto zip_it_end = hpx::util::make_zip_iterator(large.end());
 
     hpx::for_each(
-        hpx::execution::datapar, zip_it_begin, zip_it_end, [](auto t) {
+        hpx::execution::simdpar, zip_it_begin, zip_it_end, [](auto t) {
             using comp_type = typename hpx::tuple_element<0, decltype(t)>::type;
             using var_type = typename std::decay<comp_type>::type;
 

--- a/libs/parallelism/executors/include/hpx/executors/datapar/execution_policy.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/datapar/execution_policy.hpp
@@ -95,9 +95,9 @@ namespace hpx { namespace execution { inline namespace v1 {
             static_assert(hpx::traits::is_executor_any<Executor>::value,
                 "hpx::traits::is_executor_any<Executor>::value");
 
-            typedef typename parallel::execution::rebind_executor<
-                simd_task_policy, Executor, executor_parameters_type>::type
-                rebound_type;
+            typedef
+                typename parallel::execution::rebind_executor<simd_task_policy,
+                    Executor, executor_parameters_type>::type rebound_type;
             return rebound_type(std::forward<Executor>(exec), parameters());
         }
 
@@ -123,9 +123,9 @@ namespace hpx { namespace execution { inline namespace v1 {
             executor_type, ParametersType>::type
         with(Parameters&&... params) const
         {
-            typedef typename parallel::execution::rebind_executor<
-                simd_task_policy, executor_type, ParametersType>::type
-                rebound_type;
+            typedef
+                typename parallel::execution::rebind_executor<simd_task_policy,
+                    executor_type, ParametersType>::type rebound_type;
             return rebound_type(executor(),
                 parallel::execution::join_executor_parameters(
                     std::forward<Parameters>(params)...));
@@ -209,8 +209,7 @@ namespace hpx { namespace execution { inline namespace v1 {
         ///
         /// \returns The new sequenced_task_policy
         ///
-        constexpr simd_task_policy_shim const& operator()(
-            task_policy_tag) const
+        constexpr simd_task_policy_shim const& operator()(task_policy_tag) const
         {
             return *this;
         }
@@ -299,8 +298,7 @@ namespace hpx { namespace execution { inline namespace v1 {
         constexpr simd_task_policy_shim() = default;
 
         template <typename Executor_, typename Parameters_>
-        constexpr simd_task_policy_shim(
-            Executor_&& exec, Parameters_&& params)
+        constexpr simd_task_policy_shim(Executor_&& exec, Parameters_&& params)
           : exec_(std::forward<Executor_>(exec))
           , params_(std::forward<Parameters_>(params))
         {
@@ -389,9 +387,8 @@ namespace hpx { namespace execution { inline namespace v1 {
             static_assert(hpx::traits::is_executor_any<Executor>::value,
                 "hpx::traits::is_executor_any<Executor>::value");
 
-            typedef
-                typename parallel::execution::rebind_executor<simd_policy,
-                    Executor, executor_parameters_type>::type rebound_type;
+            typedef typename parallel::execution::rebind_executor<simd_policy,
+                Executor, executor_parameters_type>::type rebound_type;
             return rebound_type(std::forward<Executor>(exec), parameters());
         }
 
@@ -417,9 +414,8 @@ namespace hpx { namespace execution { inline namespace v1 {
             executor_type, ParametersType>::type
         with(Parameters&&... params) const
         {
-            typedef
-                typename parallel::execution::rebind_executor<simd_policy,
-                    executor_type, ParametersType>::type rebound_type;
+            typedef typename parallel::execution::rebind_executor<simd_policy,
+                executor_type, ParametersType>::type rebound_type;
             return rebound_type(executor(),
                 parallel::execution::join_executor_parameters(
                     std::forward<Parameters>(params)...));
@@ -503,8 +499,7 @@ namespace hpx { namespace execution { inline namespace v1 {
         constexpr simd_task_policy_shim<Executor, Parameters> operator()(
             task_policy_tag) const
         {
-            return simd_task_policy_shim<Executor, Parameters>(
-                exec_, params_);
+            return simd_task_policy_shim<Executor, Parameters>(exec_, params_);
         }
 
         /// Create a new simd_policy from the given
@@ -529,9 +524,9 @@ namespace hpx { namespace execution { inline namespace v1 {
             static_assert(hpx::traits::is_executor_any<Executor_>::value,
                 "hpx::traits::is_executor_any<Executor_>::value");
 
-            typedef typename parallel::execution::rebind_executor<
-                simd_policy_shim, Executor_, executor_parameters_type>::type
-                rebound_type;
+            typedef
+                typename parallel::execution::rebind_executor<simd_policy_shim,
+                    Executor_, executor_parameters_type>::type rebound_type;
             return rebound_type(std::forward<Executor_>(exec), params_);
         }
 
@@ -557,9 +552,9 @@ namespace hpx { namespace execution { inline namespace v1 {
             executor_type, ParametersType>::type
         with(Parameters_&&... params) const
         {
-            typedef typename parallel::execution::rebind_executor<
-                simd_policy_shim, executor_type, ParametersType>::type
-                rebound_type;
+            typedef
+                typename parallel::execution::rebind_executor<simd_policy_shim,
+                    executor_type, ParametersType>::type rebound_type;
             return rebound_type(exec_,
                 parallel::execution::join_executor_parameters(
                     std::forward<Parameters_>(params)...));
@@ -1201,8 +1196,7 @@ namespace hpx { namespace detail {
 
     template <typename Executor, typename Parameters>
     struct is_execution_policy<
-        hpx::execution::simd_policy_shim<Executor, Parameters>>
-      : std::true_type
+        hpx::execution::simd_policy_shim<Executor, Parameters>> : std::true_type
     {
     };
 
@@ -1261,8 +1255,7 @@ namespace hpx { namespace detail {
 
     template <typename Executor, typename Parameters>
     struct is_sequenced_execution_policy<
-        hpx::execution::simd_policy_shim<Executor, Parameters>>
-      : std::true_type
+        hpx::execution::simd_policy_shim<Executor, Parameters>> : std::true_type
     {
     };
 
@@ -1348,8 +1341,7 @@ namespace hpx { namespace detail {
 
     template <typename Executor, typename Parameters>
     struct is_vectorpack_execution_policy<
-        hpx::execution::simd_policy_shim<Executor, Parameters>>
-      : std::true_type
+        hpx::execution::simd_policy_shim<Executor, Parameters>> : std::true_type
     {
     };
 

--- a/libs/parallelism/executors/include/hpx/executors/datapar/execution_policy.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/datapar/execution_policy.hpp
@@ -25,7 +25,7 @@
 
 namespace hpx { namespace execution { inline namespace v1 {
     ///////////////////////////////////////////////////////////////////////////
-    /// Extension: The class dataseq_task_policy is an execution
+    /// Extension: The class simd_task_policy is an execution
     /// policy type used as a unique type to disambiguate parallel algorithm
     /// overloading and indicate that a parallel algorithm's execution may not
     /// be parallelized (has to run sequentially).
@@ -33,7 +33,7 @@ namespace hpx { namespace execution { inline namespace v1 {
     /// The algorithm returns a future representing the result of the
     /// corresponding algorithm when invoked with the
     /// sequenced_policy.
-    struct dataseq_task_policy
+    struct simd_task_policy
     {
         /// The type of the executor associated with this execution policy
         typedef sequenced_executor executor_type;
@@ -54,26 +54,26 @@ namespace hpx { namespace execution { inline namespace v1 {
         struct rebind
         {
             /// The type of the rebound execution policy
-            typedef dataseq_task_policy_shim<Executor_, Parameters_> type;
+            typedef simd_task_policy_shim<Executor_, Parameters_> type;
         };
 
         /// \cond NOINTERNAL
-        constexpr dataseq_task_policy() = default;
+        constexpr simd_task_policy() = default;
         /// \endcond
 
-        /// Create a new dataseq_task_policy from itself
+        /// Create a new simd_task_policy from itself
         ///
         /// \param tag          [in] Specify that the corresponding asynchronous
         ///                     execution policy should be used
         ///
         /// \returns The new sequenced_task_policy
         ///
-        constexpr dataseq_task_policy operator()(task_policy_tag) const
+        constexpr simd_task_policy operator()(task_policy_tag) const
         {
             return *this;
         }
 
-        /// Create a new dataseq_task_policy from the given
+        /// Create a new simd_task_policy from the given
         /// executor
         ///
         /// \tparam Executor    The type of the executor to associate with this
@@ -85,10 +85,10 @@ namespace hpx { namespace execution { inline namespace v1 {
         ///
         /// \note Requires: is_executor<Executor>::value is true
         ///
-        /// \returns The new dataseq_task_policy
+        /// \returns The new simd_task_policy
         ///
         template <typename Executor>
-        typename parallel::execution::rebind_executor<dataseq_task_policy,
+        typename parallel::execution::rebind_executor<simd_task_policy,
             Executor, executor_parameters_type>::type
         on(Executor&& exec) const
         {
@@ -96,12 +96,12 @@ namespace hpx { namespace execution { inline namespace v1 {
                 "hpx::traits::is_executor_any<Executor>::value");
 
             typedef typename parallel::execution::rebind_executor<
-                dataseq_task_policy, Executor, executor_parameters_type>::type
+                simd_task_policy, Executor, executor_parameters_type>::type
                 rebound_type;
             return rebound_type(std::forward<Executor>(exec), parameters());
         }
 
-        /// Create a new dataseq_task_policy from the given
+        /// Create a new simd_task_policy from the given
         /// execution parameters
         ///
         /// \tparam Parameters  The type of the executor parameters to
@@ -114,17 +114,17 @@ namespace hpx { namespace execution { inline namespace v1 {
         /// \note Requires: all parameters are executor_parameters,
         ///                 different parameter types can't be duplicated
         ///
-        /// \returns The new dataseq_task_policy
+        /// \returns The new simd_task_policy
         ///
         template <typename... Parameters,
             typename ParametersType = typename parallel::execution::
                 executor_parameters_join<Parameters...>::type>
-        typename parallel::execution::rebind_executor<dataseq_task_policy,
+        typename parallel::execution::rebind_executor<simd_task_policy,
             executor_type, ParametersType>::type
         with(Parameters&&... params) const
         {
             typedef typename parallel::execution::rebind_executor<
-                dataseq_task_policy, executor_type, ParametersType>::type
+                simd_task_policy, executor_type, ParametersType>::type
                 rebound_type;
             return rebound_type(executor(),
                 parallel::execution::join_executor_parameters(
@@ -167,7 +167,7 @@ namespace hpx { namespace execution { inline namespace v1 {
         executor_parameters_type params_;
     };
 
-    /// Extension: The class dataseq_task_policy_shim is an
+    /// Extension: The class simd_task_policy_shim is an
     /// execution policy type used as a unique type to disambiguate parallel
     /// algorithm overloading based on combining a underlying
     /// \a sequenced_task_policy and an executor and indicate that
@@ -178,7 +178,7 @@ namespace hpx { namespace execution { inline namespace v1 {
     /// corresponding algorithm when invoked with the
     /// sequenced_policy.
     template <typename Executor, typename Parameters>
-    struct dataseq_task_policy_shim : dataseq_task_policy
+    struct simd_task_policy_shim : simd_task_policy
     {
         /// The type of the executor associated with this execution policy
         typedef Executor executor_type;
@@ -199,23 +199,23 @@ namespace hpx { namespace execution { inline namespace v1 {
         struct rebind
         {
             /// The type of the rebound execution policy
-            typedef dataseq_task_policy_shim<Executor_, Parameters_> type;
+            typedef simd_task_policy_shim<Executor_, Parameters_> type;
         };
 
-        /// Create a new dataseq_task_policy_shim from itself
+        /// Create a new simd_task_policy_shim from itself
         ///
         /// \param tag          [in] Specify that the corresponding asynchronous
         ///                     execution policy should be used
         ///
         /// \returns The new sequenced_task_policy
         ///
-        constexpr dataseq_task_policy_shim const& operator()(
+        constexpr simd_task_policy_shim const& operator()(
             task_policy_tag) const
         {
             return *this;
         }
 
-        /// Create a new dataseq_task_policy_shim from the given
+        /// Create a new simd_task_policy_shim from the given
         /// executor
         ///
         /// \tparam Executor    The type of the executor to associate with this
@@ -227,10 +227,10 @@ namespace hpx { namespace execution { inline namespace v1 {
         ///
         /// \note Requires: is_executor<Executor>::value is true
         ///
-        /// \returns The new dataseq_task_policy_shim
+        /// \returns The new simd_task_policy_shim
         ///
         template <typename Executor_>
-        typename parallel::execution::rebind_executor<dataseq_task_policy_shim,
+        typename parallel::execution::rebind_executor<simd_task_policy_shim,
             Executor_, executor_parameters_type>::type
         on(Executor_&& exec) const
         {
@@ -238,12 +238,12 @@ namespace hpx { namespace execution { inline namespace v1 {
                 "hpx::traits::is_executor_any<Executor_>::value");
 
             typedef typename parallel::execution::rebind_executor<
-                dataseq_task_policy_shim, Executor_,
+                simd_task_policy_shim, Executor_,
                 executor_parameters_type>::type rebound_type;
             return rebound_type(std::forward<Executor_>(exec), params_);
         }
 
-        /// Create a new dataseq_task_policy_shim from the given
+        /// Create a new simd_task_policy_shim from the given
         /// execution parameters
         ///
         /// \tparam Parameters  The type of the executor parameters to
@@ -261,12 +261,12 @@ namespace hpx { namespace execution { inline namespace v1 {
         template <typename... Parameters_,
             typename ParametersType = typename parallel::execution::
                 executor_parameters_join<Parameters_...>::type>
-        typename parallel::execution::rebind_executor<dataseq_task_policy_shim,
+        typename parallel::execution::rebind_executor<simd_task_policy_shim,
             executor_type, ParametersType>::type
         with(Parameters_&&... params) const
         {
             typedef typename parallel::execution::rebind_executor<
-                dataseq_task_policy_shim, executor_type, ParametersType>::type
+                simd_task_policy_shim, executor_type, ParametersType>::type
                 rebound_type;
             return rebound_type(exec_,
                 parallel::execution::join_executor_parameters(
@@ -296,10 +296,10 @@ namespace hpx { namespace execution { inline namespace v1 {
         }
 
         /// \cond NOINTERNAL
-        constexpr dataseq_task_policy_shim() = default;
+        constexpr simd_task_policy_shim() = default;
 
         template <typename Executor_, typename Parameters_>
-        constexpr dataseq_task_policy_shim(
+        constexpr simd_task_policy_shim(
             Executor_&& exec, Parameters_&& params)
           : exec_(std::forward<Executor_>(exec))
           , params_(std::forward<Parameters_>(params))
@@ -324,10 +324,10 @@ namespace hpx { namespace execution { inline namespace v1 {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    /// The class dataseq_policy is an execution policy type used
+    /// The class simd_policy is an execution policy type used
     /// as a unique type to disambiguate parallel algorithm overloading and
     /// require that a parallel algorithm's execution may not be parallelized.
-    struct dataseq_policy
+    struct simd_policy
     {
         /// The type of the executor associated with this execution policy
         typedef sequenced_executor executor_type;
@@ -348,26 +348,26 @@ namespace hpx { namespace execution { inline namespace v1 {
         struct rebind
         {
             /// The type of the rebound execution policy
-            typedef dataseq_policy_shim<Executor_, Parameters_> type;
+            typedef simd_policy_shim<Executor_, Parameters_> type;
         };
 
         /// \cond NOINTERNAL
-        constexpr dataseq_policy() = default;
+        constexpr simd_policy() = default;
         /// \endcond
 
-        /// Create a new dataseq_task_policy.
+        /// Create a new simd_task_policy.
         ///
         /// \param tag          [in] Specify that the corresponding asynchronous
         ///                     execution policy should be used
         ///
-        /// \returns The new dataseq_task_policy
+        /// \returns The new simd_task_policy
         ///
-        constexpr dataseq_task_policy operator()(task_policy_tag) const
+        constexpr simd_task_policy operator()(task_policy_tag) const
         {
-            return dataseq_task_policy();
+            return simd_task_policy();
         }
 
-        /// Create a new dataseq_policy from the given
+        /// Create a new simd_policy from the given
         /// executor
         ///
         /// \tparam Executor    The type of the executor to associate with this
@@ -379,10 +379,10 @@ namespace hpx { namespace execution { inline namespace v1 {
         ///
         /// \note Requires: is_executor<Executor>::value is true
         ///
-        /// \returns The new dataseq_policy
+        /// \returns The new simd_policy
         ///
         template <typename Executor>
-        typename parallel::execution::rebind_executor<dataseq_policy, Executor,
+        typename parallel::execution::rebind_executor<simd_policy, Executor,
             executor_parameters_type>::type
         on(Executor&& exec) const
         {
@@ -390,12 +390,12 @@ namespace hpx { namespace execution { inline namespace v1 {
                 "hpx::traits::is_executor_any<Executor>::value");
 
             typedef
-                typename parallel::execution::rebind_executor<dataseq_policy,
+                typename parallel::execution::rebind_executor<simd_policy,
                     Executor, executor_parameters_type>::type rebound_type;
             return rebound_type(std::forward<Executor>(exec), parameters());
         }
 
-        /// Create a new dataseq_policy from the given
+        /// Create a new simd_policy from the given
         /// execution parameters
         ///
         /// \tparam Parameters  The type of the executor parameters to
@@ -408,17 +408,17 @@ namespace hpx { namespace execution { inline namespace v1 {
         /// \note Requires: all parameters are executor_parameters,
         ///                 different parameter types can't be duplicated
         ///
-        /// \returns The new dataseq_policy
+        /// \returns The new simd_policy
         ///
         template <typename... Parameters,
             typename ParametersType = typename parallel::execution::
                 executor_parameters_join<Parameters...>::type>
-        typename parallel::execution::rebind_executor<dataseq_policy,
+        typename parallel::execution::rebind_executor<simd_policy,
             executor_type, ParametersType>::type
         with(Parameters&&... params) const
         {
             typedef
-                typename parallel::execution::rebind_executor<dataseq_policy,
+                typename parallel::execution::rebind_executor<simd_policy,
                     executor_type, ParametersType>::type rebound_type;
             return rebound_type(executor(),
                 parallel::execution::join_executor_parameters(
@@ -463,13 +463,13 @@ namespace hpx { namespace execution { inline namespace v1 {
     };
 
     /// Default sequential execution policy object.
-    static constexpr dataseq_policy dataseq{};
+    static constexpr simd_policy simd{};
 
-    /// The class dataseq_policy is an execution policy type used
+    /// The class simd_policy is an execution policy type used
     /// as a unique type to disambiguate parallel algorithm overloading and
     /// require that a parallel algorithm's execution may not be parallelized.
     template <typename Executor, typename Parameters>
-    struct dataseq_policy_shim : dataseq_policy
+    struct simd_policy_shim : simd_policy
     {
         /// The type of the executor associated with this execution policy
         typedef Executor executor_type;
@@ -490,24 +490,24 @@ namespace hpx { namespace execution { inline namespace v1 {
         struct rebind
         {
             /// The type of the rebound execution policy
-            typedef dataseq_policy_shim<Executor_, Parameters_> type;
+            typedef simd_policy_shim<Executor_, Parameters_> type;
         };
 
-        /// Create a new dataseq_task_policy.
+        /// Create a new simd_task_policy.
         ///
         /// \param tag          [in] Specify that the corresponding asynchronous
         ///                     execution policy should be used
         ///
-        /// \returns The new dataseq_task_policy_shim
+        /// \returns The new simd_task_policy_shim
         ///
-        constexpr dataseq_task_policy_shim<Executor, Parameters> operator()(
+        constexpr simd_task_policy_shim<Executor, Parameters> operator()(
             task_policy_tag) const
         {
-            return dataseq_task_policy_shim<Executor, Parameters>(
+            return simd_task_policy_shim<Executor, Parameters>(
                 exec_, params_);
         }
 
-        /// Create a new dataseq_policy from the given
+        /// Create a new simd_policy from the given
         /// executor
         ///
         /// \tparam Executor    The type of the executor to associate with this
@@ -519,10 +519,10 @@ namespace hpx { namespace execution { inline namespace v1 {
         ///
         /// \note Requires: is_executor<Executor>::value is true
         ///
-        /// \returns The new dataseq_policy
+        /// \returns The new simd_policy
         ///
         template <typename Executor_>
-        typename parallel::execution::rebind_executor<dataseq_policy_shim,
+        typename parallel::execution::rebind_executor<simd_policy_shim,
             Executor_, executor_parameters_type>::type
         on(Executor_&& exec) const
         {
@@ -530,12 +530,12 @@ namespace hpx { namespace execution { inline namespace v1 {
                 "hpx::traits::is_executor_any<Executor_>::value");
 
             typedef typename parallel::execution::rebind_executor<
-                dataseq_policy_shim, Executor_, executor_parameters_type>::type
+                simd_policy_shim, Executor_, executor_parameters_type>::type
                 rebound_type;
             return rebound_type(std::forward<Executor_>(exec), params_);
         }
 
-        /// Create a new dataseq_policy_shim from the given
+        /// Create a new simd_policy_shim from the given
         /// execution parameters
         ///
         /// \tparam Parameters  The type of the executor parameters to
@@ -548,17 +548,17 @@ namespace hpx { namespace execution { inline namespace v1 {
         /// \note Requires: all parameters are executor_parameters,
         ///                 different parameter types can't be duplicated
         ///
-        /// \returns The new dataseq_policy_shim
+        /// \returns The new simd_policy_shim
         ///
         template <typename... Parameters_,
             typename ParametersType = typename parallel::execution::
                 executor_parameters_join<Parameters_...>::type>
-        typename parallel::execution::rebind_executor<dataseq_policy_shim,
+        typename parallel::execution::rebind_executor<simd_policy_shim,
             executor_type, ParametersType>::type
         with(Parameters_&&... params) const
         {
             typedef typename parallel::execution::rebind_executor<
-                dataseq_policy_shim, executor_type, ParametersType>::type
+                simd_policy_shim, executor_type, ParametersType>::type
                 rebound_type;
             return rebound_type(exec_,
                 parallel::execution::join_executor_parameters(
@@ -588,10 +588,10 @@ namespace hpx { namespace execution { inline namespace v1 {
         }
 
         /// \cond NOINTERNAL
-        constexpr dataseq_policy_shim() = default;
+        constexpr simd_policy_shim() = default;
 
         template <typename Executor_, typename Parameters_>
-        constexpr dataseq_policy_shim(Executor_&& exec, Parameters_&& params)
+        constexpr simd_policy_shim(Executor_&& exec, Parameters_&& params)
           : exec_(std::forward<Executor_>(exec))
           , params_(std::forward<Parameters_>(params))
         {
@@ -615,14 +615,14 @@ namespace hpx { namespace execution { inline namespace v1 {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    /// Extension: The class datapar_task_policy is an execution
+    /// Extension: The class simdpar_task_policy is an execution
     /// policy type used as a unique type to disambiguate parallel algorithm
     /// overloading and indicate that a parallel algorithm's execution may be
     /// parallelized.
     ///
     /// The algorithm returns a future representing the result of the
     /// corresponding algorithm when invoked with the parallel_policy.
-    struct datapar_task_policy
+    struct simdpar_task_policy
     {
         /// The type of the executor associated with this execution policy
         typedef parallel_executor executor_type;
@@ -643,26 +643,26 @@ namespace hpx { namespace execution { inline namespace v1 {
         struct rebind
         {
             /// The type of the rebound execution policy
-            typedef datapar_task_policy_shim<Executor_, Parameters_> type;
+            typedef simdpar_task_policy_shim<Executor_, Parameters_> type;
         };
 
         /// \cond NOINTERNAL
-        constexpr datapar_task_policy() = default;
+        constexpr simdpar_task_policy() = default;
         /// \endcond
 
-        /// Create a new datapar_task_policy from itself
+        /// Create a new simdpar_task_policy from itself
         ///
         /// \param tag          [in] Specify that the corresponding asynchronous
         ///                     execution policy should be used
         ///
-        /// \returns The new datapar_task_policy
+        /// \returns The new simdpar_task_policy
         ///
-        constexpr datapar_task_policy operator()(task_policy_tag) const
+        constexpr simdpar_task_policy operator()(task_policy_tag) const
         {
             return *this;
         }
 
-        /// Create a new datapar_task_policy from given executor
+        /// Create a new simdpar_task_policy from given executor
         ///
         /// \tparam Executor    The type of the executor to associate with this
         ///                     execution policy.
@@ -673,10 +673,10 @@ namespace hpx { namespace execution { inline namespace v1 {
         ///
         /// \note Requires: is_executor<Executor>::value is true
         ///
-        /// \returns The new datapar_task_policy
+        /// \returns The new simdpar_task_policy
         ///
         template <typename Executor>
-        typename parallel::execution::rebind_executor<datapar_task_policy,
+        typename parallel::execution::rebind_executor<simdpar_task_policy,
             Executor, executor_parameters_type>::type
         on(Executor&& exec) const
         {
@@ -684,12 +684,12 @@ namespace hpx { namespace execution { inline namespace v1 {
                 "hpx::traits::is_executor_any<Executor>::value");
 
             typedef typename parallel::execution::rebind_executor<
-                datapar_task_policy, Executor, executor_parameters_type>::type
+                simdpar_task_policy, Executor, executor_parameters_type>::type
                 rebound_type;
             return rebound_type(std::forward<Executor>(exec), parameters());
         }
 
-        /// Create a new datapar_task_policy_shim from the given
+        /// Create a new simdpar_task_policy_shim from the given
         /// execution parameters
         ///
         /// \tparam Parameters  The type of the executor parameters to
@@ -702,17 +702,17 @@ namespace hpx { namespace execution { inline namespace v1 {
         /// \note Requires: all parameters are executor_parameters,
         ///                 different parameter types can't be duplicated
         ///
-        /// \returns The new datapar_policy_shim
+        /// \returns The new simdpar_policy_shim
         ///
         template <typename... Parameters,
             typename ParametersType = typename parallel::execution::
                 executor_parameters_join<Parameters...>::type>
-        typename parallel::execution::rebind_executor<datapar_task_policy,
+        typename parallel::execution::rebind_executor<simdpar_task_policy,
             executor_type, ParametersType>::type
         with(Parameters&&... params) const
         {
             typedef typename parallel::execution::rebind_executor<
-                datapar_task_policy, executor_type, ParametersType>::type
+                simdpar_task_policy, executor_type, ParametersType>::type
                 rebound_type;
             return rebound_type(executor(),
                 parallel::execution::join_executor_parameters(
@@ -756,10 +756,10 @@ namespace hpx { namespace execution { inline namespace v1 {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    /// The class datapar_policy is an execution policy type used
+    /// The class simdpar_policy is an execution policy type used
     /// as a unique type to disambiguate parallel algorithm overloading and
     /// indicate that a parallel algorithm's execution may be parallelized.
-    struct datapar_policy
+    struct simdpar_policy
     {
         /// The type of the executor associated with this execution policy
         typedef parallel_executor executor_type;
@@ -780,36 +780,36 @@ namespace hpx { namespace execution { inline namespace v1 {
         struct rebind
         {
             /// The type of the rebound execution policy
-            typedef datapar_policy_shim<Executor_, Parameters_> type;
+            typedef simdpar_policy_shim<Executor_, Parameters_> type;
         };
 
         /// \cond NOINTERNAL
-        constexpr datapar_policy() = default;
+        constexpr simdpar_policy() = default;
         /// \endcond
 
-        /// Create a new datapar_policy referencing a chunk size.
+        /// Create a new simdpar_policy referencing a chunk size.
         ///
         /// \param tag          [in] Specify that the corresponding asynchronous
         ///                     execution policy should be used
         ///
-        /// \returns The new datapar_task_policy
+        /// \returns The new simdpar_task_policy
         ///
-        constexpr datapar_task_policy operator()(task_policy_tag) const
+        constexpr simdpar_task_policy operator()(task_policy_tag) const
         {
-            return datapar_task_policy();
+            return simdpar_task_policy();
         }
 
-        /// Create a new datapar_policy referencing an executor and
+        /// Create a new simdpar_policy referencing an executor and
         /// a chunk size.
         ///
         /// \param exec         [in] The executor to use for the execution of
         ///                     the parallel algorithm the returned execution
         ///                     policy is used with
         ///
-        /// \returns The new datapar_policy
+        /// \returns The new simdpar_policy
         ///
         template <typename Executor>
-        typename parallel::execution::rebind_executor<datapar_policy, Executor,
+        typename parallel::execution::rebind_executor<simdpar_policy, Executor,
             executor_parameters_type>::type
         on(Executor&& exec) const
         {
@@ -817,12 +817,12 @@ namespace hpx { namespace execution { inline namespace v1 {
                 "hpx::traits::is_executor_any<Executor>::value");
 
             typedef
-                typename parallel::execution::rebind_executor<datapar_policy,
+                typename parallel::execution::rebind_executor<simdpar_policy,
                     Executor, executor_parameters_type>::type rebound_type;
             return rebound_type(std::forward<Executor>(exec), parameters());
         }
 
-        /// Create a new datapar_policy from the given
+        /// Create a new simdpar_policy from the given
         /// execution parameters
         ///
         /// \tparam Parameters  The type of the executor parameters to
@@ -834,17 +834,17 @@ namespace hpx { namespace execution { inline namespace v1 {
         ///
         /// \note Requires: is_executor_parameters<Parameters>::value is true
         ///
-        /// \returns The new datapar_policy
+        /// \returns The new simdpar_policy
         ///
         template <typename... Parameters,
             typename ParametersType = typename parallel::execution::
                 executor_parameters_join<Parameters...>::type>
-        typename parallel::execution::rebind_executor<datapar_policy,
+        typename parallel::execution::rebind_executor<simdpar_policy,
             executor_type, ParametersType>::type
         with(Parameters&&... params) const
         {
             typedef
-                typename parallel::execution::rebind_executor<datapar_policy,
+                typename parallel::execution::rebind_executor<simdpar_policy,
                     executor_type, ParametersType>::type rebound_type;
             return rebound_type(executor(),
                 parallel::execution::join_executor_parameters(
@@ -888,13 +888,13 @@ namespace hpx { namespace execution { inline namespace v1 {
     };
 
     /// Default data-parallel execution policy object.
-    static constexpr datapar_policy datapar{};
+    static constexpr simdpar_policy simdpar{};
 
-    /// The class datapar_policy_shim is an execution policy type
+    /// The class simdpar_policy_shim is an execution policy type
     /// used as a unique type to disambiguate parallel algorithm overloading
     /// and indicate that a parallel algorithm's execution may be parallelized.
     template <typename Executor, typename Parameters>
-    struct datapar_policy_shim : datapar_policy
+    struct simdpar_policy_shim : simdpar_policy
     {
         /// The type of the executor associated with this execution policy
         typedef Executor executor_type;
@@ -915,24 +915,24 @@ namespace hpx { namespace execution { inline namespace v1 {
         struct rebind
         {
             /// The type of the rebound execution policy
-            typedef datapar_policy_shim<Executor_, Parameters_> type;
+            typedef simdpar_policy_shim<Executor_, Parameters_> type;
         };
 
-        /// Create a new datapar_task_policy_shim
+        /// Create a new simdpar_task_policy_shim
         ///
         /// \param tag          [in] Specify that the corresponding asynchronous
         ///                     execution policy should be used
         ///
-        /// \returns The new datapar_task_policy_shim
+        /// \returns The new simdpar_task_policy_shim
         ///
-        constexpr datapar_task_policy_shim<Executor, Parameters> operator()(
+        constexpr simdpar_task_policy_shim<Executor, Parameters> operator()(
             task_policy_tag) const
         {
-            return datapar_task_policy_shim<Executor, Parameters>(
+            return simdpar_task_policy_shim<Executor, Parameters>(
                 exec_, params_);
         }
 
-        /// Create a new datapar_task_policy_shim from the given
+        /// Create a new simdpar_task_policy_shim from the given
         /// executor
         ///
         /// \tparam Executor    The type of the executor to associate with this
@@ -947,7 +947,7 @@ namespace hpx { namespace execution { inline namespace v1 {
         /// \returns The new parallel_policy
         ///
         template <typename Executor_>
-        typename parallel::execution::rebind_executor<datapar_policy_shim,
+        typename parallel::execution::rebind_executor<simdpar_policy_shim,
             Executor_, executor_parameters_type>::type
         on(Executor_&& exec) const
         {
@@ -955,12 +955,12 @@ namespace hpx { namespace execution { inline namespace v1 {
                 "hpx::traits::is_executor_any<Executor_>::value");
 
             typedef typename parallel::execution::rebind_executor<
-                datapar_policy_shim, Executor_, executor_parameters_type>::type
+                simdpar_policy_shim, Executor_, executor_parameters_type>::type
                 rebound_type;
             return rebound_type(std::forward<Executor_>(exec), params_);
         }
 
-        /// Create a new datapar_policy_shim from the given
+        /// Create a new simdpar_policy_shim from the given
         /// execution parameters
         ///
         /// \tparam Parameters  The type of the executor parameters to
@@ -972,17 +972,17 @@ namespace hpx { namespace execution { inline namespace v1 {
         ///
         /// \note Requires: is_executor_parameters<Parameters>::value is true
         ///
-        /// \returns The new datapar_policy_shim
+        /// \returns The new simdpar_policy_shim
         ///
         template <typename... Parameters_,
             typename ParametersType = typename parallel::execution::
                 executor_parameters_join<Parameters_...>::type>
-        typename parallel::execution::rebind_executor<datapar_policy_shim,
+        typename parallel::execution::rebind_executor<simdpar_policy_shim,
             executor_type, ParametersType>::type
         with(Parameters_&&... params) const
         {
             typedef typename parallel::execution::rebind_executor<
-                datapar_policy_shim, executor_type, ParametersType>::type
+                simdpar_policy_shim, executor_type, ParametersType>::type
                 rebound_type;
             return rebound_type(exec_,
                 parallel::execution::join_executor_parameters(
@@ -1012,10 +1012,10 @@ namespace hpx { namespace execution { inline namespace v1 {
         }
 
         /// \cond NOINTERNAL
-        constexpr datapar_policy_shim() = default;
+        constexpr simdpar_policy_shim() = default;
 
         template <typename Executor_, typename Parameters_>
-        constexpr datapar_policy_shim(Executor_&& exec, Parameters_&& params)
+        constexpr simdpar_policy_shim(Executor_&& exec, Parameters_&& params)
           : exec_(std::forward<Executor_>(exec))
           , params_(std::forward<Parameters_>(params))
         {
@@ -1038,13 +1038,13 @@ namespace hpx { namespace execution { inline namespace v1 {
         /// \endcond
     };
 
-    /// The class datapar_task_policy_shim is an
+    /// The class simdpar_task_policy_shim is an
     /// execution policy type used as a unique type to disambiguate parallel
     /// algorithm overloading based on combining a underlying
-    /// \a datapar_task_policy and an executor and indicate that
+    /// \a simdpar_task_policy and an executor and indicate that
     /// a parallel algorithm's execution may be parallelized and vectorized.
     template <typename Executor, typename Parameters>
-    struct datapar_task_policy_shim : datapar_task_policy
+    struct simdpar_task_policy_shim : simdpar_task_policy
     {
         /// The type of the executor associated with this execution policy
         typedef Executor executor_type;
@@ -1065,17 +1065,17 @@ namespace hpx { namespace execution { inline namespace v1 {
         struct rebind
         {
             /// The type of the rebound execution policy
-            typedef datapar_task_policy_shim<Executor_, Parameters_> type;
+            typedef simdpar_task_policy_shim<Executor_, Parameters_> type;
         };
 
-        /// Create a new datapar_task_policy_shim from itself
+        /// Create a new simdpar_task_policy_shim from itself
         ///
         /// \param tag          [in] Specify that the corresponding asynchronous
         ///                     execution policy should be used
         ///
         /// \returns The new sequenced_task_policy
         ///
-        constexpr datapar_task_policy_shim operator()(task_policy_tag) const
+        constexpr simdpar_task_policy_shim operator()(task_policy_tag) const
         {
             return *this;
         }
@@ -1095,7 +1095,7 @@ namespace hpx { namespace execution { inline namespace v1 {
         /// \returns The new parallel_task_policy
         ///
         template <typename Executor_>
-        typename parallel::execution::rebind_executor<datapar_task_policy_shim,
+        typename parallel::execution::rebind_executor<simdpar_task_policy_shim,
             Executor_, executor_parameters_type>::type
         on(Executor_&& exec) const
         {
@@ -1103,7 +1103,7 @@ namespace hpx { namespace execution { inline namespace v1 {
                 "hpx::traits::is_executor_any<Executor_>::value");
 
             typedef typename parallel::execution::rebind_executor<
-                datapar_task_policy_shim, Executor_,
+                simdpar_task_policy_shim, Executor_,
                 executor_parameters_type>::type rebound_type;
             return rebound_type(std::forward<Executor_>(exec), params_);
         }
@@ -1126,12 +1126,12 @@ namespace hpx { namespace execution { inline namespace v1 {
         template <typename... Parameters_,
             typename ParametersType = typename parallel::execution::
                 executor_parameters_join<Parameters_...>::type>
-        typename parallel::execution::rebind_executor<datapar_task_policy_shim,
+        typename parallel::execution::rebind_executor<simdpar_task_policy_shim,
             executor_type, ParametersType>::type
         with(Parameters_&&... params) const
         {
             typedef typename parallel::execution::rebind_executor<
-                datapar_task_policy_shim, executor_type, ParametersType>::type
+                simdpar_task_policy_shim, executor_type, ParametersType>::type
                 rebound_type;
             return rebound_type(exec_,
                 parallel::execution::join_executor_parameters(
@@ -1161,10 +1161,10 @@ namespace hpx { namespace execution { inline namespace v1 {
         }
 
         /// \cond NOINTERNAL
-        constexpr datapar_task_policy_shim() = default;
+        constexpr simdpar_task_policy_shim() = default;
 
         template <typename Executor_, typename Parameters_>
-        constexpr datapar_task_policy_shim(
+        constexpr simdpar_task_policy_shim(
             Executor_&& exec, Parameters_&& params)
           : exec_(std::forward<Executor_>(exec))
           , params_(std::forward<Parameters_>(params))
@@ -1195,51 +1195,51 @@ namespace hpx { namespace detail {
 
     /// \cond NOINTERNAL
     template <>
-    struct is_execution_policy<hpx::execution::dataseq_policy> : std::true_type
+    struct is_execution_policy<hpx::execution::simd_policy> : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_execution_policy<
-        hpx::execution::dataseq_policy_shim<Executor, Parameters>>
+        hpx::execution::simd_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
 
     template <>
-    struct is_execution_policy<hpx::execution::dataseq_task_policy>
+    struct is_execution_policy<hpx::execution::simd_task_policy>
       : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_execution_policy<
-        hpx::execution::dataseq_task_policy_shim<Executor, Parameters>>
+        hpx::execution::simd_task_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
 
     template <>
-    struct is_execution_policy<hpx::execution::datapar_policy> : std::true_type
+    struct is_execution_policy<hpx::execution::simdpar_policy> : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_execution_policy<
-        hpx::execution::datapar_policy_shim<Executor, Parameters>>
+        hpx::execution::simdpar_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
 
     template <>
-    struct is_execution_policy<hpx::execution::datapar_task_policy>
+    struct is_execution_policy<hpx::execution::simdpar_task_policy>
       : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_execution_policy<
-        hpx::execution::datapar_task_policy_shim<Executor, Parameters>>
+        hpx::execution::simdpar_task_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
@@ -1248,27 +1248,27 @@ namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     /// \cond NOINTERNAL
     template <>
-    struct is_sequenced_execution_policy<hpx::execution::dataseq_policy>
+    struct is_sequenced_execution_policy<hpx::execution::simd_policy>
       : std::true_type
     {
     };
 
     template <>
-    struct is_sequenced_execution_policy<hpx::execution::dataseq_task_policy>
+    struct is_sequenced_execution_policy<hpx::execution::simd_task_policy>
       : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_sequenced_execution_policy<
-        hpx::execution::dataseq_policy_shim<Executor, Parameters>>
+        hpx::execution::simd_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_sequenced_execution_policy<
-        hpx::execution::dataseq_task_policy_shim<Executor, Parameters>>
+        hpx::execution::simd_task_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
@@ -1277,27 +1277,27 @@ namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     /// \cond NOINTERNAL
     template <>
-    struct is_async_execution_policy<hpx::execution::dataseq_task_policy>
+    struct is_async_execution_policy<hpx::execution::simd_task_policy>
       : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_async_execution_policy<
-        hpx::execution::dataseq_task_policy_shim<Executor, Parameters>>
+        hpx::execution::simd_task_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
 
     template <>
-    struct is_async_execution_policy<hpx::execution::datapar_task_policy>
+    struct is_async_execution_policy<hpx::execution::simdpar_task_policy>
       : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_async_execution_policy<
-        hpx::execution::datapar_task_policy_shim<Executor, Parameters>>
+        hpx::execution::simdpar_task_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
@@ -1306,27 +1306,27 @@ namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     /// \cond NOINTERNAL
     template <>
-    struct is_parallel_execution_policy<hpx::execution::datapar_policy>
+    struct is_parallel_execution_policy<hpx::execution::simdpar_policy>
       : std::true_type
     {
     };
 
     template <>
-    struct is_parallel_execution_policy<hpx::execution::datapar_task_policy>
+    struct is_parallel_execution_policy<hpx::execution::simdpar_task_policy>
       : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_parallel_execution_policy<
-        hpx::execution::datapar_policy_shim<Executor, Parameters>>
+        hpx::execution::simdpar_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_parallel_execution_policy<
-        hpx::execution::datapar_task_policy_shim<Executor, Parameters>>
+        hpx::execution::simdpar_task_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
@@ -1335,53 +1335,53 @@ namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     /// \cond NOINTERNAL
     template <>
-    struct is_vectorpack_execution_policy<hpx::execution::dataseq_policy>
+    struct is_vectorpack_execution_policy<hpx::execution::simd_policy>
       : std::true_type
     {
     };
 
     template <>
-    struct is_vectorpack_execution_policy<hpx::execution::dataseq_task_policy>
+    struct is_vectorpack_execution_policy<hpx::execution::simd_task_policy>
       : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_vectorpack_execution_policy<
-        hpx::execution::dataseq_policy_shim<Executor, Parameters>>
+        hpx::execution::simd_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_vectorpack_execution_policy<
-        hpx::execution::dataseq_task_policy_shim<Executor, Parameters>>
+        hpx::execution::simd_task_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
 
     template <>
-    struct is_vectorpack_execution_policy<hpx::execution::datapar_policy>
+    struct is_vectorpack_execution_policy<hpx::execution::simdpar_policy>
       : std::true_type
     {
     };
 
     template <>
-    struct is_vectorpack_execution_policy<hpx::execution::datapar_task_policy>
+    struct is_vectorpack_execution_policy<hpx::execution::simdpar_task_policy>
       : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_vectorpack_execution_policy<
-        hpx::execution::datapar_policy_shim<Executor, Parameters>>
+        hpx::execution::simdpar_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
 
     template <typename Executor, typename Parameters>
     struct is_vectorpack_execution_policy<
-        hpx::execution::datapar_task_policy_shim<Executor, Parameters>>
+        hpx::execution::simdpar_task_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };

--- a/libs/parallelism/executors/include/hpx/executors/datapar/execution_policy_fwd.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/datapar/execution_policy_fwd.hpp
@@ -12,26 +12,26 @@
 #if defined(HPX_HAVE_DATAPAR)
 namespace hpx { namespace execution { inline namespace v1 {
     ///////////////////////////////////////////////////////////////////////////
-    struct dataseq_policy;
+    struct simd_policy;
 
     template <typename Executor, typename Parameters>
-    struct dataseq_policy_shim;
+    struct simd_policy_shim;
 
-    struct dataseq_task_policy;
+    struct simd_task_policy;
 
     template <typename Executor, typename Parameters>
-    struct dataseq_task_policy_shim;
+    struct simd_task_policy_shim;
 
     ///////////////////////////////////////////////////////////////////////////
-    struct datapar_policy;
+    struct simdpar_policy;
 
     template <typename Executor, typename Parameters>
-    struct datapar_policy_shim;
+    struct simdpar_policy_shim;
 
-    struct datapar_task_policy;
+    struct simdpar_task_policy;
 
     template <typename Executor, typename Parameters>
-    struct datapar_task_policy_shim;
+    struct simdpar_task_policy_shim;
 }}}    // namespace hpx::execution::v1
 
 #endif

--- a/libs/parallelism/executors/include/hpx/executors/exception_list.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/exception_list.hpp
@@ -166,8 +166,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #if defined(HPX_HAVE_DATAPAR)
         ///////////////////////////////////////////////////////////////////////
         template <typename Result>
-        struct handle_exception_impl<hpx::execution::simd_task_policy,
-            Result> : handle_exception_task_impl<Result>
+        struct handle_exception_impl<hpx::execution::simd_task_policy, Result>
+          : handle_exception_task_impl<Result>
         {
         };
 

--- a/libs/parallelism/executors/include/hpx/executors/exception_list.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/exception_list.hpp
@@ -166,13 +166,13 @@ namespace hpx { namespace parallel { inline namespace v1 {
 #if defined(HPX_HAVE_DATAPAR)
         ///////////////////////////////////////////////////////////////////////
         template <typename Result>
-        struct handle_exception_impl<hpx::execution::dataseq_task_policy,
+        struct handle_exception_impl<hpx::execution::simd_task_policy,
             Result> : handle_exception_task_impl<Result>
         {
         };
 
         template <typename Result>
-        struct handle_exception_impl<hpx::execution::datapar_task_policy,
+        struct handle_exception_impl<hpx::execution::simdpar_task_policy,
             Result> : handle_exception_task_impl<Result>
         {
         };

--- a/tests/performance/local/transform_reduce_binary_scaling.cpp
+++ b/tests/performance/local/transform_reduce_binary_scaling.cpp
@@ -96,7 +96,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
         // do measurements
         std::uint64_t tr_time_datapar = measure_inner_product(
-            test_count, hpx::execution::datapar, data1, data2);
+            test_count, hpx::execution::simdpar, data1, data2);
         std::uint64_t tr_time_par = measure_inner_product(
             test_count, hpx::execution::par, data1, data2);
 


### PR DESCRIPTION
Fixes #5157

  - This adapts the implementation to support the data-parallel Types introduced by [P0214R9](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0214r9.pdf).
  - This will make use of GCC 11.1 `std-simd` support.

### Proposed changes
---
- Adapts the required traits with naming convention as
    - `simd_pack_alignment`, `simd_pack_type`, `simd_pack_count`, `simd_pack_load_store`.
    - New folder `detail/simd` similar to [`detail/vc`](https://github.com/STEllAR-GROUP/hpx/tree/master/libs/parallelism/execution/include/hpx/execution/traits/detail).
- Adapts new execution policy hpx::execution::simd
    - New folder `executors/simd` similar to [`executors/datapar`](https://github.com/STEllAR-GROUP/hpx/tree/master/libs/parallelism/executors/include/hpx/executors).
- Adapt the four basic utility headers required for algorithms.
    - New folder `parallel/simd` similar to [`parallel/datapar`]()

### To Do
---
- [x] Implement cmake test
- [x] Adapt traits 

    - [x] simd_pack_aligment
    - [x] simd_pack_type
    - [x] simd_pack_count
    - [x] simd_pack_load_store

- [x] Adapt new execution policy `hpx::execution::simd`

- [x] Adapt utility headers
    - [x] iterator_helpers.hpp
    - [x] loop.hpp
    - [x] transform_loop.hpp
    - [x] zip_iterator.hpp