### PR TITLE
Add CUDA timestamp support to HPX Hardware Clock

### DIFF
--- a/libs/core/hardware/CMakeLists.txt
+++ b/libs/core/hardware/CMakeLists.txt
@@ -27,7 +27,6 @@ set(hardware_compat_headers
     hpx/util/hardware/cpuid/linux_x86.hpp => hpx/modules/hardware.hpp
     hpx/util/hardware/cpuid/msvc.hpp => hpx/modules/hardware.hpp
     hpx/util/hardware/timestamp/bgq.hpp => hpx/modules/hardware.hpp
-    hpx/util/hardware/timestamp/cuda.hpp => hpx/modules/hardware.hpp
     hpx/util/hardware/timestamp/linux_generic.hpp => hpx/modules/hardware.hpp
     hpx/util/hardware/timestamp/linux_x86_32.hpp => hpx/modules/hardware.hpp
     hpx/util/hardware/timestamp/linux_x86_64.hpp => hpx/modules/hardware.hpp

--- a/libs/core/hardware/CMakeLists.txt
+++ b/libs/core/hardware/CMakeLists.txt
@@ -11,6 +11,7 @@ set(hardware_headers
     hpx/hardware/cpuid/linux_x86.hpp
     hpx/hardware/cpuid/msvc.hpp
     hpx/hardware/timestamp/bgq.hpp
+    hpx/hardware/timestamp/cuda.hpp
     hpx/hardware/timestamp/linux_generic.hpp
     hpx/hardware/timestamp/linux_x86_32.hpp
     hpx/hardware/timestamp/linux_x86_64.hpp
@@ -26,6 +27,7 @@ set(hardware_compat_headers
     hpx/util/hardware/cpuid/linux_x86.hpp => hpx/modules/hardware.hpp
     hpx/util/hardware/cpuid/msvc.hpp => hpx/modules/hardware.hpp
     hpx/util/hardware/timestamp/bgq.hpp => hpx/modules/hardware.hpp
+    hpx/util/hardware/timestamp/cuda.hpp => hpx/modules/hardware.hpp
     hpx/util/hardware/timestamp/linux_generic.hpp => hpx/modules/hardware.hpp
     hpx/util/hardware/timestamp/linux_x86_32.hpp => hpx/modules/hardware.hpp
     hpx/util/hardware/timestamp/linux_x86_64.hpp => hpx/modules/hardware.hpp
@@ -47,6 +49,7 @@ add_hpx_module(
     "hpx/hardware/cpuid/linux_x86.hpp"
     "hpx/hardware/cpuid/msvc.hpp"
     "hpx/hardware/timestamp/bgq.hpp"
+    "hpx/hardware/timestamp/cuda.hpp"
     "hpx/hardware/timestamp/linux_generic.hpp"
     "hpx/hardware/timestamp/linux_x86_32.hpp"
     "hpx/hardware/timestamp/linux_x86_64.hpp"

--- a/libs/core/hardware/include/hpx/hardware/timestamp.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp.hpp
@@ -10,12 +10,7 @@
 
 #include <hpx/config.hpp>
 
-// clang-format off
-// nvcc complains about multiple definition error for same function prototype
-// irrespective of __host__, __device__, and __host__ __device__ attributes. 
-#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
-    #include <hpx/hardware/timestamp/cuda.hpp>
-#elif defined(HPX_MSVC)
+#if defined(HPX_MSVC)
   #include <hpx/hardware/timestamp/msvc.hpp>
 #elif defined(__amd64__) || defined(__amd64) || defined(__x86_64__) ||         \
     defined(__x86_64) || defined(_M_X64)

--- a/libs/core/hardware/include/hpx/hardware/timestamp.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp.hpp
@@ -10,6 +10,7 @@
 
 #include <hpx/config.hpp>
 
+// clang-format off
 #if defined(HPX_MSVC)
   #include <hpx/hardware/timestamp/msvc.hpp>
 #elif defined(__amd64__) || defined(__amd64) || defined(__x86_64__) ||         \

--- a/libs/core/hardware/include/hpx/hardware/timestamp.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp.hpp
@@ -11,7 +11,11 @@
 #include <hpx/config.hpp>
 
 // clang-format off
-#if defined(HPX_MSVC)
+// nvcc complains about multiple definition error for same function prototype
+// irrespective of __host__, __device__, and __host__ __device__ attributes. 
+#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
+    #include <hpx/hardware/timestamp/cuda.hpp>
+#elif defined(HPX_MSVC)
   #include <hpx/hardware/timestamp/msvc.hpp>
 #elif defined(__amd64__) || defined(__amd64) || defined(__x86_64__) ||         \
     defined(__x86_64) || defined(_M_X64)

--- a/libs/core/hardware/include/hpx/hardware/timestamp/bgq.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/bgq.hpp
@@ -17,11 +17,20 @@
 
 #include <cstdint>
 
+#include <hpx/config.hpp>
+#if defined(HPX_HAVE_CUDA)
+#include <hpx/hardware/timestamp/cuda.hpp>
+#endif
+
 namespace hpx { namespace util { namespace hardware {
 
-    inline std::uint64_t timestamp()
+    HPX_HOST_DEVICE std::uint64_t timestamp()
     {
+#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
+        return timestamp_cuda();
+#else
         return GetTimeBase();
+#endif
     }
 
 }}}    // namespace hpx::util::hardware

--- a/libs/core/hardware/include/hpx/hardware/timestamp/bgq.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/bgq.hpp
@@ -18,13 +18,14 @@
 #include <cstdint>
 
 #include <hpx/config.hpp>
-#if defined(HPX_HAVE_CUDA)
+
+#if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
 #include <hpx/hardware/timestamp/cuda.hpp>
 #endif
 
 namespace hpx { namespace util { namespace hardware {
 
-    HPX_HOST_DEVICE std::uint64_t timestamp()
+    HPX_HOST_DEVICE inline std::uint64_t timestamp()
     {
 #if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
         return timestamp_cuda();

--- a/libs/core/hardware/include/hpx/hardware/timestamp/bgq.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/bgq.hpp
@@ -15,11 +15,11 @@
 
 #include <hwi/include/bqc/A2_inlines.h>
 
-#include <cstdint>
-
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
+#include <cstdint>
+
+#if defined(HPX_HAVE_CUDA) && defined(HPX_COMPUTE_CODE)
 #include <hpx/hardware/timestamp/cuda.hpp>
 #endif
 
@@ -27,7 +27,7 @@ namespace hpx { namespace util { namespace hardware {
 
     HPX_HOST_DEVICE inline std::uint64_t timestamp()
     {
-#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
+#if defined(HPX_HAVE_CUDA) && defined(HPX_COMPUTE_DEVICE_CODE)
         return timestamp_cuda();
 #else
         return GetTimeBase();

--- a/libs/core/hardware/include/hpx/hardware/timestamp/cuda.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/cuda.hpp
@@ -9,10 +9,11 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <cstdint>
 
 namespace hpx { namespace util { namespace hardware {
 
-    HPX_DEVICE std::uint64_t timestamp_cuda()
+    HPX_DEVICE inline std::uint64_t timestamp_cuda()
     {
         std::uint64_t cur;
         asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(cur));

--- a/libs/core/hardware/include/hpx/hardware/timestamp/cuda.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/cuda.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+
 #include <cstdint>
 
 namespace hpx { namespace util { namespace hardware {

--- a/libs/core/hardware/include/hpx/hardware/timestamp/cuda.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/cuda.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-//  Copyright (c) 2012 Thomas Heller
+//  Copyright (c) 2021 Nikunj Gupta
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,13 +8,11 @@
 
 #pragma once
 
-#include <cuda.h>
-
 #include <hpx/config.hpp>
 
 namespace hpx { namespace util { namespace hardware {
 
-    HPX_HOST_DEVICE std::uint64_t timestamp()
+    HPX_DEVICE std::uint64_t timestamp_cuda()
     {
         std::uint64_t cur;
         asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(cur));

--- a/libs/core/hardware/include/hpx/hardware/timestamp/cuda.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/cuda.hpp
@@ -8,19 +8,17 @@
 
 #pragma once
 
-#include <cstdint>
-
-#include <time.h>
+#include <cuda.h>
 
 #include <hpx/config.hpp>
 
 namespace hpx { namespace util { namespace hardware {
 
-    inline std::uint64_t timestamp()
+    HPX_HOST_DEVICE std::uint64_t timestamp()
     {
-        struct timespec res;
-        clock_gettime(CLOCK_MONOTONIC, &res);
-        return 1000 * res.tv_sec + res.tv_nsec / 1000000;
+        std::uint64_t cur;
+        asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(cur));
+        return cur;
     }
 
 }}}    // namespace hpx::util::hardware

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_generic.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_generic.hpp
@@ -14,13 +14,21 @@
 
 #include <hpx/config.hpp>
 
+#if define(HPX_HAVE_CUDA)
+#include <hpx/hardware/timestamp/cuda.hpp>
+#endif
+
 namespace hpx { namespace util { namespace hardware {
 
-    inline std::uint64_t timestamp()
+    HPX_HOST_DEVICE std::uint64_t timestamp()
     {
+#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
+        return timestamp_cuda();
+#else
         struct timespec res;
         clock_gettime(CLOCK_MONOTONIC, &res);
         return 1000 * res.tv_sec + res.tv_nsec / 1000000;
+#endif
     }
 
 }}}    // namespace hpx::util::hardware

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_generic.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_generic.hpp
@@ -12,12 +12,11 @@
 
 #include <time.h>
 
+#include <hpx/config.hpp>
+
 namespace hpx { namespace util { namespace hardware {
 
-#if defined(HPX_HAVE_CUDA)
-    HPX_HOST_DEVICE
-#endif
-    inline std::uint64_t timestamp()
+    HPX_HOST_DEVICE inline std::uint64_t timestamp()
     {
 #if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
         std::uint64_t cur;

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_generic.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_generic.hpp
@@ -14,11 +14,20 @@
 
 namespace hpx { namespace util { namespace hardware {
 
+#if defined(HPX_HAVE_CUDA)
+    HPX_HOST_DEVICE
+#endif
     inline std::uint64_t timestamp()
     {
+#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
+        std::uint64_t cur;
+        asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(cur));
+        return cur;
+#else
         struct timespec res;
         clock_gettime(CLOCK_MONOTONIC, &res);
         return 1000 * res.tv_sec + res.tv_nsec / 1000000;
+#endif
     }
 
 }}}    // namespace hpx::util::hardware

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_generic.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_generic.hpp
@@ -8,13 +8,13 @@
 
 #pragma once
 
-#include <cstdint>
+#include <hpx/config.hpp>
 
 #include <time.h>
 
-#include <hpx/config.hpp>
+#include <cstdint>
 
-#if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
+#if defined(HPX_HAVE_CUDA) && defined(HPX_COMPUTE_CODE)
 #include <hpx/hardware/timestamp/cuda.hpp>
 #endif
 
@@ -22,7 +22,7 @@ namespace hpx { namespace util { namespace hardware {
 
     HPX_HOST_DEVICE inline std::uint64_t timestamp()
     {
-#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
+#if defined(HPX_HAVE_CUDA) && defined(HPX_COMPUTE_DEVICE_CODE)
         return timestamp_cuda();
 #else
         struct timespec res;

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_generic.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_generic.hpp
@@ -14,13 +14,13 @@
 
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_CUDA)
+#if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
 #include <hpx/hardware/timestamp/cuda.hpp>
 #endif
 
 namespace hpx { namespace util { namespace hardware {
 
-    HPX_HOST_DEVICE std::uint64_t timestamp()
+    HPX_HOST_DEVICE inline std::uint64_t timestamp()
     {
 #if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
         return timestamp_cuda();

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_generic.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_generic.hpp
@@ -14,7 +14,7 @@
 
 #include <hpx/config.hpp>
 
-#if define(HPX_HAVE_CUDA)
+#if defined(HPX_HAVE_CUDA)
 #include <hpx/hardware/timestamp/cuda.hpp>
 #endif
 

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_32.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_32.hpp
@@ -9,14 +9,12 @@
 #pragma once
 
 #include <cstdint>
+#include <hpx/config.hpp>
 
 namespace hpx { namespace util { namespace hardware {
 
     // clang-format off
-#if defined(HPX_HAVE_CUDA)
-    HPX_HOST_DEVICE
-#endif
-    inline std::uint64_t timestamp()
+    HPX_HOST_DEVICE inline std::uint64_t timestamp()
     {
 #if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
         std::uint64_t cur;

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_32.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_32.hpp
@@ -11,11 +11,18 @@
 #include <cstdint>
 #include <hpx/config.hpp>
 
+#if define(HPX_HAVE_CUDA)
+#include <hpx/hardware/timestamp/cuda.hpp>
+#endif
+
 namespace hpx { namespace util { namespace hardware {
 
     // clang-format off
     inline std::uint64_t timestamp()
     {
+#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
+        return timestamp_cuda();
+#else
         std::uint64_t r = 0;
 
         #if defined(HPX_HAVE_RDTSCP)
@@ -37,6 +44,7 @@ namespace hpx { namespace util { namespace hardware {
         #endif
 
         return r;
+#endif
     }
     // clang-format on
 

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_32.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_32.hpp
@@ -8,10 +8,11 @@
 
 #pragma once
 
-#include <cstdint>
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
+#include <cstdint>
+
+#if defined(HPX_HAVE_CUDA) && defined(HPX_COMPUTE_CODE)
 #include <hpx/hardware/timestamp/cuda.hpp>
 #endif
 
@@ -20,7 +21,7 @@ namespace hpx { namespace util { namespace hardware {
     // clang-format off
     HPX_HOST_DEVICE inline std::uint64_t timestamp()
     {
-#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
+#if defined(HPX_HAVE_CUDA) && defined(HPX_COMPUTE_DEVICE_CODE)
         return timestamp_cuda();
 #else
         std::uint64_t r = 0;

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_32.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_32.hpp
@@ -11,14 +11,14 @@
 #include <cstdint>
 #include <hpx/config.hpp>
 
-#if define(HPX_HAVE_CUDA)
+#if defined(HPX_HAVE_CUDA)
 #include <hpx/hardware/timestamp/cuda.hpp>
 #endif
 
 namespace hpx { namespace util { namespace hardware {
 
     // clang-format off
-    inline std::uint64_t timestamp()
+    HPX_HOST_DEVICE std::uint64_t timestamp()
     {
 #if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
         return timestamp_cuda();

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_32.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_32.hpp
@@ -11,14 +11,14 @@
 #include <cstdint>
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_CUDA)
+#if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
 #include <hpx/hardware/timestamp/cuda.hpp>
 #endif
 
 namespace hpx { namespace util { namespace hardware {
 
     // clang-format off
-    HPX_HOST_DEVICE std::uint64_t timestamp()
+    HPX_HOST_DEVICE inline std::uint64_t timestamp()
     {
 #if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
         return timestamp_cuda();

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_32.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_32.hpp
@@ -14,13 +14,8 @@
 namespace hpx { namespace util { namespace hardware {
 
     // clang-format off
-    HPX_HOST_DEVICE inline std::uint64_t timestamp()
+    inline std::uint64_t timestamp()
     {
-#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
-        std::uint64_t cur;
-        asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(cur));
-        return cur;
-#else
         std::uint64_t r = 0;
 
         #if defined(HPX_HAVE_RDTSCP)
@@ -42,7 +37,6 @@ namespace hpx { namespace util { namespace hardware {
         #endif
 
         return r;
-#endif
     }
     // clang-format on
 

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_32.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_32.hpp
@@ -13,8 +13,16 @@
 namespace hpx { namespace util { namespace hardware {
 
     // clang-format off
+#if defined(HPX_HAVE_CUDA)
+    HPX_HOST_DEVICE
+#endif
     inline std::uint64_t timestamp()
     {
+#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
+        std::uint64_t cur;
+        asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(cur));
+        return cur;
+#else
         std::uint64_t r = 0;
 
         #if defined(HPX_HAVE_RDTSCP)
@@ -36,6 +44,7 @@ namespace hpx { namespace util { namespace hardware {
         #endif
 
         return r;
+#endif
     }
     // clang-format on
 

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_64.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_64.hpp
@@ -11,7 +11,7 @@
 #include <cstdint>
 #include <hpx/config.hpp>
 
-#if define(HPX_HAVE_CUDA)
+#if defined(HPX_HAVE_CUDA)
 #include <hpx/hardware/timestamp/cuda.hpp>
 #endif
 

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_64.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_64.hpp
@@ -11,14 +11,14 @@
 #include <cstdint>
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_CUDA)
+#if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
 #include <hpx/hardware/timestamp/cuda.hpp>
 #endif
 
 namespace hpx { namespace util { namespace hardware {
 
     // clang-format off
-    inline std::uint64_t timestamp()
+    HPX_HOST_DEVICE inline std::uint64_t timestamp()
     {
 #if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
         return timestamp_cuda();

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_64.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_64.hpp
@@ -14,13 +14,8 @@
 namespace hpx { namespace util { namespace hardware {
 
     // clang-format off
-    HPX_HOST_DEVICE inline std::uint64_t timestamp()
+    inline std::uint64_t timestamp()
     {
-#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
-        std::uint64_t cur;
-        asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(cur));
-        return cur;
-#else
         std::uint32_t lo = 0, hi = 0;
         #if defined(HPX_HAVE_RDTSCP)
             __asm__ __volatile__(
@@ -37,7 +32,6 @@ namespace hpx { namespace util { namespace hardware {
                 : "rbx", "rcx");
         #endif
         return ((static_cast<std::uint64_t>(hi)) << 32) | lo;
-#endif
     }
     // clang-format on
 

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_64.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_64.hpp
@@ -11,11 +11,18 @@
 #include <cstdint>
 #include <hpx/config.hpp>
 
+#if define(HPX_HAVE_CUDA)
+#include <hpx/hardware/timestamp/cuda.hpp>
+#endif
+
 namespace hpx { namespace util { namespace hardware {
 
     // clang-format off
     inline std::uint64_t timestamp()
     {
+#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
+        return timestamp_cuda();
+#else
         std::uint32_t lo = 0, hi = 0;
         #if defined(HPX_HAVE_RDTSCP)
             __asm__ __volatile__(
@@ -32,6 +39,7 @@ namespace hpx { namespace util { namespace hardware {
                 : "rbx", "rcx");
         #endif
         return ((static_cast<std::uint64_t>(hi)) << 32) | lo;
+#endif
     }
     // clang-format on
 

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_64.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_64.hpp
@@ -12,9 +12,17 @@
 
 namespace hpx { namespace util { namespace hardware {
 
+#if defined(HPX_HAVE_CUDA)
+    HPX_HOST_DEVICE
+#endif
     // clang-format off
     inline std::uint64_t timestamp()
     {
+#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
+        std::uint64_t cur;
+        asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(cur));
+        return cur;
+#else
         std::uint32_t lo = 0, hi = 0;
         #if defined(HPX_HAVE_RDTSCP)
             __asm__ __volatile__(
@@ -31,6 +39,7 @@ namespace hpx { namespace util { namespace hardware {
                 : "rbx", "rcx");
         #endif
         return ((static_cast<std::uint64_t>(hi)) << 32) | lo;
+#endif
     }
     // clang-format on
 

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_64.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_64.hpp
@@ -9,14 +9,12 @@
 #pragma once
 
 #include <cstdint>
+#include <hpx/config.hpp>
 
 namespace hpx { namespace util { namespace hardware {
 
-#if defined(HPX_HAVE_CUDA)
-    HPX_HOST_DEVICE
-#endif
     // clang-format off
-    inline std::uint64_t timestamp()
+    HPX_HOST_DEVICE inline std::uint64_t timestamp()
     {
 #if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
         std::uint64_t cur;

--- a/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_64.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/linux_x86_64.hpp
@@ -8,10 +8,11 @@
 
 #pragma once
 
-#include <cstdint>
 #include <hpx/config.hpp>
 
-#if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
+#include <cstdint>
+
+#if defined(HPX_HAVE_CUDA) && defined(HPX_COMPUTE_CODE)
 #include <hpx/hardware/timestamp/cuda.hpp>
 #endif
 
@@ -20,7 +21,7 @@ namespace hpx { namespace util { namespace hardware {
     // clang-format off
     HPX_HOST_DEVICE inline std::uint64_t timestamp()
     {
-#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
+#if defined(HPX_HAVE_CUDA) && defined(HPX_COMPUTE_DEVICE_CODE)
         return timestamp_cuda();
 #else
         std::uint32_t lo = 0, hi = 0;

--- a/libs/core/hardware/include/hpx/hardware/timestamp/msvc.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/msvc.hpp
@@ -16,12 +16,20 @@
 #include <intrin.h>
 #include <windows.h>
 
+#if defined(HPX_HAVE_CUDA)
+#include <hpx/hardware/timestamp/cuda.hpp>
+#endif
+
 namespace hpx { namespace util { namespace hardware {
     inline std::uint64_t timestamp()
     {
+#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
+        return timestamp_cuda();
+#else
         LARGE_INTEGER now;
         QueryPerformanceCounter(&now);
         return static_cast<std::uint64_t>(now.QuadPart);
+#endif
     }
 }}}    // namespace hpx::util::hardware
 

--- a/libs/core/hardware/include/hpx/hardware/timestamp/msvc.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/msvc.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+
 #if defined(HPX_WINDOWS)
 
 #include <cstdint>
@@ -16,14 +17,14 @@
 #include <intrin.h>
 #include <windows.h>
 
-#if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
+#if defined(HPX_HAVE_CUDA) && defined(HPX_COMPUTE_CODE)
 #include <hpx/hardware/timestamp/cuda.hpp>
 #endif
 
 namespace hpx { namespace util { namespace hardware {
     HPX_HOST_DEVICE inline std::uint64_t timestamp()
     {
-#if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
+#if defined(HPX_HAVE_CUDA) && defined(HPX_COMPUTE_DEVICE_CODE)
         return timestamp_cuda();
 #else
         LARGE_INTEGER now;

--- a/libs/core/hardware/include/hpx/hardware/timestamp/msvc.hpp
+++ b/libs/core/hardware/include/hpx/hardware/timestamp/msvc.hpp
@@ -16,12 +16,12 @@
 #include <intrin.h>
 #include <windows.h>
 
-#if defined(HPX_HAVE_CUDA)
+#if defined(HPX_HAVE_CUDA) && defined(__CUDACC__)
 #include <hpx/hardware/timestamp/cuda.hpp>
 #endif
 
 namespace hpx { namespace util { namespace hardware {
-    inline std::uint64_t timestamp()
+    HPX_HOST_DEVICE inline std::uint64_t timestamp()
     {
 #if defined(HPX_HAVE_CUDA) && defined(__CUDA_ARCH__)
         return timestamp_cuda();


### PR DESCRIPTION
This PR provides support for timestamps in CUDA kernels. The output is received in nanosecond duration and more information can be found [here](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-globaltimer).

I'm adding CUDA support so that I can use timestamp instead of relying on asm directly within my hpx-kokkos-resilience project.