### PR TITLE
Fixing timed_executor specializations of customization points

### DIFF
--- a/libs/parallelism/execution/include/hpx/execution/executors/execution_parameters.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/executors/execution_parameters.hpp
@@ -644,7 +644,7 @@ namespace hpx { namespace parallel { namespace execution {
                 Executor&& exec) const
             {
                 auto& wrapped =
-                    static_cast<unwrapper<Wrapper>*>(this)->member_.get();
+                    static_cast<unwrapper<Wrapper> const*>(this)->member_.get();
                 return wrapped.processing_units_count(
                     std::forward<Executor>(exec));
             }

--- a/libs/parallelism/execution/include/hpx/execution/executors/execution_parameters.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/executors/execution_parameters.hpp
@@ -43,6 +43,9 @@ namespace hpx { namespace parallel { namespace execution {
                 make_with_property_t<Property, CheckForProperty>>
         {
         private:
+            using derived_propery_t =
+                make_with_property_t<Property, CheckForProperty>;
+
             template <typename T>
             using check_for_property = CheckForProperty<std::decay_t<T>>;
 
@@ -54,8 +57,8 @@ namespace hpx { namespace parallel { namespace execution {
                 )>
             // clang-format on
             friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-                make_with_property_t, Executor&& /*exec*/,
-                Parameters&& /*params*/, Property prop)
+                derived_propery_t, Executor&& /*exec*/, Parameters&& /*params*/,
+                Property prop)
             {
                 return std::make_pair(prop, prop);
             }
@@ -70,7 +73,7 @@ namespace hpx { namespace parallel { namespace execution {
                 )>
             // clang-format on
             friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-                make_with_property_t, Executor&& exec, Parameters&& params,
+                derived_propery_t, Executor&& exec, Parameters&& params,
                 Property /*prop*/)
             {
                 return std::pair<Parameters&&, Executor&&>(
@@ -87,9 +90,8 @@ namespace hpx { namespace parallel { namespace execution {
                     check_for_property<Executor>::value
                 )>
             // clang-format on
-            friend HPX_FORCEINLINE decltype(auto) tag_invoke(
-                make_with_property_t, Executor&& exec, Parameters&& params,
-                Property /*prop*/)
+            friend HPX_FORCEINLINE decltype(auto) tag_invoke(derived_propery_t,
+                Executor&& exec, Parameters&& params, Property /*prop*/)
             {
                 return std::pair<Executor&&, Parameters&&>(
                     std::forward<Executor>(exec),
@@ -540,10 +542,10 @@ namespace hpx { namespace parallel { namespace execution {
         {
             template <typename Executor>
             HPX_FORCEINLINE std::size_t maximal_number_of_chunks(
-                Executor&& exec, std::size_t cores, std::size_t num_tasks)
+                Executor&& exec, std::size_t cores, std::size_t num_tasks) const
             {
                 auto& wrapped =
-                    static_cast<unwrapper<Wrapper>*>(this)->member_.get();
+                    static_cast<unwrapper<Wrapper> const*>(this)->member_.get();
                 return wrapped.maximal_number_of_chunks(
                     std::forward<Executor>(exec), cores, num_tasks);
             }
@@ -561,10 +563,10 @@ namespace hpx { namespace parallel { namespace execution {
         {
             template <typename Executor, typename F>
             HPX_FORCEINLINE std::size_t get_chunk_size(Executor&& exec, F&& f,
-                std::size_t cores, std::size_t num_tasks)
+                std::size_t cores, std::size_t num_tasks) const
             {
                 auto& wrapped =
-                    static_cast<unwrapper<Wrapper>*>(this)->member_.get();
+                    static_cast<unwrapper<Wrapper> const*>(this)->member_.get();
                 return wrapped.get_chunk_size(std::forward<Executor>(exec),
                     std::forward<F>(f), cores, num_tasks);
             }
@@ -638,7 +640,8 @@ namespace hpx { namespace parallel { namespace execution {
             std::enable_if_t<has_processing_units_count<T>::value>>
         {
             template <typename Executor>
-            HPX_FORCEINLINE std::size_t processing_units_count(Executor&& exec)
+            HPX_FORCEINLINE std::size_t processing_units_count(
+                Executor&& exec) const
             {
                 auto& wrapped =
                     static_cast<unwrapper<Wrapper>*>(this)->member_.get();

--- a/libs/parallelism/execution/tests/unit/executor_parameters_dispatching.cpp
+++ b/libs/parallelism/execution/tests/unit/executor_parameters_dispatching.cpp
@@ -33,7 +33,7 @@ struct test_executor_get_chunk_size : hpx::execution::parallel_executor
     }
 
     template <typename Parameters, typename F>
-    std::size_t get_chunk_size(Parameters&& /* params */, F&& /* f */,
+    static std::size_t get_chunk_size(Parameters&& /* params */, F&& /* f */,
         std::size_t cores, std::size_t count)
     {
         ++exec_count;
@@ -51,7 +51,7 @@ namespace hpx { namespace parallel { namespace execution {
 struct test_chunk_size
 {
     template <typename Executor, typename F>
-    std::size_t get_chunk_size(Executor&& /* exec */, F&& /* f */,
+    static std::size_t get_chunk_size(Executor&& /* exec */, F&& /* f */,
         std::size_t cores, std::size_t count)
     {
         ++params_count;
@@ -108,7 +108,7 @@ struct test_executor_maximal_number_of_chunks
     }
 
     template <typename Parameters>
-    std::size_t maximal_number_of_chunks(
+    static std::size_t maximal_number_of_chunks(
         Parameters&&, std::size_t, std::size_t num_tasks)
     {
         ++exec_count;
@@ -181,7 +181,7 @@ struct test_executor_reset_thread_distribution
     }
 
     template <typename Parameters>
-    void reset_thread_distribution(Parameters&&)
+    static void reset_thread_distribution(Parameters&&)
     {
         ++exec_count;
     }
@@ -249,7 +249,7 @@ struct test_executor_processing_units_count : hpx::execution::parallel_executor
     }
 
     template <typename Parameters>
-    std::size_t processing_units_count(Parameters&&)
+    static std::size_t processing_units_count(Parameters&&)
     {
         ++exec_count;
         return 1;
@@ -267,7 +267,7 @@ namespace hpx { namespace parallel { namespace execution {
 struct test_processing_units
 {
     template <typename Executor>
-    std::size_t processing_units_count(Executor&&)
+    static std::size_t processing_units_count(Executor&&)
     {
         ++params_count;
         return 1;


### PR DESCRIPTION
This is a leftover from #5331