### PR TITLE
Making sure hpx::util::hardware::timestamp() is always defined

### DIFF
--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_generic.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_generic.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#if defined(__unix__)
-
 #include <cstdint>
 
 #include <time.h>
@@ -24,5 +22,3 @@ namespace hpx { namespace util { namespace hardware {
     }
 
 }}}    // namespace hpx::util::hardware
-
-#endif


### PR DESCRIPTION
Fixes #5333

@diehlpk could you please check whether this solves your issue?