### PR TITLE
Sender overloads for parallel algorithms

### DIFF
--- a/libs/parallelism/algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/CMakeLists.txt
@@ -151,6 +151,7 @@ set(algorithms_headers
     hpx/parallel/util/detail/handle_remote_exceptions.hpp
     hpx/parallel/util/detail/partitioner_iteration.hpp
     hpx/parallel/util/detail/scoped_executor_parameters.hpp
+    hpx/parallel/util/detail/sender_util.hpp
     hpx/parallel/util/detail/select_partitioner.hpp
     hpx/parallel/util/foreach_partitioner.hpp
     hpx/parallel/util/invoke_projected.hpp

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/adjacent_find.hpp
@@ -122,11 +122,11 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/executors/execution_policy.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/parallel/algorithms/adjacent_find.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/invoke_projected.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
@@ -246,7 +246,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
 namespace hpx {
     HPX_INLINE_CONSTEXPR_VARIABLE struct adjacent_find_t final
-      : hpx::functional::tag_fallback<adjacent_find_t>
+      : hpx::detail::tag_parallel_algorithm<adjacent_find_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/all_any_none.hpp
@@ -229,7 +229,7 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/type_support/void_guard.hpp>
@@ -557,7 +557,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::none_of
     HPX_INLINE_CONSTEXPR_VARIABLE struct none_of_t final
-      : hpx::functional::tag_fallback<none_of_t>
+      : hpx::detail::tag_parallel_algorithm<none_of_t>
     {
     private:
         // clang-format off
@@ -601,7 +601,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::any_of
     HPX_INLINE_CONSTEXPR_VARIABLE struct any_of_t final
-      : hpx::functional::tag_fallback<any_of_t>
+      : hpx::detail::tag_parallel_algorithm<any_of_t>
     {
     private:
         // clang-format off
@@ -645,7 +645,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::all_of
     HPX_INLINE_CONSTEXPR_VARIABLE struct all_of_t final
-      : hpx::functional::tag_fallback<all_of_t>
+      : hpx::detail::tag_parallel_algorithm<all_of_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -204,7 +204,7 @@ namespace hpx {
 #include <hpx/assert.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>
@@ -654,7 +654,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::copy
     HPX_INLINE_CONSTEXPR_VARIABLE struct copy_t final
-      : hpx::functional::tag_fallback<copy_t>
+      : hpx::detail::tag_parallel_algorithm<copy_t>
     {
     private:
         // clang-format off
@@ -696,7 +696,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::copy_n
     HPX_INLINE_CONSTEXPR_VARIABLE struct copy_n_t final
-      : hpx::functional::tag_fallback<copy_n_t>
+      : hpx::detail::tag_parallel_algorithm<copy_n_t>
     {
     private:
         // clang-format off
@@ -768,7 +768,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::copy_if
     HPX_INLINE_CONSTEXPR_VARIABLE struct copy_if_t final
-      : hpx::functional::tag_fallback<copy_if_t>
+      : hpx::detail::tag_parallel_algorithm<copy_if_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/count.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/count.hpp
@@ -157,10 +157,10 @@ namespace hpx {
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/bind_back.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/pack_traversal/unwrap.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>
 #include <hpx/execution/traits/vector_pack_count_bits.hpp>
@@ -440,7 +440,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::count
     HPX_INLINE_CONSTEXPR_VARIABLE struct count_t final
-      : hpx::functional::tag_fallback<count_t>
+      : hpx::detail::tag_parallel_algorithm<count_t>
     {
     private:
         // clang-format off
@@ -491,7 +491,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::count_if
     HPX_INLINE_CONSTEXPR_VARIABLE struct count_if_t final
-      : hpx::functional::tag_fallback<count_if_t>
+      : hpx::detail::tag_parallel_algorithm<count_if_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/destroy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/destroy.hpp
@@ -106,7 +106,7 @@ namespace hpx {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 
 #include <hpx/execution/algorithms/detail/is_negative.hpp>
@@ -311,7 +311,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::destroy
     HPX_INLINE_CONSTEXPR_VARIABLE struct destroy_t final
-      : hpx::functional::tag_fallback<destroy_t>
+      : hpx::detail::tag_parallel_algorithm<destroy_t>
     {
     private:
         // clang-format off
@@ -354,7 +354,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::destroy_n
     HPX_INLINE_CONSTEXPR_VARIABLE struct destroy_n_t final
-      : hpx::functional::tag_fallback<destroy_n_t>
+      : hpx::detail::tag_parallel_algorithm<destroy_n_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/equal.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/equal.hpp
@@ -182,6 +182,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
@@ -458,7 +459,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::equal
     HPX_INLINE_CONSTEXPR_VARIABLE struct equal_t final
-      : hpx::functional::tag_fallback<equal_t>
+      : hpx::detail::tag_parallel_algorithm<equal_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/fill.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/fill.hpp
@@ -108,7 +108,7 @@ namespace hpx {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/algorithms/traits/is_value_proxy.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/type_support/void_guard.hpp>
@@ -294,7 +294,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::fill
     HPX_INLINE_CONSTEXPR_VARIABLE struct fill_t final
-      : hpx::functional::tag_fallback<fill_t>
+      : hpx::detail::tag_parallel_algorithm<fill_t>
     {
     private:
         // clang-format off
@@ -341,7 +341,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::fill_n
     HPX_INLINE_CONSTEXPR_VARIABLE struct fill_n_t final
-      : hpx::functional::tag_fallback<fill_n_t>
+      : hpx::detail::tag_parallel_algorithm<fill_n_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/find.hpp
@@ -376,7 +376,7 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>
@@ -1073,7 +1073,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::find
     HPX_INLINE_CONSTEXPR_VARIABLE struct find_t final
-      : hpx::functional::tag_fallback<find_t>
+      : hpx::detail::tag_parallel_algorithm<find_t>
     {
     private:
         // clang-format off
@@ -1118,7 +1118,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::find_if
     HPX_INLINE_CONSTEXPR_VARIABLE struct find_if_t final
-      : hpx::functional::tag_fallback<find_if_t>
+      : hpx::detail::tag_parallel_algorithm<find_if_t>
     {
     private:
         // clang-format off
@@ -1169,7 +1169,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::find_if_not
     HPX_INLINE_CONSTEXPR_VARIABLE struct find_if_not_t final
-      : hpx::functional::tag_fallback<find_if_not_t>
+      : hpx::detail::tag_parallel_algorithm<find_if_not_t>
     {
     private:
         // clang-format off
@@ -1220,7 +1220,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::find_end
     HPX_INLINE_CONSTEXPR_VARIABLE struct find_end_t final
-      : hpx::functional::tag_fallback<find_end_t>
+      : hpx::detail::tag_parallel_algorithm<find_end_t>
     {
     private:
         // clang-format off
@@ -1331,7 +1331,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::find_first_of
     HPX_INLINE_CONSTEXPR_VARIABLE struct find_first_of_t final
-      : hpx::functional::tag_fallback<find_first_of_t>
+      : hpx::detail::tag_parallel_algorithm<find_first_of_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_each.hpp
@@ -240,13 +240,13 @@ namespace hpx {
 #include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/detail/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
@@ -678,7 +678,7 @@ namespace hpx {
     //       disabled for other, possibly external specializations.
     //
     HPX_INLINE_CONSTEXPR_VARIABLE struct for_each_t final
-      : hpx::functional::tag_fallback<for_each_t>
+      : hpx::detail::tag_parallel_algorithm<for_each_t>
     {
     private:
         // clang-format off
@@ -736,7 +736,7 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_INLINE_CONSTEXPR_VARIABLE struct for_each_n_t final
-      : hpx::functional::tag_fallback<for_each_n_t>
+      : hpx::detail::tag_parallel_algorithm<for_each_n_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/for_loop.hpp
@@ -735,10 +735,10 @@ namespace hpx {
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/functional/detail/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/threading_base.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/type_support/pack.hpp>
 #include <hpx/type_support/unused.hpp>
 
@@ -1316,7 +1316,7 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_INLINE_CONSTEXPR_VARIABLE struct for_loop_t final
-      : hpx::functional::tag_fallback<for_loop_t>
+      : hpx::detail::tag_parallel_algorithm<for_loop_t>
     {
     private:
         // clang-format off
@@ -1365,7 +1365,7 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_INLINE_CONSTEXPR_VARIABLE struct for_loop_strided_t final
-      : hpx::functional::tag_fallback<for_loop_strided_t>
+      : hpx::detail::tag_parallel_algorithm<for_loop_strided_t>
     {
     private:
         // clang-format off
@@ -1419,7 +1419,7 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_INLINE_CONSTEXPR_VARIABLE struct for_loop_n_t final
-      : hpx::functional::tag_fallback<for_loop_n_t>
+      : hpx::detail::tag_parallel_algorithm<for_loop_n_t>
     {
     private:
         // clang-format off
@@ -1469,7 +1469,7 @@ namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_INLINE_CONSTEXPR_VARIABLE struct for_loop_n_strided_t final
-      : hpx::functional::tag_fallback<for_loop_n_strided_t>
+      : hpx::detail::tag_parallel_algorithm<for_loop_n_strided_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/generate.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/generate.hpp
@@ -130,7 +130,7 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 
 #include <hpx/execution/algorithms/detail/is_negative.hpp>
@@ -296,7 +296,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::generate
     HPX_INLINE_CONSTEXPR_VARIABLE struct generate_t final
-      : hpx::functional::tag_fallback<generate_t>
+      : hpx::detail::tag_parallel_algorithm<generate_t>
     {
     private:
         // clang-format off
@@ -339,7 +339,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::generate_n
     HPX_INLINE_CONSTEXPR_VARIABLE struct generate_n_t final
-      : hpx::functional::tag_fallback<generate_n_t>
+      : hpx::detail::tag_parallel_algorithm<generate_n_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/includes.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/includes.hpp
@@ -96,7 +96,7 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 
 #include <hpx/execution/algorithms/detail/predicates.hpp>
@@ -344,7 +344,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::includes
     HPX_INLINE_CONSTEXPR_VARIABLE struct includes_t final
-      : hpx::functional::tag_fallback<includes_t>
+      : hpx::detail::tag_parallel_algorithm<includes_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_heap.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_heap.hpp
@@ -137,7 +137,7 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
@@ -451,7 +451,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::is_heap
     HPX_INLINE_CONSTEXPR_VARIABLE struct is_heap_t final
-      : hpx::functional::tag_fallback<is_heap_t>
+      : hpx::detail::tag_parallel_algorithm<is_heap_t>
     {
     private:
         // clang-format off
@@ -508,7 +508,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::is_heap_until
     HPX_INLINE_CONSTEXPR_VARIABLE struct is_heap_until_t final
-      : hpx::functional::tag_fallback<is_heap_until_t>
+      : hpx::detail::tag_parallel_algorithm<is_heap_until_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_partitioned.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_partitioned.hpp
@@ -109,11 +109,11 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/invoke_projected.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
@@ -255,7 +255,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
 namespace hpx {
     HPX_INLINE_CONSTEXPR_VARIABLE struct is_partitioned_t final
-      : hpx::functional::tag_fallback<is_partitioned_t>
+      : hpx::detail::tag_parallel_algorithm<is_partitioned_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
@@ -225,13 +225,13 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/is_sorted.hpp>
 #include <hpx/parallel/util/cancellation_token.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/invoke_projected.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner.hpp>
@@ -448,7 +448,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 
 namespace hpx {
     HPX_INLINE_CONSTEXPR_VARIABLE struct is_sorted_t final
-      : hpx::functional::tag_fallback<is_sorted_t>
+      : hpx::detail::tag_parallel_algorithm<is_sorted_t>
     {
     private:
         template <typename FwdIter,
@@ -498,7 +498,7 @@ namespace hpx {
     } is_sorted{};
 
     HPX_INLINE_CONSTEXPR_VARIABLE struct is_sorted_until_t final
-      : hpx::functional::tag_fallback<is_sorted_until_t>
+      : hpx::detail::tag_parallel_algorithm<is_sorted_until_t>
     {
     private:
         template <typename FwdIter,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
@@ -159,8 +159,8 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/executors/execution_policy.hpp>
@@ -336,7 +336,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::lexicographical_compare
     HPX_INLINE_CONSTEXPR_VARIABLE struct lexicographical_compare_t final
-      : hpx::functional::tag_fallback<lexicographical_compare_t>
+      : hpx::detail::tag_parallel_algorithm<lexicographical_compare_t>
     {
         // clang-format off
         template <typename InIter1, typename InIter2,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
@@ -105,7 +105,7 @@ namespace hpx {
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/functional/bind_front.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
@@ -414,7 +414,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::make_heap
     HPX_INLINE_CONSTEXPR_VARIABLE struct make_heap_t final
-      : hpx::functional::tag_fallback<make_heap_t>
+      : hpx::detail::tag_parallel_algorithm<make_heap_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/merge.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/merge.hpp
@@ -170,7 +170,7 @@ namespace hpx {
 #include <hpx/assert.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>
@@ -794,7 +794,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::merge
     HPX_INLINE_CONSTEXPR_VARIABLE struct merge_t final
-      : hpx::functional::tag_fallback<merge_t>
+      : hpx::detail::tag_parallel_algorithm<merge_t>
     {
     private:
         // clang-format off
@@ -880,7 +880,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::inplace_merge
     HPX_INLINE_CONSTEXPR_VARIABLE struct inplace_merge_t final
-      : hpx::functional::tag_fallback<inplace_merge_t>
+      : hpx::detail::tag_parallel_algorithm<inplace_merge_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/mismatch.hpp
@@ -175,7 +175,7 @@ namespace hpx {
 
 #include <hpx/config.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 
 #include <hpx/execution/algorithms/detail/predicates.hpp>
@@ -497,7 +497,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::mismatch
     HPX_INLINE_CONSTEXPR_VARIABLE struct mismatch_t final
-      : hpx::functional::tag_fallback<mismatch_t>
+      : hpx::detail::tag_parallel_algorithm<mismatch_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/move.hpp
@@ -74,7 +74,7 @@ namespace hpx {
 
 #include <hpx/config.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/copy.hpp>
@@ -204,7 +204,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::move
     HPX_INLINE_CONSTEXPR_VARIABLE struct move_t final
-      : hpx::functional::tag_fallback<move_t>
+      : hpx::detail::tag_parallel_algorithm<move_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partial_sort.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/partial_sort.hpp
@@ -54,8 +54,8 @@ namespace hpx {
 #include <hpx/async_local/dataflow.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/type_support/decay.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>
@@ -473,7 +473,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 namespace hpx {
 
     HPX_INLINE_CONSTEXPR_VARIABLE struct partial_sort_t final
-      : hpx::functional::tag_fallback<partial_sort_t>
+      : hpx::detail::tag_parallel_algorithm<partial_sort_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -215,7 +215,7 @@ namespace hpx {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_sentinel_for.hpp>
 #include <hpx/pack_traversal/unwrap.hpp>
@@ -385,7 +385,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::reduce
     HPX_INLINE_CONSTEXPR_VARIABLE struct reduce_t final
-      : hpx::functional::tag_fallback<reduce_t>
+      : hpx::detail::tag_parallel_algorithm<reduce_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove.hpp
@@ -211,8 +211,8 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/tagged_pair.hpp>
 #include <hpx/type_support/unused.hpp>
 
@@ -467,7 +467,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::remove_if
     HPX_INLINE_CONSTEXPR_VARIABLE struct remove_if_t final
-      : hpx::functional::tag_fallback<remove_if_t>
+      : hpx::detail::tag_parallel_algorithm<remove_if_t>
     {
         // clang-format off
         template <typename FwdIter,
@@ -478,7 +478,7 @@ namespace hpx {
                 >
             )>
         // clang-format on
-        friend FwdIter tag_dispatch(
+        friend FwdIter tag_fallback_dispatch(
             hpx::remove_if_t, FwdIter first, FwdIter last, Pred&& pred)
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
@@ -502,8 +502,8 @@ namespace hpx {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             FwdIter>::type
-        tag_dispatch(hpx::remove_if_t, ExPolicy&& policy, FwdIter first,
-            FwdIter last, Pred&& pred)
+        tag_fallback_dispatch(hpx::remove_if_t, ExPolicy&& policy,
+            FwdIter first, FwdIter last, Pred&& pred)
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Required at least forward iterator.");
@@ -519,7 +519,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::remove
     HPX_INLINE_CONSTEXPR_VARIABLE struct remove_t final
-      : hpx::functional::tag_fallback<remove_t>
+      : hpx::detail::tag_parallel_algorithm<remove_t>
     {
     private:
         // clang-format off
@@ -528,7 +528,7 @@ namespace hpx {
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
-        friend FwdIter tag_dispatch(
+        friend FwdIter tag_fallback_dispatch(
             hpx::remove_t, FwdIter first, FwdIter last, T const& value)
         {
             typedef typename std::iterator_traits<FwdIter>::value_type Type;
@@ -546,7 +546,7 @@ namespace hpx {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             FwdIter>::type
-        tag_dispatch(hpx::remove_t, ExPolicy&& policy, FwdIter first,
+        tag_fallback_dispatch(hpx::remove_t, ExPolicy&& policy, FwdIter first,
             FwdIter last, T const& value)
         {
             typedef typename std::iterator_traits<FwdIter>::value_type Type;

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
@@ -254,8 +254,8 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/tagged_pair.hpp>
 
 #include <hpx/executors/execution_policy.hpp>
@@ -455,7 +455,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::remove_copy_if
     HPX_INLINE_CONSTEXPR_VARIABLE struct remove_copy_if_t final
-      : hpx::functional::tag_fallback<remove_copy_if_t>
+      : hpx::detail::tag_parallel_algorithm<remove_copy_if_t>
     {
         // clang-format off
         template <typename InIter, typename OutIter,
@@ -520,7 +520,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::remove_copy
     HPX_INLINE_CONSTEXPR_VARIABLE struct remove_copy_t final
-      : hpx::functional::tag_fallback<remove_copy_t>
+      : hpx::detail::tag_parallel_algorithm<remove_copy_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/replace.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/replace.hpp
@@ -472,8 +472,8 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>
@@ -880,7 +880,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::replace_if
     HPX_INLINE_CONSTEXPR_VARIABLE struct replace_if_t final
-      : hpx::functional::tag_fallback<replace_if_t>
+      : hpx::detail::tag_parallel_algorithm<replace_if_t>
     {
     private:
         // clang-format off
@@ -933,7 +933,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::replace
     HPX_INLINE_CONSTEXPR_VARIABLE struct replace_t final
-      : hpx::functional::tag_fallback<replace_t>
+      : hpx::detail::tag_parallel_algorithm<replace_t>
     {
     private:
         // clang-format off
@@ -983,7 +983,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::replace_copy_if
     HPX_INLINE_CONSTEXPR_VARIABLE struct replace_copy_if_t final
-      : hpx::functional::tag_fallback<replace_copy_if_t>
+      : hpx::detail::tag_parallel_algorithm<replace_copy_if_t>
     {
     private:
         // clang-format off
@@ -1049,7 +1049,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::replace_copy
     HPX_INLINE_CONSTEXPR_VARIABLE struct replace_copy_t final
-      : hpx::functional::tag_fallback<replace_copy_t>
+      : hpx::detail::tag_parallel_algorithm<replace_copy_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reverse.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/reverse.hpp
@@ -180,8 +180,8 @@ namespace hpx {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/tagged_pair.hpp>
 
 #include <hpx/executors/execution_policy.hpp>
@@ -366,7 +366,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::reverse
     HPX_INLINE_CONSTEXPR_VARIABLE struct reverse_t final
-      : hpx::functional::tag_fallback<reverse_t>
+      : hpx::detail::tag_parallel_algorithm<reverse_t>
     {
     private:
         // clang-format off
@@ -411,7 +411,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::reverse_copy
     HPX_INLINE_CONSTEXPR_VARIABLE struct reverse_copy_t final
-      : hpx::functional::tag_fallback<reverse_copy_t>
+      : hpx::detail::tag_parallel_algorithm<reverse_copy_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/search.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/search.hpp
@@ -12,11 +12,11 @@
 #include <hpx/config.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/executors/execution_policy.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/detail/search.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 
 #include <cstddef>
 #include <iterator>
@@ -369,7 +369,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 namespace hpx {
 
     HPX_INLINE_CONSTEXPR_VARIABLE struct search_t final
-      : hpx::functional::tag_fallback<search_t>
+      : hpx::detail::tag_parallel_algorithm<search_t>
     {
     private:
         // clang-format off
@@ -422,7 +422,7 @@ namespace hpx {
     } search{};
 
     HPX_INLINE_CONSTEXPR_VARIABLE struct search_n_t final
-      : hpx::functional::tag_fallback<search_n_t>
+      : hpx::detail::tag_parallel_algorithm<search_n_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_difference.hpp
@@ -111,7 +111,7 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 
 #include <hpx/execution/algorithms/detail/predicates.hpp>
@@ -307,7 +307,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::set_difference
     HPX_INLINE_CONSTEXPR_VARIABLE struct set_difference_t final
-      : hpx::functional::tag_fallback<set_difference_t>
+      : hpx::detail::tag_parallel_algorithm<set_difference_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_intersection.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_intersection.hpp
@@ -111,7 +111,7 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 
 #include <hpx/execution/algorithms/detail/predicates.hpp>
@@ -286,7 +286,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::set_intersection
     HPX_INLINE_CONSTEXPR_VARIABLE struct set_intersection_t final
-      : hpx::functional::tag_fallback<set_intersection_t>
+      : hpx::detail::tag_parallel_algorithm<set_intersection_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
@@ -116,7 +116,7 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 
 #include <hpx/execution/algorithms/detail/predicates.hpp>
@@ -323,7 +323,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::set_symmetric_difference
     HPX_INLINE_CONSTEXPR_VARIABLE struct set_symmetric_difference_t final
-      : hpx::functional::tag_fallback<set_symmetric_difference_t>
+      : hpx::detail::tag_parallel_algorithm<set_symmetric_difference_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_union.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/set_union.hpp
@@ -111,7 +111,7 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 
 #include <hpx/execution/algorithms/detail/predicates.hpp>
@@ -310,7 +310,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::set_union
     HPX_INLINE_CONSTEXPR_VARIABLE struct set_union_t final
-      : hpx::functional::tag_fallback<set_union_t>
+      : hpx::detail::tag_parallel_algorithm<set_union_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform.hpp
@@ -180,9 +180,9 @@ namespace hpx {
 #include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
 #include <hpx/datastructures/tuple.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/result_types.hpp>
 
 #include <hpx/algorithms/traits/projected.hpp>
@@ -904,7 +904,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::transform
     HPX_INLINE_CONSTEXPR_VARIABLE struct transform_t final
-      : hpx::functional::tag_fallback<transform_t>
+      : hpx::detail::tag_parallel_algorithm<transform_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/transform_reduce.hpp
@@ -256,7 +256,7 @@ namespace hpx {
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke.hpp>
 #include <hpx/functional/invoke_result.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
@@ -771,7 +771,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::transform_reduce
     HPX_INLINE_CONSTEXPR_VARIABLE struct transform_reduce_t final
-      : hpx::functional::tag_fallback<transform_reduce_t>
+      : hpx::detail::tag_parallel_algorithm<transform_reduce_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_copy.hpp
@@ -200,6 +200,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner_with_cleanup.hpp>
 #include <hpx/parallel/util/result_types.hpp>
@@ -519,7 +520,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::uninitialized_copy
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_copy_t final
-      : hpx::functional::tag_fallback<uninitialized_copy_t>
+      : hpx::detail::tag_parallel_algorithm<uninitialized_copy_t>
     {
         // clang-format off
         template <typename InIter, typename FwdIter,
@@ -571,7 +572,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::uninitialized_copy_n
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_copy_n_t final
-      : hpx::functional::tag_fallback<uninitialized_copy_n_t>
+      : hpx::detail::tag_parallel_algorithm<uninitialized_copy_n_t>
     {
         // clang-format off
         template <typename InIter, typename Size,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_default_construct.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_default_construct.hpp
@@ -175,6 +175,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner_with_cleanup.hpp>
 #include <hpx/parallel/util/zip_iterator.hpp>
@@ -442,7 +443,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::uninitialized_default_construct
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_default_construct_t final
-      : hpx::functional::tag_fallback<uninitialized_default_construct_t>
+      : hpx::detail::tag_parallel_algorithm<uninitialized_default_construct_t>
     {
         // clang-format off
         template <typename FwdIter,
@@ -491,7 +492,7 @@ namespace hpx {
     // DPO for hpx::uninitialized_default_construct_n
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_default_construct_n_t
         final
-      : hpx::functional::tag_fallback<uninitialized_default_construct_n_t>
+      : hpx::detail::tag_parallel_algorithm<uninitialized_default_construct_n_t>
     {
         // clang-format off
         template <typename FwdIter, typename Size,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_fill.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_fill.hpp
@@ -180,6 +180,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner_with_cleanup.hpp>
 #include <hpx/parallel/util/zip_iterator.hpp>
@@ -442,7 +443,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::uninitialized_fill
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_fill_t final
-      : hpx::functional::tag_fallback<uninitialized_fill_t>
+      : hpx::detail::tag_parallel_algorithm<uninitialized_fill_t>
     {
         // clang-format off
         template <typename FwdIter, typename T,
@@ -489,7 +490,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::uninitialized_fill_n
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_fill_n_t final
-      : hpx::functional::tag_fallback<uninitialized_fill_n_t>
+      : hpx::detail::tag_parallel_algorithm<uninitialized_fill_n_t>
     {
         // clang-format off
         template <typename FwdIter, typename Size, typename T,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_move.hpp
@@ -206,6 +206,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/tagspec.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/partitioner_with_cleanup.hpp>
 #include <hpx/parallel/util/result_types.hpp>
@@ -591,7 +592,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::uninitialized_move
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_move_t final
-      : hpx::functional::tag_fallback<uninitialized_move_t>
+      : hpx::detail::tag_parallel_algorithm<uninitialized_move_t>
     {
         // clang-format off
         template <typename InIter, typename FwdIter,
@@ -643,7 +644,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::uninitialized_move_n
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_move_n_t final
-      : hpx::functional::tag_fallback<uninitialized_move_n_t>
+      : hpx::detail::tag_parallel_algorithm<uninitialized_move_n_t>
     {
         // clang-format off
         template <typename InIter, typename Size,

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_value_construct.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/uninitialized_value_construct.hpp
@@ -175,6 +175,7 @@ namespace hpx {
 #include <hpx/execution/algorithms/detail/is_negative.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/loop.hpp>
@@ -445,7 +446,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::uninitialized_value_construct
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_value_construct_t final
-      : hpx::functional::tag_fallback<uninitialized_value_construct_t>
+      : hpx::detail::tag_parallel_algorithm<uninitialized_value_construct_t>
     {
         // clang-format off
         template <typename FwdIter,
@@ -492,7 +493,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::uninitialized_value_construct_n
     HPX_INLINE_CONSTEXPR_VARIABLE struct uninitialized_value_construct_n_t final
-      : hpx::functional::tag_fallback<uninitialized_value_construct_n_t>
+      : hpx::detail::tag_parallel_algorithm<uninitialized_value_construct_n_t>
     {
         // clang-format off
         template <typename FwdIter, typename Size,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/adjacent_find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/adjacent_find.hpp
@@ -271,7 +271,7 @@ namespace hpx { namespace ranges {
 
 namespace hpx { namespace ranges {
     HPX_INLINE_CONSTEXPR_VARIABLE struct adjacent_find_t final
-      : hpx::functional::tag_fallback<adjacent_find_t>
+      : hpx::detail::tag_parallel_algorithm<adjacent_find_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/all_any_none.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/all_any_none.hpp
@@ -222,7 +222,7 @@ namespace hpx { namespace ranges {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
 
@@ -352,7 +352,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::none_of
     HPX_INLINE_CONSTEXPR_VARIABLE struct none_of_t final
-      : hpx::functional::tag_fallback<none_of_t>
+      : hpx::detail::tag_parallel_algorithm<none_of_t>
     {
     private:
         // clang-format off
@@ -465,7 +465,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::any_of
     HPX_INLINE_CONSTEXPR_VARIABLE struct any_of_t final
-      : hpx::functional::tag_fallback<any_of_t>
+      : hpx::detail::tag_parallel_algorithm<any_of_t>
     {
     private:
         // clang-format off
@@ -577,7 +577,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::all_of
     HPX_INLINE_CONSTEXPR_VARIABLE struct all_of_t final
-      : hpx::functional::tag_fallback<all_of_t>
+      : hpx::detail::tag_parallel_algorithm<all_of_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/copy.hpp
@@ -349,7 +349,7 @@ namespace hpx { namespace ranges {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
@@ -378,7 +378,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::copy
     HPX_INLINE_CONSTEXPR_VARIABLE struct copy_t final
-      : hpx::functional::tag_fallback<copy_t>
+      : hpx::detail::tag_parallel_algorithm<copy_t>
     {
     private:
         // clang-format off
@@ -469,7 +469,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::copy_n
     HPX_INLINE_CONSTEXPR_VARIABLE struct copy_n_t final
-      : hpx::functional::tag_fallback<copy_n_t>
+      : hpx::detail::tag_parallel_algorithm<copy_n_t>
     {
     private:
         // clang-format off
@@ -536,7 +536,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::copy_if
     HPX_INLINE_CONSTEXPR_VARIABLE struct copy_if_t final
-      : hpx::functional::tag_fallback<copy_if_t>
+      : hpx::detail::tag_parallel_algorithm<copy_if_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/count.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/count.hpp
@@ -245,7 +245,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::count
     HPX_INLINE_CONSTEXPR_VARIABLE struct count_t final
-      : hpx::functional::tag_fallback<count_t>
+      : hpx::detail::tag_parallel_algorithm<count_t>
     {
     private:
         // clang-format off
@@ -356,7 +356,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::count_if
     HPX_INLINE_CONSTEXPR_VARIABLE struct count_if_t final
-      : hpx::functional::tag_fallback<count_if_t>
+      : hpx::detail::tag_parallel_algorithm<count_if_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/destroy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/destroy.hpp
@@ -105,7 +105,6 @@ namespace hpx { namespace ranges {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_dispatch.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
 
@@ -117,6 +116,7 @@ namespace hpx { namespace ranges {
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -131,7 +131,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::destroy
     HPX_INLINE_CONSTEXPR_VARIABLE struct destroy_t final
-      : hpx::functional::tag<destroy_t>
+      : hpx::detail::tag_parallel_algorithm<destroy_t>
     {
     private:
         // clang-format off
@@ -143,7 +143,7 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             typename hpx::traits::range_iterator<Rng>::type>::type
-        tag_dispatch(destroy_t, ExPolicy&& policy, Rng&& rng)
+        tag_fallback_dispatch(destroy_t, ExPolicy&& policy, Rng&& rng)
         {
             using iterator_type =
                 typename hpx::traits::range_iterator<Rng>::type;
@@ -166,7 +166,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             Iter>::type
-        tag_dispatch(destroy_t, ExPolicy&& policy, Iter first, Sent last)
+        tag_fallback_dispatch(
+            destroy_t, ExPolicy&& policy, Iter first, Sent last)
         {
             static_assert((hpx::traits::is_forward_iterator<Iter>::value),
                 "Required at least forward iterator.");
@@ -181,8 +182,8 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_range<Rng>::value
             )>
         // clang-format on
-        friend typename hpx::traits::range_iterator<Rng>::type tag_dispatch(
-            destroy_t, Rng&& rng)
+        friend typename hpx::traits::range_iterator<Rng>::type
+        tag_fallback_dispatch(destroy_t, Rng&& rng)
         {
             using iterator_type =
                 typename hpx::traits::range_iterator<Rng>::type;
@@ -202,7 +203,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_iterator<Iter>::value
             )>
         // clang-format on
-        friend Iter tag_dispatch(destroy_t, Iter first, Sent last)
+        friend Iter tag_fallback_dispatch(destroy_t, Iter first, Sent last)
         {
             static_assert((hpx::traits::is_forward_iterator<Iter>::value),
                 "Required at least forward iterator.");
@@ -215,7 +216,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::destroy_n
     HPX_INLINE_CONSTEXPR_VARIABLE struct destroy_n_t final
-      : hpx::functional::tag<destroy_n_t>
+      : hpx::detail::tag_parallel_algorithm<destroy_n_t>
     {
     private:
         // clang-format off
@@ -227,7 +228,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             FwdIter>::type
-        tag_dispatch(destroy_n_t, ExPolicy&& policy, FwdIter first, Size count)
+        tag_fallback_dispatch(
+            destroy_n_t, ExPolicy&& policy, FwdIter first, Size count)
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Requires at least forward iterator.");
@@ -249,7 +251,8 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_iterator<FwdIter>::value
             )>
         // clang-format on
-        friend FwdIter tag_dispatch(destroy_n_t, FwdIter first, Size count)
+        friend FwdIter tag_fallback_dispatch(
+            destroy_n_t, FwdIter first, Size count)
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Requires at least forward iterator.");

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/equal.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/equal.hpp
@@ -217,6 +217,7 @@ namespace hpx { namespace ranges {
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/parallel/algorithms/equal.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/invoke_projected.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 
@@ -228,7 +229,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::equal
     HPX_INLINE_CONSTEXPR_VARIABLE struct equal_t final
-      : hpx::functional::tag<equal_t>
+      : hpx::detail::tag_parallel_algorithm<equal_t>
     {
     private:
         // clang-format off
@@ -248,8 +249,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             bool>::type
-        tag_dispatch(equal_t, ExPolicy&& policy, Iter1 first1, Sent1 last1,
-            Iter2 first2, Sent2 last2, Pred&& op = Pred(),
+        tag_fallback_dispatch(equal_t, ExPolicy&& policy, Iter1 first1,
+            Sent1 last1, Iter2 first2, Sent2 last2, Pred&& op = Pred(),
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
             static_assert((hpx::traits::is_forward_iterator<Iter1>::value),
@@ -282,8 +283,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             bool>::type
-        tag_dispatch(equal_t, ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2,
-            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+        tag_fallback_dispatch(equal_t, ExPolicy&& policy, Rng1&& rng1,
+            Rng2&& rng2, Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
         {
             static_assert(
@@ -317,7 +318,7 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend bool tag_dispatch(equal_t, Iter1 first1, Sent1 last1,
+        friend bool tag_fallback_dispatch(equal_t, Iter1 first1, Sent1 last1,
             Iter2 first2, Sent2 last2, Pred&& op = Pred(),
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
@@ -348,7 +349,7 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend bool tag_dispatch(equal_t, Rng1&& rng1, Rng2&& rng2,
+        friend bool tag_fallback_dispatch(equal_t, Rng1&& rng1, Rng2&& rng2,
             Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
         {

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/fill.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/fill.hpp
@@ -187,7 +187,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::fill
     HPX_INLINE_CONSTEXPR_VARIABLE struct fill_t final
-      : hpx::functional::tag_fallback<fill_t>
+      : hpx::detail::tag_parallel_algorithm<fill_t>
     {
     private:
         // clang-format off
@@ -274,7 +274,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::fill_n
     HPX_INLINE_CONSTEXPR_VARIABLE struct fill_n_t final
-      : hpx::functional::tag_fallback<fill_n_t>
+      : hpx::detail::tag_parallel_algorithm<fill_n_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/find.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/find.hpp
@@ -642,7 +642,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::find
     HPX_INLINE_CONSTEXPR_VARIABLE struct find_t final
-      : hpx::functional::tag_fallback<find_t>
+      : hpx::detail::tag_parallel_algorithm<find_t>
     {
     private:
         // clang-format off
@@ -739,7 +739,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::find_if
     HPX_INLINE_CONSTEXPR_VARIABLE struct find_if_t final
-      : hpx::functional::tag_fallback<find_if_t>
+      : hpx::detail::tag_parallel_algorithm<find_if_t>
     {
     private:
         // clang-format off
@@ -853,7 +853,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::find_if_not
     HPX_INLINE_CONSTEXPR_VARIABLE struct find_if_not_t final
-      : hpx::functional::tag_fallback<find_if_not_t>
+      : hpx::detail::tag_parallel_algorithm<find_if_not_t>
     {
     private:
         // clang-format off
@@ -967,7 +967,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::find_end
     HPX_INLINE_CONSTEXPR_VARIABLE struct find_end_t final
-      : hpx::functional::tag_fallback<find_end_t>
+      : hpx::detail::tag_parallel_algorithm<find_end_t>
     {
     private:
         // clang-format off
@@ -1112,7 +1112,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::find_first_of
     HPX_INLINE_CONSTEXPR_VARIABLE struct find_first_of_t final
-      : hpx::functional::tag_fallback<find_first_of_t>
+      : hpx::detail::tag_parallel_algorithm<find_first_of_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/for_each.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/for_each.hpp
@@ -383,6 +383,7 @@ namespace hpx { namespace ranges {
 
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/parallel/algorithms/for_each.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 
 #include <type_traits>
@@ -421,7 +422,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::for_each
     HPX_INLINE_CONSTEXPR_VARIABLE struct for_each_t final
-      : hpx::functional::tag_fallback<for_each_t>
+      : hpx::detail::tag_parallel_algorithm<for_each_t>
     {
         // clang-format off
         template <typename InIter, typename Sent, typename F,
@@ -530,7 +531,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::for_each_n
     HPX_INLINE_CONSTEXPR_VARIABLE struct for_each_n_t final
-      : hpx::functional::tag_fallback<for_each_n_t>
+      : hpx::detail::tag_parallel_algorithm<for_each_n_t>
     {
         // clang-format off
         template <typename InIter, typename Size, typename F,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/for_loop.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/for_loop.hpp
@@ -718,13 +718,13 @@ namespace hpx { namespace ranges {
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
-#include <hpx/functional/tag_dispatch.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/type_support.hpp>
 #include <hpx/parallel/algorithms/for_loop.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -734,7 +734,7 @@ namespace hpx { namespace ranges {
 
 namespace hpx { namespace ranges {
     HPX_INLINE_CONSTEXPR_VARIABLE struct for_loop_t final
-      : hpx::functional::tag<for_loop_t>
+      : hpx::detail::tag_parallel_algorithm<for_loop_t>
     {
     private:
         // clang-format off
@@ -746,8 +746,8 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy>::type
-        tag_dispatch(hpx::ranges::for_loop_t, ExPolicy&& policy, Iter first,
-            Sent last, Args&&... args)
+        tag_fallback_dispatch(hpx::ranges::for_loop_t, ExPolicy&& policy,
+            Iter first, Sent last, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop must be called with at least a function object");
@@ -766,7 +766,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_sentinel_for<Sent, Iter>::value
             )>
         // clang-format on
-        friend void tag_dispatch(
+        friend void tag_fallback_dispatch(
             hpx::ranges::for_loop_t, Iter first, Sent last, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
@@ -786,7 +786,7 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy>::type
-        tag_dispatch(
+        tag_fallback_dispatch(
             hpx::ranges::for_loop_t, ExPolicy&& policy, R&& rng, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
@@ -806,7 +806,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_range<Rng>::value
             )>
         // clang-format on
-        friend void tag_dispatch(
+        friend void tag_fallback_dispatch(
             hpx::ranges::for_loop_t, Rng&& rng, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
@@ -821,7 +821,7 @@ namespace hpx { namespace ranges {
     } for_loop{};
 
     HPX_INLINE_CONSTEXPR_VARIABLE struct for_loop_strided_t final
-      : hpx::functional::tag<for_loop_strided_t>
+      : hpx::detail::tag_parallel_algorithm<for_loop_strided_t>
     {
     private:
         // clang-format off
@@ -835,8 +835,8 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy>::type
-        tag_dispatch(hpx::ranges::for_loop_strided_t, ExPolicy&& policy,
-            Iter first, Sent last, S stride, Args&&... args)
+        tag_fallback_dispatch(hpx::ranges::for_loop_strided_t,
+            ExPolicy&& policy, Iter first, Sent last, S stride, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop_strided must be called with at least a function "
@@ -857,8 +857,8 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_sentinel_for<Sent, Iter>::value
             )>
         // clang-format on
-        friend void tag_dispatch(hpx::ranges::for_loop_strided_t, Iter first,
-            Sent last, S stride, Args&&... args)
+        friend void tag_fallback_dispatch(hpx::ranges::for_loop_strided_t,
+            Iter first, Sent last, S stride, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop_strided must be called with at least a function "
@@ -880,8 +880,8 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy>::type
-        tag_dispatch(hpx::ranges::for_loop_strided_t, ExPolicy&& policy,
-            Rng&& rng, S stride, Args&&... args)
+        tag_fallback_dispatch(hpx::ranges::for_loop_strided_t,
+            ExPolicy&& policy, Rng&& rng, S stride, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop_strided must be called with at least a function "
@@ -902,8 +902,8 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_range<Rng>::value
             )>
         // clang-format on
-        friend void tag_dispatch(hpx::ranges::for_loop_strided_t, Rng&& rng,
-            S stride, Args&&... args)
+        friend void tag_fallback_dispatch(hpx::ranges::for_loop_strided_t,
+            Rng&& rng, S stride, Args&&... args)
         {
             static_assert(sizeof...(Args) >= 1,
                 "for_loop_strided must be called with at least a function "

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/generate.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/generate.hpp
@@ -234,7 +234,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::generate
     HPX_INLINE_CONSTEXPR_VARIABLE struct generate_t final
-      : hpx::functional::tag_fallback<generate_t>
+      : hpx::detail::tag_parallel_algorithm<generate_t>
     {
     private:
         // clang-format off
@@ -321,7 +321,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::generate_n
     HPX_INLINE_CONSTEXPR_VARIABLE struct generate_n_t final
-      : hpx::functional::tag_fallback<generate_n_t>
+      : hpx::detail::tag_parallel_algorithm<generate_n_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/includes.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/includes.hpp
@@ -205,7 +205,6 @@ namespace hpx { namespace ranges {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_dispatch.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/traits/is_sentinel_for.hpp>
@@ -216,6 +215,7 @@ namespace hpx { namespace ranges {
 #include <hpx/parallel/algorithms/includes.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/result_types.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 
 #include <algorithm>
 #include <iterator>
@@ -227,7 +227,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::includes
     HPX_INLINE_CONSTEXPR_VARIABLE struct includes_t final
-      : hpx::functional::tag<includes_t>
+      : hpx::detail::tag_parallel_algorithm<includes_t>
     {
     private:
         // clang-format off
@@ -250,8 +250,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             bool>::type
-        tag_dispatch(includes_t, ExPolicy&& policy, Iter1 first1, Sent1 last1,
-            Iter2 first2, Sent2 last2, Pred&& op = Pred(),
+        tag_fallback_dispatch(includes_t, ExPolicy&& policy, Iter1 first1,
+            Sent1 last1, Iter2 first2, Sent2 last2, Pred&& op = Pred(),
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
             static_assert((hpx::traits::is_forward_iterator<Iter1>::value),
@@ -282,7 +282,7 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend bool tag_dispatch(includes_t, Iter1 first1, Sent1 last1,
+        friend bool tag_fallback_dispatch(includes_t, Iter1 first1, Sent1 last1,
             Iter2 first2, Sent2 last2, Pred&& op = Pred(),
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
@@ -316,8 +316,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             bool>::type
-        tag_dispatch(includes_t, ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2,
-            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+        tag_fallback_dispatch(includes_t, ExPolicy&& policy, Rng1&& rng1,
+            Rng2&& rng2, Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
         {
             using iterator_type1 =
@@ -356,7 +356,7 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend bool tag_dispatch(includes_t, Rng1&& rng1, Rng2&& rng2,
+        friend bool tag_fallback_dispatch(includes_t, Rng1&& rng1, Rng2&& rng2,
             Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
         {

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/is_heap.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/is_heap.hpp
@@ -289,7 +289,6 @@ namespace hpx {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_dispatch.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
@@ -297,6 +296,7 @@ namespace hpx {
 #include <hpx/algorithms/traits/projected.hpp>
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/parallel/algorithms/is_heap.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 
 #include <type_traits>
@@ -387,7 +387,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::is_heap
     HPX_INLINE_CONSTEXPR_VARIABLE struct is_heap_t final
-      : hpx::functional::tag<is_heap_t>
+      : hpx::detail::tag_parallel_algorithm<is_heap_t>
     {
     private:
         // clang-format off
@@ -406,7 +406,7 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             bool>::type
-        tag_dispatch(is_heap_t, ExPolicy&& policy, Rng&& rng,
+        tag_fallback_dispatch(is_heap_t, ExPolicy&& policy, Rng&& rng,
             Comp&& comp = Comp(), Proj&& proj = Proj())
         {
             using iterator_type =
@@ -437,8 +437,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             bool>::type
-        tag_dispatch(is_heap_t, ExPolicy&& policy, Iter first, Sent last,
-            Comp&& comp = Comp(), Proj&& proj = Proj())
+        tag_fallback_dispatch(is_heap_t, ExPolicy&& policy, Iter first,
+            Sent last, Comp&& comp = Comp(), Proj&& proj = Proj())
         {
             static_assert((hpx::traits::is_random_access_iterator<Iter>::value),
                 "Requires a random access iterator.");
@@ -462,7 +462,7 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend bool tag_dispatch(
+        friend bool tag_fallback_dispatch(
             is_heap_t, Rng&& rng, Comp&& comp = Comp(), Proj&& proj = Proj())
         {
             using iterator_type =
@@ -490,7 +490,7 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend bool tag_dispatch(is_heap_t, Iter first, Sent last,
+        friend bool tag_fallback_dispatch(is_heap_t, Iter first, Sent last,
             Comp&& comp = Comp(), Proj&& proj = Proj())
         {
             static_assert((hpx::traits::is_random_access_iterator<Iter>::value),
@@ -505,7 +505,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::is_heap_until
     HPX_INLINE_CONSTEXPR_VARIABLE struct is_heap_until_t final
-      : hpx::functional::tag<is_heap_until_t>
+      : hpx::detail::tag_parallel_algorithm<is_heap_until_t>
     {
     private:
         // clang-format off
@@ -524,7 +524,7 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             typename hpx::traits::range_iterator<Rng>::type>::type
-        tag_dispatch(is_heap_until_t, ExPolicy&& policy, Rng&& rng,
+        tag_fallback_dispatch(is_heap_until_t, ExPolicy&& policy, Rng&& rng,
             Comp&& comp = Comp(), Proj&& proj = Proj())
         {
             using iterator_type =
@@ -555,8 +555,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             Iter>::type
-        tag_dispatch(is_heap_until_t, ExPolicy&& policy, Iter first, Sent last,
-            Comp&& comp = Comp(), Proj&& proj = Proj())
+        tag_fallback_dispatch(is_heap_until_t, ExPolicy&& policy, Iter first,
+            Sent last, Comp&& comp = Comp(), Proj&& proj = Proj())
         {
             static_assert((hpx::traits::is_random_access_iterator<Iter>::value),
                 "Requires a random access iterator.");
@@ -580,8 +580,8 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend typename hpx::traits::range_iterator<Rng>::type tag_dispatch(
-            is_heap_until_t, Rng&& rng, Comp&& comp = Comp(),
+        friend typename hpx::traits::range_iterator<Rng>::type
+        tag_fallback_dispatch(is_heap_until_t, Rng&& rng, Comp&& comp = Comp(),
             Proj&& proj = Proj())
         {
             using iterator_type =
@@ -610,8 +610,8 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend Iter tag_dispatch(is_heap_until_t, Iter first, Sent last,
-            Comp&& comp = Comp(), Proj&& proj = Proj())
+        friend Iter tag_fallback_dispatch(is_heap_until_t, Iter first,
+            Sent last, Comp&& comp = Comp(), Proj&& proj = Proj())
         {
             static_assert((hpx::traits::is_random_access_iterator<Iter>::value),
                 "Requires a random access iterator.");

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/is_partitioned.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/is_partitioned.hpp
@@ -238,10 +238,10 @@ namespace hpx {
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/functional/invoke.hpp>
-#include <hpx/functional/tag_dispatch.hpp>
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/parallel/algorithms/is_partitioned.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -253,7 +253,7 @@ namespace hpx {
 
 namespace hpx { namespace ranges {
     HPX_INLINE_CONSTEXPR_VARIABLE struct is_partitioned_t final
-      : hpx::functional::tag<is_partitioned_t>
+      : hpx::detail::tag_parallel_algorithm<is_partitioned_t>
     {
     private:
         // clang-format off
@@ -269,8 +269,8 @@ namespace hpx { namespace ranges {
                     hpx::parallel::traits::projected<Proj, FwdIter>>::value
             )>
         // clang-format on
-        friend bool tag_dispatch(hpx::ranges::is_partitioned_t, FwdIter first,
-            Sent last, Pred&& pred, Proj&& proj = Proj())
+        friend bool tag_fallback_dispatch(hpx::ranges::is_partitioned_t,
+            FwdIter first, Sent last, Pred&& pred, Proj&& proj = Proj())
         {
             return hpx::parallel::v1::detail::is_partitioned<FwdIter, Sent>()
                 .call(hpx::execution::seq, first, last,
@@ -292,7 +292,7 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             bool>::type
-        tag_dispatch(hpx::ranges::is_partitioned_t, ExPolicy&& policy,
+        tag_fallback_dispatch(hpx::ranges::is_partitioned_t, ExPolicy&& policy,
             FwdIter first, Sent last, Pred&& pred, Proj&& proj = Proj())
         {
             return hpx::parallel::v1::detail::is_partitioned<FwdIter, Sent>()
@@ -312,8 +312,8 @@ namespace hpx { namespace ranges {
                     hpx::parallel::traits::projected_range<Proj, Rng>>::value
             )>
         // clang-format on
-        friend bool tag_dispatch(hpx::ranges::is_partitioned_t, Rng&& rng,
-            Pred&& pred, Proj&& proj = Proj())
+        friend bool tag_fallback_dispatch(hpx::ranges::is_partitioned_t,
+            Rng&& rng, Pred&& pred, Proj&& proj = Proj())
         {
             using iterator_type =
                 typename hpx::traits::range_traits<Rng>::iterator_type;
@@ -339,7 +339,7 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             bool>::type
-        tag_dispatch(hpx::ranges::is_partitioned_t, ExPolicy&& policy,
+        tag_fallback_dispatch(hpx::ranges::is_partitioned_t, ExPolicy&& policy,
             Rng&& rng, Pred&& pred, Proj&& proj = Proj())
         {
             using iterator_type =

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/is_sorted.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/is_sorted.hpp
@@ -485,13 +485,13 @@ namespace hpx { namespace ranges {
 
 #include <hpx/config.hpp>
 #include <hpx/algorithms/traits/projected_range.hpp>
-#include <hpx/functional/tag_dispatch.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/is_sorted.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -503,7 +503,7 @@ namespace hpx { namespace ranges {
 
 namespace hpx { namespace ranges {
     HPX_INLINE_CONSTEXPR_VARIABLE struct is_sorted_t final
-      : hpx::functional::tag<is_sorted_t>
+      : hpx::detail::tag_parallel_algorithm<is_sorted_t>
     {
     private:
         template <typename FwdIter, typename Sent,
@@ -521,8 +521,9 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend bool tag_dispatch(hpx::ranges::is_sorted_t, FwdIter first,
-            Sent last, Pred&& pred = Pred(), Proj&& proj = Proj())
+        friend bool tag_fallback_dispatch(hpx::ranges::is_sorted_t,
+            FwdIter first, Sent last, Pred&& pred = Pred(),
+            Proj&& proj = Proj())
         {
             return hpx::parallel::v1::detail::is_sorted<FwdIter, Sent>().call(
                 hpx::execution::seq, first, last, std::forward<Pred>(pred),
@@ -547,8 +548,9 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             bool>::type
-        tag_dispatch(hpx::ranges::is_sorted_t, ExPolicy&& policy, FwdIter first,
-            Sent last, Pred&& pred = Pred(), Proj&& proj = Proj())
+        tag_fallback_dispatch(hpx::ranges::is_sorted_t, ExPolicy&& policy,
+            FwdIter first, Sent last, Pred&& pred = Pred(),
+            Proj&& proj = Proj())
         {
             return hpx::parallel::v1::detail::is_sorted<FwdIter, Sent>().call(
                 std::forward<ExPolicy>(policy), first, last,
@@ -568,7 +570,7 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend bool tag_dispatch(hpx::ranges::is_sorted_t, Rng&& rng,
+        friend bool tag_fallback_dispatch(hpx::ranges::is_sorted_t, Rng&& rng,
             Pred&& pred = Pred(), Proj&& proj = Proj())
         {
             return hpx::parallel::v1::detail::is_sorted<
@@ -596,8 +598,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             bool>::type
-        tag_dispatch(hpx::ranges::is_sorted_t, ExPolicy&& policy, Rng&& rng,
-            Pred&& pred = Pred(), Proj&& proj = Proj())
+        tag_fallback_dispatch(hpx::ranges::is_sorted_t, ExPolicy&& policy,
+            Rng&& rng, Pred&& pred = Pred(), Proj&& proj = Proj())
         {
             return hpx::parallel::v1::detail::is_sorted<
                 typename hpx::traits::range_iterator<Rng>::type,
@@ -609,7 +611,7 @@ namespace hpx { namespace ranges {
     } is_sorted{};
 
     HPX_INLINE_CONSTEXPR_VARIABLE struct is_sorted_until_t final
-      : hpx::functional::tag<is_sorted_until_t>
+      : hpx::detail::tag_parallel_algorithm<is_sorted_until_t>
     {
     private:
         template <typename FwdIter, typename Sent,
@@ -627,7 +629,7 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend FwdIter tag_dispatch(hpx::ranges::is_sorted_until_t,
+        friend FwdIter tag_fallback_dispatch(hpx::ranges::is_sorted_until_t,
             FwdIter first, Sent last, Pred&& pred = Pred(),
             Proj&& proj = Proj())
         {
@@ -654,7 +656,7 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             FwdIter>::type
-        tag_dispatch(hpx::ranges::is_sorted_until_t, ExPolicy&& policy,
+        tag_fallback_dispatch(hpx::ranges::is_sorted_until_t, ExPolicy&& policy,
             FwdIter first, Sent last, Pred&& pred = Pred(),
             Proj&& proj = Proj())
         {
@@ -676,9 +678,9 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend typename hpx::traits::range_iterator<Rng>::type tag_dispatch(
-            hpx::ranges::is_sorted_until_t, Rng&& rng, Pred&& pred = Pred(),
-            Proj&& proj = Proj())
+        friend typename hpx::traits::range_iterator<Rng>::type
+        tag_fallback_dispatch(hpx::ranges::is_sorted_until_t, Rng&& rng,
+            Pred&& pred = Pred(), Proj&& proj = Proj())
         {
             return hpx::parallel::v1::detail::is_sorted_until<
                 typename hpx::traits::range_iterator<Rng>::type,
@@ -705,7 +707,7 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             typename hpx::traits::range_iterator<Rng>::type>::type
-        tag_dispatch(hpx::ranges::is_sorted_until_t, ExPolicy&& policy,
+        tag_fallback_dispatch(hpx::ranges::is_sorted_until_t, ExPolicy&& policy,
             Rng&& rng, Pred&& pred = Pred(), Proj&& proj = Proj())
         {
             return hpx::parallel::v1::detail::is_sorted_until<

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/lexicographical_compare.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/lexicographical_compare.hpp
@@ -371,10 +371,10 @@ namespace hpx { namespace ranges {
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/executors/execution_policy.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/parallel/algorithms/lexicographical_compare.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 
 #include <algorithm>
@@ -386,7 +386,7 @@ namespace hpx { namespace ranges {
 
 namespace hpx { namespace ranges {
     HPX_INLINE_CONSTEXPR_VARIABLE struct lexicographical_compare_t final
-      : hpx::functional::tag_fallback<lexicographical_compare_t>
+      : hpx::detail::tag_parallel_algorithm<lexicographical_compare_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/make_heap.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/make_heap.hpp
@@ -122,7 +122,6 @@ namespace hpx { namespace ranges {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_dispatch.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
@@ -131,6 +130,7 @@ namespace hpx { namespace ranges {
 #include <hpx/algorithms/traits/projected.hpp>
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/algorithms/make_heap.hpp>
 #include <hpx/parallel/util/result_types.hpp>
 
@@ -143,7 +143,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::make_heap
     HPX_INLINE_CONSTEXPR_VARIABLE struct make_heap_t final
-      : hpx::functional::tag<make_heap_t>
+      : hpx::detail::tag_parallel_algorithm<make_heap_t>
     {
     private:
         // clang-format off
@@ -161,8 +161,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             Iter>::type
-        tag_dispatch(make_heap_t, ExPolicy&& policy, Iter first, Sent last,
-            Comp&& comp, Proj&& proj = Proj{})
+        tag_fallback_dispatch(make_heap_t, ExPolicy&& policy, Iter first,
+            Sent last, Comp&& comp, Proj&& proj = Proj{})
         {
             static_assert(hpx::traits::is_random_access_iterator<Iter>::value,
                 "Requires random access iterator.");
@@ -186,8 +186,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             typename hpx::traits::range_iterator<Rng>::type>::type
-        tag_dispatch(make_heap_t, ExPolicy&& policy, Rng& rng, Comp&& comp,
-            Proj&& proj = Proj{})
+        tag_fallback_dispatch(make_heap_t, ExPolicy&& policy, Rng& rng,
+            Comp&& comp, Proj&& proj = Proj{})
         {
             using iterator_type =
                 typename hpx::traits::range_iterator<Rng>::type;
@@ -217,8 +217,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             Iter>::type
-        tag_dispatch(make_heap_t, ExPolicy&& policy, Iter first, Sent last,
-            Proj&& proj = Proj{})
+        tag_fallback_dispatch(make_heap_t, ExPolicy&& policy, Iter first,
+            Sent last, Proj&& proj = Proj{})
         {
             static_assert(hpx::traits::is_random_access_iterator<Iter>::value,
                 "Requires random access iterator.");
@@ -247,7 +247,7 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             typename hpx::traits::range_iterator<Rng>::type>::type
-        tag_dispatch(
+        tag_fallback_dispatch(
             make_heap_t, ExPolicy&& policy, Rng&& rng, Proj&& proj = Proj{})
         {
             using iterator_type =
@@ -278,7 +278,7 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend Iter tag_dispatch(make_heap_t, Iter first, Sent last,
+        friend Iter tag_fallback_dispatch(make_heap_t, Iter first, Sent last,
             Comp&& comp, Proj&& proj = Proj{})
         {
             static_assert(hpx::traits::is_random_access_iterator<Iter>::value,
@@ -301,7 +301,8 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend typename hpx::traits::range_iterator<Rng>::type tag_dispatch(
+        friend typename hpx::traits::range_iterator<Rng>::type
+        tag_fallback_dispatch(
             make_heap_t, Rng& rng, Comp&& comp, Proj&& proj = Proj{})
         {
             using iterator_type =
@@ -329,7 +330,7 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend Iter tag_dispatch(
+        friend Iter tag_fallback_dispatch(
             make_heap_t, Iter first, Sent last, Proj&& proj = Proj{})
         {
             static_assert(hpx::traits::is_random_access_iterator<Iter>::value,
@@ -357,8 +358,8 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend typename hpx::traits::range_iterator<Rng>::type tag_dispatch(
-            make_heap_t, Rng&& rng, Proj&& proj = Proj{})
+        friend typename hpx::traits::range_iterator<Rng>::type
+        tag_fallback_dispatch(make_heap_t, Rng&& rng, Proj&& proj = Proj{})
         {
             using iterator_type =
                 typename hpx::traits::range_iterator<Rng>::type;

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/merge.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/merge.hpp
@@ -384,7 +384,6 @@ namespace hpx { namespace ranges {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_dispatch.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/traits/is_sentinel_for.hpp>
@@ -393,6 +392,7 @@ namespace hpx { namespace ranges {
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/merge.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/result_types.hpp>
 
@@ -518,7 +518,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::merge
     HPX_INLINE_CONSTEXPR_VARIABLE struct merge_t final
-      : hpx::functional::tag<merge_t>
+      : hpx::detail::tag_parallel_algorithm<merge_t>
     {
     private:
         // clang-format off
@@ -543,9 +543,9 @@ namespace hpx { namespace ranges {
             hpx::ranges::merge_result<
                 typename hpx::traits::range_iterator<Rng1>::type,
                 typename hpx::traits::range_iterator<Rng2>::type, Iter3>>::type
-        tag_dispatch(merge_t, ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2,
-            Iter3 dest, Comp&& comp = Comp(), Proj1&& proj1 = Proj1(),
-            Proj2&& proj2 = Proj2())
+        tag_fallback_dispatch(merge_t, ExPolicy&& policy, Rng1&& rng1,
+            Rng2&& rng2, Iter3 dest, Comp&& comp = Comp(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
             using iterator_type1 =
                 typename hpx::traits::range_iterator<Rng1>::type;
@@ -592,9 +592,10 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             hpx::ranges::merge_result<Iter1, Iter2, Iter3>>::type
-        tag_dispatch(merge_t, ExPolicy&& policy, Iter1 first1, Sent1 last1,
-            Iter2 first2, Sent2 last2, Iter3 dest, Comp&& comp = Comp(),
-            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        tag_fallback_dispatch(merge_t, ExPolicy&& policy, Iter1 first1,
+            Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
+            Comp&& comp = Comp(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
         {
             static_assert(hpx::traits::is_random_access_iterator<Iter1>::value,
                 "Required at least random access iterator.");
@@ -632,7 +633,7 @@ namespace hpx { namespace ranges {
         friend hpx::ranges::merge_result<
             typename hpx::traits::range_iterator<Rng1>::type,
             typename hpx::traits::range_iterator<Rng2>::type, Iter3>
-        tag_dispatch(merge_t, Rng1&& rng1, Rng2&& rng2, Iter3 dest,
+        tag_fallback_dispatch(merge_t, Rng1&& rng1, Rng2&& rng2, Iter3 dest,
             Comp&& comp = Comp(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
         {
@@ -679,10 +680,10 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend hpx::ranges::merge_result<Iter1, Iter2, Iter3> tag_dispatch(
-            merge_t, Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2,
-            Iter3 dest, Comp&& comp = Comp(), Proj1&& proj1 = Proj1(),
-            Proj2&& proj2 = Proj2())
+        friend hpx::ranges::merge_result<Iter1, Iter2, Iter3>
+        tag_fallback_dispatch(merge_t, Iter1 first1, Sent1 last1, Iter2 first2,
+            Sent2 last2, Iter3 dest, Comp&& comp = Comp(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
             static_assert(hpx::traits::is_random_access_iterator<Iter1>::value,
                 "Required at least random access iterator.");
@@ -703,7 +704,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::inplace_merge
     HPX_INLINE_CONSTEXPR_VARIABLE struct inplace_merge_t final
-      : hpx::functional::tag<inplace_merge_t>
+      : hpx::detail::tag_parallel_algorithm<inplace_merge_t>
     {
     private:
         // clang-format off
@@ -724,8 +725,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             Iter>::type
-        tag_dispatch(inplace_merge_t, ExPolicy&& policy, Rng&& rng, Iter middle,
-            Comp&& comp = Comp(), Proj&& proj = Proj())
+        tag_fallback_dispatch(inplace_merge_t, ExPolicy&& policy, Rng&& rng,
+            Iter middle, Comp&& comp = Comp(), Proj&& proj = Proj())
         {
             using iterator_type =
                 typename hpx::traits::range_iterator<Rng>::type;
@@ -758,7 +759,7 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             Iter>::type
-        tag_dispatch(inplace_merge_t, ExPolicy&& policy, Iter first,
+        tag_fallback_dispatch(inplace_merge_t, ExPolicy&& policy, Iter first,
             Iter middle, Sent last, Comp&& comp = Comp(), Proj&& proj = Proj())
         {
             static_assert(hpx::traits::is_random_access_iterator<Iter>::value,
@@ -785,8 +786,8 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend Iter tag_dispatch(inplace_merge_t, Rng&& rng, Iter middle,
-            Comp&& comp = Comp(), Proj&& proj = Proj())
+        friend Iter tag_fallback_dispatch(inplace_merge_t, Rng&& rng,
+            Iter middle, Comp&& comp = Comp(), Proj&& proj = Proj())
         {
             using iterator_type =
                 typename hpx::traits::range_iterator<Rng>::type;
@@ -817,8 +818,8 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend Iter tag_dispatch(inplace_merge_t, Iter first, Iter middle,
-            Sent last, Comp&& comp = Comp(), Proj&& proj = Proj())
+        friend Iter tag_fallback_dispatch(inplace_merge_t, Iter first,
+            Iter middle, Sent last, Comp&& comp = Comp(), Proj&& proj = Proj())
         {
             static_assert(hpx::traits::is_random_access_iterator<Iter>::value,
                 "Required at least random access iterator.");

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/mismatch.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/mismatch.hpp
@@ -222,6 +222,7 @@ namespace hpx { namespace ranges {
 #include <hpx/parallel/util/invoke_projected.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 #include <hpx/parallel/util/result_types.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -235,7 +236,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::mismatch
     HPX_INLINE_CONSTEXPR_VARIABLE struct mismatch_t final
-      : hpx::functional::tag<mismatch_t>
+      : hpx::detail::tag_parallel_algorithm<mismatch_t>
     {
     private:
         // clang-format off
@@ -255,8 +256,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             mismatch_result<Iter1, Iter2>>::type
-        tag_dispatch(mismatch_t, ExPolicy&& policy, Iter1 first1, Sent1 last1,
-            Iter2 first2, Sent2 last2, Pred&& op = Pred(),
+        tag_fallback_dispatch(mismatch_t, ExPolicy&& policy, Iter1 first1,
+            Sent1 last1, Iter2 first2, Sent2 last2, Pred&& op = Pred(),
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
             static_assert((hpx::traits::is_forward_iterator<Iter1>::value),
@@ -292,8 +293,8 @@ namespace hpx { namespace ranges {
             mismatch_result<
                 typename hpx::traits::range_traits<Rng1>::iterator_type,
                 typename hpx::traits::range_traits<Rng2>::iterator_type>>::type
-        tag_dispatch(mismatch_t, ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2,
-            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+        tag_fallback_dispatch(mismatch_t, ExPolicy&& policy, Rng1&& rng1,
+            Rng2&& rng2, Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
         {
             static_assert(
@@ -331,7 +332,7 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend mismatch_result<Iter1, Iter2> tag_dispatch(mismatch_t,
+        friend mismatch_result<Iter1, Iter2> tag_fallback_dispatch(mismatch_t,
             Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2,
             Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
@@ -367,8 +368,9 @@ namespace hpx { namespace ranges {
         friend mismatch_result<
             typename hpx::traits::range_traits<Rng1>::iterator_type,
             typename hpx::traits::range_traits<Rng2>::iterator_type>
-        tag_dispatch(mismatch_t, Rng1&& rng1, Rng2&& rng2, Pred&& op = Pred(),
-            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        tag_fallback_dispatch(mismatch_t, Rng1&& rng1, Rng2&& rng2,
+            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
         {
             static_assert(
                 (hpx::traits::is_forward_iterator<typename hpx::traits::

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/move.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/move.hpp
@@ -132,6 +132,7 @@ namespace hpx {
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
 #include <hpx/parallel/util/result_types.hpp>
 
@@ -148,7 +149,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::move
     HPX_INLINE_CONSTEXPR_VARIABLE struct move_t final
-      : hpx::functional::tag<move_t>
+      : hpx::detail::tag_parallel_algorithm<move_t>
     {
     private:
         // clang-format off
@@ -162,7 +163,7 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             move_result<Iter1, Iter2>>::type
-        tag_dispatch(
+        tag_fallback_dispatch(
             move_t, ExPolicy&& policy, Iter1 first, Sent1 last, Iter2 dest)
         {
             return hpx::parallel::v1::detail::transfer<
@@ -181,7 +182,7 @@ namespace hpx { namespace ranges {
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             move_result<typename hpx::traits::range_iterator<Rng>::type,
                 Iter2>>::type
-        tag_dispatch(move_t, ExPolicy&& policy, Rng&& rng, Iter2 dest)
+        tag_fallback_dispatch(move_t, ExPolicy&& policy, Rng&& rng, Iter2 dest)
         {
             using iterator_type =
                 typename hpx::traits::range_iterator<Rng>::type;
@@ -199,7 +200,7 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_iterator<Iter2>::value
             )>
         // clang-format on
-        friend move_result<Iter1, Iter2> tag_dispatch(
+        friend move_result<Iter1, Iter2> tag_fallback_dispatch(
             move_t, Iter1 first, Sent1 last, Iter2 dest)
         {
             return hpx::parallel::v1::detail::transfer<
@@ -216,7 +217,7 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend move_result<typename hpx::traits::range_iterator<Rng>::type,
             Iter2>
-        tag_dispatch(move_t, Rng&& rng, Iter2 dest)
+        tag_fallback_dispatch(move_t, Rng&& rng, Iter2 dest)
         {
             using iterator_type =
                 typename hpx::traits::range_iterator<Rng>::type;

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/reduce.hpp
@@ -408,7 +408,7 @@ namespace hpx { namespace ranges {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
@@ -430,7 +430,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::reduce
     HPX_INLINE_CONSTEXPR_VARIABLE struct reduce_t final
-      : hpx::functional::tag_fallback<reduce_t>
+      : hpx::detail::tag_parallel_algorithm<reduce_t>
     {
         // clang-format off
         template <typename ExPolicy, typename FwdIter, typename Sent,

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove.hpp
@@ -478,6 +478,7 @@ namespace hpx { namespace ranges {
 #include <hpx/algorithms/traits/projected.hpp>
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/parallel/algorithms/remove.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -539,7 +540,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::remove_if
     HPX_INLINE_CONSTEXPR_VARIABLE struct remove_if_t final
-      : hpx::functional::tag<remove_if_t>
+      : hpx::detail::tag_parallel_algorithm<remove_if_t>
     {
     private:
         // clang-format off
@@ -554,8 +555,9 @@ namespace hpx { namespace ranges {
                 >
             )>
         // clang-format on
-        friend subrange_t<Iter, Sent> tag_dispatch(hpx::ranges::remove_if_t,
-            Iter first, Sent sent, Pred&& pred, Proj&& proj = Proj())
+        friend subrange_t<Iter, Sent> tag_fallback_dispatch(
+            hpx::ranges::remove_if_t, Iter first, Sent sent, Pred&& pred,
+            Proj&& proj = Proj())
         {
             static_assert((hpx::traits::is_input_iterator<Iter>::value),
                 "Required at least input iterator.");
@@ -581,7 +583,7 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend subrange_t<typename hpx::traits::range_iterator<Rng>::type>
-        tag_dispatch(hpx::ranges::remove_if_t, Rng&& rng, Pred&& pred,
+        tag_fallback_dispatch(hpx::ranges::remove_if_t, Rng&& rng, Pred&& pred,
             Proj&& proj = Proj())
         {
             static_assert(
@@ -614,8 +616,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             subrange_t<FwdIter, Sent>>::type
-        tag_dispatch(hpx::ranges::remove_if_t, ExPolicy&& policy, FwdIter first,
-            Sent sent, Pred&& pred, Proj&& proj = Proj())
+        tag_fallback_dispatch(hpx::ranges::remove_if_t, ExPolicy&& policy,
+            FwdIter first, Sent sent, Pred&& pred, Proj&& proj = Proj())
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Required at least forward iterator.");
@@ -640,8 +642,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             subrange_t<typename hpx::traits::range_iterator<Rng>::type>>::type
-        tag_dispatch(hpx::ranges::remove_if_t, ExPolicy&& policy, Rng&& rng,
-            Pred&& pred, Proj&& proj = Proj())
+        tag_fallback_dispatch(hpx::ranges::remove_if_t, ExPolicy&& policy,
+            Rng&& rng, Pred&& pred, Proj&& proj = Proj())
         {
             static_assert(
                 (hpx::traits::is_forward_iterator<
@@ -663,7 +665,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::remove
     HPX_INLINE_CONSTEXPR_VARIABLE struct remove_t final
-      : hpx::functional::tag<remove_t>
+      : hpx::detail::tag_parallel_algorithm<remove_t>
     {
     private:
         // clang-format off
@@ -675,8 +677,9 @@ namespace hpx { namespace ranges {
                 hpx::traits::is_sentinel_for<Sent, Iter>::value
             )>
         // clang-format on
-        friend subrange_t<Iter, Sent> tag_dispatch(hpx::ranges::remove_t,
-            Iter first, Sent last, T const& value, Proj&& proj = Proj())
+        friend subrange_t<Iter, Sent> tag_fallback_dispatch(
+            hpx::ranges::remove_t, Iter first, Sent last, T const& value,
+            Proj&& proj = Proj())
         {
             static_assert((hpx::traits::is_input_iterator<Iter>::value),
                 "Required at least input iterator.");
@@ -698,7 +701,7 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend subrange_t<typename hpx::traits::range_iterator<Rng>::type>
-        tag_dispatch(hpx::ranges::remove_t, Rng&& rng, T const& value,
+        tag_fallback_dispatch(hpx::ranges::remove_t, Rng&& rng, T const& value,
             Proj&& proj = Proj())
         {
             static_assert(
@@ -728,8 +731,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             subrange_t<FwdIter, Sent>>::type
-        tag_dispatch(hpx::ranges::remove_t, ExPolicy&& policy, FwdIter first,
-            Sent last, T const& value, Proj&& proj = Proj())
+        tag_fallback_dispatch(hpx::ranges::remove_t, ExPolicy&& policy,
+            FwdIter first, Sent last, T const& value, Proj&& proj = Proj())
         {
             static_assert((hpx::traits::is_forward_iterator<FwdIter>::value),
                 "Required at least forward iterator.");
@@ -753,8 +756,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             subrange_t<typename hpx::traits::range_iterator<Rng>::type>>::type
-        tag_dispatch(hpx::ranges::remove_t, ExPolicy&& policy, Rng&& rng,
-            T const& value, Proj&& proj = Proj())
+        tag_fallback_dispatch(hpx::ranges::remove_t, ExPolicy&& policy,
+            Rng&& rng, T const& value, Proj&& proj = Proj())
         {
             static_assert(
                 (hpx::traits::is_forward_iterator<

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove_copy.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/remove_copy.hpp
@@ -583,6 +583,7 @@ namespace hpx { namespace ranges {
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/parallel/algorithms/remove_copy.hpp>
 #include <hpx/parallel/tagspec.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 #include <hpx/parallel/util/result_types.hpp>
 
@@ -662,7 +663,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::remove_copy_if
     HPX_INLINE_CONSTEXPR_VARIABLE struct remove_copy_if_t final
-      : hpx::functional::tag<remove_copy_if_t>
+      : hpx::detail::tag_parallel_algorithm<remove_copy_if_t>
     {
         // clang-format off
         template <typename I, typename Sent, typename O, typename Pred,
@@ -677,7 +678,7 @@ namespace hpx { namespace ranges {
                 >
             )>
         // clang-format on
-        friend remove_copy_if_result<I, O> tag_dispatch(
+        friend remove_copy_if_result<I, O> tag_fallback_dispatch(
             hpx::ranges::remove_copy_if_t, I first, Sent last, O dest,
             Pred&& pred, Proj&& proj = Proj())
         {
@@ -708,7 +709,7 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend remove_copy_if_result<
             typename hpx::traits::range_iterator<Rng>::type, O>
-        tag_dispatch(hpx::ranges::remove_copy_if_t, Rng&& rng, O dest,
+        tag_fallback_dispatch(hpx::ranges::remove_copy_if_t, Rng&& rng, O dest,
             Pred&& pred, Proj&& proj = Proj())
         {
             static_assert(
@@ -740,8 +741,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             remove_copy_if_result<I, O>>::type
-        tag_dispatch(hpx::ranges::remove_copy_if_t, ExPolicy&& policy, I first,
-            Sent last, O dest, Pred&& pred, Proj&& proj = Proj())
+        tag_fallback_dispatch(hpx::ranges::remove_copy_if_t, ExPolicy&& policy,
+            I first, Sent last, O dest, Pred&& pred, Proj&& proj = Proj())
         {
             static_assert((hpx::traits::is_forward_iterator<I>::value),
                 "Required at least forward iterator.");
@@ -772,7 +773,7 @@ namespace hpx { namespace ranges {
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             remove_copy_if_result<
                 typename hpx::traits::range_iterator<Rng>::type, O>>::type
-        tag_dispatch(hpx::ranges::remove_copy_if_t, ExPolicy&& policy,
+        tag_fallback_dispatch(hpx::ranges::remove_copy_if_t, ExPolicy&& policy,
             Rng&& rng, O dest, Pred&& pred, Proj&& proj = Proj())
         {
             static_assert(
@@ -792,7 +793,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::remove_copy
     HPX_INLINE_CONSTEXPR_VARIABLE struct remove_copy_t final
-      : hpx::functional::tag<remove_copy_t>
+      : hpx::detail::tag_parallel_algorithm<remove_copy_t>
     {
     private:
         // clang-format off
@@ -805,8 +806,9 @@ namespace hpx { namespace ranges {
                 hpx::parallel::traits::is_projected<Proj, I>::value
             )>
         // clang-format on
-        friend remove_copy_result<I, O> tag_dispatch(hpx::ranges::remove_copy_t,
-            I first, Sent last, O dest, T const& value, Proj&& proj = Proj())
+        friend remove_copy_result<I, O> tag_fallback_dispatch(
+            hpx::ranges::remove_copy_t, I first, Sent last, O dest,
+            T const& value, Proj&& proj = Proj())
         {
             static_assert((hpx::traits::is_input_iterator<I>::value),
                 "Required at least input iterator.");
@@ -829,7 +831,7 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend remove_copy_result<
             typename hpx::traits::range_iterator<Rng>::type, O>
-        tag_dispatch(hpx::ranges::remove_copy_t, Rng&& rng, O dest,
+        tag_fallback_dispatch(hpx::ranges::remove_copy_t, Rng&& rng, O dest,
             T const& value, Proj&& proj = Proj())
         {
             static_assert(
@@ -860,8 +862,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             remove_copy_result<I, O>>::type
-        tag_dispatch(hpx::ranges::remove_copy_t, ExPolicy&& policy, I first,
-            Sent last, O dest, T const& value, Proj&& proj = Proj())
+        tag_fallback_dispatch(hpx::ranges::remove_copy_t, ExPolicy&& policy,
+            I first, Sent last, O dest, T const& value, Proj&& proj = Proj())
         {
             static_assert((hpx::traits::is_forward_iterator<I>::value),
                 "Required at least forward iterator.");
@@ -886,8 +888,8 @@ namespace hpx { namespace ranges {
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             remove_copy_result<typename hpx::traits::range_iterator<Rng>::type,
                 O>>::type
-        tag_dispatch(hpx::ranges::remove_copy_t, ExPolicy&& policy, Rng&& rng,
-            O dest, T const& value, Proj&& proj = Proj())
+        tag_fallback_dispatch(hpx::ranges::remove_copy_t, ExPolicy&& policy,
+            Rng&& rng, O dest, T const& value, Proj&& proj = Proj())
         {
             static_assert(
                 (hpx::traits::is_forward_iterator<

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/replace.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/replace.hpp
@@ -1069,9 +1069,9 @@ namespace hpx { namespace ranges {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_fallback_dispatch.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/tagged_pair.hpp>
 
 #include <hpx/algorithms/traits/projected_range.hpp>
@@ -1206,7 +1206,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::replace_if
     HPX_INLINE_CONSTEXPR_VARIABLE struct replace_if_t final
-      : hpx::functional::tag_fallback<replace_if_t>
+      : hpx::detail::tag_parallel_algorithm<replace_if_t>
     {
     private:
         // clang-format off
@@ -1319,7 +1319,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::replace
     HPX_INLINE_CONSTEXPR_VARIABLE struct replace_t final
-      : hpx::functional::tag_fallback<replace_t>
+      : hpx::detail::tag_parallel_algorithm<replace_t>
     {
     private:
         // clang-format off
@@ -1434,7 +1434,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::replace_copy_if
     HPX_INLINE_CONSTEXPR_VARIABLE struct replace_copy_if_t final
-      : hpx::functional::tag_fallback<replace_copy_if_t>
+      : hpx::detail::tag_parallel_algorithm<replace_copy_if_t>
     {
     private:
         // clang-format off
@@ -1574,7 +1574,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::replace_copy
     HPX_INLINE_CONSTEXPR_VARIABLE struct replace_copy_t final
-      : hpx::functional::tag_fallback<replace_copy_t>
+      : hpx::detail::tag_parallel_algorithm<replace_copy_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/reverse.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/reverse.hpp
@@ -430,7 +430,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::reverse
     HPX_INLINE_CONSTEXPR_VARIABLE struct reverse_t final
-      : hpx::functional::tag_fallback<reverse_t>
+      : hpx::detail::tag_parallel_algorithm<reverse_t>
     {
     private:
         // clang-format off
@@ -517,7 +517,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::reverse_copy
     HPX_INLINE_CONSTEXPR_VARIABLE struct reverse_copy_t final
-      : hpx::functional::tag_fallback<reverse_copy_t>
+      : hpx::detail::tag_parallel_algorithm<reverse_copy_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/search.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/search.hpp
@@ -18,6 +18,7 @@
 #include <hpx/algorithms/traits/projected.hpp>
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/parallel/algorithms/detail/search.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 
 #include <cstddef>
 #include <type_traits>
@@ -761,7 +762,7 @@ namespace hpx { namespace parallel { inline namespace v1 {
 namespace hpx { namespace ranges {
 
     HPX_INLINE_CONSTEXPR_VARIABLE struct search_t final
-      : hpx::functional::tag<search_t>
+      : hpx::detail::tag_parallel_algorithm<search_t>
     {
     private:
         // clang-format off
@@ -784,9 +785,10 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend FwdIter tag_dispatch(hpx::ranges::search_t, FwdIter first,
-            Sent last, FwdIter2 s_first, Sent2 s_last, Pred&& op = Pred(),
-            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        friend FwdIter tag_fallback_dispatch(hpx::ranges::search_t,
+            FwdIter first, Sent last, FwdIter2 s_first, Sent2 s_last,
+            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
         {
             return hpx::parallel::v1::detail::search<FwdIter, Sent>().call(
                 hpx::execution::seq, first, last, s_first, s_last,
@@ -817,9 +819,10 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename parallel::util::detail::algorithm_result<ExPolicy,
             FwdIter>::type
-        tag_dispatch(hpx::ranges::search_t, ExPolicy&& policy, FwdIter first,
-            Sent last, FwdIter2 s_first, Sent2 s_last, Pred&& op = Pred(),
-            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        tag_fallback_dispatch(hpx::ranges::search_t, ExPolicy&& policy,
+            FwdIter first, Sent last, FwdIter2 s_first, Sent2 s_last,
+            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
         {
             return hpx::parallel::v1::detail::search<FwdIter, Sent>().call(
                 std::forward<ExPolicy>(policy), first, last, s_first, s_last,
@@ -844,9 +847,10 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend typename hpx::traits::range_iterator<Rng1>::type tag_dispatch(
-            hpx::ranges::search_t, Rng1&& rng1, Rng2&& rng2, Pred&& op = Pred(),
-            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        friend typename hpx::traits::range_iterator<Rng1>::type
+        tag_fallback_dispatch(hpx::ranges::search_t, Rng1&& rng1, Rng2&& rng2,
+            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
         {
             using fwditer_type =
                 typename hpx::traits::range_iterator<Rng1>::type;
@@ -878,9 +882,9 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             typename hpx::traits::range_iterator<Rng1>::type>::type
-        tag_dispatch(hpx::ranges::search_t, ExPolicy&& policy, Rng1&& rng1,
-            Rng2&& rng2, Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
-            Proj2&& proj2 = Proj2())
+        tag_fallback_dispatch(hpx::ranges::search_t, ExPolicy&& policy,
+            Rng1&& rng1, Rng2&& rng2, Pred&& op = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
             using fwditer_type =
                 typename hpx::traits::range_iterator<Rng1>::type;
@@ -896,7 +900,7 @@ namespace hpx { namespace ranges {
     } search{};
 
     HPX_INLINE_CONSTEXPR_VARIABLE struct search_n_t final
-      : hpx::functional::tag<search_n_t>
+      : hpx::detail::tag_parallel_algorithm<search_n_t>
     {
     private:
         // clang-format off
@@ -917,8 +921,8 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend FwdIter tag_dispatch(hpx::ranges::search_n_t, FwdIter first,
-            std::size_t count, FwdIter2 s_first, Sent2 s_last,
+        friend FwdIter tag_fallback_dispatch(hpx::ranges::search_n_t,
+            FwdIter first, std::size_t count, FwdIter2 s_first, Sent2 s_last,
             Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
         {
@@ -949,8 +953,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             FwdIter>::type
-        tag_dispatch(hpx::ranges::search_n_t, ExPolicy&& policy, FwdIter first,
-            std::size_t count, FwdIter2 s_first, Sent2 s_last,
+        tag_fallback_dispatch(hpx::ranges::search_n_t, ExPolicy&& policy,
+            FwdIter first, std::size_t count, FwdIter2 s_first, Sent2 s_last,
             Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
         {
@@ -977,10 +981,10 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend typename hpx::traits::range_iterator<Rng1>::type tag_dispatch(
-            hpx::ranges::search_n_t, Rng1&& rng1, std::size_t count,
-            Rng2&& rng2, Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
-            Proj2&& proj2 = Proj2())
+        friend typename hpx::traits::range_iterator<Rng1>::type
+        tag_fallback_dispatch(hpx::ranges::search_n_t, Rng1&& rng1,
+            std::size_t count, Rng2&& rng2, Pred&& op = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
             using fwditer_type =
                 typename hpx::traits::range_iterator<Rng1>::type;
@@ -1013,8 +1017,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             typename hpx::traits::range_iterator<Rng1>::type>::type
-        tag_dispatch(hpx::ranges::search_n_t, ExPolicy&& policy, Rng1&& rng1,
-            std::size_t count, Rng2&& rng2, Pred&& op = Pred(),
+        tag_fallback_dispatch(hpx::ranges::search_n_t, ExPolicy&& policy,
+            Rng1&& rng1, std::size_t count, Rng2&& rng2, Pred&& op = Pred(),
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
             using fwditer_type =

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_difference.hpp
@@ -241,7 +241,6 @@ namespace hpx { namespace ranges {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_dispatch.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/traits/is_sentinel_for.hpp>
@@ -249,6 +248,7 @@ namespace hpx { namespace ranges {
 #include <hpx/algorithms/traits/projected.hpp>
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/algorithms/set_difference.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/result_types.hpp>
@@ -266,7 +266,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::set_difference
     HPX_INLINE_CONSTEXPR_VARIABLE struct set_difference_t final
-      : hpx::functional::tag<set_difference_t>
+      : hpx::detail::tag_parallel_algorithm<set_difference_t>
     {
     private:
         // clang-format off
@@ -290,7 +290,7 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             set_difference_result<Iter1, Iter3>>::type
-        tag_dispatch(set_difference_t, ExPolicy&& policy, Iter1 first1,
+        tag_fallback_dispatch(set_difference_t, ExPolicy&& policy, Iter1 first1,
             Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
             Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
@@ -338,7 +338,7 @@ namespace hpx { namespace ranges {
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             set_difference_result<
                 typename hpx::traits::range_iterator<Rng1>::type, Iter3>>::type
-        tag_dispatch(set_difference_t, ExPolicy&& policy, Rng1&& rng1,
+        tag_fallback_dispatch(set_difference_t, ExPolicy&& policy, Rng1&& rng1,
             Rng2&& rng2, Iter3 dest, Pred&& op = Pred(),
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
@@ -393,7 +393,7 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend set_difference_result<Iter1, Iter3> tag_dispatch(
+        friend set_difference_result<Iter1, Iter3> tag_fallback_dispatch(
             set_difference_t, Iter1 first1, Sent1 last1, Iter2 first2,
             Sent2 last2, Iter3 dest, Pred&& op = Pred(),
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
@@ -433,8 +433,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend set_difference_result<
             typename hpx::traits::range_iterator<Rng1>::type, Iter3>
-        tag_dispatch(set_difference_t, Rng1&& rng1, Rng2&& rng2, Iter3 dest,
-            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+        tag_fallback_dispatch(set_difference_t, Rng1&& rng1, Rng2&& rng2,
+            Iter3 dest, Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
         {
             using iterator_type1 =

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_intersection.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_intersection.hpp
@@ -242,7 +242,6 @@ namespace hpx { namespace ranges {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_dispatch.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/traits/is_sentinel_for.hpp>
@@ -251,6 +250,7 @@ namespace hpx { namespace ranges {
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/set_intersection.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/result_types.hpp>
 
@@ -267,7 +267,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::set_intersection
     HPX_INLINE_CONSTEXPR_VARIABLE struct set_intersection_t final
-      : hpx::functional::tag<set_intersection_t>
+      : hpx::detail::tag_parallel_algorithm<set_intersection_t>
     {
     private:
         // clang-format off
@@ -291,8 +291,8 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             set_intersection_result<Iter1, Iter2, Iter3>>::type
-        tag_dispatch(set_intersection_t, ExPolicy&& policy, Iter1 first1,
-            Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
+        tag_fallback_dispatch(set_intersection_t, ExPolicy&& policy,
+            Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
             Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
         {
@@ -340,8 +340,8 @@ namespace hpx { namespace ranges {
             set_intersection_result<
                 typename hpx::traits::range_iterator<Rng1>::type,
                 typename hpx::traits::range_iterator<Rng2>::type, Iter3>>::type
-        tag_dispatch(set_intersection_t, ExPolicy&& policy, Rng1&& rng1,
-            Rng2&& rng2, Iter3 dest, Pred&& op = Pred(),
+        tag_fallback_dispatch(set_intersection_t, ExPolicy&& policy,
+            Rng1&& rng1, Rng2&& rng2, Iter3 dest, Pred&& op = Pred(),
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
             using iterator_type1 =
@@ -396,9 +396,9 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend set_intersection_result<Iter1, Iter2, Iter3> tag_dispatch(
-            set_intersection_t, Iter1 first1, Sent1 last1, Iter2 first2,
-            Sent2 last2, Iter3 dest, Pred&& op = Pred(),
+        friend set_intersection_result<Iter1, Iter2, Iter3>
+        tag_fallback_dispatch(set_intersection_t, Iter1 first1, Sent1 last1,
+            Iter2 first2, Sent2 last2, Iter3 dest, Pred&& op = Pred(),
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
             static_assert((hpx::traits::is_input_iterator<Iter1>::value),
@@ -437,8 +437,8 @@ namespace hpx { namespace ranges {
         friend set_intersection_result<
             typename hpx::traits::range_iterator<Rng1>::type,
             typename hpx::traits::range_iterator<Rng2>::type, Iter3>
-        tag_dispatch(set_intersection_t, Rng1&& rng1, Rng2&& rng2, Iter3 dest,
-            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+        tag_fallback_dispatch(set_intersection_t, Rng1&& rng1, Rng2&& rng2,
+            Iter3 dest, Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
         {
             using iterator_type1 =

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_symmetric_difference.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_symmetric_difference.hpp
@@ -249,7 +249,6 @@ namespace hpx { namespace ranges {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_dispatch.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/traits/is_sentinel_for.hpp>
@@ -259,6 +258,7 @@ namespace hpx { namespace ranges {
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/set_symmetric_difference.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/result_types.hpp>
 
 #include <algorithm>
@@ -275,7 +275,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::set_symmetric_difference
     HPX_INLINE_CONSTEXPR_VARIABLE struct set_symmetric_difference_t final
-      : hpx::functional::tag<set_symmetric_difference_t>
+      : hpx::detail::tag_parallel_algorithm<set_symmetric_difference_t>
     {
     private:
         // clang-format off
@@ -299,7 +299,7 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             set_symmetric_difference_result<Iter1, Iter2, Iter3>>::type
-        tag_dispatch(set_symmetric_difference_t, ExPolicy&& policy,
+        tag_fallback_dispatch(set_symmetric_difference_t, ExPolicy&& policy,
             Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
             Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
@@ -350,8 +350,8 @@ namespace hpx { namespace ranges {
             set_symmetric_difference_result<
                 typename hpx::traits::range_iterator<Rng1>::type,
                 typename hpx::traits::range_iterator<Rng2>::type, Iter3>>::type
-        tag_dispatch(set_symmetric_difference_t, ExPolicy&& policy, Rng1&& rng1,
-            Rng2&& rng2, Iter3 dest, Pred&& op = Pred(),
+        tag_fallback_dispatch(set_symmetric_difference_t, ExPolicy&& policy,
+            Rng1&& rng1, Rng2&& rng2, Iter3 dest, Pred&& op = Pred(),
             Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
             using iterator_type1 =
@@ -408,9 +408,10 @@ namespace hpx { namespace ranges {
             )>
         // clang-format on
         friend set_symmetric_difference_result<Iter1, Iter2, Iter3>
-        tag_dispatch(set_symmetric_difference_t, Iter1 first1, Sent1 last1,
-            Iter2 first2, Sent2 last2, Iter3 dest, Pred&& op = Pred(),
-            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        tag_fallback_dispatch(set_symmetric_difference_t, Iter1 first1,
+            Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
+            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
         {
             static_assert((hpx::traits::is_input_iterator<Iter1>::value),
                 "Requires at least input iterator.");
@@ -450,9 +451,9 @@ namespace hpx { namespace ranges {
         friend set_symmetric_difference_result<
             typename hpx::traits::range_iterator<Rng1>::type,
             typename hpx::traits::range_iterator<Rng2>::type, Iter3>
-        tag_dispatch(set_symmetric_difference_t, Rng1&& rng1, Rng2&& rng2,
-            Iter3 dest, Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
-            Proj2&& proj2 = Proj2())
+        tag_fallback_dispatch(set_symmetric_difference_t, Rng1&& rng1,
+            Rng2&& rng2, Iter3 dest, Pred&& op = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
             using iterator_type1 =
                 typename hpx::traits::range_iterator<Rng1>::type;

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_union.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/set_union.hpp
@@ -242,7 +242,6 @@ namespace hpx { namespace ranges {
 
 #include <hpx/config.hpp>
 #include <hpx/concepts/concepts.hpp>
-#include <hpx/functional/tag_dispatch.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/traits/is_sentinel_for.hpp>
@@ -251,6 +250,7 @@ namespace hpx { namespace ranges {
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/set_union.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/result_types.hpp>
 
@@ -267,7 +267,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::set_union
     HPX_INLINE_CONSTEXPR_VARIABLE struct set_union_t final
-      : hpx::functional::tag<set_union_t>
+      : hpx::detail::tag_parallel_algorithm<set_union_t>
     {
     private:
         // clang-format off
@@ -291,9 +291,10 @@ namespace hpx { namespace ranges {
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             set_union_result<Iter1, Iter2, Iter3>>::type
-        tag_dispatch(set_union_t, ExPolicy&& policy, Iter1 first1, Sent1 last1,
-            Iter2 first2, Sent2 last2, Iter3 dest, Pred&& op = Pred(),
-            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        tag_fallback_dispatch(set_union_t, ExPolicy&& policy, Iter1 first1,
+            Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
+            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
         {
             static_assert((hpx::traits::is_forward_iterator<Iter1>::value),
                 "Requires at least forward iterator.");
@@ -338,9 +339,9 @@ namespace hpx { namespace ranges {
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
             set_union_result<typename hpx::traits::range_iterator<Rng1>::type,
                 typename hpx::traits::range_iterator<Rng2>::type, Iter3>>::type
-        tag_dispatch(set_union_t, ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2,
-            Iter3 dest, Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
-            Proj2&& proj2 = Proj2())
+        tag_fallback_dispatch(set_union_t, ExPolicy&& policy, Rng1&& rng1,
+            Rng2&& rng2, Iter3 dest, Pred&& op = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
         {
             using iterator_type1 =
                 typename hpx::traits::range_iterator<Rng1>::type;
@@ -394,9 +395,9 @@ namespace hpx { namespace ranges {
                 >::value
             )>
         // clang-format on
-        friend set_union_result<Iter1, Iter2, Iter3> tag_dispatch(set_union_t,
-            Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest,
-            Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
+        friend set_union_result<Iter1, Iter2, Iter3> tag_fallback_dispatch(
+            set_union_t, Iter1 first1, Sent1 last1, Iter2 first2, Sent2 last2,
+            Iter3 dest, Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
         {
             static_assert((hpx::traits::is_input_iterator<Iter1>::value),
@@ -435,7 +436,7 @@ namespace hpx { namespace ranges {
         friend set_union_result<
             typename hpx::traits::range_iterator<Rng1>::type,
             typename hpx::traits::range_iterator<Rng2>::type, Iter3>
-        tag_dispatch(set_union_t, Rng1&& rng1, Rng2&& rng2, Iter3 dest,
+        tag_fallback_dispatch(set_union_t, Rng1&& rng1, Rng2&& rng2, Iter3 dest,
             Pred&& op = Pred(), Proj1&& proj1 = Proj1(),
             Proj2&& proj2 = Proj2())
         {

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform.hpp
@@ -384,8 +384,8 @@ namespace hpx { namespace ranges {
         ranges::binary_transform_result<
             typename hpx::traits::range_iterator<Rng1>::type,
             typename hpx::traits::range_iterator<Rng2>::type, FwdIter>>::type
-    tag_dispatch(hpx::ranges::transform_t, ExPolicy&& policy, Rng1&& rng1,
-        Rng2&& rng2, FwdIter dest, F&& f, Proj1&& proj1 = Proj1(),
+    tag_fallback_dispatch(hpx::ranges::transform_t, ExPolicy&& policy,
+        Rng1&& rng1, Rng2&& rng2, FwdIter dest, F&& f, Proj1&& proj1 = Proj1(),
         Proj2&& proj2 = Proj2())
 
 }}       // namespace hpx::ranges
@@ -401,6 +401,7 @@ namespace hpx { namespace ranges {
 #include <hpx/algorithms/traits/projected_range.hpp>
 #include <hpx/parallel/algorithms/transform.hpp>
 #include <hpx/parallel/tagspec.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/projection_identity.hpp>
 
 #include <type_traits>
@@ -550,7 +551,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::transform
     HPX_INLINE_CONSTEXPR_VARIABLE struct transform_t final
-      : hpx::functional::tag_fallback<transform_t>
+      : hpx::detail::tag_parallel_algorithm<transform_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_reduce.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/transform_reduce.hpp
@@ -247,7 +247,7 @@ namespace hpx {
 #include <hpx/algorithms/traits/segmented_iterator_traits.hpp>
 #include <hpx/concepts/concepts.hpp>
 #include <hpx/functional/invoke_result.hpp>
-#include <hpx/functional/tag_dispatch.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/functional/traits/is_invocable.hpp>
 #include <hpx/iterator_support/range.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
@@ -277,7 +277,7 @@ namespace hpx { namespace ranges {
     ///////////////////////////////////////////////////////////////////////////
     // DPO for hpx::ranges::transform_reduce
     HPX_INLINE_CONSTEXPR_VARIABLE struct transform_reduce_t final
-      : hpx::functional::tag_fallback<transform_reduce_t>
+      : hpx::detail::tag_parallel_algorithm<transform_reduce_t>
     {
     private:
         // clang-format off

--- a/libs/parallelism/algorithms/include/hpx/parallel/util/detail/sender_util.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/util/detail/sender_util.hpp
@@ -1,0 +1,125 @@
+//  Copyright (c) ETH Zurich 2021
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
+#include <hpx/execution/algorithms/let_value.hpp>
+#include <hpx/execution/algorithms/transform.hpp>
+#include <hpx/execution/traits/is_execution_policy.hpp>
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/executors/execution_policy.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx { namespace detail {
+    // This is a lighter-weight alternative to bind for use in parallel
+    // algorithm overloads, where one needs to bind an execution policy to an
+    // algorithm for use in execution::transform. Typically used together with
+    // transform_with_bound_algorithm.
+    template <typename Tag, typename ExPolicy>
+    struct bound_algorithm
+    {
+        std::decay_t<ExPolicy> policy;
+
+        template <typename T1, typename... Ts>
+        auto operator()(T1&& t1, Ts&&... ts) -> decltype(Tag{}(
+            std::move(policy), std::forward<T1>(t1), std::forward<Ts>(ts)...))
+        {
+            return Tag{}(std::move(policy), std::forward<T1>(t1),
+                std::forward<Ts>(ts)...);
+        }
+    };
+
+    // Detects if the given type is a bound_algorithm.
+    template <typename Bound>
+    struct is_bound_algorithm : std::false_type
+    {
+    };
+
+    template <typename Tag, typename ExPolicy>
+    struct is_bound_algorithm<bound_algorithm<Tag, ExPolicy>> : std::true_type
+    {
+    };
+
+    // Helper function for use in creating overloads of parallel algorithms that
+    // take senders. Takes an execution policy, a predecessor sender, and an
+    // "algorithm" (i.e. a tag) and applies transform with the predecessor
+    // sender and the execution policy bound to the algorithm.
+    template <typename Tag, typename ExPolicy, typename Predecessor>
+    auto transform_with_bound_algorithm(
+        Predecessor&& predecessor, ExPolicy&& policy)
+    {
+        // If the given execution policy can has a task policy, i.e. the
+        // algorithm can return a future, we use the task policy since we can
+        // then directly return the future as a sender and avoid potential
+        // blocking that may happen internally.
+        if constexpr (hpx::execution::detail::has_async_execution_policy_v<
+                          ExPolicy>)
+        {
+            auto task_policy =
+                std::forward<ExPolicy>(policy)(hpx::execution::task);
+            return hpx::execution::experimental::let_value(
+                std::forward<Predecessor>(predecessor),
+                bound_algorithm<Tag, decltype(task_policy)>{
+                    std::move(task_policy)});
+        }
+        // If the policy does not have a task policy, the algorithm can only be
+        // called synchronously. In this case we only use transform to chain the
+        // algorithm after the predecessor sender.
+        else
+        {
+            return hpx::execution::experimental::transform(
+                std::forward<Predecessor>(predecessor),
+                bound_algorithm<Tag, ExPolicy>{std::forward<ExPolicy>(policy)});
+        }
+    }
+
+    // Helper base class for implementing parallel algorithm DPOs. See
+    // tag_fallback documentation for details. Compared to tag_fallback this
+    // adds two tag_fallback_dispatch overloads that are generic for all
+    // parallel algorithms:
+    //
+    //   1. An overload taking a predecessor sender which sends all arguments
+    //      for the regular parallel algorithm overload, except an execution
+    //      policy; and an execution policy.
+    //   2. An overload taking only an execution policy. This overload returns a
+    //      partially applied parallel algorithm, and needs to be supplied a
+    //      predecessor sender. The partially applied algorithm is callable with
+    //      a predecessor sender: partially_applied_algorithm(predecessor). The
+    //      predecessor can also be supplied  using the operator| overload:
+    //      predecessor | partially_applied_parallel_algorithm.
+    template <typename Tag>
+    struct tag_parallel_algorithm : hpx::functional::tag_fallback<Tag>
+    {
+        // clang-format off
+        template <typename Predecessor, typename ExPolicy,
+            HPX_CONCEPT_REQUIRES_(
+                std::conjunction_v<
+                    hpx::is_execution_policy<ExPolicy>,
+                    std::negation<detail::is_bound_algorithm<Predecessor>>,
+                    hpx::execution::experimental::is_sender<
+                        std::decay_t<Predecessor>>>
+            )>
+        // clang-format on
+        friend auto tag_fallback_dispatch(
+            Tag, Predecessor&& predecessor, ExPolicy&& policy)
+        {
+            return detail::transform_with_bound_algorithm<Tag>(
+                std::forward<Predecessor>(predecessor),
+                std::forward<ExPolicy>(policy));
+        }
+
+        template <typename ExPolicy,
+            HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy<ExPolicy>::value)>
+        friend auto tag_fallback_dispatch(Tag, ExPolicy&& policy)
+        {
+            return hpx::execution::experimental::detail::partial_algorithm<Tag,
+                ExPolicy>{std::forward<ExPolicy>(policy)};
+        }
+    };
+}}    // namespace hpx::detail

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/foreach_range.cpp
@@ -27,6 +27,12 @@ void test_for_each()
 
     test_for_each_async(seq(task), IteratorTag());
     test_for_each_async(par(task), IteratorTag());
+
+    test_for_each_sender(seq, IteratorTag());
+    test_for_each_sender(par, IteratorTag());
+    test_for_each_sender(par_unseq, IteratorTag());
+    test_for_each_sender(seq(task), IteratorTag());
+    test_for_each_sender(par(task), IteratorTag());
 }
 
 void for_each_test()
@@ -51,6 +57,11 @@ void test_for_each_exception()
 
     test_for_each_exception_async(seq(task), IteratorTag());
     test_for_each_exception_async(par(task), IteratorTag());
+
+    test_for_each_exception_sender(seq, IteratorTag());
+    test_for_each_exception_sender(par, IteratorTag());
+    test_for_each_exception_sender(seq(task), IteratorTag());
+    test_for_each_exception_sender(par(task), IteratorTag());
 }
 
 void for_each_exception_test()
@@ -75,6 +86,11 @@ void test_for_each_bad_alloc()
 
     test_for_each_bad_alloc_async(seq(task), IteratorTag());
     test_for_each_bad_alloc_async(par(task), IteratorTag());
+
+    test_for_each_bad_alloc_sender(seq, IteratorTag());
+    test_for_each_bad_alloc_sender(par, IteratorTag());
+    test_for_each_bad_alloc_sender(seq(task), IteratorTag());
+    test_for_each_bad_alloc_sender(par(task), IteratorTag());
 }
 
 void for_each_bad_alloc_test()

--- a/libs/parallelism/executors/include/hpx/executors/execution_policy.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/execution_policy.hpp
@@ -34,6 +34,24 @@ namespace hpx { namespace execution {
     /// Default sequential execution policy object.
     HPX_INLINE_CONSTEXPR_VARIABLE task_policy_tag task{};
 
+    namespace detail {
+        template <typename T, typename Enable = void>
+        struct has_async_execution_policy : std::false_type
+        {
+        };
+
+        template <typename T>
+        struct has_async_execution_policy<T,
+            std::void_t<decltype(std::declval<std::decay_t<T>>()(task))>>
+          : std::true_type
+        {
+        };
+
+        template <typename T>
+        inline constexpr bool has_async_execution_policy_v =
+            has_async_execution_policy<T>::value;
+    }    // namespace detail
+
     ///////////////////////////////////////////////////////////////////////////
     /// Extension: The class sequenced_task_policy is an execution
     /// policy type used as a unique type to disambiguate parallel algorithm
@@ -1222,18 +1240,6 @@ namespace hpx { namespace execution {
         constexpr parallel_unsequenced_policy() = default;
         /// \endcond
 
-        /// Create a new parallel_unsequenced_policy from itself
-        ///
-        /// \param tag [in] Specify that the corresponding asynchronous
-        ///            execution policy should be used
-        ///
-        /// \returns The new parallel_unsequenced_policy
-        ///
-        parallel_unsequenced_policy operator()(task_policy_tag /*tag*/) const
-        {
-            return *this;
-        }
-
     public:
         /// Return the associated executor object.
         executor_type& executor()
@@ -1297,18 +1303,6 @@ namespace hpx { namespace execution {
         constexpr unsequenced_policy() = default;
         /// \endcond
 
-        /// Create a new parallel_unsequenced_policy from itself
-        ///
-        /// \param tag [in] Specify that the corresponding asynchronous
-        ///            execution policy should be used
-        ///
-        /// \returns The new parallel_unsequenced_policy
-        ///
-        unsequenced_policy operator()(task_policy_tag /*tag*/) const
-        {
-            return *this;
-        }
-
     public:
         /// Return the associated executor object.
         executor_type& executor()
@@ -1369,51 +1363,62 @@ namespace hpx { namespace parallel { namespace execution {
         "hpx::execution::task instead.")
     HPX_INLINE_CONSTEXPR_VARIABLE hpx::execution::task_policy_tag task{};
     using parallel_executor HPX_DEPRECATED_V(1, 6,
-        "hpx::parallel::execution::parallel_executor is deprecated. Please use "
+        "hpx::parallel::execution::parallel_executor is deprecated. Please "
+        "use "
         "hpx::execution::parallel_executor instead.") =
         hpx::execution::parallel_executor;
     using parallel_policy HPX_DEPRECATED_V(1, 6,
-        "hpx::parallel::execution::parallel_policy is deprecated. Please use "
+        "hpx::parallel::execution::parallel_policy is deprecated. Please "
+        "use "
         "hpx::execution::parallel_policy instead.") =
         hpx::execution::parallel_policy;
     template <typename Executor, typename Parameters>
     using parallel_policy_shim HPX_DEPRECATED_V(1, 6,
-        "hpx::parallel::execution::parallel_policy_shim is deprecated. Please "
+        "hpx::parallel::execution::parallel_policy_shim is deprecated. "
+        "Please "
         "use hpx::execution::parallel_policy_shim instead.") =
         hpx::execution::parallel_policy_shim<Executor, Parameters>;
     using parallel_task_policy HPX_DEPRECATED_V(1, 6,
-        "hpx::parallel::execution::parallel_task_policy is deprecated. Please "
+        "hpx::parallel::execution::parallel_task_policy is deprecated. "
+        "Please "
         "use hpx::execution::parallel_task_policy instead.") =
         hpx::execution::parallel_task_policy;
     template <typename Executor, typename Parameters>
     using parallel_task_policy_shim HPX_DEPRECATED_V(1, 6,
-        "hpx::parallel::execution::parallel_task_policy_shim is deprecated. "
+        "hpx::parallel::execution::parallel_task_policy_shim is "
+        "deprecated. "
         "Please use hpx::execution::parallel_task_policy_shim instead.") =
         hpx::execution::parallel_task_policy_shim<Executor, Parameters>;
     using parallel_unsequenced_policy HPX_DEPRECATED_V(1, 6,
-        "hpx::parallel::execution::parallel_unsequenced_policy is deprecated. "
+        "hpx::parallel::execution::parallel_unsequenced_policy is "
+        "deprecated. "
         "Please use hpx::execution::parallel_unsequenced_policy instead.") =
         hpx::execution::parallel_unsequenced_policy;
     using sequenced_executor HPX_DEPRECATED_V(1, 6,
-        "hpx::parallel::execution::sequenced_executor is deprecated. Please "
+        "hpx::parallel::execution::sequenced_executor is deprecated. "
+        "Please "
         "use hpx::execution::sequenced_executor instead.") =
         hpx::execution::sequenced_executor;
     using sequenced_policy HPX_DEPRECATED_V(1, 6,
-        "hpx::parallel::execution::sequenced_policy is deprecated. Please use "
+        "hpx::parallel::execution::sequenced_policy is deprecated. Please "
+        "use "
         "hpx::execution::sequenced_policy instead.") =
         hpx::execution::sequenced_policy;
     template <typename Executor, typename Parameters>
     using sequenced_policy_shim HPX_DEPRECATED_V(1, 6,
-        "hpx::parallel::execution::sequenced_policy_shim is deprecated. Please "
+        "hpx::parallel::execution::sequenced_policy_shim is deprecated. "
+        "Please "
         "use hpx::execution::sequenced_policy_shim instead.") =
         hpx::execution::sequenced_policy_shim<Executor, Parameters>;
     using sequenced_task_policy HPX_DEPRECATED_V(1, 6,
-        "hpx::parallel::execution::sequenced_task_policy is deprecated. Please "
+        "hpx::parallel::execution::sequenced_task_policy is deprecated. "
+        "Please "
         "use hpx::execution::sequenced_task_policy instead.") =
         hpx::execution::sequenced_task_policy;
     template <typename Executor, typename Parameters>
     using sequenced_task_policy_shim HPX_DEPRECATED_V(1, 6,
-        "hpx::parallel::execution::sequenced_task_policy_shim is deprecated. "
+        "hpx::parallel::execution::sequenced_task_policy_shim is "
+        "deprecated. "
         "Please use hpx::execution::sequenced_task_policy_shim instead.") =
         hpx::execution::sequenced_task_policy_shim<Executor, Parameters>;
 }}}    // namespace hpx::parallel::execution


### PR DESCRIPTION
The changes here are not meant to be *the* way to do this, but rather a place to discuss the alternatives in using P0443/1897 functionality with the parallel algorithms.

The last commit (https://github.com/STEllAR-GROUP/hpx/commit/131faa11ee48996c49398faf575999a9e1d6e8b6) of this adds the very simplest way I can think of currently integrating algorithms into task graphs, that also allows customization on the execution policy (not P0443 executors or schedulers). The overload is this (simplified):

```
auto tag_invoke(for_each_t, ExecutionPolicy p, PredecessorSender s) {
    return transform(s, bind_front(for_each_t{}, p));
}
```
where `PredecessorSender s` has `value_types` that are required by the plain synchronous `tag_invoke` overloads.

`for_each` can then be used in a task graph like this:
```
auto iter = sync_wait(ranges::for_each(some_exec_policy, when_all(range_sender, just(f))));
```
The sender from `for_each` can of course be used to chain further algorithms to it as well.

Some points to consider:
1. The `tag_invoke` overload could possibly be optimized by somehow taking advantage of the `task` policy. However, that would (as far as I can tell) involve roundtripping the `PredecessorSender` into a future to be able to use `dataflow` in place of `transform` (senders of senders are not collapsed like futures of futures are). It'd also be nice if it didn't need to rely on futures (in the long term).
2. The execution policy is not part of the `PredecessorSender` here to allow easier customization. If it were part of the sender it I'm not sure we would be able to optimally schedule e.g. CUDA versions of the algorithms (read: it would require unnecessary yielding instead of just attaching a continuation to an event).
3. Just directly doing `transform(predecessor, for_each)` in user code seems (to me) unlikely to ever happen in the standard library, at least for the non-ranges overloads, as long as they are not CPOs.
4. How should/can/might this interact with pipelining of ranges algorithms/views (@gonidelis)?
5. Note that something like `args_sender | on/via(std_thread_scheduler) | for_each(cuda_policy) | ...` would be fine and would mean the work should be *submitted* from a `std::thread` but *executed* according to the `cuda_policy` on a GPU, i.e. `on/via` would not control where the algorithm is executed.

Edit:
A possible alternative implementation that takes advantage of the task policy would look a bit like this:
```
auto tag_invoke(for_each_t, ExecutionPolicy p, PredecessorSender s) {
    return let_value(s, [policy](auto... ts) { return for_each_t{}(policy(task), ts...); });
}
```
I have no idea if there would be a noticeable difference in overheads.

To do:
- [x] rebase
- [x] add extensive tests for at least one of the algorithms