### PR TITLE
Making sure collective operations can be reused by preallocating communicator

### DIFF
--- a/examples/1d_stencil/1d_stencil_8.cpp
+++ b/examples/1d_stencil/1d_stencil_8.cpp
@@ -628,8 +628,6 @@ stepper_server::space stepper_server::do_work(std::size_t local_np,
     return U_[nt % 2];
 }
 
-HPX_REGISTER_GATHER(stepper_server::space, stepper_server_space_gatherer);
-
 ///////////////////////////////////////////////////////////////////////////////
 void do_all_work(std::uint64_t nt, std::uint64_t nx, std::uint64_t np,
     std::uint64_t nd)

--- a/libs/core/config/include/hpx/config.hpp
+++ b/libs/core/config/include/hpx/config.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2018 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c) 2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/core/config/include/hpx/config.hpp
+++ b/libs/core/config/include/hpx/config.hpp
@@ -14,6 +14,15 @@
 #error Boost.Config was included before the hpx config header. This might lead to subtle failures and compile errors. Please include <hpx/config.hpp> before any other boost header
 #endif
 
+#include <hpx/config/defines.hpp>
+
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__)
+// On Windows, make sure winsock.h is not included even if windows.h is
+// included before winsock2.h
+#define _WINSOCKAPI_
+#include <winsock2.h>
+#endif
+
 #include <hpx/config/attributes.hpp>
 #include <hpx/config/branch_hints.hpp>
 #include <hpx/config/compiler_fence.hpp>
@@ -21,7 +30,6 @@
 #include <hpx/config/compiler_specific.hpp>
 #include <hpx/config/constexpr.hpp>
 #include <hpx/config/debug.hpp>
-#include <hpx/config/defines.hpp>
 #include <hpx/config/deprecation.hpp>
 #include <hpx/config/emulate_deleted.hpp>
 #include <hpx/config/export_definitions.hpp>
@@ -43,12 +51,6 @@
 
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/preprocessor/stringize.hpp>
-
-#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__)
-// On Windows, make sure winsock.h is not included even if windows.h is
-// included before winsock2.h
-#define _WINSOCKAPI_
-#endif
 
 // clang-format off
 

