### PR TITLE
Disable pkgconfig by default again on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -628,7 +628,8 @@ hpx_option(
 # pkgconfig file generation
 # ##############################################################################
 set(HPX_WITH_PKGCONFIG_DEFAULT ON)
-if(MSVC
+if(APPLE
+   OR MSVC
    OR HPX_WITH_CUDA
    OR HPX_WITH_HIP
 )


### PR DESCRIPTION
I unintentionally re-enabled the build unit test with pkgbuild on macOS in #5330. This turns it off by default on macOS.