### PR TITLE
Adapt lexicographical_compare to C++20

### DIFF
--- a/docs/sphinx/api/public_api.rst
+++ b/docs/sphinx/api/public_api.rst
@@ -58,7 +58,7 @@ Functions
 - :cpp:func:`hpx::is_partitioned`
 - :cpp:func:`hpx::is_sorted`
 - :cpp:func:`hpx::is_sorted_until`
-- :cpp:func:`hpx::parallel::v1::lexicographical_compare`
+- :cpp:func:`hpx::lexicographical_compare`
 - :cpp:func:`hpx::make_heap`
 - :cpp:func:`hpx::parallel::v1::max_element`
 - :cpp:func:`hpx::merge`

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -407,7 +407,7 @@ Parallel algorithms
      * Applies a function to a number of elements.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`for_each_n`
-   * * :cpp:func:`hpx::parallel::v1::lexicographical_compare`
+   * * :cpp:func:`hpx::lexicographical_compare`
      * Checks if a range of values is lexicographically less than another range of values.
      * ``<hpx/algorithm.hpp>``
      * :cppreference-algorithm:`lexicographical_compare`
@@ -1013,4 +1013,3 @@ function enables this use case::
 without an explicit executor object. In this case the task will be run using the
 executor associated with the execution policy that was used to call
 :cpp:func:`hpx::parallel::v2::define_task_block`.
-

