### PR TITLE
Adding enable_logging/disable_logging API functions

### DIFF
--- a/libs/core/logging/include/hpx/logging/manipulator.hpp
+++ b/libs/core/logging/include/hpx/logging/manipulator.hpp
@@ -39,7 +39,7 @@ namespace hpx { namespace util { namespace logging {
         /// @brief What to use as base class, for your formatter classes
         struct HPX_CORE_EXPORT manipulator
         {
-            virtual void operator()(std::ostream& to) const = 0;
+            virtual void operator()(std::ostream&) const = 0;
 
             friend void format_value(std::ostream& os,
                 boost::string_ref /*spec*/, manipulator const& value)
@@ -72,7 +72,7 @@ namespace hpx { namespace util { namespace logging {
         /// @brief What to use as base class, for your destination classes
         struct HPX_CORE_EXPORT manipulator
         {
-            virtual void operator()(message const& val) = 0;
+            virtual void operator()(message const&) = 0;
 
             /// @brief Override this if you want to allow configuration through
             /// scripting.

--- a/libs/core/logging/include/hpx/modules/logging.hpp
+++ b/libs/core/logging/include/hpx/modules/logging.hpp
@@ -18,7 +18,7 @@ namespace hpx {
         destination_app = 4,
         destination_debuglog = 5
     };
-}
+}    // namespace hpx
 
 #if defined(HPX_HAVE_LOGGING)
 
@@ -42,6 +42,7 @@ namespace hpx {
 
 ////////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace util {
+
     ////////////////////////////////////////////////////////////////////////////
     namespace detail {
         HPX_CORE_EXPORT hpx::util::logging::level get_log_level(

--- a/libs/core/logging/src/logging.cpp
+++ b/libs/core/logging/src/logging.cpp
@@ -96,4 +96,17 @@ namespace hpx { namespace util { namespace logging {
 
 }}}    // namespace hpx::util::logging
 
+#else
+
+namespace hpx { namespace util {
+
+    //////////////////////////////////////////////////////////////////////////
+    void enable_logging(
+        logging_destination, std::string const&, std::string, std::string)
+    {
+    }
+
+    void disable_logging(logging_destination dest) {}
+}}    // namespace hpx::util
+
 #endif    // HPX_HAVE_LOGGING

--- a/libs/full/init_runtime/CMakeLists.txt
+++ b/libs/full/init_runtime/CMakeLists.txt
@@ -21,7 +21,7 @@ set(init_runtime_headers
     hpx/init_runtime/detail/init_logging.hpp
 )
 
-set(init_runtime_sources hpx_init.cpp hpx_main_winsocket.cpp)
+set(init_runtime_sources hpx_init.cpp hpx_main_winsocket.cpp init_logging.cpp)
 
 if(HPX_WITH_DISTRIBUTED_RUNTIME)
   set(init_runtime_headers ${init_runtime_headers}

--- a/libs/full/init_runtime/include/hpx/init_runtime/detail/init_logging.hpp
+++ b/libs/full/init_runtime/include/hpx/init_runtime/detail/init_logging.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -8,139 +8,15 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/init_runtime_local/detail/init_logging.hpp>
 
 #if defined(HPX_HAVE_LOGGING)
-#include <hpx/ini/ini.hpp>
-#include <hpx/init_runtime_local/detail/init_logging.hpp>
-#include <hpx/runtime_local/runtime_local_fwd.hpp>
-
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
-#include <hpx/agas/addressing_service.hpp>
-#include <hpx/runtime_components/console_logging.hpp>
-#endif
-
-#include <cstddef>
-#include <cstdint>
-#include <cstdlib>
-#include <ostream>
-#include <string>
-#include <vector>
-
-#if defined(ANDROID) || defined(__ANDROID__)
-#include <android/log.h>
-#endif
-
-#if defined(HPX_MSVC_WARNING_PRAGMA)
-#pragma warning(push)
-#pragma warning(                                                               \
-    disable : 4250)    // 'class1' : inherits 'class2::member' via dominance
-#endif
+#include <hpx/runtime_configuration/runtime_configuration.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace util {
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
-    ///////////////////////////////////////////////////////////////////////////
-    // custom formatter: HPX component id of current thread
-    struct thread_component_id : logging::formatter::manipulator
-    {
-        void operator()(std::ostream& to) const override
-        {
-            std::uint64_t component_id = threads::get_self_component_id();
-            if (0 != component_id)
-            {
-                // called from inside a HPX thread
-                util::format_to(to, "{:016x}", component_id);
-            }
-            else
-            {
-                // called from outside a HPX thread
-                to << std::string(16, '-');
-            }
-        }
-    };
-#endif
+namespace hpx { namespace util { namespace detail {
 
-    ///////////////////////////////////////////////////////////////////////////
-    // custom log destination: send generated strings to console
-    struct console : logging::destination::manipulator
-    {
-        console(logging::level level, logging_destination dest)
-          : level_(level)
-          , dest_(dest)
-        {
-        }
-
-        void operator()(logging::message const& msg) override
-        {
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
-            components::console_logging(
-                dest_, static_cast<std::size_t>(level_), msg.full_string());
-#else
-            switch (dest_)
-            {
-            default:
-            case destination_hpx:
-                LHPX_CONSOLE_(level_) << msg;
-                break;
-
-            case destination_timing:
-                LTIM_CONSOLE_(level_) << msg;
-                break;
-
-            case destination_agas:
-                LAGAS_CONSOLE_(level_) << msg;
-                break;
-
-            case destination_parcel:
-                LPT_CONSOLE_(level_) << msg;
-                break;
-
-            case destination_app:
-                LAPP_CONSOLE_(level_) << msg;
-                break;
-
-            case destination_debuglog:
-                LDEB_CONSOLE_ << msg;
-                break;
-            }
-#endif
-        }
-
-        bool operator==(console const& rhs) const
-        {
-            return dest_ == rhs.dest_;
-        }
-
-        logging::level level_;
-        logging_destination dest_;
-    };    // namespace util
-
-    namespace detail {
-        inline void define_formatters(logger_writer_type& writer)
-        {
-            writer.set_formatter("osthread", shepherd_thread_id());
-            writer.set_formatter("locality", locality_prefix());
-            writer.set_formatter("hpxthread", thread_id());
-            writer.set_formatter("hpxphase", thread_phase());
-            writer.set_formatter("hpxparent", parent_thread_id());
-            writer.set_formatter("hpxparentphase", parent_thread_phase());
-            writer.set_formatter("parentloc", parent_thread_locality());
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
-            writer.set_formatter("hpxcomponent", thread_component_id());
-#endif
-        }
-    }    // namespace detail
-}}       // namespace hpx::util
-
-#else
-
-#include <hpx/init_runtime_local/detail/init_logging.hpp>
-
-namespace hpx { namespace util {
-    struct console;
-    namespace detail {
-        inline void define_formatters() {}
-    }    // namespace detail
-}}       // namespace hpx::util
+    HPX_EXPORT void init_logging_full(runtime_configuration&);
+}}}    // namespace hpx::util::detail
 
 #endif

--- a/libs/full/init_runtime/src/hpx_init.cpp
+++ b/libs/full/init_runtime/src/hpx_init.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c)      2017 Shoshana Jakobovits
 //  Copyright (c) 2010-2011 Phillip LeBlanc, Dylan Stark
 //  Copyright (c)      2011 Bryce Lelbach
@@ -372,9 +372,11 @@ namespace hpx {
                 cmdline.rtcfg_.get_spinlock_deadlock_detection_limit());
 #endif
 
-            util::detail::init_logging<util::console>(cmdline.rtcfg_,
-                cmdline.rtcfg_.mode_ == runtime_mode::console,
-                util::detail::define_formatters);
+#if defined(HPX_HAVE_LOGGING)
+            util::detail::init_logging_full(cmdline.rtcfg_);
+#else
+            util::detail::warn_if_logging_requested(cmdline.rtcfg_);
+#endif
 
 #if defined(HPX_HAVE_NETWORKING)
             if (cmdline.num_localities_ != 1 || cmdline.node_ != 0 ||

--- a/libs/full/init_runtime/src/init_logging.cpp
+++ b/libs/full/init_runtime/src/init_logging.cpp
@@ -1,0 +1,93 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_LOGGING)
+#include <hpx/init_runtime/detail/init_logging.hpp>
+#include <hpx/modules/logging.hpp>
+#include <hpx/runtime_configuration/runtime_mode.hpp>
+
+#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
+#include <hpx/runtime_components/console_logging.hpp>
+#include <hpx/threading_base/thread_data.hpp>
+#endif
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <string>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace util {
+
+#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
+    ///////////////////////////////////////////////////////////////////////////
+    // custom formatter: HPX component id of current thread
+    struct thread_component_id : logging::formatter::manipulator
+    {
+        void operator()(std::ostream& to) const override
+        {
+            std::uint64_t component_id = threads::get_self_component_id();
+            if (0 != component_id)
+            {
+                // called from inside a HPX thread
+                util::format_to(to, "{:016x}", component_id);
+            }
+            else
+            {
+                // called from outside a HPX thread
+                to << std::string(16, '-');
+            }
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    // custom log destination: send generated strings to console
+    struct console : console_local
+    {
+        console(logging::level level, logging_destination dest)
+          : console_local(level, dest)
+        {
+        }
+
+        void operator()(logging::message const& msg) override
+        {
+            components::console_logging(
+                dest_, static_cast<std::size_t>(level_), msg.full_string());
+        }
+    };    // namespace util
+#else
+    using console = console_local;
+#endif
+
+    namespace detail {
+
+        void get_console(logging::writer::named_write& writer, char const* name,
+            logging::level lvl, logging_destination dest)
+        {
+            writer.set_destination(name, console(lvl, dest));
+        }
+
+        void define_formatters(logging::writer::named_write& writer)
+        {
+            define_common_formatters(writer);
+
+#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
+            writer.set_formatter("hpxcomponent", thread_component_id());
+#endif
+        }
+
+        void init_logging_full(runtime_configuration& ini)
+        {
+            init_logging(ini, ini.mode_ == runtime_mode::console, get_console,
+                define_formatters);
+        }
+    }    // namespace detail
+}}       // namespace hpx::util
+
+#endif

--- a/libs/full/init_runtime_local/include/hpx/init_runtime_local/detail/init_logging.hpp
+++ b/libs/full/init_runtime_local/include/hpx/init_runtime_local/detail/init_logging.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -8,193 +8,16 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/modules/logging.hpp>
+#include <hpx/runtime_configuration/runtime_configuration.hpp>
+
+#include <string>
 
 #if defined(HPX_HAVE_LOGGING)
-#include <hpx/logging/format/named_write.hpp>
-#include <hpx/logging/manipulator.hpp>
-#include <hpx/modules/logging.hpp>
-#include <hpx/modules/threading_base.hpp>
-#include <hpx/runtime_configuration/runtime_configuration.hpp>
-#include <hpx/runtime_local/get_locality_id.hpp>
-#include <hpx/threading_base/thread_data.hpp>
-#include <hpx/type_support/static.hpp>
-#include <hpx/util/get_entry_as.hpp>
-
-#include <cstddef>
-#include <cstdint>
-#include <cstdlib>
-#include <ostream>
-#include <string>
-#include <vector>
-
-#if defined(ANDROID) || defined(__ANDROID__)
-#include <android/log.h>
-#endif
-
-#if defined(HPX_MSVC_WARNING_PRAGMA)
-#pragma warning(push)
-#pragma warning(                                                               \
-    disable : 4250)    // 'class1' : inherits 'class2::member' via dominance
-#endif
-
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace util {
-    using logger_writer_type = logging::writer::named_write;
 
-    ///////////////////////////////////////////////////////////////////////////
-    // custom formatter: shepherd
-    struct shepherd_thread_id : logging::formatter::manipulator
-    {
-        shepherd_thread_id() {}
-
-        void operator()(std::ostream& to) const override
-        {
-            error_code ec(lightweight);
-            std::size_t thread_num = hpx::get_worker_thread_num(ec);
-
-            if (std::size_t(-1) != thread_num)
-            {
-                util::format_to(to, "{:016x}", thread_num);
-            }
-            else
-            {
-                to << std::string(16, '-');
-            }
-        }
-    };
-
-    ///////////////////////////////////////////////////////////////////////////
-    // custom formatter: locality prefix
-    struct locality_prefix : logging::formatter::manipulator
-    {
-        locality_prefix() {}
-
-        void operator()(std::ostream& to) const override
-        {
-            std::uint32_t locality_id = hpx::get_locality_id();
-
-            if (~static_cast<std::uint32_t>(0) != locality_id)
-            {
-                util::format_to(to, "{:08x}", locality_id);
-            }
-            else
-            {
-                // called from outside a HPX thread
-                to << std::string(8, '-');
-            }
-        }
-    };
-
-    ///////////////////////////////////////////////////////////////////////////
-    // custom formatter: HPX thread id
-    struct thread_id : logging::formatter::manipulator
-    {
-        void operator()(std::ostream& to) const override
-        {
-            threads::thread_self* self = threads::get_self_ptr();
-            if (nullptr != self)
-            {
-                // called from inside a HPX thread
-                threads::thread_id_type id = threads::get_self_id();
-                if (id != threads::invalid_thread_id)
-                {
-                    std::ptrdiff_t value =
-                        reinterpret_cast<std::ptrdiff_t>(id.get());
-                    util::format_to(to, "{:016x}", value);
-                    return;
-                }
-            }
-
-            // called from outside a HPX thread or invalid thread id
-            to << std::string(16, '-');
-        }
-    };
-
-    ///////////////////////////////////////////////////////////////////////////
-    // custom formatter: HPX thread phase
-    struct thread_phase : logging::formatter::manipulator
-    {
-        void operator()(std::ostream& to) const override
-        {
-            threads::thread_self* self = threads::get_self_ptr();
-            if (nullptr != self)
-            {
-                // called from inside a HPX thread
-                std::size_t phase = self->get_thread_phase();
-                if (0 != phase)
-                {
-                    util::format_to(to, "{:04x}", self->get_thread_phase());
-                    return;
-                }
-            }
-
-            // called from outside a HPX thread or no phase given
-            to << std::string(4, '-');
-        }
-    };
-
-    ///////////////////////////////////////////////////////////////////////////
-    // custom formatter: locality prefix of parent thread
-    struct parent_thread_locality : logging::formatter::manipulator
-    {
-        void operator()(std::ostream& to) const override
-        {
-            std::uint32_t parent_locality_id =
-                threads::get_parent_locality_id();
-            if (~static_cast<std::uint32_t>(0) != parent_locality_id)
-            {
-                // called from inside a HPX thread
-                util::format_to(to, "{:08x}", parent_locality_id);
-            }
-            else
-            {
-                // called from outside a HPX thread
-                to << std::string(8, '-');
-            }
-        }
-    };
-
-    ///////////////////////////////////////////////////////////////////////////
-    // custom formatter: HPX parent thread id
-    struct parent_thread_id : logging::formatter::manipulator
-    {
-        void operator()(std::ostream& to) const override
-        {
-            threads::thread_id_type parent_id = threads::get_parent_id();
-            if (nullptr != parent_id && threads::invalid_thread_id != parent_id)
-            {
-                // called from inside a HPX thread
-                std::ptrdiff_t value =
-                    reinterpret_cast<std::ptrdiff_t>(parent_id.get());
-                util::format_to(to, "{:016x}", value);
-            }
-            else
-            {
-                // called from outside a HPX thread
-                to << std::string(16, '-');
-            }
-        }
-    };
-
-    ///////////////////////////////////////////////////////////////////////////
-    // custom formatter: HPX parent thread phase
-    struct parent_thread_phase : logging::formatter::manipulator
-    {
-        void operator()(std::ostream& to) const override
-        {
-            std::size_t parent_phase = threads::get_parent_phase();
-            if (0 != parent_phase)
-            {
-                // called from inside a HPX thread
-                util::format_to(to, "{:04x}", parent_phase);
-            }
-            else
-            {
-                // called from outside a HPX thread
-                to << std::string(4, '-');
-            }
-        }
-    };
+    /// \cond NOINTERNAL
 
     ///////////////////////////////////////////////////////////////////////////
     // custom log destination: send generated strings to console
@@ -206,557 +29,71 @@ namespace hpx { namespace util {
         {
         }
 
-        void operator()(logging::message const& msg) override
+        HPX_EXPORT void operator()(logging::message const& msg) override;
+
+        friend bool operator==(
+            console_local const& lhs, console_local const& rhs)
         {
-            switch (dest_)
-            {
-            default:
-            case destination_hpx:
-                LHPX_CONSOLE_(level_) << msg;
-                break;
-
-            case destination_timing:
-                LTIM_CONSOLE_(level_) << msg;
-                break;
-
-            case destination_agas:
-                LAGAS_CONSOLE_(level_) << msg;
-                break;
-
-            case destination_parcel:
-                LPT_CONSOLE_(level_) << msg;
-                break;
-
-            case destination_app:
-                LAPP_CONSOLE_(level_) << msg;
-                break;
-
-            case destination_debuglog:
-                LDEB_CONSOLE_ << msg;
-                break;
-            }
-        }
-
-        bool operator==(console_local const& rhs) const
-        {
-            return dest_ == rhs.dest_;
+            return lhs.dest_ == rhs.dest_;
         }
 
         logging::level level_;
         logging_destination dest_;
-    };    // namespace util
-
-#if defined(ANDROID) || defined(__ANDROID__)
-    // default log destination for Android
-    struct android_log : logging::destination::manipulator
-    {
-        android_log(char const* tag_)
-          : tag(tag_)
-        {
-        }
-
-        void operator()(logging::message const& msg) override
-        {
-            __android_log_write(
-                ANDROID_LOG_DEBUG, tag.c_str(), msg.full_string().c_str());
-        }
-
-        bool operator==(android_log const& rhs) const
-        {
-            return tag == rhs.tag;
-        }
-
-        std::string tag;
     };
-#endif
 
+    ///////////////////////////////////////////////////////////////////////////
     namespace detail {
-        // unescape config entry
-        inline std::string unescape(std::string const& value)
+
+        struct log_settings
         {
-            std::string result;
-            std::string::size_type pos = 0;
-            std::string::size_type pos1 = value.find_first_of('\\', 0);
-            if (std::string::npos != pos1)
-            {
-                do
-                {
-                    switch (value[pos1 + 1])
-                    {
-                    case '\\':
-                    case '\"':
-                    case '?':
-                        result = result + value.substr(pos, pos1 - pos);
-                        pos1 = value.find_first_of('\\', (pos = pos1 + 1) + 1);
-                        break;
+            std::string level_;
+            std::string dest_;
+            std::string format_;
+        };
 
-                    case 'n':
-                        result = result + value.substr(pos, pos1 - pos) + "\n";
-                        pos1 = value.find_first_of('\\', pos = pos1 + 1);
-                        ++pos;
-                        break;
+        HPX_EXPORT void define_common_formatters(
+            logging::writer::named_write& writer);
 
-                    default:
-                        result = result + value.substr(pos, pos1 - pos + 1);
-                        pos1 = value.find_first_of('\\', pos = pos1 + 1);
-                    }
+        HPX_EXPORT void define_formatters_local(
+            logging::writer::named_write& writer);
 
-                } while (pos1 != std::string::npos);
-                result = result + value.substr(pos);
-            }
-            else
-            {
-                // the string doesn't contain any escaped character sequences
-                result = value;
-            }
-            return result;
-        }
+        HPX_EXPORT log_settings get_log_settings(
+            util::section const&, char const*);
 
-        inline void define_formatters_local(logger_writer_type& writer)
-        {
-            writer.set_formatter("osthread", shepherd_thread_id());
-            writer.set_formatter("locality", locality_prefix());
-            writer.set_formatter("hpxthread", thread_id());
-            writer.set_formatter("hpxphase", thread_phase());
-            writer.set_formatter("hpxparent", parent_thread_id());
-            writer.set_formatter("hpxparentphase", parent_thread_phase());
-            writer.set_formatter("parentloc", parent_thread_locality());
-        }
+        HPX_EXPORT void init_logging(runtime_configuration& ini, bool isconsole,
+            void (*set_console_dest)(logging::writer::named_write&, char const*,
+                logging::level, logging_destination),
+            void (*define_formatters)(logging::writer::named_write&));
+
+        HPX_EXPORT void init_logging_local(runtime_configuration&);
     }    // namespace detail
 
-    // initialize logging for AGAS
-    template <typename ConsoleDestination, typename DefineFormatters>
-    void init_agas_log(util::section const& ini, bool isconsole,
-        DefineFormatters&& define_formatters)
-    {
-        std::string loglevel, logdest, logformat;
+    /// \endcond
 
-        if (ini.has_section("hpx.logging.agas"))
-        {
-            util::section const* logini = ini.get_section("hpx.logging.agas");
-            HPX_ASSERT(nullptr != logini);
+    //////////////////////////////////////////////////////////////////////////
+    /// Enable logging for given destination
+    HPX_EXPORT void enable_logging(logging_destination dest,
+        std::string const& lvl = "5", std::string logdest = "",
+        std::string logformat = "");
 
-            std::string empty;
-            loglevel = logini->get_entry("level", empty);
-            if (!loglevel.empty())
-            {
-                logdest = logini->get_entry("destination", empty);
-                logformat =
-                    detail::unescape(logini->get_entry("format", empty));
-            }
-        }
-
-        auto lvl = hpx::util::logging::level::disable_all;
-        if (!loglevel.empty())
-            lvl = detail::get_log_level(loglevel);
-
-        if (hpx::util::logging::level::disable_all != lvl)
-        {
-            logger_writer_type& writer = agas_logger()->writer();
-
-#if defined(ANDROID) || defined(__ANDROID__)
-            if (logdest.empty())    // ensure minimal defaults
-                logdest = isconsole ? "android_log" : "console";
-            agas_logger()->writer().set_destination(
-                "android_log", android_log("hpx.agas"));
-#else
-            if (logdest.empty())    // ensure minimal defaults
-                logdest = isconsole ? "cerr" : "console";
-#endif
-            if (logformat.empty())
-                logformat = "|\\n";
-
-            writer.set_destination("console",
-                ConsoleDestination(lvl, destination_agas));    //-V106
-            writer.write(logformat, logdest);
-            define_formatters(writer);
-
-            agas_logger()->mark_as_initialized();
-            agas_logger()->set_enabled(lvl);
-        }
-    }
-
-    // initialize logging for the parcel transport
-    template <typename ConsoleDestination, typename DefineFormatters>
-    void init_parcel_log(util::section const& ini, bool isconsole,
-        DefineFormatters&& define_formatters)
-    {
-        std::string loglevel, logdest, logformat;
-
-        if (ini.has_section("hpx.logging.parcel"))
-        {
-            util::section const* logini = ini.get_section("hpx.logging.parcel");
-            HPX_ASSERT(nullptr != logini);
-
-            std::string empty;
-            loglevel = logini->get_entry("level", empty);
-            if (!loglevel.empty())
-            {
-                logdest = logini->get_entry("destination", empty);
-                logformat =
-                    detail::unescape(logini->get_entry("format", empty));
-            }
-        }
-
-        auto lvl = hpx::util::logging::level::disable_all;
-        if (!loglevel.empty())
-            lvl = detail::get_log_level(loglevel);
-
-        if (hpx::util::logging::level::disable_all != lvl)
-        {
-            logger_writer_type& writer = parcel_logger()->writer();
-
-#if defined(ANDROID) || defined(__ANDROID__)
-            if (logdest.empty())    // ensure minimal defaults
-                logdest = isconsole ? "android_log" : "console";
-            parcel_logger()->writer().set_destination(
-                "android_log", android_log("hpx.parcel"));
-#else
-            if (logdest.empty())    // ensure minimal defaults
-                logdest = isconsole ? "cerr" : "console";
-#endif
-            if (logformat.empty())
-                logformat = "|\\n";
-
-            writer.set_destination("console",
-                ConsoleDestination(lvl, destination_parcel));    //-V106
-            writer.write(logformat, logdest);
-            define_formatters(writer);
-
-            parcel_logger()->mark_as_initialized();
-            parcel_logger()->set_enabled(lvl);
-        }
-    }
-
-    // initialize logging for performance measurements
-    template <typename ConsoleDestination, typename DefineFormatters>
-    void init_timing_log(util::section const& ini, bool isconsole,
-        DefineFormatters&& define_formatters)
-    {
-        std::string loglevel, logdest, logformat;
-
-        if (ini.has_section("hpx.logging.timing"))
-        {
-            util::section const* logini = ini.get_section("hpx.logging.timing");
-            HPX_ASSERT(nullptr != logini);
-
-            std::string empty;
-            loglevel = logini->get_entry("level", empty);
-            if (!loglevel.empty())
-            {
-                logdest = logini->get_entry("destination", empty);
-                logformat =
-                    detail::unescape(logini->get_entry("format", empty));
-            }
-        }
-
-        auto lvl = hpx::util::logging::level::disable_all;
-        if (!loglevel.empty())
-            lvl = detail::get_log_level(loglevel);
-
-        if (hpx::util::logging::level::disable_all != lvl)
-        {
-            logger_writer_type& writer = timing_logger()->writer();
-
-#if defined(ANDROID) || defined(__ANDROID__)
-            if (logdest.empty())    // ensure minimal defaults
-                logdest = isconsole ? "android_log" : "console";
-
-            writer.set_destination("android_log", android_log("hpx.timing"));
-#else
-            if (logdest.empty())    // ensure minimal defaults
-                logdest = isconsole ? "cerr" : "console";
-#endif
-            if (logformat.empty())
-                logformat = "|\\n";
-
-            writer.set_destination("console",
-                ConsoleDestination(lvl, destination_timing));    //-V106
-            writer.write(logformat, logdest);
-            define_formatters(writer);
-
-            timing_logger()->mark_as_initialized();
-            timing_logger()->set_enabled(lvl);
-        }
-    }
-
-    template <typename ConsoleDestination, typename DefineFormatters>
-    void init_hpx_logs(util::section const& ini, bool isconsole,
-        DefineFormatters&& define_formatters)
-    {
-        std::string loglevel, logdest, logformat;
-
-        if (ini.has_section("hpx.logging"))
-        {
-            util::section const* logini = ini.get_section("hpx.logging");
-            HPX_ASSERT(nullptr != logini);
-
-            std::string empty;
-            loglevel = logini->get_entry("level", empty);
-            if (!loglevel.empty())
-            {
-                logdest = logini->get_entry("destination", empty);
-                logformat =
-                    detail::unescape(logini->get_entry("format", empty));
-            }
-        }
-
-        auto lvl = hpx::util::logging::level::disable_all;
-        if (!loglevel.empty())
-            lvl = detail::get_log_level(loglevel, true);
-
-        logger_writer_type& writer = hpx_logger()->writer();
-        logger_writer_type& error_writer = hpx_error_logger()->writer();
-
-#if defined(ANDROID) || defined(__ANDROID__)
-        if (logdest.empty())    // ensure minimal defaults
-            logdest = isconsole ? "android_log" : "console";
-
-        writer.set_destination("android_log", android_log("hpx"));
-        error_writer.set_destination("android_log", android_log("hpx"));
-#else
-        if (logdest.empty())    // ensure minimal defaults
-            logdest = isconsole ? "cerr" : "console";
-#endif
-        if (logformat.empty())
-            logformat = "|\\n";
-
-        if (hpx::util::logging::level::disable_all != lvl)
-        {
-            writer.set_destination(
-                "console", ConsoleDestination(lvl, destination_hpx));    //-V106
-            writer.write(logformat, logdest);
-            define_formatters(writer);
-
-            hpx_logger()->mark_as_initialized();
-            hpx_logger()->set_enabled(lvl);
-
-            // errors are logged to the given destination and to cerr
-            error_writer.set_destination(
-                "console", ConsoleDestination(lvl, destination_hpx));    //-V106
-#if !defined(ANDROID) && !defined(__ANDROID__)
-            if (logdest != "cerr")
-                error_writer.write(logformat, logdest + " cerr");
-#endif
-            define_formatters(error_writer);
-
-            hpx_error_logger()->mark_as_initialized();
-            hpx_error_logger()->set_enabled(lvl);
-        }
-        else
-        {
-            // errors are always logged to cerr
-            if (!isconsole)
-            {
-                error_writer.set_destination("console",
-                    ConsoleDestination(lvl, destination_hpx));    //-V106
-                error_writer.write(logformat, "console");
-            }
-            else
-            {
-#if defined(ANDROID) || defined(__ANDROID__)
-                error_writer.write(logformat, "android_log");
-#else
-                error_writer.write(logformat, "cerr");
-#endif
-            }
-            define_formatters(error_writer);
-
-            hpx_error_logger()->mark_as_initialized();
-            hpx_error_logger()->set_enabled(hpx::util::logging::level::fatal);
-        }
-    }
-
-    // initialize logging for application
-    template <typename ConsoleDestination, typename DefineFormatters>
-    void init_app_logs(util::section const& ini, bool isconsole,
-        DefineFormatters&& define_formatters)
-    {
-        std::string loglevel, logdest, logformat;
-
-        if (ini.has_section("hpx.logging.application"))
-        {
-            util::section const* logini =
-                ini.get_section("hpx.logging.application");
-            HPX_ASSERT(nullptr != logini);
-
-            std::string empty;
-            loglevel = logini->get_entry("level", empty);
-            if (!loglevel.empty())
-            {
-                logdest = logini->get_entry("destination", empty);
-                logformat =
-                    detail::unescape(logini->get_entry("format", empty));
-            }
-        }
-
-        auto lvl = hpx::util::logging::level::disable_all;
-        if (!loglevel.empty())
-            lvl = detail::get_log_level(loglevel);
-
-        if (hpx::util::logging::level::disable_all != lvl)
-        {
-            logger_writer_type& writer = app_logger()->writer();
-
-#if defined(ANDROID) || defined(__ANDROID__)
-            if (logdest.empty())    // ensure minimal defaults
-                logdest = isconsole ? "android_log" : "console";
-            writer.set_destination(
-                "android_log", android_log("hpx.application"));
-#else
-            if (logdest.empty())    // ensure minimal defaults
-                logdest = isconsole ? "cerr" : "console";
-#endif
-            if (logformat.empty())
-                logformat = "|\\n";
-
-            writer.set_destination(
-                "console", ConsoleDestination(lvl, destination_app));    //-V106
-            writer.write(logformat, logdest);
-            define_formatters(writer);
-
-            app_logger()->mark_as_initialized();
-            app_logger()->set_enabled(lvl);
-        }
-    }
-
-    // initialize logging for application
-    template <typename ConsoleDestination, typename DefineFormatters>
-    void init_debuglog_logs(util::section const& ini, bool isconsole,
-        DefineFormatters&& define_formatters)
-    {
-        std::string loglevel, logdest, logformat;
-
-        if (ini.has_section("hpx.logging.debuglog"))
-        {
-            util::section const* logini =
-                ini.get_section("hpx.logging.debuglog");
-            HPX_ASSERT(nullptr != logini);
-
-            std::string empty;
-            loglevel = logini->get_entry("level", empty);
-            if (!loglevel.empty())
-            {
-                logdest = logini->get_entry("destination", empty);
-                logformat =
-                    detail::unescape(logini->get_entry("format", empty));
-            }
-        }
-
-        auto lvl = hpx::util::logging::level::disable_all;
-        if (!loglevel.empty())
-            lvl = detail::get_log_level(loglevel);
-
-        if (hpx::util::logging::level::disable_all != lvl)
-        {
-            logger_writer_type& writer = debuglog_logger()->writer();
-
-#if defined(ANDROID) || defined(__ANDROID__)
-            if (logdest.empty())    // ensure minimal defaults
-                logdest = isconsole ? "android_log" : "console";
-            writer.set_destination("android_log", android_log("hpx.debuglog"));
-#else
-            if (logdest.empty())    // ensure minimal defaults
-                logdest = isconsole ? "cerr" : "console";
-#endif
-            if (logformat.empty())
-                logformat = "|\\n";
-
-            writer.set_destination("console",
-                ConsoleDestination(lvl, destination_debuglog));    //-V106
-            writer.write(logformat, logdest);
-            define_formatters(writer);
-
-            debuglog_logger()->mark_as_initialized();
-            debuglog_logger()->set_enabled(lvl);
-        }
-    }
-
-    // initialize logging for AGAS
-    void init_agas_console_log(util::section const& ini);
-    // initialize logging for the parcel transport
-    void init_parcel_console_log(util::section const& ini);
-    // initialize logging for performance measurements
-    void init_timing_console_log(util::section const& ini);
-    // initialize logging for HPX runtime
-    void init_hpx_console_log(util::section const& ini);
-    // initialize logging for applications
-    void init_app_console_log(util::section const& ini);
-    // initialize logging for applications
-    void init_debuglog_console_log(util::section const& ini);
+    /// Disable all logging for the given destination
+    HPX_EXPORT void disable_logging(logging_destination dest);
 }}    // namespace hpx::util
-
-///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace util { namespace detail {
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename ConsoleDestination, typename DefineFormatters>
-    void init_logging(runtime_configuration& ini, bool isconsole,
-        DefineFormatters&& define_formatters)
-    {
-        // initialize normal logs
-        init_agas_log<ConsoleDestination>(ini, isconsole, define_formatters);
-        init_parcel_log<ConsoleDestination>(ini, isconsole, define_formatters);
-        init_timing_log<ConsoleDestination>(ini, isconsole, define_formatters);
-        init_hpx_logs<ConsoleDestination>(ini, isconsole, define_formatters);
-        init_app_logs<ConsoleDestination>(ini, isconsole, define_formatters);
-        init_debuglog_logs<ConsoleDestination>(
-            ini, isconsole, define_formatters);
-
-        // initialize console logs
-        init_agas_console_log(ini);
-        init_parcel_console_log(ini);
-        init_timing_console_log(ini);
-        init_hpx_console_log(ini);
-        init_app_console_log(ini);
-        init_debuglog_console_log(ini);
-    }
-}}}    // namespace hpx::util::detail
-
-#if defined(HPX_MSVC_WARNING_PRAGMA)
-#pragma warning(pop)
-#endif
 
 #else    // HPX_HAVE_LOGGING
 
-#include <hpx/modules/logging.hpp>
-#include <hpx/runtime_configuration/runtime_configuration.hpp>
-#include <hpx/util/get_entry_as.hpp>
-
-#include <iostream>
-#include <string>
-#include <vector>
-
 namespace hpx { namespace util {
-    struct console_local;
     namespace detail {
-        inline void define_formatters_local() {}
-        template <typename ConsoleDestination, typename DefineFormatters>
-        void init_logging(runtime_configuration& ini, bool, DefineFormatters&&)
-        {
-            // warn if logging is requested
 
-            if (util::get_entry_as<int>(ini, "hpx.logging.level", -1) > 0 ||
-                util::get_entry_as<int>(ini, "hpx.logging.timing.level", -1) >
-                    0 ||
-                util::get_entry_as<int>(ini, "hpx.logging.agas.level", -1) >
-                    0 ||
-                util::get_entry_as<int>(ini, "hpx.logging.debuglog.level", -1) >
-                    0 ||
-                util::get_entry_as<int>(
-                    ini, "hpx.logging.application.level", -1) > 0)
-            {
-                std::cerr << "hpx::init_logging: warning: logging is "
-                             "requested "
-                             "even "
-                             "while it was disabled at compile time. If you "
-                             "need logging to be functional, please "
-                             "reconfigure "
-                             "and "
-                             "rebuild HPX with HPX_WITH_LOGGING set to ON."
-                          << std::endl;
-            }
-        }
-    }    // namespace detail
-}}       // namespace hpx::util
+        HPX_EXPORT void warn_if_logging_requested(runtime_configuration&);
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    HPX_EXPORT void enable_logging(logging_destination dest,
+        std::string const& lvl = "5", std::string logdest = "",
+        std::string logformat = "");
+
+    HPX_EXPORT void disable_logging(logging_destination dest);
+}}    // namespace hpx::util
 
 #endif    // HPX_HAVE_LOGGING