--- a/libs/full/collectives/CMakeLists.txt
+++ b/libs/full/collectives/CMakeLists.txt
@@ -21,8 +21,10 @@ set(collectives_headers
     hpx/collectives/communication_set.hpp
     hpx/collectives/detail/communication_set_node.hpp
     hpx/collectives/detail/communicator.hpp
+    hpx/collectives/exclusive_scan.hpp
     hpx/collectives/fold.hpp
     hpx/collectives/gather.hpp
+    hpx/collectives/inclusive_scan.hpp
     hpx/collectives/latch.hpp
     hpx/collectives/reduce.hpp
     hpx/collectives/reduce_direct.hpp

--- a/libs/full/collectives/CMakeLists.txt
+++ b/libs/full/collectives/CMakeLists.txt
@@ -25,6 +25,7 @@ set(collectives_headers
     hpx/collectives/gather.hpp
     hpx/collectives/latch.hpp
     hpx/collectives/reduce.hpp
+    hpx/collectives/reduce_direct.hpp
     hpx/collectives/scatter.hpp
     hpx/collectives/spmd_block.hpp
     hpx/collectives/detail/barrier_node.hpp

--- a/libs/full/collectives/CMakeLists.txt
+++ b/libs/full/collectives/CMakeLists.txt
@@ -19,6 +19,7 @@ set(collectives_headers
     hpx/collectives/broadcast.hpp
     hpx/collectives/broadcast_direct.hpp
     hpx/collectives/communication_set.hpp
+    hpx/collectives/create_communicator.hpp
     hpx/collectives/detail/communication_set_node.hpp
     hpx/collectives/detail/communicator.hpp
     hpx/collectives/exclusive_scan.hpp
@@ -52,8 +53,8 @@ set(collectives_compat_headers
 
 # Default location is $HPX_ROOT/libs/collectives/src
 set(collectives_sources
-    barrier.cpp create_communication_set.cpp latch.cpp detail/barrier_node.cpp
-    detail/communication_set_node.cpp detail/communicator.cpp
+    barrier.cpp create_communication_set.cpp create_communicator.cpp latch.cpp
+    detail/barrier_node.cpp detail/communication_set_node.cpp
 )
 
 include(HPX_AddModule)

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2019 Hartmut Kaiser
+//  Copyright (c) 2019-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -81,7 +81,7 @@ namespace hpx { namespace lcos {
     ///             ready once the all_gather operation has been completed.
     ///
     template <typename T>
-    hpx::future<std::vector<typename std::decay<T>::type>>
+    hpx::future<std::vector<std::decay_t<T>>>
     all_gather(char const* basename,
         T&& result,
         std::size_t num_sites = std::size_t(-1),
@@ -101,10 +101,8 @@ namespace hpx { namespace lcos {
 #include <hpx/async_distributed/async.hpp>
 #include <hpx/async_local/dataflow.hpp>
 #include <hpx/collectives/detail/communicator.hpp>
-#include <hpx/components/basename_registration.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/futures/traits/acquire_shared_state.hpp>
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/naming_base/id_type.hpp>
 #include <hpx/thread_support/assert_owns_lock.hpp>
@@ -139,7 +137,7 @@ namespace hpx { namespace traits {
         template <typename Result, typename T>
         Result get(std::size_t which, T&& t)
         {
-            using arg_type = typename std::decay<T>::type;
+            using arg_type = std::decay_t<T>;
             using mutex_type = typename Communicator::mutex_type;
             using lock_type = std::unique_lock<mutex_type>;
 
@@ -241,16 +239,15 @@ namespace hpx { namespace lcos {
     ///////////////////////////////////////////////////////////////////////////
     // all_gather plain values
     template <typename T>
-    hpx::future<std::vector<typename std::decay<T>::type>> all_gather(
-        communicator fid, T&& local_result,
-        std::size_t this_site = std::size_t(-1))
+    hpx::future<std::vector<std::decay_t<T>>> all_gather(communicator fid,
+        T&& local_result, std::size_t this_site = std::size_t(-1))
     {
         if (this_site == std::size_t(-1))
         {
             this_site = static_cast<std::size_t>(agas::get_locality_id());
         }
 
-        using arg_type = typename std::decay<T>::type;
+        using arg_type = std::decay_t<T>;
 
         auto all_gather_data_direct =
             [local_result = std::forward<T>(local_result), this_site](
@@ -275,9 +272,8 @@ namespace hpx { namespace lcos {
     }
 
     template <typename T>
-    hpx::future<std::vector<typename std::decay<T>::type>> all_gather(
-        char const* basename, T&& local_result,
-        std::size_t num_sites = std::size_t(-1),
+    hpx::future<std::vector<std::decay_t<T>>> all_gather(char const* basename,
+        T&& local_result, std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -12,36 +12,7 @@
 // clang-format off
 namespace hpx { namespace collectives {
 
-    /// Create a new communicator object usable with all_gather
-    ///
-    /// This functions creates a new communicator object that can be called in
-    /// order to pre-allocate a communicator object usable with multiple
-    /// invocations of \a all_gather.
-    ///
-    /// \param  basename    The base name identifying the all_gather operation
-    /// \param  num_sites   The number of participating sites (default: all
-    ///                     localities).
-    /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the all_gather operation performed on the
-    ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the all_gather operation on the
-    ///                     given base name has to be performed more than once.
-    /// \param this_site    The sequence number of this invocation (usually
-    ///                     the locality id). This value is optional and
-    ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \params root_site   The site that is responsible for creating the
-    ///                     all_gather support object. This value is optional
-    ///                     and defaults to '0' (zero).
-    ///
-    /// \returns    This function returns a new communicator object usable
-    ///             with all_gather
-    ///
-    communicator create_all_gather(char const* basename,
-        std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
-
-    /// AllToAll a set of values from different call sites
+    /// AllGather a set of values from different call sites
     ///
     /// This function receives a set of values from all call sites operating on
     /// the given base name.
@@ -76,7 +47,7 @@ namespace hpx { namespace collectives {
         std::size_t this_site = std::size_t(-1),
         std::size_t root_site = 0);
 
-    /// AllToAll a set of values from different call sites
+    /// AllGather a set of values from different call sites
     ///
     /// This function receives a set of values from all call sites operating on
     /// the given base name.
@@ -108,7 +79,7 @@ namespace hpx { namespace collectives {
 
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_distributed/async.hpp>
-#include <hpx/collectives/detail/communicator.hpp>
+#include <hpx/collectives/create_communicator.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/type_support/unused.hpp>
@@ -116,7 +87,6 @@ namespace hpx { namespace collectives {
 #include <cstddef>
 #include <memory>
 #include <mutex>
-#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -186,16 +156,6 @@ namespace hpx { namespace traits {
 namespace hpx { namespace collectives {
 
     ///////////////////////////////////////////////////////////////////////////
-    inline communicator create_all_gather(char const* basename,
-        std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
-    {
-        return detail::create_communicator(
-            basename, num_sites, generation, this_site, root_site);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
     // all_gather plain values
     template <typename T>
     hpx::future<std::vector<std::decay_t<T>>> all_gather(communicator fid,
@@ -236,7 +196,7 @@ namespace hpx { namespace collectives {
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {
-        return all_gather(create_all_gather(basename, num_sites, generation,
+        return all_gather(create_communicator(basename, num_sites, generation,
                               this_site, root_site),
             std::forward<T>(local_result), this_site);
     }
@@ -248,5 +208,5 @@ namespace hpx { namespace collectives {
 ////////////////////////////////////////////////////////////////////////////////
 #define HPX_REGISTER_ALLGATHER(...)             /**/
 
-#endif    // COMPUTE_HOST_CODE
+#endif    // !HPX_COMPUTE_DEVICE_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2019 Hartmut Kaiser
+//  Copyright (c) 2019-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -101,10 +101,8 @@ namespace hpx { namespace lcos {
 #include <hpx/async_distributed/async.hpp>
 #include <hpx/async_local/dataflow.hpp>
 #include <hpx/collectives/detail/communicator.hpp>
-#include <hpx/components/basename_registration.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/futures/traits/acquire_shared_state.hpp>
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/naming_base/id_type.hpp>
 #include <hpx/parallel/algorithms/reduce.hpp>
@@ -140,7 +138,7 @@ namespace hpx { namespace traits {
         template <typename Result, typename T, typename F>
         Result get(std::size_t which, T&& t, F&& op)
         {
-            using arg_type = typename std::decay<T>::type;
+            using arg_type = std::decay_t<T>;
             using mutex_type = typename Communicator::mutex_type;
             using lock_type = std::unique_lock<mutex_type>;
 
@@ -215,7 +213,7 @@ namespace hpx { namespace lcos {
         auto all_reduce_data =
             [op = std::forward<F>(op), this_site](communicator&& c,
                 hpx::future<T>&& local_result) mutable -> hpx::future<T> {
-            using func_type = typename std::decay<F>::type;
+            using func_type = std::decay_t<F>;
             using action_type = typename detail::communicator_server::
                 template communication_get_action<
                     traits::communication::all_reduce_tag, hpx::future<T>, T,
@@ -251,21 +249,21 @@ namespace hpx { namespace lcos {
     ////////////////////////////////////////////////////////////////////////////
     // all_reduce plain values
     template <typename T, typename F>
-    hpx::future<typename std::decay<T>::type> all_reduce(communicator fid,
-        T&& local_result, F&& op, std::size_t this_site = std::size_t(-1))
+    hpx::future<std::decay_t<T>> all_reduce(communicator fid, T&& local_result,
+        F&& op, std::size_t this_site = std::size_t(-1))
     {
         if (this_site == std::size_t(-1))
         {
             this_site = static_cast<std::size_t>(agas::get_locality_id());
         }
 
-        using arg_type = typename std::decay<T>::type;
+        using arg_type = std::decay_t<T>;
 
         auto all_reduce_data_direct =
             [op = std::forward<F>(op),
                 local_result = std::forward<T>(local_result),
                 this_site](communicator&& c) mutable -> hpx::future<arg_type> {
-            using func_type = typename std::decay<F>::type;
+            using func_type = std::decay_t<F>;
             using action_type = typename detail::communicator_server::
                 template communication_get_action<
                     traits::communication::all_reduce_tag,
@@ -286,7 +284,7 @@ namespace hpx { namespace lcos {
     }
 
     template <typename T, typename F>
-    hpx::future<typename std::decay<T>::type> all_reduce(char const* basename,
+    hpx::future<std::decay_t<T>> all_reduce(char const* basename,
         T&& local_result, F&& op, std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -12,35 +12,6 @@
 // clang-format off
 namespace hpx { namespace collectives {
 
-    /// Create a new communicator object usable with all_reduce
-    ///
-    /// This functions creates a new communicator object that can be called in
-    /// order to pre-allocate a communicator object usable with multiple
-    /// invocations of \a all_reduce.
-    ///
-    /// \param  basename    The base name identifying the all_reduce operation
-    /// \param  num_sites   The number of participating sites (default: all
-    ///                     localities).
-    /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the all_reduce operation performed on the
-    ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the all_reduce operation on the
-    ///                     given base name has to be performed more than once.
-    /// \param this_site    The sequence number of this invocation (usually
-    ///                     the locality id). This value is optional and
-    ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \params root_site   The site that is responsible for creating the
-    ///                     all_reduce support object. This value is optional
-    ///                     and defaults to '0' (zero).
-    ///
-    /// \returns    This function returns a new communicator object usable
-    ///             with all_reduce
-    ///
-    communicator create_all_reduce(char const* basename,
-        std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
-
     /// AllReduce a set of values from different call sites
     ///
     /// This function receives a set of values from all call sites operating on
@@ -108,7 +79,7 @@ namespace hpx { namespace collectives {
 
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_distributed/async.hpp>
-#include <hpx/collectives/detail/communicator.hpp>
+#include <hpx/collectives/create_communicator.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/parallel/algorithms/reduce.hpp>
@@ -117,7 +88,6 @@ namespace hpx { namespace collectives {
 #include <cstddef>
 #include <memory>
 #include <mutex>
-#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -197,16 +167,6 @@ namespace hpx { namespace traits {
 
 namespace hpx { namespace collectives {
 
-    ///////////////////////////////////////////////////////////////////////////
-    inline communicator create_all_reduce(char const* basename,
-        std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
-    {
-        return detail::create_communicator(
-            basename, num_sites, generation, this_site, root_site);
-    }
-
     ////////////////////////////////////////////////////////////////////////////
     // all_reduce plain values
     template <typename T, typename F>
@@ -250,7 +210,7 @@ namespace hpx { namespace collectives {
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {
-        return all_reduce(create_all_reduce(basename, num_sites, generation,
+        return all_reduce(create_communicator(basename, num_sites, generation,
                               this_site, root_site),
             std::forward<T>(local_result), std::forward<F>(op), this_site);
     }
@@ -262,5 +222,5 @@ namespace hpx { namespace collectives {
 ////////////////////////////////////////////////////////////////////////////////
 #define HPX_REGISTER_ALLREDUCE(...)             /**/
 
-#endif    // COMPUTE_HOST_CODE
+#endif    // !HPX_COMPUTE_DEVICE_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -12,6 +12,35 @@
 // clang-format off
 namespace hpx { namespace lcos {
 
+    /// Create a new communicator object usable with all_to_all
+    ///
+    /// This functions creates a new communicator object that can be called in
+    /// order to pre-allocate a communicator object usable with multiple
+    /// invocations of \a all_to_all.
+    ///
+    /// \param  basename    The base name identifying the all_to_all operation
+    /// \param  num_sites   The number of participating sites (default: all
+    ///                     localities).
+    /// \param  generation  The generational counter identifying the sequence
+    ///                     number of the all_to_all operation performed on the
+    ///                     given base name. This is optional and needs to be
+    ///                     supplied only if the all_to_all operation on the
+    ///                     given base name has to be performed more than once.
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
+    /// \params root_site   The site that is responsible for creating the
+    ///                     all_to_all support object. This value is optional
+    ///                     and defaults to '0' (zero).
+    ///
+    /// \returns    This function returns a new communicator object usable
+    ///             with all_to_all
+    ///
+    communicator create_all_to_all(char const* basename,
+        std::size_t num_sites = std::size_t(-1),
+        std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
+
     /// AllToAll a set of values from different call sites
     ///
     /// This function receives a set of values from all call sites operating on
@@ -34,21 +63,40 @@ namespace hpx { namespace lcos {
     ///                     all_to_all support object. This value is optional
     ///                     and defaults to '0' (zero).
     ///
-    /// \note       Each all_to_all operation has to be accompanied with a unique
-    ///             usage of the \a HPX_REGISTER_ALLTOALL macro to define the
-    ///             necessary internal facilities used by \a all_to_all.
+    /// \returns    This function returns a future holding a vector with all
+    ///             values send by all participating sites. It will become
+    ///             ready once the all_to_all operation has been completed.
+    ///
+    template <typename T>
+    hpx::future<std::vector<T>>
+    all_to_all(char const* basename,
+        hpx::future<std::vector<T>>&& result,
+        std::size_t num_sites = std::size_t(-1),
+        std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1),
+        std::size_t root_site = 0);
+
+    /// AllToAll a set of values from different call sites
+    ///
+    /// This function receives a set of values from all call sites operating on
+    /// the given base name.
+    ///
+    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param  local_result A future referring to the value to transmit to all
+    ///                     participating sites from this call site.
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
     ///
     /// \returns    This function returns a future holding a vector with all
     ///             values send by all participating sites. It will become
     ///             ready once the all_to_all operation has been completed.
     ///
     template <typename T>
-    hpx::future<std::vector<T>> all_to_all(char const* basename,
+    hpx::future<std::vector<T>>
+    all_to_all(communicator comm,
         hpx::future<std::vector<T>>&& result,
-        std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1),
-        std::size_t root_site = 0);
+        std::size_t this_site = std::size_t(-1));
 
     /// AllToAll a set of values from different call sites
     ///
@@ -72,20 +120,37 @@ namespace hpx { namespace lcos {
     ///                     all_to_all support object. This value is optional
     ///                     and defaults to '0' (zero).
     ///
-    /// \note       Each all_to_all operation has to be accompanied with a unique
-    ///             usage of the \a HPX_REGISTER_ALLTOALL macro to define the
-    ///             necessary internal facilities used by \a all_to_all.
+    /// \returns    This function returns a future holding a vector with all
+    ///             values send by all participating sites. It will become
+    ///             ready once the all_to_all operation has been completed.
+    ///
+    template <typename T>
+    hpx::future<std::vector<std::decay_t<T>>>
+    all_to_all(char const* basename, T&& result,
+        std::size_t num_sites = std::size_t(-1),
+        std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
+
+    /// AllToAll a set of values from different call sites
+    ///
+    /// This function receives a set of values from all call sites operating on
+    /// the given base name.
+    ///
+    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param  local_result The value to transmit to all
+    ///                     participating sites from this call site.
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
     ///
     /// \returns    This function returns a future holding a vector with all
     ///             values send by all participating sites. It will become
     ///             ready once the all_to_all operation has been completed.
     ///
     template <typename T>
-    hpx::future<std::vector<std::decay_t<T>>> all_to_all(
-        char const* basename, T&& result,
-        std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
+    hpx::future<std::vector<std::decay_t<T>>>
+    all_to_all(communicator comm, T&& result,
+        std::size_t this_site = std::size_t(-1)0);
 }}    // namespace hpx::lcos
 
 // clang-format on
@@ -103,7 +168,6 @@ namespace hpx { namespace lcos {
 #include <hpx/futures/future.hpp>
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/naming_base/id_type.hpp>
-#include <hpx/thread_support/assert_owns_lock.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <cstddef>
@@ -178,8 +242,6 @@ namespace hpx { namespace traits {
 
             if (communicator_.gate_.set(which, std::move(l)))
             {
-                HPX_ASSERT_DOESNT_OWN_LOCK(l);
-
                 l = lock_type(communicator_.mtx_);
                 communicator_.invalidate_data(l);
             }

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2019-2020 Hartmut Kaiser
+//  Copyright (c) 2019-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -81,7 +81,7 @@ namespace hpx { namespace lcos {
     ///             ready once the all_to_all operation has been completed.
     ///
     template <typename T>
-    hpx::future<std::vector<typename std::decay<T>::type>> all_to_all(
+    hpx::future<std::vector<std::decay_t<T>>> all_to_all(
         char const* basename, T&& result,
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
@@ -99,10 +99,8 @@ namespace hpx { namespace lcos {
 #include <hpx/async_distributed/async.hpp>
 #include <hpx/async_local/dataflow.hpp>
 #include <hpx/collectives/detail/communicator.hpp>
-#include <hpx/components/basename_registration.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/futures/traits/acquire_shared_state.hpp>
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/naming_base/id_type.hpp>
 #include <hpx/thread_support/assert_owns_lock.hpp>
@@ -137,7 +135,7 @@ namespace hpx { namespace traits {
         template <typename Result, typename T>
         Result get(std::size_t which, std::vector<T>&& t)
         {
-            using arg_type = typename std::decay<T>::type;
+            using arg_type = std::decay_t<T>;
             using data_type = std::vector<arg_type>;
             using mutex_type = typename Communicator::mutex_type;
             using lock_type = std::unique_lock<mutex_type>;

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -129,7 +129,7 @@ namespace hpx { namespace traits {
       : std::enable_shared_from_this<communication_operation<Communicator,
             communication::all_to_all_tag>>
     {
-        communication_operation(Communicator& comm)
+        explicit communication_operation(Communicator& comm)
           : communicator_(comm)
         {
         }
@@ -138,19 +138,20 @@ namespace hpx { namespace traits {
         Result get(std::size_t which, std::vector<T>&& t)
         {
             using arg_type = typename std::decay<T>::type;
+            using data_type = std::vector<arg_type>;
             using mutex_type = typename Communicator::mutex_type;
+            using lock_type = std::unique_lock<mutex_type>;
 
             auto this_ = this->shared_from_this();
-            auto on_ready =
-                [this_ = std::move(this_), which](
-                    shared_future<void>&& f) -> std::vector<arg_type> {
+            auto on_ready = [this_ = std::move(this_), which](
+                                shared_future<void>&& f) -> data_type {
+                HPX_UNUSED(this_);
                 f.get();    // propagate any exceptions
 
                 auto& communicator = this_->communicator_;
 
-                std::unique_lock<mutex_type> l(communicator.mtx_);
-                auto& data =
-                    communicator.template access_data<std::vector<arg_type>>(l);
+                lock_type l(communicator.mtx_);
+                auto& data = communicator.template access_data<data_type>(l);
 
                 // slice the overall data based on the locality id of the
                 // requesting site
@@ -165,33 +166,26 @@ namespace hpx { namespace traits {
                 return result;
             };
 
-            std::unique_lock<mutex_type> l(communicator_.mtx_);
-            util::ignore_while_checking<std::unique_lock<mutex_type>> il(&l);
+            lock_type l(communicator_.mtx_);
+            util::ignore_while_checking<lock_type> il(&l);
 
-            hpx::future<std::vector<arg_type>> f =
+            hpx::future<data_type> f =
                 communicator_.gate_.get_shared_future(l).then(
                     hpx::launch::sync, on_ready);
 
             communicator_.gate_.synchronize(1, l);
 
-            auto& data =
-                communicator_.template access_data<std::vector<arg_type>>(l);
+            auto& data = communicator_.template access_data<data_type>(l);
             data[which] = std::move(t);
 
-            if (communicator_.gate_.set(which, l))
+            if (communicator_.gate_.set(which, std::move(l)))
             {
                 HPX_ASSERT_DOESNT_OWN_LOCK(l);
-                {
-                    std::unique_lock<mutex_type> l(communicator_.mtx_);
-                    communicator_.invalidate_data(l);
-                }
 
-                // this is a one-shot object (generations counters are not
-                // supported), unregister ourselves (but only once)
-                hpx::unregister_with_basename(
-                    std::move(communicator_.name_), communicator_.site_)
-                    .get();
+                l = lock_type(communicator_.mtx_);
+                communicator_.invalidate_data(l);
             }
+
             return f;
         }
 
@@ -202,18 +196,18 @@ namespace hpx { namespace traits {
 namespace hpx { namespace lcos {
 
     ///////////////////////////////////////////////////////////////////////////
-    inline hpx::future<hpx::id_type> create_all_to_all(char const* basename,
+    inline communicator create_all_to_all(char const* basename,
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1))
+        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {
         return detail::create_communicator(
-            basename, num_sites, generation, this_site);
+            basename, num_sites, generation, this_site, root_site);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    hpx::future<std::vector<T>> all_to_all(hpx::future<hpx::id_type>&& fid,
+    hpx::future<std::vector<T>> all_to_all(communicator fid,
         hpx::future<std::vector<T>>&& local_result,
         std::size_t this_site = std::size_t(-1))
     {
@@ -222,7 +216,7 @@ namespace hpx { namespace lcos {
             this_site = static_cast<std::size_t>(agas::get_locality_id());
         }
 
-        auto all_to_all_data = [this_site](hpx::future<hpx::id_type>&& f,
+        auto all_to_all_data = [this_site](communicator&& c,
                                    hpx::future<std::vector<T>>&& local_result)
             -> hpx::future<std::vector<T>> {
             using action_type = typename detail::communicator_server::
@@ -230,13 +224,13 @@ namespace hpx { namespace lcos {
                     traits::communication::all_to_all_tag,
                     hpx::future<std::vector<T>>, std::vector<T>>;
 
-            // make sure id is kept alive as long as the returned future
-            hpx::id_type id = f.get();
-            auto result =
-                async(action_type(), id, this_site, local_result.get());
+            // make sure id is kept alive as long as the returned future,
+            // explicitly unwrap returned future
+            hpx::future<std::vector<T>> result =
+                async(action_type(), c, this_site, local_result.get());
 
             traits::detail::get_shared_state(result)->set_on_completed(
-                [id = std::move(id)]() { HPX_UNUSED(id); });
+                [client = std::move(c)]() { HPX_UNUSED(client); });
 
             return result;
         };
@@ -252,37 +246,15 @@ namespace hpx { namespace lcos {
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {
-        if (num_sites == std::size_t(-1))
-        {
-            num_sites = static_cast<std::size_t>(
-                agas::get_num_localities(hpx::launch::sync));
-        }
-        if (this_site == std::size_t(-1))
-        {
-            this_site = static_cast<std::size_t>(agas::get_locality_id());
-        }
-
-        if (this_site == root_site)
-        {
-            return all_to_all(
-                create_all_to_all(basename, num_sites, generation, root_site),
-                std::move(local_result), this_site);
-        }
-
-        std::string name(basename);
-        if (generation != std::size_t(-1))
-        {
-            name += std::to_string(generation) + "/";
-        }
-
-        return all_to_all(hpx::find_from_basename(std::move(name), root_site),
+        return all_to_all(create_all_to_all(basename, num_sites, generation,
+                              this_site, root_site),
             std::move(local_result), this_site);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     // all_to_all plain values
     template <typename T>
-    hpx::future<std::vector<T>> all_to_all(hpx::future<hpx::id_type>&& fid,
+    hpx::future<std::vector<T>> all_to_all(communicator fid,
         std::vector<T>&& local_result, std::size_t this_site = std::size_t(-1))
     {
         if (this_site == std::size_t(-1))
@@ -292,19 +264,19 @@ namespace hpx { namespace lcos {
 
         auto all_to_all_data_direct =
             [local_result = std::move(local_result), this_site](
-                hpx::future<hpx::id_type>&& f) -> hpx::future<std::vector<T>> {
+                communicator&& c) -> hpx::future<std::vector<T>> {
             using action_type = typename detail::communicator_server::
                 template communication_get_action<
                     traits::communication::all_to_all_tag,
                     hpx::future<std::vector<T>>, std::vector<T>>;
 
-            // make sure id is kept alive as long as the returned future
-            hpx::id_type id = f.get();
-            auto result =
-                async(action_type(), id, this_site, std::move(local_result));
+            // make sure id is kept alive as long as the returned future,
+            // explicitly unwrap returned future
+            hpx::future<std::vector<T>> result =
+                async(action_type(), c, this_site, std::move(local_result));
 
             traits::detail::get_shared_state(result)->set_on_completed(
-                [id = std::move(id)]() { HPX_UNUSED(id); });
+                [client = std::move(c)]() { HPX_UNUSED(client); });
 
             return result;
         };
@@ -318,30 +290,8 @@ namespace hpx { namespace lcos {
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {
-        if (num_sites == std::size_t(-1))
-        {
-            num_sites = static_cast<std::size_t>(
-                agas::get_num_localities(hpx::launch::sync));
-        }
-        if (this_site == std::size_t(-1))
-        {
-            this_site = static_cast<std::size_t>(agas::get_locality_id());
-        }
-
-        if (this_site == root_site)
-        {
-            return all_to_all(
-                create_all_to_all(basename, num_sites, generation, root_site),
-                std::move(local_result), this_site);
-        }
-
-        std::string name(basename);
-        if (generation != std::size_t(-1))
-        {
-            name += std::to_string(generation) + "/";
-        }
-
-        return all_to_all(hpx::find_from_basename(std::move(name), root_site),
+        return all_to_all(create_all_to_all(basename, num_sites, generation,
+                              this_site, root_site),
             std::move(local_result), this_site);
     }
 }}    // namespace hpx::lcos

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -12,35 +12,6 @@
 // clang-format off
 namespace hpx { namespace collectives {
 
-    /// Create a new communicator object usable with all_to_all
-    ///
-    /// This functions creates a new communicator object that can be called in
-    /// order to pre-allocate a communicator object usable with multiple
-    /// invocations of \a all_to_all.
-    ///
-    /// \param  basename    The base name identifying the all_to_all operation
-    /// \param  num_sites   The number of participating sites (default: all
-    ///                     localities).
-    /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the all_to_all operation performed on the
-    ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the all_to_all operation on the
-    ///                     given base name has to be performed more than once.
-    /// \param this_site    The sequence number of this invocation (usually
-    ///                     the locality id). This value is optional and
-    ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \params root_site   The site that is responsible for creating the
-    ///                     all_to_all support object. This value is optional
-    ///                     and defaults to '0' (zero).
-    ///
-    /// \returns    This function returns a new communicator object usable
-    ///             with all_to_all
-    ///
-    communicator create_all_to_all(char const* basename,
-        std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
-
     /// AllToAll a set of values from different call sites
     ///
     /// This function receives a set of values from all call sites operating on
@@ -105,7 +76,7 @@ namespace hpx { namespace collectives {
 
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_distributed/async.hpp>
-#include <hpx/collectives/detail/communicator.hpp>
+#include <hpx/collectives/create_communicator.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/type_support/unused.hpp>
@@ -113,7 +84,6 @@ namespace hpx { namespace collectives {
 #include <cstddef>
 #include <memory>
 #include <mutex>
-#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -195,16 +165,6 @@ namespace hpx { namespace traits {
 namespace hpx { namespace collectives {
 
     ///////////////////////////////////////////////////////////////////////////
-    inline communicator create_all_to_all(char const* basename,
-        std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
-    {
-        return detail::create_communicator(
-            basename, num_sites, generation, this_site, root_site);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
     // all_to_all plain values
     template <typename T>
     hpx::future<std::vector<T>> all_to_all(communicator fid,
@@ -243,7 +203,7 @@ namespace hpx { namespace collectives {
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {
-        return all_to_all(create_all_to_all(basename, num_sites, generation,
+        return all_to_all(create_communicator(basename, num_sites, generation,
                               this_site, root_site),
             std::move(local_result), this_site);
     }
@@ -255,5 +215,5 @@ namespace hpx { namespace collectives {
 ////////////////////////////////////////////////////////////////////////////////
 #define HPX_REGISTER_ALLTOALL(...)             /**/
 
-#endif    // COMPUTE_HOST_CODE
+#endif    // !HPX_COMPUTE_DEVICE_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/broadcast.hpp
+++ b/libs/full/collectives/include/hpx/collectives/broadcast.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2020-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -128,10 +128,8 @@ namespace hpx { namespace lcos {
 #include <hpx/async_distributed/async.hpp>
 #include <hpx/async_local/dataflow.hpp>
 #include <hpx/collectives/detail/communicator.hpp>
-#include <hpx/components/basename_registration.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/futures/traits/acquire_shared_state.hpp>
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/naming_base/id_type.hpp>
 #include <hpx/type_support/unused.hpp>
@@ -204,7 +202,7 @@ namespace hpx { namespace traits {
         template <typename Result, typename T>
         Result set(std::size_t which, T&& t)
         {
-            using arg_type = typename std::decay<T>::type;
+            using arg_type = std::decay_t<T>;
             using mutex_type = typename Communicator::mutex_type;
             using lock_type = std::unique_lock<mutex_type>;
 
@@ -305,7 +303,7 @@ namespace hpx { namespace lcos {
     }
 
     template <typename T>
-    hpx::future<typename std::decay<T>::type> broadcast_to(communicator fid,
+    hpx::future<std::decay_t<T>> broadcast_to(communicator fid,
         T&& local_result, std::size_t this_site = std::size_t(-1))
     {
         if (this_site == std::size_t(-1))
@@ -313,7 +311,7 @@ namespace hpx { namespace lcos {
             this_site = static_cast<std::size_t>(agas::get_locality_id());
         }
 
-        using arg_type = typename std::decay<T>::type;
+        using arg_type = std::decay_t<T>;
 
         auto broadcast_data =
             [this_site](communicator&& c,
@@ -339,7 +337,7 @@ namespace hpx { namespace lcos {
     }
 
     template <typename T>
-    hpx::future<typename std::decay<T>::type> broadcast_to(char const* basename,
+    hpx::future<std::decay_t<T>> broadcast_to(char const* basename,
         T&& local_result, std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1))

--- a/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
@@ -1,0 +1,73 @@
+//  Copyright (c) 2020-2021 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file create_communicator.hpp
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(DOXYGEN)
+// clang-format off
+namespace hpx { namespace collectives {
+
+    /// Create a new communicator object usable with any collective operation
+    ///
+    /// This functions creates a new communicator object that can be called in
+    /// order to pre-allocate a communicator object usable with multiple
+    /// invocations of any of the collective operations (such as \a all_gather,
+    /// \a all_reduce, \a all_to_all, \a broadcast, etc.).
+    ///
+    /// \param  basename    The base name identifying the collective operation
+    /// \param  num_sites   The number of participating sites (default: all
+    ///                     localities).
+    /// \param  generation  The generational counter identifying the sequence
+    ///                     number of the collective operation performed on the
+    ///                     given base name. This is optional and needs to be
+    ///                     supplied only if the collective operation on the
+    ///                     given base name has to be performed more than once.
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
+    /// \params root_site   The site that is responsible for creating the
+    ///                     collective support object. This value is optional
+    ///                     and defaults to '0' (zero).
+    ///
+    /// \returns    This function returns a new communicator object usable
+    ///             with the collective operation.
+    ///
+    communicator create_communicator(char const* basename,
+        std::size_t num_sites = std::size_t(-1),
+        std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
+}}
+// clang-format on
+
+#else
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/collectives/detail/communicator.hpp>
+#include <hpx/components/client.hpp>
+
+#include <cstddef>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx { namespace collectives {
+
+    using communicator = hpx::components::client<detail::communicator_server>;
+
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_EXPORT communicator create_communicator(char const* basename,
+        std::size_t num_sites = std::size_t(-1),
+        std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
+
+}}    // namespace hpx::collectives
+
+#endif    // !HPX_COMPUTE_DEVICE_CODE
+#endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
@@ -61,8 +61,8 @@ namespace hpx { namespace lcos { namespace detail {
             HPX_ASSERT(false);    // shouldn't ever be called
         }
 
-        communicator_server(std::size_t num_sites,
-            std::size_t site, std::size_t num_values)
+        communicator_server(
+            std::size_t num_sites, std::size_t site, std::size_t num_values)
           : data_()
           , gate_(num_sites)
           , num_values_(num_values)

--- a/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2020-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
@@ -36,6 +36,10 @@ namespace hpx { namespace collectives {
     ///                     exclusive_scan support object. This value is optional
     ///                     and defaults to '0' (zero).
     ///
+    /// \note       The result returned on the root_site is always the same as
+    ///             the result returned on thus_site == 1 and is the same as the
+    ///             value provided by the thje root_site.
+    ///
     /// \returns    This function returns a future holding a vector with all
     ///             values send by all participating sites. It will become
     ///             ready once the exclusive_scan operation has been completed.
@@ -59,6 +63,10 @@ namespace hpx { namespace collectives {
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
+    ///
+    /// \note       The result returned on the root_site is always the same as
+    ///             the result returned on thus_site == 1 and is the same as the
+    ///             value provided by the thje root_site.
     ///
     /// \returns    This function returns a future holding a vector with all
     ///             values send by all participating sites. It will become
@@ -137,7 +145,7 @@ namespace hpx { namespace traits {
                     dest.resize(data.size());
 
                     auto it = data.begin();
-                    hpx::parallel::exclusive_scan(hpx::execution::seq, ++it,
+                    hpx::parallel::exclusive_scan(hpx::execution::seq, it,
                         data.end(), dest.begin(), *it, std::forward<F>(op));
 
                     std::swap(data, dest);

--- a/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
@@ -4,7 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file all_to_all.hpp
+/// \file exclusive_scan.hpp
 
 #pragma once
 
@@ -12,69 +12,70 @@
 // clang-format off
 namespace hpx { namespace collectives {
 
-    /// Create a new communicator object usable with all_to_all
+    /// Create a new communicator object usable with exclusive_scan
     ///
     /// This functions creates a new communicator object that can be called in
     /// order to pre-allocate a communicator object usable with multiple
-    /// invocations of \a all_to_all.
+    /// invocations of \a exclusive_scan.
     ///
-    /// \param  basename    The base name identifying the all_to_all operation
+    /// \param  basename    The base name identifying the exclusive_scan operation
     /// \param  num_sites   The number of participating sites (default: all
     ///                     localities).
     /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the all_to_all operation performed on the
+    ///                     number of the exclusive_scan operation performed on the
     ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the all_to_all operation on the
+    ///                     supplied only if the exclusive_scan operation on the
     ///                     given base name has to be performed more than once.
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     /// \params root_site   The site that is responsible for creating the
-    ///                     all_to_all support object. This value is optional
+    ///                     exclusive_scan support object. This value is optional
     ///                     and defaults to '0' (zero).
     ///
     /// \returns    This function returns a new communicator object usable
-    ///             with all_to_all
+    ///             with exclusive_scan
     ///
-    communicator create_all_to_all(char const* basename,
+    communicator create_exclusive_scan(char const* basename,
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
 
-    /// AllToAll a set of values from different call sites
+    /// Exclusive scan a set of values from different call sites
     ///
     /// This function receives a set of values from all call sites operating on
     /// the given base name.
     ///
-    /// \param  basename    The base name identifying the all_to_all operation
+    /// \param  basename    The base name identifying the exclusive_scan operation
     /// \param  local_result The value to transmit to all
     ///                     participating sites from this call site.
+    /// \param  op          Reduction operation to apply to all values supplied
+    ///                     from all participating sites
     /// \param  num_sites   The number of participating sites (default: all
     ///                     localities).
     /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the all_to_all operation performed on the
+    ///                     number of the exclusive_scan operation performed on the
     ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the all_to_all operation on the
+    ///                     supplied only if the exclusive_scan operation on the
     ///                     given base name has to be performed more than once.
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     /// \params root_site   The site that is responsible for creating the
-    ///                     all_to_all support object. This value is optional
+    ///                     exclusive_scan support object. This value is optional
     ///                     and defaults to '0' (zero).
     ///
     /// \returns    This function returns a future holding a vector with all
     ///             values send by all participating sites. It will become
-    ///             ready once the all_to_all operation has been completed.
+    ///             ready once the exclusive_scan operation has been completed.
     ///
-    template <typename T>
-    hpx::future<std::vector<std::decay_t<T>>>
-    all_to_all(char const* basename, T&& result,
-        std::size_t num_sites = std::size_t(-1),
+    template <typename T, typename F>
+    hpx::future<std::decay_t<T>> exclusive_scan(char const* basename, T&& result,
+        F&& op, std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
 
-    /// AllToAll a set of values from different call sites
+    /// Exclusive scan a set of values from different call sites
     ///
     /// This function receives a set of values from all call sites operating on
     /// the given base name.
@@ -82,18 +83,20 @@ namespace hpx { namespace collectives {
     /// \param  comm        A communicator object returned from \a create_reducer
     /// \param  local_result The value to transmit to all
     ///                     participating sites from this call site.
+    /// \param  op          Reduction operation to apply to all values supplied
+    ///                     from all participating sites
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     ///
     /// \returns    This function returns a future holding a vector with all
     ///             values send by all participating sites. It will become
-    ///             ready once the all_to_all operation has been completed.
+    ///             ready once the exclusive_scan operation has been completed.
     ///
-    template <typename T>
-    hpx::future<std::vector<std::decay_t<T>>>
-    all_to_all(communicator comm, T&& result,
-        std::size_t this_site = std::size_t(-1)0);
+    template <typename T, typename F>
+    hpx::future<std::decay_t<T>>
+    exclusive_scan(communicator comm,
+        T&& result, F&& op, std::size_t this_site = std::size_t(-1));
 }}    // namespace hpx::collectives
 
 // clang-format on
@@ -108,6 +111,7 @@ namespace hpx { namespace collectives {
 #include <hpx/collectives/detail/communicator.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/futures/future.hpp>
+#include <hpx/parallel/algorithms/exclusive_scan.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <cstddef>
@@ -121,63 +125,68 @@ namespace hpx { namespace collectives {
 namespace hpx { namespace traits {
 
     namespace communication {
-        struct all_to_all_tag;
+        struct exclusive_scan_tag;
     }    // namespace communication
 
     ///////////////////////////////////////////////////////////////////////////
-    // support for all_to_all
+    // support for exclusive_scan
     template <typename Communicator>
-    struct communication_operation<Communicator, communication::all_to_all_tag>
+    struct communication_operation<Communicator,
+        communication::exclusive_scan_tag>
       : std::enable_shared_from_this<communication_operation<Communicator,
-            communication::all_to_all_tag>>
+            communication::exclusive_scan_tag>>
     {
         explicit communication_operation(Communicator& comm)
           : communicator_(comm)
         {
         }
 
-        template <typename Result, typename T>
-        Result get(std::size_t which, std::vector<T>&& t)
+        template <typename Result, typename T, typename F>
+        Result get(std::size_t which, T&& t, F&& op)
         {
-            using data_type = std::vector<T>;
+            using arg_type = std::decay_t<T>;
             using mutex_type = typename Communicator::mutex_type;
             using lock_type = std::unique_lock<mutex_type>;
 
             auto this_ = this->shared_from_this();
-            auto on_ready = [this_ = std::move(this_), which](
-                                shared_future<void>&& f) -> data_type {
+            auto on_ready =
+                [which, this_ = std::move(this_), op = std::forward<F>(op)](
+                    hpx::shared_future<void> f) mutable -> arg_type {
                 HPX_UNUSED(this_);
                 f.get();    // propagate any exceptions
 
                 auto& communicator = this_->communicator_;
 
                 lock_type l(communicator.mtx_);
-                auto& data = communicator.template access_data<data_type>(l);
+                util::ignore_while_checking<lock_type> il(&l);
 
-                // slice the overall data based on the locality id of the
-                // requesting site
-                std::vector<T> result;
-                result.reserve(data.size());
-
-                for (auto const& v : data)
+                auto& data = communicator.template access_data<arg_type>(l);
+                if (!communicator.data_available_)
                 {
-                    result.push_back(v[which]);
-                }
+                    std::vector<arg_type> dest;
+                    dest.resize(data.size());
 
-                return result;
+                    auto it = data.begin();
+                    hpx::parallel::exclusive_scan(hpx::execution::seq, ++it,
+                        data.end(), dest.begin(), *it, std::forward<F>(op));
+
+                    std::swap(data, dest);
+                    communicator.data_available_ = true;
+                }
+                return data[which];
             };
 
             lock_type l(communicator_.mtx_);
             util::ignore_while_checking<lock_type> il(&l);
 
-            hpx::future<data_type> f =
+            hpx::future<arg_type> f =
                 communicator_.gate_.get_shared_future(l).then(
-                    hpx::launch::sync, on_ready);
+                    hpx::launch::sync, std::move(on_ready));
 
             communicator_.gate_.synchronize(1, l);
 
-            auto& data = communicator_.template access_data<data_type>(l);
-            data[which] = std::move(t);
+            auto& data = communicator_.template access_data<arg_type>(l);
+            data[which] = std::forward<T>(t);
 
             if (communicator_.gate_.set(which, std::move(l)))
             {
@@ -195,7 +204,7 @@ namespace hpx { namespace traits {
 namespace hpx { namespace collectives {
 
     ///////////////////////////////////////////////////////////////////////////
-    inline communicator create_all_to_all(char const* basename,
+    inline communicator create_exclusive_scan(char const* basename,
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
@@ -204,29 +213,33 @@ namespace hpx { namespace collectives {
             basename, num_sites, generation, this_site, root_site);
     }
 
-    ///////////////////////////////////////////////////////////////////////////
-    // all_to_all plain values
-    template <typename T>
-    hpx::future<std::vector<T>> all_to_all(communicator fid,
-        std::vector<T>&& local_result, std::size_t this_site = std::size_t(-1))
+    ////////////////////////////////////////////////////////////////////////////
+    // exclusive_scan plain values
+    template <typename T, typename F>
+    hpx::future<std::decay_t<T>> exclusive_scan(communicator fid,
+        T&& local_result, F&& op, std::size_t this_site = std::size_t(-1))
     {
         if (this_site == std::size_t(-1))
         {
             this_site = static_cast<std::size_t>(agas::get_locality_id());
         }
 
-        auto all_to_all_data_direct =
-            [local_result = std::move(local_result), this_site](
-                communicator&& c) -> hpx::future<std::vector<T>> {
+        using arg_type = std::decay_t<T>;
+
+        auto scan_data_direct =
+            [op = std::forward<F>(op),
+                local_result = std::forward<T>(local_result),
+                this_site](communicator&& c) mutable -> hpx::future<arg_type> {
+            using func_type = std::decay_t<F>;
             using action_type = typename detail::communicator_server::
                 template communication_get_action<
-                    traits::communication::all_to_all_tag,
-                    hpx::future<std::vector<T>>, std::vector<T>>;
+                    traits::communication::exclusive_scan_tag,
+                    hpx::future<arg_type>, arg_type, func_type>;
 
             // make sure id is kept alive as long as the returned future,
             // explicitly unwrap returned future
-            hpx::future<std::vector<T>> result =
-                async(action_type(), c, this_site, std::move(local_result));
+            hpx::future<arg_type> result = async(action_type(), c, this_site,
+                std::forward<T>(local_result), std::forward<F>(op));
 
             traits::detail::get_shared_state(result)->set_on_completed(
                 [client = std::move(c)]() { HPX_UNUSED(client); });
@@ -234,26 +247,20 @@ namespace hpx { namespace collectives {
             return result;
         };
 
-        return fid.then(hpx::launch::sync, std::move(all_to_all_data_direct));
+        return fid.then(hpx::launch::sync, std::move(scan_data_direct));
     }
 
-    template <typename T>
-    hpx::future<std::vector<T>> all_to_all(char const* basename,
-        std::vector<T>&& local_result, std::size_t num_sites = std::size_t(-1),
+    template <typename T, typename F>
+    hpx::future<std::decay_t<T>> exclusive_scan(char const* basename,
+        T&& local_result, F&& op, std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {
-        return all_to_all(create_all_to_all(basename, num_sites, generation,
-                              this_site, root_site),
-            std::move(local_result), this_site);
+        return exclusive_scan(create_exclusive_scan(basename, num_sites,
+                                  generation, this_site, root_site),
+            std::forward<T>(local_result), std::forward<F>(op), this_site);
     }
 }}    // namespace hpx::collectives
-
-////////////////////////////////////////////////////////////////////////////////
-#define HPX_REGISTER_ALLTOALL_DECLARATION(...) /**/
-
-////////////////////////////////////////////////////////////////////////////////
-#define HPX_REGISTER_ALLTOALL(...)             /**/
 
 #endif    // COMPUTE_HOST_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
@@ -12,35 +12,6 @@
 // clang-format off
 namespace hpx { namespace collectives {
 
-    /// Create a new communicator object usable with exclusive_scan
-    ///
-    /// This functions creates a new communicator object that can be called in
-    /// order to pre-allocate a communicator object usable with multiple
-    /// invocations of \a exclusive_scan.
-    ///
-    /// \param  basename    The base name identifying the exclusive_scan operation
-    /// \param  num_sites   The number of participating sites (default: all
-    ///                     localities).
-    /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the exclusive_scan operation performed on the
-    ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the exclusive_scan operation on the
-    ///                     given base name has to be performed more than once.
-    /// \param this_site    The sequence number of this invocation (usually
-    ///                     the locality id). This value is optional and
-    ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \params root_site   The site that is responsible for creating the
-    ///                     exclusive_scan support object. This value is optional
-    ///                     and defaults to '0' (zero).
-    ///
-    /// \returns    This function returns a new communicator object usable
-    ///             with exclusive_scan
-    ///
-    communicator create_exclusive_scan(char const* basename,
-        std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
-
     /// Exclusive scan a set of values from different call sites
     ///
     /// This function receives a set of values from all call sites operating on
@@ -108,7 +79,7 @@ namespace hpx { namespace collectives {
 
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_distributed/async.hpp>
-#include <hpx/collectives/detail/communicator.hpp>
+#include <hpx/collectives/create_communicator.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/parallel/algorithms/exclusive_scan.hpp>
@@ -117,7 +88,6 @@ namespace hpx { namespace collectives {
 #include <cstddef>
 #include <memory>
 #include <mutex>
-#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -203,16 +173,6 @@ namespace hpx { namespace traits {
 
 namespace hpx { namespace collectives {
 
-    ///////////////////////////////////////////////////////////////////////////
-    inline communicator create_exclusive_scan(char const* basename,
-        std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
-    {
-        return detail::create_communicator(
-            basename, num_sites, generation, this_site, root_site);
-    }
-
     ////////////////////////////////////////////////////////////////////////////
     // exclusive_scan plain values
     template <typename T, typename F>
@@ -256,11 +216,11 @@ namespace hpx { namespace collectives {
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {
-        return exclusive_scan(create_exclusive_scan(basename, num_sites,
+        return exclusive_scan(create_communicator(basename, num_sites,
                                   generation, this_site, root_site),
             std::forward<T>(local_result), std::forward<F>(op), this_site);
     }
 }}    // namespace hpx::collectives
 
-#endif    // COMPUTE_HOST_CODE
+#endif    // !HPX_COMPUTE_DEVICE_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -12,6 +12,35 @@
 // clang-format off
 namespace hpx { namespace lcos {
 
+    /// Create a new communicator object usable with gather_here and gather_there
+    ///
+    /// This functions creates a new communicator object that can be called in
+    /// order to pre-allocate a communicator object usable with multiple
+    /// invocations of \a gather_here and \a gather_there.
+    ///
+    /// \param  basename    The base name identifying the gather operation
+    /// \param  num_sites   The number of participating sites (default: all
+    ///                     localities).
+    /// \param  generation  The generational counter identifying the sequence
+    ///                     number of the gather operation performed on the
+    ///                     given base name. This is optional and needs to be
+    ///                     supplied only if the gather operation on the
+    ///                     given base name has to be performed more than once.
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
+    /// \params root_site   The site that is responsible for creating the
+    ///                     gather support object. This value is optional
+    ///                     and defaults to '0' (zero).
+    ///
+    /// \returns    This function returns a new communicator object usable
+    ///             with gather_here and gather_there
+    ///
+    communicator create_gatherer(char const* basename,
+        std::size_t num_sites = std::size_t(-1),
+        std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
+
     /// Gather a set of values from different call sites
     ///
     /// This function receives a set of values from all call sites operating on
@@ -30,11 +59,6 @@ namespace hpx { namespace lcos {
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
-    ///
-    /// \note       Each gather operation has to be accompanied with a unique
-    ///             usage of the \a HPX_REGISTER_GATHER macro to define the
-    ///             necessary internal facilities used by \a gather_here and
-    ///             \a gather_there
     ///
     /// \returns    This function returns a future holding a vector with all
     ///             gathered values. It will become ready once the gather
@@ -47,6 +71,27 @@ namespace hpx { namespace lcos {
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1));
 
+    /// Gather a set of values from different call sites
+    ///
+    /// This function receives a set of values from all call sites operating on
+    /// the given base name.
+    ///
+    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param  result      A future referring to the value to transmit to the
+    ///                     central gather point from this call site.
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
+    ///
+    /// \returns    This function returns a future holding a vector with all
+    ///             gathered values. It will become ready once the gather
+    ///             operation has been completed.
+    ///
+    template <typename T>
+    hpx::future<std::vector<T>> gather_here(communicator comm,
+        hpx::future<T> result,
+        std::size_t this_site = std::size_t(-1));
+
     /// Gather a given value at the given call site
     ///
     /// This function transmits the value given by \a result to a central gather
@@ -67,11 +112,6 @@ namespace hpx { namespace lcos {
     ///                     (usually the locality id). This value is optional
     ///                     and defaults to 0.
     ///
-    /// \note       Each gather operation has to be accompanied with a unique
-    ///             usage of the \a HPX_REGISTER_GATHER macro to define the
-    ///             necessary internal facilities used by \a gather_here and
-    ///             \a gather_there
-    ///
     /// \returns    This function returns a future holding a vector with all
     ///             gathered values. It will become ready once the gather
     ///             operation has been completed.
@@ -82,6 +122,27 @@ namespace hpx { namespace lcos {
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1),
         std::size_t root_site = 0);
+
+    /// Gather a given value at the given call site
+    ///
+    /// This function transmits the value given by \a result to a central gather
+    /// site (where the corresponding \a gather_here is executed)
+    ///
+    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param  result      A future referring to the value to transmit to the
+    ///                     central gather point from this call site.
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
+    ///
+    /// \returns    This function returns a future holding a vector with all
+    ///             gathered values. It will become ready once the gather
+    ///             operation has been completed.
+    ///
+    template <typename T>
+    hpx::future<std::vector<T>> gather_there(communicator comm,
+        hpx::future<T> result,
+        std::size_t this_site = std::size_t(-1));
 
     /// Gather a set of values from different call sites
     ///
@@ -102,11 +163,6 @@ namespace hpx { namespace lcos {
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     ///
-    /// \note       Each gather operation has to be accompanied with a unique
-    ///             usage of the \a HPX_REGISTER_GATHER macro to define the
-    ///             necessary internal facilities used by \a gather_here and
-    ///             \a gather_there
-    ///
     /// \returns    This function returns a future holding a vector with all
     ///             gathered values. It will become ready once the gather
     ///             operation has been completed.
@@ -116,6 +172,27 @@ namespace hpx { namespace lcos {
         char const* basename, T&& result,
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1));
+
+    /// Gather a set of values from different call sites
+    ///
+    /// This function receives a set of values from all call sites operating on
+    /// the given base name.
+    ///
+    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param  result      The value to transmit to the central gather point
+    ///                     from this call site.
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
+    ///
+    /// \returns    This function returns a future holding a vector with all
+    ///             gathered values. It will become ready once the gather
+    ///             operation has been completed.
+    ///
+    template <typename T>
+    hpx::future<std::vector<decay_t<T>>> gather_here(
+        communicator comm, T&& result,
         std::size_t this_site = std::size_t(-1));
 
     /// Gather a given value at the given call site
@@ -138,11 +215,6 @@ namespace hpx { namespace lcos {
     ///                     (usually the locality id). This value is optional
     ///                     and defaults to 0.
     ///
-    /// \note       Each gather operation has to be accompanied with a unique
-    ///             usage of the \a HPX_REGISTER_GATHER macro to define the
-    ///             necessary internal facilities used by \a gather_here and
-    ///             \a gather_there
-    ///
     /// \returns    This function returns a future holding a vector with all
     ///             gathered values. It will become ready once the gather
     ///             operation has been completed.
@@ -154,6 +226,27 @@ namespace hpx { namespace lcos {
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1),
         std::size_t root_site = 0);
+
+    /// Gather a given value at the given call site
+    ///
+    /// This function transmits the value given by \a result to a central gather
+    /// site (where the corresponding \a gather_here is executed)
+    ///
+    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param  result      The value to transmit to the central gather point
+    ///                     from this call site.
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
+    ///
+    /// \returns    This function returns a future holding a vector with all
+    ///             gathered values. It will become ready once the gather
+    ///             operation has been completed.
+    ///
+    template <typename T>
+    hpx::future<std::vector<decay_t<T>>>
+    gather_there(communicator comm, T&& result,
+        std::size_t this_site = std::size_t(-1));
 }}    // namespace hpx::lcos
 
 // clang-format on
@@ -172,7 +265,6 @@ namespace hpx { namespace lcos {
 #include <hpx/futures/future.hpp>
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/naming_base/id_type.hpp>
-#include <hpx/thread_support/assert_owns_lock.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <cstddef>
@@ -235,8 +327,6 @@ namespace hpx { namespace traits {
 
             if (communicator_.gate_.set(which, std::move(l)))
             {
-                HPX_ASSERT_DOESNT_OWN_LOCK(l);
-
                 l = lock_type(communicator_.mtx_);
                 communicator_.invalidate_data(l);
             }
@@ -271,8 +361,6 @@ namespace hpx { namespace traits {
 
             if (communicator_.gate_.set(which, std::move(l)))
             {
-                HPX_ASSERT_DOESNT_OWN_LOCK(l);
-
                 l = lock_type(communicator_.mtx_);
                 communicator_.invalidate_data(l);
             }

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -10,7 +10,7 @@
 
 #if defined(DOXYGEN)
 // clang-format off
-namespace hpx { namespace lcos {
+namespace hpx { namespace collectives {
 
     /// Create a new communicator object usable with gather_here and gather_there
     ///
@@ -40,109 +40,6 @@ namespace hpx { namespace lcos {
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
-
-    /// Gather a set of values from different call sites
-    ///
-    /// This function receives a set of values from all call sites operating on
-    /// the given base name.
-    ///
-    /// \param  basename    The base name identifying the gather operation
-    /// \param  result      A future referring to the value to transmit to the
-    ///                     central gather point from this call site.
-    /// \param  num_sites   The number of participating sites (default: all
-    ///                     localities).
-    /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the gather operation performed on the
-    ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the gather operation on the given
-    ///                     base name has to be performed more than once.
-    /// \param this_site    The sequence number of this invocation (usually
-    ///                     the locality id). This value is optional and
-    ///                     defaults to whatever hpx::get_locality_id() returns.
-    ///
-    /// \returns    This function returns a future holding a vector with all
-    ///             gathered values. It will become ready once the gather
-    ///             operation has been completed.
-    ///
-    template <typename T>
-    hpx::future<std::vector<T>> gather_here(char const* basename,
-        hpx::future<T> result,
-        std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1));
-
-    /// Gather a set of values from different call sites
-    ///
-    /// This function receives a set of values from all call sites operating on
-    /// the given base name.
-    ///
-    /// \param  comm        A communicator object returned from \a create_reducer
-    /// \param  result      A future referring to the value to transmit to the
-    ///                     central gather point from this call site.
-    /// \param this_site    The sequence number of this invocation (usually
-    ///                     the locality id). This value is optional and
-    ///                     defaults to whatever hpx::get_locality_id() returns.
-    ///
-    /// \returns    This function returns a future holding a vector with all
-    ///             gathered values. It will become ready once the gather
-    ///             operation has been completed.
-    ///
-    template <typename T>
-    hpx::future<std::vector<T>> gather_here(communicator comm,
-        hpx::future<T> result,
-        std::size_t this_site = std::size_t(-1));
-
-    /// Gather a given value at the given call site
-    ///
-    /// This function transmits the value given by \a result to a central gather
-    /// site (where the corresponding \a gather_here is executed)
-    ///
-    /// \param  basename    The base name identifying the gather operation
-    /// \param  result      A future referring to the value to transmit to the
-    ///                     central gather point from this call site.
-    /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the gather operation performed on the
-    ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the gather operation on the given
-    ///                     base name has to be performed more than once.
-    /// \param this_site    The sequence number of this invocation (usually
-    ///                     the locality id). This value is optional and
-    ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \param root_site    The sequence number of the central gather point
-    ///                     (usually the locality id). This value is optional
-    ///                     and defaults to 0.
-    ///
-    /// \returns    This function returns a future holding a vector with all
-    ///             gathered values. It will become ready once the gather
-    ///             operation has been completed.
-    ///
-    template <typename T>
-    hpx::future<std::vector<T>> gather_there(char const* basename,
-        hpx::future<T> result,
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1),
-        std::size_t root_site = 0);
-
-    /// Gather a given value at the given call site
-    ///
-    /// This function transmits the value given by \a result to a central gather
-    /// site (where the corresponding \a gather_here is executed)
-    ///
-    /// \param  comm        A communicator object returned from \a create_reducer
-    /// \param  result      A future referring to the value to transmit to the
-    ///                     central gather point from this call site.
-    /// \param this_site    The sequence number of this invocation (usually
-    ///                     the locality id). This value is optional and
-    ///                     defaults to whatever hpx::get_locality_id() returns.
-    ///
-    /// \returns    This function returns a future holding a vector with all
-    ///             gathered values. It will become ready once the gather
-    ///             operation has been completed.
-    ///
-    template <typename T>
-    hpx::future<std::vector<T>> gather_there(communicator comm,
-        hpx::future<T> result,
-        std::size_t this_site = std::size_t(-1));
 
     /// Gather a set of values from different call sites
     ///
@@ -221,8 +118,7 @@ namespace hpx { namespace lcos {
     ///
     template <typename T>
     hpx::future<std::vector<decay_t<T>>>
-    gather_there(char const* basename,
-        T&& result,
+    gather_there(char const* basename, T&& result,
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1),
         std::size_t root_site = 0);
@@ -247,7 +143,7 @@ namespace hpx { namespace lcos {
     hpx::future<std::vector<decay_t<T>>>
     gather_there(communicator comm, T&& result,
         std::size_t this_site = std::size_t(-1));
-}}    // namespace hpx::lcos
+}}    // namespace hpx::collectives
 
 // clang-format on
 #else
@@ -259,12 +155,9 @@ namespace hpx { namespace lcos {
 #include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_distributed/async.hpp>
-#include <hpx/async_local/dataflow.hpp>
 #include <hpx/collectives/detail/communicator.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/modules/execution_base.hpp>
-#include <hpx/naming_base/id_type.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <cstddef>
@@ -372,7 +265,7 @@ namespace hpx { namespace traits {
     };
 }}    // namespace hpx::traits
 
-namespace hpx { namespace lcos {
+namespace hpx { namespace collectives {
 
     ///////////////////////////////////////////////////////////////////////////
     inline communicator create_gatherer(char const* basename,
@@ -382,51 +275,6 @@ namespace hpx { namespace lcos {
     {
         return detail::create_communicator(
             basename, num_sites, generation, this_site, root_site);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    // destination site needs to be handled differently
-    template <typename T>
-    hpx::future<std::vector<T>> gather_here(communicator fid,
-        hpx::future<T>&& result, std::size_t this_site = std::size_t(-1))
-    {
-        if (this_site == std::size_t(-1))
-        {
-            this_site = static_cast<std::size_t>(agas::get_locality_id());
-        }
-
-        auto gather_data =
-            [this_site](communicator&& c,
-                hpx::future<T>&& local_result) -> hpx::future<std::vector<T>> {
-            using action_type = typename detail::communicator_server::
-                template communication_get_action<
-                    traits::communication::gather_tag,
-                    hpx::future<std::vector<T>>, T>;
-
-            // make sure id is kept alive as long as the returned future,
-            // explicitly unwrap returned future
-            hpx::future<std::vector<T>> result =
-                async(action_type(), c, this_site, local_result.get());
-
-            traits::detail::get_shared_state(result)->set_on_completed(
-                [client = std::move(c)]() { HPX_UNUSED(client); });
-
-            return result;
-        };
-
-        return dataflow(hpx::launch::sync, std::move(gather_data),
-            std::move(fid), std::move(result));
-    }
-
-    template <typename T>
-    hpx::future<std::vector<T>> gather_here(char const* basename,
-        hpx::future<T>&& result, std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1))
-    {
-        return gather_here(create_gatherer(basename, num_sites, generation,
-                               this_site, this_site),
-            std::move(result), this_site);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -477,49 +325,6 @@ namespace hpx { namespace lcos {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T>
-    hpx::future<void> gather_there(communicator fid,
-        hpx::future<T>&& local_result, std::size_t this_site = std::size_t(-1))
-    {
-        if (this_site == std::size_t(-1))
-        {
-            this_site = static_cast<std::size_t>(agas::get_locality_id());
-        }
-
-        auto gather_there_data =
-            [this_site](communicator&& c,
-                hpx::future<T>&& local_result) -> hpx::future<void> {
-            using action_type = typename detail::communicator_server::
-                template communication_set_action<
-                    traits::communication::gather_tag, hpx::future<void>, T>;
-
-            // make sure id is kept alive as long as the returned future,
-            // explicitly unwrap returned future
-            hpx::future<void> result =
-                async(action_type(), c, this_site, local_result.get());
-
-            traits::detail::get_shared_state(result)->set_on_completed(
-                [client = std::move(c)]() { HPX_UNUSED(client); });
-
-            return result;
-        };
-
-        return dataflow(hpx::launch::sync, std::move(gather_there_data),
-            std::move(fid), std::move(local_result));
-    }
-
-    template <typename T>
-    hpx::future<void> gather_there(char const* basename,
-        hpx::future<T>&& result, std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
-    {
-        HPX_ASSERT(this_site != root_site);
-        return gather_there(create_gatherer(basename, std::size_t(-1),
-                                generation, this_site, root_site),
-            std::move(result), this_site);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
     // gather plain values
     template <typename T>
     hpx::future<void> gather_there(communicator fid, T&& local_result,
@@ -565,14 +370,7 @@ namespace hpx { namespace lcos {
                                 generation, this_site, root_site),
             std::forward<T>(local_result), this_site);
     }
-}}    // namespace hpx::lcos
-
-///////////////////////////////////////////////////////////////////////////////
-namespace hpx {
-    using lcos::create_gatherer;
-    using lcos::gather_here;
-    using lcos::gather_there;
-}    // namespace hpx
+}}    // namespace hpx::collectives
 
 ///////////////////////////////////////////////////////////////////////////////
 #define HPX_REGISTER_GATHER_DECLARATION(...) /**/

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2017 Hartmut Kaiser
+//  Copyright (c) 2014-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -112,7 +112,7 @@ namespace hpx { namespace lcos {
     ///             operation has been completed.
     ///
     template <typename T>
-    hpx::future<std::vector<typename std::decay<T>::type>> gather_here(
+    hpx::future<std::vector<decay_t<T>>> gather_here(
         char const* basename, T&& result,
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
@@ -148,7 +148,7 @@ namespace hpx { namespace lcos {
     ///             operation has been completed.
     ///
     template <typename T>
-    hpx::future<std::vector<typename std::decay<T>::type>>
+    hpx::future<std::vector<decay_t<T>>>
     gather_there(char const* basename,
         T&& result,
         std::size_t generation = std::size_t(-1),
@@ -168,10 +168,8 @@ namespace hpx { namespace lcos {
 #include <hpx/async_distributed/async.hpp>
 #include <hpx/async_local/dataflow.hpp>
 #include <hpx/collectives/detail/communicator.hpp>
-#include <hpx/components/basename_registration.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/futures/traits/acquire_shared_state.hpp>
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/naming_base/id_type.hpp>
 #include <hpx/thread_support/assert_owns_lock.hpp>
@@ -206,7 +204,7 @@ namespace hpx { namespace traits {
         template <typename Result, typename T>
         Result get(std::size_t which, T&& t)
         {
-            using arg_type = typename std::decay<T>::type;
+            using arg_type = std::decay_t<T>;
             using data_type = std::vector<arg_type>;
             using mutex_type = typename Communicator::mutex_type;
             using lock_type = std::unique_lock<mutex_type>;
@@ -249,7 +247,7 @@ namespace hpx { namespace traits {
         template <typename Result, typename T>
         Result set(std::size_t which, T&& t)
         {
-            using arg_type = typename std::decay<T>::type;
+            using arg_type = std::decay_t<T>;
             using mutex_type = typename Communicator::mutex_type;
             using lock_type = std::unique_lock<mutex_type>;
 
@@ -346,16 +344,15 @@ namespace hpx { namespace lcos {
     ///////////////////////////////////////////////////////////////////////////
     // gather plain values
     template <typename T>
-    hpx::future<std::vector<typename std::decay<T>::type>> gather_here(
-        communicator fid, T&& local_result,
-        std::size_t this_site = std::size_t(-1))
+    hpx::future<std::vector<std::decay_t<T>>> gather_here(communicator fid,
+        T&& local_result, std::size_t this_site = std::size_t(-1))
     {
         if (this_site == std::size_t(-1))
         {
             this_site = static_cast<std::size_t>(agas::get_locality_id());
         }
 
-        using arg_type = typename std::decay<T>::type;
+        using arg_type = std::decay_t<T>;
 
         auto gather_data_direct =
             [this_site](communicator&& c,
@@ -381,9 +378,8 @@ namespace hpx { namespace lcos {
     }
 
     template <typename T>
-    hpx::future<std::vector<typename std::decay<T>::type>> gather_here(
-        char const* basename, T&& result,
-        std::size_t num_sites = std::size_t(-1),
+    hpx::future<std::vector<std::decay_t<T>>> gather_here(char const* basename,
+        T&& result, std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1))
     {
@@ -446,7 +442,7 @@ namespace hpx { namespace lcos {
             this_site = static_cast<std::size_t>(agas::get_locality_id());
         }
 
-        using arg_type = typename std::decay<T>::type;
+        using arg_type = std::decay_t<T>;
 
         auto gather_there_data_direct =
             [this_site](communicator&& c,

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -163,6 +163,7 @@ namespace hpx { namespace lcos {
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_distributed/async.hpp>
 #include <hpx/async_local/dataflow.hpp>
@@ -197,7 +198,7 @@ namespace hpx { namespace traits {
       : std::enable_shared_from_this<
             communication_operation<Communicator, communication::gather_tag>>
     {
-        communication_operation(Communicator& comm)
+        explicit communication_operation(Communicator& comm)
           : communicator_(comm)
         {
         }
@@ -206,24 +207,26 @@ namespace hpx { namespace traits {
         Result get(std::size_t which, T&& t)
         {
             using arg_type = typename std::decay<T>::type;
+            using data_type = std::vector<arg_type>;
             using mutex_type = typename Communicator::mutex_type;
+            using lock_type = std::unique_lock<mutex_type>;
 
             auto this_ = this->shared_from_this();
-            auto on_ready =
-                [this_ = std::move(this_)](
-                    shared_future<void>&& f) -> std::vector<arg_type> {
+            auto on_ready = [this_ = std::move(this_)](
+                                shared_future<void>&& f) -> data_type {
+                HPX_UNUSED(this_);
                 f.get();    // propagate any exceptions
 
                 auto& communicator = this_->communicator_;
 
-                std::unique_lock<mutex_type> l(communicator.mtx_);
+                lock_type l(communicator.mtx_);
                 return communicator.template access_data<arg_type>(l);
             };
 
-            std::unique_lock<mutex_type> l(communicator_.mtx_);
-            util::ignore_while_checking<std::unique_lock<mutex_type>> il(&l);
+            lock_type l(communicator_.mtx_);
+            util::ignore_while_checking<lock_type> il(&l);
 
-            hpx::future<std::vector<arg_type>> f =
+            hpx::future<data_type> f =
                 communicator_.gate_.get_shared_future(l).then(
                     hpx::launch::sync, std::move(on_ready));
 
@@ -232,50 +235,51 @@ namespace hpx { namespace traits {
             auto& data = communicator_.template access_data<arg_type>(l);
             data[which] = std::forward<T>(t);
 
-            if (communicator_.gate_.set(which, l))
+            if (communicator_.gate_.set(which, std::move(l)))
             {
                 HPX_ASSERT_DOESNT_OWN_LOCK(l);
-                {
-                    std::unique_lock<mutex_type> l(communicator_.mtx_);
-                    communicator_.invalidate_data(l);
-                }
 
-                // this is a one-shot object (generations counters are not
-                // supported), unregister ourselves (but only once)
-                hpx::unregister_with_basename(
-                    std::move(communicator_.name_), communicator_.site_)
-                    .get();
+                l = lock_type(communicator_.mtx_);
+                communicator_.invalidate_data(l);
             }
+
             return f;
         }
 
         template <typename Result, typename T>
-        void set(std::size_t which, T&& t)
+        Result set(std::size_t which, T&& t)
         {
             using arg_type = typename std::decay<T>::type;
             using mutex_type = typename Communicator::mutex_type;
+            using lock_type = std::unique_lock<mutex_type>;
 
-            std::unique_lock<mutex_type> l(communicator_.mtx_);
-            util::ignore_while_checking<std::unique_lock<mutex_type>> il(&l);
+            auto this_ = this->shared_from_this();
+            auto on_ready = [this_ = std::move(this_)](
+                                shared_future<void>&& f) {
+                HPX_UNUSED(this_);
+                f.get();    // propagate any exceptions
+            };
+
+            lock_type l(communicator_.mtx_);
+            util::ignore_while_checking<lock_type> il(&l);
+
+            hpx::future<void> f = communicator_.gate_.get_shared_future(l).then(
+                hpx::launch::sync, std::move(on_ready));
 
             communicator_.gate_.synchronize(1, l);
 
-            communicator_.template access_data<arg_type>(l)[which] = t;
+            auto& data = communicator_.template access_data<arg_type>(l);
+            data[which] = std::forward<T>(t);
 
-            if (communicator_.gate_.set(which, l))
+            if (communicator_.gate_.set(which, std::move(l)))
             {
                 HPX_ASSERT_DOESNT_OWN_LOCK(l);
-                {
-                    std::unique_lock<mutex_type> l(communicator_.mtx_);
-                    communicator_.invalidate_data(l);
-                }
 
-                // this is a one-shot object (generations counters are not
-                // supported), unregister ourselves (but only once)
-                hpx::unregister_with_basename(
-                    std::move(communicator_.name_), communicator_.site_)
-                    .get();
+                l = lock_type(communicator_.mtx_);
+                communicator_.invalidate_data(l);
             }
+
+            return f;
         }
 
         Communicator& communicator_;
@@ -285,19 +289,19 @@ namespace hpx { namespace traits {
 namespace hpx { namespace lcos {
 
     ///////////////////////////////////////////////////////////////////////////
-    inline hpx::future<hpx::id_type> create_gatherer(char const* basename,
+    inline communicator create_gatherer(char const* basename,
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1))
+        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {
         return detail::create_communicator(
-            basename, num_sites, generation, this_site);
+            basename, num_sites, generation, this_site, root_site);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     // destination site needs to be handled differently
     template <typename T>
-    hpx::future<std::vector<T>> gather_here(hpx::future<hpx::id_type>&& fid,
+    hpx::future<std::vector<T>> gather_here(communicator fid,
         hpx::future<T>&& result, std::size_t this_site = std::size_t(-1))
     {
         if (this_site == std::size_t(-1))
@@ -306,20 +310,20 @@ namespace hpx { namespace lcos {
         }
 
         auto gather_data =
-            [this_site](hpx::future<hpx::id_type>&& fid,
+            [this_site](communicator&& c,
                 hpx::future<T>&& local_result) -> hpx::future<std::vector<T>> {
             using action_type = typename detail::communicator_server::
                 template communication_get_action<
                     traits::communication::gather_tag,
                     hpx::future<std::vector<T>>, T>;
 
-            // make sure id is kept alive as long as the returned future
-            hpx::id_type id = fid.get();
-            auto result =
-                async(action_type(), id, this_site, local_result.get());
+            // make sure id is kept alive as long as the returned future,
+            // explicitly unwrap returned future
+            hpx::future<std::vector<T>> result =
+                async(action_type(), c, this_site, local_result.get());
 
             traits::detail::get_shared_state(result)->set_on_completed(
-                [id = std::move(id)]() { HPX_UNUSED(id); });
+                [client = std::move(c)]() { HPX_UNUSED(client); });
 
             return result;
         };
@@ -330,22 +334,12 @@ namespace hpx { namespace lcos {
 
     template <typename T>
     hpx::future<std::vector<T>> gather_here(char const* basename,
-        hpx::future<T> result, std::size_t num_sites = std::size_t(-1),
+        hpx::future<T>&& result, std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1))
     {
-        if (num_sites == std::size_t(-1))
-        {
-            num_sites = static_cast<std::size_t>(
-                agas::get_num_localities(hpx::launch::sync));
-        }
-        if (this_site == std::size_t(-1))
-        {
-            this_site = static_cast<std::size_t>(agas::get_locality_id());
-        }
-
-        return gather_here(
-            create_gatherer(basename, num_sites, generation, this_site),
+        return gather_here(create_gatherer(basename, num_sites, generation,
+                               this_site, this_site),
             std::move(result), this_site);
     }
 
@@ -353,7 +347,7 @@ namespace hpx { namespace lcos {
     // gather plain values
     template <typename T>
     hpx::future<std::vector<typename std::decay<T>::type>> gather_here(
-        hpx::future<hpx::id_type>&& fid, T&& local_result,
+        communicator fid, T&& local_result,
         std::size_t this_site = std::size_t(-1))
     {
         if (this_site == std::size_t(-1))
@@ -361,23 +355,23 @@ namespace hpx { namespace lcos {
             this_site = static_cast<std::size_t>(agas::get_locality_id());
         }
 
-        typedef typename std::decay<T>::type arg_type;
+        using arg_type = typename std::decay<T>::type;
 
         auto gather_data_direct =
-            [this_site](hpx::future<hpx::id_type>&& fid,
+            [this_site](communicator&& c,
                 T&& local_result) -> hpx::future<std::vector<arg_type>> {
             using action_type = typename detail::communicator_server::
                 template communication_get_action<
                     traits::communication::gather_tag,
                     hpx::future<std::vector<arg_type>>, arg_type>;
 
-            // make sure id is kept alive as long as the returned future
-            hpx::id_type id = fid.get();
-            auto result = async(
-                action_type(), id, this_site, std::forward<T>(local_result));
+            // make sure id is kept alive as long as the returned future,
+            // explicitly unwrap returned future
+            hpx::future<std::vector<arg_type>> result = async(
+                action_type(), c, this_site, std::forward<T>(local_result));
 
             traits::detail::get_shared_state(result)->set_on_completed(
-                [id = std::move(id)]() { HPX_UNUSED(id); });
+                [client = std::move(c)]() { HPX_UNUSED(client); });
 
             return result;
         };
@@ -393,24 +387,14 @@ namespace hpx { namespace lcos {
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1))
     {
-        if (num_sites == std::size_t(-1))
-        {
-            num_sites = static_cast<std::size_t>(
-                agas::get_num_localities(hpx::launch::sync));
-        }
-        if (this_site == std::size_t(-1))
-        {
-            this_site = static_cast<std::size_t>(agas::get_locality_id());
-        }
-
-        return gather_here(
-            create_gatherer(basename, num_sites, generation, this_site),
+        return gather_here(create_gatherer(basename, num_sites, generation,
+                               this_site, this_site),
             std::forward<T>(result), this_site);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    hpx::future<void> gather_there(hpx::future<hpx::id_type>&& fid,
+    hpx::future<void> gather_there(communicator fid,
         hpx::future<T>&& local_result, std::size_t this_site = std::size_t(-1))
     {
         if (this_site == std::size_t(-1))
@@ -419,19 +403,19 @@ namespace hpx { namespace lcos {
         }
 
         auto gather_there_data =
-            [this_site](hpx::future<hpx::id_type>&& fid,
+            [this_site](communicator&& c,
                 hpx::future<T>&& local_result) -> hpx::future<void> {
             using action_type = typename detail::communicator_server::
                 template communication_set_action<
-                    traits::communication::gather_tag, void, T>;
+                    traits::communication::gather_tag, hpx::future<void>, T>;
 
-            // make sure id is kept alive as long as the returned future
-            hpx::id_type id = fid.get();
-            auto result =
-                async(action_type(), id, this_site, local_result.get());
+            // make sure id is kept alive as long as the returned future,
+            // explicitly unwrap returned future
+            hpx::future<void> result =
+                async(action_type(), c, this_site, local_result.get());
 
             traits::detail::get_shared_state(result)->set_on_completed(
-                [id = std::move(id)]() { HPX_UNUSED(id); });
+                [client = std::move(c)]() { HPX_UNUSED(client); });
 
             return result;
         };
@@ -445,21 +429,17 @@ namespace hpx { namespace lcos {
         hpx::future<T>&& result, std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {
-        std::string name(basename);
-        if (generation != std::size_t(-1))
-        {
-            name += std::to_string(generation) + "/";
-        }
-
-        return gather_there(hpx::find_from_basename(std::move(name), root_site),
+        HPX_ASSERT(this_site != root_site);
+        return gather_there(create_gatherer(basename, std::size_t(-1),
+                                generation, this_site, root_site),
             std::move(result), this_site);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     // gather plain values
     template <typename T>
-    hpx::future<void> gather_there(hpx::future<hpx::id_type>&& fid,
-        T&& local_result, std::size_t this_site = std::size_t(-1))
+    hpx::future<void> gather_there(communicator fid, T&& local_result,
+        std::size_t this_site = std::size_t(-1))
     {
         if (this_site == std::size_t(-1))
         {
@@ -469,19 +449,20 @@ namespace hpx { namespace lcos {
         using arg_type = typename std::decay<T>::type;
 
         auto gather_there_data_direct =
-            [this_site](hpx::future<hpx::id_type>&& fid,
+            [this_site](communicator&& c,
                 arg_type&& local_result) -> hpx::future<void> {
             using action_type = typename detail::communicator_server::
                 template communication_set_action<
-                    traits::communication::gather_tag, void, arg_type>;
+                    traits::communication::gather_tag, hpx::future<void>,
+                    arg_type>;
 
-            // make sure id is kept alive as long as the returned future
-            hpx::id_type id = fid.get();
-            auto result = async(
-                action_type(), id, this_site, std::forward<T>(local_result));
+            // make sure id is kept alive as long as the returned future,
+            // explicitly unwrap returned future
+            hpx::future<void> result = async(
+                action_type(), c, this_site, std::forward<T>(local_result));
 
             traits::detail::get_shared_state(result)->set_on_completed(
-                [id = std::move(id)]() { HPX_UNUSED(id); });
+                [client = std::move(c)]() { HPX_UNUSED(client); });
 
             return result;
         };
@@ -495,13 +476,9 @@ namespace hpx { namespace lcos {
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {
-        std::string name(basename);
-        if (generation != std::size_t(-1))
-        {
-            name += std::to_string(generation) + "/";
-        }
-
-        return gather_there(hpx::find_from_basename(std::move(name), root_site),
+        HPX_ASSERT(this_site != root_site);
+        return gather_there(create_gatherer(basename, std::size_t(-1),
+                                generation, this_site, root_site),
             std::forward<T>(local_result), this_site);
     }
 }}    // namespace hpx::lcos

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -12,35 +12,6 @@
 // clang-format off
 namespace hpx { namespace collectives {
 
-    /// Create a new communicator object usable with gather_here and gather_there
-    ///
-    /// This functions creates a new communicator object that can be called in
-    /// order to pre-allocate a communicator object usable with multiple
-    /// invocations of \a gather_here and \a gather_there.
-    ///
-    /// \param  basename    The base name identifying the gather operation
-    /// \param  num_sites   The number of participating sites (default: all
-    ///                     localities).
-    /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the gather operation performed on the
-    ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the gather operation on the
-    ///                     given base name has to be performed more than once.
-    /// \param this_site    The sequence number of this invocation (usually
-    ///                     the locality id). This value is optional and
-    ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \params root_site   The site that is responsible for creating the
-    ///                     gather support object. This value is optional
-    ///                     and defaults to '0' (zero).
-    ///
-    /// \returns    This function returns a new communicator object usable
-    ///             with gather_here and gather_there
-    ///
-    communicator create_gatherer(char const* basename,
-        std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
-
     /// Gather a set of values from different call sites
     ///
     /// This function receives a set of values from all call sites operating on
@@ -155,7 +126,7 @@ namespace hpx { namespace collectives {
 #include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_distributed/async.hpp>
-#include <hpx/collectives/detail/communicator.hpp>
+#include <hpx/collectives/create_communicator.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/type_support/unused.hpp>
@@ -163,7 +134,6 @@ namespace hpx { namespace collectives {
 #include <cstddef>
 #include <memory>
 #include <mutex>
-#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -268,16 +238,6 @@ namespace hpx { namespace traits {
 namespace hpx { namespace collectives {
 
     ///////////////////////////////////////////////////////////////////////////
-    inline communicator create_gatherer(char const* basename,
-        std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
-    {
-        return detail::create_communicator(
-            basename, num_sites, generation, this_site, root_site);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
     // gather plain values
     template <typename T>
     hpx::future<std::vector<std::decay_t<T>>> gather_here(communicator fid,
@@ -319,7 +279,7 @@ namespace hpx { namespace collectives {
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1))
     {
-        return gather_here(create_gatherer(basename, num_sites, generation,
+        return gather_here(create_communicator(basename, num_sites, generation,
                                this_site, this_site),
             std::forward<T>(result), this_site);
     }
@@ -366,7 +326,7 @@ namespace hpx { namespace collectives {
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {
         HPX_ASSERT(this_site != root_site);
-        return gather_there(create_gatherer(basename, std::size_t(-1),
+        return gather_there(create_communicator(basename, std::size_t(-1),
                                 generation, this_site, root_site),
             std::forward<T>(local_result), this_site);
     }
@@ -378,5 +338,5 @@ namespace hpx { namespace collectives {
 ///////////////////////////////////////////////////////////////////////////////
 #define HPX_REGISTER_GATHER(...)             /**/
 
-#endif    // COMPUTE_HOST_CODE
+#endif    // !HPX_COMPUTE_DEVICE_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
@@ -12,35 +12,6 @@
 // clang-format off
 namespace hpx { namespace collectives {
 
-    /// Create a new communicator object usable with inclusive_scan
-    ///
-    /// This functions creates a new communicator object that can be called in
-    /// order to pre-allocate a communicator object usable with multiple
-    /// invocations of \a inclusive_scan.
-    ///
-    /// \param  basename    The base name identifying the inclusive_scan operation
-    /// \param  num_sites   The number of participating sites (default: all
-    ///                     localities).
-    /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the inclusive_scan operation performed on the
-    ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the inclusive_scan operation on the
-    ///                     given base name has to be performed more than once.
-    /// \param this_site    The sequence number of this invocation (usually
-    ///                     the locality id). This value is optional and
-    ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \params root_site   The site that is responsible for creating the
-    ///                     inclusive_scan support object. This value is optional
-    ///                     and defaults to '0' (zero).
-    ///
-    /// \returns    This function returns a new communicator object usable
-    ///             with inclusive_scan
-    ///
-    communicator create_inclusive_scan(char const* basename,
-        std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
-
     /// Inclusive inclusive_scan a set of values from different call sites
     ///
     /// This function receives a set of values from all call sites operating on
@@ -116,7 +87,6 @@ namespace hpx { namespace collectives {
 #include <cstddef>
 #include <memory>
 #include <mutex>
-#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -202,16 +172,6 @@ namespace hpx { namespace traits {
 
 namespace hpx { namespace collectives {
 
-    ///////////////////////////////////////////////////////////////////////////
-    inline communicator create_inclusive_scan(char const* basename,
-        std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
-    {
-        return detail::create_communicator(
-            basename, num_sites, generation, this_site, root_site);
-    }
-
     ////////////////////////////////////////////////////////////////////////////
     // inclusive_scan plain values
     template <typename T, typename F>
@@ -255,11 +215,11 @@ namespace hpx { namespace collectives {
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {
-        return inclusive_scan(create_inclusive_scan(basename, num_sites,
+        return inclusive_scan(create_communicator(basename, num_sites,
                                   generation, this_site, root_site),
             std::forward<T>(local_result), std::forward<F>(op), this_site);
     }
 }}    // namespace hpx::collectives
 
-#endif    // COMPUTE_HOST_CODE
+#endif    // !HPX_COMPUTE_DEVICE_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
@@ -78,7 +78,7 @@ namespace hpx { namespace collectives {
 
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_distributed/async.hpp>
-#include <hpx/collectives/detail/communicator.hpp>
+#include <hpx/collectives/create_communicator.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/parallel/algorithms/inclusive_scan.hpp>

--- a/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
@@ -4,7 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file all_to_all.hpp
+/// \file inclusive_scan.hpp
 
 #pragma once
 
@@ -12,69 +12,70 @@
 // clang-format off
 namespace hpx { namespace collectives {
 
-    /// Create a new communicator object usable with all_to_all
+    /// Create a new communicator object usable with inclusive_scan
     ///
     /// This functions creates a new communicator object that can be called in
     /// order to pre-allocate a communicator object usable with multiple
-    /// invocations of \a all_to_all.
+    /// invocations of \a inclusive_scan.
     ///
-    /// \param  basename    The base name identifying the all_to_all operation
+    /// \param  basename    The base name identifying the inclusive_scan operation
     /// \param  num_sites   The number of participating sites (default: all
     ///                     localities).
     /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the all_to_all operation performed on the
+    ///                     number of the inclusive_scan operation performed on the
     ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the all_to_all operation on the
+    ///                     supplied only if the inclusive_scan operation on the
     ///                     given base name has to be performed more than once.
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     /// \params root_site   The site that is responsible for creating the
-    ///                     all_to_all support object. This value is optional
+    ///                     inclusive_scan support object. This value is optional
     ///                     and defaults to '0' (zero).
     ///
     /// \returns    This function returns a new communicator object usable
-    ///             with all_to_all
+    ///             with inclusive_scan
     ///
-    communicator create_all_to_all(char const* basename,
+    communicator create_inclusive_scan(char const* basename,
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
 
-    /// AllToAll a set of values from different call sites
+    /// Inclusive inclusive_scan a set of values from different call sites
     ///
     /// This function receives a set of values from all call sites operating on
     /// the given base name.
     ///
-    /// \param  basename    The base name identifying the all_to_all operation
+    /// \param  basename    The base name identifying the inclusive_scan operation
     /// \param  local_result The value to transmit to all
     ///                     participating sites from this call site.
+    /// \param  op          Reduction operation to apply to all values supplied
+    ///                     from all participating sites
     /// \param  num_sites   The number of participating sites (default: all
     ///                     localities).
     /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the all_to_all operation performed on the
+    ///                     number of the inclusive_scan operation performed on the
     ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the all_to_all operation on the
+    ///                     supplied only if the inclusive_scan operation on the
     ///                     given base name has to be performed more than once.
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     /// \params root_site   The site that is responsible for creating the
-    ///                     all_to_all support object. This value is optional
+    ///                     inclusive_scan support object. This value is optional
     ///                     and defaults to '0' (zero).
     ///
     /// \returns    This function returns a future holding a vector with all
     ///             values send by all participating sites. It will become
-    ///             ready once the all_to_all operation has been completed.
+    ///             ready once the inclusive_scan operation has been completed.
     ///
-    template <typename T>
-    hpx::future<std::vector<std::decay_t<T>>>
-    all_to_all(char const* basename, T&& result,
-        std::size_t num_sites = std::size_t(-1),
+    template <typename T, typename F>
+    hpx::future<std::decay_t<T>> inclusive_scan(char const* basename, T&& result,
+        F&& op, std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
 
-    /// AllToAll a set of values from different call sites
+    /// Inclusive inclusive_scan a set of values from different call sites
     ///
     /// This function receives a set of values from all call sites operating on
     /// the given base name.
@@ -82,18 +83,19 @@ namespace hpx { namespace collectives {
     /// \param  comm        A communicator object returned from \a create_reducer
     /// \param  local_result The value to transmit to all
     ///                     participating sites from this call site.
+    /// \param  op          Reduction operation to apply to all values supplied
+    ///                     from all participating sites
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     ///
     /// \returns    This function returns a future holding a vector with all
     ///             values send by all participating sites. It will become
-    ///             ready once the all_to_all operation has been completed.
+    ///             ready once the inclusive_scan operation has been completed.
     ///
-    template <typename T>
-    hpx::future<std::vector<std::decay_t<T>>>
-    all_to_all(communicator comm, T&& result,
-        std::size_t this_site = std::size_t(-1)0);
+    template <typename T, typename F>
+    hpx::future<std::decay_t<T>> inclusive_scan(communicator comm,
+        T&& result, F&& op, std::size_t this_site = std::size_t(-1));
 }}    // namespace hpx::collectives
 
 // clang-format on
@@ -108,6 +110,7 @@ namespace hpx { namespace collectives {
 #include <hpx/collectives/detail/communicator.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/futures/future.hpp>
+#include <hpx/parallel/algorithms/inclusive_scan.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <cstddef>
@@ -121,63 +124,68 @@ namespace hpx { namespace collectives {
 namespace hpx { namespace traits {
 
     namespace communication {
-        struct all_to_all_tag;
+        struct inclusive_scan_tag;
     }    // namespace communication
 
     ///////////////////////////////////////////////////////////////////////////
-    // support for all_to_all
+    // support for inclusive_scan
     template <typename Communicator>
-    struct communication_operation<Communicator, communication::all_to_all_tag>
+    struct communication_operation<Communicator,
+        communication::inclusive_scan_tag>
       : std::enable_shared_from_this<communication_operation<Communicator,
-            communication::all_to_all_tag>>
+            communication::inclusive_scan_tag>>
     {
         explicit communication_operation(Communicator& comm)
           : communicator_(comm)
         {
         }
 
-        template <typename Result, typename T>
-        Result get(std::size_t which, std::vector<T>&& t)
+        template <typename Result, typename T, typename F>
+        Result get(std::size_t which, T&& t, F&& op)
         {
-            using data_type = std::vector<T>;
+            using arg_type = std::decay_t<T>;
             using mutex_type = typename Communicator::mutex_type;
             using lock_type = std::unique_lock<mutex_type>;
 
             auto this_ = this->shared_from_this();
-            auto on_ready = [this_ = std::move(this_), which](
-                                shared_future<void>&& f) -> data_type {
+            auto on_ready =
+                [which, this_ = std::move(this_), op = std::forward<F>(op)](
+                    hpx::shared_future<void> f) mutable -> arg_type {
                 HPX_UNUSED(this_);
                 f.get();    // propagate any exceptions
 
                 auto& communicator = this_->communicator_;
 
                 lock_type l(communicator.mtx_);
-                auto& data = communicator.template access_data<data_type>(l);
+                util::ignore_while_checking<lock_type> il(&l);
 
-                // slice the overall data based on the locality id of the
-                // requesting site
-                std::vector<T> result;
-                result.reserve(data.size());
-
-                for (auto const& v : data)
+                auto& data = communicator.template access_data<arg_type>(l);
+                if (!communicator.data_available_)
                 {
-                    result.push_back(v[which]);
-                }
+                    std::vector<arg_type> dest;
+                    dest.resize(data.size());
 
-                return result;
+                    hpx::parallel::inclusive_scan(hpx::execution::seq,
+                        data.begin(), data.end(), dest.begin(),
+                        std::forward<F>(op));
+
+                    std::swap(data, dest);
+                    communicator.data_available_ = true;
+                }
+                return data[which];
             };
 
             lock_type l(communicator_.mtx_);
             util::ignore_while_checking<lock_type> il(&l);
 
-            hpx::future<data_type> f =
+            hpx::future<arg_type> f =
                 communicator_.gate_.get_shared_future(l).then(
-                    hpx::launch::sync, on_ready);
+                    hpx::launch::sync, std::move(on_ready));
 
             communicator_.gate_.synchronize(1, l);
 
-            auto& data = communicator_.template access_data<data_type>(l);
-            data[which] = std::move(t);
+            auto& data = communicator_.template access_data<arg_type>(l);
+            data[which] = std::forward<T>(t);
 
             if (communicator_.gate_.set(which, std::move(l)))
             {
@@ -195,7 +203,7 @@ namespace hpx { namespace traits {
 namespace hpx { namespace collectives {
 
     ///////////////////////////////////////////////////////////////////////////
-    inline communicator create_all_to_all(char const* basename,
+    inline communicator create_inclusive_scan(char const* basename,
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
@@ -204,29 +212,33 @@ namespace hpx { namespace collectives {
             basename, num_sites, generation, this_site, root_site);
     }
 
-    ///////////////////////////////////////////////////////////////////////////
-    // all_to_all plain values
-    template <typename T>
-    hpx::future<std::vector<T>> all_to_all(communicator fid,
-        std::vector<T>&& local_result, std::size_t this_site = std::size_t(-1))
+    ////////////////////////////////////////////////////////////////////////////
+    // inclusive_scan plain values
+    template <typename T, typename F>
+    hpx::future<std::decay_t<T>> inclusive_scan(communicator fid,
+        T&& local_result, F&& op, std::size_t this_site = std::size_t(-1))
     {
         if (this_site == std::size_t(-1))
         {
             this_site = static_cast<std::size_t>(agas::get_locality_id());
         }
 
-        auto all_to_all_data_direct =
-            [local_result = std::move(local_result), this_site](
-                communicator&& c) -> hpx::future<std::vector<T>> {
+        using arg_type = std::decay_t<T>;
+
+        auto scan_data_direct =
+            [op = std::forward<F>(op),
+                local_result = std::forward<T>(local_result),
+                this_site](communicator&& c) mutable -> hpx::future<arg_type> {
+            using func_type = std::decay_t<F>;
             using action_type = typename detail::communicator_server::
                 template communication_get_action<
-                    traits::communication::all_to_all_tag,
-                    hpx::future<std::vector<T>>, std::vector<T>>;
+                    traits::communication::inclusive_scan_tag,
+                    hpx::future<arg_type>, arg_type, func_type>;
 
             // make sure id is kept alive as long as the returned future,
             // explicitly unwrap returned future
-            hpx::future<std::vector<T>> result =
-                async(action_type(), c, this_site, std::move(local_result));
+            hpx::future<arg_type> result = async(action_type(), c, this_site,
+                std::forward<T>(local_result), std::forward<F>(op));
 
             traits::detail::get_shared_state(result)->set_on_completed(
                 [client = std::move(c)]() { HPX_UNUSED(client); });
@@ -234,26 +246,20 @@ namespace hpx { namespace collectives {
             return result;
         };
 
-        return fid.then(hpx::launch::sync, std::move(all_to_all_data_direct));
+        return fid.then(hpx::launch::sync, std::move(scan_data_direct));
     }
 
-    template <typename T>
-    hpx::future<std::vector<T>> all_to_all(char const* basename,
-        std::vector<T>&& local_result, std::size_t num_sites = std::size_t(-1),
+    template <typename T, typename F>
+    hpx::future<std::decay_t<T>> inclusive_scan(char const* basename,
+        T&& local_result, F&& op, std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {
-        return all_to_all(create_all_to_all(basename, num_sites, generation,
-                              this_site, root_site),
-            std::move(local_result), this_site);
+        return inclusive_scan(create_inclusive_scan(basename, num_sites,
+                                  generation, this_site, root_site),
+            std::forward<T>(local_result), std::forward<F>(op), this_site);
     }
 }}    // namespace hpx::collectives
-
-////////////////////////////////////////////////////////////////////////////////
-#define HPX_REGISTER_ALLTOALL_DECLARATION(...) /**/
-
-////////////////////////////////////////////////////////////////////////////////
-#define HPX_REGISTER_ALLTOALL(...)             /**/
 
 #endif    // COMPUTE_HOST_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/reduce.hpp
@@ -10,7 +10,7 @@
 
 #if defined(DOXYGEN)
 // clang-format off
-namespace hpx { namespace lcos {
+namespace hpx { namespace collectives {
 
     /// Create a new communicator object usable with reduce_here and reduce_there
     ///
@@ -40,113 +40,6 @@ namespace hpx { namespace lcos {
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
-
-    /// Reduce a set of values from different call sites
-    ///
-    /// This function receives a set of values that are the result of applying
-    /// a given operator on values supplied from all call sites operating on
-    /// the given base name.
-    ///
-    /// \param  basename    The base name identifying the all_reduce operation
-    /// \param  local_result A future referring to the value to reduce onall
-    ///                     participating sites from this call site.
-    /// \param  op          Reduction operation to apply to all values supplied
-    ///                     from all participating sites
-    /// \param  num_sites   The number of participating sites (default: all
-    ///                     localities).
-    /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the all_reduce operation performed on the
-    ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the all_reduce operation on the
-    ///                     given base name has to be performed more than once.
-    /// \param this_site    The sequence number of this invocation (usually
-    ///                     the locality id). This value is optional and
-    ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \params root_site   The site that is responsible for creating the
-    ///                     all_reduce support object. This value is optional
-    ///                     and defaults to '0' (zero).
-    ///
-    /// \returns    This function returns a future holding a value calculated
-    ///             based on the values send by all participating sites. It will
-    ///             become ready once the all_reduce operation has been completed.
-    ///
-    template <typename T, typename F>
-    hpx::future<T> reduce_here(char const* basename, hpx::future<T> local_result,
-        F&& op, std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
-
-    /// Reduce a set of values from different call sites
-    ///
-    /// This function receives a set of values that are the result of applying
-    /// a given operator on values supplied from all call sites operating on
-    /// the given base name.
-    ///
-    /// \param  comm        A communicator object returned from \a create_reducer
-    /// \param  local_result A future referring to the value to reduce on the
-    ///                     central reduction point from this call site.
-    /// \param  op          Reduction operation to apply to all values supplied
-    ///                     from all participating sites
-    /// \param this_site    The sequence number of this invocation (usually
-    ///                     the locality id). This value is optional and
-    ///                     defaults to whatever hpx::get_locality_id() returns.
-    ///
-    /// \returns    This function returns a future holding a value calculated
-    ///             based on the values send by all participating sites. It will
-    ///             become ready once the all_reduce operation has been completed.
-    ///
-    template <typename T, typename F>
-    hpx::future<T> reduce_here(communicator comm, hpx::future<T> local_result,
-        F&& op, std::size_t this_site = std::size_t(-1));
-
-    /// Reduce a given value at the given call site
-    ///
-    /// This function transmits the value given by \a result to a central reduce
-    /// site (where the corresponding \a reduce_here is executed)
-    ///
-    /// \param  basename    The base name identifying the reduction operation
-    /// \param  result      A future referring to the value to reduce on the
-    ///                     central reduction point from this call site.
-    /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the reduction operation performed on the
-    ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the reduction operation on the given
-    ///                     base name has to be performed more than once.
-    /// \param this_site    The sequence number of this invocation (usually
-    ///                     the locality id). This value is optional and
-    ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \param root_site    The sequence number of the central reduction point
-    ///                     (usually the locality id). This value is optional
-    ///                     and defaults to 0.
-    ///
-    /// \returns    This function returns a future<void>. It will become ready
-    ///             once the reduction operation has been completed.
-    ///
-    template <typename T>
-    hpx::future<void> reduce_there(char const* basename, hpx::future<T> result,
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1),
-        std::size_t root_site = 0);
-
-    /// Reduce a given value at the given call site
-    ///
-    /// This function transmits the value given by \a result to a central reduce
-    /// site (where the corresponding \a reduce_here is executed)
-    ///
-    /// \param  comm        A communicator object returned from \a create_reducer
-    /// \param  local_result A future referring to the value to reduce on the
-    ///                     central reduction point from this call site.
-    /// \param this_site    The sequence number of this invocation (usually
-    ///                     the locality id). This value is optional and
-    ///                     defaults to whatever hpx::get_locality_id() returns.
-    ///
-    /// \returns    This function returns a future holding a value calculated
-    ///             based on the values send by all participating sites. It will
-    ///             become ready once the all_reduce operation has been completed.
-    ///
-    template <typename T>
-    hpx::future<void> reduce_there(communicator comm, hpx::future<T> local_result,
-        std::size_t this_site = std::size_t(-1));
 
     /// Reduce a set of values from different call sites
     ///
@@ -252,7 +145,7 @@ namespace hpx { namespace lcos {
     template <typename T>
     hpx::future<void> reduce_there(communicator comm, T&& local_result,
         std::size_t this_site = std::size_t(-1));
-}}    // namespace hpx::lcos
+}}    // namespace hpx::collectives
 
 // clang-format on
 #else
@@ -264,12 +157,9 @@ namespace hpx { namespace lcos {
 #include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_distributed/async.hpp>
-#include <hpx/async_local/dataflow.hpp>
 #include <hpx/collectives/detail/communicator.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/modules/execution_base.hpp>
-#include <hpx/naming_base/id_type.hpp>
 #include <hpx/parallel/algorithms/reduce.hpp>
 #include <hpx/type_support/unused.hpp>
 
@@ -383,7 +273,7 @@ namespace hpx { namespace traits {
     };
 }}    // namespace hpx::traits
 
-namespace hpx { namespace lcos {
+namespace hpx { namespace collectives {
 
     ///////////////////////////////////////////////////////////////////////////
     inline communicator create_reducer(char const* basename,
@@ -393,52 +283,6 @@ namespace hpx { namespace lcos {
     {
         return detail::create_communicator(
             basename, num_sites, generation, this_site, root_site);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    // destination site needs to be handled differently
-    template <typename T, typename F>
-    hpx::future<T> reduce_here(communicator fid, hpx::future<T>&& result,
-        F&& op, std::size_t this_site = std::size_t(-1))
-    {
-        if (this_site == std::size_t(-1))
-        {
-            this_site = static_cast<std::size_t>(agas::get_locality_id());
-        }
-
-        auto reduction_data =
-            [op = std::forward<F>(op), this_site](communicator&& c,
-                hpx::future<T>&& local_result) mutable -> hpx::future<T> {
-            using func_type = std::decay_t<F>;
-            using action_type = typename detail::communicator_server::
-                template communication_get_action<
-                    traits::communication::reduce_tag, hpx::future<T>, T,
-                    func_type>;
-
-            // make sure id is kept alive as long as the returned future,
-            // explicitly unwrap returned future
-            hpx::future<T> result = async(action_type(), c, this_site,
-                local_result.get(), std::forward<F>(op));
-
-            traits::detail::get_shared_state(result)->set_on_completed(
-                [client = std::move(c)]() { HPX_UNUSED(client); });
-
-            return result;
-        };
-
-        return dataflow(hpx::launch::sync, std::move(reduction_data),
-            std::move(fid), std::move(result));
-    }
-
-    template <typename T, typename F>
-    hpx::future<T> reduce_here(char const* basename, hpx::future<T>&& result,
-        F&& op, std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1))
-    {
-        return reduce_here(create_reducer(basename, num_sites, generation,
-                               this_site, this_site),
-            std::move(result), std::forward<F>(op), this_site);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -490,49 +334,6 @@ namespace hpx { namespace lcos {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T>
-    hpx::future<void> reduce_there(communicator fid,
-        hpx::future<T>&& local_result, std::size_t this_site = std::size_t(-1))
-    {
-        if (this_site == std::size_t(-1))
-        {
-            this_site = static_cast<std::size_t>(agas::get_locality_id());
-        }
-
-        auto reduction_there_data =
-            [this_site](communicator&& c,
-                hpx::future<T>&& local_result) -> hpx::future<void> {
-            using action_type = typename detail::communicator_server::
-                template communication_set_action<
-                    traits::communication::reduce_tag, hpx::future<void>, T>;
-
-            // make sure id is kept alive as long as the returned future,
-            // explicitly unwrap returned future
-            hpx::future<void> result =
-                async(action_type(), c, this_site, local_result.get());
-
-            traits::detail::get_shared_state(result)->set_on_completed(
-                [client = std::move(c)]() { HPX_UNUSED(client); });
-
-            return result;
-        };
-
-        return dataflow(hpx::launch::sync, std::move(reduction_there_data),
-            std::move(fid), std::move(local_result));
-    }
-
-    template <typename T>
-    hpx::future<void> reduce_there(char const* basename,
-        hpx::future<T>&& result, std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
-    {
-        HPX_ASSERT(this_site != root_site);
-        return reduce_there(create_reducer(basename, std::size_t(-1),
-                                generation, this_site, root_site),
-            std::move(result), this_site);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
     // reduce plain values
     template <typename T>
     hpx::future<void> reduce_there(communicator fid, T&& local_result,
@@ -578,14 +379,7 @@ namespace hpx { namespace lcos {
                                 generation, this_site, root_site),
             std::forward<T>(local_result), this_site);
     }
-}}    // namespace hpx::lcos
-
-///////////////////////////////////////////////////////////////////////////////
-namespace hpx {
-    using lcos::create_reducer;
-    using lcos::reduce_here;
-    using lcos::reduce_there;
-}    // namespace hpx
+}}    // namespace hpx::collectives
 
 #endif    // COMPUTE_HOST_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/reduce.hpp
@@ -18,19 +18,19 @@ namespace hpx { namespace lcos {
     /// order to pre-allocate a communicator object usable with multiple
     /// invocations of \a reduce_here and \a reduce_there.
     ///
-    /// \param  basename    The base name identifying the all_reduce operation
+    /// \param  basename    The base name identifying the reduce operation
     /// \param  num_sites   The number of participating sites (default: all
     ///                     localities).
     /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the all_reduce operation performed on the
+    ///                     number of the reduce operation performed on the
     ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the all_reduce operation on the
+    ///                     supplied only if the reduce operation on the
     ///                     given base name has to be performed more than once.
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     /// \params root_site   The site that is responsible for creating the
-    ///                     all_reduce support object. This value is optional
+    ///                     reduce support object. This value is optional
     ///                     and defaults to '0' (zero).
     ///
     /// \returns    This function returns a new communicator object usable
@@ -172,10 +172,6 @@ namespace hpx { namespace lcos {
     ///                     all_reduce support object. This value is optional
     ///                     and defaults to '0' (zero).
     ///
-    /// \note       Each all_reduce operation has to be accompanied with a unique
-    ///             usage of the \a HPX_REGISTER_ALLREDUCE macro to define the
-    ///             necessary internal facilities used by \a all_reduce.
-    ///
     /// \returns    This function returns a future holding a vector with all
     ///             values send by all participating sites. It will become
     ///             ready once the all_reduce operation has been completed.
@@ -265,6 +261,7 @@ namespace hpx { namespace lcos {
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
+#include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_distributed/async.hpp>
 #include <hpx/async_local/dataflow.hpp>
@@ -274,7 +271,6 @@ namespace hpx { namespace lcos {
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/naming_base/id_type.hpp>
 #include <hpx/parallel/algorithms/reduce.hpp>
-#include <hpx/thread_support/assert_owns_lock.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <cstddef>
@@ -342,8 +338,6 @@ namespace hpx { namespace traits {
 
             if (communicator_.gate_.set(which, std::move(l)))
             {
-                HPX_ASSERT_DOESNT_OWN_LOCK(l);
-
                 l = lock_type(communicator_.mtx_);
                 communicator_.invalidate_data(l);
             }
@@ -378,8 +372,6 @@ namespace hpx { namespace traits {
 
             if (communicator_.gate_.set(which, std::move(l)))
             {
-                HPX_ASSERT_DOESNT_OWN_LOCK(l);
-
                 l = lock_type(communicator_.mtx_);
                 communicator_.invalidate_data(l);
             }
@@ -594,12 +586,6 @@ namespace hpx {
     using lcos::reduce_here;
     using lcos::reduce_there;
 }    // namespace hpx
-
-////////////////////////////////////////////////////////////////////////////////
-#define HPX_REGISTER_REDUCE_DECLARATION(...) /**/
-
-////////////////////////////////////////////////////////////////////////////////
-#define HPX_REGISTER_REDUCE(...)             /**/
 
 #endif    // COMPUTE_HOST_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/reduce_direct.hpp
+++ b/libs/full/collectives/include/hpx/collectives/reduce_direct.hpp
@@ -1,0 +1,434 @@
+//  Copyright (c) 2013 Hartmut Kaiser
+//  Copyright (c) 2013 Thomas Heller
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file lcos/reduce_direct.hpp
+
+#pragma once
+
+#if defined(DOXYGEN)
+namespace hpx { namespace lcos {
+
+    /// \brief Perform a distributed reduction operation
+    ///
+    /// The function hpx::lcos::reduce performs a distributed reduction
+    /// operation over results returned from action invocations on a given set
+    /// of global identifiers. The action can be either a plain action (in
+    /// which case the global identifiers have to refer to localities) or a
+    /// component action (in which case the global identifiers have to refer
+    /// to instances of a component type which exposes the action.
+    ///
+    /// \param ids       [in] A list of global identifiers identifying the
+    ///                  target objects for which the given action will be
+    ///                  invoked.
+    /// \param reduce_op [in] A binary function expecting two results as
+    ///                  returned from the action invocations. The function
+    ///                  (or function object) is expected to return the result
+    ///                  of the reduction operation performed on its arguments.
+    /// \param argN      [in] Any number of arbitrary arguments (passed by
+    ///                  by const reference) which will be forwarded to the
+    ///                  action invocation.
+    ///
+    /// \returns         This function returns a future representing the result
+    ///                  of the overall reduction operation.
+    ///
+    template <typename Action, typename ReduceOp, typename ArgN, ...>
+    hpx::future<decltype(Action(hpx::id_type, ArgN, ...))> reduce(
+        std::vector<hpx::id_type> const& ids, ReduceOp&& reduce_op, ArgN argN,
+        ...);
+
+    /// \brief Perform a distributed reduction operation
+    ///
+    /// The function hpx::lcos::reduce_with_index performs a distributed reduction
+    /// operation over results returned from action invocations on a given set
+    /// of global identifiers. The action can be either plain action (in
+    /// which case the global identifiers have to refer to localities) or a
+    /// component action (in which case the global identifiers have to refer
+    /// to instances of a component type which exposes the action.
+    ///
+    /// The function passes the index of the global identifier in the given
+    /// list of identifiers as the last argument to the action.
+    ///
+    /// \param ids       [in] A list of global identifiers identifying the
+    ///                  target objects for which the given action will be
+    ///                  invoked.
+    /// \param reduce_op [in] A binary function expecting two results as
+    ///                  returned from the action invocations. The function
+    ///                  (or function object) is expected to return the result
+    ///                  of the reduction operation performed on its arguments.
+    /// \param argN      [in] Any number of arbitrary arguments (passed by
+    ///                  by const reference) which will be forwarded to the
+    ///                  action invocation.
+    ///
+    /// \returns         This function returns a future representing the result
+    ///                  of the overall reduction operation.
+    ///
+    template <typename Action, typename ReduceOp, typename ArgN, ...>
+    hpx::future<decltype(Action(hpx::id_type, ArgN, ..., std::size_t))>
+    reduce_with_index(std::vector<hpx::id_type> const& ids,
+        ReduceOp&& reduce_op, ArgN argN, ...);
+}}    // namespace hpx::lcos
+#else
+
+#include <hpx/config.hpp>
+#include <hpx/actions/transfer_action.hpp>
+#include <hpx/actions_base/actions_base_support.hpp>
+#include <hpx/actions_base/traits/extract_action.hpp>
+#include <hpx/assert.hpp>
+#include <hpx/async_colocated/async_colocated.hpp>
+#include <hpx/async_combinators/when_all.hpp>
+#include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/datastructures/tuple.hpp>
+#include <hpx/futures/future.hpp>
+#include <hpx/futures/traits/promise_local_result.hpp>
+#include <hpx/naming_base/id_type.hpp>
+#include <hpx/preprocessor/cat.hpp>
+#include <hpx/preprocessor/expand.hpp>
+#include <hpx/preprocessor/nargs.hpp>
+#include <hpx/serialization/vector.hpp>
+#include <hpx/type_support/pack.hpp>
+#include <hpx/util/calculate_fanout.hpp>
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#if !defined(HPX_REDUCE_FANOUT)
+#define HPX_REDUCE_FANOUT 16
+#endif
+
+namespace hpx { namespace lcos {
+
+    namespace detail {
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Action>
+        struct reduce_with_index
+        {
+            typedef typename Action::arguments_type arguments_type;
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Action>
+        struct reduce_result
+          : traits::promise_local_result<typename hpx::traits::extract_action<
+                Action>::remote_result_type>
+        {
+        };
+
+        template <typename Action>
+        struct reduce_result<reduce_with_index<Action>> : reduce_result<Action>
+        {
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Action, typename ReduceOp, typename... Ts>
+        typename reduce_result<Action>::type reduce_impl(Action const& act,
+            std::vector<hpx::id_type> const& ids, ReduceOp&& reduce_op,
+            std::size_t global_idx, Ts const&... vs);
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Action, typename Futures, typename... Ts>
+        void reduce_invoke(Action, Futures& futures, hpx::id_type const& id,
+            std::size_t, Ts const&... vs)
+        {
+            futures.push_back(hpx::async<Action>(id, vs...));
+        }
+
+        template <typename Action, typename Futures, typename... Ts>
+        void reduce_invoke(reduce_with_index<Action>, Futures& futures,
+            hpx::id_type const& id, std::size_t global_idx, Ts const&... vs)
+        {
+            futures.push_back(hpx::async<Action>(id, vs..., global_idx));
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Action, typename ReduceOp, typename... Ts>
+        struct reduce_invoker
+        {
+            //static hpx::future<typename reduce_result<Action>::type>
+            static typename reduce_result<Action>::type call(Action const& act,
+                std::vector<hpx::id_type> const& ids, ReduceOp const& reduce_op,
+                std::size_t global_idx, Ts const&... vs)
+            {
+                return reduce_impl(act, ids, reduce_op, global_idx, vs...);
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Action, typename Is>
+        struct make_reduce_action_impl;
+
+        template <typename Action, std::size_t... Is>
+        struct make_reduce_action_impl<Action, util::index_pack<Is...>>
+        {
+            typedef typename reduce_result<Action>::type action_result;
+
+            template <typename ReduceOp>
+            struct reduce_invoker_helper
+            {
+                typedef typename std::decay<ReduceOp>::type reduce_op_type;
+
+                typedef detail::reduce_invoker<Action, reduce_op_type,
+                    typename hpx::tuple_element<Is,
+                        typename Action::arguments_type>::type...>
+                    reduce_invoker_type;
+
+                typedef typename HPX_MAKE_ACTION(
+                    reduce_invoker_type::call)::type type;
+            };
+        };
+
+        template <typename Action>
+        struct make_reduce_action
+          : make_reduce_action_impl<Action,
+                typename util::make_index_pack<Action::arity>::type>
+        {
+        };
+
+        template <typename Action>
+        struct make_reduce_action<reduce_with_index<Action>>
+          : make_reduce_action_impl<reduce_with_index<Action>,
+                typename util::make_index_pack<Action::arity - 1>::type>
+        {
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Result, typename ReduceOp>
+        struct perform_reduction
+        {
+            perform_reduction(ReduceOp const& reduce_op)
+              : reduce_op_(reduce_op)
+            {
+            }
+
+            Result operator()(
+                hpx::future<std::vector<hpx::future<Result>>> r) const
+            {
+                std::vector<hpx::future<Result>> fres = std::move(r.get());
+
+                HPX_ASSERT(!fres.empty());
+
+                if (fres.size() == 1)
+                    return fres[0].get();
+
+                Result res = reduce_op_(fres[0].get(), fres[1].get());
+                for (std::size_t i = 2; i != fres.size(); ++i)
+                    res = reduce_op_(res, fres[i].get());
+
+                return res;
+            }
+
+            ReduceOp const& reduce_op_;
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Action, typename ReduceOp, typename... Ts>
+        typename reduce_result<Action>::type reduce_impl(Action const& act,
+            std::vector<hpx::id_type> const& ids, ReduceOp&& reduce_op,
+            std::size_t global_idx, Ts const&... vs)
+        {
+            typedef typename reduce_result<Action>::type result_type;
+
+            if (ids.empty())
+                return result_type();
+
+            std::size_t const local_fanout = HPX_REDUCE_FANOUT;
+            std::size_t local_size = (std::min)(ids.size(), local_fanout);
+            std::size_t fanout =
+                util::calculate_fanout(ids.size(), local_fanout);
+
+            std::vector<hpx::future<result_type>> reduce_futures;
+            reduce_futures.reserve(local_size + (ids.size() / fanout) + 1);
+            for (std::size_t i = 0; i != local_size; ++i)
+            {
+                reduce_invoke(
+                    act, reduce_futures, ids[i], global_idx + i, vs...);
+            }
+
+            if (ids.size() > local_fanout)
+            {
+                std::size_t applied = local_fanout;
+                std::vector<hpx::id_type>::const_iterator it =
+                    ids.begin() + local_fanout;
+
+                typedef typename detail::make_reduce_action<
+                    Action>::template reduce_invoker_helper<ReduceOp>::type
+                    reduce_impl_action;
+
+                while (it != ids.end())
+                {
+                    HPX_ASSERT(ids.size() >= applied);
+
+                    std::size_t next_fan =
+                        (std::min)(fanout, ids.size() - applied);
+                    std::vector<hpx::id_type> ids_next(it, it + next_fan);
+
+                    hpx::id_type id(ids_next[0]);
+                    reduce_futures.push_back(
+                        hpx::detail::async_colocated<reduce_impl_action>(id,
+                            act, std::move(ids_next), reduce_op,
+                            global_idx + applied, vs...));
+
+                    applied += next_fan;
+                    it += next_fan;
+                }
+            }
+
+            return hpx::when_all(reduce_futures)
+                .then(perform_reduction<result_type, ReduceOp>(reduce_op))
+                .get();
+        }
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Action, typename ReduceOp, typename... Ts>
+    hpx::future<typename detail::reduce_result<Action>::type> reduce(
+        std::vector<hpx::id_type> const& ids, ReduceOp&& reduce_op,
+        Ts const&... vs)
+    {
+        typedef typename detail::make_reduce_action<Action>::
+            template reduce_invoker_helper<ReduceOp>::type reduce_impl_action;
+
+        typedef typename detail::reduce_result<Action>::type action_result;
+
+        if (ids.empty())
+        {
+            return hpx::make_exceptional_future<action_result>(
+                HPX_GET_EXCEPTION(bad_parameter, "hpx::lcos::reduce",
+                    "empty list of targets for reduce operation"));
+        }
+
+        return hpx::detail::async_colocated<reduce_impl_action>(
+            ids[0], Action(), ids, std::forward<ReduceOp>(reduce_op), 0, vs...);
+    }
+
+    template <typename Component, typename Signature, typename Derived,
+        typename ReduceOp, typename... Ts>
+    hpx::future<typename detail::reduce_result<Derived>::type> reduce(
+        hpx::actions::basic_action<Component, Signature, Derived> /* act */
+        ,
+        std::vector<hpx::id_type> const& ids, ReduceOp&& reduce_op,
+        Ts const&... vs)
+    {
+        return reduce<Derived>(ids, std::forward<ReduceOp>(reduce_op), vs...);
+    }
+
+    template <typename Action, typename ReduceOp, typename... Ts>
+    hpx::future<typename detail::reduce_result<Action>::type> reduce_with_index(
+        std::vector<hpx::id_type> const& ids, ReduceOp&& reduce_op,
+        Ts const&... vs)
+    {
+        return reduce<detail::reduce_with_index<Action>>(
+            ids, std::forward<ReduceOp>(reduce_op), vs...);
+    }
+
+    template <typename Component, typename Signature, typename Derived,
+        typename ReduceOp, typename... Ts>
+    hpx::future<typename detail::reduce_result<Derived>::type>
+    reduce_with_index(
+        hpx::actions::basic_action<Component, Signature, Derived> /* act */
+        ,
+        std::vector<hpx::id_type> const& ids, ReduceOp&& reduce_op,
+        Ts const&... vs)
+    {
+        return reduce<detail::reduce_with_index<Derived>>(
+            ids, std::forward<ReduceOp>(reduce_op), vs...);
+    }
+}}    // namespace hpx::lcos
+
+///////////////////////////////////////////////////////////////////////////////
+#define HPX_REGISTER_REDUCE_ACTION_DECLARATION(...)                            \
+    HPX_REGISTER_REDUCE_ACTION_DECLARATION_(__VA_ARGS__)                       \
+/**/
+#define HPX_REGISTER_REDUCE_ACTION_DECLARATION_(...)                           \
+    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_REDUCE_ACTION_DECLARATION_,          \
+        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
+    /**/
+
+#define HPX_REGISTER_REDUCE_ACTION_DECLARATION_2(Action, ReduceOp)             \
+    HPX_REGISTER_ACTION_DECLARATION(                                           \
+        ::hpx::lcos::detail::make_reduce_action<                               \
+            Action>::reduce_invoker_helper<ReduceOp>::type,                    \
+        HPX_PP_CAT(HPX_PP_CAT(reduce_, Action), ReduceOp))                     \
+/**/
+#define HPX_REGISTER_REDUCE_ACTION_DECLARATION_3(Action, ReduceOp, Name)       \
+    HPX_REGISTER_ACTION_DECLARATION(                                           \
+        ::hpx::lcos::detail::make_reduce_action<                               \
+            Action>::reduce_invoker_helper<ReduceOp>::type,                    \
+        HPX_PP_CAT(reduce_, Name))                                             \
+/**/
+
+///////////////////////////////////////////////////////////////////////////////
+#define HPX_REGISTER_REDUCE_ACTION(...)                                        \
+    HPX_REGISTER_REDUCE_ACTION_(__VA_ARGS__)                                   \
+/**/
+#define HPX_REGISTER_REDUCE_ACTION_(...)                                       \
+    HPX_PP_EXPAND(HPX_PP_CAT(                                                  \
+        HPX_REGISTER_REDUCE_ACTION_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))  \
+    /**/
+
+#define HPX_REGISTER_REDUCE_ACTION_2(Action, ReduceOp)                         \
+    HPX_REGISTER_ACTION(::hpx::lcos::detail::make_reduce_action<               \
+                            Action>::reduce_invoker_helper<ReduceOp>::type,    \
+        HPX_PP_CAT(HPX_PP_CAT(reduce_, Action), ReduceOp))                     \
+/**/
+#define HPX_REGISTER_REDUCE_ACTION_3(Action, ReduceOp, Name)                   \
+    HPX_REGISTER_ACTION(::hpx::lcos::detail::make_reduce_action<               \
+                            Action>::reduce_invoker_helper<ReduceOp>::type,    \
+        HPX_PP_CAT(reduce_, Name))                                             \
+/**/
+
+///////////////////////////////////////////////////////////////////////////////
+#define HPX_REGISTER_REDUCE_WITH_INDEX_ACTION_DECLARATION(...)                 \
+    HPX_REGISTER_REDUCE_WITH_INDEX_ACTION_DECLARATION_(__VA_ARGS__)            \
+/**/
+#define HPX_REGISTER_REDUCE_WITH_INDEX_ACTION_DECLARATION_(...)                \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_REGISTER_REDUCE_WITH_INDEX_ACTION_DECLARATION_,         \
+            HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                           \
+    /**/
+
+#define HPX_REGISTER_REDUCE_WITH_INDEX_ACTION_DECLARATION_2(Action, ReduceOp)  \
+    HPX_REGISTER_ACTION_DECLARATION(                                           \
+        ::hpx::lcos::detail::make_reduce_action<                               \
+            ::hpx::lcos::detail::reduce_with_index<Action>>::                  \
+            reduce_invoker_helper<ReduceOp>::type,                             \
+        HPX_PP_CAT(HPX_PP_CAT(reduce_, Action), ReduceOp))                     \
+/**/
+#define HPX_REGISTER_REDUCE_WITH_INDEX_ACTION_DECLARATION_3(                   \
+    Action, ReduceOp, Name)                                                    \
+    HPX_REGISTER_ACTION_DECLARATION(                                           \
+        ::hpx::lcos::detail::make_reduce_action<                               \
+            ::hpx::lcos::detail::reduce_with_index<Action>>::                  \
+            reduce_invoker_helper<ReduceOp>::type,                             \
+        HPX_PP_CAT(reduce_, Name))                                             \
+/**/
+
+///////////////////////////////////////////////////////////////////////////////
+#define HPX_REGISTER_REDUCE_WITH_INDEX_ACTION(...)                             \
+    HPX_REGISTER_REDUCE_WITH_INDEX_ACTION_(__VA_ARGS__)                        \
+/**/
+#define HPX_REGISTER_REDUCE_WITH_INDEX_ACTION_(...)                            \
+    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_REDUCE_WITH_INDEX_ACTION_,           \
+        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
+    /**/
+
+#define HPX_REGISTER_REDUCE_WITH_INDEX_ACTION_2(Action, ReduceOp)              \
+    HPX_REGISTER_ACTION(::hpx::lcos::detail::make_reduce_action<               \
+                            ::hpx::lcos::detail::reduce_with_index<Action>>::  \
+                            reduce_invoker_helper<ReduceOp>::type,             \
+        HPX_PP_CAT(HPX_PP_CAT(reduce_, Action), ReduceOp))                     \
+/**/
+#define HPX_REGISTER_REDUCE_WITH_INDEX_ACTION_3(Action, ReduceOp, Name)        \
+    HPX_REGISTER_ACTION(::hpx::lcos::detail::make_reduce_action<               \
+                            ::hpx::lcos::detail::reduce_with_index<Action>>::  \
+                            reduce_invoker_helper<ReduceOp>::type,             \
+        HPX_PP_CAT(reduce_, Name))                                             \
+    /**/
+
+#endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -10,7 +10,7 @@
 
 #if defined(DOXYGEN)
 // clang-format off
-namespace hpx { namespace lcos {
+namespace hpx { namespace collectives {
 
     /// Create a new communicator object usable with scatter_from and scatter_to
     ///
@@ -40,109 +40,6 @@ namespace hpx { namespace lcos {
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
-
-    /// Scatter (receive) a set of values to different call sites
-    ///
-    /// This function receives an element of a set of values operating on
-    /// the given base name.
-    ///
-    /// \param  basename    The base name identifying the scatter operation
-    /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the scatter operation performed on the
-    ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the scatter operation on the given
-    ///                     base name has to be performed more than once.
-    /// \param this_site    The sequence number of this invocation (usually
-    ///                     the locality id). This value is optional and
-    ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \param root_site    The sequence number of the central scatter point
-    ///                     (usually the locality id). This value is optional
-    ///                     and defaults to 0.
-    ///
-    /// \returns    This function returns a future holding a the
-    ///             scattered value. It will become ready once the scatter
-    ///             operation has been completed.
-    ///
-    template <typename T>
-    hpx::future<T> scatter_from(char const* basename,
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1),
-        std::size_t root_site = 0);
-
-    /// Scatter (receive) a set of values to different call sites
-    ///
-    /// This function receives an element of a set of values operating on
-    /// the given base name.
-    ///
-    /// \param  comm        A communicator object returned from \a create_reducer
-    /// \param this_site    The sequence number of this invocation (usually
-    ///                     the locality id). This value is optional and
-    ///                     defaults to whatever hpx::get_locality_id() returns.
-    ///
-    /// \returns    This function returns a future holding a the
-    ///             scattered value. It will become ready once the scatter
-    ///             operation has been completed.
-    ///
-    template <typename T>
-    hpx::future<T> scatter_from(communicator comm,
-        std::size_t this_site = std::size_t(-1));
-
-    /// Scatter (send) a part of the value set at the given call site
-    ///
-    /// This function transmits the value given by \a result to a central scatter
-    /// site (where the corresponding \a scatter_from is executed)
-    ///
-    /// \param  basename    The base name identifying the scatter operation
-    /// \param  result      A future referring to the value to transmit to the
-    ///                     central scatter point from this call site.
-    /// \param  num_sites   The number of participating sites (default: all
-    ///                     localities).
-    /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the scatter operation performed on the
-    ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the scatter operation on the given
-    ///                     base name has to be performed more than once.
-    /// \param this_site    The sequence number of this invocation (usually
-    ///                     the locality id). This value is optional and
-    ///                     defaults to whatever hpx::get_locality_id() returns.
-    ///
-    /// \returns    This function returns a future holding a the
-    ///             scattered value. It will become ready once the scatter
-    ///             operation has been completed.
-    ///
-    template <typename T>
-    hpx::future<T> scatter_to(char const* basename,
-        hpx::future<std::vector<T>> result,
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1));
-
-    /// Scatter (send) a part of the value set at the given call site
-    ///
-    /// This function transmits the value given by \a result to a central scatter
-    /// site (where the corresponding \a scatter_from is executed)
-    ///
-    /// \param  comm        A communicator object returned from \a create_reducer
-    /// \param  result      A future referring to the value to transmit to the
-    ///                     central scatter point from this call site.
-    /// \param  num_sites   The number of participating sites (default: all
-    ///                     localities).
-    /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the scatter operation performed on the
-    ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the scatter operation on the given
-    ///                     base name has to be performed more than once.
-    /// \param this_site    The sequence number of this invocation (usually
-    ///                     the locality id). This value is optional and
-    ///                     defaults to whatever hpx::get_locality_id() returns.
-    ///
-    /// \returns    This function returns a future holding a the
-    ///             scattered value. It will become ready once the scatter
-    ///             operation has been completed.
-    ///
-    template <typename T>
-    hpx::future<T> scatter_to(communicator comm,
-        hpx::future<std::vector<T>> result,
-        std::size_t this_site = std::size_t(-1));
 
     /// Scatter (receive) a set of values to different call sites
     ///
@@ -238,9 +135,8 @@ namespace hpx { namespace lcos {
     ///
     template <typename T>
     hpx::future<T> scatter_to(communicator comm,
-        std::vector<T>&& result,
-        std::size_t this_site = std::size_t(-1));
-}}    // namespace hpx::lcos
+        std::vector<T>&& result, std::size_t this_site = std::size_t(-1));
+}}    // namespace hpx::collectives
 
 // clang-format on
 #else
@@ -252,12 +148,9 @@ namespace hpx { namespace lcos {
 #include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_distributed/async.hpp>
-#include <hpx/async_local/dataflow.hpp>
 #include <hpx/collectives/detail/communicator.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/modules/execution_base.hpp>
-#include <hpx/naming_base/id_type.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <cstddef>
@@ -369,7 +262,7 @@ namespace hpx { namespace traits {
     };
 }}    // namespace hpx::traits
 
-namespace hpx { namespace lcos {
+namespace hpx { namespace collectives {
 
     ///////////////////////////////////////////////////////////////////////////
     inline communicator create_scatterer(char const* basename,
@@ -422,53 +315,6 @@ namespace hpx { namespace lcos {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    // scatter_to
-    template <typename T>
-    hpx::future<T> scatter_to(communicator fid,
-        hpx::future<std::vector<T>>&& result,
-        std::size_t this_site = std::size_t(-1))
-    {
-        if (this_site == std::size_t(-1))
-        {
-            this_site = static_cast<std::size_t>(agas::get_locality_id());
-        }
-
-        auto scatter_to_data =
-            [this_site](communicator&& c,
-                hpx::future<std::vector<T>>&& local_result) -> hpx::future<T> {
-            using action_type = typename detail::communicator_server::
-                template communication_set_action<
-                    traits::communication::scatter_tag, hpx::future<T>,
-                    std::vector<T>>;
-
-            // make sure id is kept alive as long as the returned future,
-            // explicitly unwrap returned future
-            hpx::future<T> result =
-                async(action_type(), c, this_site, local_result.get());
-
-            traits::detail::get_shared_state(result)->set_on_completed(
-                [client = std::move(c)]() { HPX_UNUSED(client); });
-
-            return result;
-        };
-
-        return dataflow(hpx::launch::sync, std::move(scatter_to_data),
-            std::move(fid), std::move(result));
-    }
-
-    template <typename T>
-    hpx::future<T> scatter_to(char const* basename,
-        hpx::future<std::vector<T>>&& result,
-        std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1))
-    {
-        return scatter_to(create_scatterer(basename, num_sites, generation,
-                              this_site, this_site),
-            std::move(result), this_site);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
     // scatter plain values
     template <typename T>
     hpx::future<T> scatter_to(communicator fid, std::vector<T>&& local_result,
@@ -512,13 +358,7 @@ namespace hpx { namespace lcos {
                               this_site, this_site),
             std::move(local_result), this_site);
     }
-}}    // namespace hpx::lcos
-
-///////////////////////////////////////////////////////////////////////////////
-namespace hpx {
-    using lcos::scatter_from;
-    using lcos::scatter_to;
-}    // namespace hpx
+}}    // namespace hpx::collectives
 
 ///////////////////////////////////////////////////////////////////////////////
 #define HPX_REGISTER_SCATTER_DECLARATION(...) /**/

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2020 Hartmut Kaiser
+//  Copyright (c) 2014-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -171,10 +171,8 @@ namespace hpx { namespace lcos {
 #include <hpx/async_distributed/async.hpp>
 #include <hpx/async_local/dataflow.hpp>
 #include <hpx/collectives/detail/communicator.hpp>
-#include <hpx/components/basename_registration.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/futures/future.hpp>
-#include <hpx/futures/traits/acquire_shared_state.hpp>
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/naming_base/id_type.hpp>
 #include <hpx/thread_support/assert_owns_lock.hpp>

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -12,14 +12,41 @@
 // clang-format off
 namespace hpx { namespace lcos {
 
+    /// Create a new communicator object usable with scatter_from and scatter_to
+    ///
+    /// This functions creates a new communicator object that can be called in
+    /// order to pre-allocate a communicator object usable with multiple
+    /// invocations of \a scatter_from and \a scatter_to.
+    ///
+    /// \param  basename    The base name identifying the scatter operation
+    /// \param  num_sites   The number of participating sites (default: all
+    ///                     localities).
+    /// \param  generation  The generational counter identifying the sequence
+    ///                     number of the scatter operation performed on the
+    ///                     given base name. This is optional and needs to be
+    ///                     supplied only if the scatter operation on the
+    ///                     given base name has to be performed more than once.
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
+    /// \params root_site   The site that is responsible for creating the
+    ///                     scatter support object. This value is optional
+    ///                     and defaults to '0' (zero).
+    ///
+    /// \returns    This function returns a new communicator object usable
+    ///             with scatter_from and scatter_to
+    ///
+    communicator create_scatterer(char const* basename,
+        std::size_t num_sites = std::size_t(-1),
+        std::size_t generation = std::size_t(-1),
+        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
+
     /// Scatter (receive) a set of values to different call sites
     ///
     /// This function receives an element of a set of values operating on
     /// the given base name.
     ///
     /// \param  basename    The base name identifying the scatter operation
-    /// \param  result      A future referring to the value to transmit to the
-    ///                     central scatter point from this call site.
     /// \param  generation  The generational counter identifying the sequence
     ///                     number of the scatter operation performed on the
     ///                     given base name. This is optional and needs to be
@@ -32,11 +59,6 @@ namespace hpx { namespace lcos {
     ///                     (usually the locality id). This value is optional
     ///                     and defaults to 0.
     ///
-    /// \note       Each scatter operation has to be accompanied with a unique
-    ///             usage of the \a HPX_REGISTER_SCATTER macro to define the
-    ///             necessary internal facilities used by \a scatter_from and
-    ///             \a scatter_to
-    ///
     /// \returns    This function returns a future holding a the
     ///             scattered value. It will become ready once the scatter
     ///             operation has been completed.
@@ -46,6 +68,24 @@ namespace hpx { namespace lcos {
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1),
         std::size_t root_site = 0);
+
+    /// Scatter (receive) a set of values to different call sites
+    ///
+    /// This function receives an element of a set of values operating on
+    /// the given base name.
+    ///
+    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
+    ///
+    /// \returns    This function returns a future holding a the
+    ///             scattered value. It will become ready once the scatter
+    ///             operation has been completed.
+    ///
+    template <typename T>
+    hpx::future<T> scatter_from(communicator comm,
+        std::size_t this_site = std::size_t(-1));
 
     /// Scatter (send) a part of the value set at the given call site
     ///
@@ -65,11 +105,6 @@ namespace hpx { namespace lcos {
     /// \param this_site    The sequence number of this invocation (usually
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
-    ///
-    /// \note       Each scatter operation has to be accompanied with a unique
-    ///             usage of the \a HPX_REGISTER_SCATTER macro to define the
-    ///             necessary internal facilities used by \a scatter_from and
-    ///             \a scatter_to
     ///
     /// \returns    This function returns a future holding a the
     ///             scattered value. It will become ready once the scatter
@@ -81,14 +116,40 @@ namespace hpx { namespace lcos {
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1));
 
+    /// Scatter (send) a part of the value set at the given call site
+    ///
+    /// This function transmits the value given by \a result to a central scatter
+    /// site (where the corresponding \a scatter_from is executed)
+    ///
+    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param  result      A future referring to the value to transmit to the
+    ///                     central scatter point from this call site.
+    /// \param  num_sites   The number of participating sites (default: all
+    ///                     localities).
+    /// \param  generation  The generational counter identifying the sequence
+    ///                     number of the scatter operation performed on the
+    ///                     given base name. This is optional and needs to be
+    ///                     supplied only if the scatter operation on the given
+    ///                     base name has to be performed more than once.
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
+    ///
+    /// \returns    This function returns a future holding a the
+    ///             scattered value. It will become ready once the scatter
+    ///             operation has been completed.
+    ///
+    template <typename T>
+    hpx::future<T> scatter_to(communicator comm,
+        hpx::future<std::vector<T>> result,
+        std::size_t this_site = std::size_t(-1));
+
     /// Scatter (receive) a set of values to different call sites
     ///
     /// This function receives an element of a set of values operating on
     /// the given base name.
     ///
     /// \param  basename    The base name identifying the scatter operation
-    /// \param  result      The value to transmit to the central scatter point
-    ///                     from this call site.
     /// \param  generation  The generational counter identifying the sequence
     ///                     number of the scatter operation performed on the
     ///                     given base name. This is optional and needs to be
@@ -101,11 +162,6 @@ namespace hpx { namespace lcos {
     ///                     (usually the locality id). This value is optional
     ///                     and defaults to 0.
     ///
-    /// \note       Each scatter operation has to be accompanied with a unique
-    ///             usage of the \a HPX_REGISTER_SCATTER macro to define the
-    ///             necessary internal facilities used by \a scatter_from and
-    ///             \a scatter_to
-    ///
     /// \returns    This function returns a future holding a the
     ///             scattered value. It will become ready once the scatter
     ///             operation has been completed.
@@ -115,6 +171,24 @@ namespace hpx { namespace lcos {
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1),
         std::size_t root_site = 0);
+
+    /// Scatter (receive) a set of values to different call sites
+    ///
+    /// This function receives an element of a set of values operating on
+    /// the given base name.
+    ///
+    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
+    ///
+    /// \returns    This function returns a future holding a the
+    ///             scattered value. It will become ready once the scatter
+    ///             operation has been completed.
+    ///
+    template <typename T>
+    hpx::future<T> scatter_from(communicator comm,
+        std::size_t this_site = std::size_t(-1));
 
     /// Scatter (send) a part of the value set at the given call site
     ///
@@ -135,27 +209,36 @@ namespace hpx { namespace lcos {
     ///                     the locality id). This value is optional and
     ///                     defaults to whatever hpx::get_locality_id() returns.
     ///
-    /// \note       Each scatter operation has to be accompanied with a unique
-    ///             usage of the \a HPX_REGISTER_SCATTER macro to define the
-    ///             necessary internal facilities used by \a scatter_from and
-    ///             \a scatter_to
-    ///
     /// \returns    This function returns a future holding a the
     ///             scattered value. It will become ready once the scatter
     ///             operation has been completed.
     ///
     template <typename T>
     hpx::future<T> scatter_to(char const* basename,
-        std::vector<T> const& result,
+        std::vector<T>&& result,
         std::size_t num_sites = std::size_t(-1),
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1));
 
+    /// Scatter (send) a part of the value set at the given call site
+    ///
+    /// This function transmits the value given by \a result to a central scatter
+    /// site (where the corresponding \a scatter_from is executed)
+    ///
+    /// \param  comm        A communicator object returned from \a create_reducer
+    /// \param  num_sites   The number of participating sites (default: all
+    ///                     localities).
+    /// \param this_site    The sequence number of this invocation (usually
+    ///                     the locality id). This value is optional and
+    ///                     defaults to whatever hpx::get_locality_id() returns.
+    ///
+    /// \returns    This function returns a future holding a the
+    ///             scattered value. It will become ready once the scatter
+    ///             operation has been completed.
+    ///
     template <typename T>
-    hpx::future<T> scatter_to(char const* basename,
+    hpx::future<T> scatter_to(communicator comm,
         std::vector<T>&& result,
-        std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1));
 }}    // namespace hpx::lcos
 
@@ -175,7 +258,6 @@ namespace hpx { namespace lcos {
 #include <hpx/futures/future.hpp>
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/naming_base/id_type.hpp>
-#include <hpx/thread_support/assert_owns_lock.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <cstddef>
@@ -236,8 +318,6 @@ namespace hpx { namespace traits {
 
             if (communicator_.gate_.set(which, std::move(l)))
             {
-                HPX_ASSERT_DOESNT_OWN_LOCK(l);
-
                 l = lock_type(communicator_.mtx_);
                 communicator_.invalidate_data(l);
             }
@@ -278,8 +358,6 @@ namespace hpx { namespace traits {
 
             if (communicator_.gate_.set(which, std::move(l)))
             {
-                HPX_ASSERT_DOESNT_OWN_LOCK(l);
-
                 l = lock_type(communicator_.mtx_);
                 communicator_.invalidate_data(l);
             }

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -12,35 +12,6 @@
 // clang-format off
 namespace hpx { namespace collectives {
 
-    /// Create a new communicator object usable with scatter_from and scatter_to
-    ///
-    /// This functions creates a new communicator object that can be called in
-    /// order to pre-allocate a communicator object usable with multiple
-    /// invocations of \a scatter_from and \a scatter_to.
-    ///
-    /// \param  basename    The base name identifying the scatter operation
-    /// \param  num_sites   The number of participating sites (default: all
-    ///                     localities).
-    /// \param  generation  The generational counter identifying the sequence
-    ///                     number of the scatter operation performed on the
-    ///                     given base name. This is optional and needs to be
-    ///                     supplied only if the scatter operation on the
-    ///                     given base name has to be performed more than once.
-    /// \param this_site    The sequence number of this invocation (usually
-    ///                     the locality id). This value is optional and
-    ///                     defaults to whatever hpx::get_locality_id() returns.
-    /// \params root_site   The site that is responsible for creating the
-    ///                     scatter support object. This value is optional
-    ///                     and defaults to '0' (zero).
-    ///
-    /// \returns    This function returns a new communicator object usable
-    ///             with scatter_from and scatter_to
-    ///
-    communicator create_scatterer(char const* basename,
-        std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0);
-
     /// Scatter (receive) a set of values to different call sites
     ///
     /// This function receives an element of a set of values operating on
@@ -148,7 +119,7 @@ namespace hpx { namespace collectives {
 #include <hpx/assert.hpp>
 #include <hpx/async_base/launch_policy.hpp>
 #include <hpx/async_distributed/async.hpp>
-#include <hpx/collectives/detail/communicator.hpp>
+#include <hpx/collectives/create_communicator.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/type_support/unused.hpp>
@@ -156,7 +127,6 @@ namespace hpx { namespace collectives {
 #include <cstddef>
 #include <memory>
 #include <mutex>
-#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -265,16 +235,6 @@ namespace hpx { namespace traits {
 namespace hpx { namespace collectives {
 
     ///////////////////////////////////////////////////////////////////////////
-    inline communicator create_scatterer(char const* basename,
-        std::size_t num_sites = std::size_t(-1),
-        std::size_t generation = std::size_t(-1),
-        std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
-    {
-        return detail::create_communicator(
-            basename, num_sites, generation, this_site, root_site);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
     // destination site needs to be handled differently
     template <typename T>
     hpx::future<T> scatter_from(
@@ -309,7 +269,7 @@ namespace hpx { namespace collectives {
         std::size_t this_site = std::size_t(-1), std::size_t root_site = 0)
     {
         HPX_ASSERT(this_site != root_site);
-        return scatter_from<T>(create_scatterer(basename, std::size_t(-1),
+        return scatter_from<T>(create_communicator(basename, std::size_t(-1),
                                    generation, this_site, root_site),
             this_site);
     }
@@ -354,7 +314,7 @@ namespace hpx { namespace collectives {
         std::size_t generation = std::size_t(-1),
         std::size_t this_site = std::size_t(-1))
     {
-        return scatter_to(create_scatterer(basename, num_sites, generation,
+        return scatter_to(create_communicator(basename, num_sites, generation,
                               this_site, this_site),
             std::move(local_result), this_site);
     }
@@ -366,5 +326,5 @@ namespace hpx { namespace collectives {
 ///////////////////////////////////////////////////////////////////////////////
 #define HPX_REGISTER_SCATTER(...)             /**/
 
-#endif    // COMPUTE_HOST_CODE
+#endif    // !HPX_COMPUTE_DEVICE_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/src/create_communication_set.cpp
+++ b/libs/full/collectives/src/create_communication_set.cpp
@@ -10,6 +10,7 @@
 #include <hpx/collectives/communication_set.hpp>
 #include <hpx/collectives/detail/communication_set_node.hpp>
 #include <hpx/collectives/detail/communicator.hpp>
+#include <hpx/components/basename_registration.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/naming_base/id_type.hpp>

--- a/libs/full/collectives/src/create_communication_set.cpp
+++ b/libs/full/collectives/src/create_communication_set.cpp
@@ -59,7 +59,7 @@ namespace hpx { namespace lcos {
         if (num_sites == std::size_t(-1))
         {
             num_sites = static_cast<std::size_t>(
-                hpx::get_num_localities(hpx::launch::sync));
+                agas::get_num_localities(hpx::launch::sync));
         }
         if (this_site == std::size_t(-1))
         {

--- a/libs/full/collectives/src/create_communicator.cpp
+++ b/libs/full/collectives/src/create_communicator.cpp
@@ -9,7 +9,7 @@
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
 #include <hpx/assert.hpp>
-#include <hpx/collectives/detail/communicator.hpp>
+#include <hpx/collectives/create_communicator.hpp>
 #include <hpx/components/basename_registration.hpp>
 #include <hpx/components/client.hpp>
 #include <hpx/components_base/agas_interface.hpp>
@@ -31,12 +31,12 @@ using collectives_component =
 
 HPX_REGISTER_COMPONENT(collectives_component);
 
-namespace hpx { namespace collectives { namespace detail {
+namespace hpx { namespace collectives {
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::components::client<detail::communicator_server> create_communicator(
         char const* basename, std::size_t num_sites, std::size_t generation,
-        std::size_t this_site, std::size_t root_site, std::size_t num_values)
+        std::size_t this_site, std::size_t root_site)
     {
         if (num_sites == std::size_t(-1))
         {
@@ -50,10 +50,6 @@ namespace hpx { namespace collectives { namespace detail {
             {
                 root_site = this_site;
             }
-        }
-        if (num_values == std::size_t(-1))
-        {
-            num_values = num_sites;
         }
 
         HPX_ASSERT(this_site < num_sites);
@@ -70,8 +66,7 @@ namespace hpx { namespace collectives { namespace detail {
         if (this_site == root_site)
         {
             // create a new communicator
-            client_type c =
-                hpx::local_new<client_type>(num_sites, this_site, num_values);
+            client_type c = hpx::local_new<client_type>(num_sites, this_site);
 
             // register the communicator's id using the given basename,
             // this keeps the communicator alive
@@ -97,6 +92,6 @@ namespace hpx { namespace collectives { namespace detail {
         // find existing communicator
         return hpx::find_from_basename<client_type>(std::move(name), root_site);
     }
-}}}    // namespace hpx::collectives::detail
+}}    // namespace hpx::collectives
 
-#endif
+#endif    // !HPX_COMPUTE_DEVICE_CODE

--- a/libs/full/collectives/src/detail/communicator.cpp
+++ b/libs/full/collectives/src/detail/communicator.cpp
@@ -17,10 +17,8 @@
 #include <hpx/exception.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/futures.hpp>
-#include <hpx/naming_base/id_type.hpp>
 #include <hpx/runtime_components/component_factory.hpp>
 #include <hpx/runtime_components/new.hpp>
-#include <hpx/runtime_distributed/find_here.hpp>
 #include <hpx/runtime_distributed/server/runtime_support.hpp>
 
 #include <cstddef>
@@ -29,11 +27,11 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 using collectives_component =
-    hpx::components::component<hpx::lcos::detail::communicator_server>;
+    hpx::components::component<hpx::collectives::detail::communicator_server>;
 
 HPX_REGISTER_COMPONENT(collectives_component);
 
-namespace hpx { namespace lcos { namespace detail {
+namespace hpx { namespace collectives { namespace detail {
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::components::client<detail::communicator_server> create_communicator(
@@ -86,7 +84,7 @@ namespace hpx { namespace lcos { namespace detail {
                     if (!result)
                     {
                         HPX_THROW_EXCEPTION(bad_parameter,
-                            "hpx::lcos::detail::create_communicator",
+                            "hpx::collectives::detail::create_communicator",
                             hpx::util::format(
                                 "the given base name for the communicator "
                                 "operation was already registered: {}",
@@ -99,6 +97,6 @@ namespace hpx { namespace lcos { namespace detail {
         // find existing communicator
         return hpx::find_from_basename<client_type>(std::move(name), root_site);
     }
-}}}    // namespace hpx::lcos::detail
+}}}    // namespace hpx::collectives::detail
 
 #endif

--- a/libs/full/collectives/src/detail/communicator.cpp
+++ b/libs/full/collectives/src/detail/communicator.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2020-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/collectives/tests/regressions/multiple_gather_ops_2001.cpp
+++ b/libs/full/collectives/tests/regressions/multiple_gather_ops_2001.cpp
@@ -26,13 +26,12 @@ int hpx_main()
 {
     for (int i = 0; i < 10; ++i)
     {
-        hpx::future<std::uint32_t> value =
-            hpx::make_ready_future(hpx::get_locality_id());
+        std::uint32_t value = hpx::get_locality_id();
 
         if (hpx::get_locality_id() == 0)
         {
             hpx::future<std::vector<std::uint32_t>> overall_result =
-                hpx::lcos::gather_here(gather_basename, std::move(value),
+                hpx::collectives::gather_here(gather_basename, std::move(value),
                     hpx::get_num_localities(hpx::launch::sync), i);
 
             std::vector<std::uint32_t> sol = overall_result.get();
@@ -44,8 +43,8 @@ int hpx_main()
         }
         else
         {
-            hpx::future<void> overall_result =
-                hpx::lcos::gather_there(gather_basename, std::move(value), i);
+            hpx::future<void> overall_result = hpx::collectives::gather_there(
+                gather_basename, std::move(value), i);
 
             overall_result.get();
         }

--- a/libs/full/collectives/tests/regressions/multiple_gather_ops_2001.cpp
+++ b/libs/full/collectives/tests/regressions/multiple_gather_ops_2001.cpp
@@ -22,8 +22,6 @@
 
 char const* gather_basename = "/test/gather/";
 
-HPX_REGISTER_GATHER(std::uint32_t, test_gather);
-
 int hpx_main()
 {
     for (int i = 0; i < 10; ++i)

--- a/libs/full/collectives/tests/unit/CMakeLists.txt
+++ b/libs/full/collectives/tests/unit/CMakeLists.txt
@@ -13,9 +13,11 @@ set(tests
     broadcast_apply
     broadcast_component
     communication_set
+    exclusive_scan_
     fold
     gather
     global_spmd_block
+    inclusive_scan_
     reduce
     reduce_direct
     remote_latch

--- a/libs/full/collectives/tests/unit/CMakeLists.txt
+++ b/libs/full/collectives/tests/unit/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020 Hartmut Kaiser
+# Copyright (c) 2019-2021 Hartmut Kaiser
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,19 +9,20 @@ set(tests
     all_reduce
     all_to_all
     barrier
-    broadcast_direct
+    broadcast
     broadcast_apply
     broadcast_component
     communication_set
     fold
     gather
-    reduce
-    remote_latch
     global_spmd_block
+    reduce
+    reduce_direct
+    remote_latch
 )
 
 if(HPX_WITH_NETWORKING)
-  set(tests ${tests} broadcast scatter)
+  set(tests ${tests} broadcast_direct scatter)
 endif()
 
 foreach(test ${tests})

--- a/libs/full/collectives/tests/unit/CMakeLists.txt
+++ b/libs/full/collectives/tests/unit/CMakeLists.txt
@@ -9,13 +9,11 @@ set(tests
     all_reduce
     all_to_all
     barrier
-    broadcast
     broadcast_apply
     broadcast_component
     communication_set
     exclusive_scan_
     fold
-    gather
     global_spmd_block
     inclusive_scan_
     reduce
@@ -24,7 +22,7 @@ set(tests
 )
 
 if(HPX_WITH_NETWORKING)
-  set(tests ${tests} broadcast_direct scatter)
+  set(tests ${tests} broadcast broadcast_direct gather scatter)
 endif()
 
 foreach(test ${tests})

--- a/libs/full/collectives/tests/unit/all_gather.cpp
+++ b/libs/full/collectives/tests/unit/all_gather.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2019 Hartmut Kaiser
+//  Copyright (c) 2019-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/collectives/tests/unit/all_gather.cpp
+++ b/libs/full/collectives/tests/unit/all_gather.cpp
@@ -18,31 +18,11 @@
 #include <utility>
 #include <vector>
 
-constexpr char const* all_gather_basename = "/test/all_gather/";
 constexpr char const* all_gather_direct_basename = "/test/all_gather_direct/";
 
 void test_one_shot_use()
 {
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
-
-    // test functionality based on future<> of local result
-    for (int i = 0; i != 10; ++i)
-    {
-        hpx::future<std::uint32_t> value =
-            hpx::make_ready_future(hpx::get_locality_id());
-
-        hpx::future<std::vector<std::uint32_t>> overall_result =
-            hpx::all_gather(
-                all_gather_basename, std::move(value), num_localities, i);
-
-        std::vector<std::uint32_t> r = overall_result.get();
-        HPX_TEST_EQ(r.size(), num_localities);
-
-        for (std::size_t j = 0; j != r.size(); ++j)
-        {
-            HPX_TEST_EQ(r[j], j);
-        }
-    }
 
     // test functionality based on immediate local result value
     for (int i = 0; i != 10; ++i)
@@ -50,7 +30,7 @@ void test_one_shot_use()
         std::uint32_t value = hpx::get_locality_id();
 
         hpx::future<std::vector<std::uint32_t>> overall_result =
-            hpx::all_gather(
+            hpx::collectives::all_gather(
                 all_gather_direct_basename, value, num_localities, i);
 
         std::vector<std::uint32_t> r = overall_result.get();
@@ -67,37 +47,16 @@ void test_multiple_use()
 {
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
 
-    auto all_gather_client =
-        hpx::create_all_gather(all_gather_basename, num_localities);
-
-    // test functionality based on future<> of local result
-    for (int i = 0; i != 10; ++i)
-    {
-        hpx::future<std::uint32_t> value =
-            hpx::make_ready_future(hpx::get_locality_id());
-
-        hpx::future<std::vector<std::uint32_t>> overall_result =
-            hpx::all_gather(all_gather_client, std::move(value));
-
-        std::vector<std::uint32_t> r = overall_result.get();
-        HPX_TEST_EQ(r.size(), num_localities);
-
-        for (std::size_t j = 0; j != r.size(); ++j)
-        {
-            HPX_TEST_EQ(r[j], j);
-        }
-    }
-
     // test functionality based on immediate local result value
-    auto all_gather_direct_client =
-        hpx::create_all_gather(all_gather_direct_basename, num_localities);
+    auto all_gather_direct_client = hpx::collectives::create_all_gather(
+        all_gather_direct_basename, num_localities);
 
     for (int i = 0; i != 10; ++i)
     {
         std::uint32_t value = hpx::get_locality_id();
 
         hpx::future<std::vector<std::uint32_t>> overall_result =
-            hpx::all_gather(all_gather_direct_client, value);
+            hpx::collectives::all_gather(all_gather_direct_client, value);
 
         std::vector<std::uint32_t> r = overall_result.get();
         HPX_TEST_EQ(r.size(), num_localities);

--- a/libs/full/collectives/tests/unit/all_gather.cpp
+++ b/libs/full/collectives/tests/unit/all_gather.cpp
@@ -21,7 +21,7 @@
 constexpr char const* all_gather_basename = "/test/all_gather/";
 constexpr char const* all_gather_direct_basename = "/test/all_gather_direct/";
 
-int hpx_main()
+void test_one_shot_use()
 {
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
 
@@ -61,6 +61,58 @@ int hpx_main()
             HPX_TEST_EQ(r[j], j);
         }
     }
+}
+
+void test_multiple_use()
+{
+    std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
+
+    auto all_gather_client =
+        hpx::create_all_gather(all_gather_basename, num_localities);
+
+    // test functionality based on future<> of local result
+    for (int i = 0; i != 10; ++i)
+    {
+        hpx::future<std::uint32_t> value =
+            hpx::make_ready_future(hpx::get_locality_id());
+
+        hpx::future<std::vector<std::uint32_t>> overall_result =
+            hpx::all_gather(all_gather_client, std::move(value));
+
+        std::vector<std::uint32_t> r = overall_result.get();
+        HPX_TEST_EQ(r.size(), num_localities);
+
+        for (std::size_t j = 0; j != r.size(); ++j)
+        {
+            HPX_TEST_EQ(r[j], j);
+        }
+    }
+
+    // test functionality based on immediate local result value
+    auto all_gather_direct_client =
+        hpx::create_all_gather(all_gather_direct_basename, num_localities);
+
+    for (int i = 0; i != 10; ++i)
+    {
+        std::uint32_t value = hpx::get_locality_id();
+
+        hpx::future<std::vector<std::uint32_t>> overall_result =
+            hpx::all_gather(all_gather_direct_client, value);
+
+        std::vector<std::uint32_t> r = overall_result.get();
+        HPX_TEST_EQ(r.size(), num_localities);
+
+        for (std::size_t j = 0; j != r.size(); ++j)
+        {
+            HPX_TEST_EQ(r[j], j);
+        }
+    }
+}
+
+int hpx_main()
+{
+    test_one_shot_use();
+    test_multiple_use();
 
     return hpx::finalize();
 }

--- a/libs/full/collectives/tests/unit/all_gather.cpp
+++ b/libs/full/collectives/tests/unit/all_gather.cpp
@@ -48,7 +48,7 @@ void test_multiple_use()
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
 
     // test functionality based on immediate local result value
-    auto all_gather_direct_client = hpx::collectives::create_all_gather(
+    auto all_gather_direct_client = hpx::collectives::create_communicator(
         all_gather_direct_basename, num_localities);
 
     for (int i = 0; i != 10; ++i)

--- a/libs/full/collectives/tests/unit/all_reduce.cpp
+++ b/libs/full/collectives/tests/unit/all_reduce.cpp
@@ -93,9 +93,8 @@ void test_multiple_use()
     {
         std::uint32_t value = hpx::get_locality_id();
 
-        hpx::future<std::uint32_t> overall_result =
-            hpx::all_reduce(all_reduce_direct_client, value,
-                std::plus<std::uint32_t>{});
+        hpx::future<std::uint32_t> overall_result = hpx::all_reduce(
+            all_reduce_direct_client, value, std::plus<std::uint32_t>{});
 
         std::uint32_t sum = 0;
         for (std::uint32_t j = 0; j != num_localities; ++j)

--- a/libs/full/collectives/tests/unit/all_reduce.cpp
+++ b/libs/full/collectives/tests/unit/all_reduce.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2019 Hartmut Kaiser
+//  Copyright (c) 2019-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/collectives/tests/unit/all_reduce.cpp
+++ b/libs/full/collectives/tests/unit/all_reduce.cpp
@@ -46,7 +46,7 @@ void test_multiple_use()
 {
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
 
-    auto all_reduce_direct_client = hpx::collectives::create_all_reduce(
+    auto all_reduce_direct_client = hpx::collectives::create_communicator(
         all_reduce_direct_basename, num_localities);
 
     // test functionality based on immediate local result value

--- a/libs/full/collectives/tests/unit/all_to_all.cpp
+++ b/libs/full/collectives/tests/unit/all_to_all.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2019 Hartmut Kaiser
+//  Copyright (c) 2019-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/collectives/tests/unit/all_to_all.cpp
+++ b/libs/full/collectives/tests/unit/all_to_all.cpp
@@ -22,7 +22,7 @@
 constexpr char const* all_to_all_basename = "/test/all_to_all/";
 constexpr char const* all_to_all_direct_basename = "/test/all_to_all_direct/";
 
-int hpx_main()
+void test_one_shot_use()
 {
     std::uint32_t this_locality = hpx::get_locality_id();
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
@@ -67,6 +67,63 @@ int hpx_main()
             HPX_TEST_EQ(r[j], j);
         }
     }
+}
+
+void test_multiple_use()
+{
+    std::uint32_t this_locality = hpx::get_locality_id();
+    std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
+
+    auto all_to_all_client =
+        hpx::create_all_to_all(all_to_all_basename, num_localities);
+
+    // test functionality based on future<> of local result
+    for (int i = 0; i != 10; ++i)
+    {
+        std::vector<std::uint32_t> values(num_localities);
+        std::fill(values.begin(), values.end(), this_locality);
+
+        hpx::future<std::vector<std::uint32_t>> value =
+            hpx::make_ready_future(std::move(values));
+
+        hpx::future<std::vector<std::uint32_t>> overall_result =
+            hpx::all_to_all(all_to_all_client, std::move(value));
+
+        std::vector<std::uint32_t> r = overall_result.get();
+        HPX_TEST_EQ(r.size(), num_localities);
+
+        for (std::size_t j = 0; j != r.size(); ++j)
+        {
+            HPX_TEST_EQ(r[j], j);
+        }
+    }
+
+    auto all_to_all_direct_client =
+        hpx::create_all_reduce(all_to_all_direct_basename, num_localities);
+
+    // test functionality based on immediate local result value
+    for (int i = 0; i != 10; ++i)
+    {
+        std::vector<std::uint32_t> values(num_localities);
+        std::fill(values.begin(), values.end(), this_locality);
+
+        hpx::future<std::vector<std::uint32_t>> overall_result =
+            hpx::all_to_all(all_to_all_direct_client, std::move(values));
+
+        std::vector<std::uint32_t> r = overall_result.get();
+        HPX_TEST_EQ(r.size(), num_localities);
+
+        for (std::size_t j = 0; j != r.size(); ++j)
+        {
+            HPX_TEST_EQ(r[j], j);
+        }
+    }
+}
+
+int hpx_main()
+{
+    test_one_shot_use();
+    test_multiple_use();
 
     return hpx::finalize();
 }

--- a/libs/full/collectives/tests/unit/all_to_all.cpp
+++ b/libs/full/collectives/tests/unit/all_to_all.cpp
@@ -19,35 +19,12 @@
 #include <utility>
 #include <vector>
 
-constexpr char const* all_to_all_basename = "/test/all_to_all/";
 constexpr char const* all_to_all_direct_basename = "/test/all_to_all_direct/";
 
 void test_one_shot_use()
 {
     std::uint32_t this_locality = hpx::get_locality_id();
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
-
-    // test functionality based on future<> of local result
-    for (int i = 0; i != 10; ++i)
-    {
-        std::vector<std::uint32_t> values(num_localities);
-        std::fill(values.begin(), values.end(), this_locality);
-
-        hpx::future<std::vector<std::uint32_t>> value =
-            hpx::make_ready_future(std::move(values));
-
-        hpx::future<std::vector<std::uint32_t>> overall_result =
-            hpx::all_to_all(
-                all_to_all_basename, std::move(value), num_localities, i);
-
-        std::vector<std::uint32_t> r = overall_result.get();
-        HPX_TEST_EQ(r.size(), num_localities);
-
-        for (std::size_t j = 0; j != r.size(); ++j)
-        {
-            HPX_TEST_EQ(r[j], j);
-        }
-    }
 
     // test functionality based on immediate local result value
     for (int i = 0; i != 10; ++i)
@@ -56,8 +33,8 @@ void test_one_shot_use()
         std::fill(values.begin(), values.end(), this_locality);
 
         hpx::future<std::vector<std::uint32_t>> overall_result =
-            hpx::all_to_all(all_to_all_direct_basename, std::move(values),
-                num_localities, i);
+            hpx::collectives::all_to_all(all_to_all_direct_basename,
+                std::move(values), num_localities, i);
 
         std::vector<std::uint32_t> r = overall_result.get();
         HPX_TEST_EQ(r.size(), num_localities);
@@ -74,32 +51,8 @@ void test_multiple_use()
     std::uint32_t this_locality = hpx::get_locality_id();
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
 
-    auto all_to_all_client =
-        hpx::create_all_to_all(all_to_all_basename, num_localities);
-
-    // test functionality based on future<> of local result
-    for (int i = 0; i != 10; ++i)
-    {
-        std::vector<std::uint32_t> values(num_localities);
-        std::fill(values.begin(), values.end(), this_locality);
-
-        hpx::future<std::vector<std::uint32_t>> value =
-            hpx::make_ready_future(std::move(values));
-
-        hpx::future<std::vector<std::uint32_t>> overall_result =
-            hpx::all_to_all(all_to_all_client, std::move(value));
-
-        std::vector<std::uint32_t> r = overall_result.get();
-        HPX_TEST_EQ(r.size(), num_localities);
-
-        for (std::size_t j = 0; j != r.size(); ++j)
-        {
-            HPX_TEST_EQ(r[j], j);
-        }
-    }
-
-    auto all_to_all_direct_client =
-        hpx::create_all_reduce(all_to_all_direct_basename, num_localities);
+    auto all_to_all_direct_client = hpx::collectives::create_all_reduce(
+        all_to_all_direct_basename, num_localities);
 
     // test functionality based on immediate local result value
     for (int i = 0; i != 10; ++i)
@@ -108,7 +61,8 @@ void test_multiple_use()
         std::fill(values.begin(), values.end(), this_locality);
 
         hpx::future<std::vector<std::uint32_t>> overall_result =
-            hpx::all_to_all(all_to_all_direct_client, std::move(values));
+            hpx::collectives::all_to_all(
+                all_to_all_direct_client, std::move(values));
 
         std::vector<std::uint32_t> r = overall_result.get();
         HPX_TEST_EQ(r.size(), num_localities);

--- a/libs/full/collectives/tests/unit/all_to_all.cpp
+++ b/libs/full/collectives/tests/unit/all_to_all.cpp
@@ -51,7 +51,7 @@ void test_multiple_use()
     std::uint32_t this_locality = hpx::get_locality_id();
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
 
-    auto all_to_all_direct_client = hpx::collectives::create_all_reduce(
+    auto all_to_all_direct_client = hpx::collectives::create_communicator(
         all_to_all_direct_basename, num_localities);
 
     // test functionality based on immediate local result value

--- a/libs/full/collectives/tests/unit/broadcast.cpp
+++ b/libs/full/collectives/tests/unit/broadcast.cpp
@@ -18,7 +18,6 @@
 #include <utility>
 #include <vector>
 
-constexpr char const* broadcast_basename = "/test/broadcast/";
 constexpr char const* broadcast_direct_basename = "/test/broadcast_direct/";
 
 void test_one_shot_use()
@@ -26,31 +25,12 @@ void test_one_shot_use()
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
     HPX_TEST_LTE(std::uint32_t(2), num_localities);
 
-    // test functionality based on future<> of local result
-    for (std::uint32_t i = 0; i != 10; ++i)
-    {
-        if (hpx::get_locality_id() == 0)
-        {
-            hpx::future<std::uint32_t> result = broadcast_to(broadcast_basename,
-                hpx::make_ready_future(i + 42), num_localities, i);
-
-            HPX_TEST_EQ(i + 42, result.get());
-        }
-        else
-        {
-            hpx::future<std::uint32_t> result =
-                hpx::broadcast_from<std::uint32_t>(broadcast_basename, i);
-
-            HPX_TEST_EQ(i + 42, result.get());
-        }
-    }
-
     // test functionality based on immediate local result value
     for (std::uint32_t i = 0; i != 10; ++i)
     {
         if (hpx::get_locality_id() == 0)
         {
-            hpx::future<std::uint32_t> result = hpx::broadcast_to(
+            hpx::future<std::uint32_t> result = hpx::collectives::broadcast_to(
                 broadcast_direct_basename, i + 42, num_localities, i);
 
             HPX_TEST_EQ(i + 42, result.get());
@@ -58,7 +38,7 @@ void test_one_shot_use()
         else
         {
             hpx::future<std::uint32_t> result =
-                hpx::broadcast_from<std::uint32_t>(
+                hpx::collectives::broadcast_from<std::uint32_t>(
                     broadcast_direct_basename, i);
 
             HPX_TEST_EQ(i + 42, result.get());
@@ -71,30 +51,8 @@ void test_multiple_use()
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
     HPX_TEST_LTE(std::uint32_t(2), num_localities);
 
-    auto broadcast_client =
-        hpx::create_all_to_all(broadcast_basename, num_localities);
-
-    // test functionality based on future<> of local result
-    for (std::uint32_t i = 0; i != 10; ++i)
-    {
-        if (hpx::get_locality_id() == 0)
-        {
-            hpx::future<std::uint32_t> result =
-                broadcast_to(broadcast_client, hpx::make_ready_future(i + 42));
-
-            HPX_TEST_EQ(i + 42, result.get());
-        }
-        else
-        {
-            hpx::future<std::uint32_t> result =
-                hpx::broadcast_from<std::uint32_t>(broadcast_client);
-
-            HPX_TEST_EQ(i + 42, result.get());
-        }
-    }
-
-    auto broadcast_direct_client =
-        hpx::create_all_to_all(broadcast_direct_basename, num_localities);
+    auto broadcast_direct_client = hpx::collectives::create_broadcast(
+        broadcast_direct_basename, num_localities);
 
     // test functionality based on immediate local result value
     for (std::uint32_t i = 0; i != 10; ++i)
@@ -102,14 +60,15 @@ void test_multiple_use()
         if (hpx::get_locality_id() == 0)
         {
             hpx::future<std::uint32_t> result =
-                hpx::broadcast_to(broadcast_direct_client, i + 42);
+                hpx::collectives::broadcast_to(broadcast_direct_client, i + 42);
 
             HPX_TEST_EQ(i + 42, result.get());
         }
         else
         {
             hpx::future<std::uint32_t> result =
-                hpx::broadcast_from<std::uint32_t>(broadcast_direct_client);
+                hpx::collectives::broadcast_from<std::uint32_t>(
+                    broadcast_direct_client);
 
             HPX_TEST_EQ(i + 42, result.get());
         }

--- a/libs/full/collectives/tests/unit/broadcast.cpp
+++ b/libs/full/collectives/tests/unit/broadcast.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2020-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/collectives/tests/unit/broadcast.cpp
+++ b/libs/full/collectives/tests/unit/broadcast.cpp
@@ -51,7 +51,7 @@ void test_multiple_use()
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
     HPX_TEST_LTE(std::uint32_t(2), num_localities);
 
-    auto broadcast_direct_client = hpx::collectives::create_broadcast(
+    auto broadcast_direct_client = hpx::collectives::create_communicator(
         broadcast_direct_basename, num_localities);
 
     // test functionality based on immediate local result value

--- a/libs/full/collectives/tests/unit/communication_set.cpp
+++ b/libs/full/collectives/tests/unit/communication_set.cpp
@@ -118,10 +118,8 @@ namespace hpx { namespace traits {
 
             communicator_.gate_.synchronize(1, l);
 
-            if (communicator_.gate_.set(communicator_.which_++, l))
-            {
-                HPX_ASSERT_DOESNT_OWN_LOCK(l);
-            }
+            communicator_.gate_.set(communicator_.which_++, std::move(l));
+
             return f;
         }
 

--- a/libs/full/collectives/tests/unit/exclusive_scan_.cpp
+++ b/libs/full/collectives/tests/unit/exclusive_scan_.cpp
@@ -33,12 +33,20 @@ void test_one_shot_use()
             hpx::collectives::exclusive_scan(all_reduce_direct_basename, value,
                 std::plus<std::uint32_t>{}, num_localities, i);
 
-        std::uint32_t sum = 0;
-        for (std::uint32_t j = 0; j != value; ++j)
+        if (value == 0)
         {
-            sum += j;
+            // root_site is special
+            HPX_TEST_EQ(std::uint32_t(0), overall_result.get());
         }
-        HPX_TEST_EQ(sum, overall_result.get());
+        else
+        {
+            std::uint32_t sum = 0;
+            for (std::uint32_t j = 0; j != value; ++j)
+            {
+                sum += j;
+            }
+            HPX_TEST_EQ(sum, overall_result.get());
+        }
     }
 }
 
@@ -58,12 +66,20 @@ void test_multiple_use()
             hpx::collectives::exclusive_scan(
                 all_reduce_direct_client, value, std::plus<std::uint32_t>{});
 
-        std::uint32_t sum = 0;
-        for (std::uint32_t j = 0; j != value; ++j)
+        if (value == 0)
         {
-            sum += j;
+            // root_site is special
+            HPX_TEST_EQ(std::uint32_t(0), overall_result.get());
         }
-        HPX_TEST_EQ(sum, overall_result.get());
+        else
+        {
+            std::uint32_t sum = 0;
+            for (std::uint32_t j = 0; j != value; ++j)
+            {
+                sum += j;
+            }
+            HPX_TEST_EQ(sum, overall_result.get());
+        }
     }
 }
 

--- a/libs/full/collectives/tests/unit/exclusive_scan_.cpp
+++ b/libs/full/collectives/tests/unit/exclusive_scan_.cpp
@@ -46,7 +46,7 @@ void test_multiple_use()
 {
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
 
-    auto all_reduce_direct_client = hpx::collectives::create_exclusive_scan(
+    auto all_reduce_direct_client = hpx::collectives::create_communicator(
         all_reduce_direct_basename, num_localities);
 
     // test functionality based on immediate local result value

--- a/libs/full/collectives/tests/unit/exclusive_scan_.cpp
+++ b/libs/full/collectives/tests/unit/exclusive_scan_.cpp
@@ -30,11 +30,11 @@ void test_one_shot_use()
         std::uint32_t value = hpx::get_locality_id();
 
         hpx::future<std::uint32_t> overall_result =
-            hpx::collectives::all_reduce(all_reduce_direct_basename, value,
+            hpx::collectives::exclusive_scan(all_reduce_direct_basename, value,
                 std::plus<std::uint32_t>{}, num_localities, i);
 
         std::uint32_t sum = 0;
-        for (std::uint32_t j = 0; j != num_localities; ++j)
+        for (std::uint32_t j = 0; j != value; ++j)
         {
             sum += j;
         }
@@ -46,7 +46,7 @@ void test_multiple_use()
 {
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
 
-    auto all_reduce_direct_client = hpx::collectives::create_all_reduce(
+    auto all_reduce_direct_client = hpx::collectives::create_exclusive_scan(
         all_reduce_direct_basename, num_localities);
 
     // test functionality based on immediate local result value
@@ -55,11 +55,11 @@ void test_multiple_use()
         std::uint32_t value = hpx::get_locality_id();
 
         hpx::future<std::uint32_t> overall_result =
-            hpx::collectives::all_reduce(
+            hpx::collectives::exclusive_scan(
                 all_reduce_direct_client, value, std::plus<std::uint32_t>{});
 
         std::uint32_t sum = 0;
-        for (std::uint32_t j = 0; j != num_localities; ++j)
+        for (std::uint32_t j = 0; j != value; ++j)
         {
             sum += j;
         }

--- a/libs/full/collectives/tests/unit/gather.cpp
+++ b/libs/full/collectives/tests/unit/gather.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2020-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/collectives/tests/unit/gather.cpp
+++ b/libs/full/collectives/tests/unit/gather.cpp
@@ -56,7 +56,7 @@ void test_multiple_use()
     std::uint32_t this_locality = hpx::get_locality_id();
 
     // test functionality based on immediate local result value
-    auto gather_direct_client = hpx::collectives::create_gatherer(
+    auto gather_direct_client = hpx::collectives::create_communicator(
         gather_direct_basename, num_localities);
 
     for (std::uint32_t i = 0; i != 10; ++i)

--- a/libs/full/collectives/tests/unit/inclusive_scan_.cpp
+++ b/libs/full/collectives/tests/unit/inclusive_scan_.cpp
@@ -30,11 +30,11 @@ void test_one_shot_use()
         std::uint32_t value = hpx::get_locality_id();
 
         hpx::future<std::uint32_t> overall_result =
-            hpx::collectives::all_reduce(all_reduce_direct_basename, value,
+            hpx::collectives::inclusive_scan(all_reduce_direct_basename, value,
                 std::plus<std::uint32_t>{}, num_localities, i);
 
         std::uint32_t sum = 0;
-        for (std::uint32_t j = 0; j != num_localities; ++j)
+        for (std::uint32_t j = 0; j != value + 1; ++j)
         {
             sum += j;
         }
@@ -46,7 +46,7 @@ void test_multiple_use()
 {
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
 
-    auto all_reduce_direct_client = hpx::collectives::create_all_reduce(
+    auto all_reduce_direct_client = hpx::collectives::create_inclusive_scan(
         all_reduce_direct_basename, num_localities);
 
     // test functionality based on immediate local result value
@@ -55,11 +55,11 @@ void test_multiple_use()
         std::uint32_t value = hpx::get_locality_id();
 
         hpx::future<std::uint32_t> overall_result =
-            hpx::collectives::all_reduce(
+            hpx::collectives::inclusive_scan(
                 all_reduce_direct_client, value, std::plus<std::uint32_t>{});
 
         std::uint32_t sum = 0;
-        for (std::uint32_t j = 0; j != num_localities; ++j)
+        for (std::uint32_t j = 0; j != value + 1; ++j)
         {
             sum += j;
         }

--- a/libs/full/collectives/tests/unit/inclusive_scan_.cpp
+++ b/libs/full/collectives/tests/unit/inclusive_scan_.cpp
@@ -46,7 +46,7 @@ void test_multiple_use()
 {
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
 
-    auto all_reduce_direct_client = hpx::collectives::create_inclusive_scan(
+    auto all_reduce_direct_client = hpx::collectives::create_communicator(
         all_reduce_direct_basename, num_localities);
 
     // test functionality based on immediate local result value

--- a/libs/full/collectives/tests/unit/reduce.cpp
+++ b/libs/full/collectives/tests/unit/reduce.cpp
@@ -57,7 +57,7 @@ void test_multiple_use()
     std::uint32_t num_localities = hpx::get_num_localities(hpx::launch::sync);
     std::uint32_t this_locality = hpx::get_locality_id();
 
-    auto reduce_direct_client = hpx::collectives::create_reducer(
+    auto reduce_direct_client = hpx::collectives::create_communicator(
         reduce_direct_basename, num_localities);
 
     // test functionality based on immediate local result value

--- a/libs/full/collectives/tests/unit/reduce_direct.cpp
+++ b/libs/full/collectives/tests/unit/reduce_direct.cpp
@@ -1,0 +1,126 @@
+//  Copyright (c) 2013 Hartmut Kaiser
+//  Copyright (c) 2013 Thomas Heller
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/runtime.hpp>
+#include <hpx/modules/collectives.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+std::uint32_t f1()
+{
+    return hpx::get_locality_id();
+}
+HPX_PLAIN_ACTION(f1);
+
+typedef std::plus<std::uint32_t> std_plus_type;
+HPX_REGISTER_REDUCE_ACTION_DECLARATION(f1_action, std_plus_type)
+HPX_REGISTER_REDUCE_ACTION(f1_action, std_plus_type)
+
+std::uint32_t f3(std::uint32_t i)
+{
+    return hpx::get_locality_id() + i;
+}
+HPX_PLAIN_ACTION(f3);
+
+HPX_REGISTER_REDUCE_ACTION_DECLARATION(f3_action, std_plus_type)
+HPX_REGISTER_REDUCE_ACTION(f3_action, std_plus_type)
+
+std::uint32_t f1_idx(std::size_t idx)
+{
+    return hpx::get_locality_id() + std::uint32_t(idx);
+}
+HPX_PLAIN_ACTION(f1_idx);
+
+HPX_REGISTER_REDUCE_WITH_INDEX_ACTION_DECLARATION(f1_idx_action, std_plus_type)
+HPX_REGISTER_REDUCE_WITH_INDEX_ACTION(f1_idx_action, std_plus_type)
+
+std::uint32_t f3_idx(std::uint32_t i, std::size_t idx)
+{
+    return hpx::get_locality_id() + i + std::uint32_t(idx);
+}
+HPX_PLAIN_ACTION(f3_idx);
+
+HPX_REGISTER_REDUCE_WITH_INDEX_ACTION_DECLARATION(f3_idx_action, std_plus_type)
+HPX_REGISTER_REDUCE_WITH_INDEX_ACTION(f3_idx_action, std_plus_type)
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main()
+{
+    hpx::id_type here = hpx::find_here();
+    hpx::id_type there = here;
+    std::vector<hpx::id_type> localities = hpx::find_all_localities();
+
+    {
+        std::uint32_t f1_res =
+            hpx::lcos::reduce<f1_action>(localities, std::plus<std::uint32_t>())
+                .get();
+
+        std::uint32_t f1_result = 0;
+        for (std::size_t i = 0; i != localities.size(); ++i)
+        {
+            f1_result += hpx::naming::get_locality_id_from_id(localities[i]);
+        }
+        HPX_TEST_EQ(f1_res, f1_result);
+
+        std::uint32_t f3_res = hpx::lcos::reduce<f3_action>(
+            localities, std::plus<std::uint32_t>(), 1)
+                                   .get();
+
+        std::uint32_t f3_result = 0;
+        for (std::size_t i = 0; i != localities.size(); ++i)
+        {
+            f3_result +=
+                hpx::naming::get_locality_id_from_id(localities[i]) + 1;
+        }
+        HPX_TEST_EQ(f3_res, f3_result);
+    }
+
+    {
+        std::uint32_t f1_res = hpx::lcos::reduce_with_index<f1_idx_action>(
+            localities, std::plus<std::uint32_t>())
+                                   .get();
+
+        std::uint32_t f1_result = 0;
+        for (std::size_t i = 0; i != localities.size(); ++i)
+        {
+            f1_result += hpx::naming::get_locality_id_from_id(localities[i]) +
+                std::uint32_t(i);
+        }
+        HPX_TEST_EQ(f1_res, f1_result);
+
+        std::uint32_t f3_res = hpx::lcos::reduce_with_index<f3_idx_action>(
+            localities, std::plus<std::uint32_t>(), 1)
+                                   .get();
+
+        std::uint32_t f3_result = 0;
+        for (std::size_t i = 0; i != localities.size(); ++i)
+        {
+            f3_result += hpx::naming::get_locality_id_from_id(localities[i]) +
+                std::uint32_t(i) + 1;
+        }
+        HPX_TEST_EQ(f3_res, f3_result);
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(
+        hpx::init(argc, argv), 0, "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}
+#endif

--- a/libs/full/collectives/tests/unit/scatter.cpp
+++ b/libs/full/collectives/tests/unit/scatter.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2020 Hartmut Kaiser
+//  Copyright (c) 2020-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/collectives/tests/unit/scatter.cpp
+++ b/libs/full/collectives/tests/unit/scatter.cpp
@@ -59,7 +59,7 @@ void test_multiple_use()
 
     std::uint32_t this_locality = hpx::get_locality_id();
 
-    auto scatter_direct_client = hpx::collectives::create_scatterer(
+    auto scatter_direct_client = hpx::collectives::create_communicator(
         scatter_direct_basename, num_localities);
 
     // test functionality based on immediate local result value

--- a/libs/full/components/include/hpx/components/basename_registration_fwd.hpp
+++ b/libs/full/components/include/hpx/components/basename_registration_fwd.hpp
@@ -29,7 +29,7 @@ namespace hpx {
             std::string const& basename, std::size_t idx);
         HPX_EXPORT std::string name_from_basename(
             std::string&& basename, std::size_t idx);
-    }
+    }    // namespace detail
     /// \endcond
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/full/components/include/hpx/components/basename_registration_fwd.hpp
+++ b/libs/full/components/include/hpx/components/basename_registration_fwd.hpp
@@ -27,6 +27,8 @@ namespace hpx {
 
         HPX_EXPORT std::string name_from_basename(
             std::string const& basename, std::size_t idx);
+        HPX_EXPORT std::string name_from_basename(
+            std::string&& basename, std::size_t idx);
     }
     /// \endcond
 

--- a/libs/full/components/include/hpx/components/client.hpp
+++ b/libs/full/components/include/hpx/components/client.hpp
@@ -45,6 +45,10 @@ namespace hpx { namespace components {
           : base_type(std::move(f))
         {
         }
+        client(future<client>&& c) noexcept
+          : base_type(std::move(c))
+        {
+        }
 
         client(client const& rhs)
           : base_type(rhs.shared_state_)

--- a/libs/full/components/include/hpx/components/client_base.hpp
+++ b/libs/full/components/include/hpx/components/client_base.hpp
@@ -10,13 +10,13 @@
 #include <hpx/actions_base/traits/action_remote_result.hpp>
 #include <hpx/actions_base/traits/is_client.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/components/basename_registration.hpp>
 #include <hpx/components/components_fwd.hpp>
 #include <hpx/components/make_client.hpp>
 #include <hpx/components_base/agas_interface.hpp>
 #include <hpx/components_base/component_type.hpp>
 #include <hpx/components_base/stub_base.hpp>
 #include <hpx/execution_base/detail/try_catch_exception_ptr.hpp>
-#include <hpx/functional/bind_back.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/futures/traits/acquire_future.hpp>
 #include <hpx/futures/traits/future_access.hpp>

--- a/libs/full/components/include/hpx/components/client_base.hpp
+++ b/libs/full/components/include/hpx/components/client_base.hpp
@@ -121,11 +121,9 @@ namespace hpx { namespace traits {
                 Derived&& src, Destination& dest)
             {
                 dest.set_value(src.get());
-
-                using future_data = lcos::detail::future_data<id_type>;
-                static_cast<future_data&>(dest).registered_name_ =
-                    std::move(static_cast<future_data*>(src.shared_state_.get())
-                                  ->registered_name_);
+                dest.set_registered_name(
+                    src.shared_state_->get_registered_name());
+                src.shared_state_->set_registered_name("");
             }
         };
 
@@ -217,6 +215,10 @@ namespace hpx { namespace lcos { namespace detail {
         std::string const& get_registered_name() const override
         {
             return registered_name_;
+        }
+        void set_registered_name(std::string name) override
+        {
+            registered_name_ = std::move(name);
         }
         bool register_as(std::string name, bool manage_lifetime) override
         {

--- a/libs/full/components/include/hpx/components/client_base.hpp
+++ b/libs/full/components/include/hpx/components/client_base.hpp
@@ -61,15 +61,14 @@ namespace hpx { namespace traits {
         ///////////////////////////////////////////////////////////////////////
         template <typename Derived>
         struct is_future_customization_point<Derived,
-            typename std::enable_if<is_client<Derived>::value>::type>
-          : std::true_type
+            std::enable_if_t<is_client<Derived>::value>> : std::true_type
         {
         };
 
         ///////////////////////////////////////////////////////////////////////
         template <typename Derived>
         struct future_traits_customization_point<Derived,
-            typename std::enable_if<is_client<Derived>::value>::type>
+            std::enable_if_t<is_client<Derived>::value>>
         {
             using type = id_type;
             using result_type = id_type;
@@ -78,7 +77,7 @@ namespace hpx { namespace traits {
         ///////////////////////////////////////////////////////////////////////
         template <typename Derived>
         struct future_access_customization_point<Derived,
-            typename std::enable_if<is_client<Derived>::value>::type>
+            std::enable_if_t<is_client<Derived>::value>>
         {
             template <typename SharedState>
             HPX_FORCEINLINE static Derived create(
@@ -102,15 +101,15 @@ namespace hpx { namespace traits {
                     hpx::intrusive_ptr<SharedState>(shared_state, addref)));
             }
 
-            HPX_FORCEINLINE static
-                typename traits::detail::shared_state_ptr<id_type>::type const&
-                get_shared_state(Derived const& client)
+            HPX_FORCEINLINE static traits::detail::shared_state_ptr_t<
+                id_type> const&
+            get_shared_state(Derived const& client)
             {
                 return client.shared_state_;
             }
 
-            HPX_FORCEINLINE static typename traits::detail::shared_state_ptr<
-                id_type>::type::element_type*
+            HPX_FORCEINLINE static typename traits::detail::shared_state_ptr_t<
+                id_type>::element_type*
             detach_shared_state(Derived const& f)
             {
                 return f.shared_state_.get();
@@ -123,14 +122,14 @@ namespace hpx { namespace traits {
                 dest.set_value(src.get());
                 dest.set_registered_name(
                     src.shared_state_->get_registered_name());
-                src.shared_state_->set_registered_name("");
+                src.shared_state_->set_registered_name(std::string());
             }
         };
 
         ///////////////////////////////////////////////////////////////////////
         template <typename Derived>
         struct acquire_future_impl<Derived,
-            typename std::enable_if<is_client<Derived>::value>::type>
+            std::enable_if_t<is_client<Derived>::value>>
         {
             using type = Derived;
 
@@ -144,8 +143,8 @@ namespace hpx { namespace traits {
         ///////////////////////////////////////////////////////////////////////
         template <typename Derived>
         struct shared_state_ptr_for<Derived,
-            typename std::enable_if<is_client<Derived>::value>::type>
-          : shared_state_ptr<typename traits::future_traits<Derived>::type>
+            std::enable_if_t<is_client<Derived>::value>>
+          : shared_state_ptr<traits::future_traits_t<Derived>>
         {
         };
     }    // namespace detail
@@ -155,7 +154,7 @@ namespace hpx { namespace lcos { namespace detail {
 
     template <typename Derived>
     struct future_unwrap_result<Derived,
-        typename std::enable_if<traits::is_client<Derived>::value>::type>
+        std::enable_if_t<traits::is_client<Derived>::value>>
     {
         using result_type = id_type;
         using type = Derived;
@@ -163,7 +162,7 @@ namespace hpx { namespace lcos { namespace detail {
 
     template <typename Derived>
     struct future_unwrap_result<future<Derived>,
-        typename std::enable_if<traits::is_client<Derived>::value>::type>
+        std::enable_if_t<traits::is_client<Derived>::value>>
     {
         using result_type = id_type;
         using type = Derived;
@@ -544,8 +543,7 @@ namespace hpx { namespace components {
             using continuation_result_type =
                 typename hpx::util::invoke_result<F, Derived>::type;
             using shared_state_ptr =
-                typename hpx::traits::detail::shared_state_ptr<
-                    result_type>::type;
+                hpx::traits::detail::shared_state_ptr_t<result_type>;
 
             shared_state_ptr p =
                 lcos::detail::make_continuation<continuation_result_type>(
@@ -580,7 +578,7 @@ namespace hpx { namespace components {
                     "this client_base has no valid shared state");
             }
 
-            typename hpx::traits::detail::shared_state_ptr<bool>::type p =
+            hpx::traits::detail::shared_state_ptr_t<bool> p =
                 lcos::detail::make_continuation<bool>(*this, launch::sync,
                     [=, symbolic_name = std::move(symbolic_name)](
                         client_base const& f) mutable -> bool {

--- a/libs/full/components/src/basename_registration.cpp
+++ b/libs/full/components/src/basename_registration.cpp
@@ -28,13 +28,40 @@ namespace hpx {
             HPX_ASSERT(!basename.empty());
 
             std::string name;
-
             if (basename[0] != '/')
-                name += '/';
+            {
+                name = '/';
+            }
 
             name += basename;
             if (name[name.size() - 1] != '/')
+            {
                 name += '/';
+            }
+            name += std::to_string(idx);
+
+            return name;
+        }
+
+        std::string name_from_basename(std::string&& basename, std::size_t idx)
+        {
+            HPX_ASSERT(!basename.empty());
+
+            std::string name;
+            if (basename[0] != '/')
+            {
+                name = '/';
+                name += std::move(basename);
+            }
+            else
+            {
+                name = std::move(basename);
+            }
+
+            if (name[name.size() - 1] != '/')
+            {
+                name += '/';
+            }
             name += std::to_string(idx);
 
             return name;
@@ -92,10 +119,11 @@ namespace hpx {
 
         if (sequence_nr == ~static_cast<std::size_t>(0))
         {
-            sequence_nr = std::size_t(agas::get_locality_id());
+            sequence_nr = static_cast<std::size_t>(agas::get_locality_id());
         }
 
-        std::string name = detail::name_from_basename(basename, sequence_nr);
+        std::string name =
+            detail::name_from_basename(std::move(basename), sequence_nr);
         return agas::on_symbol_namespace_event(std::move(name), true);
     }
 
@@ -110,10 +138,11 @@ namespace hpx {
 
         if (sequence_nr == ~static_cast<std::size_t>(0))
         {
-            sequence_nr = std::size_t(agas::get_locality_id());
+            sequence_nr = static_cast<std::size_t>(agas::get_locality_id());
         }
 
-        std::string name = detail::name_from_basename(basename, sequence_nr);
+        std::string name =
+            detail::name_from_basename(std::move(basename), sequence_nr);
         return agas::register_name(std::move(name), id);
     }
 
@@ -139,10 +168,11 @@ namespace hpx {
 
         if (sequence_nr == ~static_cast<std::size_t>(0))
         {
-            sequence_nr = std::size_t(agas::get_locality_id());
+            sequence_nr = static_cast<std::size_t>(agas::get_locality_id());
         }
 
-        std::string name = detail::name_from_basename(basename, sequence_nr);
+        std::string name =
+            detail::name_from_basename(std::move(basename), sequence_nr);
         return agas::unregister_name(std::move(name));
     }
 }    // namespace hpx

--- a/libs/parallelism/futures/include/hpx/futures/detail/future_data.hpp
+++ b/libs/parallelism/futures/include/hpx/futures/detail/future_data.hpp
@@ -293,8 +293,7 @@ namespace hpx { namespace lcos { namespace detail {
                 "future_data_base::get_registered_name",
                 "this future does not support name registration");
         }
-        virtual void register_as(
-            std::string const& /*name*/, bool /*manage_lifetime*/)
+        virtual bool register_as(std::string /*name*/, bool /*manage_lifetime*/)
         {
             HPX_THROW_EXCEPTION(invalid_status,
                 "future_data_base::set_registered_name",

--- a/libs/parallelism/futures/include/hpx/futures/detail/future_data.hpp
+++ b/libs/parallelism/futures/include/hpx/futures/detail/future_data.hpp
@@ -301,8 +301,7 @@ namespace hpx { namespace lcos { namespace detail {
         }
         virtual bool register_as(std::string /*name*/, bool /*manage_lifetime*/)
         {
-            HPX_THROW_EXCEPTION(invalid_status,
-                "future_data_base::register_as",
+            HPX_THROW_EXCEPTION(invalid_status, "future_data_base::register_as",
                 "this future does not support name registration");
         }
 

--- a/libs/parallelism/futures/include/hpx/futures/detail/future_data.hpp
+++ b/libs/parallelism/futures/include/hpx/futures/detail/future_data.hpp
@@ -293,10 +293,16 @@ namespace hpx { namespace lcos { namespace detail {
                 "future_data_base::get_registered_name",
                 "this future does not support name registration");
         }
-        virtual bool register_as(std::string /*name*/, bool /*manage_lifetime*/)
+        virtual void set_registered_name(std::string /*name*/)
         {
             HPX_THROW_EXCEPTION(invalid_status,
                 "future_data_base::set_registered_name",
+                "this future does not support name registration");
+        }
+        virtual bool register_as(std::string /*name*/, bool /*manage_lifetime*/)
+        {
+            HPX_THROW_EXCEPTION(invalid_status,
+                "future_data_base::register_as",
                 "this future does not support name registration");
         }
 

--- a/libs/parallelism/futures/include/hpx/futures/packaged_continuation.hpp
+++ b/libs/parallelism/futures/include/hpx/futures/packaged_continuation.hpp
@@ -35,7 +35,10 @@ namespace hpx { namespace lcos { namespace detail {
         std::false_type, Source&& src, Destination& dest)
     {
         hpx::detail::try_catch_exception_ptr(
-            [&]() { dest.set_value(src.get()); },
+            [&]() {
+                traits::future_access<Source>::transfer_result(
+                    std::forward<Source>(src), dest);
+            },
             [&](std::exception_ptr ep) { dest.set_exception(std::move(ep)); });
     }
 

--- a/libs/parallelism/futures/include/hpx/futures/packaged_continuation.hpp
+++ b/libs/parallelism/futures/include/hpx/futures/packaged_continuation.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2019 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //  Copyright (c) 2014-2015 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -30,40 +30,21 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace lcos { namespace detail {
-    template <typename Source, typename Destination>
-    HPX_FORCEINLINE void transfer_result_impl(
-        std::false_type, Source&& src, Destination& dest)
-    {
-        hpx::detail::try_catch_exception_ptr(
-            [&]() {
-                traits::future_access<Source>::transfer_result(
-                    std::forward<Source>(src), dest);
-            },
-            [&](std::exception_ptr ep) { dest.set_exception(std::move(ep)); });
-    }
-
-    template <typename Source, typename Destination>
-    HPX_FORCEINLINE void transfer_result_impl(
-        std::true_type, Source&& src, Destination& dest)
-    {
-        hpx::detail::try_catch_exception_ptr(
-            [&]() {
-                src.get();
-                dest.set_value(util::unused);
-            },
-            [&](std::exception_ptr ep) { dest.set_exception(std::move(ep)); });
-    }
 
     template <typename Future, typename SourceState, typename DestinationState>
     HPX_FORCEINLINE void transfer_result(
         SourceState&& src, DestinationState const& dest)
     {
-        using is_void =
-            std::is_void<typename traits::future_traits<Future>::type>;
-        transfer_result_impl(is_void{},
-            traits::future_access<Future>::create(
-                std::forward<SourceState>(src)),
-            *dest);
+        hpx::detail::try_catch_exception_ptr(
+            [&]() {
+                traits::future_access<Future>::transfer_result(
+                    traits::future_access<Future>::create(
+                        std::forward<SourceState>(src)),
+                    *dest);
+            },
+            [&](std::exception_ptr ep) {
+                (*dest).set_exception(std::move(ep));
+            });
     }
 
     template <typename Func, typename Future, typename Continuation>
@@ -88,12 +69,11 @@ namespace hpx { namespace lcos { namespace detail {
     }
 
     template <typename Func, typename Future, typename Continuation>
-    typename std::enable_if<!traits::detail::is_unique_future<
-        typename util::invoke_result<Func, Future>::type>::value>::type
+    std::enable_if_t<!traits::detail::is_unique_future<
+        util::invoke_result_t<Func, Future>>::value>
     invoke_continuation(Func& func, Future&& future, Continuation& cont)
     {
-        typedef std::is_void<typename util::invoke_result<Func, Future>::type>
-            is_void;
+        using is_void = std::is_void<util::invoke_result_t<Func, Future>>;
 
         hpx::util::annotate_function annotate(func);
         invoke_continuation_nounwrap(
@@ -101,16 +81,15 @@ namespace hpx { namespace lcos { namespace detail {
     }
 
     template <typename Func, typename Future, typename Continuation>
-    typename std::enable_if<traits::detail::is_unique_future<
-        typename util::invoke_result<Func, Future>::type>::value>::type
+    std::enable_if_t<traits::detail::is_unique_future<
+        util::invoke_result_t<Func, Future>>::value>
     invoke_continuation(Func& func, Future&& future, Continuation& cont)
     {
         hpx::detail::try_catch_exception_ptr(
             [&]() {
-                typedef typename util::invoke_result<Func, Future>::type
-                    inner_future;
-                typedef typename traits::detail::shared_state_ptr_for<
-                    inner_future>::type inner_shared_state_ptr;
+                using inner_future = util::invoke_result_t<Func, Future>;
+                using inner_shared_state_ptr =
+                    traits::detail::shared_state_ptr_for_t<inner_future>;
 
                 // take by value, as the future may go away immediately
                 inner_shared_state_ptr inner_state =
@@ -143,13 +122,13 @@ namespace hpx { namespace lcos { namespace detail {
     template <typename ContResult>
     struct continuation_result
     {
-        typedef ContResult type;
+        using type = ContResult;
     };
 
     template <typename ContResult>
     struct continuation_result<future<ContResult>>
     {
-        typedef ContResult type;
+        using type = ContResult;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -157,10 +136,10 @@ namespace hpx { namespace lcos { namespace detail {
     class continuation : public detail::future_data<ContResult>
     {
     private:
-        typedef future_data<ContResult> base_type;
+        using base_type = future_data<ContResult>;
 
-        typedef typename base_type::mutex_type mutex_type;
-        typedef typename base_type::result_type result_type;
+        using mutex_type = typename base_type::mutex_type;
+        using result_type = typename base_type::result_type;
 
     protected:
         threads::thread_id_type get_id() const
@@ -190,11 +169,11 @@ namespace hpx { namespace lcos { namespace detail {
         };
 
     public:
-        typedef typename base_type::init_no_addref init_no_addref;
+        using init_no_addref = typename base_type::init_no_addref;
 
         template <typename Func,
-            typename Enable = typename std::enable_if<!std::is_same<
-                typename std::decay<Func>::type, continuation>::value>::type>
+            typename Enable = std::enable_if_t<
+                !std::is_same<std::decay_t<Func>, continuation>::value>>
         // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
         continuation(Func&& f)
           : started_(false)
@@ -213,18 +192,16 @@ namespace hpx { namespace lcos { namespace detail {
         }
 
     protected:
-        void run_impl(
-            typename traits::detail::shared_state_ptr_for<Future>::type&& f)
+        void run_impl(traits::detail::shared_state_ptr_for_t<Future>&& f)
         {
             Future future = traits::future_access<Future>::create(std::move(f));
             invoke_continuation(f_, std::move(future), *this);
         }
 
         void run_impl_nounwrap(
-            typename traits::detail::shared_state_ptr_for<Future>::type&& f)
+            traits::detail::shared_state_ptr_for_t<Future>&& f)
         {
-            using is_void =
-                std::is_void<typename util::invoke_result<F, Future>::type>;
+            using is_void = std::is_void<util::invoke_result_t<F, Future>>;
 
             Future future = traits::future_access<Future>::create(std::move(f));
             invoke_continuation_nounwrap(
@@ -232,8 +209,7 @@ namespace hpx { namespace lcos { namespace detail {
         }
 
     public:
-        void run(
-            typename traits::detail::shared_state_ptr_for<Future>::type&& f,
+        void run(traits::detail::shared_state_ptr_for_t<Future>&& f,
             error_code& ec = throws)
         {
             {
@@ -253,8 +229,7 @@ namespace hpx { namespace lcos { namespace detail {
                 ec = make_success_code();
         }
 
-        void run_nounwrap(
-            typename traits::detail::shared_state_ptr_for<Future>::type&& f,
+        void run_nounwrap(traits::detail::shared_state_ptr_for_t<Future>&& f,
             error_code& ec = throws)
         {
             {
@@ -276,8 +251,7 @@ namespace hpx { namespace lcos { namespace detail {
         }
 
     protected:
-        void async_impl(
-            typename traits::detail::shared_state_ptr_for<Future>::type&& f)
+        void async_impl(traits::detail::shared_state_ptr_for_t<Future>&& f)
         {
             reset_id r(*this);
 
@@ -286,10 +260,9 @@ namespace hpx { namespace lcos { namespace detail {
         }
 
         void async_impl_nounwrap(
-            typename traits::detail::shared_state_ptr_for<Future>::type&& f)
+            traits::detail::shared_state_ptr_for_t<Future>&& f)
         {
-            using is_void =
-                std::is_void<typename util::invoke_result<F, Future>::type>;
+            using is_void = std::is_void<util::invoke_result_t<F, Future>>;
 
             reset_id r(*this);
 
@@ -301,8 +274,7 @@ namespace hpx { namespace lcos { namespace detail {
     public:
         ///////////////////////////////////////////////////////////////////////
         template <typename Spawner>
-        void async(
-            typename traits::detail::shared_state_ptr_for<Future>::type&& f,
+        void async(traits::detail::shared_state_ptr_for_t<Future>&& f,
             Spawner&& spawner, error_code& ec = hpx::throws)
         {
             {
@@ -332,8 +304,7 @@ namespace hpx { namespace lcos { namespace detail {
 
         ///////////////////////////////////////////////////////////////////////
         template <typename Spawner>
-        void async_nounwrap(
-            typename traits::detail::shared_state_ptr_for<Future>::type&& f,
+        void async_nounwrap(traits::detail::shared_state_ptr_for_t<Future>&& f,
             Spawner&& spawner, error_code& ec = hpx::throws)
         {
             {
@@ -411,11 +382,11 @@ namespace hpx { namespace lcos { namespace detail {
         // TODO: Reduce duplication!
         template <typename Spawner, typename Policy>
         void attach(Future const& future,
-            typename std::remove_reference<Spawner>::type& spawner,
-            Policy&& policy, error_code& /*ec*/ = throws)
+            std::remove_reference_t<Spawner>& spawner, Policy&& policy,
+            error_code& /*ec*/ = throws)
         {
-            typedef typename traits::detail::shared_state_ptr_for<Future>::type
-                shared_state_ptr;
+            using shared_state_ptr =
+                traits::detail::shared_state_ptr_for_t<Future>;
 
             // bind an on_completed handler to this future which will invoke
             // the continuation
@@ -447,11 +418,11 @@ namespace hpx { namespace lcos { namespace detail {
 
         template <typename Spawner, typename Policy>
         void attach(Future const& future,
-            typename std::remove_reference<Spawner>::type&& spawner,
-            Policy&& policy, error_code& /*ec*/ = throws)
+            std::remove_reference_t<Spawner>&& spawner, Policy&& policy,
+            error_code& /*ec*/ = throws)
         {
-            typedef typename traits::detail::shared_state_ptr_for<Future>::type
-                shared_state_ptr;
+            using shared_state_ptr =
+                traits::detail::shared_state_ptr_for_t<Future>;
 
             // bind an on_completed handler to this future which will invoke
             // the continuation
@@ -484,11 +455,11 @@ namespace hpx { namespace lcos { namespace detail {
         ///////////////////////////////////////////////////////////////////////
         template <typename Spawner, typename Policy>
         void attach_nounwrap(Future const& future,
-            typename std::remove_reference<Spawner>::type& spawner,
-            Policy&& policy, error_code& /*ec*/ = throws)
+            std::remove_reference_t<Spawner>& spawner, Policy&& policy,
+            error_code& /*ec*/ = throws)
         {
-            typedef typename traits::detail::shared_state_ptr_for<Future>::type
-                shared_state_ptr;
+            using shared_state_ptr =
+                traits::detail::shared_state_ptr_for_t<Future>;
 
             // bind an on_completed handler to this future which will invoke
             // the continuation
@@ -520,11 +491,11 @@ namespace hpx { namespace lcos { namespace detail {
 
         template <typename Spawner, typename Policy>
         void attach_nounwrap(Future const& future,
-            typename std::remove_reference<Spawner>::type&& spawner,
-            Policy&& policy, error_code& /*ec*/ = throws)
+            std::remove_reference_t<Spawner>&& spawner, Policy&& policy,
+            error_code& /*ec*/ = throws)
         {
-            typedef typename traits::detail::shared_state_ptr_for<Future>::type
-                shared_state_ptr;
+            using shared_state_ptr =
+                traits::detail::shared_state_ptr_for_t<Future>;
 
             // bind an on_completed handler to this future which will invoke
             // the continuation
@@ -557,21 +528,20 @@ namespace hpx { namespace lcos { namespace detail {
     protected:
         bool started_;
         threads::thread_id_type id_;
-        typename std::decay<F>::type f_;
+        std::decay_t<F> f_;
     };
 
     template <typename Allocator, typename Future, typename F,
         typename ContResult>
     class continuation_allocator : public continuation<Future, F, ContResult>
     {
-        typedef continuation<Future, F, ContResult> base_type;
+        using base_type = continuation<Future, F, ContResult>;
 
-        typedef typename std::allocator_traits<
-            Allocator>::template rebind_alloc<continuation_allocator>
-            other_allocator;
+        using other_allocator = typename std::allocator_traits<
+            Allocator>::template rebind_alloc<continuation_allocator>;
 
     public:
-        typedef typename base_type::init_no_addref init_no_addref;
+        using init_no_addref = typename base_type::init_no_addref;
 
         template <typename Func>
         continuation_allocator(other_allocator const& alloc, Func&& f)
@@ -591,7 +561,7 @@ namespace hpx { namespace lcos { namespace detail {
     private:
         void destroy() override
         {
-            typedef std::allocator_traits<other_allocator> traits;
+            using traits = std::allocator_traits<other_allocator>;
 
             other_allocator alloc(alloc_);
             traits::destroy(alloc, this);
@@ -608,9 +578,8 @@ namespace hpx { namespace traits { namespace detail {
     struct shared_state_allocator<
         lcos::detail::continuation<Future, F, ContResult>, Allocator>
     {
-        typedef lcos::detail::continuation_allocator<Allocator, Future, F,
-            ContResult>
-            type;
+        using type = lcos::detail::continuation_allocator<Allocator, Future, F,
+            ContResult>;
     };
 }}}    // namespace hpx::traits::detail
 
@@ -623,24 +592,18 @@ namespace hpx { namespace lcos { namespace detail {
     private:
         template <typename Inner>
         void on_inner_ready(
-            typename traits::detail::shared_state_ptr_for<Inner>::type&&
-                inner_state)
+            traits::detail::shared_state_ptr_for_t<Inner>&& inner_state)
         {
-            hpx::detail::try_catch_exception_ptr(
-                [&]() { transfer_result<Inner>(std::move(inner_state), this); },
-                [&](std::exception_ptr ep) {
-                    this->set_exception(std::move(ep));
-                });
+            transfer_result<Inner>(std::move(inner_state), this);
         }
 
         template <typename Outer>
         void on_outer_ready(
-            typename traits::detail::shared_state_ptr_for<Outer>::type&&
-                outer_state)
+            traits::detail::shared_state_ptr_for_t<Outer>&& outer_state)
         {
-            typedef typename traits::future_traits<Outer>::type inner_future;
-            typedef typename traits::detail::shared_state_ptr_for<
-                inner_future>::type inner_shared_state_ptr;
+            using inner_future = traits::future_traits_t<Outer>;
+            using inner_shared_state_ptr =
+                traits::detail::shared_state_ptr_for_t<inner_future>;
 
             // Bind an on_completed handler to this future which will transfer
             // its result to the new future.
@@ -680,9 +643,9 @@ namespace hpx { namespace lcos { namespace detail {
         }
 
     public:
-        typedef typename future_data<ContResult>::init_no_addref init_no_addref;
+        using init_no_addref = typename future_data<ContResult>::init_no_addref;
 
-        unwrap_continuation() {}
+        unwrap_continuation() = default;
 
         unwrap_continuation(init_no_addref no_addref)
           : future_data<ContResult>(no_addref)
@@ -692,8 +655,8 @@ namespace hpx { namespace lcos { namespace detail {
         template <typename Future>
         void attach(Future&& future)
         {
-            typedef typename traits::detail::shared_state_ptr_for<Future>::type
-                outer_shared_state_ptr;
+            using outer_shared_state_ptr =
+                traits::detail::shared_state_ptr_for_t<Future>;
 
             // Bind an on_completed handler to this future which will wait for
             // the inner future and will transfer its result to the new future.
@@ -747,7 +710,7 @@ namespace hpx { namespace lcos { namespace detail {
     private:
         void destroy() override
         {
-            typedef std::allocator_traits<other_allocator> traits;
+            using traits = std::allocator_traits<other_allocator>;
 
             other_allocator alloc(alloc_);
             traits::destroy(alloc, this);
@@ -770,8 +733,8 @@ namespace hpx { namespace traits { namespace detail {
 
 namespace hpx { namespace lcos { namespace detail {
     template <typename Allocator, typename Future>
-    inline typename traits::detail::shared_state_ptr<
-        typename future_unwrap_result<Future>::result_type>::type
+    inline traits::detail::shared_state_ptr_t<
+        typename future_unwrap_result<Future>::result_type>
     unwrap_impl_alloc(Allocator const& a, Future&& future, error_code& /*ec*/)
     {
         using base_allocator = Allocator;
@@ -796,16 +759,16 @@ namespace hpx { namespace lcos { namespace detail {
         traits::construct(alloc, p.get(), init_no_addref{}, alloc);
 
         // create a continuation
-        typename hpx::traits::detail::shared_state_ptr<result_type>::type
-            result(p.release(), false);
+        hpx::traits::detail::shared_state_ptr_t<result_type> result(
+            p.release(), false);
         static_cast<shared_state*>(result.get())
             ->attach(std::forward<Future>(future));
         return result;
     }
 
     template <typename Future>
-    inline typename traits::detail::shared_state_ptr<
-        typename future_unwrap_result<Future>::result_type>::type
+    inline traits::detail::shared_state_ptr_t<
+        typename future_unwrap_result<Future>::result_type>
     unwrap_impl(Future&& future, error_code& ec)
     {
         return unwrap_impl_alloc(
@@ -813,16 +776,16 @@ namespace hpx { namespace lcos { namespace detail {
     }
 
     template <typename Allocator, typename Future>
-    inline typename traits::detail::shared_state_ptr<
-        typename future_unwrap_result<Future>::result_type>::type
+    inline traits::detail::shared_state_ptr_t<
+        typename future_unwrap_result<Future>::result_type>
     unwrap_alloc(Allocator const& a, Future&& future, error_code& ec)
     {
         return unwrap_impl_alloc(a, std::forward<Future>(future), ec);
     }
 
     template <typename Future>
-    inline typename traits::detail::shared_state_ptr<
-        typename future_unwrap_result<Future>::result_type>::type
+    inline traits::detail::shared_state_ptr_t<
+        typename future_unwrap_result<Future>::result_type>
     unwrap(Future&& future, error_code& ec)
     {
         return unwrap_impl(std::forward<Future>(future), ec);

--- a/libs/parallelism/futures/include/hpx/futures/traits/future_access.hpp
+++ b/libs/parallelism/futures/include/hpx/futures/traits/future_access.hpp
@@ -167,6 +167,13 @@ namespace hpx { namespace traits {
         {
             return f.shared_state_.detach();
         }
+
+        template <typename Destination>
+        HPX_FORCEINLINE static void transfer_result(
+            lcos::future<R>&& src, Destination& dest)
+        {
+            dest.set_value(src.get());
+        }
     };
 
     template <typename R>
@@ -223,6 +230,13 @@ namespace hpx { namespace traits {
             detach_shared_state(lcos::shared_future<R> const& f)
         {
             return f.shared_state_.get();
+        }
+
+        template <typename Destination>
+        HPX_FORCEINLINE static void transfer_result(
+            lcos::shared_future<R>&& src, Destination& dest)
+        {
+            dest.set_value(src.get());
         }
     };
 

--- a/libs/parallelism/futures/include/hpx/futures/traits/future_traits.hpp
+++ b/libs/parallelism/futures/include/hpx/futures/traits/future_traits.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2021 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -68,6 +68,9 @@ namespace hpx { namespace traits {
         typedef void result_type;
     };
 
+    template <typename Future>
+    using future_traits_t = typename future_traits<Future>::type;
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename Future, typename Enable = void>
     struct is_future_void : std::false_type
@@ -75,9 +78,8 @@ namespace hpx { namespace traits {
     };
 
     template <typename Future>
-    struct is_future_void<Future,
-        typename std::enable_if<is_future<Future>::value>::type>
-      : std::is_void<typename future_traits<Future>::type>
+    struct is_future_void<Future, std::enable_if_t<is_future<Future>::value>>
+      : std::is_void<future_traits_t<Future>>
     {
     };
 }}    // namespace hpx::traits

--- a/libs/parallelism/lcos_local/include/hpx/lcos_local/trigger.hpp
+++ b/libs/parallelism/lcos_local/include/hpx/lcos_local/trigger.hpp
@@ -38,7 +38,7 @@ namespace hpx { namespace lcos { namespace local {
         {
         }
 
-        base_trigger(base_trigger&& rhs)
+        base_trigger(base_trigger&& rhs) noexcept
           : mtx_()
           , promise_(std::move(rhs.promise_))
           , generation_(rhs.generation_)
@@ -47,7 +47,7 @@ namespace hpx { namespace lcos { namespace local {
             rhs.generation_ = std::size_t(-1);
         }
 
-        base_trigger& operator=(base_trigger&& rhs)
+        base_trigger& operator=(base_trigger&& rhs) noexcept
         {
             if (this != &rhs)
             {
@@ -148,7 +148,7 @@ namespace hpx { namespace lcos { namespace local {
         /// \brief Wait for the generational counter to reach the requested
         ///        stage.
         void synchronize(std::size_t generation_value,
-            char const* function_name = "base_and_gate<>::synchronize",
+            char const* function_name = "trigger::synchronize",
             error_code& ec = throws)
         {
             std::unique_lock<mutex_type> l(mtx_);
@@ -158,7 +158,7 @@ namespace hpx { namespace lcos { namespace local {
     protected:
         template <typename Lock>
         void synchronize(std::size_t generation_value, Lock& l,
-            char const* function_name = "base_and_gate<>::synchronize",
+            char const* function_name = "trigger::synchronize",
             error_code& ec = throws)
         {
             HPX_ASSERT_OWNS_LOCK(l);
@@ -226,12 +226,12 @@ namespace hpx { namespace lcos { namespace local {
     public:
         trigger() {}
 
-        trigger(trigger&& rhs)
+        trigger(trigger&& rhs) noexcept
           : base_type(std::move(static_cast<base_type&>(rhs)))
         {
         }
 
-        trigger& operator=(trigger&& rhs)
+        trigger& operator=(trigger&& rhs) noexcept
         {
             if (this != &rhs)
                 static_cast<base_type&>(*this) = std::move(rhs);


### PR DESCRIPTION
- fixing issues with `client`/`client_base` allowing to propagate names registered with AGAS that are associated with a client, fixing lifetime management
- adding `transfer_result` to `future_access` trait
- change `set()` API exposed by `and_gate`, it now forces lock to be moved into the function
- removing overloads of collective operations that rely on futures as those can easily be emulated using `future::then` (this is a breaking change without compatibility option)
- moving all collective operations into namespace `hpx::collectives` (this is a breaking change without compatibility option)
- adding `hpx::collectives::reduce`, `hpx::collectives::inclusive_scan`, `hpx::collectives::exclusive_scan`
- adding new `hpx::collectives::create_communicator` usable with all collective operations
- flyby: remove obsolete `reset_registered_name()` API function from `client_base`
- flyby: working around an #include conflict on recent Windows toolkits
- flyby: modernize future access traits and packaged_continuation facilities 