### PR TITLE
Fix timed_executor static cast conversion

### DIFF
--- a/libs/parallelism/execution/include/hpx/execution/executors/execution_parameters.hpp
+++ b/libs/parallelism/execution/include/hpx/execution/executors/execution_parameters.hpp
@@ -672,7 +672,7 @@ namespace hpx { namespace parallel { namespace execution {
                 Executor&& exec) const
             {
                 auto& wrapped =
-                    static_cast<unwrapper<Wrapper>*>(this)->member_.get();
+                    static_cast<unwrapper<Wrapper> const*>(this)->member_.get();
                 return wrapped.processing_units_count(
                     std::forward<Executor>(exec));
             }


### PR DESCRIPTION
Fixes #5338

## Proposed Changes

  - static cast [result](https://github.com/STEllAR-GROUP/hpx/blob/timed_executors/libs/parallelism/execution/include/hpx/execution/executors/execution_parameters.hpp#L675) to `const*`