--- a/libs/full/init_runtime_local/src/init_logging.cpp
+++ b/libs/full/init_runtime_local/src/init_logging.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -8,289 +8,1090 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_LOGGING)
-#include <hpx/assert.hpp>
 #include <hpx/init_runtime_local/detail/init_logging.hpp>
+#include <hpx/runtime_configuration/runtime_configuration.hpp>
+#include <hpx/runtime_local/get_locality_id.hpp>
+#include <hpx/runtime_local/get_worker_thread_num.hpp>
+#include <hpx/threading_base/thread_data.hpp>
 
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
 #include <string>
+
+#if defined(ANDROID) || defined(__ANDROID__)
+#include <android/log.h>
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace util {
-    void init_agas_console_log(util::section const& ini)
+
+    using logger_writer_type = logging::writer::named_write;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // custom formatter: shepherd
+    struct shepherd_thread_id : logging::formatter::manipulator
     {
-        std::string loglevel, logdest, logformat;
-
-        if (ini.has_section("hpx.logging.console.agas"))
+        void operator()(std::ostream& to) const override
         {
-            util::section const* logini =
-                ini.get_section("hpx.logging.console.agas");
-            HPX_ASSERT(nullptr != logini);
+            error_code ec(lightweight);
+            std::size_t thread_num = hpx::get_worker_thread_num(ec);
 
-            std::string empty;
-            loglevel = logini->get_entry("level", empty);
-            if (!loglevel.empty())
+            if (std::size_t(-1) != thread_num)
             {
-                logdest = logini->get_entry("destination", empty);
-                logformat =
-                    detail::unescape(logini->get_entry("format", empty));
+                util::format_to(to, "{:016x}", thread_num);
+            }
+            else
+            {
+                to << std::string(16, '-');
             }
         }
+    };
 
-        auto lvl = hpx::util::logging::level::disable_all;
-        if (!loglevel.empty())
-            lvl = detail::get_log_level(loglevel, true);
-
-        if (hpx::util::logging::level::disable_all != lvl)
+    ///////////////////////////////////////////////////////////////////////////
+    // custom formatter: locality prefix
+    struct locality_prefix : logging::formatter::manipulator
+    {
+        void operator()(std::ostream& to) const override
         {
-            logger_writer_type& writer = agas_console_logger()->writer();
+            std::uint32_t locality_id = hpx::get_locality_id();
+
+            if (~static_cast<std::uint32_t>(0) != locality_id)
+            {
+                util::format_to(to, "{:08x}", locality_id);
+            }
+            else
+            {
+                // called from outside a HPX thread
+                to << std::string(8, '-');
+            }
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    // custom formatter: HPX thread id
+    struct thread_id : logging::formatter::manipulator
+    {
+        void operator()(std::ostream& to) const override
+        {
+            threads::thread_self* self = threads::get_self_ptr();
+            if (nullptr != self)
+            {
+                // called from inside a HPX thread
+                threads::thread_id_type id = threads::get_self_id();
+                if (id != threads::invalid_thread_id)
+                {
+                    std::ptrdiff_t value =
+                        reinterpret_cast<std::ptrdiff_t>(id.get());
+                    util::format_to(to, "{:016x}", value);
+                    return;
+                }
+            }
+
+            // called from outside a HPX thread or invalid thread id
+            to << std::string(16, '-');
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    // custom formatter: HPX thread phase
+    struct thread_phase : logging::formatter::manipulator
+    {
+        void operator()(std::ostream& to) const override
+        {
+            threads::thread_self* self = threads::get_self_ptr();
+            if (nullptr != self)
+            {
+                // called from inside a HPX thread
+                std::size_t phase = self->get_thread_phase();
+                if (0 != phase)
+                {
+                    util::format_to(to, "{:04x}", self->get_thread_phase());
+                    return;
+                }
+            }
+
+            // called from outside a HPX thread or no phase given
+            to << std::string(4, '-');
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    // custom formatter: locality prefix of parent thread
+    struct parent_thread_locality : logging::formatter::manipulator
+    {
+        void operator()(std::ostream& to) const override
+        {
+            std::uint32_t parent_locality_id =
+                threads::get_parent_locality_id();
+            if (~static_cast<std::uint32_t>(0) != parent_locality_id)
+            {
+                // called from inside a HPX thread
+                util::format_to(to, "{:08x}", parent_locality_id);
+            }
+            else
+            {
+                // called from outside a HPX thread
+                to << std::string(8, '-');
+            }
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    // custom formatter: HPX parent thread id
+    struct parent_thread_id : logging::formatter::manipulator
+    {
+        void operator()(std::ostream& to) const override
+        {
+            threads::thread_id_type parent_id = threads::get_parent_id();
+            if (nullptr != parent_id && threads::invalid_thread_id != parent_id)
+            {
+                // called from inside a HPX thread
+                std::ptrdiff_t value =
+                    reinterpret_cast<std::ptrdiff_t>(parent_id.get());
+                util::format_to(to, "{:016x}", value);
+            }
+            else
+            {
+                // called from outside a HPX thread
+                to << std::string(16, '-');
+            }
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    // custom formatter: HPX parent thread phase
+    struct parent_thread_phase : logging::formatter::manipulator
+    {
+        void operator()(std::ostream& to) const override
+        {
+            std::size_t parent_phase = threads::get_parent_phase();
+            if (0 != parent_phase)
+            {
+                // called from inside a HPX thread
+                util::format_to(to, "{:04x}", parent_phase);
+            }
+            else
+            {
+                // called from outside a HPX thread
+                to << std::string(4, '-');
+            }
+        }
+    };
+
+#if defined(ANDROID) || defined(__ANDROID__)
+    // default log destination for Android
+    struct android_log : logging::destination::manipulator
+    {
+        android_log(char const* tag_)
+          : tag(tag_)
+        {
+        }
+
+        void operator()(logging::message const& msg) override
+        {
+            __android_log_write(
+                ANDROID_LOG_DEBUG, tag.c_str(), msg.full_string().c_str());
+        }
+
+        bool operator==(android_log const& rhs) const
+        {
+            return tag == rhs.tag;
+        }
+
+        std::string tag;
+    };
+#endif
+
+    ///////////////////////////////////////////////////////////////////////////
+    struct dummy_thread_component_id : logging::formatter::manipulator
+    {
+        void operator()(std::ostream& to) const override
+        {
+            to << std::string(16, '-');
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    // custom log destination: send generated strings to console
+    void console_local::operator()(logging::message const& msg)
+    {
+        switch (dest_)
+        {
+        default:
+        case destination_hpx:
+            LHPX_CONSOLE_(level_) << msg;
+            break;
+
+        case destination_timing:
+            LTIM_CONSOLE_(level_) << msg;
+            break;
+
+        case destination_agas:
+            LAGAS_CONSOLE_(level_) << msg;
+            break;
+
+        case destination_parcel:
+            LPT_CONSOLE_(level_) << msg;
+            break;
+
+        case destination_app:
+            LAPP_CONSOLE_(level_) << msg;
+            break;
+
+        case destination_debuglog:
+            LDEB_CONSOLE_ << msg;
+            break;
+        }
+    }
+
+    namespace detail {
+
+        // unescape config entry
+        std::string unescape(std::string const& value)
+        {
+            std::string result;
+            std::string::size_type pos = 0;
+            std::string::size_type pos1 = value.find_first_of('\\', 0);
+            if (std::string::npos != pos1)
+            {
+                do
+                {
+                    switch (value[pos1 + 1])
+                    {
+                    case '\\':
+                    case '\"':
+                    case '?':
+                        result = result + value.substr(pos, pos1 - pos);
+                        pos1 = value.find_first_of('\\', (pos = pos1 + 1) + 1);
+                        break;
+
+                    case 'n':
+                        result = result + value.substr(pos, pos1 - pos) + "\n";
+                        pos1 = value.find_first_of('\\', pos = pos1 + 1);
+                        ++pos;
+                        break;
+
+                    default:
+                        result = result + value.substr(pos, pos1 - pos + 1);
+                        pos1 = value.find_first_of('\\', pos = pos1 + 1);
+                    }
+
+                } while (pos1 != std::string::npos);
+                result = result + value.substr(pos);
+            }
+            else
+            {
+                // the string doesn't contain any escaped character sequences
+                result = value;
+            }
+            return result;
+        }
+
+        void define_common_formatters(logger_writer_type& writer)
+        {
+            writer.set_formatter("osthread", shepherd_thread_id());
+            writer.set_formatter("locality", locality_prefix());
+            writer.set_formatter("hpxthread", thread_id());
+            writer.set_formatter("hpxphase", thread_phase());
+            writer.set_formatter("hpxparent", parent_thread_id());
+            writer.set_formatter("hpxparentphase", parent_thread_phase());
+            writer.set_formatter("parentloc", parent_thread_locality());
+        }
+
+        void define_formatters_local(logger_writer_type& writer)
+        {
+            define_common_formatters(writer);
+            writer.set_formatter("hpxcomponent", dummy_thread_component_id());
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        static std::string empty_string;
+
+        log_settings get_log_settings(util::section const& ini, char const* sec)
+        {
+            log_settings result;
+            if (ini.has_section(sec))
+            {
+                util::section const* logini = ini.get_section(sec);
+                HPX_ASSERT(nullptr != logini);
+
+                result.level_ = logini->get_entry("level", empty_string);
+                if (!result.level_.empty())
+                {
+                    result.dest_ =
+                        logini->get_entry("destination", empty_string);
+                    result.format_ = detail::unescape(
+                        logini->get_entry("format", empty_string));
+                }
+            }
+            return result;
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        void get_console_local(logger_writer_type& writer, char const* name,
+            logging::level lvl, logging_destination dest)
+        {
+            writer.set_destination(name, console_local(lvl, dest));
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        // initialize logging for AGAS
+        void init_agas_log(logging::level lvl, std::string logdest,
+            std::string logformat, bool isconsole,
+            void (*set_console_dest)(logger_writer_type&, char const*,
+                logging::level, logging_destination),
+            void (*define_formatters)(logging::writer::named_write&))
+        {
+            if (hpx::util::logging::level::disable_all != lvl)
+            {
+                logger_writer_type& writer = agas_logger()->writer();
+
+#if defined(ANDROID) || defined(__ANDROID__)
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = isconsole ? "android_log" : "console";
+                agas_logger()->writer().set_destination(
+                    "android_log", android_log("hpx.agas"));
+#else
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = isconsole ? "cerr" : "console";
+#endif
+                if (logformat.empty())
+                    logformat = "|\\n";
+
+                set_console_dest(
+                    writer, "console", lvl, destination_agas);    //-V106
+                writer.write(logformat, logdest);
+                define_formatters(writer);
+
+                agas_logger()->mark_as_initialized();
+            }
+            agas_logger()->set_enabled(lvl);
+        }
+
+        void init_agas_log(runtime_configuration& ini, bool isconsole,
+            void (*set_console_dest)(logger_writer_type&, char const*,
+                logging::level, logging_destination),
+            void (*define_formatters)(logging::writer::named_write&))
+        {
+            auto settings = detail::get_log_settings(ini, "hpx.logging.agas");
+
+            auto lvl = hpx::util::logging::level::disable_all;
+            if (!settings.level_.empty())
+                lvl = detail::get_log_level(settings.level_, true);
+
+            init_agas_log(lvl, std::move(settings.dest_),
+                std::move(settings.format_), isconsole, set_console_dest,
+                define_formatters);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        // initialize logging for the parcel transport
+        void init_parcel_log(logging::level lvl, std::string logdest,
+            std::string logformat, bool isconsole,
+            void (*set_console_dest)(logger_writer_type&, char const*,
+                logging::level, logging_destination),
+            void (*define_formatters)(logging::writer::named_write&))
+        {
+            if (hpx::util::logging::level::disable_all != lvl)
+            {
+                logger_writer_type& writer = parcel_logger()->writer();
+
+#if defined(ANDROID) || defined(__ANDROID__)
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = isconsole ? "android_log" : "console";
+                parcel_logger()->writer().set_destination(
+                    "android_log", android_log("hpx.parcel"));
+#else
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = isconsole ? "cerr" : "console";
+#endif
+                if (logformat.empty())
+                    logformat = "|\\n";
+
+                set_console_dest(
+                    writer, "console", lvl, destination_parcel);    //-V106
+                writer.write(logformat, logdest);
+                define_formatters(writer);
+
+                parcel_logger()->mark_as_initialized();
+            }
+            parcel_logger()->set_enabled(lvl);
+        }
+
+        void init_parcel_log(runtime_configuration& ini, bool isconsole,
+            void (*set_console_dest)(logger_writer_type&, char const*,
+                logging::level, logging_destination),
+            void (*define_formatters)(logging::writer::named_write&))
+        {
+            auto settings = detail::get_log_settings(ini, "hpx.logging.parcel");
+
+            auto lvl = hpx::util::logging::level::disable_all;
+            if (!settings.level_.empty())
+                lvl = detail::get_log_level(settings.level_, true);
+
+            init_parcel_log(lvl, std::move(settings.dest_),
+                std::move(settings.format_), isconsole, set_console_dest,
+                define_formatters);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        // initialize logging for performance measurements
+        void init_timing_log(logging::level lvl, std::string logdest,
+            std::string logformat, bool isconsole,
+            void (*set_console_dest)(logger_writer_type&, char const*,
+                logging::level, logging_destination),
+            void (*define_formatters)(logging::writer::named_write&))
+        {
+            if (hpx::util::logging::level::disable_all != lvl)
+            {
+                logger_writer_type& writer = timing_logger()->writer();
+
+#if defined(ANDROID) || defined(__ANDROID__)
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = isconsole ? "android_log" : "console";
+
+                writer.set_destination(
+                    "android_log", android_log("hpx.timing"));
+#else
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = isconsole ? "cerr" : "console";
+#endif
+                if (logformat.empty())
+                    logformat = "|\\n";
+
+                set_console_dest(
+                    writer, "console", lvl, destination_timing);    //-V106
+                writer.write(logformat, logdest);
+                define_formatters(writer);
+
+                timing_logger()->mark_as_initialized();
+            }
+            timing_logger()->set_enabled(lvl);
+        }
+
+        void init_timing_log(runtime_configuration& ini, bool isconsole,
+            void (*set_console_dest)(logger_writer_type&, char const*,
+                logging::level, logging_destination),
+            void (*define_formatters)(logging::writer::named_write&))
+        {
+            auto settings = detail::get_log_settings(ini, "hpx.logging.timing");
+
+            auto lvl = hpx::util::logging::level::disable_all;
+            if (!settings.level_.empty())
+                lvl = detail::get_log_level(settings.level_, true);
+
+            init_timing_log(lvl, std::move(settings.dest_),
+                std::move(settings.format_), isconsole, set_console_dest,
+                define_formatters);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        void init_hpx_log(logging::level lvl, std::string logdest,
+            std::string logformat, bool isconsole,
+            void (*set_console_dest)(logger_writer_type&, char const*,
+                logging::level, logging_destination),
+            void (*define_formatters)(logging::writer::named_write&))
+        {
+            logger_writer_type& writer = hpx_logger()->writer();
+            logger_writer_type& error_writer = hpx_error_logger()->writer();
 
 #if defined(ANDROID) || defined(__ANDROID__)
             if (logdest.empty())    // ensure minimal defaults
-                logdest = "android_log";
-            writer.set_destination("android_log", android_log("hpx.agas"));
+                logdest = isconsole ? "android_log" : "console";
+
+            writer.set_destination("android_log", android_log("hpx"));
+            error_writer.set_destination("android_log", android_log("hpx"));
 #else
             if (logdest.empty())    // ensure minimal defaults
-                logdest = "cerr";
+                logdest = isconsole ? "cerr" : "console";
 #endif
             if (logformat.empty())
                 logformat = "|\\n";
 
-            writer.write(logformat, logdest);
+            if (hpx::util::logging::level::disable_all != lvl)
+            {
+                set_console_dest(
+                    writer, "console", lvl, destination_hpx);    //-V106
+                writer.write(logformat, logdest);
+                define_formatters(writer);
 
-            agas_console_logger()->mark_as_initialized();
+                hpx_logger()->mark_as_initialized();
+                hpx_logger()->set_enabled(lvl);
+
+                // errors are logged to the given destination and to cerr
+                set_console_dest(
+                    error_writer, "console", lvl, destination_hpx);    //-V106
+#if !defined(ANDROID) && !defined(__ANDROID__)
+                if (logdest != "cerr")
+                    error_writer.write(logformat, logdest + " cerr");
+#endif
+                define_formatters(error_writer);
+
+                hpx_error_logger()->mark_as_initialized();
+                hpx_error_logger()->set_enabled(lvl);
+            }
+            else
+            {
+                // errors are always logged to cerr
+                if (!isconsole)
+                {
+                    set_console_dest(
+                        writer, "console", lvl, destination_hpx);    //-V106
+                    error_writer.write(logformat, "console");
+                }
+                else
+                {
+#if defined(ANDROID) || defined(__ANDROID__)
+                    error_writer.write(logformat, "android_log");
+#else
+                    error_writer.write(logformat, "cerr");
+#endif
+                }
+                define_formatters(error_writer);
+
+                hpx_error_logger()->mark_as_initialized();
+                hpx_error_logger()->set_enabled(
+                    hpx::util::logging::level::fatal);
+            }
+        }
+
+        void init_hpx_log(runtime_configuration& ini, bool isconsole,
+            void (*set_console_dest)(logger_writer_type&, char const*,
+                logging::level, logging_destination),
+            void (*define_formatters)(logging::writer::named_write&))
+        {
+            auto settings = detail::get_log_settings(ini, "hpx.logging");
+
+            auto lvl = hpx::util::logging::level::disable_all;
+            if (!settings.level_.empty())
+                lvl = detail::get_log_level(settings.level_, true);
+
+            init_hpx_log(lvl, std::move(settings.dest_),
+                std::move(settings.format_), isconsole, set_console_dest,
+                define_formatters);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        // initialize logging for application
+        void init_app_log(logging::level lvl, std::string logdest,
+            std::string logformat, bool isconsole,
+            void (*set_console_dest)(logger_writer_type&, char const*,
+                logging::level, logging_destination),
+            void (*define_formatters)(logging::writer::named_write&))
+        {
+            if (hpx::util::logging::level::disable_all != lvl)
+            {
+                logger_writer_type& writer = app_logger()->writer();
+
+#if defined(ANDROID) || defined(__ANDROID__)
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = isconsole ? "android_log" : "console";
+                writer.set_destination(
+                    "android_log", android_log("hpx.application"));
+#else
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = isconsole ? "cerr" : "console";
+#endif
+                if (logformat.empty())
+                    logformat = "|\\n";
+
+                set_console_dest(
+                    writer, "console", lvl, destination_app);    //-V106
+                writer.write(logformat, logdest);
+                define_formatters(writer);
+
+                app_logger()->mark_as_initialized();
+            }
+            app_logger()->set_enabled(lvl);
+        }
+
+        void init_app_log(runtime_configuration& ini, bool isconsole,
+            void (*set_console_dest)(logger_writer_type&, char const*,
+                logging::level, logging_destination),
+            void (*define_formatters)(logging::writer::named_write&))
+        {
+            auto settings =
+                detail::get_log_settings(ini, "hpx.logging.application");
+
+            auto lvl = hpx::util::logging::level::disable_all;
+            if (!settings.level_.empty())
+                lvl = detail::get_log_level(settings.level_, true);
+
+            init_app_log(lvl, std::move(settings.dest_),
+                std::move(settings.format_), isconsole, set_console_dest,
+                define_formatters);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        // initialize logging for application
+        void init_debuglog_log(logging::level lvl, std::string logdest,
+            std::string logformat, bool isconsole,
+            void (*set_console_dest)(logger_writer_type&, char const*,
+                logging::level, logging_destination),
+            void (*define_formatters)(logging::writer::named_write&))
+        {
+            if (hpx::util::logging::level::disable_all != lvl)
+            {
+                logger_writer_type& writer = debuglog_logger()->writer();
+
+#if defined(ANDROID) || defined(__ANDROID__)
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = isconsole ? "android_log" : "console";
+                writer.set_destination(
+                    "android_log", android_log("hpx.debuglog"));
+#else
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = isconsole ? "cerr" : "console";
+#endif
+                if (logformat.empty())
+                    logformat = "|\\n";
+
+                set_console_dest(
+                    writer, "console", lvl, destination_debuglog);    //-V106
+                writer.write(logformat, logdest);
+                define_formatters(writer);
+
+                debuglog_logger()->mark_as_initialized();
+            }
+            debuglog_logger()->set_enabled(lvl);
+        }
+
+        void init_debuglog_log(runtime_configuration& ini, bool isconsole,
+            void (*set_console_dest)(logger_writer_type&, char const*,
+                logging::level, logging_destination),
+            void (*define_formatters)(logging::writer::named_write&))
+        {
+            auto settings =
+                detail::get_log_settings(ini, "hpx.logging.debuglog");
+
+            auto lvl = hpx::util::logging::level::disable_all;
+            if (!settings.level_.empty())
+                lvl = detail::get_log_level(settings.level_, true);
+
+            init_debuglog_log(lvl, std::move(settings.dest_),
+                std::move(settings.format_), isconsole, set_console_dest,
+                define_formatters);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        void init_agas_console_log(
+            logging::level lvl, std::string logdest, std::string logformat)
+        {
+            if (hpx::util::logging::level::disable_all != lvl)
+            {
+                logger_writer_type& writer = agas_console_logger()->writer();
+
+#if defined(ANDROID) || defined(__ANDROID__)
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = "android_log";
+                writer.set_destination("android_log", android_log("hpx.agas"));
+#else
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = "cerr";
+#endif
+                if (logformat.empty())
+                    logformat = "|\\n";
+
+                writer.write(logformat, logdest);
+
+                agas_console_logger()->mark_as_initialized();
+            }
             agas_console_logger()->set_enabled(lvl);
         }
-    }
 
-    void init_parcel_console_log(util::section const& ini)
-    {
-        std::string loglevel, logdest, logformat;
-
-        if (ini.has_section("hpx.logging.console.parcel"))
+        void init_agas_console_log(util::section const& ini)
         {
-            util::section const* logini =
-                ini.get_section("hpx.logging.console.parcel");
-            HPX_ASSERT(nullptr != logini);
+            auto settings =
+                detail::get_log_settings(ini, "hpx.logging.console.agas");
 
-            std::string empty;
-            loglevel = logini->get_entry("level", empty);
-            if (!loglevel.empty())
-            {
-                logdest = logini->get_entry("destination", empty);
-                logformat =
-                    detail::unescape(logini->get_entry("format", empty));
-            }
+            auto lvl = hpx::util::logging::level::disable_all;
+            if (!settings.level_.empty())
+                lvl = detail::get_log_level(settings.level_, true);
+
+            init_agas_console_log(
+                lvl, std::move(settings.dest_), std::move(settings.format_));
         }
 
-        auto lvl = hpx::util::logging::level::disable_all;
-        if (!loglevel.empty())
-            lvl = detail::get_log_level(loglevel, true);
-
-        if (hpx::util::logging::level::disable_all != lvl)
+        ///////////////////////////////////////////////////////////////////////
+        void init_parcel_console_log(
+            logging::level lvl, std::string logdest, std::string logformat)
         {
-            logger_writer_type& writer = parcel_console_logger()->writer();
+            if (hpx::util::logging::level::disable_all != lvl)
+            {
+                logger_writer_type& writer = parcel_console_logger()->writer();
 
 #if defined(ANDROID) || defined(__ANDROID__)
-            if (logdest.empty())    // ensure minimal defaults
-                logdest = "android_log";
-            writer.set_destination("android_log", android_log("hpx.parcel"));
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = "android_log";
+                writer.set_destination(
+                    "android_log", android_log("hpx.parcel"));
 #else
-            if (logdest.empty())    // ensure minimal defaults
-                logdest = "cerr";
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = "cerr";
 #endif
-            if (logformat.empty())
-                logformat = "|\\n";
+                if (logformat.empty())
+                    logformat = "|\\n";
 
-            writer.write(logformat, logdest);
+                writer.write(logformat, logdest);
 
-            parcel_console_logger()->mark_as_initialized();
+                parcel_console_logger()->mark_as_initialized();
+            }
             parcel_console_logger()->set_enabled(lvl);
         }
-    }
 
-    void init_timing_console_log(util::section const& ini)
-    {
-        std::string loglevel, logdest, logformat;
-
-        if (ini.has_section("hpx.logging.console.timing"))
+        void init_parcel_console_log(util::section const& ini)
         {
-            util::section const* logini =
-                ini.get_section("hpx.logging.console.timing");
-            HPX_ASSERT(nullptr != logini);
+            auto settings =
+                detail::get_log_settings(ini, "hpx.logging.console.parcel");
 
-            std::string empty;
-            loglevel = logini->get_entry("level", empty);
-            if (!loglevel.empty())
-            {
-                logdest = logini->get_entry("destination", empty);
-                logformat =
-                    detail::unescape(logini->get_entry("format", empty));
-            }
+            auto lvl = hpx::util::logging::level::disable_all;
+            if (!settings.level_.empty())
+                lvl = detail::get_log_level(settings.level_, true);
+
+            init_parcel_console_log(
+                lvl, std::move(settings.dest_), std::move(settings.format_));
         }
 
-        auto lvl = hpx::util::logging::level::disable_all;
-        if (!loglevel.empty())
-            lvl = detail::get_log_level(loglevel, true);
-
-        if (hpx::util::logging::level::disable_all != lvl)
+        ///////////////////////////////////////////////////////////////////////
+        void init_timing_console_log(
+            logging::level lvl, std::string logdest, std::string logformat)
         {
-            logger_writer_type& writer = timing_console_logger()->writer();
+            if (hpx::util::logging::level::disable_all != lvl)
+            {
+                logger_writer_type& writer = timing_console_logger()->writer();
 
 #if defined(ANDROID) || defined(__ANDROID__)
-            if (logdest.empty())    // ensure minimal defaults
-                logdest = "android_log";
-            writer.set_destination("android_log", android_log("hpx.timing"));
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = "android_log";
+                writer.set_destination(
+                    "android_log", android_log("hpx.timing"));
 #else
-            if (logdest.empty())    // ensure minimal defaults
-                logdest = "cerr";
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = "cerr";
 #endif
-            if (logformat.empty())
-                logformat = "|\\n";
+                if (logformat.empty())
+                    logformat = "|\\n";
 
-            writer.write(logformat, logdest);
+                writer.write(logformat, logdest);
 
-            timing_console_logger()->mark_as_initialized();
+                timing_console_logger()->mark_as_initialized();
+            }
             timing_console_logger()->set_enabled(lvl);
         }
-    }
 
-    void init_hpx_console_log(util::section const& ini)
-    {
-        std::string loglevel, logdest, logformat;
-
-        if (ini.has_section("hpx.logging.console"))
+        void init_timing_console_log(util::section const& ini)
         {
-            util::section const* logini =
-                ini.get_section("hpx.logging.console");
-            HPX_ASSERT(nullptr != logini);
+            auto settings =
+                detail::get_log_settings(ini, "hpx.logging.console.timing");
 
-            std::string empty;
-            loglevel = logini->get_entry("level", empty);
-            if (!loglevel.empty())
-            {
-                logdest = logini->get_entry("destination", empty);
-                logformat =
-                    detail::unescape(logini->get_entry("format", empty));
-            }
+            auto lvl = hpx::util::logging::level::disable_all;
+            if (!settings.level_.empty())
+                lvl = detail::get_log_level(settings.level_, true);
+
+            init_timing_console_log(
+                lvl, std::move(settings.dest_), std::move(settings.format_));
         }
 
-        auto lvl = hpx::util::logging::level::disable_all;
-        if (!loglevel.empty())
-            lvl = detail::get_log_level(loglevel, true);
-
-        if (hpx::util::logging::level::disable_all != lvl)
+        ///////////////////////////////////////////////////////////////////////
+        void init_hpx_console_log(
+            logging::level lvl, std::string logdest, std::string logformat)
         {
-            logger_writer_type& writer = hpx_console_logger()->writer();
+            if (hpx::util::logging::level::disable_all != lvl)
+            {
+                logger_writer_type& writer = hpx_console_logger()->writer();
 
 #if defined(ANDROID) || defined(__ANDROID__)
-            if (logdest.empty())    // ensure minimal defaults
-                logdest = "android_log";
-            writer.set_destination("android_log", android_log("hpx"));
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = "android_log";
+                writer.set_destination("android_log", android_log("hpx"));
 #else
-            if (logdest.empty())    // ensure minimal defaults
-                logdest = "cerr";
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = "cerr";
 #endif
-            if (logformat.empty())
-                logformat = "|\\n";
+                if (logformat.empty())
+                    logformat = "|\\n";
 
-            writer.write(logformat, logdest);
+                writer.write(logformat, logdest);
 
-            hpx_console_logger()->mark_as_initialized();
+                hpx_console_logger()->mark_as_initialized();
+            }
             hpx_console_logger()->set_enabled(lvl);
         }
-    }
 
-    void init_app_console_log(util::section const& ini)
-    {
-        std::string loglevel, logdest, logformat;
-
-        if (ini.has_section("hpx.logging.console.application"))
+        void init_hpx_console_log(util::section const& ini)
         {
-            util::section const* logini =
-                ini.get_section("hpx.logging.console.application");
-            HPX_ASSERT(nullptr != logini);
+            auto settings =
+                detail::get_log_settings(ini, "hpx.logging.console");
 
-            std::string empty;
-            loglevel = logini->get_entry("level", empty);
-            if (!loglevel.empty())
-            {
-                logdest = logini->get_entry("destination", empty);
-                logformat =
-                    detail::unescape(logini->get_entry("format", empty));
-            }
+            auto lvl = hpx::util::logging::level::disable_all;
+            if (!settings.level_.empty())
+                lvl = detail::get_log_level(settings.level_, true);
+
+            init_hpx_console_log(
+                lvl, std::move(settings.dest_), std::move(settings.format_));
         }
 
-        auto lvl = hpx::util::logging::level::disable_all;
-        if (!loglevel.empty())
-            lvl = detail::get_log_level(loglevel, true);
-
-        if (hpx::util::logging::level::disable_all != lvl)
+        ///////////////////////////////////////////////////////////////////////
+        void init_app_console_log(
+            logging::level lvl, std::string logdest, std::string logformat)
         {
-            logger_writer_type& writer = app_console_logger()->writer();
+            if (hpx::util::logging::level::disable_all != lvl)
+            {
+                logger_writer_type& writer = app_console_logger()->writer();
 
 #if defined(ANDROID) || defined(__ANDROID__)
-            if (logdest.empty())    // ensure minimal defaults
-                logdest = "android_log";
-            writer.set_destination(
-                "android_log", android_log("hpx.application"));
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = "android_log";
+                writer.set_destination(
+                    "android_log", android_log("hpx.application"));
 #else
-            if (logdest.empty())    // ensure minimal defaults
-                logdest = "cerr";
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = "cerr";
 #endif
-            if (logformat.empty())
-                logformat = "|\\n";
+                if (logformat.empty())
+                    logformat = "|\\n";
 
-            writer.write(logformat, logdest);
+                writer.write(logformat, logdest);
 
-            app_console_logger()->mark_as_initialized();
+                app_console_logger()->mark_as_initialized();
+            }
             app_console_logger()->set_enabled(lvl);
         }
-    }
 
-    void init_debuglog_console_log(util::section const& ini)
-    {
-        std::string loglevel, logdest, logformat;
-
-        if (ini.has_section("hpx.logging.console.debuglog"))
+        void init_app_console_log(util::section const& ini)
         {
-            util::section const* logini =
-                ini.get_section("hpx.logging.console.debuglog");
-            HPX_ASSERT(nullptr != logini);
+            auto settings = detail::get_log_settings(
+                ini, "hpx.logging.console.application");
 
-            std::string empty;
-            loglevel = logini->get_entry("level", empty);
-            if (!loglevel.empty())
-            {
-                logdest = logini->get_entry("destination", empty);
-                logformat =
-                    detail::unescape(logini->get_entry("format", empty));
-            }
+            auto lvl = hpx::util::logging::level::disable_all;
+            if (!settings.level_.empty())
+                lvl = detail::get_log_level(settings.level_, true);
+
+            init_app_console_log(
+                lvl, std::move(settings.dest_), std::move(settings.format_));
         }
 
-        auto lvl = hpx::util::logging::level::disable_all;
-        if (!loglevel.empty())
-            lvl = detail::get_log_level(loglevel, true);
-
-        if (hpx::util::logging::level::disable_all != lvl)
+        ///////////////////////////////////////////////////////////////////////
+        void init_debuglog_console_log(
+            logging::level lvl, std::string logdest, std::string logformat)
         {
-            logger_writer_type& writer = debuglog_console_logger()->writer();
+            if (hpx::util::logging::level::disable_all != lvl)
+            {
+                logger_writer_type& writer =
+                    debuglog_console_logger()->writer();
 
 #if defined(ANDROID) || defined(__ANDROID__)
-            if (logdest.empty())    // ensure minimal defaults
-                logdest = "android_log";
-            writer.set_destination("android_log", android_log("hpx.debuglog"));
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = "android_log";
+                writer.set_destination(
+                    "android_log", android_log("hpx.debuglog"));
 #else
-            if (logdest.empty())    // ensure minimal defaults
-                logdest = "cerr";
+                if (logdest.empty())    // ensure minimal defaults
+                    logdest = "cerr";
 #endif
-            if (logformat.empty())
-                logformat = "|\\n";
+                if (logformat.empty())
+                    logformat = "|\\n";
 
-            writer.write(logformat, logdest);
+                writer.write(logformat, logdest);
 
-            debuglog_console_logger()->mark_as_initialized();
+                debuglog_console_logger()->mark_as_initialized();
+            }
             debuglog_console_logger()->set_enabled(lvl);
+        }
+
+        void init_debuglog_console_log(util::section const& ini)
+        {
+            auto settings =
+                detail::get_log_settings(ini, "hpx.logging.console.debuglog");
+
+            auto lvl = hpx::util::logging::level::disable_all;
+            if (!settings.level_.empty())
+                lvl = detail::get_log_level(settings.level_, true);
+
+            init_debuglog_console_log(
+                lvl, std::move(settings.dest_), std::move(settings.format_));
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        static void (*default_set_console_dest)(logger_writer_type&,
+            char const*, logging::level,
+            logging_destination) = get_console_local;
+
+        static void (*default_define_formatters)(
+            logging::writer::named_write&) = define_formatters_local;
+
+        static bool default_isconsole = true;
+
+        void init_logging(runtime_configuration& ini, bool isconsole,
+            void (*set_console_dest)(logger_writer_type&, char const*,
+                logging::level, logging_destination),
+            void (*define_formatters)(logging::writer::named_write&))
+        {
+            default_isconsole = isconsole;
+            default_set_console_dest = set_console_dest;
+            default_define_formatters = define_formatters;
+
+            // initialize normal logs
+            init_agas_log(ini, isconsole, set_console_dest, define_formatters);
+            init_parcel_log(
+                ini, isconsole, set_console_dest, define_formatters);
+            init_timing_log(
+                ini, isconsole, set_console_dest, define_formatters);
+            init_hpx_log(ini, isconsole, set_console_dest, define_formatters);
+            init_app_log(ini, isconsole, set_console_dest, define_formatters);
+            init_debuglog_log(
+                ini, isconsole, set_console_dest, define_formatters);
+
+            // initialize console logs
+            init_agas_console_log(ini);
+            init_parcel_console_log(ini);
+            init_timing_console_log(ini);
+            init_hpx_console_log(ini);
+            init_app_console_log(ini);
+            init_debuglog_console_log(ini);
+        }
+
+        void init_logging_local(runtime_configuration& ini)
+        {
+            init_logging(ini, true, util::detail::get_console_local,
+                util::detail::define_formatters_local);
+        }
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
+    void disable_logging(logging_destination dest)
+    {
+        switch (dest)
+        {
+        case destination_hpx:
+            hpx_logger()->set_enabled(logging::level::disable_all);
+            hpx_console_logger()->set_enabled(logging::level::disable_all);
+            break;
+
+        case destination_timing:
+            timing_logger()->set_enabled(logging::level::disable_all);
+            timing_console_logger()->set_enabled(logging::level::disable_all);
+            break;
+
+        case destination_agas:
+            agas_logger()->set_enabled(logging::level::disable_all);
+            agas_console_logger()->set_enabled(logging::level::disable_all);
+            break;
+
+        case destination_parcel:
+            parcel_logger()->set_enabled(logging::level::disable_all);
+            parcel_console_logger()->set_enabled(logging::level::disable_all);
+            break;
+
+        case destination_app:
+            app_logger()->set_enabled(logging::level::disable_all);
+            app_console_logger()->set_enabled(logging::level::disable_all);
+            break;
+
+        case destination_debuglog:
+            debuglog_logger()->set_enabled(logging::level::disable_all);
+            debuglog_console_logger()->set_enabled(logging::level::disable_all);
+            break;
+        }
+    }
+
+    void enable_logging(logging_destination dest, std::string const& level,
+        std::string logdest, std::string logformat)
+    {
+        auto lvl = hpx::util::logging::level::enable_all;
+        if (!level.empty())
+        {
+            lvl = detail::get_log_level(level, true);
+        }
+
+        switch (dest)
+        {
+        case destination_hpx:
+            detail::init_hpx_log(lvl, logdest, logformat,
+                detail::default_isconsole, detail::default_set_console_dest,
+                detail::default_define_formatters);
+            detail::init_hpx_console_log(
+                lvl, std::move(logdest), std::move(logformat));
+            break;
+
+        case destination_timing:
+            detail::init_debuglog_log(lvl, logdest, logformat,
+                detail::default_isconsole, detail::default_set_console_dest,
+                detail::default_define_formatters);
+            detail::init_debuglog_console_log(
+                lvl, std::move(logdest), std::move(logformat));
+            break;
+
+        case destination_agas:
+            detail::init_agas_log(lvl, logdest, logformat,
+                detail::default_isconsole, detail::default_set_console_dest,
+                detail::default_define_formatters);
+            detail::init_agas_console_log(
+                lvl, std::move(logdest), std::move(logformat));
+            break;
+
+        case destination_parcel:
+            detail::init_parcel_log(lvl, logdest, logformat,
+                detail::default_isconsole, detail::default_set_console_dest,
+                detail::default_define_formatters);
+            detail::init_parcel_console_log(
+                lvl, std::move(logdest), std::move(logformat));
+            break;
+
+        case destination_app:
+            detail::init_app_log(lvl, logdest, logformat,
+                detail::default_isconsole, detail::default_set_console_dest,
+                detail::default_define_formatters);
+            detail::init_app_console_log(
+                lvl, std::move(logdest), std::move(logformat));
+            break;
+
+        case destination_debuglog:
+            detail::init_debuglog_log(lvl, logdest, logformat,
+                detail::default_isconsole, detail::default_set_console_dest,
+                detail::default_define_formatters);
+            detail::init_debuglog_console_log(
+                lvl, std::move(logdest), std::move(logformat));
+            break;
         }
     }
 }}    // namespace hpx::util
+
+#else
+
+#include <hpx/init_runtime_local/detail/init_logging.hpp>
+#include <hpx/util/get_entry_as.hpp>
+
+#include <iostream>
+#include <string>
+
+namespace hpx { namespace util {
+
+    //////////////////////////////////////////////////////////////////////////
+    namespace detail {
+
+        void warn_if_logging_requested(runtime_configuration& ini)
+        {
+            using util::get_entry_as;
+
+            // warn if logging is requested
+            if (get_entry_as<int>(ini, "hpx.logging.level", -1) > 0 ||
+                get_entry_as<int>(ini, "hpx.logging.timing.level", -1) > 0 ||
+                get_entry_as<int>(ini, "hpx.logging.agas.level", -1) > 0 ||
+                get_entry_as<int>(ini, "hpx.logging.debuglog.level", -1) > 0 ||
+                get_entry_as<int>(ini, "hpx.logging.application.level", -1) > 0)
+            {
+                std::cerr
+                    << "hpx::init_logging: warning: logging is requested even "
+                       "while it was disabled at compile time. If you "
+                       "need logging to be functional, please reconfigure and "
+                       "rebuild HPX with HPX_WITH_LOGGING set to ON."
+                    << std::endl;
+            }
+        }
+    }    // namespace detail
+}}       // namespace hpx::util
 
 #endif    // HPX_HAVE_LOGGING

--- a/libs/full/init_runtime_local/src/init_runtime_local.cpp
+++ b/libs/full/init_runtime_local/src/init_runtime_local.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c)      2017 Shoshana Jakobovits
 //  Copyright (c) 2010-2011 Phillip LeBlanc, Dylan Stark
 //  Copyright (c)      2011 Bryce Lelbach
@@ -258,9 +258,11 @@ namespace hpx {
                 util::detail::set_spinlock_deadlock_detection_limit(
                     cmdline.rtcfg_.get_spinlock_deadlock_detection_limit());
 #endif
-
-                util::detail::init_logging<util::console_local>(cmdline.rtcfg_,
-                    true, util::detail::define_formatters_local);
+#if defined(HPX_HAVE_LOGGING)
+                util::detail::init_logging_local(cmdline.rtcfg_);
+#else
+                util::detail::warn_if_logging_requested(cmdline.rtcfg_);
+#endif
             }
 
             ///////////////////////////////////////////////////////////////////////

--- a/libs/full/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/full/runtime_configuration/src/runtime_configuration.cpp
@@ -376,16 +376,17 @@ namespace hpx { namespace util {
 
     void runtime_configuration::pre_initialize_logging_ini()
     {
+#if defined(HPX_HAVE_LOGGING)
         std::vector<std::string> lines = {
         // clang-format off
-#if defined(HPX_HAVE_LOGGING)
 #define HPX_TIMEFORMAT "$hh:$mm.$ss.$mili"
+#define HPX_LOGFORMAT "(T%locality%/%hpxthread%.%hpxphase%/%hpxcomponent%) "
+
             // general logging
             "[hpx.logging]",
             "level = ${HPX_LOGLEVEL:0}",
             "destination = ${HPX_LOGDESTINATION:console}",
-            "format = ${HPX_LOGFORMAT:"
-                "(T%locality%/%hpxthread%.%hpxphase%/%hpxcomponent%) "
+            "format = ${HPX_LOGFORMAT:" HPX_LOGFORMAT
                 "P%parentloc%/%hpxparent%.%hpxparentphase% %time%("
                 HPX_TIMEFORMAT ") [%idx%]|\\n}",
 
@@ -404,8 +405,7 @@ namespace hpx { namespace util {
             "[hpx.logging.timing]",
             "level = ${HPX_TIMING_LOGLEVEL:-1}",
             "destination = ${HPX_TIMING_LOGDESTINATION:console}",
-            "format = ${HPX_TIMING_LOGFORMAT:"
-                "(T%locality%/%hpxthread%.%hpxphase%/%hpxcomponent%) "
+            "format = ${HPX_TIMING_LOGFORMAT:" HPX_LOGFORMAT
                 "P%parentloc%/%hpxparent%.%hpxparentphase% %time%("
                 HPX_TIMEFORMAT ") [%idx%] [TIM] |\\n}",
 
@@ -425,8 +425,7 @@ namespace hpx { namespace util {
             "level = ${HPX_AGAS_LOGLEVEL:-1}",
             "destination = ${HPX_AGAS_LOGDESTINATION:"
                 "file(hpx.agas.$[system.pid].log)}",
-            "format = ${HPX_AGAS_LOGFORMAT:"
-                "(T%locality%/%hpxthread%.%hpxphase%/%hpxcomponent%) "
+            "format = ${HPX_AGAS_LOGFORMAT:" HPX_LOGFORMAT
                 "P%parentloc%/%hpxparent%.%hpxparentphase% %time%("
                     HPX_TIMEFORMAT ") [%idx%][AGAS] |\\n}",
 
@@ -446,8 +445,7 @@ namespace hpx { namespace util {
             "level = ${HPX_PARCEL_LOGLEVEL:-1}",
             "destination = ${HPX_PARCEL_LOGDESTINATION:"
                 "file(hpx.parcel.$[system.pid].log)}",
-            "format = ${HPX_PARCEL_LOGFORMAT:"
-                "(T%locality%/%hpxthread%.%hpxphase%/%hpxcomponent%) "
+            "format = ${HPX_PARCEL_LOGFORMAT:" HPX_LOGFORMAT
                 "P%parentloc%/%hpxparent%.%hpxparentphase% %time%("
                 HPX_TIMEFORMAT ") [%idx%][  PT] |\\n}",
 
@@ -466,8 +464,7 @@ namespace hpx { namespace util {
             "[hpx.logging.application]",
             "level = ${HPX_APP_LOGLEVEL:-1}",
             "destination = ${HPX_APP_LOGDESTINATION:console}",
-            "format = ${HPX_APP_LOGFORMAT:"
-                "(T%locality%/%hpxthread%.%hpxphase%/%hpxcomponent%) "
+            "format = ${HPX_APP_LOGFORMAT:" HPX_LOGFORMAT
                 "P%parentloc%/%hpxparent%.%hpxparentphase% %time%("
                 HPX_TIMEFORMAT ") [%idx%] [APP] |\\n}",
 
@@ -486,8 +483,7 @@ namespace hpx { namespace util {
             "[hpx.logging.debuglog]",
             "level = ${HPX_DEB_LOGLEVEL:-1}",
             "destination = ${HPX_DEB_LOGDESTINATION:console}",
-            "format = ${HPX_DEB_LOGFORMAT:"
-                "(T%locality%/%hpxthread%.%hpxphase%/%hpxcomponent%) "
+            "format = ${HPX_DEB_LOGFORMAT:" HPX_LOGFORMAT
                 "P%parentloc%/%hpxparent%.%hpxparentphase% %time%("
                 HPX_TIMEFORMAT ") [%idx%] [DEB] |\\n}",
 
@@ -502,12 +498,13 @@ namespace hpx { namespace util {
             "format = ${HPX_CONSOLE_DEB_LOGFORMAT:|}"
 
 #undef HPX_TIMEFORMAT
-#endif
+#undef HPX_LOGFORMAT
             // clang-format on
         };
 
         // don't overload user overrides
         this->parse("<static logging defaults>", lines, false, false);
+#endif
     }
 
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- flyby: simplify logging initialization, moving code to source files

@diehlpk you should be able to use this to enable logging from the command line and disable it first thing in `hpx_main` (add `--hpx:debug-hpx-log=<filename>` on the command line, and insert a `hpx::util::disable_logging(hpx::destination_hpx);` in `hpx_main`). This might help diagnosing the startup hangs on summit.