--- a/libs/full/include_local/include/hpx/local/algorithm.hpp
+++ b/libs/full/include_local/include/hpx/local/algorithm.hpp
@@ -11,7 +11,6 @@
 #include <hpx/parallel/container_algorithms.hpp>
 
 namespace hpx {
-    using hpx::parallel::lexicographical_compare;
     using hpx::parallel::max_element;
     using hpx::parallel::min_element;
     using hpx::parallel::minmax_element;

--- a/libs/parallelism/algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/CMakeLists.txt
@@ -99,6 +99,7 @@ set(algorithms_headers
     hpx/parallel/container_algorithms/is_heap.hpp
     hpx/parallel/container_algorithms/is_partitioned.hpp
     hpx/parallel/container_algorithms/is_sorted.hpp
+    hpx/parallel/container_algorithms/lexicographical_compare.hpp
     hpx/parallel/container_algorithms/make_heap.hpp
     hpx/parallel/container_algorithms/merge.hpp
     hpx/parallel/container_algorithms/minmax.hpp

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
@@ -9,116 +9,69 @@
 
 #pragma once
 
-#include <hpx/config.hpp>
-#include <hpx/functional/invoke.hpp>
-#include <hpx/iterator_support/traits/is_iterator.hpp>
+#if defined(DOXYGEN)
+namespace hpx {
 
-#include <hpx/execution/algorithms/detail/predicates.hpp>
-#include <hpx/executors/execution_policy.hpp>
-#include <hpx/parallel/algorithms/detail/dispatch.hpp>
-#include <hpx/parallel/algorithms/for_each.hpp>
-#include <hpx/parallel/algorithms/mismatch.hpp>
-#include <hpx/parallel/util/detail/algorithm_result.hpp>
-#include <hpx/parallel/util/loop.hpp>
-#include <hpx/parallel/util/partitioner.hpp>
-#include <hpx/parallel/util/zip_iterator.hpp>
-
-#include <algorithm>
-#include <cstddef>
-#include <iterator>
-#include <type_traits>
-#include <utility>
-#include <vector>
-
-namespace hpx { namespace parallel { inline namespace v1 {
-    ///////////////////////////////////////////////////////////////////////////
-    // lexicographical_compare
-    namespace detail {
-        /// \cond NOINTERNAL
-        struct lexicographical_compare
-          : public detail::algorithm<lexicographical_compare, bool>
-        {
-            lexicographical_compare()
-              : lexicographical_compare::algorithm("lexicographical_compare")
-            {
-            }
-
-            template <typename ExPolicy, typename InIter1, typename InIter2,
-                typename Pred>
-            static bool sequential(ExPolicy, InIter1 first1, InIter1 last1,
-                InIter2 first2, InIter2 last2, Pred&& pred)
-            {
-                return std::lexicographical_compare(
-                    first1, last1, first2, last2, pred);
-            }
-
-            template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-                typename Pred>
-            static typename util::detail::algorithm_result<ExPolicy, bool>::type
-            parallel(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
-                FwdIter2 first2, FwdIter2 last2, Pred&& pred)
-            {
-                typedef hpx::util::zip_iterator<FwdIter1, FwdIter2>
-                    zip_iterator;
-                typedef typename zip_iterator::reference reference;
-
-                std::size_t count1 = std::distance(first1, last1);
-                std::size_t count2 = std::distance(first2, last2);
-
-                // An empty range is lexicographically less than any non-empty
-                // range
-                if (count1 == 0 && count2 != 0)
-                {
-                    return util::detail::algorithm_result<ExPolicy, bool>::get(
-                        true);
-                }
-
-                if (count2 == 0 && count1 != 0)
-                {
-                    return util::detail::algorithm_result<ExPolicy, bool>::get(
-                        false);
-                }
-
-                std::size_t count = (std::min)(count1, count2);
-                util::cancellation_token<std::size_t> tok(count);
-
-                auto f1 = [tok, pred](zip_iterator it, std::size_t part_count,
-                              std::size_t base_idx) mutable -> void {
-                    util::loop_idx_n(base_idx, it, part_count, tok,
-                        [&pred, &tok](reference t, std::size_t i) -> void {
-                            using hpx::get;
-                            using hpx::util::invoke;
-                            if (invoke(pred, get<0>(t), get<1>(t)) ||
-                                invoke(pred, get<1>(t), get<0>(t)))
-                            {
-                                tok.cancel(i);
-                            }
-                        });
-                };
-
-                auto f2 =
-                    [tok, first1, first2, last1, last2, pred](
-                        std::vector<hpx::future<void>>&&) mutable -> bool {
-                    std::size_t mismatched = tok.get_data();
-
-                    std::advance(first1, mismatched);
-                    std::advance(first2, mismatched);
-
-                    if (first1 != last1 && first2 != last2)
-                        return hpx::util::invoke(pred, *first1, *first2);
-
-                    return first2 != last2;
-                };
-
-                using hpx::util::make_zip_iterator;
-                return util::partitioner<ExPolicy, bool, void>::call_with_index(
-                    std::forward<ExPolicy>(policy),
-                    make_zip_iterator(first1, first2), count, 1, std::move(f1),
-                    std::move(f2));
-            }
-        };
-        /// \endcond
-    }    // namespace detail
+    /// Checks if the first range [first1, last1) is lexicographically less than
+    /// the second range [first2, last2). uses a provided predicate to compare
+    /// elements.
+    ///
+    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
+    ///         operation, where N1 = std::distance(first1, last)
+    ///         and N2 = std::distance(first2, last2).
+    ///
+    /// \tparam InIter1    The type of the source iterators used for the
+    ///                     first range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam InIter2    The type of the source iterators used for the
+    ///                     second range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a lexicographical_compare requires \a Pred to
+    ///                     meet the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    ///
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     of the first range the algorithm will be applied to.
+    /// \param last1        Refers to the end of the sequence of elements of
+    ///                     the first range the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the sequence of elements
+    ///                     of the second range the algorithm will be applied to.
+    /// \param last2        Refers to the end of the sequence of elements of
+    ///                     the second range the algorithm will be applied to.
+    /// \param pred         Refers to the comparison function that the first
+    ///                     and second ranges will be applied to
+    ///
+    /// The comparison operations in the parallel \a lexicographical_compare
+    /// algorithm invoked without an execution policy object execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \note     Lexicographical comparison is an operation with the
+    ///           following properties
+    ///             - Two ranges are compared element by element
+    ///             - The first mismatching element defines which range
+    ///               is lexicographically
+    ///               \a less or \a greater than the other
+    ///             - If one range is a prefix of another, the shorter range is
+    ///               lexicographically \a less than the other
+    ///             - If two ranges have equivalent elements and are of the same length,
+    ///               then the ranges are lexicographically \a equal
+    ///             - An empty range is lexicographically \a less than any non-empty
+    ///               range
+    ///             - Two empty ranges are lexicographically \a equal
+    ///
+    /// \returns  The \a lexicographically_compare algorithm returns a
+    ///           returns \a bool if the execution policy object is not passed in.
+    ///           The \a lexicographically_compare algorithm returns true
+    ///           if the first range is lexicographically less, otherwise
+    ///           it returns false.
+    ///           range [first2, last2), it returns false.
+    template <typename InIter1, typename InIter2, typename Pred>
+    bool lexicographical_compare(InIter1 first1, InIter1 last1, InIter2 first2,
+        InIter2 last2, Pred&& pred);
 
     /// Checks if the first range [first1, last1) is lexicographically less than
     /// the second range [first2, last2). uses a provided predicate to compare
@@ -193,22 +146,250 @@ namespace hpx { namespace parallel { inline namespace v1 {
     ///           The \a lexicographically_compare algorithm returns true
     ///           if the first range is lexicographically less, otherwise
     ///           it returns false.
-    /// range [first2, last2), it returns false.
-    ///
-    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
-        typename Pred = detail::less>
-    inline typename std::enable_if<hpx::is_execution_policy<ExPolicy>::value,
-        typename util::detail::algorithm_result<ExPolicy, bool>::type>::type
+    ///           range [first2, last2), it returns false.
+    template <typename FwdIter1, typename FwdIter2, typename Pred>
+    typename util::detail::algorithm_result<ExPolicy, bool>::type
     lexicographical_compare(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
-        FwdIter2 first2, FwdIter2 last2, Pred&& pred = Pred())
+        FwdIter2 first2, FwdIter2 last2, Pred&& pred);
+
+}    // namespace hpx
+
+#else    // DOXYGEN
+
+#include <hpx/config.hpp>
+#include <hpx/concepts/concepts.hpp>
+#include <hpx/functional/invoke.hpp>
+#include <hpx/functional/tag_fallback_invoke.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+
+#include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/algorithms/for_each.hpp>
+#include <hpx/parallel/algorithms/mismatch.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/loop.hpp>
+#include <hpx/parallel/util/partitioner.hpp>
+#include <hpx/parallel/util/zip_iterator.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace parallel { inline namespace v1 {
+    ///////////////////////////////////////////////////////////////////////////
+    // lexicographical_compare
+    namespace detail {
+        /// \cond NOINTERNAL
+        struct lexicographical_compare
+          : public detail::algorithm<lexicographical_compare, bool>
+        {
+            lexicographical_compare()
+              : lexicographical_compare::algorithm("lexicographical_compare")
+            {
+            }
+
+            template <typename ExPolicy, typename InIter1, typename Sent1,
+                typename InIter2, typename Sent2, typename Pred, typename Proj1,
+                typename Proj2>
+            static bool sequential(ExPolicy, InIter1 first1, Sent1 last1,
+                InIter2 first2, Sent2 last2, Pred&& pred, Proj1&& proj1,
+                Proj2&& proj2)
+            {
+                for (; (first1 != last1) && (first2 != last2);
+                     ++first1, (void) ++first2)
+                {
+                    if (hpx::util::invoke(pred,
+                            hpx::util::invoke(proj1, *first1),
+                            hpx::util::invoke(proj2, *first2)))
+                        return true;
+                    if (hpx::util::invoke(pred,
+                            hpx::util::invoke(proj2, *first2),
+                            hpx::util::invoke(proj1, *first1)))
+                        return false;
+                }
+                return (first1 == last1) && (first2 != last2);
+            }
+
+            template <typename ExPolicy, typename FwdIter1, typename Sent1,
+                typename FwdIter2, typename Sent2, typename Pred,
+                typename Proj1, typename Proj2>
+            static typename util::detail::algorithm_result<ExPolicy, bool>::type
+            parallel(ExPolicy&& policy, FwdIter1 first1, Sent1 last1,
+                FwdIter2 first2, Sent2 last2, Pred&& pred, Proj1&& proj1,
+                Proj2&& proj2)
+            {
+                typedef hpx::util::zip_iterator<FwdIter1, FwdIter2>
+                    zip_iterator;
+                typedef typename zip_iterator::reference reference;
+
+                std::size_t count1 = std::distance(first1, last1);
+                std::size_t count2 = std::distance(first2, last2);
+
+                // An empty range is lexicographically less than any non-empty
+                // range
+                if (count1 == 0 && count2 != 0)
+                {
+                    return util::detail::algorithm_result<ExPolicy, bool>::get(
+                        true);
+                }
+
+                if (count2 == 0 && count1 != 0)
+                {
+                    return util::detail::algorithm_result<ExPolicy, bool>::get(
+                        false);
+                }
+
+                std::size_t count = (std::min)(count1, count2);
+                util::cancellation_token<std::size_t> tok(count);
+
+                auto f1 = [tok, pred, proj1, proj2](zip_iterator it,
+                              std::size_t part_count,
+                              std::size_t base_idx) mutable -> void {
+                    util::loop_idx_n(base_idx, it, part_count, tok,
+                        [&pred, &tok](reference t, std::size_t i) -> void {
+                            using hpx::get;
+                            using hpx::util::invoke;
+                            if (invoke(pred, invoke(proj1, get<0>(t)),
+                                    invoke(proj2, get<1>(t))) ||
+                                invoke(pred, invoke(proj2, get<1>(t)),
+                                    invoke(proj1, get<0>(t))))
+                            {
+                                tok.cancel(i);
+                            }
+                        });
+                };
+
+                auto f2 =
+                    [tok, first1, first2, last1, last2, pred, proj1, proj2](
+                        std::vector<hpx::future<void>>&&) mutable -> bool {
+                    std::size_t mismatched = tok.get_data();
+
+                    std::advance(first1, mismatched);
+                    std::advance(first2, mismatched);
+
+                    if (first1 != last1 && first2 != last2)
+                        return hpx::util::invoke(pred,
+                            hpx::util::invoke(proj1, *first1),
+                            hpx::util::invoke(proj2, *first2));
+
+                    return first2 != last2;
+                };
+
+                using hpx::util::make_zip_iterator;
+                return util::partitioner<ExPolicy, bool, void>::call_with_index(
+                    std::forward<ExPolicy>(policy),
+                    make_zip_iterator(first1, first2), count, 1, std::move(f1),
+                    std::move(f2));
+            }
+        };
+        /// \endcond
+    }    // namespace detail
+
+    // clang-format off
+    template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+        typename Pred = detail::less,
+        HPX_CONCEPT_REQUIRES_(
+            hpx::is_execution_policy<ExPolicy>::value &&
+            hpx::traits::is_iterator<FwdIter1>::value &&
+            hpx::traits::is_iterator<FwdIter2>::value &&
+            hpx::is_invocable_v<Pred,
+                typename std::iterator_traits<FwdIter1>::value_type,
+                typename std::iterator_traits<FwdIter2>::value_type
+            >
+        )>
+    // clang-format on
+    HPX_DEPRECATED_V(1, 7,
+        "hpx::parallel::lexicographical_compare is deprecated, use "
+        "hpx::lexicographical_compare "
+        "instead") typename util::detail::algorithm_result<ExPolicy, bool>::type
+        lexicographical_compare(ExPolicy&& policy, FwdIter1 first1,
+            FwdIter1 last1, FwdIter2 first2, FwdIter2 last2,
+            Pred&& pred = Pred())
     {
-        static_assert((hpx::traits::is_forward_iterator<FwdIter1>::value),
+        static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
             "Requires at least forward iterator.");
-        static_assert((hpx::traits::is_forward_iterator<FwdIter2>::value),
+        static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
             "Requires at least forward iterator.");
 
         return detail::lexicographical_compare().call(
             std::forward<ExPolicy>(policy), first1, last1, first2, last2,
-            std::forward<Pred>(pred));
+            std::forward<Pred>(pred),
+            hpx::parallel::util::projection_identity{},
+            hpx::parallel::util::projection_identity{});
     }
+
 }}}    // namespace hpx::parallel::v1
+
+namespace hpx {
+    ///////////////////////////////////////////////////////////////////////////
+    // CPO for hpx::lexicographical_compare
+    HPX_INLINE_CONSTEXPR_VARIABLE struct lexicographical_compare_t final
+      : hpx::functional::tag_fallback<lexicographical_compare_t>
+    {
+        // clang-format off
+        template <typename InIter1, typename InIter2,
+            typename Pred = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<InIter1>::value &&
+                hpx::traits::is_iterator<InIter2>::value &&
+                hpx::is_invocable_v<Pred,
+                    typename std::iterator_traits<InIter1>::value_type,
+                    typename std::iterator_traits<InIter2>::value_type
+                >
+            )>
+        // clang-format on
+        friend bool tag_fallback_invoke(hpx::lexicographical_compare_t,
+            InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
+            Pred&& pred = Pred())
+        {
+            static_assert(hpx::traits::is_input_iterator<InIter1>::value,
+                "Requires at least input iterator.");
+            static_assert(hpx::traits::is_input_iterator<InIter2>::value,
+                "Requires at least input iterator.");
+
+            return hpx::parallel::v1::detail::lexicographical_compare().call(
+                hpx::execution::seq, first1, last1, first2, last2,
+                std::forward<Pred>(pred),
+                hpx::parallel::util::projection_identity{},
+                hpx::parallel::util::projection_identity{});
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
+            typename Pred = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_iterator<FwdIter1>::value &&
+                hpx::traits::is_iterator<FwdIter2>::value &&
+                hpx::is_invocable_v<Pred,
+                    typename std::iterator_traits<FwdIter1>::value_type,
+                    typename std::iterator_traits<FwdIter2>::value_type
+                >
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            bool>::type
+        tag_fallback_invoke(hpx::lexicographical_compare_t, ExPolicy&& policy,
+            FwdIter1 first1, FwdIter1 last1, FwdIter2 first2, FwdIter2 last2,
+            Pred&& pred = Pred())
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::lexicographical_compare().call(
+                std::forward<ExPolicy>(policy), first1, last1, first2, last2,
+                std::forward<Pred>(pred),
+                hpx::parallel::util::projection_identity{},
+                hpx::parallel::util::projection_identity{});
+        }
+
+    } lexicographical_compare{};
+}    // namespace hpx
+
+#endif    // DOXYGEN

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
@@ -165,6 +165,7 @@ namespace hpx {
 #include <hpx/execution/algorithms/detail/predicates.hpp>
 #include <hpx/executors/execution_policy.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/for_each.hpp>
 #include <hpx/parallel/algorithms/mismatch.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
@@ -226,8 +227,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                     zip_iterator;
                 typedef typename zip_iterator::reference reference;
 
-                std::size_t count1 = std::distance(first1, last1);
-                std::size_t count2 = std::distance(first2, last2);
+                std::size_t count1 = detail::distance(first1, last1);
+                std::size_t count2 = detail::distance(first2, last2);
 
                 // An empty range is lexicographically less than any non-empty
                 // range
@@ -316,11 +317,18 @@ namespace hpx { namespace parallel { inline namespace v1 {
         static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
             "Requires at least forward iterator.");
 
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
         return detail::lexicographical_compare().call(
             std::forward<ExPolicy>(policy), first1, last1, first2, last2,
             std::forward<Pred>(pred),
             hpx::parallel::util::projection_identity{},
             hpx::parallel::util::projection_identity{});
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 100000
+#pragma GCC diagnostic pop
+#endif
     }
 
 }}}    // namespace hpx::parallel::v1

--- a/libs/parallelism/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/algorithms/lexicographical_compare.hpp
@@ -250,7 +250,8 @@ namespace hpx { namespace parallel { inline namespace v1 {
                               std::size_t part_count,
                               std::size_t base_idx) mutable -> void {
                     util::loop_idx_n(base_idx, it, part_count, tok,
-                        [&pred, &tok](reference t, std::size_t i) -> void {
+                        [&pred, &tok, &proj1, &proj2](
+                            reference t, std::size_t i) -> void {
                             using hpx::get;
                             using hpx::util::invoke;
                             if (invoke(pred, invoke(proj1, get<0>(t)),

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms.hpp
@@ -23,6 +23,7 @@
 #include <hpx/parallel/container_algorithms/is_heap.hpp>
 #include <hpx/parallel/container_algorithms/is_partitioned.hpp>
 #include <hpx/parallel/container_algorithms/is_sorted.hpp>
+#include <hpx/parallel/container_algorithms/lexicographical_compare.hpp>
 #include <hpx/parallel/container_algorithms/make_heap.hpp>
 #include <hpx/parallel/container_algorithms/merge.hpp>
 #include <hpx/parallel/container_algorithms/minmax.hpp>

--- a/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/lexicographical_compare.hpp
+++ b/libs/parallelism/algorithms/include/hpx/parallel/container_algorithms/lexicographical_compare.hpp
@@ -1,0 +1,549 @@
+//  Copyright (c) 2020 ETH Zurich
+//  Copyright (c) 2014 Grant Mercer
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/container_algorithms/lexicographical_compare.hpp
+
+#pragma once
+
+#if defined(DOXYGEN)
+
+namespace hpx { namespace ranges {
+
+    /// Checks if the first range [first1, last1) is lexicographically less than
+    /// the second range [first2, last2). uses a provided predicate to compare
+    /// elements.
+    ///
+    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
+    ///         operation, where N1 = std::distance(first1, last)
+    ///         and N2 = std::distance(first2, last2).
+    ///
+    /// \tparam InIter1     The type of the source iterators used for the
+    ///                     first range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Sent1       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter1.
+    /// \tparam InIter2     The type of the source iterators used for the
+    ///                     second range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     input iterator.
+    /// \tparam Sent2       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for InIter2.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a lexicographical_compare requires \a Pred to
+    ///                     meet the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function for FwdIter1. This
+    ///                     defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function for FwdIter2. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     of the first range the algorithm will be applied to.
+    /// \param last1        Refers to the end of the sequence of elements of
+    ///                     the first range the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the sequence of elements
+    ///                     of the second range the algorithm will be applied to.
+    /// \param last2        Refers to the end of the sequence of elements of
+    ///                     the second range the algorithm will be applied to.
+    /// \param pred         Refers to the comparison function that the first
+    ///                     and second ranges will be applied to
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the first range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the second range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The comparison operations in the parallel \a lexicographical_compare
+    /// algorithm invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The comparison operations in the parallel \a lexicographical_compare
+    /// algorithm invoked with an execution policy object of type
+    /// \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \note     Lexicographical comparison is an operation with the
+    ///           following properties
+    ///             - Two ranges are compared element by element
+    ///             - The first mismatching element defines which range
+    ///               is lexicographically
+    ///               \a less or \a greater than the other
+    ///             - If one range is a prefix of another, the shorter range is
+    ///               lexicographically \a less than the other
+    ///             - If two ranges have equivalent elements and are of the same length,
+    ///               then the ranges are lexicographically \a equal
+    ///             - An empty range is lexicographically \a less than any non-empty
+    ///               range
+    ///             - Two empty ranges are lexicographically \a equal
+    ///
+    /// \returns  The \a lexicographically_compare algorithm returns a
+    ///           \a hpx::future<bool> if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a bool otherwise.
+    ///           The \a lexicographically_compare algorithm returns true
+    ///           if the first range is lexicographically less, otherwise
+    ///           it returns false.
+    ///           range [first2, last2), it returns false.
+    template <typename InIter1, typename Sent1, typename InIter2,
+        typename Sent2,
+        typename Proj1 = hpx::parallel::util::projection_identity,
+        typename Proj2 = hpx::parallel::util::projection_identity,
+        typename Pred = detail::less>
+    bool lexicographical_compare(InIter1 first1, Sent1 last1, InIter2 first2,
+        Sent2 last2, Pred&& pred = Pred(), Proj1&& proj1 = Proj1(),
+        Proj2&& proj2 = Proj2());
+
+    /// Checks if the first range [first1, last1) is lexicographically less than
+    /// the second range [first2, last2). uses a provided predicate to compare
+    /// elements.
+    ///
+    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
+    ///         operation, where N1 = std::distance(first1, last)
+    ///         and N2 = std::distance(first2, last2).
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam FwdIter1    The type of the source iterators used for the
+    ///                     first range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent1       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter1.
+    /// \tparam FwdIter2    The type of the source iterators used for the
+    ///                     second range (deduced).
+    ///                     This iterator type must meet the requirements of an
+    ///                     forward iterator.
+    /// \tparam Sent2       The type of the source sentinel (deduced). This
+    ///                     sentinel type must be a sentinel for FwdIter2.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a lexicographical_compare requires \a Pred to
+    ///                     meet the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function for FwdIter1. This
+    ///                     defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function for FwdIter2. This
+    ///                     defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first1       Refers to the beginning of the sequence of elements
+    ///                     of the first range the algorithm will be applied to.
+    /// \param last1        Refers to the end of the sequence of elements of
+    ///                     the first range the algorithm will be applied to.
+    /// \param first2       Refers to the beginning of the sequence of elements
+    ///                     of the second range the algorithm will be applied to.
+    /// \param last2        Refers to the end of the sequence of elements of
+    ///                     the second range the algorithm will be applied to.
+    /// \param pred         Refers to the comparison function that the first
+    ///                     and second ranges will be applied to
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the first range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the second range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The comparison operations in the parallel \a lexicographical_compare
+    /// algorithm invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The comparison operations in the parallel \a lexicographical_compare
+    /// algorithm invoked with an execution policy object of type
+    /// \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \note     Lexicographical comparison is an operation with the
+    ///           following properties
+    ///             - Two ranges are compared element by element
+    ///             - The first mismatching element defines which range
+    ///               is lexicographically
+    ///               \a less or \a greater than the other
+    ///             - If one range is a prefix of another, the shorter range is
+    ///               lexicographically \a less than the other
+    ///             - If two ranges have equivalent elements and are of the same length,
+    ///               then the ranges are lexicographically \a equal
+    ///             - An empty range is lexicographically \a less than any non-empty
+    ///               range
+    ///             - Two empty ranges are lexicographically \a equal
+    ///
+    /// \returns  The \a lexicographically_compare algorithm returns a
+    ///           \a hpx::future<bool> if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a bool otherwise.
+    ///           The \a lexicographically_compare algorithm returns true
+    ///           if the first range is lexicographically less, otherwise
+    ///           it returns false.
+    ///           range [first2, last2), it returns false.
+
+    template <typename ExPolicy, typename FwdIter1, typename Sent1,
+        typename FwdIter2, typename Sent2,
+        typename Proj1 = hpx::parallel::util::projection_identity,
+        typename Proj2 = hpx::parallel::util::projection_identity,
+        typename Pred = detail::less>
+    typename parallel::util::detail::algorithm_result<ExPolicy, bool>::type
+    lexicographical_compare(ExPolicy&& policy, FwdIter1 first1, Sent1 last1,
+        FwdIter2 first2, Sent2 last2, Pred&& pred = Pred(),
+        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+
+    /// Checks if the first range rng1 is lexicographically less than
+    /// the second range rng2. uses a provided predicate to compare
+    /// elements.
+    ///
+    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
+    ///         operation, where N1 = std::distance(std::begin(rng1), std::end(rng1))
+    ///         and N2 = std::distance(std::begin(rng2), std::end(rng2)).
+    ///
+    /// \tparam Rng1        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Rng2        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a lexicographical_compare requires \a Pred to
+    ///                     meet the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function for elements of the first range.
+    ///                     This defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function for elements of the second range.
+    ///                     This defaults to \a util::projection_identity
+    ///
+    /// \param rng1         Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param rng2         Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param pred         Refers to the comparison function that the first
+    ///                     and second ranges will be applied to
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the first range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the second range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The comparison operations in the parallel \a lexicographical_compare
+    /// algorithm invoked without an execution policy object  execute in sequential
+    /// order in the calling thread.
+    ///
+    /// \note     Lexicographical comparison is an operation with the
+    ///           following properties
+    ///             - Two ranges are compared element by element
+    ///             - The first mismatching element defines which range
+    ///               is lexicographically
+    ///               \a less or \a greater than the other
+    ///             - If one range is a prefix of another, the shorter range is
+    ///               lexicographically \a less than the other
+    ///             - If two ranges have equivalent elements and are of the same length,
+    ///               then the ranges are lexicographically \a equal
+    ///             - An empty range is lexicographically \a less than any non-empty
+    ///               range
+    ///             - Two empty ranges are lexicographically \a equal
+    ///
+    /// \returns  The \a lexicographically_compare algorithm returns \a bool.
+    ///           The \a lexicographically_compare algorithm returns true
+    ///           if the first range is lexicographically less, otherwise
+    ///           it returns false.
+    ///           range [first2, last2), it returns false.
+    template <typename Rng1, typename Rng2,
+        typename Proj1 = hpx::parallel::util::projection_identity,
+        typename Proj2 = hpx::parallel::util::projection_identity,
+        typename Pred = detail::less>
+    bool lexicographical_compare(Rng1&& rng1, Rng2&& rng2, Pred&& pred = Pred(),
+        Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+
+    /// Checks if the first range rng1 is lexicographically less than
+    /// the second range rng2. uses a provided predicate to compare
+    /// elements.
+    ///
+    /// \note   Complexity: At most 2 * min(N1, N2) applications of the comparison
+    ///         operation, where N1 = std::distance(std::begin(rng1), std::end(rng1))
+    ///         and N2 = std::distance(std::begin(rng2), std::end(rng2)).
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam Rng1        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Rng2        The type of the source range used (deduced).
+    ///                     The iterators extracted from this range type must
+    ///                     meet the requirements of an input iterator.
+    /// \tparam Pred        The type of an optional function/function object to use.
+    ///                     Unlike its sequential form, the parallel
+    ///                     overload of \a lexicographical_compare requires \a Pred to
+    ///                     meet the requirements of \a CopyConstructible. This defaults
+    ///                     to std::less<>
+    /// \tparam Proj1       The type of an optional projection function for elements of the first range.
+    ///                     This defaults to \a util::projection_identity
+    /// \tparam Proj2       The type of an optional projection function for elements of the second range.
+    ///                     This defaults to \a util::projection_identity
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param rng1         Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param rng2         Refers to the sequence of elements the algorithm
+    ///                     will be applied to.
+    /// \param pred         Refers to the comparison function that the first
+    ///                     and second ranges will be applied to
+    /// \param proj1        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the first range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    /// \param proj2        Specifies the function (or function object) which
+    ///                     will be invoked for each of the elements of the second range
+    ///                     as a projection operation before the actual predicate
+    ///                     \a is invoked.
+    ///
+    /// The comparison operations in the parallel \a lexicographical_compare
+    /// algorithm invoked with an execution policy object of type
+    /// \a sequenced_policy execute in sequential order in the
+    /// calling thread.
+    ///
+    /// The comparison operations in the parallel \a lexicographical_compare
+    /// algorithm invoked with an execution policy object of type
+    /// \a parallel_policy
+    /// or \a parallel_task_policy are permitted to execute in an unordered
+    /// fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \note     Lexicographical comparison is an operation with the
+    ///           following properties
+    ///             - Two ranges are compared element by element
+    ///             - The first mismatching element defines which range
+    ///               is lexicographically
+    ///               \a less or \a greater than the other
+    ///             - If one range is a prefix of another, the shorter range is
+    ///               lexicographically \a less than the other
+    ///             - If two ranges have equivalent elements and are of the same length,
+    ///               then the ranges are lexicographically \a equal
+    ///             - An empty range is lexicographically \a less than any non-empty
+    ///               range
+    ///             - Two empty ranges are lexicographically \a equal
+    ///
+    /// \returns  The \a lexicographically_compare algorithm returns a
+    ///           \a hpx::future<bool> if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a bool otherwise.
+    ///           The \a lexicographically_compare algorithm returns true
+    ///           if the first range is lexicographically less, otherwise
+    ///           it returns false.
+    ///           range [first2, last2), it returns false.
+
+    template <typename ExPolicy, typename Rng1, typename Rng2,
+        typename Proj1 = hpx::parallel::util::projection_identity,
+        typename Proj2 = hpx::parallel::util::projection_identity,
+        typename Pred = detail::less>
+    typename parallel::util::detail::algorithm_result<ExPolicy, bool>::type
+    lexicographical_compare(ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2,
+        Pred&& pred = Pred(), Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2());
+}}    // namespace hpx::ranges
+#else
+
+#include <hpx/config.hpp>
+#include <hpx/algorithms/traits/projected_range.hpp>
+#include <hpx/execution/algorithms/detail/predicates.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/iterator_support/traits/is_iterator.hpp>
+#include <hpx/parallel/algorithms/lexicographical_compare.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/projection_identity.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace ranges {
+    HPX_INLINE_CONSTEXPR_VARIABLE struct lexicographical_compare_t final
+      : hpx::functional::tag_fallback<lexicographical_compare_t>
+    {
+    private:
+        // clang-format off
+        template <typename InIter1, typename Sent1, typename InIter2, typename Sent2,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            typename Pred = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_iterator<InIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent1, InIter1>::value &&
+                hpx::traits::is_iterator<InIter2>::value &&
+                hpx::traits::is_sentinel_for<Sent2, InIter2>::value &&
+                hpx::parallel::traits::is_projected<Proj1, InIter1>::value &&
+                hpx::parallel::traits::is_projected<Proj2, InIter2>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::execution::sequenced_policy, Pred,
+                    hpx::parallel::traits::projected<Proj1, InIter1>,
+                    hpx::parallel::traits::projected<Proj2, InIter2>
+                >::value
+            )>
+        // clang-format on
+        friend bool tag_fallback_invoke(hpx::ranges::lexicographical_compare_t,
+            InIter1 first1, Sent1 last1, InIter2 first2, Sent2 last2,
+            Pred&& pred = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            static_assert(hpx::traits::is_input_iterator<InIter1>::value,
+                "Requires at least input iterator.");
+            static_assert(hpx::traits::is_input_iterator<InIter2>::value,
+                "Requires at least input iterator.");
+
+            return hpx::parallel::v1::detail::lexicographical_compare().call(
+                hpx::execution::seq, first1, last1, first2, last2,
+                std::forward<Pred>(pred), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename FwdIter1, typename Sent1,
+            typename FwdIter2, typename Sent2,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            typename Pred = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_forward_iterator<FwdIter1>::value &&
+                hpx::traits::is_sentinel_for<Sent1, FwdIter1>::value &&
+                hpx::traits::is_forward_iterator<FwdIter2>::value &&
+                hpx::traits::is_sentinel_for<Sent2, FwdIter2>::value &&
+                hpx::parallel::traits::is_projected<Proj1, FwdIter1>::value &&
+                hpx::parallel::traits::is_projected<Proj2, FwdIter2>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    ExPolicy, Pred,
+                    hpx::parallel::traits::projected<Proj1, FwdIter1>,
+                    hpx::parallel::traits::projected<Proj2, FwdIter2>
+                >::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            bool>::type
+        tag_fallback_invoke(hpx::ranges::lexicographical_compare_t,
+            ExPolicy&& policy, FwdIter1 first1, Sent1 last1, FwdIter2 first2,
+            Sent2 last2, Pred&& pred = Pred(), Proj1&& proj1 = Proj1(),
+            Proj2&& proj2 = Proj2())
+        {
+            static_assert(hpx::traits::is_forward_iterator<FwdIter1>::value,
+                "Requires at least forward iterator.");
+            static_assert(hpx::traits::is_forward_iterator<FwdIter2>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::lexicographical_compare().call(
+                std::forward<ExPolicy>(policy), first1, last1, first2, last2,
+                std::forward<Pred>(pred), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename Rng1, typename Rng2,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            typename Pred = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value &&
+                hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
+                hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    hpx::execution::sequenced_policy, Pred,
+                    hpx::parallel::traits::projected_range<Proj1, Rng1>,
+                    hpx::parallel::traits::projected_range<Proj2, Rng2>
+                >::value
+            )>
+        // clang-format on
+        friend bool tag_fallback_invoke(hpx::ranges::lexicographical_compare_t,
+            Rng1&& rng1, Rng2&& rng2, Pred&& pred = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_traits<Rng1>::iterator_type;
+            using iterator_type2 =
+                typename hpx::traits::range_traits<Rng2>::iterator_type;
+
+            static_assert(hpx::traits::is_input_iterator<iterator_type1>::value,
+                "Requires at least input iterator.");
+
+            static_assert(hpx::traits::is_input_iterator<iterator_type2>::value,
+                "Requires at least input iterator.");
+
+            return hpx::parallel::v1::detail::lexicographical_compare().call(
+                hpx::execution::seq, std::begin(rng1), std::end(rng1),
+                std::begin(rng2), std::end(rng2), std::forward<Pred>(pred),
+                std::forward<Proj1>(proj1), std::forward<Proj2>(proj2));
+        }
+
+        // clang-format off
+        template <typename ExPolicy, typename Rng1, typename Rng2,
+            typename Proj1 = hpx::parallel::util::projection_identity,
+            typename Proj2 = hpx::parallel::util::projection_identity,
+            typename Pred = hpx::parallel::v1::detail::less,
+            HPX_CONCEPT_REQUIRES_(
+                hpx::is_execution_policy<ExPolicy>::value &&
+                hpx::traits::is_range<Rng1>::value &&
+                hpx::traits::is_range<Rng2>::value &&
+                hpx::parallel::traits::is_projected_range<Proj1, Rng1>::value &&
+                hpx::parallel::traits::is_projected_range<Proj2, Rng2>::value &&
+                hpx::parallel::traits::is_indirect_callable<
+                    ExPolicy, Pred,
+                    hpx::parallel::traits::projected_range<Proj1, Rng1>,
+                    hpx::parallel::traits::projected_range<Proj2, Rng2>
+                >::value
+            )>
+        // clang-format on
+        friend typename parallel::util::detail::algorithm_result<ExPolicy,
+            bool>::type
+        tag_fallback_invoke(hpx::ranges::lexicographical_compare_t,
+            ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2, Pred&& pred = Pred(),
+            Proj1&& proj1 = Proj1(), Proj2&& proj2 = Proj2())
+        {
+            using iterator_type1 =
+                typename hpx::traits::range_traits<Rng1>::iterator_type;
+            using iterator_type2 =
+                typename hpx::traits::range_traits<Rng2>::iterator_type;
+
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type1>::value,
+                "Requires at least forward iterator.");
+
+            static_assert(
+                hpx::traits::is_forward_iterator<iterator_type2>::value,
+                "Requires at least forward iterator.");
+
+            return hpx::parallel::v1::detail::lexicographical_compare().call(
+                std::forward<ExPolicy>(policy), std::begin(rng1),
+                std::end(rng1), std::begin(rng2), std::end(rng2),
+                std::forward<Pred>(pred), std::forward<Proj1>(proj1),
+                std::forward<Proj2>(proj2));
+        }
+    } lexicographical_compare{};
+}}    // namespace hpx::ranges
+
+#endif

--- a/libs/parallelism/algorithms/tests/unit/algorithms/lexicographical_compare.cpp
+++ b/libs/parallelism/algorithms/tests/unit/algorithms/lexicographical_compare.cpp
@@ -22,6 +22,25 @@
 int seed = std::random_device{}();
 std::mt19937 gen(seed);
 
+template <typename IteratorTag>
+void test_lexicographical_compare1(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), 0);
+
+    //d is lexicographical less than c
+    std::vector<std::size_t> d(10006);
+    std::iota(std::begin(d), std::end(d), 0);
+
+    bool res = hpx::lexicographical_compare(iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(d), std::end(d));
+
+    HPX_TEST(!res);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_lexicographical_compare1(ExPolicy policy, IteratorTag)
 {
@@ -38,9 +57,8 @@ void test_lexicographical_compare1(ExPolicy policy, IteratorTag)
     std::vector<std::size_t> d(10006);
     std::iota(std::begin(d), std::end(d), 0);
 
-    bool res =
-        hpx::parallel::lexicographical_compare(policy, iterator(std::begin(c)),
-            iterator(std::end(c)), std::begin(d), std::end(d));
+    bool res = hpx::lexicographical_compare(policy, iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(d), std::end(d));
 
     HPX_TEST(!res);
 }
@@ -59,7 +77,7 @@ void test_lexicographical_compare1_async(ExPolicy p, IteratorTag)
     std::iota(std::begin(d), std::end(d), 0);
 
     hpx::future<bool> f =
-        hpx::parallel::lexicographical_compare(p, iterator(std::begin(c)),
+        hpx::lexicographical_compare(p, iterator(std::begin(c)),
             iterator(std::end(c)), std::begin(d), std::end(d));
 
     f.wait();
@@ -73,6 +91,7 @@ template <typename IteratorTag>
 void test_lexicographical_compare1()
 {
     using namespace hpx::execution;
+    test_lexicographical_compare1(IteratorTag());
     test_lexicographical_compare1(seq, IteratorTag());
     test_lexicographical_compare1(par, IteratorTag());
     test_lexicographical_compare1(par_unseq, IteratorTag());
@@ -88,6 +107,25 @@ void lexicographical_compare_test1()
 }
 
 ////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_lexicographical_compare2(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    // lexicographically equal, so result is false
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), 0);
+
+    std::vector<std::size_t> d(10007);
+    std::iota(std::begin(d), std::end(d), 0);
+
+    bool res = hpx::lexicographical_compare(iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(d), std::end(d));
+
+    HPX_TEST(!res);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_lexicographical_compare2(ExPolicy policy, IteratorTag)
 {
@@ -104,9 +142,8 @@ void test_lexicographical_compare2(ExPolicy policy, IteratorTag)
     std::vector<std::size_t> d(10007);
     std::iota(std::begin(d), std::end(d), 0);
 
-    bool res =
-        hpx::parallel::lexicographical_compare(policy, iterator(std::begin(c)),
-            iterator(std::end(c)), std::begin(d), std::end(d));
+    bool res = hpx::lexicographical_compare(policy, iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(d), std::end(d));
 
     HPX_TEST(!res);
 }
@@ -125,7 +162,7 @@ void test_lexicographical_compare2_async(ExPolicy p, IteratorTag)
     std::iota(std::begin(d), std::end(d), 0);
 
     hpx::future<bool> f =
-        hpx::parallel::lexicographical_compare(p, iterator(std::begin(c)),
+        hpx::lexicographical_compare(p, iterator(std::begin(c)),
             iterator(std::end(c)), std::begin(d), std::end(d));
 
     f.wait();
@@ -137,6 +174,7 @@ template <typename IteratorTag>
 void test_lexicographical_compare2()
 {
     using namespace hpx::execution;
+    test_lexicographical_compare2(IteratorTag());
     test_lexicographical_compare2(seq, IteratorTag());
     test_lexicographical_compare2(par, IteratorTag());
     test_lexicographical_compare2(par_unseq, IteratorTag());
@@ -152,6 +190,28 @@ void lexicographical_compare_test2()
 }
 
 ////////////////////////////////////////////////////////////////////////////
+template <typename IteratorTag>
+void test_lexicographical_compare3(IteratorTag)
+{
+    typedef std::vector<std::size_t>::iterator base_iterator;
+    typedef test::test_iterator<base_iterator, IteratorTag> iterator;
+
+    // C is lexicographically less due to the (gen() % size + 1)th
+    // element being less than D
+    std::vector<std::size_t> c(10007);
+    std::iota(std::begin(c), std::end(c), 0);
+    std::uniform_int_distribution<> dis(1, 5000);
+    c[dis(gen)] = 0;    //-V108
+
+    std::vector<std::size_t> d(10007);
+    std::iota(std::begin(d), std::end(d), 0);
+
+    bool res = hpx::lexicographical_compare(iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(d), std::end(d));
+
+    HPX_TEST(res);
+}
+
 template <typename ExPolicy, typename IteratorTag>
 void test_lexicographical_compare3(ExPolicy policy, IteratorTag)
 {
@@ -171,9 +231,8 @@ void test_lexicographical_compare3(ExPolicy policy, IteratorTag)
     std::vector<std::size_t> d(10007);
     std::iota(std::begin(d), std::end(d), 0);
 
-    bool res =
-        hpx::parallel::lexicographical_compare(policy, iterator(std::begin(c)),
-            iterator(std::end(c)), std::begin(d), std::end(d));
+    bool res = hpx::lexicographical_compare(policy, iterator(std::begin(c)),
+        iterator(std::end(c)), std::begin(d), std::end(d));
 
     HPX_TEST(res);
 }
@@ -193,7 +252,7 @@ void test_lexicographical_compare3_async(ExPolicy p, IteratorTag)
     std::iota(std::begin(d), std::end(d), 0);
 
     hpx::future<bool> f =
-        hpx::parallel::lexicographical_compare(p, iterator(std::begin(c)),
+        hpx::lexicographical_compare(p, iterator(std::begin(c)),
             iterator(std::end(c)), std::begin(d), std::end(d));
 
     f.wait();
@@ -205,6 +264,7 @@ template <typename IteratorTag>
 void test_lexicographical_compare3()
 {
     using namespace hpx::execution;
+    test_lexicographical_compare3(IteratorTag());
     test_lexicographical_compare3(seq, IteratorTag());
     test_lexicographical_compare3(par, IteratorTag());
     test_lexicographical_compare3(par_unseq, IteratorTag());
@@ -239,7 +299,7 @@ void test_lexicographical_compare_exception(ExPolicy policy, IteratorTag)
     bool caught_exception = false;
     try
     {
-        hpx::parallel::lexicographical_compare(policy,
+        hpx::lexicographical_compare(policy,
             decorated_iterator(
                 std::begin(c), []() { throw std::runtime_error("test"); }),
             decorated_iterator(
@@ -277,7 +337,7 @@ void test_lexicographical_compare_async_exception(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<bool> f = hpx::parallel::lexicographical_compare(p,
+        hpx::future<bool> f = hpx::lexicographical_compare(p,
             decorated_iterator(
                 std::begin(c), []() { throw std::runtime_error("test"); }),
             decorated_iterator(
@@ -342,7 +402,7 @@ void test_lexicographical_compare_bad_alloc(ExPolicy policy, IteratorTag)
     bool caught_bad_alloc = false;
     try
     {
-        hpx::parallel::lexicographical_compare(policy,
+        hpx::lexicographical_compare(policy,
             decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c), []() { throw std::bad_alloc(); }),
             std::begin(h), std::end(h));
@@ -377,7 +437,7 @@ void test_lexicographical_compare_async_bad_alloc(ExPolicy p, IteratorTag)
     bool returned_from_algorithm = false;
     try
     {
-        hpx::future<bool> f = hpx::parallel::lexicographical_compare(p,
+        hpx::future<bool> f = hpx::lexicographical_compare(p,
             decorated_iterator(std::begin(c), []() { throw std::bad_alloc(); }),
             decorated_iterator(std::end(c), []() { throw std::bad_alloc(); }),
             std::begin(h), std::end(h));

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/CMakeLists.txt
@@ -53,6 +53,7 @@ set(tests
     is_partitioned_projection_range
     is_sorted_range
     is_sorted_until_range
+    lexicographical_compare_range
     make_heap_range
     max_element_range
     merge_range

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/lexicographical_compare_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/lexicographical_compare_range.cpp
@@ -1,0 +1,281 @@
+//  Copyright (c) 2018 Christopher Ogle
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/iterator_support/tests/iter_sent.hpp>
+#include <hpx/local/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/container_algorithms/lexicographical_compare.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+#include <algorithm>
+
+#include "test_utils.hpp"
+
+////////////////////////////////////////////////////////////////////////////
+unsigned int seed;
+std::mt19937 gen;
+std::uniform_int_distribution<> dis(0, 25);
+
+void test_fill_sent()
+{
+    std::vector<char> c1(10);
+    std::generate(
+        std::begin(c1), std::end(c1), []() { return 'a' + dis(gen); });
+
+    std::vector<char> c2(10);
+    std::generate(
+        std::begin(c2), std::end(c2), []() { return 'a' + dis(gen); });
+
+    bool actual_result1 = std::lexicographical_compare(
+        std::begin(c1), std::begin(c1) + 5, std::begin(c2), std::begin(c2) + 5);
+    bool result1 = hpx::ranges::lexicographical_compare(std::begin(c1),
+        sentinel<char>{*(std::begin(c1) + 5)}, std::begin(c2),
+        sentinel<char>{*(std::begin(c2) + 5)});
+
+    bool actual_result2 = std::lexicographical_compare(
+        std::begin(c2), std::begin(c2) + 5, std::begin(c1), std::begin(c1) + 5);
+    bool result2 = hpx::ranges::lexicographical_compare(std::begin(c2),
+        sentinel<char>{*(std::begin(c2) + 5)}, std::begin(c1),
+        sentinel<char>{*(std::begin(c1) + 5)});
+
+    bool actual_result3 = std::lexicographical_compare(
+        std::begin(c1), std::begin(c1) + 5, std::begin(c1), std::begin(c1) + 5);
+    bool result3 = hpx::ranges::lexicographical_compare(std::begin(c1),
+        sentinel<char>{*(std::begin(c1) + 5)}, std::begin(c1),
+        sentinel<char>{*(std::begin(c1) + 5)});
+
+    HPX_TEST_EQ(actual_result1, result1);
+    HPX_TEST_EQ(actual_result2, result2);
+    HPX_TEST_EQ(actual_result3, result3);
+
+    // check corner cases
+    std::vector<char> c3 = {1, 1, 1, 1, 3, 2, 2, 8};
+    std::vector<char> c4 = {1, 1, 1, 1, 3, 5, 5, 8};
+    auto result4 = hpx::ranges::lexicographical_compare(
+        std::begin(c3), sentinel<char>{3}, std::begin(c4), sentinel<char>{3});
+    auto result5 = hpx::ranges::lexicographical_compare(
+        std::begin(c3), sentinel<char>{8}, std::begin(c4), sentinel<char>{8});
+
+    HPX_TEST_EQ(false, result4);
+    HPX_TEST_EQ(true, result5);
+}
+
+template <typename ExPolicy>
+void test_fill_sent(ExPolicy policy)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    std::vector<char> c1(10);
+    std::generate(
+        std::begin(c1), std::end(c1), []() { return 'a' + dis(gen); });
+
+    std::vector<char> c2(10);
+    std::generate(
+        std::begin(c2), std::end(c2), []() { return 'a' + dis(gen); });
+
+    bool actual_result1 = std::lexicographical_compare(
+        std::begin(c1), std::begin(c1) + 5, std::begin(c2), std::begin(c2) + 5);
+    bool result1 = hpx::ranges::lexicographical_compare(policy, std::begin(c1),
+        sentinel<char>{*(std::begin(c1) + 5)}, std::begin(c2),
+        sentinel<char>{*(std::begin(c2) + 5)});
+
+    bool actual_result2 = std::lexicographical_compare(
+        std::begin(c2), std::begin(c2) + 5, std::begin(c1), std::begin(c1) + 5);
+    bool result2 = hpx::ranges::lexicographical_compare(policy, std::begin(c2),
+        sentinel<char>{*(std::begin(c2) + 5)}, std::begin(c1),
+        sentinel<char>{*(std::begin(c1) + 5)});
+
+    bool actual_result3 = std::lexicographical_compare(
+        std::begin(c1), std::begin(c1) + 5, std::begin(c1), std::begin(c1) + 5);
+    bool result3 = hpx::ranges::lexicographical_compare(policy, std::begin(c1),
+        sentinel<char>{*(std::begin(c1) + 5)}, std::begin(c1),
+        sentinel<char>{*(std::begin(c1) + 5)});
+
+    HPX_TEST_EQ(actual_result1, result1);
+    HPX_TEST_EQ(actual_result2, result2);
+    HPX_TEST_EQ(actual_result3, result3);
+
+    // check corner cases
+    std::vector<char> c3 = {1, 1, 1, 1, 3, 2, 2, 8};
+    std::vector<char> c4 = {1, 1, 1, 1, 3, 5, 5, 8};
+    auto result4 = hpx::ranges::lexicographical_compare(policy, std::begin(c3),
+        sentinel<char>{3}, std::begin(c4), sentinel<char>{3});
+    auto result5 = hpx::ranges::lexicographical_compare(policy, std::begin(c3),
+        sentinel<char>{8}, std::begin(c4), sentinel<char>{8});
+
+    HPX_TEST_EQ(false, result4);
+    HPX_TEST_EQ(true, result5);
+}
+
+template <typename IteratorTag>
+void test_lexicographical_compare(IteratorTag)
+{
+    std::vector<char> c1(10);
+    std::generate(std::begin(c1), std::end(c1),
+        []() { return 'a' + dis(gen); });
+
+    std::vector<char> c2(10);
+    std::generate(
+        std::begin(c2), std::end(c2), []() { return 'a' + dis(gen); });
+
+    bool actual_result1 = std::lexicographical_compare(
+        std::begin(c1), std::end(c1), std::begin(c2), std::end(c2));
+    bool result1 = hpx::ranges::lexicographical_compare(c1, c2);
+
+    bool actual_result2 = std::lexicographical_compare(
+        std::begin(c1), std::end(c1), std::begin(c2), std::end(c2));
+    bool result2 = hpx::ranges::lexicographical_compare(c1, c2);
+
+    bool actual_result3 = std::lexicographical_compare(
+        std::begin(c1), std::end(c1), std::begin(c2), std::end(c2));
+    bool result3 = hpx::ranges::lexicographical_compare(c1, c2);
+
+    HPX_TEST_EQ(actual_result1, result1);
+    HPX_TEST_EQ(actual_result2, result2);
+    HPX_TEST_EQ(actual_result3, result3);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_lexicographical_compare(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    std::vector<char> c1(10);
+    std::generate(
+        std::begin(c1), std::end(c1), []() { return 'a' + dis(gen); });
+
+    std::vector<char> c2(10);
+    std::generate(
+        std::begin(c2), std::end(c2), []() { return 'a' + dis(gen); });
+
+    bool actual_result1 = std::lexicographical_compare(
+        std::begin(c1), std::end(c1), std::begin(c2), std::end(c2));
+    bool result1 = hpx::ranges::lexicographical_compare(policy, c1, c2);
+
+    bool actual_result2 = std::lexicographical_compare(
+        std::begin(c1), std::end(c1), std::begin(c2), std::end(c2));
+    bool result2 = hpx::ranges::lexicographical_compare(policy, c1, c2);
+
+    bool actual_result3 = std::lexicographical_compare(
+        std::begin(c1), std::end(c1), std::begin(c2), std::end(c2));
+    bool result3 = hpx::ranges::lexicographical_compare(policy, c1, c2);
+
+    HPX_TEST_EQ(actual_result1, result1);
+    HPX_TEST_EQ(actual_result2, result2);
+    HPX_TEST_EQ(actual_result3, result3);
+}
+
+template <typename ExPolicy, typename IteratorTag>
+void test_fill_async(ExPolicy policy, IteratorTag)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    std::vector<char> c1(10);
+    std::generate(
+        std::begin(c1), std::end(c1), []() { return 'a' + dis(gen); });
+
+    std::vector<char> c2(10);
+    std::generate(
+        std::begin(c2), std::end(c2), []() { return 'a' + dis(gen); });
+
+    bool actual_result1 = std::lexicographical_compare(
+        std::begin(c1), std::end(c1), std::begin(c2), std::end(c2));
+    hpx::future<bool> result1 =
+        hpx::ranges::lexicographical_compare(policy, c1, c2);
+
+    bool actual_result2 = std::lexicographical_compare(
+        std::begin(c1), std::end(c1), std::begin(c2), std::end(c2));
+    hpx::future<bool> result2 =
+        hpx::ranges::lexicographical_compare(policy, c1, c2);
+
+    bool actual_result3 = std::lexicographical_compare(
+        std::begin(c1), std::end(c1), std::begin(c2), std::end(c2));
+    hpx::future<bool> result3 =
+        hpx::ranges::lexicographical_compare(policy, c1, c2);
+
+    result1.wait();
+    result2.wait();
+    result3.wait();
+
+    HPX_TEST_EQ(actual_result1, result1.get());
+    HPX_TEST_EQ(actual_result2, result2.get());
+    HPX_TEST_EQ(actual_result3, result3.get());
+}
+
+template <typename IteratorTag>
+void test_lexicographical_compare()
+{
+    using namespace hpx::execution;
+
+    test_lexicographical_compare(IteratorTag());
+    test_lexicographical_compare(seq, IteratorTag());
+    test_lexicographical_compare(par, IteratorTag());
+    test_lexicographical_compare(par_unseq, IteratorTag());
+
+    test_fill_async(seq(task), IteratorTag());
+    test_fill_async(par(task), IteratorTag());
+
+    test_fill_sent();
+    test_fill_sent(seq);
+    test_fill_sent(par);
+    test_fill_sent(par_unseq);
+}
+
+void lexicographical_compare_test()
+{
+    test_lexicographical_compare<std::random_access_iterator_tag>();
+    test_lexicographical_compare<std::forward_iterator_tag>();
+}
+
+////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed1 = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed1 = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed1 << std::endl;
+    std::srand(seed1);
+
+    seed = seed1;
+    gen = std::mt19937(seed);
+
+    lexicographical_compare_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/lexicographical_compare_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/lexicographical_compare_range.cpp
@@ -28,11 +28,11 @@ std::uniform_int_distribution<> dis(0, 25);
 void test_fill_sent()
 {
     // ensure all characters are unique
-    std::unordered_set<char> uset;
+    std::unordered_set<unsigned char> uset;
 
     std::vector<char> c1(7);
     std::generate(std::begin(c1), std::end(c1), [&uset]() {
-        char c = 'a' + dis(gen);
+        unsigned char c = 'a' + dis(gen);
         while (uset.find(c) != uset.end())
         {
             c = 'a' + dis(gen);
@@ -44,7 +44,7 @@ void test_fill_sent()
     uset.clear();
     std::vector<char> c2(7);
     std::generate(std::begin(c2), std::end(c2), [&uset]() {
-        char c = 'a' + dis(gen);
+        unsigned char c = 'a' + dis(gen);
         while (uset.find(c) != uset.end())
         {
             c = 'a' + dis(gen);
@@ -94,11 +94,11 @@ void test_fill_sent(ExPolicy policy)
         "hpx::is_execution_policy<ExPolicy>::value");
 
     // ensure all characters are unique
-    std::unordered_set<char> uset;
+    std::unordered_set<unsigned char> uset;
 
     std::vector<char> c1(7);
     std::generate(std::begin(c1), std::end(c1), [&uset]() {
-        char c = 'a' + dis(gen);
+        unsigned char c = 'a' + dis(gen);
         while (uset.find(c) != uset.end())
         {
             c = 'a' + dis(gen);
@@ -110,7 +110,7 @@ void test_fill_sent(ExPolicy policy)
     uset.clear();
     std::vector<char> c2(7);
     std::generate(std::begin(c2), std::end(c2), [&uset]() {
-        char c = 'a' + dis(gen);
+        unsigned char c = 'a' + dis(gen);
         while (uset.find(c) != uset.end())
         {
             c = 'a' + dis(gen);

--- a/libs/parallelism/algorithms/tests/unit/container_algorithms/lexicographical_compare_range.cpp
+++ b/libs/parallelism/algorithms/tests/unit/container_algorithms/lexicographical_compare_range.cpp
@@ -10,13 +10,13 @@
 #include <hpx/modules/testing.hpp>
 #include <hpx/parallel/container_algorithms/lexicographical_compare.hpp>
 
-#include <cstddef>
+#include <algorithm>
 #include <iostream>
 #include <iterator>
-#include <numeric>
+#include <random>
 #include <string>
+#include <unordered_set>
 #include <vector>
-#include <algorithm>
 
 #include "test_utils.hpp"
 
@@ -27,13 +27,31 @@ std::uniform_int_distribution<> dis(0, 25);
 
 void test_fill_sent()
 {
-    std::vector<char> c1(10);
-    std::generate(
-        std::begin(c1), std::end(c1), []() { return 'a' + dis(gen); });
+    // ensure all characters are unique
+    std::unordered_set<char> uset;
 
-    std::vector<char> c2(10);
-    std::generate(
-        std::begin(c2), std::end(c2), []() { return 'a' + dis(gen); });
+    std::vector<char> c1(7);
+    std::generate(std::begin(c1), std::end(c1), [&uset]() {
+        char c = 'a' + dis(gen);
+        while (uset.find(c) != uset.end())
+        {
+            c = 'a' + dis(gen);
+        }
+        uset.insert(c);
+        return c;
+    });
+
+    uset.clear();
+    std::vector<char> c2(7);
+    std::generate(std::begin(c2), std::end(c2), [&uset]() {
+        char c = 'a' + dis(gen);
+        while (uset.find(c) != uset.end())
+        {
+            c = 'a' + dis(gen);
+        }
+        uset.insert(c);
+        return c;
+    });
 
     bool actual_result1 = std::lexicographical_compare(
         std::begin(c1), std::begin(c1) + 5, std::begin(c2), std::begin(c2) + 5);
@@ -75,13 +93,31 @@ void test_fill_sent(ExPolicy policy)
     static_assert(hpx::is_execution_policy<ExPolicy>::value,
         "hpx::is_execution_policy<ExPolicy>::value");
 
-    std::vector<char> c1(10);
-    std::generate(
-        std::begin(c1), std::end(c1), []() { return 'a' + dis(gen); });
+    // ensure all characters are unique
+    std::unordered_set<char> uset;
 
-    std::vector<char> c2(10);
-    std::generate(
-        std::begin(c2), std::end(c2), []() { return 'a' + dis(gen); });
+    std::vector<char> c1(7);
+    std::generate(std::begin(c1), std::end(c1), [&uset]() {
+        char c = 'a' + dis(gen);
+        while (uset.find(c) != uset.end())
+        {
+            c = 'a' + dis(gen);
+        }
+        uset.insert(c);
+        return c;
+    });
+
+    uset.clear();
+    std::vector<char> c2(7);
+    std::generate(std::begin(c2), std::end(c2), [&uset]() {
+        char c = 'a' + dis(gen);
+        while (uset.find(c) != uset.end())
+        {
+            c = 'a' + dis(gen);
+        }
+        uset.insert(c);
+        return c;
+    });
 
     bool actual_result1 = std::lexicographical_compare(
         std::begin(c1), std::begin(c1) + 5, std::begin(c2), std::begin(c2) + 5);
@@ -121,8 +157,8 @@ template <typename IteratorTag>
 void test_lexicographical_compare(IteratorTag)
 {
     std::vector<char> c1(10);
-    std::generate(std::begin(c1), std::end(c1),
-        []() { return 'a' + dis(gen); });
+    std::generate(
+        std::begin(c1), std::end(c1), []() { return 'a' + dis(gen); });
 
     std::vector<char> c2(10);
     std::generate(


### PR DESCRIPTION
Adapted lexicographical_compare to C++ 20 and added container overloads. (range and sentinel)

## Any background context you want to provide?
Issue #4822
Issue #3646
Issue #1668