### PR TITLE
Make the sequenced_executor processing_units_count member function const

### DIFF
--- a/libs/parallelism/executors/include/hpx/executors/sequenced_executor.hpp
+++ b/libs/parallelism/executors/include/hpx/executors/sequenced_executor.hpp
@@ -122,7 +122,7 @@ namespace hpx { namespace execution {
         }
 
         template <typename Parameters>
-        std::size_t processing_units_count(Parameters&&)
+        std::size_t processing_units_count(Parameters&&) const
         {
             return 1;
         }


### PR DESCRIPTION
@srinivasyadav18 this should fix your build error on the GCC 11 build.